### PR TITLE
Rename IntelliJ pages

### DIFF
--- a/_includes/setup/editor-setup.md
+++ b/_includes/setup/editor-setup.md
@@ -3,6 +3,6 @@
 Using the `flutter` command-line tools, you can use any editor to develop Flutter applications.
 Type `flutter help` at a prompt to view the available tools.
 
-We recommend using our IntelliJ plug-ins for a  [rich IDE experience](/intellij-ide/) 
-supporting editing, running, and debugging Flutter apps. See [IntelliJ Setup](/intellij-setup/)
+We recommend using our IntelliJ plug-ins for a  [rich IDE experience](/using-ide/) 
+supporting editing, running, and debugging Flutter apps. See [IntelliJ Setup](/ide-setup/)
 for detailed steps.

--- a/_includes/setup/get-sdk-win.md
+++ b/_includes/setup/get-sdk-win.md
@@ -54,7 +54,7 @@ itself. Subsequent runs should be much faster.
 
 The following sections describe how to perform these tasks and finish the setup process.
 You'll see in `flutter doctor` output that if you choose to use an IDE, plugins
-are available for IntelliJ IDEA. See [IntelliJ Setup](/intellij-setup/)
+are available for IntelliJ IDEA. See [IntelliJ Setup](/ide-setup/)
 for the steps to install the Flutter and Dart plugins.
 
 Once you have installed any missing dependencies, run the `flutter doctor` command again to

--- a/_includes/setup/get-sdk.md
+++ b/_includes/setup/get-sdk.md
@@ -47,7 +47,7 @@ itself. Subsequent runs should be much faster.
 
 The following sections describe how to perform these tasks and finish the setup process.
 You'll see in `flutter doctor` output that if you choose to use an IDE, plugins
-are available for IntelliJ IDEA. See [IntelliJ Setup](/intellij-setup/)
+are available for IntelliJ IDEA. See [IntelliJ Setup](/ide-setup/)
 for the steps to install the Flutter and Dart plugins.
 
 Once you have installed any missing dependencies, run the `flutter doctor` command again to

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -5,7 +5,7 @@
     <ul class="sidebar-items">
       <li><a href="/setup/">Install</a></li>
       <li><a href="/getting-started/">Create and run your first app</a></li>
-      <li><a href="/intellij-setup/">Setting up IntelliJ</a></li>
+      <li><a href="/ide-setup/">Setting up the IDE</a></li>
       <li><a href="/bootstrap-into-dart/">Bootstrap into Dart</a></li>
     </ul>
 
@@ -44,7 +44,7 @@
   <li class="sidebar-title">Development and tools</li>
 
     <ul class="sidebar-items">
-      <li><a href="/intellij-ide/">Using Flutter IDEs</a></li>
+      <li><a href="/using-ide/">Using Flutter IDEs</a></li>
       <li><a href="/hot-reload/">Using hot reload</a></li>
       <li><a href="/testing/">Test your app</a></li>
       <li><a href="/debugging/">Debug your app</a></li>

--- a/debugging.md
+++ b/debugging.md
@@ -16,7 +16,7 @@ applications.
 Before running your applications, test your code with `flutter analyze`. This
 tool (which is a wrapper around the `dartanalyzer` tool) will analyze your code
 and help you find possible mistakes. If you're using the
-[Flutter plugin for IntelliJ](/intellij-ide/), this is already happening for you.
+[Flutter plugin for IntelliJ](/using-ide/), this is already happening for you.
 
 The Dart analyzer makes heavy use of type annotations that you put in
 your code to help track problems down. You are encouraged to use them

--- a/faq.md
+++ b/faq.md
@@ -147,7 +147,7 @@ built with Flutter to users. We'd love to hear what you're building!
 ### Does Flutter work with any editors or IDEs?
 
 We are building plugins for [IntelliJ IDEA](https://www.jetbrains.com/idea/),
-enabling [fully integrated development experience](/intellij-ide/) for Flutter.
+enabling [fully integrated development experience](/using-ide/) for Flutter.
 The plugins work in both the Ultimate and the free Community editions.
 
 Alternatively, you can use a combination of the `flutter` command in a terminal

--- a/firebase.json
+++ b/firebase.json
@@ -47,6 +47,16 @@
         "source" : "/platform-plugins*",
         "destination" : "/using-packages/",
         "type" : 301
+      },
+      {
+        "source" : "/intellij-setup/",
+        "destination" : "/ide-setup/",
+        "type" : 301
+      },
+      {
+        "source" : "/intellij-ide/",
+        "destination" : "/using-ide/",
+        "type" : 301
       }
     ]
   }

--- a/formatting.md
+++ b/formatting.md
@@ -23,7 +23,7 @@ time may be better spent on code behavior rather than code style.
 ### Automatically formatting code in IntelliJ
 
 Automatic formatting of code is supported in IntelliJ if you have the
-`Dart` plugin (see [IntelliJ setup](/intellij-setup/)).
+`Dart` plugin (see [IntelliJ setup](/ide-setup/)).
 
 To automatically format the code in the current source code window, right-click
 in the code window and select `Reformat with Dart style`. You can add a keyboard

