### PR TITLE
Clarify package upgrades

### DIFF
--- a/src/using-packages.md
+++ b/src/using-packages.md
@@ -109,7 +109,12 @@ run `flutter packages get`.
 If you want to upgrade to a new version of the package, for example to use new
 features in that package, run `flutter packages upgrade` ('Upgrade dependencies'
 in IntelliJ). This will retrieve the highest available version of the package,
-which is allowed by the version constraint you have specified in `pubspec.yaml`.
+which is allowed by the [version constraint](https://www.dartlang.org/tools/pub/versioning#version-constraints)
+you have specified in `pubspec.yaml`.
+
+**Note:** We recommend that you ocassionally review your dependencies to see if
+never major versions are available, and that you consider upgrading your
+version constraints to allow those (e.g., update a `^1.2` constraint to `^2.0`).
 
 ### Dependencies on unpublished packages
 


### PR DESCRIPTION
Add a note detailing that upgrading to new major versions of dependencies requires manually updating the constraints