### PR TITLE
remove wacky JS fixing sidenav scrolling

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,6 +1,6 @@
 {% include custom/sidebarconfigs.html %}
 
-<ul id="mysidebar" class="nav">
+<ul id="mysidebar" class="nav affix">
     <li class="sidebarTitle">{{sidebar[0].product}} {{sidebar[0].version}}</li>
     {% for entry in sidebar %}
     {% for folder in entry.folders %}

--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -1,15 +1,6 @@
 $( document ).ready(function() {
-
-    // this script says, if the height of the viewport is greater than 800px,
-    // then insert affix class, which makes the nav bar float in a fixed
-    // position as your scroll. if you have a lot of nav items, this height may
-    // not work for you.
-    var h = $(window).height();
-    //console.log (h);
-    if (h > 800) {
-        $( "#mysidebar" ).attr("class", "nav affix");
-    }
-    // activate tooltips. although this is a bootstrap js function, it must be activated this way in your theme.
+    // activate tooltips. although this is a bootstrap js function,
+    // it must be activated this way in your theme.
     $('[data-toggle="tooltip"]').tooltip({
         placement : 'top'
     });


### PR DESCRIPTION
Now the nav stays visible, even on a laptop.

I tested on desktop and laptop, wide and narrow screens.