### PR TITLE
Apply `toc: true` by default to doc pages only

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,12 +27,15 @@ defaults:
     path: ''
   values:
     layout: default
-    toc: true
     show-nav-get-started-button: true
     # To hide banners from every page, comment out the `show_banner` setting
     # below. To selectively enable a banner (say, on the homepage) add
     # `show_banner: true` to the page's frontmatter.
     show_banner: true
+- scope:
+    path: 'docs'
+  values:
+    toc: true
 - scope:
     path: 'docs/cookbook'
   values:

--- a/src/404.md
+++ b/src/404.md
@@ -1,6 +1,5 @@
 ---
 title: Page not found
-toc: false
 sitemap: false
 ---
 

--- a/src/community/china.md
+++ b/src/community/china.md
@@ -1,7 +1,6 @@
 ---
 title: Using Flutter in China
 description: Where to find a version of flutter.io that is localized to Mandarin.
-toc: false
 ---
 
 The Flutter community has made a Mandarin version of the flutter.io

--- a/src/community/index.html
+++ b/src/community/index.html
@@ -2,7 +2,6 @@
 title: Community
 layout: landing
 body_class: landing-page community
-toc: false
 ---
 
 <section class="community__intro row text-center">

--- a/src/showcase/index.html
+++ b/src/showcase/index.html
@@ -2,7 +2,6 @@
 title: Showcase
 layout: landing
 body_class: landing-page showcase
-toc: false
 ---
 
 <section id="showcaseCarousel" class="landing-page__hero showcase__carousel carousel slide" data-interval=8000 data-ride="carousel" data-pause="false">


### PR DESCRIPTION
This in particular removes the empty TOC from the search page.

Staged, e.g., see https://ng2-io.firebaseapp.com/search?q=apple