### PR TITLE
Fixing overflowing margin issue for select pages on iOS

### DIFF
--- a/_includes/setup/get-sdk-win.md
+++ b/_includes/setup/get-sdk-win.md
@@ -19,7 +19,7 @@ To update an existing version of Flutter, see [Upgrading Flutter](/upgrading/)
 To run the `flutter` command in any terminal session, you need to add it to your PATH environment variable:
 
 * Go to "Control Panel > User Accounts > User Accounts > Change my environment variables"
-* Under "User variables" check if there is an entry called "Path":
+* Under "User variables" check if there is an entry named `Path`:
     * If the entry does exist, append the full path to `flutter\bin` using `;` as a separator from existing values.
     * If the entry does not exist, create a new user variable named `Path` with the full path to `flutter\bin` as its value.
 
@@ -28,7 +28,7 @@ Close and re-open any terminal window (e.g. command prompt or PowerShell) to app
 ### Run flutter doctor
 
 Open a new Command Prompt or PowerShell window and run the following command to
-see if there  are any dependencies you need to install to complete the setup:
+see if there are any dependencies you need to install to complete the setup:
 
 ```
 > flutter doctor
@@ -64,5 +64,5 @@ and basic crash reports. This data is used to help improve Flutter tools over ti
 Analytics is not sent on the very first run or for any runs involving `flutter config`,
 so you can opt out of analytics before any data is sent. To disable reporting, 
 type `flutter config --no-analytics` and to display the current setting, type 
-`flutter config`. See Google's privacy policy:[www.google.com/intl/en/policies/privacy](https://www.google.com/intl/en/policies/privacy/).
+`flutter config`. See [Google's privacy policy](https://www.google.com/intl/en/policies/privacy/).
 {: .alert-warning}

--- a/_includes/setup/get-sdk.md
+++ b/_includes/setup/get-sdk.md
@@ -57,5 +57,5 @@ and basic crash reports. This data is used to help improve Flutter tools over ti
 Analytics is not sent on the very first run or for any runs involving `flutter config`,
 so you can opt out of analytics before any data is sent. To disable reporting, 
 type `flutter config --no-analytics` and to display the current setting, type 
-`flutter config`. See Google's privacy policy:[www.google.com/intl/en/policies/privacy](https://www.google.com/intl/en/policies/privacy/).
+`flutter config`. See [Google's privacy policy](https://www.google.com/intl/en/policies/privacy/).
 {: .alert-warning}

--- a/_includes/setup/ios-setup.md
+++ b/_includes/setup/ios-setup.md
@@ -4,43 +4,51 @@
 
 To develop Flutter apps for iOS, you need a Mac with Xcode 7.2 or newer:
 
-1. Install Xcode 7.2 or newer (via [web download](https://developer.apple.com/xcode/) or
-the [Mac App Store](https://itunes.apple.com/us/app/xcode/id497799835)).
-1. Configure the Xcode command-line tools to use the newly-installed version of Xcode by
-running `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer` from
-the command line.
+1. Install Xcode 7.2 or newer (via [web download](https://developer.apple.com/xcode/)
+or the [Mac App Store](https://itunes.apple.com/us/app/xcode/id497799835)).
+1. Configure the Xcode command-line tools to use the newly-installed version of 
+Xcode by running:
+```
+sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+```
+at the command line.
 
-   This is the correct path for most cases, when you want to use the latest version of Xcode.
-   If you need to use a different version, specify that path instead.
-1. Make sure the Xcode license agreement is signed by either opening Xcode once and confirming or
-running `sudo xcodebuild -license` from the command line.
+   This is the correct path for most cases, when you want to use the latest 
+   version of Xcode. If you need to use a different version, specify that path 
+   instead.
+1. Make sure the Xcode license agreement is signed by either opening Xcode once
+and confirming or running `sudo xcodebuild -license` from the command line.
 
 With Xcode, you’ll be able to run Flutter apps on an iOS device or on the simulator.
 
 ### Set up the iOS simulator
 
-To prepare to run and test your Flutter app on the iOS simulator, follow these steps:
+To prepare to run and test your Flutter app on the iOS simulator, follow these 
+steps:
 
-1. On your Mac, find the Simulator via Spotlight or by using the following command:
+1. On your Mac, find the Simulator via Spotlight or by using the following 
+command:
 
     ```
     $ open -a Simulator
     ```
 
-2. Make sure your simulator is using a 64-bit device (iPhone 5s or later) by checking the settings
-in the simulator's **Hardware > Device** menu.
-3. Depending on your development machine's screen size, simulated high-screen-density iOS devices
-may overflow your screen. Set the device scale under the **Window > Scale** menu in the simulator.
+2. Make sure your simulator is using a 64-bit device (iPhone 5s or later) by 
+checking the settings in the Simulator's **Hardware > Device** menu.
+3. Depending on your development machine's screen size, simulated 
+high-screen-density iOS devices may overflow your screen. Set the device scale
+under the **Window > Scale** menu in the Simulator.
 4. Start your app by running `flutter run`.
 
 
 ### Deploy to iOS devices
 
-To deploy your Flutter app to a physical iOS device, you’ll need some additional tools, an account, and a profile:
+To deploy your Flutter app to a physical iOS device, you’ll need some additional
+tools, an account, and a profile:
 
 1. Install [homebrew](http://brew.sh/).
-1. Open the terminal and run these commands to install the tools for deploying Flutter apps to
-iOS devices.
+1. Open the terminal and run these commands to install the tools for deploying 
+Flutter apps to iOS devices.
 
    ```
    $ brew update
