### PR TITLE
Flutter plugin support for IntelliJ branded products

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -142,7 +142,8 @@ Flutter applications.
 The IntelliJ plug-ins require JetBrains [IntelliJ IDEA](https://www.jetbrains.com/idea/download/)
 in the Community or Ultimate edition, version 2016.2 or later is supported.
 
-The current version of the Flutter plugin for IntelliJ is not compatible with Android Studio and Webstorm (and various other IntelliJ branded products). Support for Android Studios and other IntelliJ products will be added in the near future.
+The current version of the Flutter plugin for IntelliJ is not compatible with Android Studio and 
+Webstorm (and various other JetBrains editors).
 
 ### Install the plugins
 

--- a/setup.md
+++ b/setup.md
@@ -140,9 +140,9 @@ Flutter applications.
 ### Installing IntelliJ
 
 The IntelliJ plug-ins require JetBrains [IntelliJ IDEA](https://www.jetbrains.com/idea/download/)
-in the Community or Ultimate edition.
+in the Community or Ultimate edition, version 2016.2 or later is supported.
 
-Version 2016.2 or later is supported.
+The current version of the Flutter plugin for IntelliJ is not compatible with Android Studio and Webstorm (and various other IntelliJ branded products). Support for Android Studios and other IntelliJ products will be added in the near future.
 
 ### Install the plugins
 


### PR DESCRIPTION
Explicitly mention that Android Studio, Webstorm, and other IntelliJ branded products are not supported by the IntelliJ Flutter plugin. Various community members tried to run install the Flutter plugin in Android Studio and Webstorm.