### PR TITLE
Fix build break

### DIFF
--- a/widgets-intro.md
+++ b/widgets-intro.md
@@ -761,7 +761,7 @@ typically end by calling
 Keys
 ----
 
-_Main article: [`Key`](https://docs.flutter.io/flutter/widgets/Key-class.html)_
+_Main article: [`Key`](https://docs.flutter.io/flutter/foundation/Key-class.html)_
 
 You can use keys to control which widgets the framework will match up with which
 other widgets when a widget rebuilds. By default, the framework matches


### PR DESCRIPTION
https://travis-ci.org/flutter/website/jobs/312406491 on master was failing with:

```
- ./_site/widgets-intro/index.html
  *  External link https://docs.flutter.io/flutter/widgets/Key-class.html failed: 404 No error
rake aborted!
HTML-Proofer found 1 failure!
```
