### PR TITLE
Tweak VS Code format text

### DIFF
--- a/get-started/codelab/index.md
+++ b/get-started/codelab/index.md
@@ -96,7 +96,7 @@ become skewed. You can fix this automatically with the Flutter tools:
 
 * Android Studio / IntelliJ IDEA: Right-click the dart code and
   select **Reformat Code with dartfmt**.
-* VS Code: Right-click the code and select **Reformat Code with dartfmt**.
+* VS Code: Right-click and select **Format Document**.
 * Terminal: Run `flutter format <filename>`.
 </aside>
 


### PR DESCRIPTION
Minor tweak - VS Code only supports full document formatting (so selection/position of click doesn't matter) and it's labelled "Format Document" on the context (Or Edit) menu.