### PR TITLE
De dupe ide steps

### DIFF
--- a/_includes/setup/editor-setup.md
+++ b/_includes/setup/editor-setup.md
@@ -1,8 +1,0 @@
-## Editor setup
-
-Using the `flutter` command-line tools, you can use any editor to develop Flutter applications.
-Type `flutter help` at a prompt to view the available tools.
-
-We recommend using our plug-ins for a [rich IDE experience](/using-ide/) 
-supporting editing, running, and debugging Flutter apps. See [Editor Setup](/get-started/editor/)
-for detailed steps.

--- a/_includes/setup/get-sdk-win.md
+++ b/_includes/setup/get-sdk-win.md
@@ -56,10 +56,6 @@ The first time you run a flutter command (such as `flutter doctor`), it download
 itself. Subsequent runs should be much faster.
 
 The following sections describe how to perform these tasks and finish the setup process.
-You'll see in `flutter doctor` output that if you choose to use an IDE, plugins
-are available for IntelliJ IDEA, Android Studio, and VS Code. See [Editor Setup](/get-started/editor/)
-for the steps to install the Flutter and Dart plugins.
-
 Once you have installed any missing dependencies, run the `flutter doctor` command again to
 verify that you’ve set everything up correctly.
 

--- a/_includes/setup/get-sdk.md
+++ b/_includes/setup/get-sdk.md
@@ -46,9 +46,6 @@ The first time you run a flutter command (such as `flutter doctor`), it download
 itself. Subsequent runs should be much faster.
 
 The following sections describe how to perform these tasks and finish the setup process.
-You'll see in `flutter doctor` output that if you choose to use an IDE, plugins
-are available for IntelliJ IDEA, Android Studio, and VS Code. See [Editor Setup](/get-started/editor/)
-for the steps to install the Flutter and Dart plugins.
 
 Once you have installed any missing dependencies, run the `flutter doctor` command again to
 verify that you’ve set everything up correctly.

--- a/get-started/setup_linux.md
+++ b/get-started/setup_linux.md
@@ -13,8 +13,6 @@ permalink: /setup-linux/
 
 {% include setup/path-mac-linux.md %}
 
-{% include setup/editor-setup.md %}
-
 {% include setup/android-setup.md %}
 
 ## Next step

--- a/get-started/setup_macos.md
+++ b/get-started/setup_macos.md
@@ -13,8 +13,6 @@ permalink: /setup-macos/
 
 {% include setup/path-mac-linux.md %}
 
-{% include setup/editor-setup.md %}
-
 ## Platform setup
 
 macOS supports developing Flutter apps for both iOS and Android. Complete at

--- a/get-started/setup_windows.md
+++ b/get-started/setup_windows.md
@@ -11,8 +11,6 @@ permalink: /setup-windows/
 
 {% include setup/get-sdk-win.md %}
 
-{% include setup/editor-setup.md %}
-
 {% include setup/android-setup.md %}
 
 ## Next step


### PR DESCRIPTION
Currently the install step (https://flutter.io/get-started/install/) has duplication of the IDE setup step (which was moved to https://flutter.io/get-started/editor/)