### PR TITLE
[dash] Drop jekyll-redirect-from gem in favor of Firebase redirect rules

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,18 +25,13 @@ defaults:
 
 # Build settings
 
+# kramdown: {show_warnings: true}
+plugins: [jekyll-toc]
 source: src
 # `symlinked-sources` can refer to individual files or directories
 # under `src` that are symlinked to somewhere outside `src`, or it can
 # refer to the root folder of the symlinked content (like `site-shared/src`):
 symlinked-sources: [site-shared/src]
-
-plugins:
-  - jekyll-redirect-from # TODO(chalin): drop this in favor of Firebase redirects
-  - jekyll-toc
-
-# kramdown: {show_warnings: true}
-
 toc:
   min_level: 2
   max_level: 4

--- a/firebase.json
+++ b/firebase.json
@@ -26,7 +26,9 @@
       { "source": "/custom-fonts", "destination": "/cookbook/design/fonts", "type": 301 },
       { "source": "/routing-and-navigation", "destination": "/cookbook/navigation/navigation-basics", "type": 301 },
       { "source": "/networking", "destination": "/cookbook/networking/fetch-data", "type": 301 },
-      { "source": "/text-input", "destination": "/cookbook/forms/text-input", "type": 301 }
+      { "source": "/text-input", "destination": "/cookbook/forms/text-input", "type": 301 },
+      { "source": "/research-signup", "destination": "https://docs.google.com/forms/d/e/1FAIpQLSe0i4De809KXVCdljGKrjMj3lxhuzbuFKCtY5PEQPCYtGxFMg/viewform?usp=sf_link", "type": 301 },
+      { "source": "/research-optout", "destination": "https://docs.google.com/forms/d/e/1FAIpQLSeG2Nhj0YQkr3m75P74Zb9G-v7zgNhAE9arCyig-a5B1A8uDw/viewform?usp=sf_link", "type": 301 }
     ]
   }
 }

--- a/src/research-optout.md
+++ b/src/research-optout.md
@@ -1,7 +1,0 @@
----
-title: Flutter UX Research - Opt Out Form
-redirect_to:
-  - https://docs.google.com/forms/d/e/1FAIpQLSeG2Nhj0YQkr3m75P74Zb9G-v7zgNhAE9arCyig-a5B1A8uDw/viewform?usp=sf_link
----
-
-

--- a/src/research-signup.md
+++ b/src/research-signup.md
@@ -1,7 +1,0 @@
----
-title: Flutter UX Research - Sign Up Form
-redirect_to:
-  - https://docs.google.com/forms/d/e/1FAIpQLSe0i4De809KXVCdljGKrjMj3lxhuzbuFKCtY5PEQPCYtGxFMg/viewform?usp=sf_link
----
-
-

--- a/tool/docker/Gemfile
+++ b/tool/docker/Gemfile
@@ -18,4 +18,3 @@ gem 'uglifier'
 # Remaining old infrastructure gems
 gem 'html-proofer' # TODO: drop
 gem 'rake' # TODO: drop (this seems to be needed only for support of html-proofer)
-gem 'jekyll-redirect-from' # TODO: drop; replace with tri-site solution.

--- a/tool/docker/Gemfile.lock
+++ b/tool/docker/Gemfile.lock
@@ -75,8 +75,6 @@ GEM
       nokogiri (~> 1.8)
       pathutil (~> 0.16)
       sprockets (>= 3.3, < 4.1.beta)
-    jekyll-redirect-from (0.14.0)
-      jekyll (~> 3.3)
     jekyll-sanity (1.2.0)
       jekyll (~> 3.1)
     jekyll-sass-converter (1.5.2)
@@ -126,7 +124,7 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    uglifier (4.1.18)
+    uglifier (4.1.19)
       execjs (>= 0.3.0, < 3)
     yell (2.0.7)
 
@@ -140,7 +138,6 @@ DEPENDENCIES
   html-proofer
   jekyll
   jekyll-assets
-  jekyll-redirect-from
   jekyll-toc!
   liquid-tag-parser
   rake


### PR DESCRIPTION
This undoes part of #1076: use Firebase redirect rules instead of an extra gem, since that is how we are handling all other site redirects.

cc @filiph 