### PR TITLE
add link to Chinese site in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,6 +11,7 @@
             <a href="https://github.com/flutter/">github</a> &bull;
             <a href="/tos">terms</a> &bull;
             <a href="https://www.google.com/intl/en/policies/privacy/">privacy</a>
+            <a href="https://flutter-io.cn">社区中文资源</a>
           </p>
 
           <p class="licenses">


### PR DESCRIPTION
Adds a single link to footer.html which connects to the Chinese site. This should help with PageRank, will give Chinese users a useful link. @chenglu has vetted the Chinese translation. 