### PR TITLE
Move editor setup out from under the Android section

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -132,10 +132,14 @@ By default, Flutter uses the version of the Android SDK where your `adb` tool is
 you want Flutter to use a different installation of the Android SDK, you must set the
 `ANDROID_HOME` environment variable to that specific installation directory.
 
+## Editor setup
+
+
 Using our command-line tools, you can use any editor to develop Flutter applications.
-If you prefer working in an IDE, we recommend using our IntelliJ plug-ins for a 
-[rich IDE experience](/intellij-ide/) supporting editing, running, and debugging 
-Flutter apps. See [IntelliJ Setup](/intellij-setup/) for detailed steps.
+
+We recommend using our IntelliJ plug-ins for a  [rich IDE experience](/intellij-ide/) 
+supporting editing, running, and debugging Flutter apps. See [IntelliJ Setup](/intellij-setup/)
+for detailed steps.
 
 ## Next steps
 


### PR DESCRIPTION
The editor/IDE paragraphs are currently placed as the last paragraph under the Android section/header. Thus, a developer that chooses to skip Android setup (e.g., an iOS developer) will never reach that paragraph and not be aware of the IDE option.

This simple moves it under a separate header.