### PR TITLE
add missing bullet between footer links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,6 +11,7 @@
             <a href="https://github.com/flutter/">github</a> &bull;
             <a href="/tos">terms</a> &bull;
             <a href="https://www.google.com/intl/en/policies/privacy/">privacy</a>
+            <a href="https://flutter-io.cn">社区中文资源</a>
           </p>
 
           <p class="licenses">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,7 +10,7 @@
             <a href="https://twitter.com/flutterio">twitter</a> &bull;
             <a href="https://github.com/flutter/">github</a> &bull;
             <a href="/tos">terms</a> &bull;
-            <a href="https://www.google.com/intl/en/policies/privacy/">privacy</a>
+            <a href="https://www.google.com/intl/en/policies/privacy/">privacy</a> &bull;
             <a href="https://flutter-io.cn">社区中文资源</a>
           </p>
 


### PR DESCRIPTION
Despite four of us looking at it, we missed a small bullet glyph between the last two links in the footer!