### PR TITLE
[dash] Sidenav from yaml, iteration 1

### DIFF
--- a/src/_assets/css/_bootstrap_config.scss
+++ b/src/_assets/css/_bootstrap_config.scss
@@ -44,7 +44,6 @@ $alert-padding-x: bs-spacer(6);
 $border-radius: 0;
 $border-radius-lg: 0;
 $border-radius-sm: 0;
-// $btn-font-weight: 400; // Default is already normal (400). TODO: drop?
 $card-border-radius: 4px;
 $card-group-margin: bs-spacer(2);
 $grid-gutter-width: 50px;

--- a/src/_assets/css/_bootstrap_config.scss
+++ b/src/_assets/css/_bootstrap_config.scss
@@ -9,13 +9,13 @@ $code-color: $site-color-body;
 // Font config
 $font-family-sans-serif: $site-font-family-base;
 $font-family-monospace: $site-font-family-monospace;
-$font-weight-base: 400;
+$font-weight-base: 400; // assert: matches Bootstrap default
 $headings-font-family: $site-font-family-alt;
-$headings-font-weight: 400;
+$headings-font-weight: $font-weight-base;
 $h1-font-size: 3rem;
 $h2-font-size: 2.25rem;
 $h3-font-size: 1.125rem;
-$dt-font-weight: 400;
+$dt-font-weight: $font-weight-base;
 
 // Spacing (extra spacers beyond Bootstrap's defaults)
 $site-spacer: 1rem; // assert: should match Bootstrap $spacer
@@ -44,7 +44,7 @@ $alert-padding-x: bs-spacer(6);
 $border-radius: 0;
 $border-radius-lg: 0;
 $border-radius-sm: 0;
-$btn-font-weight: 400;
+// $btn-font-weight: 400; // Default is already normal (400). TODO: drop?
 $card-border-radius: 4px;
 $card-group-margin: bs-spacer(2);
 $grid-gutter-width: 50px;

--- a/src/_assets/css/_sidebar.scss
+++ b/src/_assets/css/_sidebar.scss
@@ -24,14 +24,16 @@
   .nav-link {
     padding: 6px 0;
     position: relative;
+
+    .disabled { color: $btn-link-disabled-color; }
   }
 
