### PR TITLE
Make Windows requirements more specific

### DIFF
--- a/_includes/setup/system-win.md
+++ b/_includes/setup/system-win.md
@@ -2,10 +2,11 @@
 
 To install and run Flutter, your development environment must meet these minimum requirements:
 
-* **Operating Systems**: Windows 7 or later (64-bit)
+* **Operating Systems**: Windows 7 SP1 or later (64-bit)
 * **Disk Space**: 400 MB (does not include disk space for Android Studio).
-* **Tools**: Flutter depends on these command-line tools being available in your environment.
-  * [Git for Windows](https://git-scm.com/download/win) (with the Use Git from the Windows Command Prompt option)
-     
+* **Tools**: Flutter depends on these tools being available in your environment.
+  * [PowerShell 5.0](https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell#upgrading-existing-windows-powershell) or newer
+  * [Git for Windows](https://git-scm.com/download/win) (with the "Use Git from the Windows Command Prompt" option)
+
      If Git for Windows is already installed, make sure you can run `git` commands from the
      Command Prompt or PowerShell.


### PR DESCRIPTION
In a follow-up PR we will add a check to flutter_tools to fail if PowerShell 5.0 is not installed.

Preparation for https://github.com/flutter/flutter/issues/11698

/cc @pq 