### PR TITLE
Restart is needed after adding a plugin dependency

### DIFF
--- a/using-packages.md
+++ b/using-packages.md
@@ -54,7 +54,7 @@ To add a package 'css_colors' to an app:
 1. Stop and restart the app, if necessary
    * If the package brings platform-specific code (Java/Kotlin for Android, Swift/Objective-C for iOS), that code
      must be built into your app. Hot reload and hot restart do this only for the Dart code of the package, so you
-     may have to do full restart of the app to avoid errors like `MissingPluginException` when using the package.
+     may have to do a full restart of the app to avoid errors like `MissingPluginException` when using the package.
 
 The
 ['Installing'](https://pub.dartlang.org/packages/css_colors#-installing-tab-)


### PR DESCRIPTION
This does not appear to be documented anywhere, and users get landed with `MissingPluginException`s if they attempt to hot restart/hot reload the app after adding a plugin dependency.