### PR TITLE
Fixed "Ensure website uses "Material Design" (capital D)"

### DIFF
--- a/debugging.md
+++ b/debugging.md
@@ -832,7 +832,7 @@ will be misleading.
 
 When developing applications that implement [Material
 design](https://www.google.com/design/spec/material-design/introduction.html),
-it can be helpful to overlay a [Material design baseline
+it can be helpful to overlay a [Material Design baseline
 grid](https://www.google.com/design/spec/layout/metrics-keylines.html)
 over the application to help verify alignments. To that end, the
 [`MaterialApp`

--- a/tutorials/interactive/index.md
+++ b/tutorials/interactive/index.md
@@ -751,7 +751,7 @@ and prefers that the tap box handles those details.
 ## Other interactive widgets
 
 Flutter offers a variety of buttons and similar interactive widgets.
-Most of these widgets implement the [material design
+Most of these widgets implement the [Material Design
 guidelines,](https://material.io/guidelines/) which define a set of
 components with an opinionated UI.
 
@@ -804,7 +804,7 @@ The following resources may help when adding interactivity to your app.
   Reference documentation for all of the Flutter libraries.
 * [Flutter
   Gallery](https://github.com/flutter/flutter/tree/master/examples/flutter_gallery)<br>
-  Demo app showcasing many material design widgets and other Flutter features.
+  Demo app showcasing many Material Design widgets and other Flutter features.
 * [Flutter's Layered
    Design (video)](https://www.youtube.com/watch?v=dkyY9WCGMi0)<br>
    This video includes information about state and stateless widgets.

--- a/tutorials/layout/index.md
+++ b/tutorials/layout/index.md
@@ -576,7 +576,7 @@ class _MyHomePageState extends State<MyHomePage> {
 <aside class="alert alert-info" markdown="1">
 **Note:**
 The material library implements widgets that follow
-[material design principles](https://material.io/guidelines/).
+[Material Design principles](https://material.io/guidelines/).
 When designing your UI, you can exclusively use widgets from the standard
 [widgets library](https://docs.flutter.io/flutter/widgets/widgets-library.html),
 or you can use widgets from the [material
@@ -1347,12 +1347,12 @@ A Divider separates the theaters from the restaurants.<br>
 
 </div> <div class="col-md-6" markdown="1">
 
-<img src="images/listview-flutter-gallery.png" style="border:1px solid black" alt="a ListView containing shades of blue from the material design color palette">
+<img src="images/listview-flutter-gallery.png" style="border:1px solid black" alt="a ListView containing shades of blue from the Material Design color palette">
 
 Uses ListView to display the
 [Colors](https://docs.flutter.io/flutter/material/Colors-class.html)
 from the
-[material design palette](https://material.io/guidelines/style/color.html)
+[Material Design palette](https://material.io/guidelines/style/color.html)
 for a particular color family.<br>
 **Dart code:** [colors_demo.dart](https://github.com/flutter/flutter/blob/master/examples/flutter_gallery/lib/demo/colors_demo.dart)
 from the [Flutter
@@ -1504,7 +1504,7 @@ Specifying an unsupported value disables the drop shadow entirely.
 
 #### Card summary:
 
-* Implements a [material design
+* Implements a [Material Design
   card](https://material.io/guidelines/components/cards.html)
 * Used for presenting related nuggets of information
 * Accepts a single child, but that child can be a Row, Column, or other
@@ -1631,7 +1631,7 @@ The following resources may help when writing layout code.
   to Flutter features.
 * [Flutter
   Gallery](https://github.com/flutter/flutter/tree/master/examples/flutter_gallery)<br>
-  Demo app showcasing many material design widgets and other Flutter features.
+  Demo app showcasing many Material Design widgets and other Flutter features.
 * [Flutter API documentation](https://docs.flutter.io/)<br>
   Reference documentation for all of the Flutter libraries.
 * [Dealing with Box Constraints in Flutter](/layout)<br>

--- a/widgets-intro.md
+++ b/widgets-intro.md
@@ -252,7 +252,7 @@ void main() {
 class TutorialHome extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    // Scaffold is a layout for the major material design widgets.
+    // Scaffold is a layout for the major Material Design widgets.
     return new Scaffold(
       appBar: new AppBar(
         leading: new IconButton(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/8496

fixed:
- corrected Material Design spelling to always start from capital letters