### PR TITLE
[dash] Visually distinguish active main nav entries

### DIFF
--- a/src/_assets/css/_header.scss
+++ b/src/_assets/css/_header.scss
@@ -42,6 +42,11 @@
       @include media-breakpoint-up(md) {
         padding: 0 bs-spacer(4);
       }
+
+      &.active {
+        border-bottom: 0.25rem solid $site-color-primary;
+        // font-weight: $font-weight-bold;
+      }
     }
   }
 

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -1,3 +1,5 @@
+{% assign page_url_path = page.url | regex_replace: '/index$|/index\.html$|\.html$|/$' -%}
+
 <header class="site-header">
   <nav class="navbar navbar-expand-md justify-content-start justify-content-md-between">
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -13,27 +15,22 @@
       <div class="site-header__sheet-bg" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"></div>
       <div class="site-header__sheet">
         <ul class="navbar-nav">
-          <li class="nav-item">
-            <a class="nav-link" href="/docs">Documentation</a>
-          </li>
 
+          <li class="nav-item">
+            <a class="nav-link
+                {%- if page_url_path == '/docs' %} active {%- endif -%}" href="/docs">Documentation</a>
+          </li>
           <div class="site-sidebar site-sidebar--header d-md-none">
             {% include sidebar.html list=site.data.side-nav %}
           </div>
 
           <li class="nav-item">
-            <a class="nav-link" href="/showcase">Showcase</a>
+            <a class="nav-link
+                {%- if page_url_path == '/showcase' %} active {%- endif -%}" href="/showcase">Showcase</a>
           </li>
-          {% comment %}
-            <li class="nav-item">
-              <a class="nav-link" href="{{site.repo.flutter}}">GitHub</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="{{site.pub}}/flutter">Packages</a>
-            </li>
-          {% endcomment %}
           <li class="nav-item">
-            <a class="nav-link" href="/community">Community</a>
+            <a class="nav-link
+                {%- if page_url_path == '/community' %} active {%- endif -%}" href="/community">Community</a>
           </li>
         </ul>
         {% if page.show-nav-get-started-button -%}


### PR DESCRIPTION
Contributes to #1420. I've done rudimentary styling, @fertolg will need to make it prettier :).

Staged at https://ng2-io.firebaseapp.com

Screenshot:

> <img width="1049" alt="screen shot 2018-10-10 at 13 47 44" src="https://user-images.githubusercontent.com/4140793/46755455-19359180-cc93-11e8-9d06-3c005ad32d5f.png">
