### PR TITLE
Add xcode-select step for iOS installation

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -62,8 +62,11 @@ To develop Flutter apps for iOS, you need a Mac with Xcode 7.2 or newer:
 
 1. Install Xcode 7.2 or newer (via [web download](https://developer.apple.com/xcode/) or
 the [Mac App Store](https://itunes.apple.com/us/app/xcode/id497799835)).
-2.  Make sure the Xcode licence agreement is signed by either opening Xcode once and confirming or
-running `sudo xcodebuild -license` from the command-line.
+2. Configure the Xcode command-line tools to use the newly installed version of Xcode by
+running `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer` from
+the command line.
+2. Make sure the Xcode licence agreement is signed by either opening Xcode once and confirming or
+running `sudo xcodebuild -license` from the command line.
 
 With Xcode, you’ll be able to run Flutter apps on an iOS device or on the simulator.
 

--- a/setup.md
+++ b/setup.md
@@ -65,7 +65,7 @@ the [Mac App Store](https://itunes.apple.com/us/app/xcode/id497799835)).
 2. Configure the Xcode command-line tools to use the newly installed version of Xcode by
 running `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer` from
 the command line.
-2. Make sure the Xcode licence agreement is signed by either opening Xcode once and confirming or
+2. Make sure the Xcode license agreement is signed by either opening Xcode once and confirming or
 running `sudo xcodebuild -license` from the command line.
 
 With Xcode, you’ll be able to run Flutter apps on an iOS device or on the simulator.

--- a/setup.md
+++ b/setup.md
@@ -67,7 +67,7 @@ running `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer` 
 the command line.
 
   This is the correct path for most cases, when you want to use the latest version of Xcode.
-  If you need to use an older version for some reason, specify that path instead.
+  If you need to use a different version, specify that path instead.
 2. Make sure the Xcode license agreement is signed by either opening Xcode once and confirming or
 running `sudo xcodebuild -license` from the command line.
 

--- a/setup.md
+++ b/setup.md
@@ -62,7 +62,7 @@ To develop Flutter apps for iOS, you need a Mac with Xcode 7.2 or newer:
 
 1. Install Xcode 7.2 or newer (via [web download](https://developer.apple.com/xcode/) or
 the [Mac App Store](https://itunes.apple.com/us/app/xcode/id497799835)).
-2. Configure the Xcode command-line tools to use the newly installed version of Xcode by
+2. Configure the Xcode command-line tools to use the newly-installed version of Xcode by
 running `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer` from
 the command line.
 

--- a/setup.md
+++ b/setup.md
@@ -65,6 +65,9 @@ the [Mac App Store](https://itunes.apple.com/us/app/xcode/id497799835)).
 2. Configure the Xcode command-line tools to use the newly installed version of Xcode by
 running `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer` from
 the command line.
+
+  This is the correct path for most cases, when you want to use the latest version of Xcode.
+  If you need to use an older version for some reason, specify that path instead.
 2. Make sure the Xcode license agreement is signed by either opening Xcode once and confirming or
 running `sudo xcodebuild -license` from the command line.
 


### PR DESCRIPTION
Also tweak hyphenation to differentiate 'command-line' (compound
modifier to 'tools') and 'command line' (noun).