### PR TITLE
Allow linking directly to specific tool and persist across site

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -8,6 +8,8 @@ function setupToolsTabs() {
     tabContents.removeClass('current');
   }
 
+  // Searches for the tab for a tool by its ID and selects it
+  // (used to pre-select a tool from url fragement/localStorage)
   function selectTool(id) {
     var escapedId = $.escapeSelector(id);
     var tab = tabs.filter("[data-tab='" + tabIdPrefix + id + "']");

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -22,13 +22,22 @@ function setupToolsTabs() {
     $(this).addClass('current');
     $("#" + tab_id).addClass('current');
 
+    var selectedTool = tab_id.replace(tabIdPrefix, '');
+
     // Add to the url for better reloading/copy/pasting
-    location.hash = '#' + tab_id.replace(tabIdPrefix, '');
+    if (history.replaceState)
+      history.replaceState(undefined, undefined, '#' + selectedTool);
+
+    // Persist in local storage so we can pre-select around the site
+    if (window.localStorage)
+      window.localStorage.setItem('selectedTool', selectedTool);
   });
 
   // If we have a tool in the url fragement, pre-select it
   if (location.hash && location.hash.length > 1)
     selectTool(location.hash.substr(1));
+  else if (window.localStorage && window.localStorage.getItem('selectedTool'))
+    selectTool(window.localStorage.getItem('selectedTool'));
 }
 
 $(document).ready(function () {

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -1,4 +1,5 @@
 function setupToolsTabs() {
+  var tabIdPrefix = "tab-install-";
   var tabs = $('.tabs__top-bar li');
   var tabContents = $('.tabs__content');
 
@@ -9,7 +10,7 @@ function setupToolsTabs() {
 
   function selectTool(id) {
     var escapedId = $.escapeSelector(id);
-    var tab = tabs.filter("[data-tab='tab-install-" + id + "']");
+    var tab = tabs.filter("[data-tab='" + tabIdPrefix + id + "']");
     tab.click();
   }
 
@@ -20,6 +21,9 @@ function setupToolsTabs() {
 
     $(this).addClass('current');
     $("#" + tab_id).addClass('current');
+
+    // Add to the url for better reloading/copy/pasting
+    location.hash = '#' + tab_id.replace(tabIdPrefix, '');
   });
 
   // If we have a tool in the url fragement, pre-select it

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -7,6 +7,12 @@ function setupToolsTabs() {
     tabContents.removeClass('current');
   }
 
+  function selectTool(id) {
+    var escapedId = $.escapeSelector(id);
+    var tab = tabs.filter("[data-tab='tab-install-" + id + "']");
+    tab.click();
+  }
+
   tabs.click(function () {
     clearTabsCurrent();
 
@@ -15,6 +21,10 @@ function setupToolsTabs() {
     $(this).addClass('current');
     $("#" + tab_id).addClass('current');
   });
+
+  // If we have a tool in the url fragement, pre-select it
+  if (location.hash && location.hash.length > 1)
+    selectTool(location.hash.substr(1));
 }
 
 $(document).ready(function () {


### PR DESCRIPTION
@mit-mit @filiph Please lmk what you think.

I need to test in some other browsers (looks good on Chrome + Safari on my Mac). ~~I presume opening a PR will create a stage site so I easily test from others?~~

Changes:

1. When you switch tab, it will add that tool name to the url hash fragment
2. If you link to a page with a fragment (eg `#vscode`) it'll automatically select that tab
3. Your selected tab is written to localStorage and used (if there's no url fragment)