### PR TITLE
attempt to force newline in CLI instructions

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -46,10 +46,10 @@ contains the `pubspec.yaml` file for your project).
 source code, you can hit `r` to hot-reload your application (updating the source on the fly
 without actually restarting the entire app).
 
-  ```
-  $ cd myapp
-  $ flutter run
-  ```
+```
+$ cd myapp
+$ flutter run
+```
 
 If more than one device is connected, use the `flutter devices` command
 to get their IDs, and then `flutter run -d deviceID` to run your app.


### PR DESCRIPTION
this PR attempts to fix:

![screen shot 2016-11-28 at 10 02 59 am](https://cloud.githubusercontent.com/assets/5479/20679952/df28f446-b551-11e6-91bd-75b635e9d22c.png)

Notice how the second command is on the line with the first command.