### PR TITLE
Fixes https links in the footer of the site flutter.io

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,13 +10,13 @@
             <a href="https://twitter.com/flutterio">twitter</a> &bull;
             <a href="https://github.com/flutter/">github</a> &bull;
             <a href="/tos">terms</a> &bull;
-            <a href="http://www.google.com/intl/en/policies/privacy/">privacy</a>
+            <a href="https://www.google.com/intl/en/policies/privacy/">privacy</a>
           </p>
 
           <p class="licenses">
             Except as otherwise noted,
             this work is licensed under a
-            <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative
+            <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative
             Commons Attribution 4.0 International License</a>,
             and code samples are licensed under the BSD License.
           </p>


### PR DESCRIPTION
I saw that issue at flutter repository:
https://github.com/flutter/flutter/issues/14936