### PR TITLE
Update version requirements for VS Code

### DIFF
--- a/get-started/editor.md
+++ b/get-started/editor.md
@@ -64,7 +64,7 @@ To install these:
 
 ### Install VS Code
 
-  * [VS Code](https://code.visualstudio.com/), version 1.20.1 or later.
+  * [VS Code](https://code.visualstudio.com/), latest stable version.
 
 ### Install the Flutter plugin
 


### PR DESCRIPTION
We often rev the VS Code version we need as they're frequently adding new APIs we need to use. This version has caused confusion (see https://stackoverflow.com/questions/50465219/unable-to-install-dart-code-flutter-in-vs-code) so I think it's better to tell people to just be on latest stable (I don't think there are often good reasons for people to avoid upgrading Code)