### PR TITLE
Flutter for iOS — Navigation section

### DIFF
--- a/flutter-for-ios.md
+++ b/flutter-for-ios.md
@@ -27,3 +27,72 @@ that are most relevant to your needs.
 
 * TOC Placeholder
 {:toc}
+
+# Navigation
+
+## How do I navigate between pages?
+
+In iOS, to travel between view controllers, you can use a
+`UINavigationController` that manages the stack of view controllers to
+display.
+
+Flutter has a relatively similar implementation, using a `Navigator` and
+`Routes`. A `Route` is an abstraction for a “screen” or “page” of an app, and
+a `Navigator` is a [widget](https://flutter.io/technical-
+overview/#everythings-a-widget) that manages routes. A route roughly maps to a
+`UIViewController`. The navigator works in a similar way to the iOS
+`UINavigationController`, in that it can `push()` and `pop()` routes depending
+on whether you want to navigate to, or back from, a view.
+
+Unlike iOS, you will need to pass in a `Map` of names of routes to the top
+level `App` instance to declare all of your routes:
+
+<!-- skip -->
+{% prettify dart %}
+void main() {
+  runApp(new MaterialApp(
+    home: new MyAppHome(), // becomes the route named '/'
+    routes: <String, WidgetBuilder> {
+      '/a': (BuildContext context) => new MyPage(title: 'page A'),
+      '/b': (BuildContext context) => new MyPage(title: 'page B'),
+      '/c': (BuildContext context) => new MyPage(title: 'page C'),
+    },
+  ));
+}
+{% endprettify %}
+ 
+You can then navigate to a route by getting hold of the `Navigator` and
+`push`ing one of the named routes.
+
+<!-- skip -->
+{% prettify dart %}
+Navigator.of(context).pushNamed('/b');
+{% endprettify %}
+
+The `Navigator` class which handles all routing in Flutter can be used to get
+a result back from a route that you have pushed on the stack. This can be done
+by `await`ing on the `Future` returned by `push()`. For example, if you were
+to start a ‘location’ route which lets the user select their location, you
+could do:
+
+<!-- skip -->
+{% prettify dart %}
+Map coordinates = await Navigator.of(context).pushNamed('/location');
+{% endprettify %}
+
+And then, inside your ‘location’ route, once the user has selected their
+location you can `pop()` the stack with the result:
+
+<!-- skip -->
+{% prettify dart %}
+Navigator.of(context).pop({"lat":43.821757,"long":-79.226392});
+{% endprettify %}
+
+## Navigating to other apps
+
+In iOS, in order to send the user to another application, you would use a
+specific URL scheme. For the system level apps, there are specific schemes you
+would use. In order to implement this functionality in Flutter, you would need
+to create a native platform integration, or use an existing
+[plugin](#plugins), such as
+[`url_launcher`](https://pub.dartlang.org/packages/url_launcher).


### PR DESCRIPTION
This PR is for the second section of the work to create the `flutter-for-ios.md` document. Writing by @niamh-power on Novoda's behalf, I am just a proxy.

Following the same rough format as the `flutter-for-android.md` document, with iOS details instead.

The following sections have been created:

* How do I navigate between pages?
* Navigating to other apps

⚠️ **This requires #965 to be merged first!** ⚠️ 