### PR TITLE
Added missing opening [[highlight]] tags

### DIFF
--- a/tutorials/animation/index.md
+++ b/tutorials/animation/index.md
@@ -801,8 +801,8 @@ class AnimatedLogo extends AnimatedWidget {
   Widget build(BuildContext context) {
     final Animation<double> animation = listenable;
     return new Center(
-      child: new Opacity([[/highlight]]
-        opacity: _opacityTween.evaluate(animation),[[/highlight]]
+      child: [[highlight]]new Opacity([[/highlight]]
+        [[highlight]]opacity: _opacityTween.evaluate(animation),[[/highlight]]
         child: new Container(
           margin: new EdgeInsets.symmetric(vertical: 10.0),
           height: [[highlight]]_sizeTween.evaluate(animation)[[/highlight]],


### PR DESCRIPTION
I'm not 100% sure if the new tag placement is correct, so please double-check.
I spotted this problem because it made `</span>` tags appear in the example code like so:
```
  Widget build(BuildContext context) {
    final Animation<double> animation = listenable;
    return new Center(
      child: new Opacity(</span>
        opacity: _opacityTween.evaluate(animation),</span>
        child: new Container(
          margin: new EdgeInsets.symmetric(vertical: 10.0),
          height: _sizeTween.evaluate(animation),
          width: _sizeTween.evaluate(animation),
          child: new FlutterLogo(),
        ),
      ),
    );
  }
```