### PR TITLE
[dash] By default collapse sidenav level 2 entries with children

### DIFF
--- a/src/_data/side-nav.yml
+++ b/src/_data/side-nav.yml
@@ -45,7 +45,6 @@
   permalink: /development
   children:
   - title: User interface
-    # permalink: /development/ui
     children:
     - title: Tour the framework
       permalink: /development/ui/widgets-intro
@@ -53,7 +52,7 @@
       permalink: /development/ui/layout
     - title: Adding interactivity
       permalink: /development/ui/interactive
-    - title: "Assets and images"
+    - title: Assets and images
       permanlink: /development/ui/assets-and-images
     - title: Navigation & routing
       permalink: /cookbook/navigation/navigation-basics
@@ -85,22 +84,23 @@
     - title: Back-end services
     - title: Use Firebase with Flutter
     - title: Run background processes
-  - title: "Accessibility & Internationalization"
+  - title: Accessibility & internationalization
+    permalink: /accessibility
     children:
     - title: Accessibility
       permalink: /accessibility
     - title: Internationalization
       permalink: /accessibility/internationalization
-  - title: Platform Integration
+  - title: Platform integration
     children:
     - title: Embedding Flutter views in non-Flutter apps
     - title: Writing platform-specific code
       permalink: /development/platform-integration/platform-channels
-  - title: Packages & Plugins
+  - title: Packages & plugins
     children:
     - title: Using packages
       permalink: /development/packages-and-plugins/using-packages
-    - title: "Developing packages & plugins"
+    - title: Developing packages & plugins
       permalink: /development/packages-and-plugins/developing-packages
     - title: Package site
       permalink: http://pub.dartlang.org/flutter
@@ -168,6 +168,7 @@
   children:
   - title: Widget catalog
     permalink: /development/ui/widgets
+    urlExactMatch: true
   - title: API reference
     permalink: https://docs.flutter.io
   - title: Package site

--- a/src/_includes/sidebar.html
+++ b/src/_includes/sidebar.html
@@ -39,13 +39,9 @@ TODO(chalin): rename link to top_level_nav_entry
 
       <ul class="nav flex-column flex-nowrap collapse {{show}}" id="{{id}}">
         {% for child in link.children -%}
-          {% comment %}
-            TODO: rename dropdown to hasChildren
-          {% endcomment -%}
-          {% capture dropdown %}{{ child.children | size }}{% endcapture -%}
           {% if child == 'divider' -%}
             <div class="dropdown-divider"></div>
-          {%- elsif dropdown == '0' -%}
+          {%- elsif child.children == nil -%}
             {%- capture startsWithChildLink %}^{{ child.permalink }}{% endcapture -%}
             {%- capture url %}{{ page.url | regex_replace: '/index$|/index\.html$|\.html$|/$' }}{% endcapture -%}
             {%- capture p %}{{ pageUrl | regex_replace: startsWithChildLink }}{% endcapture -%}
@@ -70,29 +66,43 @@ TODO(chalin): rename link to top_level_nav_entry
               >{{child.title}}</a>
             </li>
           {%- else -%}
-            {% assign isActive = false %}
-            {% if page.sideNavGroup and page.sideNavGroup == child.sideNavGroup %}
-              {% assign isActive = true %}
-            {% elsif page.url contains child.permalink and child.sideNavGroup != 'basic' %}
-              {% assign isActive = true %}
-            {% endif %}
+            {% assign isActive = false -%}
+            {% if page.sideNavGroup and page.sideNavGroup == child.sideNavGroup -%}
+              {% assign isActive = true -%}
+            {% elsif page.url contains child.permalink and child.sideNavGroup != 'basic' -%}
+              {% assign isActive = true -%}
+            {% endif -%}
+
+            {% if isActive -%}
+              {% assign class = 'active' -%}
+            {% endif -%}
+
+            {% if isActive or child.expanded -%}
+              {% assign expanded = 'true' -%}
+              {% assign show = 'show' -%}
+            {% else -%}
+              {% assign class = 'collapsed' -%}
+              {% assign expanded = 'false' -%}
+              {% assign show = '' -%}
+            {% endif -%}
+
+            {% assign id2 = id | append: '-' | append: forloop.index -%}
+            {% assign href = child.permalink -%}
+            {% unless href -%}
+              {% assign href = '#' | append: id2 -%}
+            {% endunless -%}
+
             <li class="nav-item">
-              <a class="nav-link
-                  {%- if isActive %} active{% endif -%}
-                  {%- unless child.permalink %} disabled{% endunless -%}
-                  "
-                {% if child.permalink -%}
-                  href="{{child.permalink}}"
-                {% endif -%}
+              <a class="nav-link {{class}} {%- unless child.permalink %} disabled{% endunless -%}"
+                data-toggle="collapse" data-target="#{{id2}}"
+                href="{{href}}" role="button"
+                aria-expanded="{{expanded}}" aria-controls="{{id2}}"
                 {% comment %}
                   TODO: add title?
                   title="{{child.title}}"
                 {% endcomment -%}
               >{{child.title}}</a>
-              {% comment %}
-                TODO: also make this a collapsable entry?
-              {% endcomment -%}
-              <ul class="nav d-block">
+              <ul class="nav flex-column flex-nowrap collapse {{show}}" id="{{id2}}">
                 {%- for c in child.children -%}
                   {%- assign isActive = false -%}
                   {%- if c.urlExactMatch and pageUrl == c.permalink -%}


### PR DESCRIPTION
Closes #1398

Note that sidenav level 2 entries with children don't have a caret (per the current mocks).