### PR TITLE
Fix Firebase publishing step to be on pushes/merges to master only

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -59,14 +59,11 @@ bundle install
 echo "Building site."
 bundle exec jekyll build
 
-# TODO: deploy to a personal staging site, based on github ID, when not
-#       merging into master
-
-if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-  if [ "$TRAVIS_BRANCH" = "master" ]; then
-    echo "Deploying to Firebase."
-
-    npm install --global firebase-tools@3.0.0
-    firebase -P sweltering-fire-2088 --token "$FIREBASE_TOKEN" deploy
-  fi
+if [ "$TRAVIS_EVENT_TYPE" = "push" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+  # Deploy pushes to master to Firebase hosting.
+  # TODO: deploy to a personal staging site, based on github ID, when not
+  #       merging into master
+  echo "Deploying to Firebase."
+  npm install --global firebase-tools@3.0.0
+  firebase -P sweltering-fire-2088 --token "$FIREBASE_TOKEN" deploy
 fi


### PR DESCRIPTION
The current branching logic deploys to Firebase whenever not running for a pull-request, and when not on master. However, that means it also deploys when running a cron job, or an api job (e.g. a restart from the admin UI).

This changes the branching to only deploy when running a push job (i.e., pushing/merging) into master.

https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables

