### PR TITLE
Create flutter-for-ios.md

### DIFF
--- a/flutter-for-ios.md
+++ b/flutter-for-ios.md
@@ -5,7 +5,7 @@ permalink: /flutter-for-ios/
 ---
 
 This document is meant for iOS developers looking to apply their
-existing iOS  knowledge to build mobile apps with Flutter. If you understand
+existing iOS knowledge to build mobile apps with Flutter. If you understand
 the fundamentals of the iOS framework then you can use this document as a
 jump start to Flutter development.
 

--- a/flutter-for-ios.md
+++ b/flutter-for-ios.md
@@ -4,6 +4,12 @@ title: Flutter for iOS Developers
 permalink: /flutter-for-ios/
 ---
 
+# This document is a work in progress
+We're working on this document right now. Please do not rely on its completeness
+and accuracy until it's finished and it's shown in the sidebar as a link.
+
+---
+
 This document is meant for iOS developers looking to apply their
 existing iOS knowledge to build mobile apps with Flutter. If you understand
 the fundamentals of the iOS framework then you can use this document as a

--- a/flutter-for-ios.md
+++ b/flutter-for-ios.md
@@ -1,0 +1,23 @@
+---
+layout: page
+title: Flutter for iOS Developers
+permalink: /flutter-for-ios/
+---
+
+This document is meant for iOS developers looking to apply their
+existing iOS  knowledge to build mobile apps with Flutter. If you understand
+the fundamentals of the iOS framework then you can use this document as a
+jump start to Flutter development.
+
+Your iOS knowledge and skill set are highly valuable when building with
+Flutter, because Flutter relies on the mobile operating system for numerous
+capabilities and configurations. Flutter is a new way to build UIs for mobile,
+but it has a plugin system to communicate with iOS (and Android) for non-UI
+tasks. If you're an expert in iOS development, you don't have to relearn everything
+to use Flutter.
+
+This document can be used as a cookbook by jumping around and finding questions
+that are most relevant to your needs.
+
+* TOC Placeholder
+{:toc}


### PR DESCRIPTION
This PR creates the page for the new `Flutter for iOS devs`. It does not contain any content except for the intro (tweaked from the one in the `Flutter for Android devs` page).

Content will come in subsequent PRs, and we aren't adding the page to the sidebar yet — we'll do it when it's ready to go. For now it'll only accessible at `http://flutter.io/flutter-for-ios/` (once the PR is merged).