### PR TITLE
Remove old text about GlobalKeys and Focus

### DIFF
--- a/widgets-intro.md
+++ b/widgets-intro.md
@@ -789,21 +789,3 @@ You can use global keys to uniquely identify child widgets. Global keys must be
 globally unique across the entire widget hierarchy, unlike local keys which need
 only be unique among siblings. Because they are globally unique, a global key
 can be used to retrieve the state associated with a widget.
-
-{% comment %}
-    Need to revisit the following para, as the framework takes care of this now.
-
-Some widgets, such as
-[`Input`](https://docs.flutter.io/flutter/material/Input-class.html) require
-global keys because they can hold focus, which means they receive any text the
-user enters into the app. The
-[`Focus`](https://docs.flutter.io/flutter/widgets/Focus-class.html) widget
-keeps track of which
-[`State`](https://docs.flutter.io/flutter/material/State-class.html)
-object is focused by remembering its
-[`GlobalKey`](https://docs.flutter.io/flutter/widgets/GlobalKey-class.html).
-That way the same
-[`Input`](https://docs.flutter.io/flutter/material/Input-class.html) widget
-remains focused even if it moves around in the widget tree.
-
-{% endcomment %}


### PR DESCRIPTION
Developers no long need to worry about this topic because the framework does it
for them. We should probably have an article about focus management for
advanced developers, but that's probably best done in the dartdocs for
FocusNode or FocusScope.

Fixes #7514