### PR TITLE
Switch Travis to use the Dart SDK from flutter

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -3,13 +3,16 @@
 # Fast fail the script on failures.
 set -e
 
+# Use the version of Dart SDK from the Flutter repository instead of whatever
+# version is in the PATH.
+export PATH="`pwd`/../flutter/bin/cache/dart-sdk/bin:$PATH"
+
 echo "Extract Dart snippets from the markdown documentation."
 dart tool/extract.dart
 
 echo "Analyzing the extracted Dart libraries."
 
-pub global activate tuneup
-pub global run tuneup check
+../flutter/bin/flutter analyze example/*.dart
 
 echo "Install jekyll."
 gem install bundler


### PR DESCRIPTION
This ensures that we use the same version of the Dart SDK that we're using in
flutter.git.