### PR TITLE
Use IconButton in get-started tutorial

### DIFF
--- a/get-started/codelab/index.md
+++ b/get-started/codelab/index.md
@@ -682,7 +682,8 @@ Add the highlighted lines below:
 </li>
 
 <li markdown="1"> Make the hearts tappable in the `_buildRow`
-    function. If a word entry has already been added to favorites,
+    function by wrapping the Icon in an IconButton. 
+    If a word entry has already been added to favorites,
     tapping it again removes it from favorites.
     When the heart has been tapped, the function calls
     `setState()` to notify the framework that state has changed.
@@ -698,19 +699,25 @@ Add the highlighted lines:
         pair.asPascalCase,
         style: _biggerFont,
       ),
-      trailing: new Icon(
-        alreadySaved ? Icons.favorite : Icons.favorite_border,
-        color: alreadySaved ? Colors.red : null,
-      ),
-      [[highlight]]onTap: () {[[/highlight]]
-        [[highlight]]setState(() {[[/highlight]]
-          [[highlight]]if (alreadySaved) {[[/highlight]]
-            [[highlight]]_saved.remove(pair);[[/highlight]]
-          [[highlight]]} else {[[/highlight]]
-            [[highlight]]_saved.add(pair);[[/highlight]]
-          [[highlight]]}[[/highlight]]
-        [[highlight]]});[[/highlight]]
-      [[highlight]]},[[/highlight]]
+      [[strike]]trailing: new Icon([[/strike]]
+        [[strike]]alreadySaved ? Icons.favorite : Icons.favorite_border,[[/strike]]
+        [[strike]]color: alreadySaved ? Colors.red : null,[[/strike]]
+      [[strike]]),[[/strike]]
+      [[highlight]]trailing: new IconButton([[/highlight]]
+        [[highlight]]icon: new Icon([[/highlight]]
+          [[highlight]]alreadySaved ? Icons.favorite : Icons.favorite_border,[[/highlight]]
+          [[highlight]]color: alreadySaved ? Colors.red : null,[[/highlight]]
+        [[highlight]]),[[/highlight]]
+        [[highlight]]onPressed: () {[[/highlight]]
+          [[highlight]]setState(() {[[/highlight]]
+            [[highlight]]if (alreadySaved) {[[/highlight]]
+              [[highlight]]_saved.remove(pair);[[/highlight]]
+            [[highlight]]} else {[[/highlight]]
+              [[highlight]]_saved.add(pair);[[/highlight]]
+            [[highlight]]}[[/highlight]]
+          [[highlight]]});[[/highlight]]
+        [[highlight]]},[[/highlight]]
+      [[highlight]]),[[/highlight]]
     );
   }
 {% endprettify %}
@@ -724,7 +731,7 @@ a call to the `build()` method for the State object, resulting in
 an update to the UI.
 </aside>
 
-Hot reload the app. You should be able to tap any row to favorite, or unfavorite,
+Hot reload the app. You should be able to tap any heart to favorite, or unfavorite,
 the entry. Note that tapping a row generates an implicit ink splash animation
 that emanates from the heart icon.
 


### PR DESCRIPTION
The get-started (Write Your First Flutter App) walkthrough references making the heart tappable (and saving suggestions).  The code actually makes the ListTile tappable, which leads to some minor inconsistencies in the text.

This PR uses IconButton to wrap the Icon and make _only_ the heart tappable.  The strikethrough/highlighting is a little awkward -- even though the Icon widget is kept, the nature of the diff after adding the wrapping IconButton led me to use strikethrough on the existing trailing parameter.

There is an alternate PR which, instead of changing the code, changes the language to reference tappable tiles instead of tappable hearts.