### PR TITLE
Trim lines' end when extracting code snippets

### DIFF
--- a/tool/extract.dart
+++ b/tool/extract.dart
@@ -15,9 +15,9 @@ void main(List<String> args) {
 
   // Traverse markdown files in the root.
   int extractCount = 0;
-  Iterable<FileSystemEntity> files = Directory.current
-      .listSync()
-      .where((FileSystemEntity entity) => entity is File && entity.path.endsWith('.md'));
+  Iterable<FileSystemEntity> files = Directory.current.listSync().where(
+      (FileSystemEntity entity) =>
+          entity is File && entity.path.endsWith('.md'));
   files.forEach((FileSystemEntity file) => extractCount += _processFile(file));
   print('\n$extractCount code snippets extracted.');
 }
@@ -28,7 +28,8 @@ int _processFile(File file) {
 
   // Look for ```dart sections.
   String source = file.readAsStringSync();
-  List<String> lines = source.split('\n').map((String line) => line.trimRight());
+  List<String> lines =
+      source.split('\n').map((String line) => line.trimRight()).toList();
 
   int index = 1;
   int count = 0;
@@ -43,7 +44,8 @@ int _processFile(File file) {
       while (index < lines.length && !lines[index].startsWith('```')) {
         index++;
       }
-      _extractSnippet(name, ++count, startIndex, lines.sublist(startIndex, index),
+      _extractSnippet(
+          name, ++count, startIndex, lines.sublist(startIndex, index),
           includeSource: lastComment);
     } else if (lines[index].startsWith('<!--')) {
       // Look for <!-- comment sections.
@@ -69,7 +71,8 @@ int _processFile(File file) {
   return count;
 }
 
-void _extractSnippet(String filename, int snippet, int startLine, List<String> lines,
+void _extractSnippet(
+    String filename, int snippet, int startLine, List<String> lines,
     {String includeSource}) {
   bool hasImport = lines.any((String line) => line.startsWith('import '));
   String path = 'example/${filename.replaceAll('-', '_').replaceAll('.', '_')}_'
@@ -108,8 +111,8 @@ void clean() {
   if (!exampleDir.existsSync()) {
     exampleDir.createSync();
   }
-  Iterable<File> files = exampleDir
-      .listSync()
-      .where((FileSystemEntity entity) => entity is File && entity.path.endsWith('.dart'));
+  Iterable<File> files = exampleDir.listSync().where(
+      (FileSystemEntity entity) =>
+          entity is File && entity.path.endsWith('.dart'));
   files.forEach((File file) => file.deleteSync());
 }

--- a/tool/extract.dart
+++ b/tool/extract.dart
@@ -28,7 +28,7 @@ int _processFile(File file) {
 
   // Look for ```dart sections.
   String source = file.readAsStringSync();
-  List<String> lines = source.split('\n');
+  List<String> lines = source.split('\n').map((String line) => line.trimRight());
 
   int index = 1;
   int count = 0;


### PR DESCRIPTION
~This allows us to avoid trailing whitespace, and fixes cases where, for example, we have empty spaces after comments that prevent the code from finding the end of the comment, causing the code to run to the end of the file and failing with an index-out-of-bounds error.~

~For example:~

```markdown
...

<!-- skip --> 
{% prettify dart %}
void main() {
  runApp(new SampleApp());
}
{% endprettify %}
```

~(notice the extra whitespace at the end of the comment line)~

~Would fail the build.~

~This PR hot-fixes that issue, although a more robust error handling should eventually be built into the code so that whenever a comment is left open there's a proper error message pointing at a line number, and explaining the issue.~

EDIT: see [comment below](https://github.com/flutter/website/pull/983#issuecomment-385158897)