### PR TITLE
[dash] Main nav adjustments following 2018/10/05 meeting

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -14,7 +14,7 @@
       <div class="site-header__sheet">
         <ul class="navbar-nav">
           <li class="nav-item">
-            <a class="nav-link" href="/docs">Docs</a>
+            <a class="nav-link" href="/docs">Documentation</a>
           </li>
 
           <div class="site-sidebar site-sidebar--header d-md-none">
@@ -31,14 +31,14 @@
             <li class="nav-item">
               <a class="nav-link" href="{{site.pub}}/flutter">Packages</a>
             </li>
-            <li class="nav-item">
-              <a class="nav-link" href="/support">Support</a>
-            </li>
           {% endcomment %}
+          <li class="nav-item">
+            <a class="nav-link" href="/community">Community</a>
+          </li>
         </ul>
-        {% unless layout.nav-get-started-button == 'hide' || page.nav-get-started-button == 'hide' -%}
+        {% if page.show-nav-get-started-button -%}
         <a class="site-header__cta btn btn-primary" href="/get-started/install/">Get started</a>
-        {% endunless -%}
+        {% endif -%}
         <form action="/search/" class="site-header__search form-inline">
           <input class="site-header__searchfield form-control" type="search" name="q" id="q" autocomplete="off" placeholder="Search" aria-label="Search">
         </form>

--- a/src/_layouts/landing.html
+++ b/src/_layouts/landing.html
@@ -1,6 +1,5 @@
 ---
 layout: base
-nav-get-started-button: hide
 ---
 
 <div class="container">

--- a/src/showcase/index.md
+++ b/src/showcase/index.md
@@ -1,5 +1,6 @@
 ---
 title: Showcase
+show-nav-get-started-button: true
 toc: false
 ---
 


### PR DESCRIPTION
Main nav changes (action items) for @chalin from 2018/10/05 meeting:

- Change "Docs" to "Documentation"
- Get started button on Showcase page only
- Add "Community"

Staged, see:

- https://flutter-io-staging-2.firebaseapp.com
- https://flutter-io-staging-2.firebaseapp.com/get-started/install
- https://flutter-io-staging-2.firebaseapp.com/showcase

cc @filiph @fertolg 