### PR TITLE
Adding a codelabs page, and removing "slow mode banner" on another page.

### DIFF
--- a/codelabs/index.md
+++ b/codelabs/index.md
@@ -1,0 +1,38 @@
+---
+layout: page
+title: Codelabs
+description: "Codelabs to help you quickly get started programming Flutter."
+permalink: /codelabs/
+---
+
+#### [Write Your First Flutter App, part 1](https://codelabs.developers.google.com/codelabs/first-flutter-app-pt1/)
+
+Create a simple mobile app that generates proposed names for a startup
+company. In part one, you'll use a package that returns pairs of names
+at random and inserts them into an infinitely scrolling list.
+
+#### [Write Your First Flutter App, part 2](https://codelabs.developers.google.com/codelabs/first-flutter-app-pt2/)
+
+Create a simple mobile app that generates proposed names for a startup
+company. In part two, you'll extend the example from part 1 to allow
+the user to select favorite word pairs, and add a second "Saved Favorites"
+page where users can view the selected names.
+Finally, you'll change the app's theme color.
+
+#### [Building Beautiful UIs with Flutter](https://codelabs.developers.google.com/codelabs/flutter)
+
+A deeper "first dive" than "Write Your First Flutter App." In this codelab
+you'll create a chat app that includes a simple animation, and customizes
+the UI for iOS and Android.
+
+For a full list of available Flutter codelabs, see the
+[Flutter category](https://codelabs.developers.google.com/?cat=Flutter)
+on [Google Developers](https://codelabs.developers.google.com/).
+
+{% comment %}
+// Right now, there's only the Java->Dart lab, which is also in the
+// Flutter category, so this is (effectively) a dupe link.
+For Dart-specific codelabs, see the
+[codelabs](https://www.dartlang.org/codelabs) page on
+[dartlang.org](https://www.dartlang.org/).
+{% endcomment %}

--- a/using-ide.md
+++ b/using-ide.md
@@ -149,7 +149,7 @@ Also available in the additional actions menu:
 
 * 'Enable Slow Animations': Slow down animations to enable visual inspection.
 
-* 'Hide Slow Mode Banner': Hide the 'slow mode' banner even when running a
+* 'Hide Debug Banner': Hide the 'debug' banner even when running a
   debug build.
 
 
@@ -183,11 +183,11 @@ can assist in correcting it. They are indicated with a red lightbulb.
 #### Wrap with new widget assist
 This can be used when you have a widget that you want to wrap in a surrounding widget,
 for example if you want to wrap a widget in a `Row` or `Column`.
- 
+
 ####  Wrap widget list with new widget assist
 Similar to the assist above, but for wrapping an existing list of widgets rather than an
 individual widget.
- 
+
 #### Convert child to children assist
 Changes a child argument to a children argument, and wraps the argument value in a list.
 


### PR DESCRIPTION
Later, add nice tear-off pics to show the final app, a la webdev.dartlang.org/codelabs. For now, get the page out.

@kwalrath, please review.

@czakdesign, just an FYI.