### PR TITLE
Fix IntelliJ HowTo installation link

### DIFF
--- a/intellij-ide.md
+++ b/intellij-ide.md
@@ -13,7 +13,7 @@ fully integrated development experience in the IntelliJ IDE.
 
 ## Installation and setup
 
-Please follow the [Flutter setup](/setup/) instructions to install IntelliJ and
+Please follow the [IntelliJ setup](/intellij-setup/) instructions to install IntelliJ and
 the Dart and Flutter plugins.
 
 ### Updating the plugins<a name="updating"/>


### PR DESCRIPTION
The setup instructions no longer have IntelliJ setup, so changing to the IntelliJ page