### PR TITLE
[dash] Make a.card style more closely match a plain `<a>` element style

### DIFF
--- a/src/_assets/css/_base.scss
+++ b/src/_assets/css/_base.scss
@@ -19,23 +19,6 @@ dd {
   margin-bottom: .75rem;
 }
 
-a.card {
-  color: inherit;
-
-  .card-title { color: $site-color-primary; }
-
-  &:hover {
-    $border-height: 0.25rem;
-
-    border-bottom: $border-height solid $site-color-primary;
-    text-decoration: none;
-
-    .card-body {
-      padding-bottom: $card-spacer-x - $border-height;
-    }
-  }
-}
-
 .card-title {
   font-family: $site-font-family-alt;
   font-size: $font-size-lg;

--- a/src/_assets/css/_base.scss
+++ b/src/_assets/css/_base.scss
@@ -22,16 +22,16 @@ dd {
 a.card {
   color: inherit;
 
+  .card-title { color: $site-color-primary; }
+
   &:hover {
-    border-bottom: 4px solid $site-color-primary;
+    $border-height: 0.25rem;
+
+    border-bottom: $border-height solid $site-color-primary;
     text-decoration: none;
 
-    .card-title {
-      color: $site-color-primary;
-    }
-
     .card-body {
-      padding-bottom: 17px;
+      padding-bottom: $card-spacer-x - $border-height;
     }
   }
 }

--- a/src/_assets/css/_bootstrap_adjust.scss
+++ b/src/_assets/css/_bootstrap_adjust.scss
@@ -2,3 +2,20 @@
   > p:last-child { margin-bottom: 0; }
   > ul:last-child { margin-bottom: 0; }
 }
+
+a.card {
+  color: inherit;
+
+  .card-title { color: $site-color-primary; }
+
+  &:hover {
+    $border-height: 0.25rem;
+
+    border-bottom: $border-height solid $site-color-primary;
+    text-decoration: none;
+
+    .card-body {
+      padding-bottom: $card-spacer-x - $border-height;
+    }
+  }
+}


### PR DESCRIPTION
The base appearance of an `a.card` used to be this: 
> <img width="250" alt="screen shot 2018-09-25 at 07 20 45" src="https://user-images.githubusercontent.com/4140793/46011349-8d691600-c093-11e8-803e-124e5719276b.png">

An `a.card` now looks like this:

- Base appearance (blue title suggests that it is a link):
  <img width="261" alt="screen shot 2018-09-25 at 07 08 04" src="https://user-images.githubusercontent.com/4140793/46011060-ade4a080-c092-11e8-858f-0346e994d6fb.png">
- Hovered-state appearance:
  <img width="262" alt="screen shot 2018-09-25 at 07 08 22" src="https://user-images.githubusercontent.com/4140793/46011071-b76e0880-c092-11e8-8bd8-b5dd7bcb75f3.png">

Also: Moved BS style overrides to _bootstrap_adjust file.

@fertolg - I've split the commits so that you can view the style changes (the first commit) separately from the style move (2nd commit).

Staged at https://ng2-io.firebaseapp.com/docs
