### PR TITLE
Obfuscating Dart code

### DIFF
--- a/android-release-build.md
+++ b/android-release-build.md
@@ -147,6 +147,9 @@ If you intend to use third-party Java or Android libraries,
 you may want to reduce the size of the APK or protect that code from
 reverse engineering.
 
+For information on obfuscating Dart code, see [Obfuscating Dart
+Code](https://github.com/flutter/flutter/wiki/Obfuscating-Dart-Code).
+
 ### Step 1 - Configure Proguard
 
 Create `/android/app/proguard-rules.pro` file and add rules listed below.

--- a/android-release-build.md
+++ b/android-release-build.md
@@ -137,17 +137,17 @@ file.
    }
 ```
 
-Release builds of your app will now automatically be signed.
+Release builds of your app will now be signed automatically.
 
 
-## Minify and obfuscate
+## Enabling Proguard
 
-By default, Flutter does not obfuscate or minify the Android wrapper.
+By default, Flutter does not obfuscate or minify the Android host.
 If you intend to use third-party Java or Android libraries,
 you may want to reduce the size of the APK or protect that code from
 reverse engineering.
 
-### Step 1 - Configure obfuscation tool
+### Step 1 - Configure Proguard
 
 Create `/android/app/proguard-rules.pro` file and add rules listed below.
 
@@ -161,8 +161,9 @@ Create `/android/app/proguard-rules.pro` file and add rules listed below.
 -keep class io.flutter.plugins.**  { *; }
 ```
 
-The configuration above will only protect Flutter libraries.
-Any additional libraries e.g. Firebase will require their own rules to be added.
+The configuration above only protects Flutter libraries.
+Any additional libraries (for example, Firebase) require their own
+rules to be added.
 
 ### Step 2 - Enable obfuscation and/or minification
 

--- a/android-release-build.md
+++ b/android-release-build.md
@@ -164,7 +164,7 @@ Create `/android/app/proguard-rules.pro` file and add rules listed below.
 -keep class io.flutter.plugins.**  { *; }
 ```
 
-The configuration above only protects Flutter libraries.
+The configuration above only protects Flutter engine libraries.
 Any additional libraries (for example, Firebase) require their own
 rules to be added.
 

--- a/animations/index.md
+++ b/animations/index.md
@@ -130,7 +130,11 @@ classes.
 Animations that are broken into smaller motions, where some of the motion is delayed.
 The smaller animations may be sequential, or may partially or completely overlap.
 
-* [Staggered Animations](/animations/staggered-animations/) <img src="/images/ic_new_releases_black_24px.svg" alt="this doc is new!"> NEW<br>
+* [Staggered Animations](/animations/staggered-animations/)
+
+<!-- Save so I can remember how to add it back later.
+<img src="/images/ic_new_releases_black_24px.svg" alt="this doc is new!"> NEW<br>
+-->
 
 ## Other resources
 

--- a/animations/staggered-animations/index.md
+++ b/animations/staggered-animations/index.md
@@ -379,8 +379,12 @@ The following resources might help when writing animations:
 [Material motion spec](https://material.io/guidelines/motion/)
 : Describes motion for Material apps.
 
+{% comment %}
+Package not vetted.
+
 ## Other resources
 
 * For an alternate approach to sequence animation, see the
 [flutter_sequence_animation](https://pub.dartlang.org/packages/flutter_sequence_animation)
 package on [pub.dartlang.org](https://pub.dartlang.org/packages).
+{% endcomment %}

--- a/animations/staggered-animations/index.md
+++ b/animations/staggered-animations/index.md
@@ -378,3 +378,9 @@ The following resources might help when writing animations:
 
 [Material motion spec](https://material.io/guidelines/motion/)
 : Describes motion for Material apps.
+
+## Other resources
+
+* For an alternate approach to sequence animation, see the
+[flutter_sequence_animation](https://pub.dartlang.org/packages/flutter_sequence_animation)
+package on [pub.dartlang.org](https://pub.dartlang.org/packages).

--- a/ios-release-build.md
+++ b/ios-release-build.md
@@ -8,6 +8,9 @@ permalink: /ios-release/
 This guide provides a step-by-step walkthrough of releasing a Flutter app to
 the [App Store][appstore] and [TestFlight][testflight].
 
+For information on obfuscating Dart code, see [Obfuscating Dart
+Code](https://github.com/flutter/flutter/wiki/Obfuscating-Dart-Code).
+
 * TOC Placeholder
 {:toc}
 


### PR DESCRIPTION
A continuation of PR https://github.com/flutter/website/pull/1071.

* As Chris requested, the obfuscation details are now in the [Flutter wiki.](https://github.com/flutter/flutter/wiki/Obfuscating-Dart-Code).
* Incorporated feedback from @mit-mit, @Ehud-Banunu, and @xster.