### PR TITLE
chore: cleanup external codelab links

### DIFF
--- a/src/docs/development/data-and-backend/firebase.md
+++ b/src/docs/development/data-and-backend/firebase.md
@@ -14,7 +14,7 @@ Firebase supports Flutter. For more information, see:
    Flutter](https://firebase.google.com/docs/flutter/setup)
    in the [Firebase docs](https://firebase.google.com/docs)
 * [Firebase for Flutter
-   codelab](https://codelabs.developers.google.com/codelabs/flutter-firebase/#0)
+   codelab](https://codelabs.developers.google.com/codelabs/flutter-firebase)
 * [FlutterFire
   plugins](https://github.com/flutter/plugins/blob/master/FlutterFire.md)
 * [Using Firestore as a backend to your Flutter

--- a/src/docs/get-started/flutter-for/react-native-devs/index.md
+++ b/src/docs/get-started/flutter-for/react-native-devs/index.md
@@ -813,7 +813,7 @@ ListView.builder(
 <br>
 To learn how to implement an infinite scrolling list, see the
 [Write Your First Flutter App,
-Part 1](https://codelabs.developers.google.com/codelabs/first-flutter-app-pt1/#0)
+Part 1](https://codelabs.developers.google.com/codelabs/first-flutter-app-pt1)
 codelab.
 
 ### How do I use a Canvas to draw or paint?

--- a/src/docs/get-started/learn-more.md
+++ b/src/docs/get-started/learn-more.md
@@ -24,7 +24,7 @@ Other resources:
 
 * [Udacity online Flutter training](https://www.udacity.com/course/build-native-mobile-apps-with-flutter--ud905)
 * [Flutter Cookbook](/docs/cookbook)
-* [From Java to Dart](https://codelabs.developers.google.com/codelabs/from-java-to-dart/#0) codelab
+* [From Java to Dart](https://codelabs.developers.google.com/codelabs/from-java-to-dart) codelab
 * [Bootstrap into Dart: learn more about the language](/docs/resources/bootstrap-into-dart)
 
 Reach out to us at our [mailing list][]. We'd love to hear from you!


### PR DESCRIPTION
Drop the trailing `/#0` for external codelab links since it is unnecessary, and it makes the link checker complain about missing anchors