### PR TITLE
Added "new" operator before MethodChannel and MethodCallHandler

### DIFF
--- a/platform-channels.md
+++ b/platform-channels.md
@@ -224,9 +224,10 @@ public class MainActivity extends FlutterActivity {
     public void onCreate(Bundle savedInstanceState) {
 
         super.onCreate(savedInstanceState);
+        GeneratedPluginRegistrant.registerWith(this);
 
-        MethodChannel(getFlutterView(), CHANNEL).setMethodCallHandler(
-                MethodCallHandler() {
+        new MethodChannel(getFlutterView(), CHANNEL).setMethodCallHandler(
+                new MethodCallHandler() {
                     @Override
                     public void onMethodCall(MethodCall call, Result result) {
                         // TODO


### PR DESCRIPTION
The java code snippet provided in **Step:3a** wont work unless we use `new` operator before `MethodCannel()` and `MethodCallHandler()`. Also, `GeneratedPluginRegistrant.registerWith(this);` is missing from that snippet so, I have added it too. 

Reference taken from  this [example](https://github.com/flutter/flutter/blob/edc16473bfdafc0f5fe546610d3b0fe0eecdd080/examples/platform_channel/android/app/src/main/java/com/example/platformchannel/MainActivity.java#L53)