### PR TITLE
update the intellij docs

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -5,6 +5,7 @@
     <ul class="sidebar-items">
       <li><a href="/setup/">Install</a></li>
       <li><a href="/getting-started/">Create and run your first app</a></li>
+      <li><a href="/intellij-setup/">Setting up IntelliJ</a></li>
       <li><a href="/bootstrap-into-dart/">Bootstrap into Dart</a></li>
     </ul>
 
@@ -28,7 +29,6 @@
       <li><a href="/tutorials/internationalization">Internationalization</a></li>
     </ul>
 
-
   <li class="sidebar-title">Use device and SDK APIs</li>
 
     <ul class="sidebar-items">
@@ -40,17 +40,16 @@
       <li><a href="https://codelabs.developers.google.com/codelabs/flutter-firebase/index.html#0">Firebase for Flutter - Codelab</a></li>
     </ul>
 
-
-  <li class="sidebar-title">Test, deploy, workflows</li>
+  <li class="sidebar-title">Development and tools</li>
 
     <ul class="sidebar-items">
+      <li><a href="/intellij-ide/">Using IntelliJ</a></li>
       <li><a href="/testing/">Test your app</a></li>
       <li><a href="/debugging/">Debug your app</a></li>
-      <li><a href="/formatting/">Format your source code</a></li>
-      <li><a href="/intellij-ide/">Use IntelliJ IDE</a></li>
       <li><a href="/android-release/">Build and release for Android</a></li>
       <li><a href="/ios-release/">Build and release for iOS</a></li>
       <li><a href="/upgrading/">Upgrade your Flutter install</a></li>
+      <li><a href="/formatting/">Format your source code</a></li>
     </ul>
 
   <li class="sidebar-title">More details</li>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -43,7 +43,7 @@
   <li class="sidebar-title">Development and tools</li>
 
     <ul class="sidebar-items">
-      <li><a href="/intellij-ide/">Using IntelliJ</a></li>
+      <li><a href="/intellij-ide/">Using Flutter IDEs</a></li>
       <li><a href="/testing/">Test your app</a></li>
       <li><a href="/debugging/">Debug your app</a></li>
       <li><a href="/android-release/">Build and release for Android</a></li>

--- a/intellij-ide.md
+++ b/intellij-ide.md
@@ -5,7 +5,7 @@ title: Developing Flutter apps in the IntelliJ IDE
 permalink: /intellij-ide/
 ---
 
-The Flutter plugin for [IntelliJ IDEA](https://www.jetbrains.com/idea/) provide a
+The Flutter plugin for [IntelliJ IDEA](https://www.jetbrains.com/idea/) provides a
 fully integrated development experience in the IntelliJ IDE.
 
 * TOC Placeholder

--- a/intellij-setup.md
+++ b/intellij-setup.md
@@ -13,18 +13,18 @@ This page describes how to set up an IntelliJ IDE to develop Flutter apps.
 ## Flutter IntelliJ IDE plugins
 
 You can write Flutter apps in a text editor, but if you choose to work in an IDE we recommend 
-IntelliJ for a [rich IDE experience](/intellij-ide/). Our Flutter and Dart plug-ins support 
+IntelliJ for a rich IDE experience. Our Flutter and Dart plug-ins support
 editing, running, and debugging Flutter apps.
 
 ### Installing IntelliJ
 
-You can use the IntelliJ plug-ins with one of the following JetBrains IDEs:
+You can use the IntelliJ plugin with the following JetBrains IDEs:
 
-* [IntelliJ IDEA](https://www.jetbrains.com/idea/download/), Community (free) edition, version 2017.1 or later.
-* [IntelliJ IDEA](https://www.jetbrains.com/idea/download/), Ultimate edition, version 2017.1 or later.
-* [IntelliJ WebStorm](https://www.jetbrains.com/webstorm/download), version 2017.1 or later.
+* [IntelliJ CE](https://www.jetbrains.com/idea/download/) Community Edition (CE), version 2017.1 or later.
+* [IntelliJ IDEA](https://www.jetbrains.com/idea/download/) Ultimate edition, version 2017.1 or later.
+* [Android Studio 3.0 Preview](https://developer.android.com/studio/preview/index.html) or later.
 
-Android Studio (and various other JetBrains editors) is currently not supported.
+Both IntelliJ CE and Android Studio are free to use and supported for Flutter development.
 
 ### Installing the plugins
 
@@ -54,3 +54,7 @@ navigation panel when you create a new project.
 1. Enter or browse to your Flutter SDK directory in **Flutter SDK path**. This is the top-level `flutter`
    directory, without the `bin` subdirectory. For example, `c:\Users\obiwan\flutter` / `/Users/obiwan/flutter`.
 1. Click **OK**
+
+### Using IntelliJ
+
+See our [additional documentation](/intellij-ide/) for tips on developing with IntelliJ.


### PR DESCRIPTION
- add a link to setting up IntelliJ to the sidebar nav
- rename the sidebar nav section `Test, deploy, workflows` => `Development and tools`, and re-order to items a bit
- update the list of IntelliJ based tools

@mit-mit @sethladd 