@@ -48,12 +56,15 @@ iOS devices.
    $ brew install ideviceinstaller ios-deploy
    $ brew install cocoapods
    ```
-   If any of these commands fails with an error, run `brew doctor` and follow the instructions 
-   for resolving the issue.
+   If any of these commands fails with an error, run `brew doctor` and follow 
+   the instructions for resolving the issue.
    
-1. Follow the steps defined by Apple to configure Xcode with your Apple Developer account and enable deploying with provisioning profiles. To learn how to set up your profile, see [Apple's official documentation](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/MaintainingProfiles/MaintainingProfiles.html).
+1. Follow the steps defined by Apple to configure Xcode with your Apple Developer
+account and enable deploying with provisioning profiles. To learn how to set up
+your profile, see [Apple's official documentation](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/MaintainingProfiles/MaintainingProfiles.html).
 1. Select your Development Team for the Flutter project.
    1. Open the default Xcode workspace in your project under `ios/Runner.xcworkspace`. 
    1. Select the `Runner` project in the left navigation panel.
-   1. In the Target Settings page, make sure your Development Team is selected under **General > Signing > Team**.
+   1. In the Target Settings page, make sure your Development Team is selected
+under **General > Signing > Team**.
 1. Start your app by running `flutter run`.

--- a/_includes/setup/ios-setup.md
+++ b/_includes/setup/ios-setup.md
@@ -17,13 +17,18 @@ at the command line.
    version of Xcode. If you need to use a different version, specify that path 
    instead.
 1. Make sure the Xcode license agreement is signed by either opening Xcode once
-and confirming or running `sudo xcodebuild -license` from the command line.
+and confirming or running:
+```
+sudo xcodebuild -license
+```
+at the command line.
 
-With Xcode, you’ll be able to run Flutter apps on an iOS device or on the simulator.
+With Xcode, you’ll be able to run Flutter apps on an iOS device or on the 
+Simulator.
 
 ### Set up the iOS simulator
 
-To prepare to run and test your Flutter app on the iOS simulator, follow these 
+To prepare to run and test your Flutter app on the iOS Simulator, follow these 
 steps:
 
 1. On your Mac, find the Simulator via Spotlight or by using the following 
@@ -33,11 +38,11 @@ command:
     $ open -a Simulator
     ```
 
-2. Make sure your simulator is using a 64-bit device (iPhone 5s or later) by 
-checking the settings in the Simulator's **Hardware > Device** menu.
+2. Make sure the Simulator is using a 64-bit device (iPhone 5s or later) by 
+checking the settings in the **Hardware > Device** menu.
 3. Depending on your development machine's screen size, simulated 
 high-screen-density iOS devices may overflow your screen. Set the device scale
-under the **Window > Scale** menu in the Simulator.
+under the **Window > Scale** menu.
 4. Start your app by running `flutter run`.
 
 

