### PR TITLE
[dash] Added side- and inlined-TOC styling and scroll spy

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,22 +98,22 @@ create your own Firebase project (e.g. 'mit-flutter-staging')
 1. Tell Firebase about that project with the firebase
 [`use` command](https://firebase.googleblog.com/2016/07/deploy-to-multiple-environments-with.html):
 	```
-	$ firebase use --add
+	$ npx firebase use --add
 	? Which project do you want to add? <select the project you created>
 	? What alias do you want to use for this project? (e.g. staging) staging
 	```
 
 1. Tell Firebase that you want to deploy to staging:
 	```
-	$ firebase use staging
+	$ npx firebase use staging
 	Now using alias staging (<your project name>)
 	```
 
 1. Tell Firebase to deploy:
 	```
-	$ firebase use staging
+	$ npx firebase use staging
 	Now using alias staging (<your project name>)
-	$ firebase deploy
+	$ npx firebase deploy
 
 	=== Deploying to '<your project name>'...
 
@@ -317,13 +317,13 @@ from dartlang.org, we recommend manually running the following.
 
   ```
   pub global activate linkcheck
-  npm install -g superstatic
+  npm install
   ```
 
 * Start the localhost Firebase server:
 
   ```
-  superstatic --port 4002
+  npx superstatic --port 4002
   ```
 
 * Run the link checker:

--- a/src/_assets/css/_bootstrap_config.scss
+++ b/src/_assets/css/_bootstrap_config.scss
@@ -16,3 +16,10 @@ $font-family-sans-serif: $flutter-font-family-base;
 $font-weight-base: 300;
 $headings-font-family: $flutter-font-family-alt;
 $headings-font-weight: 400;
+
+// Spacing (extra spacers beyond Bootstrap's defaults)
+
+$site-spacer: 1rem; // assert: should match Bootstrap $spacer
+$spacers: (
+  4_5: ($site-spacer * 1.625), // 4.5
+);

--- a/src/_assets/css/_content.scss
+++ b/src/_assets/css/_content.scss
@@ -4,4 +4,15 @@
   @include media-breakpoint-up(md) {
     border-left: 1px solid $flutter-color-light-grey;
   }
+
+  &__title {
+    padding-bottom: map-get($spacers, 3);
+
+    @at-root {
+      #page-github-links {
+        @include float-right;
+        .btn { padding: 0 ($btn-padding-x / 2); }
+      }
+    }
+  }
 }

--- a/src/_assets/css/_toc.scss
+++ b/src/_assets/css/_toc.scss
@@ -1,12 +1,25 @@
 .site-toc {
-  padding-top: $flutter-content-top-padding;
+  $line-height: normal; // was: 26px // == map-get($spacers, 4_5);
+
+  @at-root {
+    #site-toc__side { display: none; }
+  }
+
+  @include media-breakpoint-up(xl) {
+    padding-top: $flutter-content-top-padding;
+
+    @at-root {
+      #site-toc__inline { display: none; }
+      #site-toc__side { display: block; }
+    }
+  }
 
   .nav-item {
     font-size: $font-size-sm;
 
     .nav-link {
       color: $flutter-color-body-light;
-      line-height: 26px;
+      line-height: $line-height;
       padding: 0;
     }
   }
@@ -14,6 +27,50 @@
   &__title {
     font-family: $flutter-font-family-alt;
     font-size: $font-size-lg;
-    margin-bottom: 8px;
+    margin-bottom: map-get($spacers, 2); // was: 8px;
   }
+
+  &--button__page-top {
+    @include float-right;
+    font-size: $font-size-sm;
+    line-height: $line-height;
+    padding-top: 0;
+    padding-right: 0;
+
+    &::after {
+      content: 'vertical_align_top'; // 'keyboard_arrow_up';
+      font: $flutter-font-icon;
+    }
+  }
+
+  // (chalin) Styles copied over from site-www as-is below this point.
+  // They'll need to be cleaned up / merged. Feel free to readjust:
+
+  ul.section-nav { // Should be equivalent to ul.nav
+    $padding: map-get($spacers, 2);
+    line-height: normal;
+
+    @include media-breakpoint-up(xl) {
+      @include list-unstyled;
+    }
+
+    > li { padding-bottom: $padding; } // Extra space for top-level entries
+  }
+
+  // Override BS defaults for .nav, etc.
+  .nav {
+    display: block;
+    .nav-link {
+      padding: 0 !important;
+      color: theme-color('primary');
+      &.active {
+        color: theme-color('secondary'); // $gray-dark;
+        // &:before {
+        //   @include md-icon-content('chevron_right'); // alt: '〉 '; // '▷ '; // '◾ '; // '▸ '; // '● ';
+        //   margin-left: -0.9rem; // We tune the margin for top-level entries below.
+        // }
+      }
+    }
+  }
+  ul.section-nav.nav > li > .nav-link:before { margin-left: -1rem; }
 }

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -2,6 +2,8 @@
 
 @import '_bootstrap_config';
 @import 'bootstrap';
+@import 'font-awesome-sprockets';
+@import 'font-awesome';
 
 @import '_base';
 @import '_header';
@@ -9,5 +11,3 @@
 @import '_toc';
 @import '_content';
 @import '_footer';
-@import 'font-awesome-sprockets';
-@import 'font-awesome';

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -1,3 +1,38 @@
 //= require vendor/jquery-3.3.1
 //= require popper
 //= require bootstrap
+
+$(function () {
+  // // Sidenav
+  // $('#sidenav i').on('click', function (e) {
+  //   e.stopPropagation();
+  //   $(this).parent('li').toggleClass('active');
+  // });
+
+  adjustToc();
+})
+
+// TODO(chalin): Copied (& tweaked) from site-www, consider moving into site-shared
+function adjustToc() {
+  // Adjustments to the jekyll-toc TOC.
+
+  var tocId = '#site-toc__side';
+  var tocWrapper = $(tocId);
+  $(tocWrapper).find('.site-toc--button__page-top').click(function() {
+    $('html, body').animate({ scrollTop: 0 }, 'fast');
+  })
+
+  // TODO: consider doing most of the HTML TOC manipulation statically (maybe requiring a jekyll-toc adaptor plugin)
+  // Bootstrap 4's ScrollSpy works only for .nav or .list-group,
+  // with items and link classes set too. Add the classes.
+  var toc = $(tocWrapper).find('ul.section-nav');
+  $(toc).addClass('nav');
+
+  var ul = $(toc).find('ul');
+  $(ul).addClass('nav');
+  var li = $(toc).find('.toc-entry');
+  $(li).addClass('nav-item');
+  $(li).find('a').addClass('nav-link');
+
+  $('body').scrollspy({ offset: 100, target: tocId });
+}

--- a/src/_includes/toc.html
+++ b/src/_includes/toc.html
@@ -1,4 +1,23 @@
-{% if page.toc -%}
-<div class="site-toc__title">Contents</div>
-{{ content | toc_only }}
+{% comment %}
+  Include parameters:
+
+  - class: CSS classes to add to toc element.
+  - header: header text, default 'Contents'
+  - kind: should be one of 'inline' or 'side'; if present it is
+    suffixed to the toc id, e.g. id="site-toc--side"
+
+  If you don't want the back-to-top button style `site-toc__back-to-top` as `display: none`.
+{% endcomment -%}
+
+{% if include.kind -%}
+  {% assign id-suffix = include.kind | prepend: '__' -%}
 {% endif -%}
+<div id="site-toc{{id-suffix}}" class="site-toc {{include.class}}">
+  <header class="site-toc__title">
+    {{include.header | default: 'Contents'}}
+    {% unless include.kind == 'inline' -%}
+      <button type="button" class="btn site-toc--button__page-top" aria-label="Page top"></button>
+    {% endunless -%}
+  </header>
+  {{ content | toc_only }}
+</div>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -2,22 +2,32 @@
 layout: base
 ---
 
+{% comment %} TODO(chalin): The following should probably just be encoded in Sass. {% endcomment -%}
+{% if page.toc -%}
+  {% assign main-col = 'col-12 col-md-9 col-xl-8' -%}
+  {% assign sidebar-col = 'col-12 col-md-3 col-xl-2' -%}
+  {% comment %}Side toc is col-xl-2{% endcomment -%}
+{% else -%}
+  {% assign main-col = 'col-12 col-md-9' -%}
+  {% assign sidebar-col = 'col-12 col-md-3' -%}
+{% endif -%}
+
 <div class="container-fluid">
   <div class="row flex-xl-nowrap">
-    <div class="sticky-col site-sidebar col-12 col-md-3 col-xl-2">
+    <div class="sticky-col site-sidebar {{sidebar-col}}">
       {% include sidebar.html %}
     </div>
-    <div class="sticky-col site-toc d-none d-xl-block col-xl-2 order-3">
-      {% include toc.html %}
-    </div>
-    <main class="site-content col-12 col-md-9 col-xl-8" role="main">
-      <div>
+    {% if page.toc -%}
+      {% include toc.html kind="side" class="sticky-col col-xl-2 order-3" %}
+    {% endif -%}
+    <main class="site-content {{main-col}}" role="main">
+      <header class="site-content__title">
         {% include shared/page-github-links.html %}
         <h1>{{ page.title }}</h1>
-      </div>
-      <div class="site-toc d-xl-none">
-        {% include toc.html %}
-      </div>
+      </header>
+      {% if page.toc -%}
+        {% include toc.html kind="inline" %}
+      {% endif -%}
       {{ content | inject_anchors }}
     </main>
   </div>


### PR DESCRIPTION
Contributes to #1259:

- Added a scroll spy for the side TOC.
- Added styling for TOC. Note that side vs. inline TOC styling is different.
- Page layout is adjusted for when there is no TOC.
- Added styling for page title and page GitHub buttons.
- Added a custom spacer for key `4_5` (representing 4.5), though it isn't really used yet.

Note: TOC styling isn't fully done. Some cleanup is still necessary (see comment in _toc.scss).

Staged, e.g., see:
- https://ng2-io.firebaseapp.com/docs for a page with a TOC
- https://ng2-io.firebaseapp.com/widgets for a page w/o a TOC

cc @filiph 