### PR TITLE
Revert "Revert "Link to platform channels from developing packages & plugins""

### DIFF
--- a/developing-packages.md
+++ b/developing-packages.md
@@ -78,7 +78,8 @@ If you want to develop a package that calls into platform-specific APIs, you
 need to develop a plugin package. A plugin package is a specialized version of a
 Dart package, that in addition to the content described above also contains
 platform-specific implementations written for Android (Java or Kotlin code), for
-iOS (Objective-C or Swift code), or for both.
+iOS (Objective-C or Swift code), or for both. The API is connected to the
+platform-specific implementation(s) using [platform channels](/platform-channels/).
 
 ### Step 1: Create the package
 
@@ -165,6 +166,10 @@ Pods/hello/Classes/` in the Project Navigator.
 
 You can run the example app by pressing the &#9654; button.
 
+#### Step 3: Connect the API and the platform code
+
+Finally, you need to connect the API written in Dart code with the platform-specific
+implementations. This is done using [platform channels](/platform-channels/).
    
 ## Publishing packages {#publish}
 

--- a/platform-channels.md
+++ b/platform-channels.md
@@ -89,6 +89,10 @@ the iOS `device.batteryLevel` API, via a single platform message,
 for Android with Java and iOS with Objective-C. For iOS with Swift, see
 [`/examples/platform_channel_swift/`](https://github.com/flutter/flutter/tree/master/examples/platform_channel_swift).
 
+*Note 2*: The example demonstrates how to write platform-specific code inside an app.
+Platform channels can also be used to develop [plugin packages](https://flutter.io/developing-packages/#plugin).
+Please see that page for details on which files to edit for a plugin package.
+
 ### Step 1: Create a new app project {#example-project}
 
 Start by creating a new app using:


### PR DESCRIPTION
Reverts flutter/website#616

Trying to land https://github.com/flutter/website/pull/615 again, now that the Travis failures has been resolved in https://github.com/flutter/website/pull/622.