### PR TITLE
Fix 'Getting Started' action buttons on front page

### DIFF
--- a/index.md
+++ b/index.md
@@ -21,7 +21,7 @@ hide_title: true
         </div>
 
         <div class="homepage__button_row">
-        <a href="/getting-started/" class="get-started-button">Get Started</a>
+        <a href="/setup/" class="get-started-button">Get Started</a>
         {% include note.html content="_Flutter is an alpha, open-source project_." %}
         </div>
 
@@ -292,7 +292,7 @@ Future<Null> getBatteryLevel() async {
         <div class="homepage__try_today">Try Flutter today. Getting started is easy.</div>
 
         <div class="homepage__button_row">
-        <a href="/getting-started/" class="get-started-button">Get Started</a>
+        <a href="/setup/" class="get-started-button">Get Started</a>
         {% include note.html content="_Flutter is an alpha, open-source project_." %}
         </div>
 


### PR DESCRIPTION
Currently the "big blue" getting started buttons link to the second subitem ('Create and run your first app') in leftnav, which then in a big blue call-out tells the user to go to the first subitem ('Flutter installation & setup').

This PR streamlines that so it actually goes directly to the first item.