### PR TITLE
Drop `https://flutter.io` prefix from intrasite page links

### DIFF
--- a/src/404.md
+++ b/src/404.md
@@ -7,4 +7,4 @@ sitemap: false
 
 You’ve stumbled onto a page that doesn’t exist. Luckily this site has other [pages](/).
 
-If you were looking for something specific, maybe try our [search page](https://flutter.io/search/).
+If you were looking for something specific, maybe try our [search page](/search).

--- a/src/docs/development/ui/assets-and-images.md
+++ b/src/docs/development/ui/assets-and-images.md
@@ -231,7 +231,8 @@ you'll also notice parameters related to scale.)
 
 ### Asset images in package dependencies {#from-packages}
 
-To load an image from a [package](https://flutter.io/using-packages/) dependency, the `package` argument must be provided to [`AssetImage`](https://docs.flutter.io/flutter/painting/AssetImage-class.html).
+To load an image from a [package](/docs/development/packages-and-plugins/using-packages) dependency,
+the `package` argument must be provided to [`AssetImage`](https://docs.flutter.io/flutter/painting/AssetImage-class.html).
 
 For instance, suppose your application depends on a package called `my_icons`, which has the following directory structure:
 

--- a/src/docs/development/ui/interactive/index.md
+++ b/src/docs/development/ui/interactive/index.md
@@ -301,7 +301,7 @@ class MyApp extends StatelessWidget {
 ### Problems?
 
 If you can't get your code to run, look in your IDE for possible errors.
-[Debugging Flutter Apps](https://flutter.io/debugging/) might help.
+[Debugging Flutter Apps](/docs/testing/debugging) might help.
 If you still can't find the problem,
 check your code against the interactive Lakes example on GitHub.
 
@@ -770,13 +770,13 @@ it's easiest to use one of the prefabricated widgets. Here's a partial list:
 
 The following resources may help when adding interactivity to your app.
 
-* [Gestures](https://flutter.io/widgets-intro/#gestures),
+* [Gestures](/docs/development/ui/widgets-intro#handling-gestures),
   a section in [A Tour of the Flutter Widget
-  Framework](https://flutter.io/widgets-intro/)<br>
+  Framework](/docs/development/ui/widgets-intro)<br>
   How to create a button and make it respond to input.
-* [Gestures in Flutter](https://flutter.io/gestures/)<br>
+* [Gestures in Flutter](/docs/development/ui/advanced/gestures)<br>
   A description of Flutter's gesture mechanism.
-* [Flutter API documentation](https://docs.flutter.io/)<br>
+* [Flutter API documentation](https://docs.flutter.io)<br>
   Reference documentation for all of the Flutter libraries.
 * [Flutter
   Gallery](https://github.com/flutter/flutter/tree/master/examples/flutter_gallery)<br>

--- a/src/docs/get-started/flutter-for/xamarin-forms-devs.md
+++ b/src/docs/get-started/flutter-for/xamarin-forms-devs.md
@@ -190,7 +190,7 @@ In Flutter, almost everything is a widget. A `Page`, called a `Route` in Flutter
 Buttons, progress bars, animation controllers are all widgets. When building a route, you create
 a widget tree.
 
-Flutter includes the [Material Components](https://flutter.io/widgets/material/)
+Flutter includes the [Material Components](/docs/reference/widgets/material)
 library. These are widgets that implement the
 [Material Design guidelines](https://material.io/design/). Material Design is a
 flexible design system [optimized for all


### PR DESCRIPTION
Contributes to #1412