### PR TITLE
Clarify Android setup steps

### DIFF
--- a/_includes/setup/android-setup.md
+++ b/_includes/setup/android-setup.md
@@ -2,15 +2,16 @@
 
 ### Install Android Studio
 
-To develop Flutter apps for Android, you can use a Mac, Windows, or Linux (64-bit) machine:
+To develop Flutter apps for Android, you can use a Mac, Windows, or Linux
+(64-bit) machine.
 
-1. Install [Android Studio](https://developer.android.com/studio/index.html).
+Flutter requires Android Studio to be installed and configured:
 
-   Flutter requires the latest Android SDK and Android SDK Platform-Tools packages.
-   You can verify these are up-to-date in **Android Studio>Configure>SDK Manager**,
-   as described in [Update the IDE and SDK Tools](https://developer.android.com/studio/intro/update.html).
+1. Download and install [Android Studio](https://developer.android.com/studio/index.html).
 
-1. Start Android Studio.
+1. Start Android Studio, and go through the 'Android Studio Setup Wizard'. This
+will install the latest Android SDK and Android SDK Platform-Tools packages,
+which are required by Flutter.
 
 ### Set up your Android device
 

--- a/_includes/setup/android-setup.md
+++ b/_includes/setup/android-setup.md
@@ -10,13 +10,13 @@ Flutter requires Android Studio to be installed and configured:
 1. Download and install [Android Studio](https://developer.android.com/studio/index.html).
 
 1. Start Android Studio, and go through the 'Android Studio Setup Wizard'. This
-will install the latest Android SDK and Android SDK Platform-Tools packages,
-which are required by Flutter.
+will install the latest Android SDK, Android SDK Platform-Tools, and Android SDK
+Build-Tools, which are required by Flutter when developing for Android.
 
 ### Set up your Android device
 
-To prepare to run and test your Flutter app on Android, you'll need an Android device running
-Android 4.1 (API level 16) or higher.
+To prepare to run and test your Flutter app on an Android device, you'll need an
+Android device running Android 4.1 (API level 16) or higher.
 
 1. Enable developer mode on your device by visiting **`Settings>About phone`** and
 tapping the **Build number** line seven times.


### PR DESCRIPTION
Validated on a clean machine, the missing 'Android Studio Setup Wizard' step is critical to ensure Android dependencies are downloaded.