### PR TITLE
Fix Android release tutorial to not break builds sans android/key.properties

### DIFF
--- a/src/docs/deployment/android-release.md
+++ b/src/docs/deployment/android-release.md
@@ -104,9 +104,11 @@ Configure signing for your app by editing the
 ```
    with the keystore information from your properties file:
 ```
-   def keystorePropertiesFile = rootProject.file("key.properties")
    def keystoreProperties = new Properties()
-   keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+   def keystorePropertiesFile = rootProject.file('key.properties')
+   if (keystorePropertiesFile.exists()) {
+       keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+   }
 
    android {
 ```


### PR DESCRIPTION
The instructions at https://flutter.io/android-release/ currently have a significant deficiency: after an app's `android/app/build.gradle` has been modified following these instructions, it is no longer possible to build and run the app without having the `android/key.properties` file present.

On any development team where only one person acts as release manager, this breaks everybody else's checkouts and `flutter run` workflow. Moreover, while the fix may be relatively obvious (as per my patch), it wasn't obvious to at least one junior developer who got stuck on the problem for more than a day. It would be good to fix the documentation to eliminate this problem.

Many (eventually all?) Flutter users run into this problem. The workaround is always the same: instructing others to edit their local `android/app/build.gradle` to comment out the keystore and release configuration. For example, from a quick google:
- https://github.com/iampawan/Flutter-UI-Kit/blob/master/README.md
- https://github.com/iampawan/Flutter-Music-Player/issues/8
- https://github.com/konifar/droidkaigi2018-flutter/issues/64

I reproduce the error from `flutter run` below for the benefit of users googling how to fix this problem:

    $ flutter run
    Using hardware rendering with device Android SDK built for x86. If you get graphics artifacts, consider enabling software rendering with "--enable-software-rendering".
    Launching lib/main.dart on Android SDK built for x86 in debug mode...
    Initializing gradle...                                       2.6s
    Resolving dependencies...                                        
    * Error running Gradle:
    Exit code 1 from: myapp/android/gradlew app:properties:
    Project evaluation failed including an error in afterEvaluate {}. Run with --stacktrace for details of the afterEvaluate {} error.

    FAILURE: Build failed with an exception.

    * Where:
    Build file 'myapp/android/app/build.gradle' line: 29

    * What went wrong:
    A problem occurred evaluating project ':app'.
    > myapp/android/key.properties (No such file or directory)

    * Try:
    Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

    * Get more help at https://help.gradle.org

    BUILD FAILED in 1s


    Please review your Gradle project setup in the android/ folder.
