### PR TITLE
[dash] Fix header clearance for dual-id cases

### DIFF
--- a/src/_assets/css/_content.scss
+++ b/src/_assets/css/_content.scss
@@ -1,8 +1,16 @@
-@mixin header-clearance {
+// Header clearance of top nav
+@mixin _header-clearance {
   $clearance: 100px;
 
   margin-top: -$clearance;
   padding-top: $clearance;
+}
+
+@mixin header-clearance {
+  @include _header-clearance;
+
+  content: "";
+  display: block;
 }
 
 .site-content {
@@ -31,11 +39,10 @@
 
   h1, h2, h3, h4, h5, h6 {
     // Invisible pre-element to avoid modifying styles on headings.
-    &[id]:not(.no_toc)::before {
-      @include header-clearance;
+    &[id]:not(.no_toc)::before { @include header-clearance; }
 
-      content: "";
-      display: block;
-    }
+    // This case is for jekyll-toc entries that use the computed header id, rather than
+    // the Kramdown id override specified using the {#foo} markdown-extension syntax.
+    > a[id]::before { @include header-clearance; }
   }
 }


### PR DESCRIPTION
Fixes #1504 

Staged, e.g., see this link which now gets the appropriate clearance:

- https://ng2-io.firebaseapp.com/development/tools/ide/vs-code#updating-the-extension

---

Note that this PR brings to light an issue with "you are here" header links when they have **focus**:

> <img width="1152" alt="screen shot 2018-10-23 at 12 29 41" src="https://user-images.githubusercontent.com/4140793/47375911-5d775780-d6bf-11e8-9d25-95c3e034a8b4.png">

This is because we haven't defined the `octicon-link` class and so it uses up the entire heading `:before` space. I'll address this in #1172.