### PR TITLE
Update interop list

### DIFF
--- a/index.md
+++ b/index.md
@@ -229,7 +229,7 @@ Future<Null> getBatteryLevel() async {
 
             <ul>
                 <li>Sub-second, stateful hot reload</li>
-                <li>IntelliJ/Android Studio: refactor, code completion, etc</li>
+                <li>Refactor, code completion, etc.</li>
                 <li>Dart language and core libs</li>
                 <li>Package manager</li>
             </ul>
@@ -238,8 +238,8 @@ Future<Null> getBatteryLevel() async {
 
             <ul>
                 <li>Interop with mobile OS APIs &amp; SDKs</li>
-                <li>Gradle/Java/Kotlin</li>
-                <li>Cocoapods/ObjC/Swift</li>
+                <li>Gradle: Java/Kotlin</li>
+                <li>Cocoapods: ObjC/Swift</li>
             </ul>
         </div>
 
@@ -279,14 +279,14 @@ Future<Null> getBatteryLevel() async {
 
             <ul>
                 <li>Native ARM code</li>
-                <li>Dead code elimination</li>
+                <li>"Tree shaking" compiler</li>
             </ul>
 
             <h4>Distribution</h4>
 
             <ul>
-                <li>App Store</li>
-                <li>Play Store</li>
+                <li>Apple App Store</li>
+                <li>Google Play Store</li>
             </ul>
         </div>
 

--- a/index.md
+++ b/index.md
@@ -208,7 +208,7 @@ Future<Null> getBatteryLevel() async {
     is an easy and fast way to build beautiful mobile apps.
     If you are an experienced iOS or Android developer,
     you can use Flutter for your views and leverage much of your
-    existing Java/ObjC/Swift investment.
+    existing Java/Kotlin/ObjC/Swift investment.
     </p>
 
     <div class="feature-lists">
@@ -229,7 +229,7 @@ Future<Null> getBatteryLevel() async {
 
             <ul>
                 <li>Sub-second, stateful hot reload</li>
-                <li>IntelliJ: refactor, code completion, etc</li>
+                <li>IntelliJ/Android Studio: refactor, code completion, etc</li>
                 <li>Dart language and core libs</li>
                 <li>Package manager</li>
             </ul>
@@ -238,7 +238,7 @@ Future<Null> getBatteryLevel() async {
 
             <ul>
                 <li>Interop with mobile OS APIs &amp; SDKs</li>
-                <li>Maven/Java</li>
+                <li>Gradle/Java/Kotlin</li>
                 <li>Cocoapods/ObjC/Swift</li>
             </ul>
         </div>


### PR DESCRIPTION
I'm playing the role of the typical keyboard autocorrect. When you say maven do you mean gradle, that's a big ommision? Also why not mention kotlin, when people are getting really engaged?

The other changes are not important ones, but if I'm coming from Android Studio I'd be alarmed if it's not mentioned.