### PR TITLE
Improve contrast of "Latest release" tag line

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -3,6 +3,7 @@
     "default": "sweltering-fire-2088",
     "flutter-io": "sweltering-fire-2088",
     "staging-1": "flutter-io-staging-1",
+    "staging-2": "flutter-io-staging-2",
     "pc2": "ng2-io",
     "sz" :  "sz-flutter",
     "sz2" : "sz-flutter-2"

--- a/src/_assets/css/_homepage.scss
+++ b/src/_assets/css/_homepage.scss
@@ -69,10 +69,12 @@ $homepage-illustration-text-break-size: 720px;
     color: white;
     font-size: 24px;
     font-weight: 300;
-    margin: 0;
+    padding: 1rem 3rem;
+    background-color: rgba(0, 0, 0, 0.1);
 
     @include media-query($homepage-illustration-text-break-size) {
         font-size: 16px;
+        padding-left: 1.5rem;
     }
 
     a, a:hover {


### PR DESCRIPTION
This _improves_ the contrast: the result is better, though not perfect. But the new site design won't have this issue, so this fix is good enough IMHO.

Fixes #1280, supports #1361.

Staged at https://flutter-io-staging-2.firebaseapp.com

---

Screenshots:

> <img width="594" alt="screen shot 2018-10-02 at 11 16 00" src="https://user-images.githubusercontent.com/4140793/46358696-93339e00-c635-11e8-9615-9be059d3b52c.png">

&nbsp;

> <img width="1011" alt="screen shot 2018-10-02 at 11 15 39" src="https://user-images.githubusercontent.com/4140793/46358708-99297f00-c635-11e8-8720-d94c9fca426c.png">
