### PR TITLE
Back out build() definition change.

### DIFF
--- a/platform-channels.md
+++ b/platform-channels.md
@@ -170,19 +170,17 @@ refreshing the valuer.
 ```dart
 @override
 Widget build(BuildContext context) {
-  return new MaterialApp(
-    home: new Material(
-      child: new Center(
-        child: new Column(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            new RaisedButton(
-              child: new Text('Get Battery Level'),
-              onPressed: _getBatteryLevel,
-            ),
-            new Text(_batteryLevel),
-          ],
-        ),
+  return new Material(
+    child: new Center(
+      child: new Column(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          new RaisedButton(
+            child: new Text('Get Battery Level'),
+            onPressed: _getBatteryLevel,
+          ),
+          new Text(_batteryLevel),
+        ],
       ),
     ),
   );


### PR DESCRIPTION
Following up from @Hixie's https://github.com/flutter/website/pull/760#issuecomment-351520631, restores `build()` as defined in the full example. 

@Hixie 

FYI @mravn-google 