### PR TITLE
[dash] Dup widget pages under development/ui/widgets

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,10 @@ defaults:
   values:
     show_breadcrumbs: true
 - scope:
+    path: 'docs/development/ui/widgets'
+  values:
+    toc: false
+- scope:
     path: 'docs/get-started'
   values:
     show_breadcrumbs: true

--- a/firebase.json
+++ b/firebase.json
@@ -25,6 +25,7 @@
       { "source": "/docs/get-started", "destination": "/docs/get-started/install", "type": 301 },
       { "source": "/docs/development/tools/ide", "destination": "/docs/development/tools/ide/android-studio", "type": 301 },
       { "source": "/docs/development/tools/sdk", "destination": "/docs/development/tools/sdk/upgrading", "type": 301 },
+      { "source": "/docs/development/ui/widgets", "destination": "/docs/development/ui/widgets/catalog", "type": 301 },
 
 
       { "source": "/accessibility", "destination": "/docs/development/accessibility-and-localization/accessibility", "type": 301 },
@@ -81,7 +82,7 @@
       { "source": "/using-ide-vscode", "destination": "/docs/development/tools/ide/vs-code", "type": 301 },
       { "source": "/using-packages", "destination": "/docs/development/packages-and-plugins/using-packages", "type": 301 },
       { "source": "/web-analogs", "destination": "/docs/get-started/flutter-for/web-devs", "type": 301 },
-      { "source": "/widgets", "destination": "/docs/reference/widgets", "type": 301 },
+      { "source": "/widgets", "destination": "/docs/reference/widgets/catalog", "type": 301 },
       { "source": "/widgets/:rest*", "destination": "/docs/reference/widgets/:rest*", "type": 301 },
       { "source": "/widgets-intro", "destination": "/docs/development/ui/widgets-intro", "type": 301 }
     ]

--- a/src/_data/docs_cards.yml
+++ b/src/_data/docs_cards.yml
@@ -3,7 +3,7 @@
   url: /docs/get-started/install
 - name: Widgets Catalog
   description: Dip into the rich set of Flutter widgets available in the SDK.
-  url: /docs/development/ui/widget-catalog
+  url: /docs/development/ui/widgets/catalog
 - name: API Docs
   description: Bookmark the API reference docs for the Flutter framework.
   url: https://docs.flutter.io

--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -81,7 +81,7 @@
               permalink: /docs/development/ui/advanced/gestures
         - title: Platform-specific theming
         - title: Widget catalog
-          permalink: /docs/development/ui/widget-catalog
+          permalink: /docs/development/ui/widgets
     - title: Data & backend
       permalink: /docs/development/data-and-backend
       children:

--- a/src/_includes/catalogpage.html
+++ b/src/_includes/catalogpage.html
@@ -15,7 +15,7 @@
         {% endfor %}
     </ul>
 
-    <p>See more widgets in the <a href="/docs/development/ui/widget-catalog">Flutter widget catalog</a>.</p>
+    <p>See more widgets in the <a href="/docs/development/ui/widgets/catalog">widget catalog</a>.</p>
 
     <div class="card-deck card-deck--responsive">
         {% for comp in site.data.catalog.widgets %}
@@ -66,5 +66,5 @@
         {% endif %}
     {% endfor %}
 
-    <p>See more widgets in the <a href="/docs/development/ui/widget-catalog">Flutter widget catalog</a>.</p>
+    <p>See more widgets in the <a href="/docs/development/ui/widgets/catalog">widget catalog</a>.</p>
 </div>

--- a/src/docs/development/ui/layout/index.md
+++ b/src/docs/development/ui/layout/index.md
@@ -454,7 +454,7 @@ it takes only a few steps to put text, an icon, or an image on the screen.
 <ol markdown="1">
 
 <li markdown="1"> Select a layout widget to hold the object.<br>
-    Choose from a variety of [layout widgets](/docs/development/ui/widget-catalog) based
+    Choose from a variety of [layout widgets](/docs/development/ui/widgets/catalog) based
     on how you want to align or constrain the visible widget,
     as these characteristics are typically passed on to the
     contained widget.
@@ -1045,7 +1045,7 @@ recommend the iPad Pro. You can change its orientation to landscape mode using
 Flutter has a rich library of layout widgets, but here a few of those most
 commonly used. The intent is to get you up and running as quickly as possible,
 rather than overwhelm you with a complete list.  For information on other
