### PR TITLE
Remove 'EULA' jargon from setup page

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -62,7 +62,7 @@ To develop Flutter apps for iOS, you need a Mac with Xcode 7.2 or newer:
 
 1. Install Xcode 7.2 or newer (via [web download](https://developer.apple.com/xcode/) or
 the [Mac App Store](https://itunes.apple.com/us/app/xcode/id497799835)).
-2.  Make sure the Xcode EULA is signed by either opening Xcode once and confirming or
+2.  Make sure the Xcode licence agreement is signed by either opening Xcode once and confirming or
 running `sudo xcodebuild -license` from the command-line.
 
 With Xcode, you’ll be able to run Flutter apps on an iOS device or on the simulator.


### PR DESCRIPTION
This caused a distraction during user study.