### PR TITLE
Fix Ruby version typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ provided by GitHub.
 
 A tldr version follows:
 
-1. Ensure you have [Ruby](https://www.ruby-lang.org/en/documentation/installation/) installed; you need version 2.3.1 or later:<br>
+1. Ensure you have [Ruby](https://www.ruby-lang.org/en/documentation/installation/) installed; you need version 2.2.2 or later:<br>
 `ruby --version`
 
 1. Ensure you have [Bundler](http://bundler.io/) installed; if not install with:<br>


### PR DESCRIPTION
Oops, the readme.md update in https://github.com/flutter/website/pull/342 should have said Ruby 2.2.2 -- that is what the travis job is running:

```
19.39s$ rvm install 2.2.2
Searching for binary rubies, this might take some time.
Found remote file https://rubies.travis-ci.org/ubuntu/12.04/x86_64/ruby-2.2.2.tar.bz2
Checking requirements for ubuntu.
Requirements installation successful.
```