### PR TITLE
Signal that it's OK to create this file if it doesn't exist

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -69,7 +69,7 @@ To install and run Flutter, your development environment must meet these minimum
    export PATH=$HOME/flutter/bin:$PATH
    ```
    and then run the `source <filename>` command to refresh the window. For example, 
-   edit and source `$HOME/.bash_profile`.
+   edit (or create) and source `$HOME/.bash_profile`.
 
 1. Verify that the `flutter/bin` directory is now in your PATH by running:
    ```


### PR DESCRIPTION
Ideally, we would automate these steps somehow. Until we have a more automated process, we can reassure our new users that it's OK to create this file if it doesn't exist.

This is a temp fix, an installer script/app would make for a better long-term fix.