### PR TITLE
Update Flutter for Android section on assets for 1.0 Beta 2

### DIFF
--- a/flutter-for-android.md
+++ b/flutter-for-android.md
@@ -1146,7 +1146,7 @@ class _SampleAppPageState extends State<SampleAppPage> {
 
 While Android has resources as a distinct notion from assets, Flutter apps have
 only assets. All your resources which would be living in the `res/drawable-*`
-folders on Android, should be instead put in an assets folder.
+folders on Android should be instead put in an assets folder.
 
 Flutter follows a simple density-based format like iOS. Assets can be `1.0x`, 
 `2.0x`, `3.0x`, or any other multiplier. Flutter doesn't have `dp`s but there
@@ -1169,12 +1169,12 @@ Assets on Flutter can be located in any arbitrary folder; there is no predefined
 folder structure. You then declare where the assets are located in the pubspec
 file, and Flutter will pick them up.
 
-Note that before Flutter 1.0 beta 2, assets
+Note that before Flutter beta 2, assets
 defined in Flutter are not accessible from the native side, and vice versa,
 native assets and resources aren't available from Flutter as they live in
 separate folders.
 
-Starting from Flutter 1.0 beta 2, Flutter assets are stored in
+Starting from Flutter beta 2, Flutter assets are stored in
 the native asset folder, and can be accessed on the native side via the Android
 `AssetManager`:
 
@@ -1183,7 +1183,7 @@ the native asset folder, and can be accessed on the native side via the Android
 val flutterAssetStream = assetManager.open("flutter_assets/assets/my_flutter_asset.png")
 {% endprettify %}
 
-As of Flutter 1.0 beta 2, Flutter still cannot access native resources, nor it can
+As of Flutter beta 2, Flutter still cannot access native resources, nor it can
 access native assets
 
 To add a new image asset called `my_icon.png` to our Flutter project, for example,

--- a/flutter-for-android.md
+++ b/flutter-for-android.md
@@ -1167,9 +1167,24 @@ The equivalent to Android's density buckets are:
 
 Assets on Flutter can be located in any arbitrary folder; there is no predefined
 folder structure. You then declare where the assets are located in the pubspec
-file, and Flutter will pick them up. Note that Flutter assets are not accessible
-from the native side, and vice versa native assets and resources aren't available
-from Flutter as they live in separate folders.
+file, and Flutter will pick them up.
+
+Note that before Flutter 1.0 beta 2, assets
+defined in Flutter are not accessible from the native side, and vice versa,
+native assets and resources aren't available from Flutter as they live in
+separate folders.
+
+Starting from Flutter 1.0 beta 2, Flutter assets are stored in
+the native asset folder, and can be accessed on the native side via the Android
+`AssetManager`:
+
+<!-- skip -->
+{% prettify kotlin %}
+val flutterAssetStream = assetManager.open("flutter_assets/assets/my_flutter_asset.png")
+{% endprettify %}
+
+As of Flutter 1.0 beta 2, Flutter still cannot access native resources, nor it can
+access native assets
 
 To add a new image asset called `my_icon.png` to our Flutter project, for example,
 and deciding that it should live in a folder we arbitrarily called `images`, you
@@ -1190,7 +1205,7 @@ assets:
  - images/my_icon.jpeg
 {% endprettify %}
 
-You can then access your images using AssetImage
+You can then access your images using `AssetImage`:
 
 <!-- skip -->
 {% prettify dart %}
@@ -1201,7 +1216,10 @@ or directly in an `Image` widget:
 
 <!-- skip -->
 {% prettify dart %}
-return new AssetImage("images/a_dot_burr.jpeg");
+@override
+Widget build(BuildContext context) {
+  return new Image.asset("images/my_image.png");
+}
 {% endprettify %}
 
 ## Where do I store strings? How do I handle localization?


### PR DESCRIPTION
This PR updates the section on assets to align it with the new assets handling for Flutter 1.0 Beta 2.

Since there is no up-to-date documentation about it, please make sure you double check the contents. I have interpolated from the code and with some experiments what is going on, and am relatively sure it makes sense, but please check again.