### PR TITLE
Update `build()` to return a MaterialApp.

### DIFF
--- a/platform-channels.md
+++ b/platform-channels.md
@@ -128,7 +128,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 ...
 class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
   static const platform = const MethodChannel('samples.flutter.io/battery');
 
   // Get battery level.
@@ -171,17 +170,19 @@ refreshing the valuer.
 ```dart
 @override
 Widget build(BuildContext context) {
-  return new Material(
-    child: new Center(
-      child: new Column(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        children: [
-          new RaisedButton(
-            child: new Text('Get Battery Level'),
-            onPressed: _getBatteryLevel,
-          ),
-          new Text(_batteryLevel),
-        ],
+  return new MaterialApp(
+    home: new Material(
+      child: new Center(
+        child: new Column(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            new RaisedButton(
+              child: new Text('Get Battery Level'),
+              onPressed: _getBatteryLevel,
+            ),
+            new Text(_batteryLevel),
+          ],
+        ),
       ),
     ),
   );


### PR DESCRIPTION
As written, `build()` produces a runtime exception:

```
══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
No Directionality widget found.
RichText widgets require a Directionality widget ancestor.
The specific widget that could not find a Directionality ancestor was:
The ownership chain for the affected widget is:
RichText ← Text ← Semantics ← Center ← Padding ← Container ← Listener ← _GestureSemantics ←
RawGestureDetector ← GestureDetector ← ⋯
Typically, the Directionality widget is introduced by the MaterialApp or WidgetsApp widget at the
top of your application widget tree. It determines the ambient reading direction and is used, for
example, to determine how to lay out text, how to interpret "start" and "end" values, and to resolve
EdgeInsetsDirectional, AlignmentDirectional, and other *Directional objects.
```

Wrapping the returned `Material` in a `MaterialApp` fixes this.

![simulator screen shot - iphone 8 - 2017-12-13 at 05 58 24](https://user-images.githubusercontent.com/67586/33942402-ab732c9e-dfca-11e7-9479-4698de05b569.png)

(Unused `_counter` reference is also removed.)

/cc @mit-mit @mravn-google 