### PR TITLE
[dash] Add sidenav link to "Dart language overview"

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -23,6 +23,8 @@
           permalink: /get-started/flutter-for/web-devs
         - title: Flutter for Xamarin.Forms devs
           permalink: /get-started/flutter-for/xamarin-forms-devs
+    - title: "Dart language overview"
+      permalink: https://www.dartlang.org/guides/language
 
 - title: Samples & codelabs
   children:

--- a/src/_includes/sidenav-level-2.html
+++ b/src/_includes/sidenav-level-2.html
@@ -15,12 +15,10 @@
 
   <li class="nav-item">
     <a class="{{class2}} {%- unless entry2.permalink %} disabled {%- endunless %}"
-      {% if entry2.permalink -%}
-        href="{{entry2.permalink}}"
-      {% endif -%}
+      {%- if entry2.permalink %} href="{{entry2.permalink}}" {%- endif -%}
+      {%- if entry2.permalink contains '://' %} target="_blank" rel="noopener" {%- endif -%}
     >{{entry2.title}}
-    {%- if entry2.permalink == nil %}
-      (TBC)
+    {%- if entry2.permalink == nil %} (TBC)
     {%- elsif entry2.permalink contains '://' -%}
       <i class="fas fa-external-link-alt"></i>
     {%- endif -%}

--- a/src/_includes/sidenav-level-3.html
+++ b/src/_includes/sidenav-level-3.html
@@ -15,12 +15,10 @@
 
   <li class="nav-item">
     <a class="{{class3}} {%- unless entry3.permalink %} disabled {%- endunless %}"
-      {% if entry3.permalink -%}
-        href="{{entry3.permalink}}"
-      {% endif -%}
+      {%- if entry3.permalink %} href="{{entry3.permalink}}" {%- endif -%}
+      {%- if entry3.permalink contains '://' %} target="_blank" rel="noopener" {%- endif -%}
     >{{entry3.title}}
-    {%- if entry3.permalink == nil %}
-      (TBC)
+    {%- if entry3.permalink == nil %} (TBC)
     {%- elsif entry3.permalink contains '://' -%}
       <i class="fas fa-external-link-alt"></i>
     {%- endif -%}

--- a/src/_includes/sidenav-level-4.html
+++ b/src/_includes/sidenav-level-4.html
@@ -9,15 +9,13 @@
 
   <li class="nav-item">
     <a class="{{class4}} {%- unless entry4.permalink %} disabled {%- endunless %}"
-        {% if entry4.permalink -%}
-          href="{{entry4.permalink}}"
-        {% endif -%}
-      >{{entry4.title}}
-      {%- if entry4.permalink == nil %}
-        (TBC)
+      {%- if entry4.permalink %} href="{{entry4.permalink}}" {%- endif -%}
+      {%- if entry4.permalink contains '://' %} target="_blank" rel="noopener" {%- endif -%}
+    >{{entry4.title}}
+      {%- if entry4.permalink == nil %} (TBC)
       {%- elsif entry4.permalink contains '://' -%}
         <i class="fas fa-external-link-alt"></i>
       {%- endif -%}
-      </a>
+    </a>
   </li>
 {% endfor -%}

--- a/src/sitemap.xml
+++ b/src/sitemap.xml
@@ -1,1 +1,1 @@
-./_shared/sitemap.xml
+_shared/sitemap.xml


### PR DESCRIPTION
I slightly shortened the sidenav entry title to be "Dart language overview" instead of "Overview: The Dart Language".

Fixes #1494

Staged at https://ng2-io.firebaseapp.com