### PR TITLE
Changed compound tween example to fade in as size increases

### DIFF
--- a/_includes/code/animation/animate5/main.dart
+++ b/_includes/code/animation/animate5/main.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 
 class AnimatedLogo extends AnimatedWidget {
   // Make the Tweens static because they don't change.
-  static final _opacityTween = new Tween<double>(begin: 1.0, end: 0.1);
+  static final _opacityTween = new Tween<double>(begin: 0.1, end: 1.0);
   static final _sizeTween = new Tween<double>(begin: 0.0, end: 300.0);
 
   AnimatedLogo({Key key, Animation<double> animation})

--- a/tutorials/animation/index.md
+++ b/tutorials/animation/index.md
@@ -760,7 +760,7 @@ final AnimationController controller =
 final Animation<double> sizeAnimation =
     new Tween(begin: 0.0, end: 300.0).animate(controller);
 final Animation<double> opacityAnimation =
-    new Tween(begin: 1.0, end: 0.3).animate(controller);
+    new Tween(begin: 0.1, end: 1.0).animate(controller);
 {% endprettify %}
 
 You can get the size with `sizeAnimation.value` and the opacity
@@ -782,7 +782,7 @@ import 'package:flutter/material.dart';
 
 class AnimatedLogo extends AnimatedWidget {
   // The Tweens are static because they don't change.
-  [[highlight]]static final _opacityTween = new Tween<double>(begin: 1.0, end: 0.1);[[/highlight]]
+  [[highlight]]static final _opacityTween = new Tween<double>(begin: 0.1, end: 1.0);[[/highlight]]
   [[highlight]]static final _sizeTween = new Tween<double>(begin: 0.0, end: 300.0);[[/highlight]]
 
   AnimatedLogo({Key key, Animation<double> animation})


### PR DESCRIPTION
It makes more sense for something to become easier to see as it gets bigger than it does for it to vanish as it does.