### PR TITLE
Update get-sdk-win's flutter doctor section

### DIFF
--- a/_includes/setup/get-sdk-win.md
+++ b/_includes/setup/get-sdk-win.md
@@ -41,15 +41,18 @@ not support third-party shells like Git Bash.
 This command checks your environment and displays a report to the terminal window.
 The Dart SDK is bundled with Flutter; it is not necessary to install Dart separately.
 Check the output carefully for other software you may need to install or further 
-tasks to perform .
+tasks to perform (shown in **bold** text).
 
 For example:
-
 ```
-✗ Minimum supported Android SDK version is 25 but this system has 23. Please upgrade.
+[-] Android toolchain - develop for Android devices
+    • Android SDK at D:\Android\sdk
+    ✗ Android SDK is missing command line tools; download from https://goo.gl/XxQghQ
+    • Try re-installing or updating your Android SDK,
+      visit https://flutter.io/setup/#android-setup for detailed instructions.
 ```
 
-The first time you run the `flutter` command, it downloads its own dependencies and compiles
+The first time you run a flutter command (such as `flutter doctor`), it downloads its own dependencies and compiles
 itself. Subsequent runs should be much faster.
 
 The following sections describe how to perform these tasks and finish the setup process.

--- a/_includes/setup/get-sdk-win.md
+++ b/_includes/setup/get-sdk-win.md
@@ -44,13 +44,13 @@ Check the output carefully for other software you may need to install or further
 tasks to perform (shown in **bold** text).
 
 For example:
-```
+<pre>
 [-] Android toolchain - develop for Android devices
     • Android SDK at D:\Android\sdk
-    ✗ Android SDK is missing command line tools; download from https://goo.gl/XxQghQ
+    <strong>✗ Android SDK is missing command line tools; download from https://goo.gl/XxQghQ</strong>
     • Try re-installing or updating your Android SDK,
       visit https://flutter.io/setup/#android-setup for detailed instructions.
-```
+</pre>
 
 The first time you run a flutter command (such as `flutter doctor`), it downloads its own dependencies and compiles
 itself. Subsequent runs should be much faster.

--- a/_includes/setup/get-sdk.md
+++ b/_includes/setup/get-sdk.md
@@ -34,13 +34,13 @@ Check the output carefully for other software you may need to install or further
 tasks to perform (shown in **bold** text).
 
 For example:
-```
+<pre>
 [-] Android toolchain - develop for Android devices
     • Android SDK at /Users/obiwan/Library/Android/sdk
-    ✗ Android SDK is missing command line tools; download from https://goo.gl/XxQghQ
+    <strong>✗ Android SDK is missing command line tools; download from https://goo.gl/XxQghQ</strong>
     • Try re-installing or updating your Android SDK,
       visit https://flutter.io/setup/#android-setup for detailed instructions.
-```
+</pre>
 
 The first time you run a flutter command (such as `flutter doctor`), it downloads its own dependencies and compiles
 itself. Subsequent runs should be much faster.


### PR DESCRIPTION
Updates the `flutter doctor` instructions on the windows get-sdk page to match those of the Linux/Mac page.