### PR TITLE
Fix link to non-existent "Managing State" section

### DIFF
--- a/text-input.md
+++ b/text-input.md
@@ -46,8 +46,8 @@ class within a
 so you can save and operate on the current value of the input.
 To learn more about
 [`StatefulWidget`](https://docs.flutter.io/flutter/widgets/StatefulWidget-class.html)
-and managing state in Flutter, please read our guide on
-[managing widget state](https://flutter.io/widgets-intro/#managing-state).
+and managing state in Flutter, you can look at this helpful example of 
+[managing widget state](https://flutter.io/widgets-intro/#changing-widgets-in-response-to-input).
 
 ## Example
 


### PR DESCRIPTION
Widgets Intro does not have a Managing State section. Instead, pointing users to example of Changing Widgets in Response to Input, which shows how to manage state.
  #383 

When we do have detailed state info, this link should be repointed there.

This broken link was not caught in previous HTMLproofer runs, so we should keep an eye out for other misses...