--- a/platform-plugins.md
+++ b/platform-plugins.md
@@ -7,8 +7,8 @@ permalink: /platform-plugins/
 This guide describes how Flutter apps can integrate with platform-specific code
 available on iOS and Android devices. This includes both device APIs (like
 [`url_launcher`](https://pub.dartlang.org/packages/url_launcher) and
-[`battery`](https://pub.dartlang.org/packages/battery)) and third-party platform SDKs 
-(like [Firebase](https://github.com/flutter/plugins/blob/master/FlutterFire.md)).
+[`battery`](https://pub.dartlang.org/packages/battery)) and third-party platform
+SDKs (like [Firebase](https://github.com/flutter/plugins/blob/master/FlutterFire.md)).
 
 * TOC
 {:toc}
@@ -48,8 +48,8 @@ implementation for Android, for iOS, or for both.
 
 ### Searching for plugins
 
-The list [Flutter plugins](https://pub.dartlang.org/flutter/plugins) displays plugins
-which are shared on the [pub](https://pub.dartlang.org/) repository.
+The list [Flutter plugins](https://pub.dartlang.org/flutter/plugins) displays 
+plugins which are shared on the [pub](https://pub.dartlang.org/) repository.
 
 {% include note.html content="Flutter is still a young platform, and only a
 fairly small set of plugins are currently available on pub. We encourage all
@@ -132,7 +132,7 @@ To use this plugin:
     }
     ```
 
-1. Run the app. When you click the 'Show Flutter homepage' you should see the
+1. Run the app. When you click **Show Flutter homepage** you should see the
 phone's default browser open, and the Flutter homepage appear.
 
 ## Create a platform plugin {#create}
@@ -142,8 +142,8 @@ can be useful to separate the code into a platform plugin located in a directory
 outside your main application. Optionally, this also enables you to
 [publish](#publish) the plugin.
 
-You can create a plugin project using the `--plugin` flag with `flutter create`. 
-Use the `--org` option to specify your organization, using reverse domain name
+You can create a plugin project using the `plugin` flag with `flutter create`. 
+Use the `org` option to specify your organization, using reverse domain name
 notation. This value is used in various package and bundle identifiers in the
 generated Android and iOS code.
 
@@ -154,17 +154,18 @@ flutter create --org com.example --plugin hello
 This creates a plugin project in the `hello/` folder with the following content:
 
 * `lib/hello.dart`:
-   - The Dart API for the plugin.
+   * The Dart API for the plugin.
 * `android/src/main/java/com/yourcompany/hello/HelloPlugin.java`:
-   - The Android platform specific implementation of the plugin API.
+   * The Android platform specific implementation of the plugin API.
 * `ios/Classes/HelloPlugin.m`: 
-   - The iOS platform specific implementation of the plugin API.
+   * The iOS platform specific implementation of the plugin API.
 * `example/`:
-   - A Flutter app that depends on the plugin, and illustrates how to use it.
+   * A Flutter app that depends on the plugin, and illustrates how to use it.
 
 By default, the plugin project uses Objective-C for iOS code and
 Java for Android code. If you prefer Swift or Kotlin, you can specify the
-iOS language using `-i` and/or the Android language using `-a`. For example:
+iOS language using `-I` and the Android language using `-a`. For example:
+
 ```
 flutter create --plugin -i swift -a kotlin hello
 ```
@@ -180,28 +181,34 @@ Project view.
 To run the plugin, you need to launch the plugin example app, which requires
 defining a launch configuration:
 
-1. Select 'Run > Edit Configurations...'.
-1. Select '+' and then 'Flutter'.
-1. In 'Dart entrypoint', enter `<plugin folder>/example/lib/main.dart`.
-1. Select 'OK'.
-1. Launch the example app with 'Run' or 'Debug'.
+1. Select **Run > Edit Configurations…**.
+1. Select **+** and then **Flutter**.
+1. In the Dart entrypoint field, enter `<plugin folder>/example/lib/main.dart`.
+1. Select **OK**.
+1. Launch the example app with **Run** or **Debug**.
 
-*Note*: [Hot reload](https://flutter.io/faq/#hot-reload) is only supported for changes to Dart code, not for Android and iOS code. 
+*Note*: [Hot reload](https://flutter.io/faq/#hot-reload) is only supported for
+changes to Dart code, not for Android and iOS code. 
 
 #### Android platform code (.java/.kt)
 
 Before editing the Android platform code in Android Studio, first make sure that
-the code has been built at least once (i.e., run the example app from IntelliJ, 
-or in a terminal execute `cd hello/example; flutter build apk`). 
+the code has been built at least once by running the example app from IntelliJ, 
+or running the following at the command line:
+
+```
+cd hello/example
+flutter build apk
+```
 
 Next,
 
-1. Launch Android Studio
-1. Select 'Import project' in 'Welcome to Android Studio' dialog, or select 
-'File > New > Import Project...'' in the menu, and select the
+1. Launch Android Studio.
+1. Select **Import project** in the Welcome screen, or select 
+**File > New > Import Project…** in the menu, and navigate to the
 `hello/example/android/build.gradle` file.
-1. In the 'Gradle Sync' dialog, select 'OK'.
-1. In the 'Android Gradle Plugin Update' dialog, select 'Don't remind me again for this project'. 
+1. In the Gradle Sync dialog, select **OK**.
+1. In the Android Gradle Plugin Update dialog, select **Don't remind me again for this project**. 
 
 The Android platform code of your plugin is located in `hello/java/com.yourcompany.hello/HelloPlugin`.
 
@@ -210,22 +217,26 @@ You can run the example app from Android Studio by pressing the &#9654; button.
 #### iOS platform code (.h+.m/.swift)
 
 Before editing the iOS platform code in Xcode, first make sure that
-the code has been built at least once (i.e., run the example app from IntelliJ, 
-or in a terminal execute `cd hello/example; flutter build ios`).
+the code has been built at least once by running the example app from IntelliJ, 
+or running the following at the command line:
+```
+cd hello/example; flutter build ios
+```
 
 Next,
 
-1. Launch Xcode
-1. Select 'File > Open', and select the `hello/example/ios/Runner.xcworkspace` file.
+1. Launch Xcode.
+1. Select **File > Open**, and select the `hello/example/ios/Runner.xcworkspace` file.
 
-The iOS platform code of your plugin is located in `Pods/Development Pods/hello/Classes/` in the Project Navigator.
+The iOS platform code of your plugin is located in `Pods/Development Pods/hello/Classes/`
+in the Project Navigator.
 
 You can run the example app by pressing the &#9654; button.
 
 ### Managing dependencies from a Flutter app to a Flutter plugin
 
 Once a plugin has been [published](#publish), you can depend on it by simply
-listing it's name in `pubspec.yaml` as illustrated by the [example](#example)
+listing its name in `pubspec.yaml` as illustrated by the [example](#example)
 above.
 
 During development of a plugin that has not yet been published, or for private
@@ -233,16 +244,16 @@ plugins not intended for public publishing, an additional way of
 depending on a plugin can be useful:
 
 * **Path** dependency: A Flutter app can depend on a plugin via a file system
- `path:` dependency. The path can be either relative, or absolute. For example, to
- depend on a plugin 'plugin1' located in a directory next to the app, use this
- syntax:
-```
-dependencies:
-    flutter:
-      sdk: flutter
-    plugin1:
-      path: ../plugin1/
-```
+ path dependency. The path can be either relative or absolute. For example, to
+ depend on the plugin named `plugin1` located in a directory next to the app,
+ use this syntax:
+ ```
+ dependencies:
+     flutter:
+       sdk: flutter
+     plugin1:
+       path: ../plugin1/
+ ```
 
 * **Git** dependency: You can also depend on a package stored in a Git
  repository. The package must be located in the root of the repo. Use this


### PR DESCRIPTION
This PR addresses https://github.com/flutter/flutter/issues/10120 and https://github.com/flutter/flutter/issues/10153. 

#10153 is fixed by giving a single instance of inline CLI syntax its own, dedicated line in the MD file.

#10120 is diagnosed, but not yet fixed. This file has multiple instances of special characters throwing kramdown for a loop. See issue conversation for the chunk of platform-plugins.md that is causing problems. I'm making a partial commit now, with formatting fixes, but the way forward is likely to address forward slash characters (/) in inline syntax. We should look at adding a kramdown option to _config.yml, to deal with these automatically (rather than individually).