### PR TITLE
[dash] Get started: adjust titles

### DIFF
--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -1,31 +1,31 @@
-- title: Getting Started
+- title: Getting started
   permalink: /get-started
   children:
-  - title: "1: Install"
+  - title: 1. Install
     permalink: /get-started/install
-  - title: "2: Configure editor"
+  - title: 2. Configure editor
     permalink: /get-started/editor
-  - title: "3: Test drive"
+  - title: 3. Test drive
     permalink: /get-started/test-drive
-  - title: "4: Write your first app"
+  - title: 4. Write your first app
     permalink: /get-started/codelab
-  - title: "5: Learn more"
+  - title: 5. Learn more
     permalink: /get-started/learn-more
   - divider
   - title: Coming from another platform?
     children:
-    - title: Flutter for Android Devs
+    - title: Flutter for Android devs
       permalink: /get-started/flutter-for/android-devs
-    - title: Flutter for iOS Devs
+    - title: Flutter for iOS devs
       permalink: /get-started/flutter-for/ios-devs
-    - title: Flutter for React Native Devs
+    - title: Flutter for React Native devs
       permalink: /get-started/flutter-for/react-native-devs
-    - title: Flutter for Web Devs
+    - title: Flutter for web devs
       permalink: /get-started/flutter-for/web-devs
-    - title: Flutter for Xamarin.Forms Devs
+    - title: Flutter for Xamarin.Forms devs
       permalink: /get-started/flutter-for/xamarin-forms-devs
 
-- title: Samples & Codelabs
+- title: Samples & codelabs
   # FIXME: we need a permalink that is common to all children
   # permalink: ?
   children:
@@ -37,7 +37,7 @@
     permalink: /codelabs
   - title: GitHub samples
     permalink: https://github.com/flutter/samples/blob/master/INDEX.md
-  - title: Flutter Gallery - demo app
+  - title: Flutter gallery - demo app
     permalink: https://github.com/flutter/flutter/tree/master/examples/flutter_gallery#flutter-gallery
 
 - title: Development
@@ -117,7 +117,7 @@
     - title: Widget inspector
       permalink: /development/tools/inspector
 
-- title: Testing & Optimization
+- title: Testing & optimization
   permalink: /testing
   children:
   - title: Debugging your app
@@ -152,7 +152,7 @@
   - title: FAQ
     permalink: /resources/faq
 
-- title: APIs & References
+- title: APIs & references
   children:
   - title: Widget catalog
     permalink: /development/ui/widgets

--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -1,10 +1,10 @@
 ---
-title: Write Your First Flutter App, part 1
+title: Write your first Flutter app, part 1
 prev:
-  title: Test Drive
+  title: Test drive
   path: /get-started/test-drive
 next:
-  title: Learn More
+  title: Learn more
   path: /get-started/learn-more
 ---
 

--- a/src/get-started/editor.md
+++ b/src/get-started/editor.md
@@ -1,10 +1,10 @@
 ---
-title: "Get Started: Configure Editor"
+title: Configure editor
 prev:
   title: Install
   path: /get-started/install
 next:
-  title: Test Drive
+  title: Test drive
   path: /get-started/test-drive
 ---
 

--- a/src/get-started/install/index.md
+++ b/src/get-started/install/index.md
@@ -1,7 +1,7 @@
 ---
-title: "Get Started: Install"
+title: Install
 next:
-  title: Configure Editor
+  title: Configure editor
   path: /get-started/editor
 toc: false
 ---

--- a/src/get-started/install/linux.md
+++ b/src/get-started/install/linux.md
@@ -1,6 +1,9 @@
 ---
 title: "Get Started: Install on Linux"
 # js: [{defer: true, url: /assets/archive.js}]
+next:
+  title: Configure editor
+  path: /get-started/editor
 ---
 
 {% assign os = 'linux' -%}

--- a/src/get-started/install/macos.md
+++ b/src/get-started/install/macos.md
@@ -1,6 +1,8 @@
 ---
 title: "Get Started: Install on macOS"
-# js: [{defer: true, url: /assets/archive.js}]
+next:
+  title: Configure editor
+  path: /get-started/editor
 ---
 
 {% assign os = 'macos' -%}

--- a/src/get-started/install/windows.md
+++ b/src/get-started/install/windows.md
@@ -1,6 +1,9 @@
 ---
 title: "Get Started: Install on Windows"
 # js: [{defer: true, url: /assets/archive.js}]
+next:
+  title: Configure editor
+  path: /get-started/editor
 ---
 
 {% assign os = 'windows' -%}

--- a/src/get-started/learn-more.md
+++ b/src/get-started/learn-more.md
@@ -1,8 +1,8 @@
 ---
-title: "Get Started: Learn More"
+title: Learn more
 description: More resources to help you learn Flutter.
 prev:
-  title: Write Your First Flutter App
+  title: Write your first Flutter app
   path: /get-started/codelab
 toc: false
 ---

--- a/src/get-started/test-drive.md
+++ b/src/get-started/test-drive.md
@@ -1,10 +1,10 @@
 ---
-title: "Get Started: Test Drive"
+title: Test drive
 prev:
-  title: Configure Editor
+  title: Configure dditor
   path: /get-started/editor
 next:
-  title: Write Your First Flutter App
+  title: Write your first Flutter app
   path: /get-started/codelab
 ---
 


### PR DESCRIPTION
Contributes to #1369

- Use sentence case for page titles
- Drop "Get started" prefix
- Adjust sidenav number formatting for steps: from "X:" to "X."