### PR TITLE
Fix list formatting in code_comp_page layout

### DIFF
--- a/_layouts/code_comp_page.html
+++ b/_layouts/code_comp_page.html
@@ -11,5 +11,5 @@ layout: default
   </header>
 </div>
     <body>
-        <article>{{ content }}</article>
+        <article class="post-content">{{ content }}</article>
     </body>


### PR DESCRIPTION
@Sfshaza pointed out that, after she fixed the list line height in https://flutter.io/tutorials/layout/ and other pages, the list items in https://flutter.io/web-analogs/ were too close together vertically. @lwalrath helped me track down what was causing the difference. We confirmed in my local build that this change doesn't have any unexpected effects on web-analogs.