### PR TITLE
Fix typo missing brackets opening

### DIFF
--- a/src/docs/get-started/flutter-for/react-native-devs/index.md
+++ b/src/docs/get-started/flutter-for/react-native-devs/index.md
@@ -169,7 +169,7 @@ if (zero == 0) {
 ```
 
 Try it out in
-DartPad](https://dartpad.dartlang.org/c85038ad677963cb6dc943eb1a0b72e6).
+[DartPad](https://dartpad.dartlang.org/c85038ad677963cb6dc943eb1a0b72e6).
 
 ### Functions
 


### PR DESCRIPTION
Fix missing brackets opening that cause broken hyperlink