### PR TITLE
Update references from Dart Code to Flutter plugin

### DIFF
--- a/formatting.md
+++ b/formatting.md
@@ -31,7 +31,7 @@ shortcut to this in Keymap section of IntelliJ Preferences.
 
 ### Automatically formatting code in VS Code
 
-Install the `Dart-Code` plugin (see [Editor setup](/get-started/editor/))
+Install the `Flutter` extension (see [Editor setup](/get-started/editor/))
 to get automatic formatting of code in VS Code.
 
 To automatically format the code in the current source code window, right-click

--- a/get-started/editor.md
+++ b/get-started/editor.md
@@ -66,12 +66,12 @@ To install these:
 
   * [VS Code](https://code.visualstudio.com/), version 1.20.1 or later.
 
-### Install the Dart Code plugin
+### Install the Flutter plugin
 
   1. Start VS Code
   1. Invoke **View>Command Palette...**
   1. Type 'install', and select the **'Extensions: Install Extension'** action
-  1. Enter `dart code` in the search field, select 'Dart Code' in the list, and
+  1. Enter `flutter` in the search field, select 'Flutter' in the list, and
      click **Install**
   1. Select 'OK' to reload VS Code
 

--- a/using-ide-vscode.md
+++ b/using-ide-vscode.md
@@ -14,7 +14,7 @@ permalink: /using-ide-vscode/
 
 <div class="tabs__content current" markdown="1">
 
-The Dart extension provides a fully integrated development experience in Visual Studio Code.
+The Flutter extension provides a fully integrated development experience in Visual Studio Code.
 
 * TOC Placeholder
 {:toc}
@@ -22,7 +22,7 @@ The Dart extension provides a fully integrated development experience in Visual 
 ## Installation and setup
 
 Please follow the [Editor Setup](/get-started/editor/#vscode) instructions to install
-the Dart extension (which includes Flutter functionality).
+the Flutter extension (which includes Flutter functionality).
 
 ### Updating the extension<a name="updating"/>
 
@@ -32,7 +32,7 @@ automatically update extensions when updates are available.
 To install updates manually:
 
 1. Click on the Extensions button in the Side Bar
-1. If the Dart extension is shown with an available update, click the update button and then
+1. If the Flutter extension is shown with an available update, click the update button and then
 the reload button
 
 ## Creating projects
@@ -56,7 +56,7 @@ To open an existing Flutter project:
 
 ## Editing code and viewing issues
 
-The Dart extension performs code analysis that enables:
+The Flutter extension performs code analysis that enables:
 
 * Syntax highlighting.
 * Code completions based on rich type analysis.
@@ -84,7 +84,7 @@ as a Flutter project. Please ensure the folder that contains your `pubspec.yaml`
 *Note*: If the status bar reads **No Devices** Flutter has not been able to discover any connected
 iOS or Android devices or simulators. You need to connect a device, or start a simulator, to proceed.
 
-The Dart extension will automatically select the last device connected, however if you have multiple
+The Flutter extension will automatically select the last device connected, however if you have multiple
 devices/simulators connected you can click on the device in the status bar to be presented with a pick-list
 at the top of the screen to allow you to select the device to use for running/debugging.
 
@@ -171,7 +171,7 @@ completion window:
 
 <img src="/images/vscode/snippets.png" style="width:706px;height258px" alt="Snippets" />
 
-The Dart extension includes the following snippets:
+The Flutter extension includes the following snippets:
 
 * Prefix `stless`: Create a new subclass of `StatelessWidget`.
 * Prefix `stful`: Create a new subclass of `StatefulWidget` and it's associated
@@ -217,7 +217,7 @@ application.
 
 All known bugs are tracked in the issue tracker:
 
-  * Dart extension: [GitHub issue
+  * Dart and Flutter extensions: [GitHub issue
    tracker](https://github.com/Dart-Code/Dart-Code/issues).
 
 We very much welcome feedback, both on bugs/issues and feature requests. Prior

--- a/using-ide-vscode.md
+++ b/using-ide-vscode.md
@@ -14,7 +14,7 @@ permalink: /using-ide-vscode/
 
 <div class="tabs__content current" markdown="1">
 
-The Flutter extension provides a fully integrated development experience in Visual Studio Code.
+The [Flutter extension](https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter) provides a fully integrated development experience in Visual Studio Code.
 
 * TOC Placeholder
 {:toc}


### PR DESCRIPTION
Turns out there aren't any hyperlinks to it, but I've updated all the references I can find.

We may also wish to consider updating `flutter doctor` too (though right now, most people won't have it, so we may wish to leave that for a while?).