### PR TITLE
Change references to Flutter Travis build to Cirrus

### DIFF
--- a/debugging.md
+++ b/debugging.md
@@ -896,7 +896,7 @@ file handlers using the `ulimit` command:
 ulimit -S -n 2048
 ```
 
-If you use Travis for testing, increase the number of available file
-handlers that Travis can open by adding the same line to
-flutter/travis.yml.
+If you use Travis or Cirrus for testing, increase the number of
+available file handlers that they can open by adding the same line to
+flutter/.travis.yml, or flutter/.cirrus.yml, respectively.
 

--- a/design-principles.md
+++ b/design-principles.md
@@ -91,10 +91,10 @@ should review the patch as soon as possible. If a reviewer finds
 problems with a patch marked TBR, the issues should be fixed as soon
 as possible.
 
-Wait for Travis to give the green light before merging a PR. Travis
+Wait for Cirrus to give the green light before merging a PR. Cirrus
 runs a bunch of precommit checks (see the tests for the
 [framework](https://github.com/flutter/flutter/blob/master/dev/bots/test.dart),
-the [engine](https://github.com/flutter/engine/blob/master/travis/build.sh),
+the [engine](https://github.com/flutter/engine/blob/master/ci/build.sh),
 and the [website](https://github.com/flutter/website/blob/master/tool/travis.sh)).
 These checks include checks on comments, so make sure you wait for the
 green light even if your patch is _obviously_ fine!
@@ -105,7 +105,7 @@ that locally first too before checking anything in.
 
 Make sure all the trees and dashboards are green before checking in:
 the [infra waterfall](https://build.chromium.org/p/client.flutter/waterfall),
-our [travis dashboard](https://travis-ci.org/flutter/flutter/builds),
+our [Cirrus dashboard](https://cirrus-ci.com/github/flutter/flutter/master),
 our [test dashboard](https://flutter-dashboard.appspot.com/build.html), and
 our [benchmarks dashboard](https://flutter-dashboard.appspot.com/benchmarks.html) (Google-only, sorry).
 

--- a/fastlane.md
+++ b/fastlane.md
@@ -102,8 +102,8 @@ The main thing to consider is that since cloud instances are ephemeral and
 untrusted, you won't be leaving your credentials like your Play Store service
 account JSON or your iTunes distribution certificate on the server.
 
-CI systems, such as [Travis](https://docs.travis-ci.com/user/environment-variables/#Encrypting-environment-variables)
-or [Cirrus](https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables)
+Continuous Integration (CI) systems, such as
+[Cirrus](https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables)
 generally support encrypted environment variables to store private data.
 
 **Take precaution not to re-echo those variable values back onto the console in
@@ -122,7 +122,7 @@ secrets in pull requests that you accept and merge.
         an encrypted environment variable. You can deserialize it on your CI
         system during the install phase with
         ```bash
-        echo "$PLAY_STORE_UPLOAD_KEY" | base64 --decode > /home/travis/[directory and filename specified in your gradle].keystore
+        echo "$PLAY_STORE_UPLOAD_KEY" | base64 --decode > /home/cirrus/[directory # and filename specified in your gradle].keystore
         ```
     * ![iOS](/images/fastlane-cd/ios.png) On iOS:
         * Move the local environment variable `FASTLANE_PASSWORD` to use
@@ -167,4 +167,4 @@ repository root.
 
 The [Flutter Gallery in the Flutter repo](https://github.com/flutter/flutter/tree/master/examples/flutter_gallery)
 uses Fastlane for continuous deployment. See the source for a working example of
-Fastlane in action. The Travis script is [here](https://github.com/flutter/flutter/blob/master/.travis.yml).
+Fastlane in action. The Flutter framework repository's Cirrus script is [here](https://github.com/flutter/flutter/blob/master/.cirrus.yml).


### PR DESCRIPTION
This changes references (and links) to Flutter's Travis builds to use Cirrus instead, since we've switched CI systems.

This should fix the website build because of fixing the broken links.