-available widgets, refer to the [Widget Overview](/docs/development/ui/widget-catalog),
+available widgets, refer to the [Widget Overview](/docs/development/ui/widgets/catalog),
 or use the Search box in the [API reference docs](https://docs.flutter.io/).
 Also, the widget pages in the API docs often make suggestions
 about similar widgets that might better suit your needs.
@@ -1574,7 +1574,7 @@ Gallery](https://github.com/flutter/flutter/tree/master/examples/flutter_gallery
 
 The following resources may help when writing layout code.
 
-* [Widget Overview](/docs/development/ui/widget-catalog)<br>
+* [Widget Overview](/docs/development/ui/widgets/catalog)<br>
   Describes many of the widgets available in Flutter.
 * [HTML/CSS Analogs in Flutter](/get-started/flutter-for/web-devs)<br>
   For those familiar with web programming, this page maps HTML/CSS functionality

--- a/src/docs/development/ui/widgets
+++ b/src/docs/development/ui/widgets
@@ -1,0 +1,1 @@
+../../reference/widgets

--- a/src/docs/development/ui/widgets-intro.md
+++ b/src/docs/development/ui/widgets-intro.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction to Widgets
+title: Introduction to widgets
 ---
 
 {% comment %} This page needs more cleanup. API references should be accumulated

--- a/src/docs/get-started/flutter-for/react-native-devs/index.md
+++ b/src/docs/get-started/flutter-for/react-native-devs/index.md
@@ -350,7 +350,7 @@ import 'package:flutter/my_widgets.dart';
 Whichever widget package you import, Dart pulls in only the widgets that are
  used in your app.
 
-For more information, see the [Flutter Widgets Catalog](/docs/development/ui/widget-catalog).
+For more information, see the [Flutter Widgets Catalog](/docs/development/ui/widgets/catalog).
 
 ### What is the equivalent of the React Native "Hello world!" app in Flutter?
 
@@ -750,7 +750,7 @@ Overview](/docs/resources/technical-overview).
 
 For more information about the core widgets from the Widgets package, see
 [Flutter Basic Widgets](/docs/reference/widgets/basics), the
-[Flutter Widget Catalog](/docs/development/ui/widget-catalog), or the
+[Flutter Widget Catalog](/docs/development/ui/widgets/catalog), or the
 [Flutter Widget Index](/docs/reference/widgets).
 
 ## Views

--- a/src/docs/reference/widgets/accessibility.md
+++ b/src/docs/reference/widgets/accessibility.md
@@ -1,4 +1,5 @@
 ---
-title: Accessibility Widgets
+title: Accessibility widgets
+short-title: Accessibility
 ---
 {% include catalogpage.html category="Accessibility" %}

--- a/src/docs/reference/widgets/animation.md
+++ b/src/docs/reference/widgets/animation.md
@@ -1,4 +1,5 @@
 ---
-title: Animation and Motion Widgets
+title: Animation and motion widgets
+short-title: Animation
 ---
 {% include catalogpage.html category="Animation and Motion" %}

--- a/src/docs/reference/widgets/assets.md
+++ b/src/docs/reference/widgets/assets.md
@@ -1,5 +1,6 @@
 ---
-title: Assets, Images, and Icon Widgets
+title: Assets, images, and icon widgets
+short-title: Assets
 toc: false
 ---
 {% include catalogpage.html category="Assets, Images, and Icons" %}

--- a/src/docs/reference/widgets/async.md
+++ b/src/docs/reference/widgets/async.md
@@ -1,4 +1,5 @@
 ---
-title: Async Widgets
+title: Async widgets
+short-title: Async
 ---
 {% include catalogpage.html category="Async" %}

--- a/src/docs/reference/widgets/basics.md
+++ b/src/docs/reference/widgets/basics.md
@@ -1,5 +1,6 @@
 ---
-title: Basic Widgets
+title: Basic widgets
+short-title: Basics
 ---
 
 {% include catalogpage.html category="Basics" %}

