### PR TITLE
[dash] Use cards for each OS on Install page

### DIFF
--- a/src/_assets/css/_base.scss
+++ b/src/_assets/css/_base.scss
@@ -106,3 +106,5 @@ dd {
   opacity: 0.5;
   vertical-align: top;
 }
+
+.fa-macos { @extend .fa-apple; }

--- a/src/get-started/install/index.md
+++ b/src/get-started/install/index.md
@@ -8,9 +8,18 @@ toc: false
 
 Select the operating system on which you are installing Flutter:
 
-{% for os in site.os-list -%}
-- [{{os}}](/get-started/install/{{os | downcase}})
+<div class="card-deck mb-8">
+{% for os in site.os-list %}
+  <a class="card" href="/get-started/install/{{os | downcase}}">
+    <div class="card-body">
+      <header class="card-title text-center m-0">
+        {{os}}
+        <i class="fab fa-{{os | downcase}}"></i>
+      </header>
+    </div>
+  </a>
 {% endfor %}
+</div>
 
 {{site.alert.important}}
   If you're in China, first read [Using Flutter in China][].


### PR DESCRIPTION
Staged at https://ng2-io.firebaseapp.com/get-started/install

Screenshots:

> <img width="335" alt="screen shot 2018-10-10 at 14 57 30" src="https://user-images.githubusercontent.com/4140793/46759400-4f780e80-cc9d-11e8-8f3f-3bb457548c19.png">

> <img width="789" alt="screen shot 2018-10-10 at 14 57 39" src="https://user-images.githubusercontent.com/4140793/46759409-569f1c80-cc9d-11e8-8fe6-2ecb5aaab299.png">

cc @filiph @fertolg 