### PR TITLE
Hide Firebase codelab from sidenav

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -41,7 +41,11 @@
       <li><a href="/reading-writing-files/">Read and write files</a></li>
       <li><a href="/networking/">Network and HTTP</a></li>
       <li><a href="/json/">JSON and serialization</a></li>
+      {% comment %}
+      <!-- Temporarily removed because the codelab is broken and possibly
+           about to be replaced by a completely new one. -->
       <li><a href="https://codelabs.developers.google.com/codelabs/flutter-firebase/index.html#0">Firebase for Flutter - Codelab</a></li>
+      {% endcomment %}
     </ul>
 
   <li class="sidebar-title">Development and tools</li>


### PR DESCRIPTION
The codelab is broken at the moment.