### PR TITLE
Flutter Stager

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,7 @@
+# Below is a list of people and organizations that have contributed
+# to the Flutter project. Names should be added to the list like so:
+#
+#   Name/Organization <email address>
+
+Google Inc.
+Faisal Abid <faisal.abid@gmail.com>

--- a/tool/before_install.sh
+++ b/tool/before_install.sh
@@ -8,3 +8,7 @@ echo "Downloading Flutter"
 # Run doctor to download the Dart SDK that is vendored with Flutter
 
 (cd ..; git clone https://github.com/flutter/flutter.git ; cd flutter ; ./bin/flutter doctor)
+
+echo "Download Google OAuth Tool"
+
+pip install --user google-oauth2l --upgrade

--- a/tool/prdeployer.dart
+++ b/tool/prdeployer.dart
@@ -1,0 +1,78 @@
+import 'package:firebase/firebase_io.dart';
+import 'dart:async';
+import 'package:github/server.dart';
+import 'dart:io';
+
+GitHub github;
+String firebaseAuth;
+PullRequest currentPullRequest;
+
+String firebaseRoot = "https://flutter-web-controller.firebaseio.com/flutter/pulls";
+
+main(List<String> arguments) async {
+  Map<String, String> env = Platform.environment;
+  github = createGitHubClient(auth: new Authentication.withToken(env["GITHUB_TOKEN"]));
+  
+  firebaseAuth = arguments[1];
+  String branchName = arguments[0];
+
+  FirebaseClient fbClient = new FirebaseClient(firebaseAuth);
+
+  List<PullRequest> prsList = await getPullRequests();
+  currentPullRequest = prsList.firstWhere((p) => p.head.ref == branchName);
+
+  String rootPath = "${firebaseRoot}.json";
+
+  Map<String, Map<String, String>> projectsData = await fbClient.get(rootPath);
+  String projectToDeploy;
+
+  await projectsData.forEach((String key, Map<String, String> value) async {
+    if (value["branch"] == branchName) {
+      // this has already been deployed.
+      // deploy again
+      projectToDeploy = value["name"];
+    } else {
+      bool oldBranch = await isBranchOld(value["branch"]);
+      if (oldBranch) {
+        await fbClient.patch("${firebaseRoot}/$key.json", {"branch": null});
+      }
+    }
+  });
+
+  if (projectToDeploy == null) {
+    await projectsData.forEach((String key, Map<String, String> value) async {
+      if (projectToDeploy != null) {
+        // project already set
+        // todo: remove this foreach with a better iterator pattern
+        return;
+      }
+      projectToDeploy = value["name"];
+      await fbClient.patch("${firebaseRoot}/$key.json", {"branch": branchName});
+      await postLinkToGithub(projectToDeploy, currentPullRequest);
+    });
+  }
+
+  print(projectToDeploy);
+}
+
+Future<bool> isBranchOld(String branchName) async {
+  List<PullRequest> pullRequests = await getPullRequests();
+  return !pullRequests.any((p) => p.head.ref == branchName);
+}
+
+Future<List<PullRequest>> getPullRequests() async {
+  Stream<PullRequest> pullRequests = await github.pullRequests.list(new RepositorySlug.full("flutter/website"));
+  return await pullRequests.toList();
+}
+
+Future<IssueComment> postLinkToGithub(String projectToDeploy, PullRequest request) async {
+  if (request == null) {
+    return null;
+  }
+
+  IssueComment issueComment = await github.issues.createComment(
+      new RepositorySlug.full("flutter/website"),
+      request.number,
+      "Staging URL Generated At https://${projectToDeploy}.firebaseapp.com . Please allow Travis Build to finish to view the URL.");
+  return issueComment;
+}

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -1,0 +1,6 @@
+name: prdeployer
+version: 0.0.1
+dependencies:
+  firebase: ^3.0.0
+  github: ^3.0.0
+

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -2,6 +2,8 @@
 
 # Fast fail the script on failures.
 set -e
+# Normalize Branch variable
+export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 
 # Use the version of Dart SDK from the Flutter repository instead of whatever
 # version is in the PATH.
@@ -76,9 +78,20 @@ bundle exec htmlproofer _site --empty-alt-ignore --url-ignore "#" --only-4xx --u
 
 if [ "$TRAVIS_EVENT_TYPE" = "push" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
   # Deploy pushes to master to Firebase hosting.
-  # TODO: deploy to a personal staging site, based on github ID, when not
-  #       merging into master
   echo "Deploying to Firebase."
   npm install --global firebase-tools@3.0.0
   firebase -P sweltering-fire-2088 --token "$FIREBASE_TOKEN" deploy
+fi
+
+if [ "$BRANCH" != "master" ]; then
+    echo "deploying to stage environment"
+    echo $FIREBASE_FILE >> ./service_account.json
+    export FIREBASE_AUTH=`oauth2l fetch --json ./service_account.json firebase.database userinfo.email 2>&1`
+    cd tool/
+    ../../flutter/bin/cache/dart-sdk/bin/pub get
+    export PROJECT_NAME=`../../flutter/bin/cache/dart-sdk/bin/dart prdeployer.dart $BRANCH $FIREBASE_AUTH 2>&1`
+    cd ../
+    echo "Deploying to $PROJECT_NAME"
+    npm install --global firebase-tools@3.0.0
+    firebase -P "$PROJECT_NAME" --token "$FIREBASE_TOKEN_DEV" deploy
 fi


### PR DESCRIPTION
Addresses the issue https://github.com/flutter/flutter/issues/8159

How it works

- There are 10 Firebase projects setup. 
- There is a Master Firebase Project Setup with Firebase Database that coordinates everything
- When a PR is made, we find a free firebase project and deploy it, storing what branch was deployed on which PR
- When an update to a PR is made, we find the project that was associated with that PR and return that
- It finds the Pull Request Issue and makes a comment from a bot account with the URL to that staging url.
- This scales well by just adding more entries to the Firebase Database
- We do a cleanup when it runs by checking the branches currently in the database still exist as Pull requests, if no then we delete the entry and let something else override it

Please review! 

I would also like to point out the following line, would like someones thoughts on this, is there a better way to do this?
```if [ "$BRANCH" != "master" ]; then```

Please ask questions if something is unclear of if something needs to be documented more.

I will be providing @sethladd with the access tokens as well as project access to all the firebase projects shortly.



