### PR TITLE
Rename Form Widgets for Clarity

### DIFF
--- a/cookbook/forms/focus.md
+++ b/cookbook/forms/focus.md
@@ -57,14 +57,14 @@ class. In addition, we need to `dispose` of them when they're no longer needed!
 <!-- skip -->
 ```dart
 // Define a Custom Form Widget
-class MyForm extends StatefulWidget {
+class MyCustomForm extends StatefulWidget {
   @override
-  _MyFormState createState() => _MyFormState();
+  _MyCustomFormState createState() => _MyCustomFormState();
 }
 
 // Define a corresponding State class. This class will hold the data related to
 // the form.
-class _MyFormState extends State<MyForm> {
+class _MyCustomFormState extends State<MyCustomForm> {
   // Create the focus node. We will pass it to the TextField below.
   final FocusNode myFocusNode = FocusNode();
 
@@ -90,7 +90,7 @@ the `build` method.
 
 <!-- skip -->
 ```dart
-class _MyFormState extends State<MyForm> {
+class _MyCustomFormState extends State<MyCustomForm> {
   // Code to create the Focus node...
 
   @override
@@ -129,20 +129,20 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Text Field Focus',
-      home: MyForm(),
+      home: MyCustomForm(),
     );
   }
 }
 
 // Define a Custom Form Widget
