### PR TITLE
Adding Edit Source and File Issue buttons to every page.

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,15 +6,17 @@ layout: default
   
   {% unless page.hide_title %}
   <header class="post-header">
-    <h1 class="post-title">{{ page.title }} </h1>
-      <div class="btn-group" role="group">
-         <a href="https://github.com/flutter/website/blob/master/{{page.path}}" class="btn btn-default">
+      <div class="btn-group contribute" role="group">
+         <a href="https://github.com/flutter/website/blob/master/{{page.path}}" class="btn btn-sm">
             <i class="glyphicon glyphicon-pencil"></i> Edit Source
          </a>
-         <a href="https://github.com/flutter/flutter/issues/new?title=Issue from website page {{page.title}}&body=From URL: {{site.url}}/{{page.path}}" class="btn btn-default">
+         <a href="https://github.com/flutter/flutter/issues/new?title=Issue from website page {{page.title}}&body=From URL: {{site.url}}/{{page.path}}" class="btn btn-sm">
             <i class="glyphicon glyphicon-paperclip"></i> File Issue
         </a>
      </div>
+   <div>
+    <h1 class="post-title">{{ page.title }} </h1>
+   </div>
 
   </header>
   {% endunless %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,7 +6,16 @@ layout: default
   
   {% unless page.hide_title %}
   <header class="post-header">
-    <h1 class="post-title">{{ page.title }}</h1>
+    <h1 class="post-title">{{ page.title }} </h1>
+      <div class="btn-group" role="group">
+         <a href="https://github.com/flutter/website/blob/master/{{page.path}}" class="btn btn-default">
+            <i class="glyphicon glyphicon-pencil"></i> Edit Source
+         </a>
+         <a href="https://github.com/flutter/flutter/issues/new?title=Issue from website page {{page.title}}&body=From URL: {{site.url}}/{{page.path}}" class="btn btn-default">
+            <i class="glyphicon glyphicon-paperclip"></i> File Issue
+        </a>
+     </div>
+
   </header>
   {% endunless %}
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -8,10 +8,10 @@ layout: default
   <header class="post-header">
       <div class="btn-group contribute" role="group">
          <a href="https://github.com/flutter/website/blob/master/{{page.path}}" class="btn btn-sm">
-            <i class="glyphicon glyphicon-pencil"></i> Edit Source
+            <i class="fa fa-pencil"></i> Edit Source
          </a>
          <a href="https://github.com/flutter/flutter/issues/new?title=Issue from website page {{page.title}}&body=From URL: {{site.url}}/{{page.path}}" class="btn btn-sm">
-            <i class="glyphicon glyphicon-paperclip"></i> File Issue
+            <i class="fa fa-github"></i> File Issue
         </a>
      </div>
    <div>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -211,3 +211,7 @@ blockquote {
     font-size: 15px;
   }
 }
+
+.contribute {
+  float: right;
+}


### PR DESCRIPTION
HIGH IMPACT CHANGE - see  https://github.com/flutter/flutter/issues/10416 for discussion. This is an incremental step toward inviting Flutter users to contribute to flutter.io.

![image](https://cloud.githubusercontent.com/assets/23464935/26798833/fc5504fe-49e6-11e7-8128-be7d9bd75468.png)


This PR adds two buttons just below the title of every page on flutter.io. 
* The Edit Source button links to the current file on the master branch in the flutter/website repo. For example, clicking this button on the Assets and Images page at https://flutter.io/assets-and-images/ will take users to this URL: `https://github.com/flutter/website/blob/master/assets-and-images.md`.
* The File Issue button creates a new issue that is prepopulated with the current page title and URL. In the above example, the URL would be `https://github.com/flutter/flutter/issues/new?title=Issue%20from%20website%20page%20Adding%20Assets%20and%20Images%20in%20Flutter&body=From%20URL:%20https://flutter.io/assets-and-images.md`

### Notes
The pencil icon is not ideal - it's horizontal (instead of diagonal like the paperclip) and smaller. Investigations and experiments with CSS, getbootstrap, other icons, and HTML entities led nowhere. Would like this icon to be larger and diagonal to match the paperclip.

Tested on Chrome and Safari on Linux and macOS. Also tested on Safari on the iOS Simulator w/iPhone5 profile. Not yet tested on IE/Windows, or Android. Suggestions on testing requirements welcome...

@cc InMatrix