### PR TITLE
correct folder name to be l10n

### DIFF
--- a/tutorials/international/index.md
+++ b/tutorials/international/index.md
@@ -407,7 +407,7 @@ Rebuilding `l10n/messages_all.dart` requires two steps.
 `l10n/intl_messages.arb` from `lib/main.dart`:
 
 {% prettify sh %}
-$ flutter pub pub run intl_translation:extract_to_arb --output-dir=lib/i10n lib/main.dart
+$ flutter pub pub run intl_translation:extract_to_arb --output-dir=lib/l10n lib/main.dart
 {% endprettify %}
 
 The `intl_messages.arb` file is a JSON format map with one entry for


### PR DESCRIPTION
there is no such thing as i10n, its a typo
i18n means internationalization
l10n means localization

i10n would mean internation

2nd command fails because first folder is wrong