### PR TITLE
[dash] Cookbook: adjust styling of all images

### DIFF
--- a/src/_assets/css/_base.scss
+++ b/src/_assets/css/_base.scss
@@ -72,6 +72,16 @@ dd {
   font: $site-font-icon;
 }
 
+.site-mobile-screenshot {
+  display: block;
+  margin: 0 auto;
+  max-height: none;
+  max-width: 100%;
+  @include media-breakpoint-up(xs) { max-width: breakpoint-min(xxs); }
+
+  &--border { border: 1px solid $site-color-light-grey; }
+}
+
 .site-image-right {
   display: block;
   margin: 0 auto;

--- a/src/_assets/css/_bootstrap_config.scss
+++ b/src/_assets/css/_bootstrap_config.scss
@@ -27,7 +27,9 @@ $container-max-widths: (
   xxl: 1330px
 );
 $grid-breakpoints: (
-  xs: 0,
+  0: 0,
+  xxs: 320px,
+  xs: 480px,
   sm: 576px,
   md: 768px,
   lg: 992px,

--- a/src/docs/cookbook/animation/opacity-animation.md
+++ b/src/docs/cookbook/animation/opacity-animation.md
@@ -205,4 +205,4 @@ class _MyHomePageState extends State<MyHomePage> {
 }
 ```
 
-![Fade In and Out Demo](/images/cookbook/fade-in-out.gif)
+![Fade In and Out Demo](/images/cookbook/fade-in-out.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/design/drawer.md
+++ b/src/docs/cookbook/design/drawer.md
@@ -187,4 +187,4 @@ class MyHomePage extends StatelessWidget {
 }
 ```
 
-![Drawer Demo](/images/cookbook/drawer.png)
+![Drawer Demo](/images/cookbook/drawer.png){:.site-mobile-screenshot}

--- a/src/docs/cookbook/design/fonts.md
+++ b/src/docs/cookbook/design/fonts.md
@@ -204,4 +204,4 @@ class MyHomePage extends StatelessWidget {
 }
 ```
 
-![Custom Fonts Demo](/images/cookbook/fonts.png)
+![Custom Fonts Demo](/images/cookbook/fonts.png){:.site-mobile-screenshot}

--- a/src/docs/cookbook/design/orientation.md
+++ b/src/docs/cookbook/design/orientation.md
@@ -118,4 +118,4 @@ class OrientationList extends StatelessWidget {
 }
 ```
 
-![Orientation Demo](/images/cookbook/orientation.gif)
+![Orientation Demo](/images/cookbook/orientation.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/design/package-fonts.md
+++ b/src/docs/cookbook/design/package-fonts.md
@@ -149,5 +149,5 @@ class MyHomePage extends StatelessWidget {
 }
 ```
 
-![Package Fonts Demo](/images/cookbook/package-fonts.png)
+![Package Fonts Demo](/images/cookbook/package-fonts.png){:.site-mobile-screenshot}
 

--- a/src/docs/cookbook/design/snackbars.md
+++ b/src/docs/cookbook/design/snackbars.md
@@ -126,4 +126,4 @@ class SnackBarPage extends StatelessWidget {
 }
 ```
 
-![SnackBar Demo](/images/cookbook/snackbar.gif)
+![SnackBar Demo](/images/cookbook/snackbar.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/design/tabs.md
+++ b/src/docs/cookbook/design/tabs.md
@@ -120,4 +120,4 @@ class TabBarDemo extends StatelessWidget {
 }
 ```
 
-![Tabs Demo](/images/cookbook/tabs.gif)
+![Tabs Demo](/images/cookbook/tabs.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/design/themes.md
+++ b/src/docs/cookbook/design/themes.md
@@ -169,4 +169,4 @@ class MyHomePage extends StatelessWidget {
 }
 ```
 
-![Themes Demo](/images/cookbook/themes.png)
+![Themes Demo](/images/cookbook/themes.png){:.site-mobile-screenshot}

--- a/src/docs/cookbook/forms/focus.md
+++ b/src/docs/cookbook/forms/focus.md
@@ -204,4 +204,4 @@ class _MyCustomFormState extends State<MyCustomForm> {
 }
 ```
 
-![Text Field Focus Demo](/images/cookbook/focus.gif)
+![Text Field Focus Demo](/images/cookbook/focus.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/forms/retrieve-input.md
+++ b/src/docs/cookbook/forms/retrieve-input.md
@@ -171,4 +171,4 @@ class _MyCustomFormState extends State<MyCustomForm> {
 }
 ```
 
-![Retrieve Text Input Demo](/images/cookbook/retrieve-input.gif)
+![Retrieve Text Input Demo](/images/cookbook/retrieve-input.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/forms/validation.md
+++ b/src/docs/cookbook/forms/validation.md
@@ -208,4 +208,4 @@ class MyCustomFormState extends State<MyCustomForm> {
 }
 ```
 
-![Form Validation Demo](/images/cookbook/form-validation.gif)
+![Form Validation Demo](/images/cookbook/form-validation.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/gestures/dismissible.md
+++ b/src/docs/cookbook/gestures/dismissible.md
@@ -182,4 +182,4 @@ class MyAppState extends State<MyApp> {
 }
 ```
 
-![Dismissible Demo](/images/cookbook/dismissible.gif)
+![Dismissible Demo](/images/cookbook/dismissible.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/gestures/handling-taps.md
+++ b/src/docs/cookbook/gestures/handling-taps.md
@@ -107,4 +107,4 @@ class MyButton extends StatelessWidget {
 }
 ```
 
-![Handling Taps Demo](/images/cookbook/handling-taps.gif)
+![Handling Taps Demo](/images/cookbook/handling-taps.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/gestures/ripples.md
+++ b/src/docs/cookbook/gestures/ripples.md
@@ -85,4 +85,4 @@ class MyButton extends StatelessWidget {
 }
 ```
 
-![Ripples Demo](/images/cookbook/ripples.gif)
+![Ripples Demo](/images/cookbook/ripples.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/images/fading-in-images.md
+++ b/src/docs/cookbook/images/fading-in-images.md
@@ -65,12 +65,13 @@ class MyApp extends StatelessWidget {
 }
 ```
 
-![Fading In Image Demo](/images/cookbook/fading-in-images.gif)
+![Fading In Image Demo](/images/cookbook/fading-in-images.gif){:.site-mobile-screenshot}
 
-### From Asset Bundle
+### From asset bundle
 
 You can also consider using local assets for placeholders. First, add the asset
-to the project’s _pubspec.yaml_ file:
+to the project’s `pubspec.yaml` file (for more details see
+[Assets and images](/docs/development/ui/assets-and-images)):
 
 <!-- skip -->
 ```diff
@@ -79,10 +80,7 @@ to the project’s _pubspec.yaml_ file:
 +    - assets/loading.gif
 ```
 
-(See [Assets and Images](/docs/development/ui/assets-and-images/)
-for a full guide to adding assets.)
-
-Then, use the [`FadeInImage.assetNetwork`](https://docs.flutter.io/flutter/widgets/FadeInImage/FadeInImage.assetNetwork.html)
+Then, use the [FadeInImage.assetNetwork()](https://docs.flutter.io/flutter/widgets/FadeInImage/FadeInImage.assetNetwork.html)
 constructor:
 
 <!-- skip -->
@@ -126,4 +124,4 @@ class MyApp extends StatelessWidget {
 }
 ```
 
-<img alt="Demo of asset fading in" height="566" src="/images/cookbook/fading-in-asset-demo.gif" width="318" />
+![Asset fade-in](/images/cookbook/fading-in-asset-demo.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/images/network-image.md
+++ b/src/docs/cookbook/images/network-image.md
@@ -65,4 +65,4 @@ class MyApp extends StatelessWidget {
 }
 ```
 
-![Network Image Demo](/images/cookbook/network-image.png)
+![Network Image Demo](/images/cookbook/network-image.png){:.site-mobile-screenshot}

--- a/src/docs/cookbook/lists/basic-list.md
+++ b/src/docs/cookbook/lists/basic-list.md
@@ -72,4 +72,4 @@ class MyApp extends StatelessWidget {
 }
 ```
 
-![Basic List Demo](/images/cookbook/basic-list.png)
+![Basic List Demo](/images/cookbook/basic-list.png){:.site-mobile-screenshot}

--- a/src/docs/cookbook/lists/horizontal-list.md
+++ b/src/docs/cookbook/lists/horizontal-list.md
@@ -92,4 +92,4 @@ class MyApp extends StatelessWidget {
 }
 ```
 
-![Horizontal List Demo](/images/cookbook/horizontal-list.gif)
+![Horizontal List Demo](/images/cookbook/horizontal-list.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/lists/long-lists.md
+++ b/src/docs/cookbook/lists/long-lists.md
@@ -87,4 +87,4 @@ class MyApp extends StatelessWidget {
 }
 ```
 
-![Long Lists Demo](/images/cookbook/long-lists.gif)
+![Long Lists Demo](/images/cookbook/long-lists.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/lists/mixed-list.md
+++ b/src/docs/cookbook/lists/mixed-list.md
@@ -184,4 +184,4 @@ class MessageItem implements ListItem {
 }
 ```
 
-![Mixed List Demo](/images/cookbook/mixed-list.png)
+![Mixed List Demo](/images/cookbook/mixed-list.png){:.site-mobile-screenshot}

--- a/src/docs/cookbook/navigation/hero-animations.md
+++ b/src/docs/cookbook/navigation/hero-animations.md
@@ -174,4 +174,4 @@ class DetailScreen extends StatelessWidget {
 }
 ```
 
-![Hero Demo](/images/cookbook/hero.gif)
+![Hero Demo](/images/cookbook/hero.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/navigation/named-routes.md
+++ b/src/docs/cookbook/navigation/named-routes.md
@@ -195,4 +195,4 @@ class SecondScreen extends StatelessWidget {
 }
 ```
 
-![Navigation Basics Demo](/images/cookbook/navigation-basics.gif)
+![Navigation Basics Demo](/images/cookbook/navigation-basics.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/navigation/navigation-basics.md
+++ b/src/docs/cookbook/navigation/navigation-basics.md
@@ -164,4 +164,4 @@ class SecondScreen extends StatelessWidget {
 }
 ```
 
-![Navigation Basics Demo](/images/cookbook/navigation-basics.gif)
+![Navigation Basics Demo](/images/cookbook/navigation-basics.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/navigation/passing-data.md
+++ b/src/docs/cookbook/navigation/passing-data.md
@@ -219,4 +219,4 @@ class DetailScreen extends StatelessWidget {
 }
 ```
 
-![Passing Data Demo](/images/cookbook/passing-data.gif)
+![Passing Data Demo](/images/cookbook/passing-data.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/navigation/returning-data.md
+++ b/src/docs/cookbook/navigation/returning-data.md
@@ -265,4 +265,4 @@ class SelectionScreen extends StatelessWidget {
 }
 ```
 
-![Returning Data Demo](/images/cookbook/returning-data.gif)
+![Returning Data Demo](/images/cookbook/returning-data.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/networking/background-parsing.md
+++ b/src/docs/cookbook/networking/background-parsing.md
@@ -241,4 +241,4 @@ class PhotosList extends StatelessWidget {
 }
 ```
 
-![Isolate Demo](/images/cookbook/isolate.gif)
+![Isolate Demo](/images/cookbook/isolate.gif){:.site-mobile-screenshot}

--- a/src/docs/cookbook/networking/web-sockets.md
+++ b/src/docs/cookbook/networking/web-sockets.md
@@ -185,4 +185,4 @@ class _MyHomePageState extends State<MyHomePage> {
 }
 ```
 
-![Web Sockets Demo](/images/cookbook/web-sockets.gif)
+![Web Sockets Demo](/images/cookbook/web-sockets.gif){:.site-mobile-screenshot}

--- a/src/docs/get-started/test-drive/_try-hot-reload.md
+++ b/src/docs/get-started/test-drive/_try-hot-reload.md
@@ -1,6 +1,6 @@
 After the app build completes, you'll see the starter app on your device.
 
-{% include app-figure.md img-class="border" image="starter-app.png" caption="Starter app" platform="iOS" %}
+{% include app-figure.md img-class="site-mobile-screenshot border" image="starter-app.png" caption="Starter app" platform="iOS" %}
 
 ## Try hot reload
 


### PR DESCRIPTION
This PR makes _all_ cookbook images responsive (and fixes the oversized-images problem).

Fixes #1529 

Staged, e.g., see (the images at the bottom of the following pages):
- https://ng2-io.firebaseapp.com/docs/cookbook/images/fading-in-images: this page has two images, one of which used to be oversized.
- https://ng2-io.firebaseapp.com/docs/cookbook/animation/opacity-animation
- https://ng2-io.firebaseapp.com/docs/cookbook/networking/web-sockets