### PR TITLE
Add a temporary redirect for the new 'get started' landing page

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -67,6 +67,11 @@
         "source": "/privacy",
         "destination": "https://www.google.com/intl/en/policies/privacy/",
         "type": 301
+      },
+      {
+        "source": "/get-started/",
+        "destination": "/setup/",
+        "type": 301
       }
     ]
   }


### PR DESCRIPTION
I'm working on the new 'get started'-experience over in https://github.com/flutter/website/pull/800. This is not quite ready yet, so adding a temporary redirect on the expected final URL, flutter.io/get-started/ to the current getting started page.

I will then remove that redirect again in PR 800.