### PR TITLE
Use responsive YouTube embed

### DIFF
--- a/_sass/_responsive_embeds.scss
+++ b/_sass/_responsive_embeds.scss
@@ -1,0 +1,29 @@
+// Use this instead of the default YouTube embed code so that the embed
+// is reposnisve.
+//
+// Example default YouTube embed:
+//     <iframe width="560" height="315"
+//             src="https://www.youtube.com/embed/CEcFnqRDfgw?rel=0"
+//             frameborder="0" allowfullscreen></iframe>
+//
+// Example responsive YouTube embed:
+//     <div class="embed-container">
+//       <iframe src="https://www.youtube.com/embed/CEcFnqRDfgw?rel=0"
+//               frameborder="0" allowfullscreen></iframe>
+//     </div>
+.embed-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  max-width: 100%;
+  margin-bottom: 1em;
+
+  iframe, object, embed {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}

--- a/_sass/_responsive_embeds.scss
+++ b/_sass/_responsive_embeds.scss
@@ -1,5 +1,5 @@
 // Use this instead of the default YouTube embed code so that the embed
-// is reposnisve.
+// is responsive.
 //
 // Example default YouTube embed:
 //     <iframe width="560" height="315"
@@ -11,9 +11,14 @@
 //       <iframe src="https://www.youtube.com/embed/CEcFnqRDfgw?rel=0"
 //               frameborder="0" allowfullscreen></iframe>
 //     </div>
+//
+// Note that this only works well for the 16:9 aspect ratio. This is by far
+// the most common aspect ratio for videos, and YouTube seems to "force" it
+// on vertical videos as well (i.e. tall videos will play in a wide 16:9
+// letterbox).
 .embed-container {
   position: relative;
-  padding-bottom: 56.25%;
+  padding-bottom: 56.25%; /* 16:9 */
   height: 0;
   overflow: hidden;
   max-width: 100%;

--- a/animations/hero-animations/index.md
+++ b/animations/hero-animations/index.md
@@ -77,7 +77,11 @@ Tapping the flippers in the blue route
 (or using the device's back-to-previous-route gesture)
 flies the flippers back to the original route.
 
-<center><iframe width="560" height="315" src="https://www.youtube.com/embed/CEcFnqRDfgw?rel=0" frameborder="0" allowfullscreen></iframe></center>
+<!-- 
+  Use this instead of the default YouTube embed code so that the embed
+  is reposnisve.
+-->
+<div class="embed-container"><iframe src="https://www.youtube.com/embed/CEcFnqRDfgw?rel=0" frameborder="0" allowfullscreen></iframe></div>
 
 **Radial hero animations**<br>
 
@@ -92,7 +96,7 @@ that displays it with a square shape.
 Tapping the square image flies the hero back to
 the original route, displayed with a circular shape.
 
-<center><iframe width="560" height="315" src="https://www.youtube.com/embed/LWKENpwDKiM?rel=0" frameborder="0" allowfullscreen></iframe></center>
+<div class="embed-container"><iframe src="https://www.youtube.com/embed/LWKENpwDKiM?rel=0" frameborder="0" allowfullscreen></iframe></div>
 
 Before moving to the sections specific to
 [standard](#standard-hero-animations)

--- a/css/main.scss
+++ b/css/main.scss
@@ -60,7 +60,8 @@ $on-laptop:        800px;
         "prism_overrides",
         "code_pre",
         "catalog",
-        "homepage"
+        "homepage",
+        "responsive_embeds"
 ;
 
 aside > :not(pre) > code[class*="language-"], aside > pre[class*="language-"] {


### PR DESCRIPTION
The default YouTube embed breaks the page on low-width screens (left and right of text beyond viewport, and no way to scroll horizontally to view it).

Reported here: https://twitter.com/SergiAndReplace/status/922425801248854017