### PR TITLE
Fix networking example

### DIFF
--- a/cookbook/networking/fetch-data.md
+++ b/cookbook/networking/fetch-data.md
@@ -83,9 +83,9 @@ we'll need to:
 ```dart
 Future<Post> fetchPost() async {
   final response = await http.get('https://jsonplaceholder.typicode.com/posts/1');
-  final _json = json.decode(response.body); 
+  final responseJson = json.decode(response.body); 
   
-  return new Post.fromJson(_json); 
+  return new Post.fromJson(responseJson); 
 }
 ```
 
@@ -134,9 +134,9 @@ import 'package:http/http.dart' as http;
 Future<Post> fetchPost() async {
   final response =
       await http.get('https://jsonplaceholder.typicode.com/posts/1');
-  final _json = json.decode(response.body);
+  final responseJson = json.decode(response.body);
 
-  return new Post.fromJson(_json);
+  return new Post.fromJson(responseJson);
 }
 
 class Post {

--- a/cookbook/networking/fetch-data.md
+++ b/cookbook/networking/fetch-data.md
@@ -83,9 +83,9 @@ we'll need to:
 ```dart
 Future<Post> fetchPost() async {
   final response = await http.get('https://jsonplaceholder.typicode.com/posts/1');
-  final json = json.decode(response.body); 
+  final _json = json.decode(response.body); 
   
-  return new Post.fromJson(json); 
+  return new Post.fromJson(_json); 
 }
 ```
 
@@ -134,9 +134,9 @@ import 'package:http/http.dart' as http;
 Future<Post> fetchPost() async {
   final response =
       await http.get('https://jsonplaceholder.typicode.com/posts/1');
-  final json = json.decode(response.body);
+  final _json = json.decode(response.body);
 
-  return new Post.fromJson(json);
+  return new Post.fromJson(_json);
 }
 
 class Post {


### PR DESCRIPTION
The networking example has this code:

```dart
final json = json.decode(response.body);
```

Which fails with the following error from the analyzer:
> Local variable 'json' can't be referenced before it is declared.

This probably came along with `json` being renamed from the now-deprecated `JSON`.

Renaming the variable to `_json` fixes it.