### PR TITLE
Integration testing recipes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,9 @@ task :checklinks do
       # Skip httpbin links as they are not allowed from TravisCI
       'http://httpbin.com',
       # Skip links that have been auto-inserted for the 'Edit Source' action (i.e. that match this regexp)
-      /github.com\/flutter\/website/
+      /github.com\/flutter\/website/,
+      # Skip links to the Chrome tracing tools
+      'chrome://tracing',
     ],
     :only_4xx => true,
     # Replace canonical link with local links.

--- a/cookbook/index.md
+++ b/cookbook/index.md
@@ -82,6 +82,12 @@ reference to help you build up an application.
   * [Introduction to Widget testing](/cookbook/testing/widget-test-introduction/)
   * [Finding Widgets in a Widget Test](/cookbook/testing/widget-test-finders/)
   * [Tapping and Dragging in Widget Tests](/cookbook/testing/widget-test-tap-drag/)
+  
+### Integration Tests
+
+  * [Introduction to integration testing](/cookbook/testing/integration-test-introduction/)
+  * [Scrolling in integration tests](/cookbook/testing/integration-test-scrolling/)
+  * [Performance profiling with integration tests](/cookbook/testing/integration-test-profiling/)
     
 ## App Maintenance
 

--- a/cookbook/testing/integration-test-introduction.md
+++ b/cookbook/testing/integration-test-introduction.md
@@ -1,0 +1,251 @@
+---
+layout: page
+title: "Introduction to Integration testing"
+permalink: /cookbook/testing/integration-test-introduction/
+---
+
+Unit tests and Widget tests are handy for testing individual classes, functions,
+or Widgets. However, they generally don't test how individual pieces work
+together as a whole or capture the performance of an application running on a
+real device. These tasks are performed with integration tests.
+
+Integration tests work as a pair: first, deploy an instrumented application to a
+real device or emulator and then "drive" the application from a separate test
+suite, checking to make sure everything is correct along the way.
+
+To create this test pair, we can use the 
+[flutter_driver](https://docs.flutter.io/flutter/flutter_driver/flutter_driver-library.html) 
+package. It provides tools to create instrumented apps and drive those apps
+from a test suite.
+
+In this recipe, we'll learn how to test a counter app. It will demonstrate
+how to setup integration tests, how to verify specific text is displayed by the 
+app, how to tap on specific Widgets, and how to run integration tests. 
+
+### Directions
+
+  1. Create an app to test
+  2. Add the `flutter_driver` dependency
+  3. Create the test files
+  4. Instrument the app
+  5. Write the integration tests
+  6. Run the integration test
+  
+### 1. Create an app to test
+
+First, we'll create an app that we can test! In this example, we'll test the 
+counter app produced by the `flutter create` command. This app allows
+a user to tap on a button to increase a counter.
+
+Furthermore, we'll also need to provide a
+[`ValueKey`](https://docs.flutter.io/flutter/foundation/ValueKey-class.html) to
+the `Text` and `FloatingActionButton` Widgets. This allows us to identify 
+and interact with these specific Widgets inside the test suite. 
+
+```dart
+import 'package:flutter/material.dart';
+
+void main() => runApp(MyApp());
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Counter App',
+      home: MyHomePage(title: 'Counter App Home Page'),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  MyHomePage({Key key, this.title}) : super(key: key);
+
+  final String title;
+
+  @override
+  _MyHomePageState createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  int _counter = 0;
+
+  void _incrementCounter() {
+    setState(() {
+      _counter++;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Text(
+              'You have pushed the button this many times:',
+            ),
+            Text(
+              '$_counter',
+              // Provide a Key to this specific Text Widget. This allows us
+              // to identify this specific Widget from inside our test suite and
+              // read the text.
+              key: Key('counter'),
+              style: Theme.of(context).textTheme.display1,
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        // Provide a Key to this the button. This allows us to find this
+        // specific button and tap it inside the test suite.
+        key: Key('increment'),
+        onPressed: _incrementCounter,
+        tooltip: 'Increment',
+        child: Icon(Icons.add),
+      ),
+    );
+  }
+}
+```
+
+### 2. Add the `flutter_test` dependency
+
+Next, we'll need the `flutter_driver` package to write integration tests. We 
+can add the `flutter_driver` dependency to the `dev_dependencies` section of 
+our apps's `pubspec.yaml` file. 
+
+```yaml
+dev_dependencies:
+  flutter_driver:
+    sdk: flutter
+```
+    
+### 3. Create the test files
+
+Unlike unit and widget tests, integration test suites do not run in the same 
+process as the app being tested. Therefore, we need to create two files that 
+reside in the same directory. By convention, the directory is named 
+`test_driver`.
+
+  1. The first file contains an "instrumented" version of the app. The
+  instrumentation allows us to "drive" the app and record performance profiles
+  from a test suite. This file can be given any name that makes sense. For this
+  example, create a file called `test_driver/app.dart`.
+  2. The second file contains the test suite, which drives the app and verifies
+  it works as expected. The test suite can also record performance profiles. 
+  The name of the test file must correspond to the name of the file that 
+  contains the instrumented app, with `_test` added at the end. Therefore, 
+  create a second file called `test_driver/app_test.dart`.
+  
+This leaves us with the following directory structure:
+
+```
+counter_app/
+  lib/
+    main.dart
+  test_driver/
+    app.dart
+    app_test.dart
+``` 
+ 
+
+### 4. Instrument the app
+
+Now, we can instrument the app. This will involve two steps:
+
+  1. Enable the flutter driver extensions
+  2. Run the app
+
+We will add this code inside the `flutter_driver/app.dart` file.
+
+```dart
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:counter_app/main.dart' as app;
+
+void main() {
+  // This line enables the extension
+  enableFlutterDriverExtension();
+
+  // Call the `main()` function of your app or call `runApp` with any widget you 
+  // are interested in testing.
+  app.main();
+}
+```
+
+### 5. Write the tests
+
+Now that we have an instrumented app, we can write tests for it! This
+will involve four steps:
+
+  1. Create
+  [`SeralizableFinders`](https://docs.flutter.io/flutter/flutter_driver/CommonFinders-class.html)
+  to locate specific Widgets
+  2. Connect to the app before our tests run in the `setUpAll` function
+  3. Test the important scenarios
+  4. Disconnect from the app in the `teardownAll` function after our tests
+  complete
+ 
+```dart
+// Imports the Flutter Driver API
+import 'package:flutter_driver/flutter_driver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Counter App', () {
+    // First, define the Finders. We can use these to locate Widgets from the
+    // test suite. Note: the Strings provided to the `byValueKey` method must
+    // be the same as the Strings we used for the Keys in step 1.
+    final counterTextFinder = find.byValueKey('counter');
+    final buttonFinder = find.byValueKey('increment');
+
+    FlutterDriver driver;
+
+    // Connect to the Flutter driver before running any tests
+    setUpAll(() async {
+      driver = await FlutterDriver.connect();
+    });
+
+    // Close the connection to the driver after the tests have completed
+    tearDownAll(() async {
+      if (driver != null) {
+        driver.close();
+      }
+    });
+
+    test('starts at 0', () async {
+      // Use the `driver.getText` method to verify the counter starts at 0.
+      expect(await driver.getText(counterTextFinder), "0");
+    });
+
+    test('increments the counter', () async {
+      // First, tap on the button
+      await driver.tap(buttonFinder);
+
+      // Then, verify the counter text has been incremented by 1
+      expect(await driver.getText(counterTextFinder), "1");
+    });
+  });
+}
+```
+
+### 6. Run the tests
+
+Now that we have an instrumented app and a test suite, we can run the tests!
+First, be sure to launch an Android Emulator, iOS Simulator, or connect your 
+computer to a real iOS / Android device.
+
+Then, run the following command from the root of the project:
+
+```
+flutter drive --target=test_driver/app.dart
+```
+
+This command:
+
+  1. builds the `--target` app and installs it on the emulator / device
+  2. launches the app
+  3. runs the `app_test.dart` test suite located in `test_driver/` folder

--- a/cookbook/testing/integration-test-introduction.md
+++ b/cookbook/testing/integration-test-introduction.md
@@ -7,7 +7,7 @@ permalink: /cookbook/testing/integration-test-introduction/
 Unit tests and Widget tests are handy for testing individual classes, functions,
 or Widgets. However, they generally don't test how individual pieces work
 together as a whole or capture the performance of an application running on a
-real device. These tasks are performed with integration tests.
+real device. These tasks are performed with *integration tests*.
 
 Integration tests work as a pair: first, deploy an instrumented application to a
 real device or emulator and then "drive" the application from a separate test
@@ -112,7 +112,7 @@ class _MyHomePageState extends State<MyHomePage> {
 }
 ```
 
-### 2. Add the `flutter_test` dependency
+### 2. Add the `flutter_driver` dependency
 
 Next, we'll need the `flutter_driver` package to write integration tests. We 
 can add the `flutter_driver` dependency to the `dev_dependencies` section of 

--- a/cookbook/testing/integration-test-introduction.md
+++ b/cookbook/testing/integration-test-introduction.md
@@ -162,6 +162,7 @@ Now, we can instrument the app. This will involve two steps:
 
 We will add this code inside the `flutter_driver/app.dart` file.
 
+<!-- skip -->
 ```dart
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:counter_app/main.dart' as app;

--- a/cookbook/testing/integration-test-profiling.md
+++ b/cookbook/testing/integration-test-profiling.md
@@ -26,7 +26,7 @@ a local file.
   2. Record the performance of the app
   3. Save the results to disk
   4. Run the test
-  5. View the summary
+  5. Review the results
 
 ### 1. Write a test that scrolls through a list of items
 
@@ -71,20 +71,21 @@ final timeline = await driver.traceAction(() async {
 
 ### 3. Save the results to disk
 
-Now that we've captured a performance timeline, we need a way to inspect it! 
+Now that we've captured a performance timeline, we need a way to review it! 
 The `Timeline` object provides detailed information about all of the events that
-took place. Therefore, it can be a bit difficult to read and understand.
+took place, but it does not provide a convenient way to review the results.
 
-Instead of inspecting the raw data contained within the `Timeline`, we can
-convert the `Timeline` into a
+Therefore, we can convert the `Timeline` into a
 [`TimelineSummary`](https://docs.flutter.io/flutter/flutter_driver/TimelineSummary-class.html).
-The `TimelineSummary` will extract statistics from the `Timeline` in a format
-that's easier to consume.
+The `TimelineSummary` can perform two tasks that make it easier to review the
+results:
 
-Finally, we need a way to review the summary. The easiest option is to save the
-summary to your local hard drive and review the results. With a more advanced
-setup, we could save a summary after each test run performed on each
-device and create a graph of the results!
+  1. It can write a json document on disk that summarizes the data contained 
+  within the `Timeline`. This summary includes information about the number of 
+  skipped frames, slowest build times, and more.
+  2. It can save the complete `Timeline` as a json file on disk. This file can 
+  be opened with the Chrome browser's tracing tools found at 
+  [`chrome://tracing`](`chrome://tracing`).
 
 <!-- skip -->
 ```dart
@@ -93,7 +94,12 @@ device and create a graph of the results!
 final summary = new TimelineSummary.summarize(timeline);
 
 // Then, save the summary to disk
-summary.writeSummaryToFile('scrolling_performance', pretty: true);
+summary.writeSummaryToFile('scrolling_summary', pretty: true);
+
+// Optionally, write the entire timeline to disk in a json format. This
+// file can be opened in the Chrome browser's tracing tools found by
+// navigating to chrome://tracing.
+summary.writeTimelineToFile('scrolling_timeline', pretty: true);
 ```
 
 ### 4. Run the test
@@ -105,13 +111,22 @@ summary of the results to disk, we can run the test with the following command:
 flutter drive --target=test_driver/app.dart
 ```
 
-### 5. Inspect the summary
+### 5. Review the results
 
-Once the test has completed successfully, find the summary inside the `build` 
-directory of the app in a file called 
-`scrolling_performance.timeline_summary.json`.
+After the test completes successfully, the `build` directory at the root of 
+the project contains two files:
 
-#### Example:
+  1. `scrolling_summary.timeline_summary.json` contains the summary. Open
+  the file with any text editor to review the information contained within.
+  With a more advanced setup, we could save a summary every time the test 
+  runs and create a graph of the results.
+  2. `scrolling_timeline.timeline.json` contains the complete timeline data.
+  Open the file using the Chrome browser's tracing tools found at 
+  [`chrome://tracing`](`chrome://tracing`). The tracing tools provide a 
+  convenient interface for inspecting the timeline data in order to discover 
+  the source of a performance issue.
+
+#### Summary Example
 
 ```json
 {
@@ -175,7 +190,12 @@ void main() {
       final summary = new TimelineSummary.summarize(timeline);
 
       // Then, save the summary to disk
-      summary.writeSummaryToFile('scrolling_performance', pretty: true);
+      summary.writeSummaryToFile('scrolling_summary', pretty: true);
+
+      // Optionally, write the entire timeline to disk in a json format. This
+      // file can be opened in the Chrome browser's tracing tools found by
+      // navigating to chrome://tracing.
+      summary.writeTimelineToFile('scrolling_timeline', pretty: true);
     });
   });
 }

--- a/cookbook/testing/integration-test-profiling.md
+++ b/cookbook/testing/integration-test-profiling.md
@@ -85,7 +85,7 @@ results:
   skipped frames, slowest build times, and more.
   2. It can save the complete `Timeline` as a json file on disk. This file can 
   be opened with the Chrome browser's tracing tools found at 
-  [`chrome://tracing`](`chrome://tracing`).
+  [chrome://tracing](chrome://tracing).
 
 <!-- skip -->
 ```dart
@@ -122,7 +122,7 @@ the project contains two files:
   runs and create a graph of the results.
   2. `scrolling_timeline.timeline.json` contains the complete timeline data.
   Open the file using the Chrome browser's tracing tools found at 
-  [`chrome://tracing`](`chrome://tracing`). The tracing tools provide a 
+  [chrome://tracing](chrome://tracing). The tracing tools provide a 
   convenient interface for inspecting the timeline data in order to discover 
   the source of a performance issue.
 

--- a/cookbook/testing/integration-test-profiling.md
+++ b/cookbook/testing/integration-test-profiling.md
@@ -1,0 +1,182 @@
+---
+layout: page
+title: "Performance profiling with integration tests"
+permalink: /cookbook/testing/integration-test-profiling/
+---
+
+When it comes to mobile apps, performance is critical to user experience. Users
+expect apps to have smooth scrolling and meaningful animations free of
+stuttering or skipped frames, known as "jank." How can we ensure our apps are
+free of jank on a wide variety of devices? 
+
+There are two options: first, we could manually test the app on different
+devices. While that approach might work for a smaller app, it will become more
+cumbersome as an app grows in size. Alternatively, we can run an integration
+test that performs a specific task and record a performance timeline. Then, we
+can examine the results to determine whether or not a specific section of our
+app needs to be improved.
+
+In this recipe, we'll learn how to write a test that records a performance
+timeline while performing a specific task and saves a summary of the results to 
+a local file.
+
+### Directions
+
+  1. Write a test that scrolls through a list of items
+  2. Record the performance of the app
+  3. Save the results to disk
+  4. Run the test
+  5. View the summary
+
+### 1. Write a test that scrolls through a list of items
+
+In this recipe, we'll record the performance of an app as it scrolls through a
+list of items. In order to focus on performance profiling, this recipe builds 
+upon the 
+[Scrolling in integration tests](/cookbook/testing/integration-test-scrolling/)
+recipe.
+
+Please follow the instructions in that recipe to create an app, instrument the
+app, and write a test to verify everything works as expected.
+
+### 2. Record the performance of the app
+
+Next, we need to record the performance of the app as it scrolls through the
+list. To achieve this task, we can use the
+[`traceAction`](https://docs.flutter.io/flutter/flutter_driver/FlutterDriver/traceAction.html)
+method provided by the
+[`FlutterDriver`](https://docs.flutter.io/flutter/flutter_driver/FlutterDriver-class.html)
+class.
+
+This method runs the the provided function and records a
+[`Timeline`](https://docs.flutter.io/flutter/flutter_driver/Timeline-class.html)
+with detailed information about the performance of the app. In this example, we
+provide a function that scrolls through the list of items, ensuring a specific
+item is displayed. When the function completes, the `traceAction` method returns
+a `Timeline`.
+
+<!-- skip -->
+```dart
+// Record a performance timeline as we scroll through the list of items
+final timeline = await driver.traceAction(() async {
+  await driver.scrollUntilVisible(
+    listFinder,
+    itemFinder,
+    dyScroll: -300.0,
+  );
+
+  expect(await driver.getText(itemFinder), 'Item 50');
+});
+```
+
+### 3. Save the results to disk
+
+Now that we've captured a performance timeline, we need a way to inspect it! 
+The `Timeline` object provides detailed information about all of the events that
+took place. Therefore, it can be a bit difficult to read and understand.
+
+Instead of inspecting the raw data contained within the `Timeline`, we can
+convert the `Timeline` into a
+[`TimelineSummary`](https://docs.flutter.io/flutter/flutter_driver/TimelineSummary-class.html).
+The `TimelineSummary` will extract statistics from the `Timeline` in a format
+that's easier to consume.
+
+Finally, we need a way to review the summary. The easiest option is to save the
+summary to your local hard drive and review the results. With a more advanced
+setup, we could save a summary after each test run performed on each
+device and create a graph of the results!
+
+<!-- skip -->
+```dart
+// Convert the Timeline into a TimelineSummary that's easier to read and
+// understand.
+final summary = new TimelineSummary.summarize(timeline);
+
+// Then, save the summary to disk
+summary.writeSummaryToFile('scrolling_performance', pretty: true);
+```
+
+### 4. Run the test
+
+After we've configured our test to capture a performance `Timeline` and save a 
+summary of the results to disk, we can run the test with the following command:
+
+```
+flutter drive --target=test_driver/app.dart
+```
+
+### 5. Inspect the summary
+
+Once the test has completed successfully, find the summary inside the `build` 
+directory of the app in a file called 
+`scrolling_performance.timeline_summary.json`.
+
+#### Example:
+
+```json
+{
+  "average_frame_build_time_millis": 4.2592592592592595,
+  "worst_frame_build_time_millis": 21.0,
+  "missed_frame_build_budget_count": 2,
+  "average_frame_rasterizer_time_millis": 5.518518518518518,
+  "worst_frame_rasterizer_time_millis": 51.0,
+  "missed_frame_rasterizer_budget_count": 10,
+  "frame_count": 54,
+  "frame_build_times": [
+    6874,
+    5019,
+    3638
+  ],
+  "frame_rasterizer_times": [
+    51955,
+    8468,
+    3129
+  ]
+}
+```
+
+### Complete example
+
+```dart
+import 'package:flutter_driver/flutter_driver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Scrollable App', () {
+    FlutterDriver driver;
+
+    setUpAll(() async {
+      driver = await FlutterDriver.connect();
+    });
+
+    tearDownAll(() async {
+      if (driver != null) {
+        driver.close();
+      }
+    });
+
+    test('verifies the list contains a specific item', () async {
+      final listFinder = find.byValueKey('long_list');
+      final itemFinder = find.byValueKey('item_50_text');
+
+      // Record a performance profile as we scroll through the list of items
+      final timeline = await driver.traceAction(() async {
+        await driver.scrollUntilVisible(
+          listFinder,
+          itemFinder,
+          dyScroll: -300.0,
+        );
+
+        expect(await driver.getText(itemFinder), 'Item 50');
+      });
+
+      // Convert the Timeline into a TimelineSummary that's easier to read and
+      // understand.
+      final summary = new TimelineSummary.summarize(timeline);
+
+      // Then, save the summary to disk
+      summary.writeSummaryToFile('scrolling_performance', pretty: true);
+    });
+  });
+}
+```

--- a/cookbook/testing/integration-test-scrolling.md
+++ b/cookbook/testing/integration-test-scrolling.md
@@ -1,0 +1,207 @@
+---
+layout: page
+title: "Scrolling in integration tests"
+permalink: /cookbook/testing/integration-test-scrolling/
+---
+
+Many apps feature lists of content, from email clients to music apps and beyond.
+In order to verify that lists contain the content we expect using integration
+tests, we need a way to scroll through lists to search for particular items.
+
+In order to scroll through lists via integration tests, we can use the methods
+provided by the
+[`FlutterDriver`](https://docs.flutter.io/flutter/flutter_driver/FlutterDriver-class.html)
+class, which is included in the
+[`flutter_driver`](https://docs.flutter.io/flutter/flutter_driver/flutter_driver-library.html)
+package:
+
+In this recipe, we'll learn how to scroll through a list of items in order to
+verify a specific Widget is being displayed, and discuss the pros on cons of
+different approaches. If you're just getting started with integration testing,
+please read through the [Introduction to integration
+testing](/cookbook/testing/integration-test-introduction/) recipe.
+
+### Directions
+
+  1. Create an app with a list of items
+  2. Instrument the app
+  3. Write a test that scrolls through the list
+  4. Run the test
+
+### 1. Create an app with a list of items
+
+In this recipe, we'll build an app that shows a long list of items. In order to
+keep this recipe focused on testing, we'll use the app we created in the
+[Working with long lists](/cookbook/lists/long-lists/) recipe. If you're unsure
+of how to work with lists of content, please see that recipe for an 
+introduction.
+
+As we did in the [Introduction to integration
+testing](/cookbook/testing/integration-test-introduction/) recipe, we'll also
+add Keys to the widgets we want to interact with inside our integration tests.
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(MyApp(
+    items: List<String>.generate(10000, (i) => "Item $i"),
+  ));
+}
+
+class MyApp extends StatelessWidget {
+  final List<String> items;
+
+  MyApp({Key key, @required this.items}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final title = 'Long List';
+
+    return MaterialApp(
+      title: title,
+      home: Scaffold(
+        appBar: AppBar(
+          title: Text(title),
+        ),
+        body: ListView.builder(
+          // Add a key to the ListView. This allows us to find the list and
+          // scroll through it in our tests
+          key: Key('long_list'),
+          itemCount: items.length,
+          itemBuilder: (context, index) {
+            return ListTile(
+              title: Text(
+                '${items[index]}',
+                // Add a key to the Text Widget for each item. This allows
+                // us to look for a particular item in the list and verify the
+                // text is correct
+                key: Key('item_${index}_text'),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+```
+
+### 2. Instrument the app
+
+Next, we'll need to create an instrumented version of our app. This code lives
+in a file called `test_driver/app.dart`.
+
+```dart
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:scrollable_app/main.dart' as app;
+
+void main() {
+  // This line enables the extension
+  enableFlutterDriverExtension();
+
+  // Call the `main()` function of your app or call `runApp` with any widget you 
+  // are interested in testing.
+  app.main();
+}
+```
+
+### 3. Write a test that scrolls through the list
+
+Now, we can write our test! In this example, we need to scroll through the list
+of items and verify that a particular item exists in the list. The
+[`FlutterDriver`](https://docs.flutter.io/flutter/flutter_driver/FlutterDriver-class.html)
+class provides three methods for scrolling through lists:
+
+  - The
+  [`scroll`](https://docs.flutter.io/flutter/flutter_driver/FlutterDriver/scroll.html)
+  method allows us to scroll through a specific list by a given amount. 
+  - The
+  [`scrollIntoView`](https://docs.flutter.io/flutter/flutter_driver/FlutterDriver/scrollIntoView.html)
+  method finds a specific Widget that's currently displayed on screen and will
+  scroll it completely into view.
+  - The
+  [`scrollUntilVisible`](https://docs.flutter.io/flutter/flutter_driver/FlutterDriver/scrollUntilVisible.html)
+  method scrolls through a list until a specific Widget is visible.
+
+While all three methods work for specific use-cases, `scrollUntilVisible` is
+oftentimes the most robust option. Why?
+
+  1. If we use the `scroll` method alone, we might incorrectly assume the height
+  of each item in the list. This could lead to scrolling too much or too little.
+  2. If we use the `scrollIntoView` method, we're assuming the Widget is visible
+  on screen. In order to verify our apps work on a broad range of devices, we
+  might run our integration tests against devices with different screen sizes.
+  Whether or not a particular Widget is visible can depend on the size of the
+  screen.
+
+Therefore, rather than assuming we know the height of all the items in a list,
+or that a particular Widget will be visible on all devices, we can use the
+`scrollUntilVisible` method to repeatedly scroll through a list of items until
+we find what we're looking for!
+
+Let's see how we can use the `scrollUntilVisible` method to look through the
+list for a particular item! This code lives in a file called
+`test_driver/app_test.dart`.
+
+```dart
+// Imports the Flutter Driver API
+import 'package:flutter_driver/flutter_driver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Scrollable App', () {
+    FlutterDriver driver;
+
+    // Connect to the Flutter driver before running any tests
+    setUpAll(() async {
+      driver = await FlutterDriver.connect();
+    });
+
+    // Close the connection to the driver after the tests have completed
+    tearDownAll(() async {
+      if (driver != null) {
+        driver.close();
+      }
+    });
+
+    test('verifies the list contains a specific item', () async {
+      // Create two SerializableFinders. We will use these to locate specific
+      // Widgets displayed by the app. The names provided to the byValueKey
+      // method correspond to the Keys we provided to our Widgets in step 1.
+      final listFinder = find.byValueKey('long_list');
+      final itemFinder = find.byValueKey('item_50_text');
+
+      await driver.scrollUntilVisible(
+        // Scroll through this list
+        listFinder,
+        // Until we find this item
+        itemFinder,
+        // In order to scroll down the list, we need to provide a negative
+        // value to dyScroll. Ensure this value is a small enough increment to
+        // scroll the item into view without potentially scrolling past it.
+        //
+        // If you need to scroll through horizontal lists, provide a dxScroll
+        // argument instead
+        dyScroll: -300.0,
+      );
+
+      // Verify the item contains the correct text
+      expect(
+        await driver.getText(itemFinder),
+        'Item 50',
+      );
+    });
+  });
+}
+```
+
+### 4. Run the test
+
+Finally, we can run the test using the following command from the root of the
+project:
+
+```
+flutter drive --target=test_driver/app.dart
+```

--- a/cookbook/testing/integration-test-scrolling.md
+++ b/cookbook/testing/integration-test-scrolling.md
@@ -120,8 +120,10 @@ class provides three methods for scrolling through lists:
   method allows us to scroll through a specific list by a given amount. 
   - The
   [`scrollIntoView`](https://docs.flutter.io/flutter/flutter_driver/FlutterDriver/scrollIntoView.html)
-  method finds a specific Widget that's currently displayed on screen and will
-  scroll it completely into view.
+  method finds a specific Widget that's already been rendered, and will scroll 
+  it completely into view. Some Widgets, such as 
+  [`ListView.builder`](https://docs.flutter.io/flutter/widgets/ListView/ListView.builder.html),
+  render items on-demand.
   - The
   [`scrollUntilVisible`](https://docs.flutter.io/flutter/flutter_driver/FlutterDriver/scrollUntilVisible.html)
   method scrolls through a list until a specific Widget is visible.
@@ -131,14 +133,15 @@ oftentimes the most robust option. Why?
 
   1. If we use the `scroll` method alone, we might incorrectly assume the height
   of each item in the list. This could lead to scrolling too much or too little.
-  2. If we use the `scrollIntoView` method, we're assuming the Widget is visible
-  on screen. In order to verify our apps work on a broad range of devices, we
-  might run our integration tests against devices with different screen sizes.
-  Whether or not a particular Widget is visible can depend on the size of the
-  screen.
+  2. If we use the `scrollIntoView` method, we assume the Widget has been
+  instantiated and rendered. In order to verify our apps work on a broad range
+  of devices, we might run our integration tests against devices with different
+  screen sizes. Since `ListView.builder` will render items on-demand,
+  whether or not a particular Widget has been rendered can depend 
+  on the size of the screen.
 
 Therefore, rather than assuming we know the height of all the items in a list,
-or that a particular Widget will be visible on all devices, we can use the
+or that a particular Widget will be rendered on all devices, we can use the
 `scrollUntilVisible` method to repeatedly scroll through a list of items until
 we find what we're looking for!
 

--- a/cookbook/testing/integration-test-scrolling.md
+++ b/cookbook/testing/integration-test-scrolling.md
@@ -93,6 +93,7 @@ class MyApp extends StatelessWidget {
 Next, we'll need to create an instrumented version of our app. This code lives
 in a file called `test_driver/app.dart`.
 
+<!-- skip -->
 ```dart
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:scrollable_app/main.dart' as app;


### PR DESCRIPTION
Hey hey :)

This adds to the other recipes on testing! The "Test your apps" page has a decent summary of writing integration tests, but I felt like it was missing a lot of important details when I first started writing integration tests. Therefore, I split that example up into smaller chunks and tried to provide a bit more detail for each part.

Three recipes included:

  * Introduction to integration testing
  * Scrolling in integration tests
  * Performance profiling with integration tests

Guidance needed: Should I change up the "Test your apps" page a bit as well? My idea: the page provides a great overview of the testing solutions that Flutter provides. I was thinking of keeping that overview and removing the examples, linking to all of these recipes instead. Thoughts?