### PR TITLE
[dash] Enable old custom tabs and use BS tabs for "Set up an editor" page

### DIFF
--- a/src/_assets/css/_tabs.scss
+++ b/src/_assets/css/_tabs.scss
@@ -1,0 +1,37 @@
+// TODO(chalin): Temporary: adapted styles originally copied from old assets
+// folder. These might be replaced by use of BS tabs (at least to some extent).
+
+$tab-accent-color: $primary;
+
+// General tabs. These are intended for instructions that vary according to user
+// selection, e.g. around editor choice in getting started.
+
+ul.tabs__top-bar {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+ul.tabs__top-bar li {
+  background: none;
+  color: gray("500");
+  display: inline-block;
+  padding: 5px 12px;
+  cursor: pointer;
+}
+
+ul.tabs__top-bar li.current{
+  background: $tab-accent-color;
+  color: $site-color-white;
+}
+
+.tabs__content{
+  display: none;
+  border: 1px solid $tab-accent-color;
+  padding: 10px;
+  margin-bottom: 20px;
+}
+
+.tabs__content.current{
+  display: inherit;
+}

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -20,6 +20,7 @@
 @import '_pygments-bg-light';
 // @import '_pygments-bg-dark';
 @import '_code_pre';
+@import '_tabs';
 
 // page types
 @import '_homepage';

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -2,6 +2,9 @@
 //= require popper
 //= require bootstrap
 //= require archive.js
+//= require tabs.js
+
+// TODO(chalin): find a way to selectively generate (as individual files) and then include archive.js and/or tabs.js
 
 $(function () {
   // // Sidenav
@@ -12,6 +15,9 @@ $(function () {
 
   adjustToc();
   initFixedColumns();
+
+  setupToolsTabs($("#tab-set-install"), "tab-install-", "selectedTool");
+  setupToolsTabs($("#tab-set-os"), "tab-os-", null, getOS());
 })
 
 // TODO(chalin): Copied (& tweaked) from site-www, consider moving into site-shared

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -16,8 +16,11 @@ $(function () {
   adjustToc();
   initFixedColumns();
 
-  setupToolsTabs($("#tab-set-install"), "tab-install-", "selectedTool");
-  setupToolsTabs($("#tab-set-os"), "tab-os-", null, getOS());
+  // New (dash) tabs
+  setupTabs($('#editor-setup'), 'io.flutter.tool-id');
+  // Old tabs
+  setupToolsTabs($('#tab-set-install'), 'tab-install-', 'io.flutter.tool-id');
+  setupToolsTabs($('#tab-set-os'), 'tab-os-', null, getOS());
 })
 
 // TODO(chalin): Copied (& tweaked) from site-www, consider moving into site-shared
@@ -65,4 +68,14 @@ function initFixedColumns() {
   // listen for scroll and execute once
   $(window).scroll(adjustFixedColumns);
   adjustFixedColumns();
+}
+
+function getOS() {
+  var ua = navigator.userAgent;
+  if (ua.indexOf("Win") !== -1)
+    return "windows";
+  if (ua.indexOf("Mac") !== -1)
+    return "macos";
+  if (ua.indexOf("Linux") !== -1 || ua.indexOf("X11") !== -1)
+    return "linux";
 }

--- a/src/_assets/js/tabs.js
+++ b/src/_assets/js/tabs.js
@@ -1,0 +1,66 @@
+function setupToolsTabs(container, tabIdPrefix, storageName, defaultTab) {
+  var tabs = $('.tabs__top-bar li', container);
+  var tabContents = $('.tabs__content', container);
+
+  console.log('>> #tabs', tabs.length);
+
+  function clearTabsCurrent() {
+    tabs.removeClass('current');
+    tabContents.removeClass('current');
+  }
+
+  // Searches for the tab for a tool by its ID and selects it
+  // (used to pre-select a tool from url fragement/localStorage)
+  function selectTool(id) {
+    var escapedId = $.escapeSelector(id);
+    var tab = tabs.filter("[data-tab='" + tabIdPrefix + id + "']");
+    tab.click();
+  }
+
+  tabs.click(function () {
+    var tab_id = $(this).attr('data-tab');
+    var tab_href = $(this).attr('data-tab-href');
+
+    if (tab_href) {
+      location.href = tab_href;
+      return;
+    }
+
+    if (!$("#" + tab_id).length) {
+      return;
+    }
+
+    clearTabsCurrent();
+
+    $(this).addClass('current');
+    $("#" + tab_id).addClass('current');
+
+    var selectedTool = tab_id.replace(tabIdPrefix, '');
+
+    // Add to the url for better reloading/copy/pasting
+    if (history.replaceState)
+      history.replaceState(undefined, undefined, '#' + selectedTool);
+
+    // Persist in local storage so we can pre-select around the site
+    if (storageName && window.localStorage)
+      window.localStorage.setItem(storageName, selectedTool);
+  });
+
+  // If we have a tool in the url fragement, pre-select it
+  if (location.hash && location.hash.length > 1)
+    selectTool(location.hash.substr(1));
+  else if (storageName && window.localStorage && window.localStorage.getItem(storageName))
+    selectTool(window.localStorage.getItem(storageName));
+  else if (defaultTab)
+    selectTool(defaultTab);
+}
+
+function getOS() {
+  var ua = navigator.userAgent;
+  if (ua.indexOf("Win") !== -1)
+    return "windows";
+  if (ua.indexOf("Mac") !== -1)
+    return "macos";
+  if (ua.indexOf("Linux") !== -1 || ua.indexOf("X11") !== -1)
+    return "linux";
+}

--- a/src/_assets/js/tabs.js
+++ b/src/_assets/js/tabs.js
@@ -1,8 +1,54 @@
+function setupTabs(container, storageName, defaultTab) {
+  var tabs = $('li a', container);
+
+  // console.log('>> #tabs', tabs.length, storageName);
+
+  tabs.click(function (e) {
+
+    // console.log('>> click event for tab:', $(this));
+    e.preventDefault();
+    $(this).tab('show');
+
+    var id = $(this).attr('href').substr(1);
+
+    // Persist to local storage so we can pre-select around the site
+    if (storageName && window.localStorage) {
+      // console.log('>> setting localStorage', storageName, id);
+      window.localStorage.setItem(storageName, id);
+    }
+
+    if (id) location.href = '#' + id;
+
+    // // Add to the url for better reloading/copy/pasting
+    // if (history.replaceState && id != location.hash) {
+    //   history.replaceState(undefined, undefined, id);
+    // }
+  });
+
+  function selectTab(id) {
+    var tab = tabs.filter('[href="#' + id + '"]');
+    tab.click();
+  }
+
+  // If we have a tool in the url fragement, pre-select it
+  if (location.hash && location.hash.length > 1) {
+    // console.log('>> setting tab from location:', location.hash)
+    selectTab(location.hash.substr(1));
+  } else if (storageName && window.localStorage && window.localStorage.getItem(storageName)) {
+    // console.log('>> setting tab from localStorage: ', window.localStorage.getItem(storageName))
+    selectTab(window.localStorage.getItem(storageName));
+  } else if (defaultTab) {
+    // console.log('>> setting tab from defaultTab')
+    selectTab(defaultTab);
+  } else {
+    // console.log('>> not setting the tab - using page default')
+  }
+}
+
+// TODO(chalin): Temporary until we convert all tabs to BS tabs
 function setupToolsTabs(container, tabIdPrefix, storageName, defaultTab) {
   var tabs = $('.tabs__top-bar li', container);
   var tabContents = $('.tabs__content', container);
-
-  console.log('>> #tabs', tabs.length);
 
   function clearTabsCurrent() {
     tabs.removeClass('current');
@@ -53,14 +99,4 @@ function setupToolsTabs(container, tabIdPrefix, storageName, defaultTab) {
     selectTool(window.localStorage.getItem(storageName));
   else if (defaultTab)
     selectTool(defaultTab);
-}
-
-function getOS() {
-  var ua = navigator.userAgent;
-  if (ua.indexOf("Win") !== -1)
-    return "windows";
-  if (ua.indexOf("Mac") !== -1)
-    return "macos";
-  if (ua.indexOf("Linux") !== -1 || ua.indexOf("X11") !== -1)
-    return "linux";
 }

--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -3,7 +3,7 @@
   children:
   - title: 1. Install
     permalink: /get-started/install
-  - title: 2. Configure editor
+  - title: 2. Set up an editor
     permalink: /get-started/editor
   - title: 3. Test drive
     permalink: /get-started/test-drive

--- a/src/get-started/editor.md
+++ b/src/get-started/editor.md
@@ -1,11 +1,12 @@
 ---
-title: Configure editor
+title: Set up an editor
 prev:
   title: Install
   path: /get-started/install
 next:
   title: Test drive
   path: /get-started/test-drive
+toc: false
 ---
 
 You can build apps with Flutter using any text editor combined with our
@@ -14,80 +15,82 @@ even better experience. With our editor plugins, you get code completion, syntax
 highlighting, widget editing assists, run & debug support, and more.
 
 Follow the steps below to add an editor plugin for Android Studio, IntelliJ, or
-VS Code. If you want to use a different editor, that's OK, simply skip ahead to
-[Next step: Create and run your first app](/get-started/test-drive/).
+VS Code. If you want to use a different editor, that's OK, skip ahead to the
+[next step: Test drive](/get-started/test-drive).
 
-<div id="tab-set-install">
-
-<ul class="tabs__top-bar">
-  <li class="tab-link current" data-tab="tab-install-androidstudio">Android Studio</li>
-  <li class="tab-link" data-tab="tab-install-vscode">VS Code</li>
+{% comment %} Nav tabs {% endcomment -%}
+<ul class="nav nav-tabs" id="editor-setup" role="tablist">
+  <li class="nav-item">
+    <a class="nav-link active" id="androidstudio-tab" href="#androidstudio" role="tab" aria-controls="androidstudio" aria-selected="true">Android Studio / IntelliJ</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" id="vscode-tab" href="#vscode" role="tab" aria-controls="vscode" aria-selected="false">Visual Studio Code</a>
+  </li>
 </ul>
 
-<div id="tab-install-androidstudio" class="tabs__content current" markdown="1">
+{% comment %} Tab panes {% endcomment -%}
+<div class="tab-content">
 
-## Android Studio setup {#androidstudio}
+<div class="tab-pane active" id="androidstudio" role="tabpanel" aria-labelledby="androidstudio-tab" markdown="1">
 
-*Android Studio:* A complete, integrated IDE experience for Flutter.
+## Install Android Studio
 
-### Install Android Studio
+Android Studio offers a complete, integrated IDE experience for Flutter.
 
-   * [Android Studio](https://developer.android.com/studio/index.html), version 3.0 or later.
+* [Android Studio](https://developer.android.com/studio/index.html), version 3.0 or later
 
 Alternatively, you can also use IntelliJ:
 
-   * [IntelliJ IDEA Community](https://www.jetbrains.com/idea/download/), version 2017.1 or later.
-   * [IntelliJ IDEA Ultimate](https://www.jetbrains.com/idea/download/), version 2017.1 or later.
+* [IntelliJ IDEA Community](https://www.jetbrains.com/idea/download/), version 2017.1 or later
+* [IntelliJ IDEA Ultimate](https://www.jetbrains.com/idea/download/), version 2017.1 or later
 
-### Install the Flutter and Dart plugins
+## Install the Flutter and Dart plugins
 
 Flutter is supported by two plugins:
 
-   * The `Flutter` plugin powers Flutter developer workflows (running,
-     debugging, hot reload, etc.).
-   * The `Dart` plugin offers code analysis (code validation as you type, code
-     completions, etc.).
+* The `Flutter` plugin powers Flutter developer workflows (running,
+  debugging, hot reload, etc.).
+* The `Dart` plugin offers code analysis (code validation as you type, code
+  completions, etc.).
 
 To install these:
 
-   1. Start Android Studio.
-   1. Open plugin preferences (**Preferences>Plugins** on macOS,
-      **File>Settings>Plugins** on Windows & Linux).
-   1. Select **Browse repositories…**,  select the Flutter plug-in and click
-      `install`.
-   1. Click `Yes` when prompted to install the Dart plugin.
-   1. Click `Restart` when prompted.
+ 1. Start Android Studio.
+ 1. Open plugin preferences (**Preferences > Plugins** on macOS,
+    **File > Settings > Plugins** on Windows & Linux).
+ 1. Select **Browse repositories**,  select the Flutter plug-in and click
+    `install`.
+ 1. Click `Yes` when prompted to install the Dart plugin.
+ 1. Click `Restart` when prompted.
 
 </div>
+<div class="tab-pane" id="vscode" role="tabpanel" aria-labelledby="vscode-tab" markdown="1">
 
-<div id="tab-install-vscode" class="tabs__content" markdown="1">
 
-## Visual Studio Code (VS Code) setup
+## Install VS Code
 
-*VS Code:* A light-weight editor with Flutter run and debug support.
+VS Code is a light-weight editor with Flutter app execution and debug support.
 
-### Install VS Code
+* [VS Code](https://code.visualstudio.com/), latest stable version
 
-  * [VS Code](https://code.visualstudio.com/), latest stable version.
+## Install the Flutter plugin
 
-### Install the Flutter plugin
-
-  1. Start VS Code
-  1. Invoke **View>Command Palette...**
-  1. Type 'install', and select the **'Extensions: Install Extension'** action
-  1. Enter `flutter` in the search field, select 'Flutter' in the list, and
-     click **Install**
-  1. Select 'OK' to reload VS Code
+ 1. Start VS Code
+ 1. Invoke **View > Command Palette...**
+ 1. Type 'install', and select the **Extensions: Install Extension** action
+ 1. Enter `flutter` in the search field, select 'Flutter' in the list, and
+    click **Install**
+ 1. Select 'OK' to reload VS Code
 
 ## Validate your setup with the Flutter Doctor
 
-  1. Invoke **View>Command Palette...**
-  1. Type 'doctor', and select the **'Flutter: Run Flutter Doctor'** action
-  1. Review the output in the 'OUTPUT' pane for any issues
+ 1. Invoke **View > Command Palette...**
+ 1. Type 'doctor', and select the **'Flutter: Run Flutter Doctor'** action
+ 1. Review the output in the 'OUTPUT' pane for any issues
 
 </div>
 
-</div>
+</div>{% comment %} End: Tab panes. {% endcomment -%}
 
 ## Next step
 

--- a/src/get-started/editor.md
+++ b/src/get-started/editor.md
@@ -20,8 +20,8 @@ VS Code. If you want to use a different editor, that's OK, simply skip ahead to
 <div id="tab-set-install">
 
 <ul class="tabs__top-bar">
-    <li class="tab-link current" data-tab="tab-install-androidstudio">Android Studio</li>
-    <li class="tab-link" data-tab="tab-install-vscode">VS Code</li>
+  <li class="tab-link current" data-tab="tab-install-androidstudio">Android Studio</li>
+  <li class="tab-link" data-tab="tab-install-vscode">VS Code</li>
 </ul>
 
 <div id="tab-install-androidstudio" class="tabs__content current" markdown="1">

--- a/src/get-started/test-drive.md
+++ b/src/get-started/test-drive.md
@@ -1,11 +1,12 @@
 ---
 title: Test drive
 prev:
-  title: Configure dditor
+  title: Configure editor
   path: /get-started/editor
 next:
   title: Write your first Flutter app
   path: /get-started/codelab
+toc: false
 ---
 
 This page describes how to "test drive" Flutter: create a new Flutter app from


### PR DESCRIPTION
Staged at https://ng2-io.firebaseapp.com/get-started/editor

---

Screenshot (note that no special styling has yet been created for the new BS tabs):

<img width="1213" alt="screen shot 2018-10-08 at 13 27 10" src="https://user-images.githubusercontent.com/4140793/46624440-c4f9a880-cafe-11e8-89b5-74a7da3cd1ca.png">

cc @filiph @fertolg 