### PR TITLE
[dash] Add GitHub org link and Twitter to main nav

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ url: https://flutter.io
 port: 4002
 github_username: flutter
 repo:
+  organization: https://github.com/flutter
   this: https://github.com/flutter/website
   flutter: https://github.com/flutter/flutter
 branch: dash # TODO: reset to master

--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -8,18 +8,16 @@
         <div class="site-footer__content">
           <p class="site-footer__link-list">
             <a href="https://groups.google.com/forum/#!forum/flutter-dev">{{ site.email  | regex_replace: '(.*?@).*', '\1' }}</a> &bull;
-            <a href="https://twitter.com/flutterio">twitter</a> &bull;
-            <a href="https://github.com/flutter/">github</a> &bull;
             <a href="/tos">terms</a> &bull;
             <a href="/security">security</a> &bull;
-            <a href="https://www.google.com/intl/en/policies/privacy/">privacy</a> &bull;
+            <a href="https://www.google.com/intl/en/policies/privacy">privacy</a> &bull;
             <a href="https://flutter-io.cn">社区中文资源</a>
           </p>
 
           <p class="licenses">
             Except as otherwise noted,
             this work is licensed under a
-            <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative
+            <a rel="license" href="https://creativecommons.org/licenses/by/4.0">Creative
             Commons Attribution 4.0 International License</a>,
             and code samples are licensed under the BSD License.
           </p>

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -37,11 +37,19 @@
           </li>
         </ul>
         {% if page.show-nav-get-started-button -%}
-        <a class="site-header__cta btn btn-primary" href="/get-started/install/">Get started</a>
+          <a class="site-header__cta btn btn-primary" href="/get-started/install/">Get started</a>
         {% endif -%}
         <form action="/search/" class="site-header__search form-inline">
           <input class="site-header__searchfield form-control" type="search" name="q" id="q" autocomplete="off" placeholder="Search" aria-label="Search">
         </form>
+        <ul class="navbar-nav">
+          <li class="nav-item">
+            <a class="nav-link pr-3" href="https://twitter.com/flutterio"><i class="fab fa-twitter fa-lg"></i></a>
+          </li>
+          <li class="nav-item">
+            <a  class="nav-link pl-0" href="{{site.repo.organization}}"><i class="fab fa-github fa-lg"></i></a>
+          </li>
+        </ul>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
Closes #1400

Staged at https://ng2-io.firebaseapp.com

- Add to main nav:
  - Link to GitHub Flutter organization as an icon
  - Link to Twitter feed
- Remove from footer:
  - GitHub org link
  - Twitter feed link

This most closely resembles what other sites have including, for example, https://angular.io.

---

Screenshots:

<img width="778" alt="screen shot 2018-10-08 at 18 30 01" src="https://user-images.githubusercontent.com/4140793/46637201-0c952a00-cb29-11e8-9db5-0fc56d793589.png">

&nbsp;

<img width="779" alt="screen shot 2018-10-08 at 18 32 46" src="https://user-images.githubusercontent.com/4140793/46637203-0f901a80-cb29-11e8-8b6e-d2d49778b1e1.png">
