### PR TITLE
Minor wording improvement for homebrew instructions

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -169,7 +169,7 @@ may overflow your screen. Set the device scale under the **Window > Scale** menu
 To deploy your Flutter app to a physical iOS device, you’ll need some additional tools, an account, and a profile:
 
 1. Install [homebrew](http://brew.sh/).
-1. Open the terminal and run this command to install the tools for deploying Flutter apps to
+1. Open the terminal and run these commands to install the tools for deploying Flutter apps to
 iOS devices.
 
    ```


### PR DESCRIPTION
Pluralise 'instruction' -> 'instructions'.