### PR TITLE
docs: update wording

### DIFF
--- a/_includes/code/animation/basic_staggered_animation/main.dart
+++ b/_includes/code/animation/basic_staggered_animation/main.dart
@@ -103,7 +103,7 @@ class StaggerAnimation extends StatelessWidget {
   final Animation<BorderRadius> borderRadius;
   final Animation<Color> color;
 
-  // This function is called each the controller "ticks" a new frame.
+  // This function is called each time the controller "ticks" a new frame.
   // When it runs, all of the animation's values will have been
   // updated to reflect the controller's current value.
   Widget _buildAnimation(BuildContext context, Widget child) {

--- a/animations/staggered-animations/index.md
+++ b/animations/staggered-animations/index.md
@@ -248,7 +248,7 @@ resulting in a call to `_buildAnimation()`.
   [[highlight]]final Animation<BorderRadius> borderRadius;[[/highlight]]
   [[highlight]]final Animation<Color> color;[[/highlight]]
 
-  // This function is called each the controller "ticks" a new frame.
+  // This function is called each time the controller "ticks" a new frame.
   // When it runs, all of the animation's values will have been
   // updated to reflect the controller's current value.
   [[highlight]]Widget _buildAnimation(BuildContext context, Widget child)[[/highlight]] {

--- a/cookbook/navigation/returning-data.md
+++ b/cookbook/navigation/returning-data.md
@@ -123,7 +123,7 @@ class SelectionScreen extends StatelessWidget {
 
 Now, we'll want to update the `onPressed` callback for both of our buttons! In
 order to return data to the first screen, we'll need to use the 
-[`Navitator.pop`](https://docs.flutter.io/flutter/widgets/Navigator/pop.html)
+[`Navigator.pop`](https://docs.flutter.io/flutter/widgets/Navigator/pop.html)
 method.
 
 `Navigator.pop` accepts an optional second argument called `result`. If we 

--- a/cookbook/persistence/key-value.md
+++ b/cookbook/persistence/key-value.md
@@ -134,9 +134,8 @@ class _MyHomePageState extends State<MyHomePage> {
   //Incrementing counter after click
   _incrementCounter() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    _counter = (prefs.getInt('counter') ?? 0) + 1;
     setState(() {
-      _counter;
+      _counter = (prefs.getInt('counter') ?? 0) + 1;
     });
     prefs.setInt('counter', _counter);
   }
@@ -190,3 +189,5 @@ const MethodChannel('plugins.flutter.io/shared_preferences')
     return null;
   });
 ```
+
+The code above should be placed inside a test file under the `test` folder.

--- a/cookbook/persistence/key-value.md
+++ b/cookbook/persistence/key-value.md
@@ -189,5 +189,3 @@ const MethodChannel('plugins.flutter.io/shared_preferences')
     return null;
   });
 ```
-
-The code above should be placed inside a test file under the `test` folder.

--- a/flutter-for-android.md
+++ b/flutter-for-android.md
@@ -33,7 +33,7 @@ every new frame, Flutter's framework creates a new tree of widget instances. In
 comparison, an Android view is drawn once and does not redraw until invalidate
 is called.
 
-Unlike Android’s view hierarchy system where the framework mutate views,
+Unlike Android’s view hierarchy system where the framework mutates views,
 widgets in Flutter are immutable. This allows Flutter widgets to be very
 lightweight.
 

--- a/flutter-for-react-native.md
+++ b/flutter-for-react-native.md
@@ -1707,8 +1707,10 @@ void _submit() {
 
 ## Platform-specific code
 
-When building a cross-platform app, you'll want to re-use as much code as possible across platforms. Scenarios may arise where it makes sense for the code to be different. In React Native, separate implementation can be given at almost anywhere in the app code by recognizing the platform the app will run on. To get the target platform,
-you can either use platform file extensions or the `Platform` module as below:
+When building a cross-platform app, you'll want to re-use as much code as possible across platforms. Scenarios may arise
+where it makes sense for the code to be different. In React Native, a separate implementation can be given almost
+anywhere in the app code by recognizing the platform the app will run on. To get the target platform, you can either use
+platform file extensions, or the `Platform` module as below:
 
 <!-- skip -->
 {% prettify javascript %}

--- a/flutter-for-react-native.md
+++ b/flutter-for-react-native.md
@@ -430,7 +430,7 @@ new CustomCard(
     ...
 {% endprettify %}
 
-The constructor for the `CustomCard` class shows a Dart feature. The curly braces inside the constructor indicates that the parameters are optional when initialising. In order to make these fields required, we have two options- first one is to remove the curly braces from the constructor and the second is to add the `@required` to the constructor. The latter approach enables the developer to provide parameter names when using the `CustomCard` class in the app code as show in the (Usage section) example above. 
+The constructor for the `CustomCard` class shows a Dart feature. The curly braces inside the constructor indicates that the parameters are optional when initialising. In order to make these fields required, we have two options- first one is to remove the curly braces from the constructor and the second is to add the `@required` to the constructor. The latter approach enables the developer to provide parameter names when using the `CustomCard` class in the app code as shown in the (Usage section) example above. 
 
 #### Preview
 
@@ -634,7 +634,7 @@ render() {
 }
 {% endprettify %}
 
-In Flutter, we use [`CustomPaint`](https://docs.flutter.io/flutter/widgets/CustomPaint-class.html) widget to draw during the paint phase. We implement abstract class [`CustomPainter`](https://docs.flutter.io/flutter/rendering/CustomPainter-class.html) and pass it to `painter` property in `CustomPaint` widget.
+In Flutter, we use the [`CustomPaint`](https://docs.flutter.io/flutter/widgets/CustomPaint-class.html) widget to draw during the paint phase. We implement abstract class [`CustomPainter`](https://docs.flutter.io/flutter/rendering/CustomPainter-class.html) and pass it to `painter` property in `CustomPaint` widget.
 
 <!-- skip -->
 {% prettify dart %}
@@ -1121,7 +1121,7 @@ class MyStatelessWidget extends StatelessWidget {
 
 ### Props
 
-In React Native, most components can be customized when they are created with different parameters. These creation parameters are called props. These parameters can be used in child component using `this.props`.
+In React Native, most components can be customized when they are created with different parameters. These creation parameters are called props. These parameters can be used in a child component using `this.props`.
 
 <!-- skip -->
 {% prettify javascript %}
@@ -1707,7 +1707,8 @@ void _submit() {
 
 ## Platform-specific code
 
-When building a cross-platform app, you'll want to re-use as much code as possible across platforms. Scenarios may arise where it makes sense for the code to be different. In React Native, separate implementation can be given at almost anywhere in the app code by recognizing the platform the app will run on. To get the target platform, you need to use this component :
+When building a cross-platform app, you'll want to re-use as much code as possible across platforms. Scenarios may arise where it makes sense for the code to be different. In React Native, separate implementation can be given at almost anywhere in the app code by recognizing the platform the app will run on. To get the target platform,
+you can either use platform file extensions or the `Platform` module as below:
 
 <!-- skip -->
 {% prettify javascript %}
@@ -1814,7 +1815,7 @@ class FadeInView extends React.Component {
     ...
 {% endprettify %}
 
-In the equivalent Flutter example, we use an [`AnimationController`](https://docs.flutter.io/flutter/animation/AnimationController-class.html) object `controller` and specify the duration inside it. We animation is defined as a [`Tween`](https://docs.flutter.io/flutter/animation/Tween-class.html) which basically describes some interpolation between a beginning and ending value. We are using a [`FadeTransition`](https://docs.flutter.io/flutter/widgets/FadeTransition-class.html) widget where we have `opacity` property which is mapped to the `animation` object. The sole job of a Tween is to define a mapping from an input range to an output range. Then we start the animation using `controller.forward()`. We can perform other operations too using the controller. In the example, We are using the [`FlutterLogo`](https://docs.flutter.io/flutter/material/FlutterLogo-class.html) inside the `FadeTransition` widget.
+In the equivalent Flutter example, we use an [`AnimationController`](https://docs.flutter.io/flutter/animation/AnimationController-class.html) object `controller` and specify the duration inside it. The animation is defined as a [`Tween`](https://docs.flutter.io/flutter/animation/Tween-class.html) which basically describes some interpolation between a beginning and ending value. We are using a [`FadeTransition`](https://docs.flutter.io/flutter/widgets/FadeTransition-class.html) widget where we have `opacity` property which is mapped to the `animation` object. The sole job of a Tween is to define a mapping from an input range to an output range. Then we start the animation using `controller.forward()`. We can perform other operations too using the controller. In the example, We are using the [`FlutterLogo`](https://docs.flutter.io/flutter/material/FlutterLogo-class.html) inside the `FadeTransition` widget.
 
 <!-- skip -->
 {% prettify dart %}

--- a/tutorials/interactive/index.md
+++ b/tutorials/interactive/index.md
@@ -41,7 +41,7 @@ that manages two stateless widgets.
 
 ## Getting ready
 
-If you've already build the layout in
+If you've already built the layout in
 [Building Layouts in Flutter](/tutorials/layout/),
 skip to the next section.
 

--- a/tutorials/layout/index.md
+++ b/tutorials/layout/index.md
@@ -1482,7 +1482,7 @@ class _MyHomePageState extends State<MyHomePage> {
 ### Card
 
 A Card, from the Material Components library, contains related nuggets of information
-and can be composed from most any widget, but is often used with ListTile.
+and can be composed from almost any widget, but is often used with ListTile.
 Card has a single child, but its child can be a column, row, list, grid,
 or other widget that supports multiple children. By default, a Card shrinks
 its size to 0 by 0 pixels. You can use

--- a/web-analogs.md
+++ b/web-analogs.md
@@ -157,10 +157,10 @@ var container = new Container( // grey box
 ### Setting Container Width
 
 To specify the width of a [Container](https://docs.flutter.io/flutter/widgets/Container-class.html)
-widget you set its ```width``` property just like in CSS. To
-mimic CSS's ```max-width``` in Flutter, use the ```constraints``` property of the Container.
+widget you set its `width` property just like in CSS. To
+mimic CSS's `max-width` in Flutter, use the `constraints` property of the Container.
 Create a new [BoxConstraints](https://docs.flutter.io/flutter/rendering/BoxConstraints-class.html)
-widget with a ```minWidth``` or ```maxWidth```.
+widget with a `minWidth` or `maxWidth`.
 
 For nested Containers, if the parent’s width is less than the child’s width,
 the child Container sizes itself to match the parent.

--- a/web-analogs.md
+++ b/web-analogs.md
@@ -79,7 +79,7 @@ the top left.
 </div>
 
 ### Setting Background Color
-In Flutter, you set background color in a [Container](https://docs.flutter.io/flutter/widgets/Container-class.html)’s
+In Flutter, you set the background color in a [Container](https://docs.flutter.io/flutter/widgets/Container-class.html)’s
 ```decoration``` property.
 
 The CSS examples use the hex color equivalents to the Material color palette.
@@ -157,9 +157,8 @@ var container = new Container( // grey box
 ### Setting Container Width
 
 To specify the width of a [Container](https://docs.flutter.io/flutter/widgets/Container-class.html)
-widget you set its ```width``` property. This is a fixed width, unlike the
-CSS max-width property which adjusts container width up to a maximum value. To
-mimic that effect in Flutter, use the ```constraints``` property of the Container.
+widget you set its ```width``` property just like in CSS. To
+mimic CSS's ```max-width``` in Flutter, use the ```constraints``` property of the Container.
 Create a new [BoxConstraints](https://docs.flutter.io/flutter/rendering/BoxConstraints-class.html)
 widget with a ```minWidth``` or ```maxWidth```.
 
@@ -665,7 +664,8 @@ var container = new Container( // grey box
 
 ### Making Circles and Ellipses
 Making a circle in CSS requires a workaround of applying a border-radius of
-50% to all four sides of a rectangle.
+50% to all four sides of a rectangle (although there are [basic-shapes](https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape)
+for some tasks).
 
 While this approach is supported with the ```borderRadius``` property of
 [BoxDecoration](https://docs.flutter.io/flutter/painting/BoxDecoration-class.html),
@@ -801,7 +801,7 @@ property.
 
 In Flutter, you transform the contents of a Text widget using the methods and
 operators of the [String class](https://docs.flutter.io/flutter/dart-core/String-class.html)
-in the dart:core library.
+in the dart:core library as you would with JavaScript instead.
 <div class="lefthighlight">
 {% prettify css%}
 <div class="greybox">

--- a/widgets-intro.md
+++ b/widgets-intro.md
@@ -350,7 +350,7 @@ class MyButton extends StatelessWidget {
 
 The
 [`GestureDetector`](https://docs.flutter.io/flutter/widgets/GestureDetector-class.html)
-widget doesn't have an visual representation but instead detects gestures made
+widget doesn't have a visual representation but instead detects gestures made
 by the user. When the user taps the
 [`Container`](https://docs.flutter.io/flutter/widgets/Container-class.html),
 the
@@ -632,7 +632,7 @@ class _ShoppingListState extends State<ShoppingList> {
 
   void _handleCartChanged(Product product, bool inCart) {
     setState(() {
-      // When user changes what is in the cart, we need to change _shoppingCart
+      // When a user changes what is in the cart, we need to change _shoppingCart
       // inside a setState call to trigger a rebuild. The framework then calls
       // build, below, which updates the visual appearance of the app.
 


### PR DESCRIPTION
Fixed some typos and made some perhaps more controversial wording changes.

I have these observations too, what would be the best way to raise these?

* A bit odd that the JS/Dart comparison is in the React Native section not the web dev section or a completely separate one?
* What is the equivalent of the React Native Hello World app in Flutter? - The Flutter one appears to "render" the app but the "render" logic isn't in the RN example?
* `CustomCard({@required this.index, @required this.onPress});` essentially has `PropTypes` but the RN example doesn't have them?