### PR TITLE
Add libimobiledevice install step

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -173,6 +173,7 @@ To deploy your Flutter app to a physical iOS device, you’ll need some addition
 iOS devices.
 
    ```
+   $ brew install --HEAD libimobiledevice
    $ brew install ideviceinstaller ios-deploy
    ```
 1. If you see the following error:


### PR DESCRIPTION
The most recently published binary version of the libimobiledevice
homebrew formula is relatively out-of-date and doesn't work with recent
Xcode releases. Update instructions to explicitly install
libimobiledevice with --HEAD so as not to pick up the out-of-date
version through an implicit dependency of ideviceinstaller.