### PR TITLE
Update firebase tool invocations to be non-interactive

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -80,7 +80,7 @@ if [ "$TRAVIS_EVENT_TYPE" = "push" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
   # Deploy pushes to master to Firebase hosting.
   echo "Deploying to Firebase."
   npm install --global firebase-tools@3.0.0
-  firebase -P sweltering-fire-2088 --token "$FIREBASE_TOKEN" deploy
+  firebase -P sweltering-fire-2088 --token "$FIREBASE_TOKEN" --non-interactive deploy
 fi
 
 
@@ -95,6 +95,6 @@ if [ "$ENABLE_PR_BOT" = "true" ]; then
         cd ../
         echo "Deploying to $PROJECT_NAME"
         npm install --global firebase-tools@3.0.0
-        firebase -P "$PROJECT_NAME" --token "$FIREBASE_TOKEN_DEV" deploy
+        firebase -P "$PROJECT_NAME" --token "$FIREBASE_TOKEN_DEV" --non-interactive deploy
     fi
 fi


### PR DESCRIPTION
Attempt at resolving the travis faillure:

```
=== Deploying to 'flutter-io-deploy-two'...
i  deploying hosting
i  hosting: preparing _site directory for upload...
FIREBASE WARNING: Exception was thrown by user callback. TypeError: this.stream.clearLine is not a function
    at ProgressBar.terminate (/home/travis/.nvm/versions/node/v6.11.0/lib/node_modules/firebase-tools/node_modules/progress/lib/node-progress.js:177:17)
    at ProgressBar.tick (/home/travis/.nvm/versions/node/v6.11.0/lib/node_modules/firebase-tools/node_modules/progress/lib/node-progress.js:91:10)
    at /home/travis/.nvm/versions/node/v6.11.0/lib/node_modules/firebase-tools/lib/deploy/hosting/deploy.js:60:17
    at /home/travis/.nvm/versions/node/v6.11.0/lib/node_modules/firebase-tools/node_modules/firebase/lib/firebase-node.js:201:710
```