### PR TITLE
[Building layouts in Flutter] Introduce the imageSection in step5 in isolation

### DIFF
--- a/tutorials/layout/index.md
+++ b/tutorials/layout/index.md
@@ -334,16 +334,22 @@ so you can now reference it from your code:
 <!-- code/layout/lakes/main.dart -->
 <!-- skip -->
 {% prettify dart %}
-body: new ListView(
-  children: [
-    new Image.asset(
+class MyApp extends StatelessWidget {
+
+  @override
+  Widget build(BuildContext context) {
+    //...
+
+    Widget imageSection = new Image.asset(
       'images/lake.jpg',
+      width: 600.0,
       height: 240.0,
       fit: BoxFit.cover,
-    ),
-    // ...
-  ],
-)
+    );
+
+    //...
+  }
+}
 {% endprettify %}
 
 `BoxFit.cover` tells the framework that the image should be as small as
@@ -362,12 +368,7 @@ when running the app on a small device.
 //...
 body: new ListView(
   children: [
-    new Image.asset(
-      'images/lake.jpg',
-      width: 600.0,
-      height: 240.0,
-      fit: BoxFit.cover,
-    ),
+    imageSection,
     titleSection,
     buttonSection,
     textSection,


### PR DESCRIPTION
I think it's easier for the reader to introduce the `imageSection` in Step 5 in isolation, similar to how the other sections are introduced.  

Silently introducing the `ListView` in step 5 is a bit confusing - instead it follows the previous sections. Also the code in Step 6 is a bit cleaner, as all sections are added via variables.