### PR TITLE
Small manual fix to underlined Get Started link on homepage.

### DIFF
--- a/_sass/_homepage.scss
+++ b/_sass/_homepage.scss
@@ -1,4 +1,5 @@
 .get-started-button {
+    text-decoration: none;
     background-color: #0091EA;
     color: #fff;
     padding: 16px;
@@ -11,6 +12,7 @@
 }
 
 .get-started-button:hover {
+    text-decoration: none;
     color: #fff;
 }
 
@@ -69,6 +71,10 @@
 
     pre[class*="language-"] {
         margin-bottom: 36px;
+    }
+
+    a {
+        text-decoration: none;
     }
 
     h1 {

--- a/index.md
+++ b/index.md
@@ -21,7 +21,7 @@ hide_title: true
         </div>
 
         <div class="homepage__button_row">
-        <a style="text-decoration:none;" href="/getting-started/" class="get-started-button">Get Started</a>
+        <a href="/getting-started/" class="get-started-button">Get Started</a>
         {% include note.html content="_Flutter is an alpha, open-source project_." %}
         </div>
 
@@ -291,7 +291,7 @@ Future<Null> getBatteryLevel() async {
         <div class="homepage__try_today">Try Flutter today. Getting started is easy.</div>
 
         <div class="homepage__button_row">
-        <a style="text-decoration:none;" href="/getting-started/" class="get-started-button">Get Started</a>
+        <a href="/getting-started/" class="get-started-button">Get Started</a>
         {% include note.html content="_Flutter is an alpha, open-source project_." %}
         </div>
 

--- a/index.md
+++ b/index.md
@@ -21,7 +21,7 @@ hide_title: true
         </div>
 
         <div class="homepage__button_row">
-        <a href="/getting-started/" class="get-started-button">Get Started</a>
+        <a style="text-decoration:none;" href="/getting-started/" class="get-started-button">Get Started</a>
         {% include note.html content="_Flutter is an alpha, open-source project_." %}
         </div>
 
@@ -291,7 +291,7 @@ Future<Null> getBatteryLevel() async {
         <div class="homepage__try_today">Try Flutter today. Getting started is easy.</div>
 
         <div class="homepage__button_row">
-        <a href="/getting-started/" class="get-started-button">Get Started</a>
+        <a style="text-decoration:none;" href="/getting-started/" class="get-started-button">Get Started</a>
         {% include note.html content="_Flutter is an alpha, open-source project_." %}
         </div>
 


### PR DESCRIPTION
Root cause is 
.card {   a {
    text-decoration: underline;
  }
}

in _catalog.scss is taking precedence over 
.get-started-button {
    text-decoration: none;
...
}
.get-started-button:hover {
    text-decoration: none;
...
}

in _homepage.scss

This humble fix doesn't address root cause but is the minimal solution for removing the underline on only the homepage. (The Widget Catalog really does need the underline for its links.) The other option is  a new layout for the homepage, and a good amount of CSS troubleshooting.