### PR TITLE
Reenable proper .md snippet extraction, fix analysis errors in cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,14 +140,14 @@ it with triple backticks followed by the language.
 
 Here's an example:
 
-<!-- skip -->
-
 	```dart
-	class SomeCode {
-	  String name;
-	}
+	class ExampleWidget extends StatelessWidget {
+      @override
+      Widget build(BuildContext context) {
+        return new Container();
+      }
+    }
 	```
-
 
 See the list of supported languages above for what to use
 following the first triple backticks.

--- a/catalog/samples/animated_list.md
+++ b/catalog/samples/animated_list.md
@@ -48,7 +48,8 @@ class AnimatedListSample extends StatefulWidget {
 }
 
 class _AnimatedListSampleState extends State<AnimatedListSample> {
-  final GlobalKey<AnimatedListState> _listKey = new GlobalKey<AnimatedListState>();
+  final GlobalKey<AnimatedListState> _listKey =
+      new GlobalKey<AnimatedListState>();
   ListModel<int> _list;
   int _selectedItem;
   int _nextItem; // The next item inserted when the user presses the '+' button.
@@ -65,7 +66,8 @@ class _AnimatedListSampleState extends State<AnimatedListSample> {
   }
 
   // Used to build list items that haven't been removed.
-  Widget _buildItem(BuildContext context, int index, Animation<double> animation) {
+  Widget _buildItem(
+      BuildContext context, int index, Animation<double> animation) {
     return new CardItem(
       animation: animation,
       item: _list[index],
@@ -83,7 +85,8 @@ class _AnimatedListSampleState extends State<AnimatedListSample> {
   // completed (even though it's gone as far this ListModel is concerned).
   // The widget will be used by the [AnimatedListState.removeItem] method's
   // [AnimatedListRemovedItemBuilder] parameter.
-  Widget _buildRemovedItem(int item, BuildContext context, Animation<double> animation) {
+  Widget _buildRemovedItem(
+      int item, BuildContext context, Animation<double> animation) {
     return new CardItem(
       animation: animation,
       item: item,
@@ -94,7 +97,8 @@ class _AnimatedListSampleState extends State<AnimatedListSample> {
 
   // Insert the "next item" into the list model.
   void _insert() {
-    final int index = _selectedItem == null ? _list.length : _list.indexOf(_selectedItem);
+    final int index =
+        _selectedItem == null ? _list.length : _list.indexOf(_selectedItem);
     _list.insert(index, _nextItem++);
   }
 
@@ -154,9 +158,9 @@ class ListModel<E> {
     @required this.listKey,
     @required this.removedItemBuilder,
     Iterable<E> initialItems,
-  }) : assert(listKey != null),
-       assert(removedItemBuilder != null),
-       _items = new List<E>.from(initialItems ?? <E>[]);
+  })  : assert(listKey != null),
+        assert(removedItemBuilder != null),
+        _items = new List<E>.from(initialItems ?? <E>[]);
 
   final GlobalKey<AnimatedListState> listKey;
   final dynamic removedItemBuilder;
@@ -172,7 +176,8 @@ class ListModel<E> {
   E removeAt(int index) {
     final E removedItem = _items.removeAt(index);
     if (removedItem != null) {
-      _animatedList.removeItem(index, (BuildContext context, Animation<double> animation) {
+      _animatedList.removeItem(index,
+          (BuildContext context, Animation<double> animation) {
         return removedItemBuilder(removedItem, context, animation);
       });
     }
@@ -180,7 +185,9 @@ class ListModel<E> {
   }
 
   int get length => _items.length;
+
   E operator [](int index) => _items[index];
+
   int indexOf(E item) => _items.indexOf(item);
 }
 
@@ -189,16 +196,16 @@ class ListModel<E> {
 /// This widget's height is based on the animation parameter, it varies
 /// from 0 to 128 as the animation varies from 0.0 to 1.0.
 class CardItem extends StatelessWidget {
-  const CardItem({
-    Key key,
-    @required this.animation,
-    this.onTap,
-    @required this.item,
-    this.selected: false
-  }) : assert(animation != null),
-       assert(item != null && item >= 0),
-       assert(selected != null),
-       super(key: key);
+  const CardItem(
+      {Key key,
+      @required this.animation,
+      this.onTap,
+      @required this.item,
+      this.selected: false})
+      : assert(animation != null),
+        assert(item != null && item >= 0),
+        assert(selected != null),
+        super(key: key);
 
   final Animation<double> animation;
   final VoidCallback onTap;

--- a/catalog/samples/app_bar_bottom.md
+++ b/catalog/samples/app_bar_bottom.md
@@ -43,7 +43,8 @@ class AppBarBottomSample extends StatefulWidget {
   _AppBarBottomSampleState createState() => new _AppBarBottomSampleState();
 }
 
-class _AppBarBottomSampleState extends State<AppBarBottomSample> with SingleTickerProviderStateMixin {
+class _AppBarBottomSampleState extends State<AppBarBottomSample>
+    with SingleTickerProviderStateMixin {
   TabController _tabController;
 
   @override
@@ -60,8 +61,7 @@ class _AppBarBottomSampleState extends State<AppBarBottomSample> with SingleTick
 
   void _nextPage(int delta) {
     final int newIndex = _tabController.index + delta;
-    if (newIndex < 0 || newIndex >= _tabController.length)
-      return;
+    if (newIndex < 0 || newIndex >= _tabController.length) return;
     _tabController.animateTo(newIndex);
   }
 
@@ -74,13 +74,17 @@ class _AppBarBottomSampleState extends State<AppBarBottomSample> with SingleTick
           leading: new IconButton(
             tooltip: 'Previous choice',
             icon: const Icon(Icons.arrow_back),
-            onPressed: () { _nextPage(-1); },
+            onPressed: () {
+              _nextPage(-1);
+            },
           ),
           actions: <Widget>[
             new IconButton(
               icon: const Icon(Icons.arrow_forward),
               tooltip: 'Next choice',
-              onPressed: () { _nextPage(1); },
+              onPressed: () {
+                _nextPage(1);
+              },
             ),
           ],
           bottom: new PreferredSize(
@@ -110,7 +114,8 @@ class _AppBarBottomSampleState extends State<AppBarBottomSample> with SingleTick
 }
 
 class Choice {
-  const Choice({ this.title, this.icon });
+  const Choice({this.title, this.icon});
+
   final String title;
   final IconData icon;
 }
@@ -125,7 +130,7 @@ const List<Choice> choices = const <Choice>[
 ];
 
 class ChoiceCard extends StatelessWidget {
-  const ChoiceCard({ Key key, this.choice }) : super(key: key);
+  const ChoiceCard({Key key, this.choice}) : super(key: key);
 
   final Choice choice;
 

--- a/catalog/samples/basic_app_bar.md
+++ b/catalog/samples/basic_app_bar.md
@@ -46,7 +46,8 @@ class _BasicAppBarSampleState extends State<BasicAppBarSample> {
   Choice _selectedChoice = choices[0]; // The app's "state".
 
   void _select(Choice choice) {
-    setState(() { // Causes the app to rebuild with the new _selectedChoice.
+    // Causes the app to rebuild with the new _selectedChoice.
+    setState(() {
       _selectedChoice = choice;
     });
   }
@@ -58,15 +59,22 @@ class _BasicAppBarSampleState extends State<BasicAppBarSample> {
         appBar: new AppBar(
           title: const Text('Basic AppBar'),
           actions: <Widget>[
-            new IconButton( // action button
+            // action button
+            new IconButton(
               icon: new Icon(choices[0].icon),
-              onPressed: () { _select(choices[0]); },
+              onPressed: () {
+                _select(choices[0]);
+              },
             ),
-            new IconButton( // action button
+            // action button
+            new IconButton(
               icon: new Icon(choices[1].icon),
-              onPressed: () { _select(choices[1]); },
+              onPressed: () {
+                _select(choices[1]);
+              },
             ),
-            new PopupMenuButton<Choice>( // overflow menu
+            // overflow menu
+            new PopupMenuButton<Choice>(
               onSelected: _select,
               itemBuilder: (BuildContext context) {
                 return choices.skip(2).map((Choice choice) {
@@ -89,7 +97,8 @@ class _BasicAppBarSampleState extends State<BasicAppBarSample> {
 }
 
 class Choice {
-  const Choice({ this.title, this.icon });
+  const Choice({this.title, this.icon});
+
   final String title;
   final IconData icon;
 }
@@ -104,7 +113,7 @@ const List<Choice> choices = const <Choice>[
 ];
 
 class ChoiceCard extends StatelessWidget {
-  const ChoiceCard({ Key key, this.choice }) : super(key: key);
+  const ChoiceCard({Key key, this.choice}) : super(key: key);
 
   final Choice choice;
 

--- a/catalog/samples/expansion_tile_sample.md
+++ b/catalog/samples/expansion_tile_sample.md
@@ -51,7 +51,8 @@ class ExpansionTileSample extends StatelessWidget {
           title: const Text('ExpansionTile'),
         ),
         body: new ListView.builder(
-          itemBuilder: (BuildContext context, int index) => new EntryItem(data[index]),
+          itemBuilder: (BuildContext context, int index) =>
+              new EntryItem(data[index]),
           itemCount: data.length,
         ),
       ),
@@ -62,15 +63,18 @@ class ExpansionTileSample extends StatelessWidget {
 // One entry in the multilevel list displayed by this app.
 class Entry {
   Entry(this.title, [this.children = const <Entry>[]]);
+
   final String title;
   final List<Entry> children;
 }
 
 // The entire multilevel list displayed by this app.
 final List<Entry> data = <Entry>[
-  new Entry('Chapter A',
+  new Entry(
+    'Chapter A',
     <Entry>[
-      new Entry('Section A0',
+      new Entry(
+        'Section A0',
         <Entry>[
           new Entry('Item A0.1'),
           new Entry('Item A0.2'),
@@ -81,17 +85,20 @@ final List<Entry> data = <Entry>[
       new Entry('Section A2'),
     ],
   ),
-  new Entry('Chapter B',
+  new Entry(
+    'Chapter B',
     <Entry>[
       new Entry('Section B0'),
       new Entry('Section B1'),
     ],
   ),
-  new Entry('Chapter C',
+  new Entry(
+    'Chapter C',
     <Entry>[
       new Entry('Section C0'),
       new Entry('Section C1'),
-      new Entry('Section C2',
+      new Entry(
+        'Section C2',
         <Entry>[
           new Entry('Item C2.0'),
           new Entry('Item C2.1'),
@@ -111,8 +118,7 @@ class EntryItem extends StatelessWidget {
   final Entry entry;
 
   Widget _buildTiles(Entry root) {
-    if (root.children.isEmpty)
-      return new ListTile(title: new Text(root.title));
+    if (root.children.isEmpty) return new ListTile(title: new Text(root.title));
     return new ExpansionTile(
       key: new PageStorageKey<Entry>(root),
       title: new Text(root.title),

--- a/catalog/samples/tabbed_app_bar.md
+++ b/catalog/samples/tabbed_app_bar.md
@@ -70,7 +70,8 @@ class TabbedAppBarSample extends StatelessWidget {
 }
 
 class Choice {
-  const Choice({ this.title, this.icon });
+  const Choice({this.title, this.icon});
+
   final String title;
   final IconData icon;
 }
@@ -85,7 +86,7 @@ const List<Choice> choices = const <Choice>[
 ];
 
 class ChoiceCard extends StatelessWidget {
-  const ChoiceCard({ Key key, this.choice }) : super(key: key);
+  const ChoiceCard({Key key, this.choice}) : super(key: key);
 
   final Choice choice;
 

--- a/cookbook/animation/opacity-animation.md
+++ b/cookbook/animation/opacity-animation.md
@@ -24,6 +24,7 @@ Widget.
 First, we'll need something to fade in and out! In this example, we'll draw a
 green box on screen.
 
+<!-- skip -->
 ```dart
 new Container(
   width: 200.0,
@@ -50,6 +51,7 @@ To construct a `StatefulWidget`, we need to create two classes: A
 for Android Studio and VSCode include the `stful` snippet to quickly generate 
 this code!
 
+<!-- skip -->
 ```dart
 // The StatefulWidget's job is to take in some data and create a State class.
 // In this case, our Widget takes in a title, and creates a _MyHomePageState.
@@ -90,6 +92,7 @@ rebuild the Widget.
 Note: For more information on working with user input, please see the 
 [Handling Gestures](/cookbook/#handling-gestures) section of the Cookbook.
 
+<!-- skip -->
 ```dart
 new FloatingActionButton(
   onPressed: () {
@@ -117,6 +120,7 @@ The `AnimatedOpacity` Widget requires three arguments:
   * `duration`: How long the animation should take to complete
   * `child`: The Widget to animate. In our case, the green box.
 
+<!-- skip -->
 ```dart
 new AnimatedOpacity(
   // If the Widget should be visible, animate to 1.0 (fully visible). If

--- a/cookbook/design/drawer.md
+++ b/cookbook/design/drawer.md
@@ -28,6 +28,7 @@ components, such as Drawers, AppBars, and SnackBars.
 
 In this case, we'll want to create a `Scaffold` with a `drawer`:
 
+<!-- skip -->
 ```dart
 new Scaffold(
   drawer: // We'll add our Drawer here in the next step!
@@ -40,6 +41,7 @@ We can now add a drawer to our `Scaffold`. A drawer could be any Widget, but
 it's often best to use the `Drawer` widget from the [material library](https://docs.flutter.io/flutter/material/material-library.html), 
 which adheres to the Material Design spec.
 
+<!-- skip -->
 ```dart
 new Scaffold(
   drawer: new Drawer(
@@ -61,6 +63,7 @@ and two [`ListTile`](https://docs.flutter.io/flutter/material/ListTile-class.htm
 Widgets. For more information on working with Lists, please see the 
 [list recipes](/cookbook/#lists).
 
+<!-- skip -->
 ```dart
 new Drawer(
   // Add a ListView to the drawer. This ensures the user can scroll
@@ -104,6 +107,7 @@ When a user opens the Drawer, Flutter will add the drawer to the navigation
 stack under the hood. Therefore, to close the drawer, we can call 
 `Navigator.pop(context)`.  
 
+<!-- skip -->
 ```dart
 new ListTile(
   title: new Text('Item 1'),

--- a/cookbook/design/fonts.md
+++ b/cookbook/design/fonts.md
@@ -94,6 +94,7 @@ To use a font as the default, we can set the `fontFamily` property as part of
 the app's `theme`. The value we provide to `fontFamily` must match the `family` 
 name declared in the `pubspec.yaml`. 
 
+<!-- skip -->
 ```dart
 new MaterialApp(
   title: 'Custom Fonts',
@@ -116,6 +117,7 @@ In this example, we'll apply the RobotoMono font to a single `Text` Widget. Once
 again, the `fontFamily` must match the `family` name we declared in the 
 `pubspec.yaml`. 
 
+<!-- skip -->
 ```dart
 new Text(
   'Roboto Mono sample',
@@ -191,7 +193,7 @@ class MyHomePage extends StatelessWidget {
       // The AppBar will use the app-default Raleway font
       appBar: new AppBar(title: new Text('Custom Fonts')),
       body: new Center(
-        // This Text Widget will use the RobotoMono font 
+        // This Text Widget will use the RobotoMono font
         child: new Text(
           'Roboto Mono sample',
           style: new TextStyle(fontFamily: 'RobotoMono'),

--- a/cookbook/design/orientation.md
+++ b/cookbook/design/orientation.md
@@ -25,6 +25,7 @@ First, we'll need a list of items to work with. Rather than using a normal list,
 we'll want a list that displays items in a Grid. For now, we'll create a grid
 with 2 columns.
 
+<!-- skip -->
 ```dart
 new GridView.count(
   // A list with 2 columns
@@ -46,6 +47,7 @@ rebuild when the `Orientation` changes.
 Using the `Orientation`, we can build a list that displays 2 columns in portrait 
 mode, or 3 columns in landscape mode.
 
+<!-- skip -->
 ```dart
 new OrientationBuilder(
   builder: (context, orientation) {

--- a/cookbook/design/package-fonts.md
+++ b/cookbook/design/package-fonts.md
@@ -71,6 +71,7 @@ to change the appearance of text. To use package fonts, we need to not only
 declare which font we'd like to use, we need to declare the `package` the font
 belongs to. 
 
+<!-- skip -->
 ```dart
 new Text(
   'Using the Raleway font from the awesome_package',
@@ -136,7 +137,7 @@ class MyHomePage extends StatelessWidget {
       // The AppBar will use the app-default Raleway font
       appBar: new AppBar(title: new Text('Package Fonts')),
       body: new Center(
-        // This Text Widget will use the RobotoMono font 
+        // This Text Widget will use the RobotoMono font
         child: new Text(
           'Using the Raleway font from the awesome_package',
           style: new TextStyle(

--- a/cookbook/design/snackbars.md
+++ b/cookbook/design/snackbars.md
@@ -29,6 +29,7 @@ Widget from the [material library](https://docs.flutter.io/flutter/material/mate
 creates this visual structure for us and ensures important Widgets don't 
 overlap!
 
+<!-- skip -->
 ```dart
 new Scaffold(
   appBar: new AppBar(
@@ -43,6 +44,7 @@ new Scaffold(
 With the `Scaffold` in place, we can display a `SnackBar`! First, we need to 
 create a `SnackBar`, then display it using the `Scaffold`.
 
+<!-- skip -->
 ```dart
 final snackBar = new SnackBar(content: new Text('Yay! A SnackBar!'));
 

--- a/cookbook/design/tabs.md
+++ b/cookbook/design/tabs.md
@@ -24,6 +24,7 @@ We can either manually create a `TabController` or use the
 Widget. Using the `DefaultTabController` is the simplest option, since it will 
 create a `TabController` for us and make it available to all descendant Widgets.
 
+<!-- skip -->
 ```dart
 new DefaultTabController(
   // The number of tabs / content sections we need to display
@@ -39,6 +40,7 @@ the [`TabBar`](https://docs.flutter.io/flutter/material/TabController-class.html
 Widget. In this example, we'll create a `TabBar` with 3 [`Tab`](https://docs.flutter.io/flutter/material/Tab-class.html) 
 Widgets and place it within an [`AppBar`](https://docs.flutter.io/flutter/material/AppBar-class.html).
 
+<!-- skip -->
 ```dart
 new DefaultTabController(
   length: 3,
@@ -69,6 +71,7 @@ Widget.
 *Note:* Order is important and must correspond to the order of the tabs in the 
 `TabBar`!
 
+<!-- skip -->
 ```dart
 new TabBarView(
   children: [

--- a/cookbook/design/themes.md
+++ b/cookbook/design/themes.md
@@ -22,6 +22,7 @@ to the `MaterialApp` constructor.
 
 If no `theme` is provided, Flutter will create a fallback theme under the hood.
 
+<!-- skip -->
 ```dart
 new MaterialApp(
   title: title,
@@ -49,6 +50,7 @@ extending the parent theme.
 If we don't want to inherit any application colors or font styles, we can create
 a `new ThemeData()` instance and pass that to the `Theme` Widget.
 
+<!-- skip -->
 ```dart
 new Theme(
   // Create a unique theme with "new ThemeData"
@@ -69,6 +71,7 @@ theme. We can achieve this by using the
 [`copyWith`](https://docs.flutter.io/flutter/material/ThemeData/copyWith.html) 
 method.
 
+<!-- skip -->
 ```dart
 new Theme(
   // Find and Extend the parent theme using "copyWith". Please see the next 
@@ -93,6 +96,7 @@ returns that. If not, it returns the App theme.
 In fact, the `FloatingActionButton` uses this exact technique to find the 
 `accentColor`!
  
+<!-- skip -->
 ```dart
 new Container(
   color: Theme.of(context).accentColor,

--- a/cookbook/forms/focus.md
+++ b/cookbook/forms/focus.md
@@ -22,6 +22,7 @@ as well as how to focus a text field when a button is tapped.
 In order to focus a text field as soon as it's visible, we can use the 
 `autofocus` property.
 
+<!-- skip -->
 ```dart
 new TextField(
   autofocus: true,
@@ -53,6 +54,7 @@ We will use the `FocusNode` to identify a specific `TextField` in Flutter's
 Since focus nodes are long-lived objects, we need to store them in a `State` 
 class. In addition, we need to `dispose` of them when they're no longer needed! 
 
+<!-- skip -->
 ```dart
 // Define a Custom Form Widget
 class MyForm extends StatefulWidget {
@@ -86,6 +88,7 @@ class _MyFormState extends State<MyForm> {
 Now that we have our `FocusNode`, we can pass it to a specific `TextField` in 
 the `build` method. 
 
+<!-- skip -->
 ```dart
 class _MyFormState extends State<MyForm> {
   // Code to create the Focus node...
@@ -105,6 +108,7 @@ Finally, we'll want to focus the text field when the user taps a floating
 action button! We'll use the [`requestFocus`](https://docs.flutter.io/flutter/widgets/FocusScopeNode/requestFocus.html) 
 method to achieve this task.
 
+<!-- skip -->
 ```dart
 new FloatingActionButton(
   // When the button is pressed, ask Flutter to focus our text field using

--- a/cookbook/forms/text-field-changes.md
+++ b/cookbook/forms/text-field-changes.md
@@ -181,7 +181,6 @@ class _MyFormState extends State<MyForm> {
   // of the TextField!
   final myController = new TextEditingController();
 
-
   @override
   void initState() {
     super.initState();

--- a/cookbook/forms/validation.md
+++ b/cookbook/forms/validation.md
@@ -33,6 +33,7 @@ When we create the form, we'll also need to provide a [`GlobalKey`](https://docs
 This will uniquely identify the `Form` that we're working with, and will allow
 us to validate the form in a later step. 
 
+<!-- skip -->
 ```dart
 // Define a Custom Form Widget
 class MyForm extends StatefulWidget {
@@ -76,6 +77,7 @@ anything.
 In this example, we will create a `validator` that ensures the `TextFormField`
 isn't empty. If it is empty, we will return a friendly error message!
 
+<!-- skip -->
 ```dart
 new TextFormField(
   // The validator receives the text the user has typed in
@@ -96,6 +98,7 @@ When the user attempts to submit the form, we'll need to check if the form is
 valid. If it is, we will show a success message. If the text field has no 
 content, we'll want to display the error message.
 
+<!-- skip -->
 ```dart
 new RaisedButton(
   onPressed: () {

--- a/cookbook/gestures/dismissible.md
+++ b/cookbook/gestures/dismissible.md
@@ -29,6 +29,7 @@ away. For more detailed instructions on how to create a list, please follow the
 In our example, we'll want 20 sample items to work with. To keep it simple, 
 we'll generate a List of Strings.
 
+<!-- skip -->
 ```dart
 final items = new List<String>.generate(20, (i) => "Item ${i + 1}");
 ```
@@ -38,6 +39,7 @@ final items = new List<String>.generate(20, (i) => "Item ${i + 1}");
 At first, we'll simply display each item in the List on screen. Users will
 not be able to swipe away with these items just yet!
 
+<!-- skip -->
 ```dart
 new ListView.builder(
   itemCount: items.length,
@@ -61,6 +63,7 @@ This is where the [`Dismissible`](https://docs.flutter.io/flutter/widgets/Dismis
 Widget comes into play! In our example, we'll update our `itemBuilder` function 
 to return a `Dismissible` Widget.
 
+<!-- skip -->
 ```dart
 new Dismissible(
   // Each Dismissible must contain a Key. Keys allow Flutter to
@@ -89,6 +92,7 @@ swipe the item off the screen. In this case, a red background!
 
 For this purpose, we'll provide a `background` parameter to the `Dismissible`.
 
+<!-- skip -->
 ```dart
 new Dismissible(
   // Show a red background as the item is swiped away

--- a/cookbook/gestures/handling-taps.md
+++ b/cookbook/gestures/handling-taps.md
@@ -17,6 +17,7 @@ we approach this?
   1. Create the button
   2. Wrap it in a `GestureDetector` with an `onTap` callback
 
+<!-- skip -->
 ```dart
 // Our GestureDetector wraps our button
 new GestureDetector(

--- a/cookbook/gestures/ripples.md
+++ b/cookbook/gestures/ripples.md
@@ -14,7 +14,8 @@ Widget to achieve this effect.
 
   1. Create a Widget we want to tap
   2. Wrap it in an `InkWell` Widget to manage tap callbacks and ripple animations 
-  
+ 
+<!-- skip -->
 ```dart
 // The InkWell Wraps our custom flat button Widget
 new InkWell(
@@ -74,8 +75,8 @@ class MyButton extends StatelessWidget {
       // When the user taps the button, show a snackbar
       onTap: () {
         Scaffold.of(context).showSnackBar(new SnackBar(
-          content: new Text('Tap'),
-        ));
+              content: new Text('Tap'),
+            ));
       },
       child: new Container(
         padding: new EdgeInsets.all(12.0),

--- a/cookbook/images/cached-images.md
+++ b/cookbook/images/cached-images.md
@@ -12,6 +12,7 @@ package.
 In addition to caching, the cached_image_network package also supports 
 placeholders and fading images in as they're loaded! 
 
+<!-- skip -->
 ```dart
 new CachedNetworkImage(
   imageUrl: 'https://github.com/flutter/website/blob/master/_includes/code/layout/lakes/images/lake.jpg?raw=true',
@@ -23,6 +24,7 @@ new CachedNetworkImage(
 The `cached_network_image` package allows us to use any Widget as a placeholder! 
 In this example, we'll display a spinner while the image loads.
 
+<!-- skip -->
 ```dart
 new CachedNetworkImage(
   placeholder: new CircularProgressIndicator(),
@@ -32,6 +34,7 @@ new CachedNetworkImage(
 
 ## Complete Example
 
+<!-- skip -->
 ```dart
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';

--- a/cookbook/images/fading-in-images.md
+++ b/cookbook/images/fading-in-images.md
@@ -20,6 +20,7 @@ package for a simple transparent placeholder. You can also consider using local
 assets for placeholders by following the [Assets and Images](/assets-and-images/)
 guide.
 
+<!-- skip -->
 ```dart
 new FadeInImage.memoryNetwork(
   placeholder: kTransparentImage,

--- a/cookbook/images/network-image.md
+++ b/cookbook/images/network-image.md
@@ -11,6 +11,7 @@ display different types of images.
 In order to work with images from a URL, use the [`Image.network`](https://docs.flutter.io/flutter/widgets/Image/Image.network.html) 
 constructor.
 
+<!-- skip -->
 ```dart
 new Image.network(
   'https://raw.githubusercontent.com/flutter/website/master/_includes/code/layout/lakes/images/lake.jpg',
@@ -22,6 +23,7 @@ new Image.network(
 One amazing thing about the `Image` Widget: It also supports animated gifs out
 of the box!
 
+<!-- skip -->
 ```dart
 new Image.network(
   'https://github.com/flutter/plugins/raw/master/packages/video_player/doc/demo_ipod.gif?raw=true',

--- a/cookbook/lists/basic-list.md
+++ b/cookbook/lists/basic-list.md
@@ -14,6 +14,7 @@ Using the standard `ListView` constructor is perfect for lists that contain only
 a few items. We will also employ the built-in `ListTile` Widget to give our 
 items a visual structure.
 
+<!-- skip -->
 ```dart
 new ListView(
   children: <Widget>[
@@ -44,7 +45,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final title = 'Basic List';
-    
+
     return new MaterialApp(
       title: title,
       home: new Scaffold(

--- a/cookbook/lists/grid-lists.md
+++ b/cookbook/lists/grid-lists.md
@@ -16,6 +16,7 @@ constructor, because it allow us to specify how many rows or columns we'd like.
 In this example, we'll generate a List of 100 Widgets that display their
 index in the list. This will help us us visualize how `GridView`  works.
 
+<!-- skip -->
 ```dart
 new GridView.count(
   // Create a grid with 2 columns. If you change the scrollDirection to 

--- a/cookbook/lists/horizontal-list.md
+++ b/cookbook/lists/horizontal-list.md
@@ -11,6 +11,7 @@ Widget supports horizontal lists out of the box.
 We'll use the standard `ListView` constructor, passing through a horizontal 
 `scrollDirection`, which will override the default vertical direction.
 
+<!-- skip -->
 ```dart
 new ListView(
   // This next line does the trick.

--- a/cookbook/lists/long-lists.md
+++ b/cookbook/lists/long-lists.md
@@ -23,6 +23,7 @@ For this example, we'll generate a list of 10000 Strings using the
 [`List.generate`](https://docs.flutter.io/flutter/dart-core/List/List.generate.html) 
 constructor.
 
+<!-- skip -->
 ```dart
 final items = new List<String>.generate(10000, (i) => "Item $i");
 ```
@@ -35,6 +36,7 @@ a Widget!
 This is where the `ListView.builder` will come into play. In our case, we'll 
 display each String on it's own line. 
 
+<!-- skip -->
 ```dart
 new ListView.builder(
   itemCount: items.length,

--- a/cookbook/lists/mixed-list.md
+++ b/cookbook/lists/mixed-list.md
@@ -26,6 +26,7 @@ In this example, we'll work on an app that shows a header followed by five
 messages. Therefore, we'll create three classes: `ListItem`, `HeadingItem`, 
 and `MessageItem`.
 
+<!-- skip -->
 ```dart
 // The base class for the different types of items the List can contain
 abstract class ListItem {}
@@ -54,6 +55,7 @@ convert that data into a list of items.
 For this example, we'll generate a list of items to work with. The list will
 contain a header followed by five messages. Rinse, repeat.
 
+<!-- skip -->
 ```dart
 final items = new List<ListItem>.generate(
   1200,
@@ -78,6 +80,7 @@ with can be handy. It's fast, and will automatically cast each item to the
 appropriate type. However, there are different ways to approach this problem if 
 you prefer another pattern!
 
+<!-- skip -->
 ```dart
 new ListView.builder(
   // Let the ListView know how many items it needs to build

--- a/cookbook/navigation/hero-animations.md
+++ b/cookbook/navigation/hero-animations.md
@@ -80,6 +80,7 @@ requires two arguments:
   screens.
   2. `child`: The Widget we want to animate across screens.
   
+<!-- skip -->
 ```dart
 new Hero(
   tag: 'imageHero',
@@ -98,6 +99,7 @@ as the first screen.
 After you apply the `Hero` Widget to the second screen, the animation between 
 screens will work!
 
+<!-- skip -->
 ```dart
 new Hero(
   tag: 'imageHero',

--- a/cookbook/navigation/navigation-basics.md
+++ b/cookbook/navigation/navigation-basics.md
@@ -83,6 +83,7 @@ new screen using a platform-specific animation.
 In the `build` method of our `FirstScreen` Widget, we'll update the `onPressed` 
 callback:
 
+<!-- skip -->
 ```dart
 // Within the `FirstScreen` Widget
 onPressed: () {
@@ -103,6 +104,7 @@ routes managed by the navigator.
 For this part, we'll need to update the `onPressed` callback found in our 
 `SecondScreen` Widget
 
+<!-- skip -->
 ```dart
 // Within the SecondScreen Widget
 onPressed: () {

--- a/cookbook/navigation/passing-data.md
+++ b/cookbook/navigation/passing-data.md
@@ -24,6 +24,7 @@ displays information about the todo.
 First, we'll need a simple way to represent Todos. For this example, we'll 
 create a class that contains two pieces of data: the title and description.
 
+<!-- skip -->
 ```dart
 class Todo {
   final String title;
@@ -41,6 +42,7 @@ Lists, please see the [`Basic List`](/cookbook/lists/basic-list/) recipe.
 
 ### Generate the List of Todos
 
+<!-- skip -->
 ```dart
 final todos = new List<Todo>.generate(
   20,
@@ -53,6 +55,7 @@ final todos = new List<Todo>.generate(
 
 ### Display the List of Todos using a ListView
 
+<!-- skip -->
 ```dart
 new ListView.builder(
   itemCount: todos.length,
@@ -74,6 +77,7 @@ title of the todo, and the body of the screen will show the description.
 Since it's a normal `StatelessWidget`, we'll simply require that users creating 
 the Screen pass through a `Todo`! Then, we'll build a UI using the given Todo.
 
+<!-- skip -->
 ```dart
 class DetailScreen extends StatelessWidget {
   // Declare a field that holds the Todo
@@ -109,6 +113,7 @@ callback for our `ListTile` Widget. Within our `onTap` callback, we'll once
 again employ the [`Navigator.push`](https://docs.flutter.io/flutter/widgets/Navigator/push.html)
 method. 
 
+<!-- skip -->
 ```dart
 new ListView.builder(
   itemCount: todos.length,

--- a/cookbook/navigation/returning-data.md
+++ b/cookbook/navigation/returning-data.md
@@ -24,6 +24,7 @@ How can we achieve this? Using [`Navigator.pop`](https://docs.flutter.io/flutter
 The home screen will display a button. When tapped, it will launch the selection 
 screen!
 
+<!-- skip -->
 ```dart
 class HomeScreen extends StatelessWidget {
   @override
@@ -46,6 +47,7 @@ Now, we'll create our SelectionButton. Our selection button will:
   1. Launch the SelectionScreen when it's tapped
   2. Wait for the SelectionScreen to return a result
 
+<!-- skip -->
 ```dart
 class SelectionButton extends StatelessWidget {
   @override
@@ -131,6 +133,7 @@ provide a result, it will be returned to the `Future` in our SelectionButton!
 
 ### Yep button
 
+<!-- skip -->
 ```dart
 new RaisedButton(
   onPressed: () {
@@ -143,6 +146,7 @@ new RaisedButton(
 
 ### Nope button
 
+<!-- skip -->
 ```dart
 new RaisedButton(
   onPressed: () {
@@ -161,6 +165,7 @@ to do something with the information that's returned!
 In this case, we'll show a Snackbar displaying the result. To do so, we'll 
 update the `_navigateAndDisplaySelection` method in our `SelectionButton`.
 
+<!-- skip -->
 ```dart
 _navigateAndDisplaySelection(BuildContext context) async {
   final result = await Navigator.push(
@@ -174,7 +179,6 @@ _navigateAndDisplaySelection(BuildContext context) async {
       .showSnackBar(new SnackBar(content: new Text("$result")));
 }
 ```
- 
 
 ## Complete Example
 

--- a/cookbook/networking/authenticated-requests.md
+++ b/cookbook/networking/authenticated-requests.md
@@ -14,6 +14,7 @@ The [`http`](https://pub.dartlang.org/packages/http) package provides a
 convenient way to add headers to your requests. You can also take advantage of 
 the `dart:io` package for common `HttpHeaders`.
 
+<!-- skip -->
 ```dart
 Future<http.Response> fetchPost() {
   return http.get(
@@ -33,6 +34,7 @@ recipe.
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+
 import 'package:http/http.dart' as http;
 
 Future<Post> fetchPost() async {
@@ -40,9 +42,9 @@ Future<Post> fetchPost() async {
     'https://jsonplaceholder.typicode.com/posts/1',
     headers: {HttpHeaders.AUTHORIZATION: "Basic your_api_token_here"},
   );
-  final json = json.decode(response.body); 
-  
-  return new Post.fromJson(json); 
+  final responseJson = json.decode(response.body);
+
+  return new Post.fromJson(responseJson);
 }
 
 class Post {

--- a/cookbook/networking/background-parsing.md
+++ b/cookbook/networking/background-parsing.md
@@ -41,6 +41,7 @@ photo objects from the [JSONPlaceholder REST API](https://jsonplaceholder.typico
 using the [`http.get`](https://docs.flutter.io/flutter/package-http_http/package-http_http-library.html) 
 method. 
 
+<!-- skip -->
 ```dart
 Future<http.Response> fetchPhotos(http.Client client) async {
   return client.get('https://jsonplaceholder.typicode.com/photos');
@@ -62,6 +63,7 @@ First, we'll need to create a `Photo` class that contains data about a photo.
 We will also include a `fromJson` factory to make it easy to create a `Photo` 
 starting with a json object.
 
+<!-- skip -->
 ```dart
 class Photo {
   final int id;
@@ -88,12 +90,13 @@ Now, we'll update the `fetchPhotos` function so it can return a
   1. Create a `parsePhotos` that converts the response body into a `List<Photo>`
   2. Use the `parsePhotos` function in the `fetchPhotos` function
 
+<!-- skip -->
 ```dart
 // A function that will convert a response body into a List<Photo>
 List<Photo> parsePhotos(String responseBody) {
-  final parsed = json.decode(responseBody);
+  final parsed = json.decode(responseBody).cast<Map<String, dynamic>>();
 
-  return parsed.map((json) => new Photo.fromJson(json)).toList();
+  return parsed.map<Photo>((json) => new Photo.fromJson(json)).toList();
 }
 
 Future<List<Photo>> fetchPhotos(http.Client client) async {
@@ -116,6 +119,7 @@ function provided by Flutter. The `compute` function will run expensive
 functions in a background isolate and return the result. In this case, we want 
 to run the `parsePhotos` function in the background!
 
+<!-- skip -->
 ```dart
 Future<List<Photo>> fetchPhotos(http.Client client) async {
   final response =
@@ -155,9 +159,9 @@ Future<List<Photo>> fetchPhotos(http.Client client) async {
 
 // A function that will convert a response body into a List<Photo>
 List<Photo> parsePhotos(String responseBody) {
-  final parsed = json.decode(responseBody);
+  final parsed = json.decode(responseBody).cast<Map<String, dynamic>>();
 
-  return parsed.map((json) => new Photo.fromJson(json)).toList();
+  return parsed.map<Photo>((json) => new Photo.fromJson(json)).toList();
 }
 
 class Photo {

--- a/cookbook/networking/fetch-data.md
+++ b/cookbook/networking/fetch-data.md
@@ -35,6 +35,7 @@ In this example, we'll fetch a sample post from the
 [`http.get`](https://docs.flutter.io/flutter/package-http_http/package-http_http-library.html) 
 method.
 
+<!-- skip -->
 ```dart
 Future<http.Response> fetchPost() {
   return http.get('https://jsonplaceholder.typicode.com/posts/1');
@@ -64,6 +65,7 @@ create a `Post` from json.
 Converting JSON by hand is only one option. For more information, please see the 
 full article on [JSON and serialization](/json). 
 
+<!-- skip -->
 ```dart
 class Post {
   final int userId;
@@ -92,6 +94,7 @@ we'll need to:
   1. Convert the response body into a json `Map` with the `dart:convert` package
   2. Convert the json `Map` into a `Post` using the `fromJson` factory.
 
+<!-- skip -->
 ```dart
 Future<Post> fetchPost() async {
   final response = await http.get('https://jsonplaceholder.typicode.com/posts/1');
@@ -118,6 +121,7 @@ We must provide two parameters:
   2. A `builder` function that tells Flutter what to render, depending on the
   state of the `Future`: loading, success, or error.
 
+<!-- skip -->
 ```dart
 new FutureBuilder<Post>(
   future: fetchPost(),

--- a/cookbook/networking/web-sockets.md
+++ b/cookbook/networking/web-sockets.md
@@ -29,6 +29,7 @@ messages from the server as well as push messages to the server.
 In Flutter, we can create a `WebSocketChannel` that connects to a server in one 
 line:
 
+<!-- skip -->
 ```dart
 final channel = new IOWebSocketChannel.connect('ws://echo.websocket.org');
 ```
@@ -45,6 +46,7 @@ a [`StreamBuilder`](https://docs.flutter.io/flutter/widgets/StreamBuilder-class.
 Widget to listen for new messages and a [`Text`](https://docs.flutter.io/flutter/widgets/Text-class.html) 
 Widget to display them.
 
+<!-- skip -->
 ```dart
 new StreamBuilder(
   stream: widget.channel.stream,
@@ -73,6 +75,7 @@ receives an event using the given `builder` function!
 In order to send data to the server, we'll `add` messages to the `sink` provided
 by the `WebSocketChannel`.
 
+<!-- skip -->
 ```dart
 channel.sink.add('Hello!');
 ```
@@ -90,6 +93,7 @@ data source.
 After we're done using the WebSocket, we'll want to close the connection! To do 
 so, we can close the `sink`.
 
+<!-- skip -->
 ```dart
 channel.sink.close();
 ```

--- a/cookbook/persistence/key-value.md
+++ b/cookbook/persistence/key-value.md
@@ -42,6 +42,7 @@ types, such as `setInt`, `setBool`, and `setString`.
 Setter methods do two things: First, synchronously update the key-value pair 
 in-memory. Then, persist the data to disk.
 
+<!-- skip -->
 ```dart
 // obtain shared preferences 
 final prefs = await SharedPreferences.getInstance();
@@ -56,6 +57,7 @@ To read data, we can use the appropriate getter method provided by the
 `SharedPreferences` class. For each setter there is a corresponding getter. 
 For example, we can use the `getInt`, `getBool`, and `getString` methods.  
 
+<!-- skip -->
 ```dart
 final prefs = await SharedPreferences.getInstance();
 
@@ -67,6 +69,7 @@ final counter = prefs.getInt('counter') ?? 0;
 
 To delete data, we can use the `remove` method.
 
+<!-- skip -->
 ```dart
 final prefs = await SharedPreferences.getInstance();
 
@@ -83,6 +86,26 @@ While it is easy and convenient to use key-value storage, it has limitations:
 For more information about Shared Preferences on Android, please visit 
 [Shared preferences documentation](https://developer.android.com/guide/topics/data/data-storage.html#pref) 
 on the Android developers website.
+
+## Testing support
+
+It can be a good idea to test code that persists data using 
+`shared_preferences`. To do so, we'll need to mock out the `MethodChannel` used 
+by the `shared_preferences` library.
+
+We can populate `SharedPreferences` with initial values in our tests by running
+the following code in a `setupAll` method in our test files:
+
+<!-- skip -->
+```dart
+const MethodChannel('plugins.flutter.io/shared_preferences')
+  .setMockMethodCallHandler((MethodCall methodCall) async {
+    if (methodCall.method == 'getAll') {
+      return <String, dynamic>{}; // set initial values here if desired
+    }
+    return null;
+  });
+```
 
 ## Example
 
@@ -123,14 +146,14 @@ class _MyHomePageState extends State<MyHomePage> {
     _loadCounter();
   }
 
-  //Loading counter value on start 
+  //Loading counter value on start
   _loadCounter() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     setState(() {
       _counter = (prefs.getInt('counter') ?? 0);
     });
   }
-  
+
   //Incrementing counter after click
   _incrementCounter() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
@@ -169,24 +192,4 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 }
-
-```
-
-## Testing support
-
-It can be a good idea to test code that persists data using 
-`shared_preferences`. To do so, we'll need to mock out the `MethodChannel` used 
-by the `shared_preferences` library.
-
-We can populate `SharedPreferences` with initial values in our tests by running
-the following code in a `setupAll` method in our test files:
-
-```dart
-const MethodChannel('plugins.flutter.io/shared_preferences')
-  .setMockMethodCallHandler((MethodCall methodCall) async {
-    if (methodCall.method == 'getAll') {
-      return <String, dynamic>{}; // set initial values here if desired
-    }
-    return null;
-  });
 ```

--- a/cookbook/persistence/reading-writing-files.md
+++ b/cookbook/persistence/reading-writing-files.md
@@ -44,6 +44,7 @@ locations:
 In our case, we'll want to store information in the documents directory! We
 can find the path to the documents directory like so:
   
+<!-- skip -->
 ```dart
 Future<String> get _localPath async {
   final directory = await getApplicationDocumentsDirectory();
@@ -59,6 +60,7 @@ file's full location. We can use the [`File`](https://docs.flutter.io/flutter/da
 class from the [dart:io](https://docs.flutter.io/flutter/dart-io/dart-io-library.html) 
 library to achieve this.
 
+<!-- skip -->
 ```dart
 Future<File> get _localFile async {
   final path = await _localPath;
@@ -72,6 +74,7 @@ Now that we have a `File` to work with, we can use it to read and write data!
 First, we'll write some data to the file. Since we're working with a counter,
 we'll simply store the integer as a String.
 
+<!-- skip -->
 ```dart
 Future<File> writeCounter(int counter) async {
   final file = await _localFile;
@@ -86,6 +89,7 @@ Future<File> writeCounter(int counter) async {
 Now that we have some data on disk, we can read it! Once again, we'll use the 
 `File` class to do so.
 
+<!-- skip -->
 ```dart
 Future<int> readCounter() async {
   try {
@@ -114,6 +118,7 @@ interact with our test environment's filesystem!
 To mock the method call, we can provide a `setupAll` function in our test file.
 This function will run before the tests are executed.
 
+<!-- skip -->
 ```dart
 setUpAll(() async {
   // Create a temporary directory to work with

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,3 +11,8 @@ dev_dependencies:
   test: ^0.12.13
   url_launcher:
   path_provider:
+  cached_network_image: 0.4.0
+  shared_preferences: 0.4.1
+  transparent_image: 0.1.0
+  css_colors: 1.0.1
+  web_socket_channel: 1.0.7

--- a/tool/extract.dart
+++ b/tool/extract.dart
@@ -13,11 +13,11 @@ void main(List<String> args) {
   // Remove any previously generated files.
   clean();
 
-  // Traverse markdown files in the root.
+  // Traverse all markdown files in the repository.
   int extractCount = 0;
   Iterable<FileSystemEntity> files = Directory.current
-      .listSync()
-      .where((FileSystemEntity entity) => entity is File && entity.path.endsWith('.md'));
+      .listSync(recursive: true)
+      .where((FileSystemEntity entity) => entity is File && entity.path.endsWith('.md') && !entity.path.contains('README.md'));
   files.forEach((FileSystemEntity file) => extractCount += _processFile(file));
   print('\n$extractCount code snippets extracted.');
 }
@@ -37,18 +37,18 @@ int _processFile(File file) {
 
   while (index < lines.length) {
     // Look for ```dart sections.
-    if (lines[index].startsWith('```dart') && lastComment?.trim() != 'skip') {
+    if (lines[index].trim().startsWith('```dart') && lastComment?.trim() != 'skip') {
       int startIndex = index + 1;
       index++;
-      while (index < lines.length && !lines[index].startsWith('```')) {
+      while (index < lines.length && !lines[index].trim().startsWith('```')) {
         index++;
       }
       _extractSnippet(name, ++count, startIndex, lines.sublist(startIndex, index),
           includeSource: lastComment);
-    } else if (lines[index].startsWith('<!--')) {
+    } else if (lines[index].trim().startsWith('<!--')) {
       // Look for <!-- comment sections.
       int startIndex = index;
-      while (!lines[index].endsWith('-->')) {
+      while (!lines[index].trim().endsWith('-->')) {
         index++;
       }
 
@@ -71,7 +71,7 @@ int _processFile(File file) {
 
 void _extractSnippet(String filename, int snippet, int startLine, List<String> lines,
     {String includeSource}) {
-  bool hasImport = lines.any((String line) => line.startsWith('import '));
+  bool hasImport = lines.any((String line) => line.trim().startsWith('import '));
   String path = 'example/${filename.replaceAll('-', '_').replaceAll('.', '_')}_'
       '$snippet.dart';
 

--- a/using-packages.md
+++ b/using-packages.md
@@ -176,32 +176,31 @@ To use this package:
 1. Run `flutter packages get` in the terminal, or click 'Packages get' in IntelliJ
 
 1. Open `lib/main.dart` and replace its full contents with:
-   ```dart
-   import 'package:flutter/material.dart';
-   import 'package:css_colors/css_colors.dart';
 
-   void main() {
-     runApp(new MyApp());
-   }
+```dart
+import 'package:css_colors/css_colors.dart';
+import 'package:flutter/material.dart';
 
-   class MyApp extends StatelessWidget {
-     @override
-     Widget build(BuildContext context) {
-       return new MaterialApp(
-         home: new DemoPage(),
-       );
-     }
-   }
+void main() {
+  runApp(new MyApp());
+}
 
-   class DemoPage extends StatelessWidget {
-     @override
-     Widget build(BuildContext context) {
-       return new Scaffold(
-         body: new Container(color: CSSColors.orange)
-       );
-     }
-   }
-   ```
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return new MaterialApp(
+      home: new DemoPage(),
+    );
+  }
+}
+
+class DemoPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return new Scaffold(body: new Container(color: CSSColors.orange));
+  }
+}
+```
 
 1. Run the app. When you click the 'Show Flutter homepage' you should see the
 phone's default browser open, and the Flutter homepage appear.
@@ -236,41 +235,42 @@ To use this plugin:
 1. Run `flutter packages get` in the terminal, or click 'Packages get' in IntelliJ
 
 1. Open `lib/main.dart` and replace its full contents with:
-   ```dart
-   import 'package:flutter/material.dart';
-   import 'package:url_launcher/url_launcher.dart';
 
-   void main() {
-     runApp(new MyApp());
-   }
+```dart
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
-   class MyApp extends StatelessWidget {
-     @override
-     Widget build(BuildContext context) {
-       return new MaterialApp(
-         home: new DemoPage(),
-       );
-     }
-   }
+void main() {
+  runApp(new MyApp());
+}
 
-   class DemoPage extends StatelessWidget {
-     launchURL() {
-       launch('https://flutter.io');
-     }
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return new MaterialApp(
+      home: new DemoPage(),
+    );
+  }
+}
 
-     @override
-     Widget build(BuildContext context) {
-       return new Scaffold(
-         body: new Center(
-           child: new RaisedButton(
-             onPressed: launchURL,
-             child: new Text('Show Flutter homepage'),
-           ),
-         ),
-       );
-     }
-   }
-   ```
+class DemoPage extends StatelessWidget {
+  launchURL() {
+    launch('https://flutter.io');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return new Scaffold(
+      body: new Center(
+        child: new RaisedButton(
+          onPressed: launchURL,
+          child: new Text('Show Flutter homepage'),
+        ),
+      ),
+    );
+  }
+}
+```
 
 1. Run the app. When you click the 'Show Flutter homepage' you should see the
 phone's default browser open, and the Flutter homepage appear.


### PR DESCRIPTION
Hey hey :) I played around with a couple techniques for fixing the cookbook analysis errors and went with the following strategy:

  - Skip sections that are meant for human consumption: In order to keep the snippets short and focused, many snippets cannot be analyzed. 
  - "Complete examples" are analyzed for correctness. In most cases, this should capture analysis errors that are relevant, since the snippets of a recipe and the corresponding complete examples should be kept in sync.

Alternative techniques attempted or discussed:

  - Group the snippets together for analysis: I tried this but realized it wouldn't quite work. Why? Some snippets are really "out of context." I.e. we have the code for a `new RaisedButton`, but do not place it inside the `build` method of a `State` class for brevity and focus.
  - Ignore some code before the snippet. We could attempt this, but it would mean repeating the complete example for each snippet, revealing only the part of the snippet that's relevant. That felt cumbersome, but happy to go this route if it's preferred. Right now, it appears you can only include some code before a snippet, rather than "around" a snippet, so we'd need to write that functionality as well.

This is a fix for https://github.com/flutter/flutter/issues/16155

## Update

  - After analysis passed, I saw formatting errors in various files throughout the codebase. These are now fixed.
  - I decided to ignore the project's README.md file, as it contains code that could not be properly analyzed (it contains dart codeblocks within  another codeblock, and the extraction tool was unable to process this)