### PR TITLE
[dash] Add support for breadcrumbs and implement them for "Get started"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,14 @@ defaults:
     # `show_banner: true` to the page's frontmatter.
     show_banner: true
 - scope:
+    path: 'get-started'
+  values:
+    show_breadcrumbs: true
+- scope:
+    path: 'get-started/flutter-for'
+  values:
+    show_breadcrumbs: false
+- scope:
     path: 'widgets'
   values:
     toc: false

--- a/src/_assets/css/_bootstrap_adjust.scss
+++ b/src/_assets/css/_bootstrap_adjust.scss
@@ -20,6 +20,10 @@ a.card {
   }
 }
 
+.breadcrumb-item+.breadcrumb-item::before {
+  // font-family: $site-font-family-icon;
+}
+
 .btn {
   font-family: $site-font-family-alt;
   padding: bs-spacer(2) bs-spacer(10);

--- a/src/_assets/css/_bootstrap_config.scss
+++ b/src/_assets/css/_bootstrap_config.scss
@@ -54,11 +54,19 @@ $spacers: (
 }
 
 // Component config
+
 $alert-padding-y: bs-spacer(6);
 $alert-padding-x: bs-spacer(6);
+
 $border-radius: 0;
 $border-radius-lg: 0;
 $border-radius-sm: 0;
+
+// $breadcrumb-divider: 'chevron_right';
+$breadcrumb-item-padding: .25rem;
+
 $card-border-radius: 4px;
 $card-group-margin: bs-spacer(2);
+
 $grid-gutter-width: 50px;
+

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -20,6 +20,9 @@ layout: base
     {% endif -%}
     <main class="site-content {{main-col}}" role="main">
       {% include banner.html -%}
+      {% if page.show_breadcrumbs -%}
+        {% include shared/breadcrumbs.html %}
+      {% endif -%}
       {% include next-prev-nav.html %}
       <header class="site-content__title">
         {% include shared/page-github-links.html %}

--- a/src/_plugins/breadcrumb.rb
+++ b/src/_plugins/breadcrumb.rb
@@ -1,0 +1,1 @@
+../_shared/_plugins/breadcrumb.rb

--- a/src/_plugins/regex_replace_filter.rb
+++ b/src/_plugins/regex_replace_filter.rb
@@ -1,1 +1,1 @@
-../../site-shared/src/_plugins/regex_replace_filter.rb
+../_shared/_plugins/regex_replace_filter.rb

--- a/src/_plugins/symlinked_sources_listener.rb
+++ b/src/_plugins/symlinked_sources_listener.rb
@@ -1,1 +1,1 @@
-../../site-shared/src/_plugins/symlinked_sources_listener.rb
+../_shared/_plugins/symlinked_sources_listener.rb

--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -1,5 +1,6 @@
 ---
 title: Write your first Flutter app, part 1
+short-title: Write your first app
 prev:
   title: Test drive
   path: /get-started/test-drive

--- a/src/get-started/index.html
+++ b/src/get-started/index.html
@@ -1,0 +1,5 @@
+---
+title: Get started
+# This is a placeholder page (Firebase rewrites this page's URL to another);
+# it is necessary to allow breadcrumbs to work.
+---

--- a/src/get-started/install/linux.md
+++ b/src/get-started/install/linux.md
@@ -1,5 +1,6 @@
 ---
-title: "Get Started: Install on Linux"
+title: Linux install
+short-title: Linux
 # js: [{defer: true, url: /assets/archive.js}]
 next:
   title: Configure editor

--- a/src/get-started/install/macos.md
+++ b/src/get-started/install/macos.md
@@ -1,5 +1,6 @@
 ---
-title: "Get Started: Install on macOS"
+title: MacOS install
+short-title: MacOS
 next:
   title: Configure editor
   path: /get-started/editor

--- a/src/get-started/install/windows.md
+++ b/src/get-started/install/windows.md
@@ -1,5 +1,6 @@
 ---
-title: "Get Started: Install on Windows"
+title: Windows install
+short-title: Windows
 # js: [{defer: true, url: /assets/archive.js}]
 next:
   title: Configure editor


### PR DESCRIPTION
Closes #1369

Staged, see, e.g.: https://ng2-io.firebaseapp.com/get-started/install/macos

---

Screenshots

> <img width="1088" alt="screen shot 2018-10-05 at 10 58 16" src="https://user-images.githubusercontent.com/4140793/46543078-fe77ad00-c88d-11e8-8f0b-6fc80be3bdfa.png">

> <img width="1092" alt="screen shot 2018-10-05 at 10 58 31" src="https://user-images.githubusercontent.com/4140793/46543087-02a3ca80-c88e-11e8-8bec-dea1d7a3d70e.png">
