### PR TITLE
Roll nodejs to 8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "5.1"
+  - "8.1"
 sudo: false
 before_install:
   - rvm install 2.2.2

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -86,7 +86,7 @@ rake checklinks
 if [ "$TRAVIS_EVENT_TYPE" = "push" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
   # Deploy pushes to master to Firebase hosting.
   echo "Deploying to Firebase."
-  npm install --global firebase-tools@3.0.0
+  npm install --global firebase-tools@3.16.0
   firebase -P sweltering-fire-2088 --token "$FIREBASE_TOKEN" --non-interactive deploy
 fi
 
@@ -101,7 +101,7 @@ if [ "$ENABLE_PR_BOT" = "true" ]; then
         export PROJECT_NAME=`../../flutter/bin/cache/dart-sdk/bin/dart prdeployer.dart $BRANCH $FIREBASE_AUTH 2>&1`
         cd ../
         echo "Deploying to $PROJECT_NAME"
-        npm install --global firebase-tools@3.0.0
+        npm install --global firebase-tools@3.16.0
         firebase -P "$PROJECT_NAME" --token "$FIREBASE_TOKEN_DEV" --non-interactive deploy
     fi
 fi


### PR DESCRIPTION
Seeing lots of warnings in travis from node, e.g.:

```
npm WARN engine rsvp@3.6.2: wanted: {"node":"0.12.* || 4.* || 6.* || >= 7.*"} (current: {"node":"5.1.1","npm":"3.3.12"})
npm WARN deprecated node-uuid@1.4.8: Use uuid module instead
npm WARN deprecated tough-cookie@2.2.2: ReDoS vulnerability parsing Set-Cookie https://nodesecurity.io/advisories/130
/home/travis/.nvm/versions/node/v5.1.1/bin/firebase -> /home/travis/.nvm/versions/node/v5.1.1/lib/node_modules/firebase-tools/bin/firebase
> iltorb@1.3.4 install /home/travis/.nvm/versions/node/v5.1.1/lib/node_modules/firebase-tools/node_modules/iltorb
> node-pre-gyp install --fallback-to-build
node-pre-gyp ERR! Tried to download(404): https://node-iltorb.s3.amazonaws.com/iltorb/v1.3.4/node-v47-linux-x64.tar.gz 
node-pre-gyp ERR! Pre-built binaries not found for iltorb@1.3.4 and node@5.1.1 (node-v47 ABI) (falling back to source compile with node-gyp) 
make: Entering directory `/home/travis/.nvm/versions/node/v5.1.1/lib/node_modules/firebase-tools/node_modules/iltorb/build'```
