### PR TITLE
updated "then" method parameter

### DIFF
--- a/tutorials/international/index.md
+++ b/tutorials/international/index.md
@@ -256,7 +256,7 @@ class DemoLocalizations {
   static Future<DemoLocalizations> load(Locale locale) {
     final String name = locale.countryCode.isEmpty ? locale.languageCode : locale.toString();
     final String localeName = Intl.canonicalizedLocale(name);
-    return initializeMessages(localeName).then((Null _) {
+    return initializeMessages(localeName).then((_) {
       Intl.defaultLocale = localeName;
       return DemoLocalizations();
     });


### PR DESCRIPTION
updated "then" method parameter to current Dart version
currently throws "The argument type '(Null) → DemoLocalizations' can't be assigned to the parameter type '(bool) → FutureOr<DemoLocalizations>'."