### PR TITLE
Change OS tabs to default to current users OS

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -1,4 +1,4 @@
-function setupToolsTabs(container, tabIdPrefix, storageName) {
+function setupToolsTabs(container, tabIdPrefix, storageName, defaultTab) {
   var tabs = $('.tabs__top-bar li', container);
   var tabContents = $('.tabs__content', container);
 
@@ -49,9 +49,21 @@ function setupToolsTabs(container, tabIdPrefix, storageName) {
     selectTool(location.hash.substr(1));
   else if (storageName && window.localStorage && window.localStorage.getItem(storageName))
     selectTool(window.localStorage.getItem(storageName));
+  else if (defaultTab)
+    selectTool(defaultTab);
 }
 
 $(document).ready(function () {
   setupToolsTabs($("#tab-set-install"), "tab-install-", "selectedTool");
-  setupToolsTabs($("#tab-set-os"), "tab-os-", null);
+  setupToolsTabs($("#tab-set-os"), "tab-os-", null, getOS());
 });
+
+function getOS() {
+  var ua = navigator.userAgent.toLowerCase();
+  if (ua.indexOf("win") !== -1)
+    return "windows";
+  if (ua.indexOf("mac") !== -1)
+    return "macos";
+  if (ua.indexOf("linux") !== -1)
+    return "linux";
+}

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -40,18 +40,18 @@ function setupToolsTabs(container, tabIdPrefix, storageName) {
       history.replaceState(undefined, undefined, '#' + selectedTool);
 
     // Persist in local storage so we can pre-select around the site
-    if (window.localStorage)
+    if (storageName && window.localStorage)
       window.localStorage.setItem(storageName, selectedTool);
   });
 
   // If we have a tool in the url fragement, pre-select it
   if (location.hash && location.hash.length > 1)
     selectTool(location.hash.substr(1));
-  else if (window.localStorage && window.localStorage.getItem(storageName))
+  else if (storageName && window.localStorage && window.localStorage.getItem(storageName))
     selectTool(window.localStorage.getItem(storageName));
 }
 
 $(document).ready(function () {
   setupToolsTabs($("#tab-set-install"), "tab-install-", "selectedTool");
-  setupToolsTabs($("#tab-set-os"), "tab-os-", "selectedOS");
+  setupToolsTabs($("#tab-set-os"), "tab-os-", null);
 });

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -59,11 +59,13 @@ $(document).ready(function () {
 });
 
 function getOS() {
-  var ua = navigator.userAgent.toLowerCase();
-  if (ua.indexOf("win") !== -1)
+  var ua = navigator.userAgent;
+  if (ua.indexOf("Win") !== -1)
     return "windows";
-  if (ua.indexOf("mac") !== -1)
+  if (ua.indexOf("Mac") !== -1)
     return "macos";
-  if (ua.indexOf("linux") !== -1)
+  if (ua.indexOf("Linux") !== -1)
+    return "linux";
+  if (ua.indexOf("X11") !== -1)
     return "linux";
 }

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -64,8 +64,6 @@ function getOS() {
     return "windows";
   if (ua.indexOf("Mac") !== -1)
     return "macos";
-  if (ua.indexOf("Linux") !== -1)
-    return "linux";
-  if (ua.indexOf("X11") !== -1)
+  if (ua.indexOf("Linux") !== -1 || ua.indexOf("X11") !== -1)
     return "linux";
 }


### PR DESCRIPTION
This makes the OS tabs default to the users current OS. It no longer persists OS selection in local storage and the hash fragment in the URL still takes precedence.

Staged here:

https://dantup-flutter-staging.firebaseapp.com/sdk-archive/

I don't know how reliable the `userAgent` check is so LMK if you have any ideas on improving it.