### PR TITLE
fix links to iOS / Android links in Showcase

### DIFF
--- a/showcase/index.md
+++ b/showcase/index.md
@@ -48,8 +48,8 @@ If you want to be featured, [let us know][]!
         {% if case.ios_download and case.android_download %}
         <p>
             Download:
-            <a href="{{case.android_download}}">iOS</a>,
-            <a href="{{case.ios_download}}">Android</a>
+            <a href="{{case.ios_download}}">iOS</a>,
+            <a href="{{case.android_download}}">Android</a>
         </p>
         {% elsif case.ios_download %}
         <p>


### PR DESCRIPTION
If links to both iOS & Android apps are present the links are backwards (iOS links to Android and vice versa).