### PR TITLE
Update scrolling.md - add "await" for driver.close

### DIFF
--- a/src/cookbook/testing/integration/scrolling.md
+++ b/src/cookbook/testing/integration/scrolling.md
@@ -164,7 +164,7 @@ void main() {
     // Close the connection to the driver after the tests have completed
     tearDownAll(() async {
       if (driver != null) {
-        driver.close();
+        await driver.close();
       }
     });
 


### PR DESCRIPTION
driver.close() returns future, so it should be "awaited" during teardown.