### PR TITLE
Add hyphens to links in post content

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -206,6 +206,10 @@
             font-size: 12px;
         }
     }
+    
+    a {
+        hyphens: auto;
+    }
 }
 
 /* Make fragment identifier links visible below the header. */


### PR DESCRIPTION
This avoids extending width of post content if links have long words (most likely to happen for words separated by underscores).

## Before:
<img src="https://user-images.githubusercontent.com/767683/37188043-17f2c968-2302-11e8-827f-94c9a0ebc5de.png" width="275"/>

## After:
<img src="https://user-images.githubusercontent.com/767683/37188041-17cacbac-2302-11e8-88a7-ceab7bd5f518.png" width="275"/>