-  // First nav level
+  // Top-level nav item
   > .nav > .nav-item {
     font-family: $site-font-family-alt;
     font-size: $font-size-lg;
 
-    .nav-link {
+    > .nav-link {
       align-items: flex-end;
       display: flex;
       justify-content: space-between;
@@ -52,22 +54,20 @@
     }
   }
 
-  // Second nav level
-  > .nav > .nav > .nav-item {
+  // Second-level nav item
+  > .nav > .nav-item > .nav > .nav-item {
     font-size: $font-size-sm;
 
     .nav-link {
       color: $site-color-body-light;
       margin-left: bs-spacer(4);
 
-      &.active {
-        font-weight: 400;
-      }
+      &.active { font-weight: $font-weight-bold; }
     }
   }
 
-  // Third nav level
-  > .nav > .nav > .nav > .nav-item {
+  // Third-level nav item
+  > .nav > .nav-item > .nav > .nav-item > .nav > .nav-item {
     font-size: $font-size-sm;
 
     .nav-link {

--- a/src/_assets/css/_sidebar.scss
+++ b/src/_assets/css/_sidebar.scss
@@ -24,7 +24,7 @@
   .nav-link {
     padding: 6px 0;
     position: relative;
-
+    color: inherit;
     .disabled { color: $btn-link-disabled-color; }
   }
 
@@ -58,7 +58,7 @@
   > .nav > .nav-item > .nav > .nav-item {
     font-size: $font-size-sm;
 
-    .nav-link {
+    > .nav-link {
       color: $site-color-body-light;
       margin-left: bs-spacer(4);
 
@@ -70,7 +70,7 @@
   > .nav > .nav-item > .nav > .nav-item > .nav > .nav-item {
     font-size: $font-size-sm;
 
-    .nav-link {
+    > .nav-link {
       border-left: 1px solid $site-color-light-grey;
       color: $site-color-body-light;
       margin-left: bs-spacer(4);

--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -1,6 +1,5 @@
 - title: Getting Started
   permalink: /get-started
-  urlExactMatch: true
   children:
   - title: "1: Install"
     permalink: /get-started/install
@@ -12,20 +11,23 @@
     permalink: /get-started/codelab
   - title: "5: Learn more"
     permalink: /get-started/learn-more
+  - divider
   - title: Coming from another platform?
     children:
-    - title: Flutter for Android devs
+    - title: Flutter for Android Devs
       permalink: /get-started/flutter-for/android-devs
-    - title: Flutter for iOS devs
+    - title: Flutter for iOS Devs
       permalink: /get-started/flutter-for/ios-devs
-    - title: Flutter for React Native devs
+    - title: Flutter for React Native Devs
       permalink: /get-started/flutter-for/react-native-devs
-    - title: Flutter for Web devs
+    - title: Flutter for Web Devs
       permalink: /get-started/flutter-for/web-devs
-    - title: Flutter for Xamarin.Forms devs
+    - title: Flutter for Xamarin.Forms Devs
       permalink: /get-started/flutter-for/xamarin-forms-devs
 
-- title: "Samples & Codelabs"
+- title: Samples & Codelabs
+  # FIXME: we need a permalink that is common to all children
+  # permalink: ?
   children:
   - title: Cookbook
     permalink: /cookbook
@@ -39,18 +41,20 @@
     permalink: https://github.com/flutter/flutter/tree/master/examples/flutter_gallery#flutter-gallery
 
 - title: Development
+  permalink: /development
   children:
   - title: User interface
+    # permalink: /development/ui
     children:
     - title: Tour the framework
-      permalink: /development/ui/widgets-into
+      permalink: /development/ui/widgets-intro
     - title: Building layouts
       permalink: /development/ui/layout
     - title: Adding interactivity
       permalink: /development/ui/interactive
     - title: "Assets and images"
       permanlink: /development/ui/assets-and-images
-    - title: "Navigation & routing"
+    - title: Navigation & routing
       permalink: /cookbook/navigation/navigation-basics
     - title: Inspect an app's UI
       permalink: /development/tools/inspector
@@ -71,6 +75,7 @@
     - title: Platform-specific theming
     - title: Widget catalog
       permalink: /development/ui/widgets
+      urlExactMatch: true
   - title: Data and backend
     children:
     - title: Architect app to manage data flow
@@ -90,7 +95,7 @@
     - title: Embedding Flutter views in non-Flutter apps
     - title: Writing platform-specific code
       permalink: /development/platform-integration/platform-channels
-  - title: "Packages & Plugins"
+  - title: Packages & Plugins
     children:
     - title: Using packages
       permalink: /development/packages-and-plugins/using-packages
@@ -100,28 +105,33 @@
       permalink: http://pub.dartlang.org/flutter
   - title: Tools
     children:
+    - title: Use Flutter in IDEs
+      permalink: /development/tools/using-ide
     - title: Using hot reload
       permalink: /development/tools/hot-reload
-    - title: Using an IDE
-      permalink: /development/tools/using-ide
-    - title: Using an IDE
-      permalink: /development/tools/using-ide/vscode
+    # TODO(chalin): The following entry is not in the IA, so I'm commenting it out for now. Should it be here? (The link is currently invalid.)
+    # - title: Using an IDE
+    #   permalink: /development/tools/using-ide/vscode
     - title: Format Flutter code
       permalink: /development/tools/formatting
     - title: Widget inspector
       permalink: /development/tools/inspector
 
-- title: "Testing & Optimization"
+- title: Testing & Optimization
+  permalink: /testing
   children:
   - title: Debugging your app
     permalink: /testing/debugging
   - title: Testing your app
     permalink: /testing
+    urlExactMatch: true
   - title: Performance profiling
     permalink: /testing/ui-performance
-  - title: Making your compiled app smaller
+  # TODO(chalin): The following entry is not in the IA, so I'm commenting it out for now. Should it be here?
+  # - title: Making your compiled app smaller
 
 - title: Deployment
+  permalink: /deployment
   children:
   - title: Build and release for Android
     permalink: /deployment/android-release
@@ -131,6 +141,7 @@
     permalink: /deployment/fastlane-cd
 
 - title: Resources
+  permalink: /resources
   children:
   - title: Dart resources
     permalink: /resources/bootstrap-into-dart
@@ -141,14 +152,14 @@
   - title: FAQ
     permalink: /resources/faq
 
-- title: "APIs & References"
+- title: APIs & References
   children:
   - title: Widget catalog
     permalink: /development/ui/widgets
   - title: API reference
-    permalink: https://docs.flutter.io/
+    permalink: https://docs.flutter.io
   - title: Package site
-    permalink: http://pub.dartlang.org/flutter
+    permalink: https://pub.dartlang.org/flutter
 
 
 

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -18,7 +18,7 @@
           </li>
 
           <div class="site-sidebar site-sidebar--header d-md-none">
-            {% include sidebar.html %}
+            {% include sidebar.html list=site.data.side-nav %}
           </div>
 
           <li class="nav-item">

--- a/src/_includes/sidebar.html
+++ b/src/_includes/sidebar.html
@@ -1,94 +1,120 @@
+{% comment %}
+  Strip out any trailing '/', etc. for exact URL match.
+{% endcomment -%}
+{% assign pageUrl = page.url | regex_replace: '/index$|/index\.html$|\.html$|/$' -%}
+
+{% comment %}
+TODO(chalin): rename link to top_level_nav_entry
+{% endcomment -%}
+
 <ul class="nav flex-column">
+    {%- for link in include.list -%}
 
-  <li class="nav-item">
-    <a class="nav-link collapsed" data-toggle="collapse" data-target="#getStartedMenu" role="button" aria-expanded="false" aria-controls="getStartedMenu">Get started</a>
-  </li>
+    {%- assign isActive = false -%}
+    {%- if link.urlExactMatch and pageUrl == link.permalink -%}
+      {%- assign isActive = true -%}
+    {%- elsif link.urlExactMatch == nil and pageUrl contains link.permalink -%}
+      {%- assign isActive = true -%}
+    {%- endif -%}
 
-  <ul class="nav flex-column flex-nowrap collapse" id="getStartedMenu">
-    <li class="nav-item"><a class="nav-link active" href="/get-started/install">1: Install</a></li>
+    {% if isActive -%}
+      {% assign class = 'active' -%}
+      {% assign expanded = 'true' -%}
+      {% assign show = 'show' -%}
+    {% else -%}
+      {% assign class = 'collapsed' -%}
+      {% assign expanded = 'false' -%}
+      {% assign show = '' -%}
+    {% endif -%}
+    {% assign id = 'side-bar-' | append: forloop.index -%}
 
-    <ul class="nav d-block" id="installSubMenu">
-      <li class="nav-item"><a class="nav-link active" href="/get-started/editor">Upgrade Flutter</a></li>
-      <li class="nav-item"><a class="nav-link" href="/get-started/test-drive">Configure editor</a></li>
-      <li class="nav-item"><a class="nav-link" href="/get-started/codelab">Use Flutter in IDEs</a></li>
-    </ul>
+    <li class="nav-item">
+      <a class="nav-link {{class}}" data-toggle="collapse" href="#{{id}}" role="button"
+        aria-expanded="{{expanded}}" aria-controls="{{id}}"
+      >{{link.title}}</a>
 
-    <li class="nav-item"><a class="nav-link" href="/get-started/editor">2: Configure editor</a></li>
-    <li class="nav-item"><a class="nav-link" href="/get-started/test-drive">3: Test drive</a></li>
-    <li class="nav-item"><a class="nav-link" href="/get-started/codelab">4: Write your first app</a></li>
-    <li class="nav-item"><a class="nav-link" href="/get-started/learn-more">5: Learn more</a></li>
-  </ul>
-
-  <li class="nav-item">
-    <a class="nav-link collapsed" data-toggle="collapse" data-target="#buildUIsMenu" role="button" aria-expanded="false" aria-controls="buildUIsMenu">Build UIs</a>
-  </li>
-
-  <ul class="nav flex-column flex-nowrap collapse" id="buildUIsMenu">
-    <li class="nav-item"><a class="nav-link" href="/development/ui/widgets-intro">Tour the framework</a></li>
-    <li class="nav-item"><a class="nav-link" href="/development/ui/widgets">Widget catalog</a></li>
-    <li class="nav-item"><a class="nav-link" href="/cookbook">Cookbook</a></li>
-    <li class="nav-item"><a class="nav-link" href="/catalog/samples">Sample catalog</a></li>
-    <li class="nav-item"><a class="nav-link" href="/codelabs">Codelabs</a></li>
-    <li class="nav-item"><a class="nav-link" href="/development/ui/layout">Build layouts - Tutorial</a></li>
-    <li class="nav-item"><a class="nav-link" href="/development/ui/interactive">Add interactivity - Tutorial</a></li>
-    <li class="nav-item"><a class="nav-link" href="/get-started/flutter-for/web-devs">Flutter for Web devs</a></li>
-    <li class="nav-item"><a class="nav-link" href="/get-started/flutter-for/android-devs">Flutter for Android devs</a></li>
-    <li class="nav-item"><a class="nav-link" href="/get-started/flutter-for/ios-devs">Flutter for iOS devs</a></li>
-    <li class="nav-item"><a class="nav-link" href="/get-started/flutter-for/react-native-devs">Flutter for React Native devs</a></li>
-    <li class="nav-item"><a class="nav-link" href="/get-started/flutter-for/xamarin-forms-devs">Flutter for Xamarin.Forms devs</a></li>
-    <li class="nav-item"><a class="nav-link" href="/development/ui/advanced/gestures">Gestures</a></li>
-    <li class="nav-item"><a class="nav-link" href="/development/ui/animations">Animations</a></li>
-    <li class="nav-item"><a class="nav-link" href="/layout">Box constraints</a></li>
-    <li class="nav-item"><a class="nav-link" href="/development/ui/assets-and-images">Assets and images</a></li>
-    <li class="nav-item"><a class="nav-link" href="/accessibility/internationalization">Internationalization</a></li>
-    <li class="nav-item"><a class="nav-link" href="/accessibility">Accessibility</a></li>
-  </ul>
-
-  <li class="nav-item">
-    <a class="nav-link collapsed" data-toggle="collapse" data-target="#apisMenu" role="button" aria-expanded="false" aria-controls="apisMenu">Use device and SDK APIs</a>
-  </li>
-
-  <ul class="nav flex-column flex-nowrap collapse" id="apisMenu">
-    <li class="nav-item"><a class="nav-link" href="/development/packages-and-plugins/using-packages">Using packages</a></li>
-    <li class="nav-item"><a class="nav-link" href="/development/packages-and-plugins/developing-packages">Developing packages</a></li>
-    <li class="nav-item"><a class="nav-link" href="/development/platform-integration/platform-channels">Platform-specific code</a></li>
-    <li class="nav-item"><a class="nav-link" href="/development/data-and-backend/json">JSON and serialization</a></li>
-    {% comment %}
-    <!-- Temporarily removed because the codelab is broken and possibly
-         about to be replaced by a completely new one. -->
-    <li class="nav-item"><a class="nav-link" href="https://codelabs.developers.google.com/codelabs/flutter-firebase/index.html#0">Firebase for Flutter - Codelab</a></li>
-    {% endcomment %}
-  </ul>
-
-  <li class="nav-item">
-    <a class="nav-link collapsed" data-toggle="collapse" data-target="#toolsMenu" role="button" aria-expanded="false" aria-controls="toolsMenu">Development and tools</a>
-  </li>
-
-  <ul class="nav flex-column flex-nowrap collapse" id="toolsMenu">
-    <li class="nav-item"><a class="nav-link" href="/development/tools/using-ide">Using Flutter IDEs</a></li>
-    <li class="nav-item"><a class="nav-link" href="/development/tools/hot-reload">Using hot reload</a></li>
-    <li class="nav-item"><a class="nav-link" href="/testing">Test your app</a></li>
-    <li class="nav-item"><a class="nav-link" href="/testing/debugging">Debug your app</a></li>
-    <li class="nav-item"><a class="nav-link" href="/testing/ui-performance">Performance Profiling</a></li>
-    <li class="nav-item"><a class="nav-link" href="/development/tools/inspector">Inspect your UI</a></li>
-    <li class="nav-item"><a class="nav-link" href="/deployment/android-release">Build and release for Android</a></li>
-    <li class="nav-item"><a class="nav-link" href="/deployment/ios-release">Build and release for iOS</a></li>
-    <li class="nav-item"><a class="nav-link" href="/deployment/fastlane-cd">Continuous deployment with fastlane</a></li>
-    <li class="nav-item"><a class="nav-link" href="/development/tools/upgrading">Upgrade your Flutter install</a></li>
-    <li class="nav-item"><a class="nav-link" href="/development/tools/formatting">Format your source code</a></li>
-  </ul>
-
-  <li class="nav-item">
-    <a class="nav-link collapsed" data-toggle="collapse" data-target="#detailsMenu" role="button" aria-expanded="false" aria-controls="detailsMenu">More details</a>
-  </li>
-
-  <ul class="nav flex-column flex-nowrap collapse" id="detailsMenu">
-    <li class="nav-item"><a class="nav-link" href="/resources/faq">FAQ</a></li>
-    <li class="nav-item"><a class="nav-link" href="/resources/technical-overview">Technical overview</a></li>
-    <li class="nav-item"><a class="nav-link" href="https://docs.google.com/presentation/d/1B3p0kP6NV_XMOimRV09Ms75ymIjU5gr6GGIX74Om_DE/edit?usp=sharing">Magic of Flutter slides</a></li>
-    <li class="nav-item"><a class="nav-link" href="https://docs.google.com/presentation/d/1cw7A4HbvM_Abv320rVgPVGiUP2msVs7tfGbkgdrTy0I/edit?usp=sharing">Architecture diagrams</a></li>
-    <li class="nav-item"><a class="nav-link" href="https://www.youtube.com/watch?v=dkyY9WCGMi0">Framework's layered design <i class="fa fa-video-camera" aria-hidden="true"></i></a></li>
-    <li class="nav-item"><a class="nav-link" href="https://www.youtube.com/watch?v=UUfXWzp0-DU">Flutter's rendering pipeline <i class="fa fa-video-camera" aria-hidden="true"></i></a></li>
-  </ul>
-
+      <ul class="nav flex-column flex-nowrap collapse {{show}}" id="{{id}}">
+        {% for child in link.children -%}
+          {% comment %}
+            TODO: rename dropdown to hasChildren
+          {% endcomment -%}
+          {% capture dropdown %}{{ child.children | size }}{% endcapture -%}
+          {% if child == 'divider' -%}
+            <div class="dropdown-divider"></div>
+          {%- elsif dropdown == '0' -%}
+            {%- capture startsWithChildLink %}^{{ child.permalink }}{% endcapture -%}
+            {%- capture url %}{{ page.url | regex_replace: '/index$|/index\.html$|\.html$|/$' }}{% endcapture -%}
+            {%- capture p %}{{ pageUrl | regex_replace: startsWithChildLink }}{% endcapture -%}
+            {%- assign isActive = false -%}
+            {%- if child.urlExactMatch and child.permalink == url -%}
+              {%- assign isActive = true -%}
+            {%- elsif child.urlExactMatch == nil and url != p -%}
+              {%- assign isActive = true -%}
+            {%- endif -%}
+            <li class="nav-item">
+              <a class="nav-link
+                  {%- if isActive %} active{% endif -%}
+                  {%- unless child.permalink %} disabled{% endunless -%}
+                  "
+                {% if child.permalink -%}
+                  href="{{child.permalink}}"
+                {% endif -%}
+                {% comment %}
+                  TODO: add title?
+                  title="{{child.title}}"
+                {% endcomment -%}
+              >{{child.title}}</a>
+            </li>
+          {%- else -%}
+            {% assign isActive = false %}
+            {% if page.sideNavGroup and page.sideNavGroup == child.sideNavGroup %}
+              {% assign isActive = true %}
+            {% elsif page.url contains child.permalink and child.sideNavGroup != 'basic' %}
+              {% assign isActive = true %}
+            {% endif %}
+            <li class="nav-item">
+              <a class="nav-link
+                  {%- if isActive %} active{% endif -%}
+                  {%- unless child.permalink %} disabled{% endunless -%}
+                  "
+                {% if child.permalink -%}
+                  href="{{child.permalink}}"
+                {% endif -%}
+                {% comment %}
+                  TODO: add title?
+                  title="{{child.title}}"
+                {% endcomment -%}
+              >{{child.title}}</a>
+              {% comment %}
+                TODO: also make this a collapsable entry?
+              {% endcomment -%}
+              <ul class="nav d-block">
+                {%- for c in child.children -%}
+                  {%- assign isActive = false -%}
+                  {%- if c.urlExactMatch and pageUrl == c.permalink -%}
+                    {%- assign isActive = true -%}
+                  {%- elsif c.urlExactMatch == nil and pageUrl contains c.permalink -%}
+                    {%- assign isActive = true -%}
+                  {%- endif -%}
+                  <li class="nav-item">
+                    <a class="nav-link
+                        {%- if isActive %} active{% endif %}
+                        {%- unless c.permalink %} disabled{% endunless -%}
+                        "
+                        {% if c.permalink -%}
+                          href="{{c.permalink}}"
+                        {% endif -%}
+                        {% comment %}
+                          TODO: add title?
+                          title="{{c.title}}"
+                        {% endcomment -%}
+                      >{{c.title}}</a>
+                  </li>
+                {%- endfor %}
+              </ul>
+          {%- endif -%}
+        {%- endfor %}
+      </ul>
+    </li>
+  {%- endfor -%}
 </ul>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -13,7 +13,7 @@ layout: base
 <div class="container-fluid">
   <div class="row flex-xl-nowrap">
     <div class="fixed-col site-sidebar site-sidebar--fixed {{sidebar-col}} d-none d-md-block" data-fixed-column>
-      {% include sidebar.html %}
+      {% include sidebar.html list=site.data.side-nav %}
     </div>
     {% if page.toc -%}
       {% include toc.html kind="side" class="fixed-col col-xl-2 order-3" %}


### PR DESCRIPTION
Contributes to #1338

While the entire sidenav is being generated, about 1/4 of the entries "don't work": i.e., visiting the page doesn't cause the corresponding top-level sidenav group to open. This will be fixed in the next iteration.

Styling might need to be tweaked too.

Staged, e.g., see https://ng2-io.firebaseapp.com/get-started/codelab