### PR TITLE
Update docs to use master rather than alpha

### DIFF
--- a/bug_reports.md
+++ b/bug_reports.md
@@ -19,7 +19,7 @@ The instructions in this document detail the current steps required to provide t
 * Run `flutter doctor` in your project directory and paste the results into the Github Issue:
 
 ```
-[✓] Flutter (on Mac OS, channel alpha)
+[✓] Flutter (on Mac OS, channel master)
     • Flutter at /Users/me/projects/flutter
     • Framework revision 8cbeb2e (4 hours ago), engine revision 5c28578
 

--- a/setup.md
+++ b/setup.md
@@ -24,7 +24,7 @@ To install and run Flutter, your development environment must meet these minimum
 To get Flutter, use `git` to clone the repository and then add the `flutter` tool to your path:
 
 <pre>
-$ git clone https://github.com/flutter/flutter.git -b alpha
+$ git clone https://github.com/flutter/flutter.git
 $ export PATH=`pwd`/flutter/bin:$PATH
 </pre>
 

--- a/tool/before_install.sh
+++ b/tool/before_install.sh
@@ -7,4 +7,4 @@ echo "Downloading Flutter"
 
 # Run doctor to download the Dart SDK that is vendored with Flutter
 
-(cd ..; git clone https://github.com/flutter/flutter.git -b alpha ; cd flutter ; ./bin/flutter doctor)
+(cd ..; git clone https://github.com/flutter/flutter.git ; cd flutter ; ./bin/flutter doctor)

--- a/upgrading.md
+++ b/upgrading.md
@@ -5,11 +5,11 @@ sidebar: home_sidebar
 permalink: /upgrading/
 ---
 
-We recommend that you
-keep your app updated to our `alpha` branch, as we update as frequently
-as every week.
+We recommend tracking the `master` branch in the flutter repository, which
+updates continuously as we improve Flutter.
 
 ## Upgrading Flutter channel and your packages
+
 To update both the Flutter SDK and your packages, use the `flutter upgrade`
 command from the root of your app (the same directory that contains the
 `pubspec.yaml` file):
@@ -19,6 +19,7 @@ $ flutter upgrade
 ```
 
 ## Upgrading your packages
+
 If you've modified your `pubspec.yaml` file, or you want to only update
 the packages your app depends upon instead of both the packages and
 Flutter itself, then use the following commands:


### PR DESCRIPTION
Folks who use alpha often find that the branch is stale and would prefer to be
on master.