### PR TITLE
Add url swapping to htmlproofer command in travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A tldr version follows:
 
 1. Prior to submitting, run link validation:<br>
 `bundle exec jekyll build`<br>
-`bundle exec htmlproofer _site --empty-alt-ignore --url-ignore "#" --only-4xx`
+`bundle exec htmlproofer _site --empty-alt-ignore --url-ignore "#" --only-4xx  --url-swap "https?\:\/\/(localhost\:4000|flutter\.io):"`
 
 ## Staging the site for external review
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -72,7 +72,7 @@ echo "Building site."
 bundle exec jekyll build
 
 echo "Validating all links."
-bundle exec htmlproofer _site --empty-alt-ignore --url-ignore "#" --only-4xx
+bundle exec htmlproofer _site --empty-alt-ignore --url-ignore "#" --only-4xx --url-swap "https?\:\/\/(localhost\:4000|flutter\.io):"
 
 if [ "$TRAVIS_EVENT_TYPE" = "push" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
   # Deploy pushes to master to Firebase hosting.


### PR DESCRIPTION
Add url swapping to htmlproofer to work around issue with permalinks causing 404s on pages not yet deployed (see https://github.com/gjtorikian/html-proofer/issues/170 for details).

Resolves issue uncovered while trying to land https://github.com/flutter/website/pull/382.