### PR TITLE
docs: Add links to the Firebase Flutter codelab.

### DIFF
--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -17,7 +17,7 @@ entries:
   - title: New to Flutter
     output: web
     folderitems:
-    
+
     - title: Set up
       url: /setup/
       output: web
@@ -57,7 +57,7 @@ entries:
     - title: Layered Design
       external_url: https://www.youtube.com/watch?v=dkyY9WCGMi0
       output: web
-      
+
     - title: Rendering pipeline
       external_url: https://www.youtube.com/watch?v=UUfXWzp0-DU
       output: web
@@ -82,6 +82,9 @@ entries:
       url: /upgrading/
       output: web
 
+    - title: Build cross-platform Firebase apps
+      url: https://codelabs.developers.google.com/codelabs/flutter/index.html
+      output: web
 
   - title: Helpful Resources
     output: web

--- a/index.md
+++ b/index.md
@@ -38,6 +38,7 @@ Learn how to accomplish specific development tasks with Flutter.
  - [Testing Flutter apps](testing)
  - [Debugging Flutter apps](debugging)
  - [Upgrading Flutter](upgrading)
+ - [Building cross-platform Firebase apps (codelab)](https://codelabs.developers.google.com/codelabs/flutter/index.html)
 
 ## Helpful Resources
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/4101

Link to stage:
[https://flutter-io-staging-69a8a.firebaseapp.com/](https://flutter-io-staging-69a8a.firebaseapp.com/)