### PR TITLE
Add new release build pages to sidebar

### DIFF
--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -94,6 +94,14 @@ entries:
       url: /layout/
       output: web
 
+    - title: Android release builds
+      url: /android-release/
+      output: web
+
+    - title: iOS release builds
+      url: /ios-release/
+      output: web
+
   - title: How-Tos
     output: web
     folderitems:


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/8722

CC @cbracken 