### PR TITLE
Migrate examples to use widget in place of config

### DIFF
--- a/_includes/_code/card/main.dart
+++ b/_includes/_code/card/main.dart
@@ -73,7 +73,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
     return new Scaffold(
       appBar: new AppBar(
-        title: new Text(config.title),
+        title: new Text(widget.title),
       ),
       body: new Center(
         child: card,

--- a/_includes/_code/column/main.dart
+++ b/_includes/_code/column/main.dart
@@ -38,7 +38,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: new AppBar(
-        title: new Text(config.title),
+        title: new Text(widget.title),
       ),
       body: new Center(
         child: new Column(

--- a/_includes/_code/container/main.dart
+++ b/_includes/_code/container/main.dart
@@ -100,7 +100,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
     return new Scaffold(
       appBar: new AppBar(
-        title: new Text(config.title),
+        title: new Text(widget.title),
       ),
       body: new Center(
         child: container,

--- a/_includes/_code/grid/main.dart
+++ b/_includes/_code/grid/main.dart
@@ -58,7 +58,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: new AppBar(
-        title: new Text(config.title),
+        title: new Text(widget.title),
       ),
       body: new Center(
         child: buildGrid(),

--- a/_includes/_code/hello-world/main.dart
+++ b/_includes/_code/hello-world/main.dart
@@ -35,7 +35,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: new AppBar(
-        title: new Text(config.title),
+        title: new Text(widget.title),
       ),
       body: new Center(
         child: new Text('Hello World'),

--- a/_includes/_code/listview/main.dart
+++ b/_includes/_code/listview/main.dart
@@ -132,7 +132,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: new AppBar(
-        title: new Text(config.title),
+        title: new Text(widget.title),
         elevation: 5, // Removing the drop shadow cast by the app bar.
       ),
       body: new Center(

--- a/_includes/_code/packed/main.dart
+++ b/_includes/_code/packed/main.dart
@@ -49,7 +49,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
     return new Scaffold(
       appBar: new AppBar(
-        title: new Text(config.title),
+        title: new Text(widget.title),
       ),
       body: new Center(
         child: packedRow,

--- a/_includes/_code/pavlova/main.dart
+++ b/_includes/_code/pavlova/main.dart
@@ -154,7 +154,7 @@ Pavlova is a meringue-based dessert named after the Russian ballerina Anna Pavlo
 
     return new Scaffold(
       appBar: new AppBar(
-        title: new Text(config.title),
+        title: new Text(widget.title),
       ),
       body: new Center(
         child: new Container(

--- a/_includes/_code/row-expanded-2/main.dart
+++ b/_includes/_code/row-expanded-2/main.dart
@@ -38,7 +38,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: new AppBar(
-        title: new Text(config.title),
+        title: new Text(widget.title),
       ),
       body: new Center(
         child: new Row(

--- a/_includes/_code/row-expanded/main.dart
+++ b/_includes/_code/row-expanded/main.dart
@@ -38,7 +38,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: new AppBar(
-        title: new Text(config.title),
+        title: new Text(widget.title),
       ),
       body: new Center(
         child: new Row(

--- a/_includes/_code/row/main.dart
+++ b/_includes/_code/row/main.dart
@@ -38,7 +38,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: new AppBar(
-        title: new Text(config.title),
+        title: new Text(widget.title),
       ),
       body: new Center(
         child: new Row(

--- a/_includes/_code/stack/main.dart
+++ b/_includes/_code/stack/main.dart
@@ -61,7 +61,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
     return new Scaffold(
       appBar: new AppBar(
-        title: new Text(config.title),
+        title: new Text(widget.title),
       ),
       body: new Center(
         child: stack,

--- a/_includes/_code/tapbox-c/main.dart
+++ b/_includes/_code/tapbox-c/main.dart
@@ -70,7 +70,7 @@ class _TapboxCState extends State<TapboxC> {
   }
 
   void _handleTap() {
-    config.onChanged(!config.active);
+    widget.onChanged(!widget.active);
   }
 
   Widget build(BuildContext context) {
@@ -84,7 +84,7 @@ class _TapboxCState extends State<TapboxC> {
       child: new Container(
         child: new Center(
           child: new Text(
-            config.active ? 'Active' : 'Inactive',
+            widget.active ? 'Active' : 'Inactive',
             style: new TextStyle(fontSize: 32.0, color: Colors.white),
           ),
         ),
@@ -92,7 +92,7 @@ class _TapboxCState extends State<TapboxC> {
         height: 200.0,
         decoration: new BoxDecoration(
           backgroundColor:
-              config.active ? Colors.lightGreen[700] : Colors.grey[600],
+              widget.active ? Colors.lightGreen[700] : Colors.grey[600],
           border: _highlight
               ? new Border.all(
                   color: Colors.teal[700],

--- a/tutorials/interactive/index.md
+++ b/tutorials/interactive/index.md
@@ -634,7 +634,7 @@ The _TapboxCState object:
   the `_highlight` state changes.
 * On a tap event, passes that state change to the parent widget to take
   appropriate action using the
-  [config](https://docs.flutter.io/flutter/widgets/State/config.html)
+  [widget](https://docs.flutter.io/flutter/widgets/State/widget.html)
   property.
 
 <!-- _code/tapbox-c/main.dart -->
@@ -701,7 +701,7 @@ class _TapboxCState extends State<TapboxC> {
   }
 
   void _handleTap() {
-    config.onChanged(!config.active);
+    widget.onChanged(!widget.active);
   }
 
   Widget build(BuildContext context) {
@@ -714,14 +714,14 @@ class _TapboxCState extends State<TapboxC> {
       onTapCancel: _handleTapCancel,
       child: new Container(
         child: new Center(
-          child: new Text(config.active ? 'Active' : 'Inactive',
+          child: new Text(widget.active ? 'Active' : 'Inactive',
               style: new TextStyle(fontSize: 32.0, color: Colors.white)),
         ),
         width: 200.0,
         height: 200.0,
         decoration: new BoxDecoration(
           backgroundColor:
-              config.active ? Colors.lightGreen[700] : Colors.grey[600],
+              widget.active ? Colors.lightGreen[700] : Colors.grey[600],
           border: _highlight
               ? new Border.all(
                   color: Colors.teal[700],

--- a/tutorials/layout/index.md
+++ b/tutorials/layout/index.md
@@ -567,7 +567,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: new AppBar(
-        title: new Text(config.title),
+        title: new Text(widget.title),
       ),
       body: new Center(
         child: new Text('Hello World', style: new TextStyle(fontSize: 32.0)),
@@ -1312,7 +1312,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: new AppBar(
-        title: new Text(config.title),
+        title: new Text(widget.title),
       ),
       body: new Center(
         child: buildGrid(),

--- a/widgets-intro.md
+++ b/widgets-intro.md
@@ -643,7 +643,7 @@ class _ShoppingListState extends State<ShoppingList> {
       ),
       body: new ListView(
         padding: new EdgeInsets.symmetric(vertical: 8.0),
-        children: config.products.map((Product product) {
+        children: widget.products.map((Product product) {
           return new ShoppingListItem(
             product: product,
             inCart: _shoppingCart.contains(product),
@@ -686,17 +686,17 @@ again.
 
 To access properties of the current `ShoppingList`, the `_ShoppingListState` can
 use its
-[`config`](https://docs.flutter.io/flutter/widgets/State-class.html#config)
+[`widget`](https://docs.flutter.io/flutter/widgets/State-class.html#widget)
 property. If the parent rebuilds and creates a new `ShoppingList`, the
 `_ShoppingListState` will also rebuild with the new
-[`config`](https://docs.flutter.io/flutter/widgets/State-class.html#config)
+[`widget`](https://docs.flutter.io/flutter/widgets/State-class.html#widget)
 value. If you wish to be notified when the
-[`config`](https://docs.flutter.io/flutter/widgets/State-class.html#config)
+[`widget`](https://docs.flutter.io/flutter/widgets/State-class.html#widget)
 property changes, you can override the
-[`didUpdateConfig`](https://docs.flutter.io/flutter/widgets/State-class.html#didUpdateConfig)
-function, which is passed the `oldConfig` to let you compare the old
-configuration with the current
-[`config`](https://docs.flutter.io/flutter/widgets/State-class.html#config).
+[`didUpdateWidget`](https://docs.flutter.io/flutter/widgets/State-class.html#didUpdateWidget)
+function, which is passed `oldWidget` to let you compare the old widget with
+the current
+[`widget`](https://docs.flutter.io/flutter/widgets/State-class.html#widget).
 
 When handling the `onCartChanged` callback, the `_ShoppingListState` mutates its
 internal state by either adding or removing a product from `_shoppingCart`. To


### PR DESCRIPTION
`config` was renamed `widget` (likewise `didUpdateConfig` is now
`didUpdateWidget`) in flutter/flutter#9273.