### PR TITLE
Update the tutorials to point to the Geolocator plugin

### DIFF
--- a/flutter-for-android.md
+++ b/flutter-for-android.md
@@ -2083,7 +2083,7 @@ class _SampleAppPageState extends State<SampleAppPage> {
 
 ## How do I access the GPS sensor?
 
-Use the [`location`](https://pub.dartlang.org/packages/location) community plugin.
+Use the [`geolocator`](https://pub.dartlang.org/packages/geolocator) community plugin.
 
 ## How do I access the camera?
 

--- a/flutter-for-ios.md
+++ b/flutter-for-ios.md
@@ -1970,7 +1970,7 @@ and [publish it on Pub](/developing-packages/#publish).
 
 ## How do I access the GPS sensor?
 
-Use the [`location`](https://pub.dartlang.org/packages/location) community plugin.
+Use the [`geolocator`](https://pub.dartlang.org/packages/geolocator) community plugin.
 
 ## How do I access the camera?
 

--- a/flutter-for-xamarin-forms.md
+++ b/flutter-for-xamarin-forms.md
@@ -2227,7 +2227,7 @@ and [publish it on Pub](/developing-packages/#publish).
 
 ## How do I access the GPS sensor?
 
-Use the [`location`](https://pub.dartlang.org/packages/location) community plugin.
+Use the [`geolocator`](https://pub.dartlang.org/packages/geolocator) community plugin.
 
 ## How do I access the camera?
 


### PR DESCRIPTION
Updated the chapter "How do I access the GPS sensor?" to point to the "geolocator" plugin instead of the "location" plugin.