### PR TITLE
Fix missing material page contents

### DIFF
--- a/widgets/materialdesign.md
+++ b/widgets/materialdesign.md
@@ -4,4 +4,4 @@ title: Material Components Widgets
 
 permalink: widgets/material/
 ---
-{% include catalogpage.html category="Material Design"%}     
+{% include catalogpage.html category="Material Components"%}     


### PR DESCRIPTION
`Material Design` was renamed to `Material Components` in https://github.com/flutter/website/pull/805, updating the catalog link too.