### PR TITLE
Drop invalid canonical page link element

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -13,7 +13,7 @@
   })(window,document,'script','dataLayer','GTM-ND4LWWZ');</script>
   <!-- End Google Tag Manager -->
 
-  {% assign page_url = page.url | replace:'index.html','' | prepend: site.url -%}
+  {% assign page_url = page.url | regex_replace: '/index$|/index.html$|\.html$|/$' -%}
   {% assign desc = page.description | default: page.content | strip_html | replace:'"','' | strip_newlines | truncatewords: 50 | split: '{%' | first %}
   <meta name="description" content="{{desc}}">
   <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
@@ -22,7 +22,7 @@
   <meta name="twitter:site" content="@flutterio">
 
   <meta property="og:title" content="{{ page.title }}">
-  <meta property="og:url" content="{{ page_url }}">
+  <meta property="og:url" content="{{ page_url | absolute_url }}">
   <meta property="og:description" content="{{desc}}">
   {% assign og_image_path = page.image | default: layout.image | default: '/images/flutter-logo-sharing.png' %}
   <meta property="og:image" content="{{og_image_path | absolute_url}}">
@@ -36,7 +36,6 @@
   {% for js in page.js -%}
     <script {% if js.defer %}defer{% endif %} src="{{js.url | default: js}}"></script>
   {% endfor -%}
-  <link rel="canonical" href="{{ page_url }}">
 
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -27,6 +27,8 @@
   {% assign og_image_path = page.image | default: layout.image | default: '/images/flutter-logo-sharing.png' %}
   <meta property="og:image" content="{{og_image_path | absolute_url}}">
 
+  <link rel="canonical" href="{{ page_url | absolute_url }}">
+
   <link href="https://fonts.googleapis.com/css?family=Google+Sans:400,500|Roboto:300,400,500|Roboto+Mono:400,700|Material+Icons" rel="stylesheet">
   {% asset main.css %}
   {% for css in page.css -%}


### PR DESCRIPTION
- Fixes #1738:
  - I considered dropping self-referential canonical link entries, but apparently it is a recommended to have a `<link rel="canonical"...>` element for every page, see [Using Rel Canonical on All Pages](http://www.thesempost.com/using-rel-canonical-on-all-pages-for-duplicate-content-protection/)
  - As of this PR canonical URLs will actually match what is in the sitemap.
- Also fixes OG (social media) page link.

Staged at https://ng2-io.firebaseapp.com, e.g., visit https://ng2-io.firebaseapp.com/docs/get-started/learn-more and **View page source**, then look for the `og:url` and `<link rel="canonical"...>`.