### PR TITLE
Align bridging sidebar titles, and shorten to fit on one line

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -20,9 +20,9 @@
       <li><a href="https://codelabs.developers.google.com/codelabs/flutter/index.html#0">Building beautiful UIs - Codelab</a></li>
       <li><a href="/tutorials/layout/">Build layouts - Tutorial</a></li>
       <li><a href="/tutorials/interactive/">Add interactivity - Tutorial</a></li>
-      <li><a href="/web-analogs/">HTML/CSS patterns</a></li>
-      <li><a href="/flutter-for-android/">Flutter for Android Developers</a></li>
-      <li><a href="/flutter-for-react-native/">Flutter for React Native Developers</a></li>
+      <li><a href="/web-analogs/">Flutter for Web devs</a></li>
+      <li><a href="/flutter-for-android/">Flutter for Android devs</a></li>
+      <li><a href="/flutter-for-react-native/">Flutter for React Native devs</a></li>
       <li><a href="/gestures/">Gestures</a></li>
       <li><a href="/animations/">Animations</a></li>
       <li><a href="/custom-fonts/">Custom fonts</a></li>

--- a/web-analogs.md
+++ b/web-analogs.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: HTML/CSS Analogs in Flutter
+title: Flutter for Web (HTML/CSS) Developers
 permalink: /web-analogs/
 ---
 


### PR DESCRIPTION
I know we don't like abbreviations, but it just looks odd with menu entries that span several lines