### PR TITLE
Update link text

### DIFF
--- a/_includes/setup/editor-setup.md
+++ b/_includes/setup/editor-setup.md
@@ -4,5 +4,5 @@ Using the `flutter` command-line tools, you can use any editor to develop Flutte
 Type `flutter help` at a prompt to view the available tools.
 
 We recommend using our IntelliJ plug-ins for a  [rich IDE experience](/using-ide/) 
-supporting editing, running, and debugging Flutter apps. See [IntelliJ Setup](/ide-setup/)
+supporting editing, running, and debugging Flutter apps. See [IDE Setup](/ide-setup/)
 for detailed steps.


### PR DESCRIPTION
Change "See IntelliJ Setup" > "See IDE Setup" to do two things:
* Better match the left nav entry "Setting up the IDE". These are still different, which is not optimal, but more similar now.
* Accommodate AS as an IDE option.