### PR TITLE
TimelineSummary requires 'new' keyword

### DIFF
--- a/src/testing.md
+++ b/src/testing.md
@@ -296,7 +296,7 @@ void main() {
       // The `timeline` object contains all the performance data recorded during
       // the scrolling session. It can be digested into a handful of useful
       // aggregate numbers, such as "average frame build time".
-      TimelineSummary summary = TimelineSummary.summarize(timeline);
+      TimelineSummary summary = new TimelineSummary.summarize(timeline);
 
       // The following line saves the timeline summary to a JSON file.
       summary.writeSummaryToFile('scrolling_performance', pretty: true);


### PR DESCRIPTION
TimelineSummary summary = TimelineSummary.summarize(timeline); causes the following error:

NoSuchMethodError: No static method 'summarize' declared in class 'TimelineSummary'.

Adding the 'new' keyword fixes this:

TimelineSummary summary = new TimelineSummary.summarize(timeline);

Flutter version tested:
Flutter 0.5.1 • channel beta • git@github.com:flutter/flutter.git
Framework • revision c7ea3ca377 (3 months ago) • 2018-05-29 21:07:33 +0200
Engine • revision 1ed25ca7b7
Tools • Dart 2.0.0-dev.58.0.flutter-f981f09760