### PR TITLE
[dash] Hide sidenav entries w/o pages (previously marked TBC)

### DIFF
--- a/src/_includes/sidenav-level-2.html
+++ b/src/_includes/sidenav-level-2.html
@@ -11,7 +11,7 @@
 
   <div class="dropdown-divider"></div>
 
-{%- elsif entry2.children == nil -%}
+{%- elsif entry2.children == nil and entry2.permalink or show_entries_wo_pages -%}
 
   <li class="nav-item">
     <a class="{{class2}} {%- unless entry2.permalink %} disabled {%- endunless %}"
@@ -25,7 +25,7 @@
     </a>
   </li>
 
-{%- else -%}
+{%- elsif entry2.children -%}
 
   {% assign class2 = class2 | append: ' collapsable' -%}
 

--- a/src/_includes/sidenav-level-3.html
+++ b/src/_includes/sidenav-level-3.html
@@ -11,7 +11,7 @@
 
   <div class="dropdown-divider"></div>
 
-{%- elsif entry3.children == nil -%}
+{%- elsif entry3.children == nil and entry3.permalink or show_entries_wo_pages -%}
 
   <li class="nav-item">
     <a class="{{class3}} {%- unless entry3.permalink %} disabled {%- endunless %}"
@@ -25,7 +25,7 @@
     </a>
   </li>
 
-{%- else -%}
+{%- elsif entry3.children -%}
 
   {% assign class3 = class3 | append: ' collapsable' -%}
 

--- a/src/_includes/sidenav-level-4.html
+++ b/src/_includes/sidenav-level-4.html
@@ -1,4 +1,5 @@
 {% for entry4 in entry3.children -%}
+  {% if entry4.permalink or show_entries_wo_pages -%}
 
   {% assign class4 = 'nav-link' -%}
   {% assign isActive4 = false -%}
@@ -18,4 +19,5 @@
       {%- endif -%}
     </a>
   </li>
+  {% endif -%}
 {% endfor -%}

--- a/src/_includes/sidenav.html
+++ b/src/_includes/sidenav.html
@@ -2,6 +2,7 @@
 {% assign page_url_path = page.url | regex_replace: '/index$|/index\.html$|\.html$|/$' -%}
 
 {% assign active_entries = include.nav | active_nav_entry_index_array: page_url_path -%}
+{% assign show_entries_wo_pages = false -%}
 
 <ul class="nav flex-column">
   {%- for entry1 in include.nav -%}


### PR DESCRIPTION
To show the TBC entries once again, set `show_entries_wo_pages = true`.

Fixes #1645 

Staged, e.g., see the sidenav of this page https://ng2-io.firebaseapp.com/docs/development/ui/advanced/slivers.

## Screenshots

Before this PR:

> <img width="264" alt="screen shot 2018-11-01 at 16 13 08" src="https://user-images.githubusercontent.com/4140793/47876994-2b69a200-ddf1-11e8-9d54-df7ed8692742.png">

With this PR:

> <img width="275" alt="screen shot 2018-11-01 at 16 12 45" src="https://user-images.githubusercontent.com/4140793/47877004-315f8300-ddf1-11e8-99ab-3a99dbf73726.png">

