### PR TITLE
Fix caps and item length in nav items

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -14,9 +14,9 @@
       <li><a href="/widgets-intro/">Tour the framework</a></li>
       <li><a href="/widgets/">Widget catalog</a></li>
       <li><a href="/catalog/samples/">Sample catalog</a></li>
-      <li><a href="https://codelabs.developers.google.com/codelabs/flutter/index.html#0">Building Beautiful UIs with Flutter - Codelab</a></li>
-      <li><a href="/tutorials/layout/">Build Layouts - Tutorial</a></li>
-      <li><a href="/tutorials/interactive/">Add Interactivity - Tutorial</a></li>
+      <li><a href="https://codelabs.developers.google.com/codelabs/flutter/index.html#0">Building beautiful UIs - Codelab</a></li>
+      <li><a href="/tutorials/layout/">Build layouts - Tutorial</a></li>
+      <li><a href="/tutorials/interactive/">Add interactivity - Tutorial</a></li>
       <li><a href="/web-analogs/">HTML/CSS patterns</a></li>
       <li><a href="/gestures/">Gestures</a></li>
       <li><a href="/animations/">Animations</a></li>


### PR DESCRIPTION
- Make the 'Building beautiful UIs - Codelab' item shorter so it doesn't wrap
- Make caps consistent