### PR TITLE
fix layout.md

### DIFF
--- a/developing-packages.md
+++ b/developing-packages.md
@@ -176,7 +176,7 @@ It is recommended practice to add the following documentation to all packages:
 
 When you publish a package, API documentation is automatically generated and
 published to dartdocs.org, see for example the
-[device_info docs](https://www.dartdocs.org/documentation/device_info/0.0.4/index.html/).
+[device_info docs](https://www.dartdocs.org/documentation/device_info/0.0.4/index.html).
 
 If you wish to generate API documentation locally on your developement machine, use the following commands:
 

--- a/layout.md
+++ b/layout.md
@@ -99,7 +99,6 @@ when the flex box is inside
 another flex box or inside a scrollable. If you do, you'll get an
 exception message pointing you at this document.
 
-In the _cross_ direction, i.e. in their width for [`Column`](https://docs.flutter.io/flutter/widgets/Column-class.html))  
-(vertical flex) and in their height for [`Row`](https://docs.flutter.io/flutter/widgets/Row-class.html) (horizontal flex), they must never
+In the _cross_ direction, i.e. in their width for [`Column`](https://docs.flutter.io/flutter/widgets/Column-class.html) (vertical flex) and in their height for [`Row`](https://docs.flutter.io/flutter/widgets/Row-class.html) (horizontal flex), they must never
 be unbounded, otherwise they would not be able to reasonably align
 their children.


### PR DESCRIPTION
Hi! Thank you for great framework and documentation.
I removed unnecessary parenthesis and line break from `layout.md`.

previous
![2017-12-22 8 19 16](https://user-images.githubusercontent.com/7473222/34279013-b4df714c-e6f1-11e7-977a-737fbff02690.png)

fixed
![2017-12-22 8 19 26](https://user-images.githubusercontent.com/7473222/34279018-bb65ff4a-e6f1-11e7-9bad-b69ca8e4aedc.png)

And I also removed unnecessary slash from `developing-packages.md`, which fails `rake checklinks`.