### PR TITLE
DefaultTextStyle.merge is now a static method

### DIFF
--- a/_includes/_code/pavlova/main.dart
+++ b/_includes/_code/pavlova/main.dart
@@ -101,8 +101,7 @@ Pavlova is a meringue-based dessert named after the Russian ballerina Anna Pavlo
 
     // DefaultTextStyle.merge allows you to create a default text
     // style that is inherited by its child and all subsequent children.
-    var iconList = new DefaultTextStyle.merge(
-      context: context,
+    var iconList = DefaultTextStyle.merge(
       style: descTextStyle,
       child: new Container(
         padding: new EdgeInsets.all(20.0),

--- a/tutorials/layout/index.md
+++ b/tutorials/layout/index.md
@@ -969,8 +969,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
     // DefaultTextStyle.merge allows you to create a default text
     // style that is inherited by its child and all subsequent children.
-    var iconList = new DefaultTextStyle.merge(
-      context: context,
+    var iconList = DefaultTextStyle.merge(
       style: descTextStyle,
       child: new Container(
         padding: new EdgeInsets.all(20.0),


### PR DESCRIPTION
In flutter/flutter#9358, DefaultTextStyle.merge was migrated from a
constructor to a static.

Announcement sent to flutter-dev:
https://groups.google.com/forum/#!topic/flutter-dev/0GFDGRYKGro