### PR TITLE
Fixed:  Image url not working

### DIFF
--- a/cookbook/images/network-image.md
+++ b/cookbook/images/network-image.md
@@ -13,7 +13,7 @@ constructor.
 
 ```dart
 new Image.network(
-  'https://github.com/flutter/website/blob/master/_includes/code/layout/lakes/images/lake.jpg?raw=true',
+  'https://raw.githubusercontent.com/flutter/website/master/_includes/code/layout/lakes/images/lake.jpg',
 )
 ```
 


### PR DESCRIPTION
The image url wasn't working when the app is run. Changed the url to the one which is working properly now.