### PR TITLE
Remove trailing comma

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -42,7 +42,7 @@
         "source" : "/platform-services/",
         "destination" : "/platform-plugins/",
         "type" : 301
-      },
+      }
     ]
   }
 }


### PR DESCRIPTION
Causing deployment error:

```
Error: There was an error loading firebase.json:
Trailing comma in array at 46:5
    ]
    ^
File: "/home/travis/build/flutter/website/firebase.json"
The command "./tool/travis.sh" exited with 1.
```