--- a/getting-started.md
+++ b/getting-started.md
@@ -51,7 +51,7 @@ to get their IDs, and then `flutter run -d deviceID` to run your app.
 Alternatively, if you are using the [IntelliJ
 IDEA](https://www.jetbrains.com/idea/) IDE (either the free Community Edition, or the
 Ultimate Edition) with the [Flutter
-plugins](/intellij-setup/), you can start your Flutter app from there:
+plugins](/ide-setup/), you can start your Flutter app from there:
 
 1. In IntelliJ, click **Create New Project** from the Welcome window or
 **File > New > Project...** from the main IDE window.
@@ -100,7 +100,7 @@ To edit your code and hot reload changes:
 
 A more detailed detailed description on how to use the IntelliJ plugin and which
 changes are supported by the hot reload feature can be found on the page
-[Developing apps in the IntelliJ IDE](../intellij-ide/).
+[Developing apps in the IntelliJ IDE](../using-ide/).
 
 ## Next steps
 

--- a/ide-setup.md
+++ b/ide-setup.md
@@ -56,5 +56,5 @@ To install the plugins:
 
 ## Using the IDEs for Flutter
 
-See our [additional documentation](/intellij-ide/) for tips on developing Flutter apps with
+See our [additional documentation](/using-ide/) for tips on developing Flutter apps with
 Android Studio or IntelliJ IDEA.

--- a/ide-setup.md
+++ b/ide-setup.md
@@ -2,7 +2,7 @@
 layout: page
 title: IDE Setup
 
-permalink: /intellij-setup/
+permalink: /ide-setup/
 ---
 
 This page describes how to set up an IDE to develop Flutter apps.

--- a/setup.md
+++ b/setup.md
@@ -39,7 +39,7 @@ to test and iterate using a simulator or physical device.
    <td>Run <code>flutter doctor</code> and resolve any issues found (<a href="/setup-macos/#run-flutter-doctor">Mac</a>) (<a href="/setup-windows/#run-flutter-doctor">Windows</a>) (<a href="/setup-linux/#run-flutter-doctor">Linux</a>)</td><td align="center">Y</td>
  </tr>
  <tr>
-   <td colspan="2"><a href="/intellij-setup/">Install and configure an IntelliJ IDE to develop Flutter apps</a></td>
+   <td colspan="2"><a href="/ide-setup/">Install and configure an IntelliJ IDE to develop Flutter apps</a></td>
  </tr>
  <tr><td class="alert-warning" colspan="2">Using an IDE is optional. However, we recommend using an IntelliJ IDE with Flutter for code completion, 
 inline error checking, and visual debugging features.</td>

--- a/technical-overview.md
+++ b/technical-overview.md
@@ -188,7 +188,7 @@ to start developing and iterating.
 Next steps:
 
 1.  [Install the Flutter SDK](/setup/).
-1.  [Set up IntelliJ](/intellij-setup/) (optional).
+1.  [Set up IntelliJ](/ide-setup/) (optional).
 1.  [Get started](/getting-started/) with the development cycle in a few simple steps.
 1.  Try [Building Layouts in Flutter](/tutorials/layout/) and
     [Adding Interactivity to Your Flutter App](/tutorials/interactive/).

--- a/tutorials/layout/index.md
+++ b/tutorials/layout/index.md
@@ -188,10 +188,10 @@ Or, at the command line, you can use
 For a faster development experience, try Flutter's hot reload feature.
 Hot reload allows you to modify your code and see the changes without
 fully restarting the app. The
-[Flutter plugin for IntelliJ](/intellij-ide/) supports
+[Flutter plugin for IntelliJ](/using-ide/) supports
 hot reload, or you can trigger from the command line.
 For more information, see [Hot Reloads vs. Full Application
-Restarts](https://flutter.io/intellij-ide/#hot-reloads-vs-full-application-restarts).
+Restarts](https://flutter.io/using-ide/#hot-reloads-vs-full-application-restarts).
 </aside>
 
 <a name="step-3"></a>

--- a/using-ide.md
+++ b/using-ide.md
@@ -1,19 +1,18 @@
 ---
 layout: page
-title: Developing Flutter apps in the IntelliJ IDE
+title: Developing Flutter apps in an IDE
 
-permalink: /intellij-ide/
+permalink: /using-ide/
 ---
 
-The Flutter plugin for [IntelliJ IDEA](https://www.jetbrains.com/idea/) provides a
-fully integrated development experience in the IntelliJ IDE.
+The Flutter plugin provides a fully integrated development experience in an IDE.
 
 * TOC Placeholder
 {:toc}
 
 ## Installation and setup
 
-Please follow the [IntelliJ setup](/intellij-setup/) instructions to install IntelliJ and
+Please follow the [IDE setup](/ide-setup/) instructions to install
 the Dart and Flutter plugins.
 
 ### Updating the plugins<a name="updating"/>


### PR DESCRIPTION
We need to get all the website docs cleaned up now that we support both IntelliJ and Android Studio.

This is a first PR to rename the two IntelliJ pages (setup and using). Once this lands I'll do a second PR to update all the page content also.