### PR TITLE
Correcting Swift error in platform-channels.md

### DIFF
--- a/platform-channels.md
+++ b/platform-channels.md
@@ -587,7 +587,7 @@ is called, we report that instead.
 batteryChannel.setMethodCallHandler({
   (call: FlutterMethodCall, result: FlutterResult) -> Void in
   if ("getBatteryLevel" == call.method) {
-    receiveBatteryLevel(result: result);
+    self.receiveBatteryLevel(result: result);
   } else {
     result(FlutterMethodNotImplemented);
   }


### PR DESCRIPTION
Update to receiveBatteryLevel in Swift example to prevent this error on build: "error: call to method 'receiveBatteryLevel' in closure requires explicit 'self.' to make capture semantics explicit."  This affects both simulated and physical iOS devices in Swift-based apps.