--- a/src/docs/reference/widgets/catalog.md
+++ b/src/docs/reference/widgets/catalog.md
@@ -11,11 +11,11 @@ you can also see all the widgets in the [Flutter widget index](/docs/reference/w
 {% for section in site.data.catalog.index %}
     <div class="card">
         <div class="card-body">
-            <a href="/docs/reference/widgets/{{section.id}}"><header class="card-title">{{section.name}}</header></a>
+            <a href="widgets/{{section.id}}"><header class="card-title">{{section.name}}</header></a>
             <p class="card-text">{{section.description}}</p>
         </div>
         <div class="card-footer card-footer--transparent">
-            <a href="/docs/reference/widgets/{{section.id}}">Visit</a>
+            <a href="widgets/{{section.id}}">Visit</a>
         </div>
     </div>
 {% endfor %}

--- a/src/docs/reference/widgets/catalog.md
+++ b/src/docs/reference/widgets/catalog.md
@@ -1,21 +1,22 @@
 ---
 title: Widget catalog
+short-title: Catalog
 toc: false
 ---
 
 Create beautiful apps faster with Flutter's collection of visual, structural,
 platform, and interactive widgets. In addition to browsing widgets by category,
-you can also see all the widgets in the [Flutter widget index](/docs/reference/widgets).
+you can also see all the widgets in the [widget index](/docs/reference/widgets).
 
 <div class="card-deck card-deck--responsive">
 {% for section in site.data.catalog.index %}
     <div class="card">
         <div class="card-body">
-            <a href="widgets/{{section.id}}"><header class="card-title">{{section.name}}</header></a>
+            <a href="{{section.id}}"><header class="card-title">{{section.name}}</header></a>
             <p class="card-text">{{section.description}}</p>
         </div>
         <div class="card-footer card-footer--transparent">
-            <a href="widgets/{{section.id}}">Visit</a>
+            <a href="{{section.id}}">Visit</a>
         </div>
     </div>
 {% endfor %}

--- a/src/docs/reference/widgets/cupertino.md
+++ b/src/docs/reference/widgets/cupertino.md
@@ -1,4 +1,5 @@
 ---
-title: Cupertino (iOS-style) Widgets
+title: Cupertino (iOS-style) widgets
+short-title: Cupertino
 ---
 {% include catalogpage.html category="Cupertino (iOS-style widgets)" %}

--- a/src/docs/reference/widgets/index.md
+++ b/src/docs/reference/widgets/index.md
@@ -6,7 +6,8 @@ show_breadcrumbs: false
 
 {% assign sorted = site.data.catalog.widgets | sort:'name' -%}
 
-This is an alphabetical list of nearly every widget that is bundled with Flutter. You can also <a href="/docs/development/ui/widget-catalog">browse widgets by category.
+This is an alphabetical list of nearly every widget that is bundled with
+Flutter. You can also [browse widgets by category][catalog].
 
 <div class="card-deck card-deck--responsive">
 {% for comp in sorted %}
@@ -26,3 +27,5 @@ This is an alphabetical list of nearly every widget that is bundled with Flutter
     </div>
 {% endfor %}
 </div>
+
+[catalog]: /docs/development/ui/widgets/catalog

--- a/src/docs/reference/widgets/input.md
+++ b/src/docs/reference/widgets/input.md
@@ -1,4 +1,5 @@
 ---
-title: Input Widgets
+title: Input widgets
+short-title: Input
 ---
 {% include catalogpage.html category="Input" %}

--- a/src/docs/reference/widgets/interaction.md
+++ b/src/docs/reference/widgets/interaction.md
@@ -1,4 +1,5 @@
 ---
-title: Interaction Model Widgets
+title: Interaction model widgets
+short-title: Interaction
 ---
 {% include catalogpage.html category="Interaction Models" %}

--- a/src/docs/reference/widgets/layout.md
+++ b/src/docs/reference/widgets/layout.md
@@ -1,4 +1,5 @@
 ---
-title: Layout Widgets
+title: Layout widgets
+short-title: Layout
 ---
 {% include catalogpage.html category="Layout" %}

--- a/src/docs/reference/widgets/material.md
+++ b/src/docs/reference/widgets/material.md
@@ -1,4 +1,5 @@
 ---
-title: Material Components Widgets
+title: Material Components widgets
+short-title: Material
 ---
 {% include catalogpage.html category="Material Components" %}

--- a/src/docs/reference/widgets/painting.md
+++ b/src/docs/reference/widgets/painting.md
@@ -1,4 +1,5 @@
 ---
-title: Painting and Effect Widgets
+title: Painting and effect widgets
+short-title: Painting
 ---
 {% include catalogpage.html category="Painting and effects" %}

--- a/src/docs/reference/widgets/scrolling.md
+++ b/src/docs/reference/widgets/scrolling.md
@@ -1,4 +1,5 @@
 ---
-title: Scrolling Widgets
+title: Scrolling widgets
+short-title: Scrolling
 ---
 {% include catalogpage.html category="Scrolling" %}

--- a/src/docs/reference/widgets/styling.md
+++ b/src/docs/reference/widgets/styling.md
@@ -1,4 +1,5 @@
 ---
-title: Styling Widgets
+title: Styling widgets
+short-title: Styling
 ---
 {% include catalogpage.html category="Styling" %}

--- a/src/docs/reference/widgets/text.md
+++ b/src/docs/reference/widgets/text.md
@@ -1,4 +1,5 @@
 ---
-title: Text Widgets
+title: Text widgets
+short-title: Text
 ---
 {% include catalogpage.html category="Text" %}

--- a/src/docs/resources/faq.md
+++ b/src/docs/resources/faq.md
@@ -231,7 +231,7 @@ No. Instead, Flutter provides a set of widgets
 (including Material Design and Cupertino (iOS-styled) widgets),
 managed and rendered by Flutter's framework and engine.
 You can browse a
-[catalog of Flutter's widgets](/docs/development/ui/widget-catalog).
+[catalog of Flutter's widgets](/docs/development/ui/widgets/catalog).
 
 We are hoping the end-result will be higher quality apps. If we reused
 the OEM widgets, the quality and performance of Flutter apps would be
@@ -849,7 +849,7 @@ Flutter is an open source project. Currently, the bulk of the development is
 done by engineers at Google. If you're excited about Flutter, we encourage
 you to join the community and contribute to Flutter!
 
-[widgets]: /docs/development/ui/widget-catalog
+[widgets]: /docs/development/ui/widgets/catalog
 
 ### What are Flutter's guiding principles?
 

--- a/src/index.html
+++ b/src/index.html
@@ -169,7 +169,7 @@ description: >
                 smooth natural scrolling, and platform awareness.
                 </p>
 
-                <a href="/docs/development/ui/widget-catalog">Browse the widget catalog</a>
+                <a href="/docs/development/ui/widgets/catalog">Browse the widget catalog</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Fixes #1637.

Staged at: https://ng2-io.firebaseapp.com/docs/development/ui/widgets