### PR TITLE
Adding codelab links to website!

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -6,7 +6,7 @@
       <li><a href="/setup/">Install</a></li>
       <li><a href="/getting-started/">Create and run your first app</a></li>
       <li><a href="/bootstrap-into-dart/">Bootstrap into Dart</a></li>
-
+      <li><a href="https://codelabs.developers.google.com/codelabs/from-java-to-dart/index.html#0">Intro to Dart for Java Developers - Codelab</a></li>
     </ul>
 
   <li class="sidebar-title">Build UIs</li>
@@ -14,6 +14,7 @@
     <ul class="sidebar-items">
       <li><a href="/widgets-intro/">Tour the framework</a></li>
       <li><a href="/widgets/">Widget catalog</a></li>
+      <li><a href="https://codelabs.developers.google.com/codelabs/flutter/index.html#0">Building Beautiful UIs with Flutter - Codelab</a></li>
       <li><a href="/tutorials/layout/">Build Layouts - Tutorial</a></li>
       <li><a href="/tutorials/interactive/">Add Interactivity - Tutorial</a></li>
       <li><a href="/web-analogs/">HTML/CSS patterns</a></li>
@@ -33,6 +34,7 @@
       <li><a href="/platform-plugins/">Plugins &amp; platform-specific code</a></li>
       <li><a href="/reading-writing-files/">Read and write files</a></li>
       <li><a href="/networking/">Network and HTTP</a></li>
+      <li><a href="https://codelabs.developers.google.com/codelabs/flutter-firebase/index.html#0">Firebase for Flutter - Codelab</a></li>
     </ul>
 
 

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -6,7 +6,6 @@
       <li><a href="/setup/">Install</a></li>
       <li><a href="/getting-started/">Create and run your first app</a></li>
       <li><a href="/bootstrap-into-dart/">Bootstrap into Dart</a></li>
-      <li><a href="https://codelabs.developers.google.com/codelabs/from-java-to-dart/index.html#0">Intro to Dart for Java Developers - Codelab</a></li>
     </ul>
 
   <li class="sidebar-title">Build UIs</li>

--- a/bootstrap-into-dart.md
+++ b/bootstrap-into-dart.md
@@ -28,6 +28,11 @@ easy for you to learn, too.
 : A good overview of Dart's powerful core libraries. Learn about
   Dart's support for collections, async, math, numbers, strings, JSON, and more.
 
+[Intro to Dart for Java Developers Codelab](https://codelabs.developers.google.com/codelabs/from-java-to-dart/index.html#0">Intro to Dart for Java Developers - Codelab)
+: Use your Java knowledge to get up and running quickly with Dart. Learn about
+  classes, constructors, parameters, and interfaces with examples from the Java
+  Tutorial. 
+
 [Effective Dart](https://www.dartlang.org/effective-dart/)
 : Guides for style, authoring documentation, usage, and more.
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -108,7 +108,7 @@ to hear from you!
 
 You might also want to check out:
 * [Introduction to Flutter's Widget Framework](/widgets-intro/)
-* [Building Beautiful UIs with Flutter - Codelab](https://codelabs.developers.google.com/codelabs/flutter	/index.html#0")
+* [Building Beautiful UIs with Flutter - Codelab](https://codelabs.developers.google.com/codelabs/flutter/index.html#0)
 * [Debugging guide](/debugging).
 
 Happy Fluttering!

--- a/getting-started.md
+++ b/getting-started.md
@@ -107,8 +107,8 @@ Please reach out to us at our [mailing list][mailinglist]. We'd love
 to hear from you!
 
 You might also want to check out:
-* [Introduction to Flutter's Widget Framework](/widgets-intro/)
 * [Building Beautiful UIs with Flutter - Codelab](https://codelabs.developers.google.com/codelabs/flutter/index.html#0)
+* [Introduction to Flutter's Widget Framework](/widgets-intro/)
 * [Debugging guide](/debugging).
 
 Happy Fluttering!

--- a/getting-started.md
+++ b/getting-started.md
@@ -106,9 +106,10 @@ changes are supported by the hot reload feature can be found on the page
 Please reach out to us at our [mailing list][mailinglist]. We'd love
 to hear from you!
 
-You might also want to check out our
-[Introduction to Flutter's Widget Framework](/widgets-intro/)
-and our [Debugging guide](/debugging).
+You might also want to check out:
+* [Introduction to Flutter's Widget Framework](/widgets-intro/)
+* [Building Beautiful UIs with Flutter - Codelab](https://codelabs.developers.google.com/codelabs/flutter	/index.html#0")
+* [Debugging guide](/debugging).
 
 Happy Fluttering!
 


### PR DESCRIPTION
1. As discussed in email, adding links to the sidenav to these codelabs:
* Intro to Dart for Java Developers
* Building Beautiful UIs with Flutter
* Firebase for Flutter
2. Adding link to Building Beautiful UIs with Flutter to the end of Create and Run your First App (getting-started.md)

cc/ @mit-mit @Sfshaza 