### PR TITLE
Changed RandomWordState to RandomWordsState

### DIFF
--- a/get-started/codelab/index.md
+++ b/get-started/codelab/index.md
@@ -326,7 +326,7 @@ a child inside the existing `MyApp` stateless widget.
     build method that generates the word pairs by moving the
     word generation code from `MyApp` to `RandomWordsState`.
 
- 3. Add the `build()` method to `RandomWordState`:
+ 3. Add the `build()` method to `RandomWordsState`:
 
     <!-- skip -->
     {% prettify dart %}


### PR DESCRIPTION
"After adding the state class, the IDE complains that the class is missing a build method. Next, you’ll add a basic build method that generates the word pairs by moving the word generation code from MyApp to **RandomWordsState**."

"Add the build() method to **RandomWordState**:"

Fixed the typo and changed RandomWordState to RandomWordsState.