-class MyForm extends StatefulWidget {
+class MyCustomForm extends StatefulWidget {
   @override
-  _MyFormState createState() => _MyFormState();
+  _MyCustomFormState createState() => _MyCustomFormState();
 }
 
 // Define a corresponding State class. This class will hold the data related to
 // the form.
-class _MyFormState extends State<MyForm> {
+class _MyCustomFormState extends State<MyCustomForm> {
   // Create the focus node. We will pass it to the TextField below.
   final FocusNode myFocusNode = FocusNode();
 

--- a/cookbook/forms/retrieve-input.md
+++ b/cookbook/forms/retrieve-input.md
@@ -30,14 +30,14 @@ object.
 <!-- skip -->
 ```dart
 // Define a Custom Form Widget
-class MyForm extends StatefulWidget {
+class MyCustomForm extends StatefulWidget {
   @override
-  _MyFormState createState() => _MyFormState();
+  _MyCustomFormState createState() => _MyCustomFormState();
 }
 
 // Define a corresponding State class. This class will hold the data related to
 // our Form.
-class _MyFormState extends State<MyForm> {
+class _MyCustomFormState extends State<MyCustomForm> {
   // Create a text controller. We will use it to retrieve the current value
   // of the TextField!
   final myController = TextEditingController();
@@ -113,20 +113,20 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Retrieve Text Input',
-      home: MyForm(),
+      home: MyCustomForm(),
     );
   }
 }
 
 // Define a Custom Form Widget
-class MyForm extends StatefulWidget {
+class MyCustomForm extends StatefulWidget {
   @override
-  _MyFormState createState() => _MyFormState();
+  _MyCustomFormState createState() => _MyCustomFormState();
 }
 
 // Define a corresponding State class. This class will hold the data related to
 // our Form.
-class _MyFormState extends State<MyForm> {
+class _MyCustomFormState extends State<MyCustomForm> {
   // Create a text controller. We will use it to retrieve the current value
   // of the TextField!
   final myController = TextEditingController();

--- a/cookbook/forms/text-field-changes.md
+++ b/cookbook/forms/text-field-changes.md
@@ -17,8 +17,10 @@ we have two options:
 
 ## 1. Supply an `onChanged` callback to a `TextField`
 
-The simplest approach is to supply an [`onChanged`](https://docs.flutter.io/flutter/material/TextField/onChanged.html) 
-callback to a [`TextField`](https://docs.flutter.io/flutter/material/TextField-class.html). 
+The simplest approach is to supply an 
+[`onChanged`](https://docs.flutter.io/flutter/material/TextField/onChanged.html) 
+callback to a 
+[`TextField`](https://docs.flutter.io/flutter/material/TextField-class.html). 
 Whenever the text changes, the callback will be invoked. One downside to this 
 approach is it does not work with `TextFormField` Widgets.
 
@@ -38,7 +40,8 @@ TextField(
 
 A more powerful, but more elaborate approach, is to supply a
 [`TextEditingController`](https://docs.flutter.io/flutter/widgets/TextEditingController-class.html)
-as the [`controller`](https://docs.flutter.io/flutter/material/TextField/controller.html)
+as the 
+[`controller`](https://docs.flutter.io/flutter/material/TextField/controller.html)
 property of the `TextField` or a `TextFormField`.
 
 To be notified when the text changes, we can listen to the controller using its
@@ -61,14 +64,14 @@ these two classes together, we can listen for changes to the text field!
 <!-- skip -->
 ```dart
 // Define a Custom Form Widget
-class MyForm extends StatefulWidget {
+class MyCustomForm extends StatefulWidget {
   @override
-  _MyFormState createState() => _MyFormState();
+  _MyCustomFormState createState() => _MyCustomFormState();
 }
 
 // Define a corresponding State class. This class will hold the data related to
 // our Form.
-class _MyFormState extends State<MyForm> {
+class _MyCustomFormState extends State<MyCustomForm> {
   // Create a text controller. We will use it to retrieve the current value
   // of the TextField!
   final myController = TextEditingController();
@@ -109,7 +112,7 @@ Now, we'll need a function that should run every time the text changes! In this
 example, we'll create a method that prints out the current value of the text
 field.
 
-This method will live inside our `_MyFormState` class.
+This method will live inside our `_MyCustomFormState` class.
 
 <!-- skip -->
 ```dart
@@ -125,12 +128,13 @@ Finally, we need to listen to the `TextEditingController` and run the
 [`addListener`](https://docs.flutter.io/flutter/foundation/ChangeNotifier/addListener.html)
 method to achieve this task.
 
-In this example, we will begin listening for changes when the `_MyFormState` 
-class is initialized, and stop listening when the `_MyFormState` is disposed.
+In this example, we will begin listening for changes when the
+`_MyCustomFormState` class is initialized, and stop listening when the
+`_MyCustomFormState` is disposed.
 
 <!-- skip -->
 ```dart
-class _MyFormState extends State<MyForm> {
+class _MyCustomFormState extends State<MyCustomForm> {
   @override
   void initState() {
     super.initState();
@@ -163,20 +167,20 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Retrieve Text Input',
-      home: MyForm(),
+      home: MyCustomForm(),
     );
   }
 }
 
 // Define a Custom Form Widget
-class MyForm extends StatefulWidget {
+class MyCustomForm extends StatefulWidget {
   @override
-  _MyFormState createState() => _MyFormState();
+  _MyCustomFormState createState() => _MyCustomFormState();
 }
 
 // Define a corresponding State class. This class will hold the data related to
 // our Form.
-class _MyFormState extends State<MyForm> {
+class _MyCustomFormState extends State<MyCustomForm> {
   // Create a text controller. We will use it to retrieve the current value
   // of the TextField!
   final myController = TextEditingController();

--- a/cookbook/forms/validation.md
+++ b/cookbook/forms/validation.md
@@ -36,19 +36,21 @@ us to validate the form in a later step.
 <!-- skip -->
 ```dart
 // Define a Custom Form Widget
-class MyForm extends StatefulWidget {
+class MyCustomForm extends StatefulWidget {
   @override
-  MyFormState createState() {
-    return MyFormState();
+  MyCustomFormState createState() {
+    return MyCustomFormState();
   }
 }
 
 // Define a corresponding State class. This class will hold the data related to 
 // the form.
-class MyFormState extends State<MyForm> {
+class MyCustomFormState extends State<MyCustomForm> {
   // Create a global key that will uniquely identify the Form widget and allow
   // us to validate the form
-  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  //
+  // Note: This is a `GlobalKey<FormState>`, not a GlobalKey<MyCustomFormState>! 
+  final _formKey = GlobalKey<FormState>();
 
   @override
   Widget build(BuildContext context) {
@@ -147,25 +149,28 @@ class MyApp extends StatelessWidget {
         appBar: AppBar(
           title: Text(appTitle),
         ),
-        body: MyForm(),
+        body: MyCustomForm(),
       ),
     );
   }
 }
 
 // Create a Form Widget
-class MyForm extends StatefulWidget {
+class MyCustomForm extends StatefulWidget {
   @override
-  MyFormState createState() {
-    return MyFormState();
+  MyCustomFormState createState() {
+    return MyCustomFormState();
   }
 }
 
 // Create a corresponding State class. This class will hold the data related to
 // the form.
-class MyFormState extends State<MyForm> {
-  // Create a global key that will uniquely identify the `Form` widget
-  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+class MyCustomFormState extends State<MyCustomForm> {
+  // Create a global key that will uniquely identify the Form widget and allow
+  // us to validate the form
+  //
+  // Note: This is a GlobalKey<FormState>, not a GlobalKey<MyCustomFormState>!
+  final _formKey = GlobalKey<FormState>();
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
This attempts to address this issue: https://github.com/flutter/flutter/issues/18304

Users reading the docs were using `GlobalKey<MyFormState>` instead of `GlobalKey<FormState>`. It's an easy mistake to make, since `MyFormState` and `FormState` look quite similar.

I've changed `MyFormState` to `MyCustomFormState` to hopefully make the two classes more distinct from one another, and added a note to the reader: You must use `GlobalKey<FormState>`.

Please let me know if you think this will help address the issue, or if you can think of something better :)