### PR TITLE
Fix links in "File issue" links

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -10,7 +10,7 @@ layout: default
          <a href="https://github.com/flutter/website/blob/master/{{page.path}}" class="btn btn-sm">
             <i class="fa fa-pencil"></i> Edit Source
          </a>
-         <a href="https://github.com/flutter/flutter/issues/new?title=Issue from website page {{page.title}}&body=From URL: {{site.url}}/{{page.path}}&labels=dev: docs - website" class="btn btn-sm">
+         <a href="https://github.com/flutter/flutter/issues/new?title=Issue from website page {{page.title}}&body=From URL: {{site.url}}{{page.url}}&labels=dev: docs - website" class="btn btn-sm">
             <i class="fa fa-github"></i> File Issue
         </a>
      </div>


### PR DESCRIPTION
`page.path` is the filename from the repo, `page.url` is the url of the resulting page. `url` also is prefixed with `/`.

Fixes https://github.com/flutter/flutter/issues/15349.