### PR TITLE
Add print styles

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -67,3 +67,27 @@ $on-laptop:        800px;
 aside > :not(pre) > code[class*="language-"], aside > pre[class*="language-"] {
     background: inherit;
 }
+
+@media print {
+    /* Don't display header, footer, sidenav when printing */
+    #side-nav-container, .site-header, .site-footer, .contribute {
+        display:none;
+    }
+
+    /* Use the whole page */
+    .main-contents, .container-fluid {
+        width: auto;
+        margin: 0;
+        padding: 1em;
+    }
+
+    /* Because we have some long code samples, allow page breaks within them */
+    pre {
+      page-break-inside: auto;
+    }
+
+    /* Remove link path */
+    a:after {
+        content: none !important;
+    }
+}


### PR DESCRIPTION
A few print styles to make it possible to read the printed version of most pages. (Specially formatted pages like /widgets/material/ still have issues.)

Before: 
![before](https://user-images.githubusercontent.com/2164483/34185281-5e2b709a-e4d9-11e7-8b26-8b396acfa346.png)

After:
![after](https://user-images.githubusercontent.com/2164483/34185285-6257c5e2-e4d9-11e7-8c89-87a158a0480a.png)
