### PR TITLE
 Fix incorrect wordSpacing code markup

### DIFF
--- a/web-analogs.md
+++ b/web-analogs.md
@@ -769,7 +769,7 @@ respectively. The amount of space can be in px, pt, cm, em, etc.
 
 In Flutter, you specify white space as logical pixels
 (negative values are allowed)
-for the `letterSpacing` and wordSpacing `properties` of a
+for the `letterSpacing` and `wordSpacing` properties of a
 [TextStyle](https://docs.flutter.io/flutter/painting/TextStyle-class.html)
 child of a Text widget.
 


### PR DESCRIPTION
This PR fixes a mixed up between "wordSpacing" and "`properties`" as seen below:

![screenshot_20180610-091728](https://user-images.githubusercontent.com/239336/41198246-f914537c-6c9e-11e8-8573-db51351e0fdd.png)
