### PR TITLE
Fix code validation issue

### DIFF
--- a/text-input.md
+++ b/text-input.md
@@ -105,7 +105,7 @@ class _ExampleWidgetState extends State<ExampleWidget> {
           onPressed: () {
             showDialog(
               context: context,
-              child: new AlertDialog(
+              builder: (_) => new AlertDialog(
                 title: new Text('What you typed'),
                 content: new Text(_controller.text),
               ),


### PR DESCRIPTION
Currently failing with `child' is deprecated and shouldn't be used at example/text_input_md_1.dart:31:15 • deprecated_member_use`