### PR TITLE
Fix CSS to make sure that h3 amd h4 are actually smaller than h2

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -248,23 +248,23 @@
         font-size: 24px;
 
         @include media-query($on-laptop) {
-            font-size: 28px;
-        }
-    }
-
-    h3 {
-        font-size: 26px;
-
-        @include media-query($on-laptop) {
             font-size: 22px;
         }
     }
 
-    h4 {
-        font-size: 20px;
+    h3 {
+        font-size: 18px;
 
         @include media-query($on-laptop) {
-            font-size: 18px;
+            font-size: 16px;
+        }
+    }
+
+    h4 {
+        font-size: 14px;
+
+        @include media-query($on-laptop) {
+            font-size: 12px;
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/6416

Cross checked with https://github.com/jekyll/minima/blob/master/_sass/minima/_layout.scss

Before:
![screen shot 2016-10-21 at 12 10 49](https://cloud.githubusercontent.com/assets/13644170/19594842/57f086ac-9787-11e6-9742-b96700dc588f.png)

After:
![screen shot 2016-10-21 at 12 10 12](https://cloud.githubusercontent.com/assets/13644170/19594829/46ff6dae-9787-11e6-845f-9534738308eb.png)

