### PR TITLE
Relocate IDE setup steps to separate page

### DIFF
--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -26,8 +26,8 @@ entries:
       url: /setup/
       output: web
       
-    - title: IDE set up
-      url: /ide-setup/
+    - title: IntelliJ set up
+      url: /intellij-setup/
       output: web
 
     - title: Get started

--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -25,6 +25,10 @@ entries:
     - title: Set up
       url: /setup/
       output: web
+      
+    - title: IDE set up
+      url: /ide-setup/
+      output: web
 
     - title: Get started
       url: /getting-started/

--- a/formatting.md
+++ b/formatting.md
@@ -23,7 +23,7 @@ time may be better spent on code behavior rather than code style.
 ### Automatically formatting code in IntelliJ
 
 Automatic formatting of code is supported in IntelliJ if you have the
-`Dart` plugin (see [IntelliJ setup](/setup/#flutter-intellij-ide-plugins)).
+`Dart` plugin (see [IntelliJ setup](/ide-setup/)).
 
 To automatically format the code in the current source code window, right-click
 in the code window and select `Reformat with Dart style`. You can add a keyboard

--- a/formatting.md
+++ b/formatting.md
@@ -23,7 +23,7 @@ time may be better spent on code behavior rather than code style.
 ### Automatically formatting code in IntelliJ
 
 Automatic formatting of code is supported in IntelliJ if you have the
-`Dart` plugin (see [IntelliJ setup](/ide-setup/)).
+`Dart` plugin (see [IntelliJ setup](/intellij-setup/)).
 
 To automatically format the code in the current source code window, right-click
 in the code window and select `Reformat with Dart style`. You can add a keyboard

--- a/getting-started.md
+++ b/getting-started.md
@@ -54,7 +54,7 @@ to get their IDs, and then `flutter run -d deviceID` to run your app.
 
 Alternatively, if you are using the [IntelliJ
 IDEA](https://www.jetbrains.com/idea/) IDE with the [Flutter
-plugins](/setup/#plugins), you can start your Flutter app from there:
+plugins](/ide-setup/), you can start your Flutter app from there:
 
 1. In IntelliJ, click **Create New Project** from the Welcome window or
 **File > New > Project...** from the main IDE window.

--- a/getting-started.md
+++ b/getting-started.md
@@ -54,7 +54,7 @@ to get their IDs, and then `flutter run -d deviceID` to run your app.
 
 Alternatively, if you are using the [IntelliJ
 IDEA](https://www.jetbrains.com/idea/) IDE with the [Flutter
-plugins](/ide-setup/), you can start your Flutter app from there:
+plugins](/intellij-setup/), you can start your Flutter app from there:
 
 1. In IntelliJ, click **Create New Project** from the Welcome window or
 **File > New > Project...** from the main IDE window.

--- a/ide-setup.md
+++ b/ide-setup.md
@@ -1,0 +1,47 @@
+---
+layout: page
+title: IDE Setup
+sidebar: home_sidebar
+permalink: /ide-setup/
+---
+
+This page describes how to set up IntelliJ IDE to develop Flutter apps.
+
+* TOC Placeholder
+{:toc}
+
+## Flutter IntelliJ IDE plugins
+
+You can write Flutter apps in a text editor, but if you choose to work in an IDE we recommend 
+IntelliJ for a [rich IDE experience](/intellij-ide/). Our Flutter and Dart plug-ins support 
+editing, running, and debugging Flutter apps.
+
+### Installing IntelliJ
+
+The IntelliJ plug-ins require JetBrains [IntelliJ IDEA](https://www.jetbrains.com/idea/download/),
+either Community (free) or Ultimate edition. Version 2016.2 or later is supported.
+
+Note that the current version of the Flutter plugin for IntelliJ is not compatible with Android 
+Studio and Webstorm (and various other JetBrains editors).
+
+### Installing the plugins
+
+We provide two plugins:
+
+  * The `Dart` plugin offers code analysis (code validation as you type, code completions, etc.)
+  * The `Flutter` plugin powers Flutter developer workflows (running, debugging, hot reload, etc.)
+
+To install the plugins:
+
+1. Open plugin preferences (**Preferences>Plugins** on macOS, **File>Settings>Plugins** on Linux)
+1. Select **"Browse repositories…"**
+1. Search for `'dart'`, select the Dart plug-in and click `install` (do not restart yet).
+1. Search for `'flutter'`,  select the Flutter plug-in and click `install`. 
+1. Click `Restart IntelliJ IDEA`.
+
+### Configure the plugins
+
+1. Open preferences (**Preferences** on macOS, **File>Settings** on Linux)
+1. Select **Languages & Frameworks>Flutter**
+1. Enter, or browse to, your Flutter SDK directory path in **Flutter SDK path**
+1. Click **OK**

--- a/intellij-setup.md
+++ b/intellij-setup.md
@@ -2,7 +2,7 @@
 layout: page
 title: IDE Setup
 sidebar: home_sidebar
-permalink: /ide-setup/
+permalink: /intellij-setup/
 ---
 
 This page describes how to set up IntelliJ IDE to develop Flutter apps.
@@ -39,7 +39,7 @@ To install the plugins:
 1. Search for `'flutter'`,  select the Flutter plug-in and click `install`. 
 1. Click `Restart IntelliJ IDEA`.
 
-### Configure the plugins
+### Configuring the plugins
 
 1. Open preferences (**Preferences** on macOS, **File>Settings** on Linux)
 1. Select **Languages & Frameworks>Flutter**

--- a/setup.md
+++ b/setup.md
@@ -129,7 +129,7 @@ you want Flutter to use a different installation of the Android SDK, you must se
 Using our command-line tools, you can use any editor to develop Flutter applications.
 If you prefer working in an IDE, we recommend using our IntelliJ plug-ins for a 
 [rich IDE experience](/intellij-ide/) supporting editing, running, and debugging 
-Flutter apps. See [IDE Setup](/ide-setup/) for detailed steps.
+Flutter apps. See [IntelliJ Setup](/intellij-setup/) for detailed steps.
 
 ## Next steps
 

--- a/setup.md
+++ b/setup.md
@@ -126,44 +126,10 @@ By default, Flutter uses the version of the Android SDK where your `adb` tool is
 you want Flutter to use a different installation of the Android SDK, you must set the
 `ANDROID_HOME` environment variable to that specific installation directory.
 
-
-<a name="plugins"/>
-
-## Flutter IntelliJ IDE plugins
-
-We recommend using our IntelliJ plug-ins for a [rich IDE
-experience](/intellij-ide/) supporting editing, running, and debugging Flutter
-apps. However, using our command-line tools, you can use any editor to develop
-Flutter applications.
-
-### Installing IntelliJ
-
-The IntelliJ plug-ins require JetBrains [IntelliJ IDEA](https://www.jetbrains.com/idea/download/)
-in the Community or Ultimate edition, version 2016.2 or later is supported.
-
-The current version of the Flutter plugin for IntelliJ is not compatible with Android Studio and 
-Webstorm (and various other JetBrains editors).
-
-### Install the plugins
-
-We provide two plugins:
-
-  * The `Dart` plugin offers code analysis (code validation as you type, code completions, etc.)
-  * The `Flutter` plugin powers flutter developer workflows (running, debugging, hot reload, etc.)
-
-To install the plugins:
-
-1. Open plugin preferences (**Preferences>Plugins** on macOS, **File>Settings>Plugins** on Linux)
-1. Select **"Browse repositories…"**
-1. search for `'dart'`; click `install` (do not click restart yet)
-1. search for `'flutter'`; click `install`, and then click `Restart IntelliJ IDEA`
-
-### Configure the plugins
-
-1. Open preferences (**Preferences** on macOS, **File>Settings** on Linux)
-1. Select **Languages & Frameworks>Flutter**
-1. Enter, or browse to, your Flutter SDK directory path in **Flutter SDK path**
-1. Click **OK**
+Using our command-line tools, you can use any editor to develop Flutter applications.
+If you prefer working in an IDE, we recommend using our IntelliJ plug-ins for a 
+[rich IDE experience](/intellij-ide/) supporting editing, running, and debugging 
+Flutter apps. See [IDE Setup](/ide-setup/) for detailed steps.
 
 ## Next steps
 


### PR DESCRIPTION
The majority of users will probably use a text editor, so streamlining the setup page for them.
Moving the IDE setup steps to a new page...