### PR TITLE
Fix external links, most broken by paragraph word-wrapping

### DIFF
--- a/src/docs/cookbook/images/fading-in-images.md
+++ b/src/docs/cookbook/images/fading-in-images.md
@@ -15,7 +15,7 @@ from the internet.
 
 ## In-Memory
 
-In this example, we'll use the [transparent_image](https://pub.dartlang.org/packages/transparent_image)
+In this example, we'll use the [transparent_image]({{site.pub-pkg}}/transparent_image)
 package for a simple transparent placeholder.
 
 <!-- skip -->

--- a/src/docs/development/ui/animations/overview.md
+++ b/src/docs/development/ui/animations/overview.md
@@ -99,7 +99,7 @@ a concrete value for the current frame of an animation, you also need an
 animation to determine the current state. There are two ways to combine a tween
 with an animation to get a concrete value:
 
-1. You can [`evaluate`](https://docs.flutter.io/flutter/animation/Tween/evaluate.html)
+1. You can [`evaluate`](https://docs.flutter.io/flutter/animation/Animatable/evaluate.html)
    the tween at the current value of an animation. This approach is most useful
    for widgets that are already listening to the animation and hence
    rebuilding whenever the animation changes value.
@@ -118,7 +118,7 @@ Animations are actually built from a number of core building blocks.
 ## Scheduler
 
 The
-[`SchedulerBinding`](https://docs.flutter.io/flutter/scheduler/SchedulerBinding-class.html)
+[`SchedulerBinding`](https://docs.flutter.io/flutter/scheduler/SchedulerBinding-mixin.html)
 is a singleton class that exposes the Flutter scheduling primitives.
 
 For this discussion, the key primitive is the frame callbacks. Each

--- a/src/docs/get-started/flutter-for/android-devs.md
+++ b/src/docs/get-started/flutter-for/android-devs.md
@@ -377,8 +377,9 @@ and `CustomPainter`, the latter of which implements your algorithm to draw to
 the canvas.
 
 To learn how to implement a signature painter in Flutter, see Collin's answer on
-[StackOverflow](https://stackoverflow.com/questions/46241071/create-signature-area-
-for-mobile-app-in-dart-flutter).
+[StackOverflow][].
+
+[StackOverflow]: https://stackoverflow.com/questions/46241071/create-signature-area-for-mobile-app-in-dart-flutter
 
 <!-- skip -->
 {% prettify dart %}
@@ -1339,7 +1340,9 @@ The observable lifecycle events are:
   event to map to on iOS
 
 For more details on the meaning of these states, see the
-[`AppLifecycleStatus` documentation](https://docs.flutter.io/flutter/dart-ui/AppLifecycleState-class.html).
+[`AppLifecycleStatus` documentation][].
+
+[`AppLifecycleStatus` documentation]: https://docs.flutter.io/flutter/dart-ui/AppLifecycleState-class.html
 
 As you might have noticed, only a small minority of the Activity lifecycle events
 are available; while `FlutterActivity` does capture almost all the activity lifecycle

--- a/src/docs/get-started/flutter-for/ios-devs.md
+++ b/src/docs/get-started/flutter-for/ios-devs.md
@@ -376,8 +376,9 @@ other classes that help you draw: `CustomPaint` and `CustomPainter`, the
 latter of which implements your algorithm to draw to the canvas.
 
 To learn how to implement a signature painter in Flutter, see Collin's answer on
-[StackOverflow](https://stackoverflow.com/questions/46241071/create-signature-area-
-for-mobile-app-in-dart-flutter).
+[StackOverflow][].
+
+[StackOverflow]: https://stackoverflow.com/questions/46241071/create-signature-area-for-mobile-app-in-dart-flutter
 
 <!-- skip -->
 {% prettify dart %}
@@ -1225,8 +1226,9 @@ the user, is not responding to user input, but is running in the background.
 has no equivalent event.
 
 For more details on the meaning of these states, see
-[`AppLifecycleStatus` documentation](https://docs.flutter.io/flutter/dart-ui
-/AppLifecycleState-class.html).
+[`AppLifecycleStatus` documentation][].
+
+[`AppLifecycleStatus` documentation]: https://docs.flutter.io/flutter/dart-ui/AppLifecycleState-class.html
 
 ## Layouts
 

--- a/src/docs/get-started/flutter-for/react-native-devs/index.md
+++ b/src/docs/get-started/flutter-for/react-native-devs/index.md
@@ -1744,8 +1744,8 @@ frame triggers, but they're most commonly used indirectly via an
 [`AnimationController`](https://docs.flutter.io/flutter/animation/AnimationController-class.html).
 `AnimationControllers` need a `TickerProvider` to obtain their `Ticker`.
 If you are creating an AnimationController from a State, then you can use the
-[`TickerProviderStateMixin`](https://docs.flutter.io/flutter/widgets/TickerProviderStateMixin-class.html)
-or [`SingleTickerProviderStateMixin`](https://docs.flutter.io/flutter/widgets/SingleTickerProviderStateMixin-class.html)
+[`TickerProviderStateMixin`](https://docs.flutter.io/flutter/widgets/TickerProviderStateMixin-mixin.html)
+or [`SingleTickerProviderStateMixin`](https://docs.flutter.io/flutter/widgets/SingleTickerProviderStateMixin-mixin.html)
 classes to obtain a suitable `TickerProvider`.
 
 The [`Scaffold`](https://docs.flutter.io/flutter/material/Scaffold-class.html)
@@ -1969,11 +1969,9 @@ GestureDetector(
 );
 ```
 For more information, including a list of Flutter `GestureDetector` callbacks,
-see the
-[GestureDetector
-class](https://docs.flutter.io/flutter/widgets/GestureDetector-class.html#Properties).
+see the [GestureDetector class][].
 
-
+[GestureDetector class]: https://docs.flutter.io/flutter/widgets/GestureDetector-class.html#instance-properties
 
 |Android|iOS|
 |:---:|:--:|

--- a/src/docs/get-started/flutter-for/xamarin-forms-devs.md
+++ b/src/docs/get-started/flutter-for/xamarin-forms-devs.md
@@ -540,8 +540,9 @@ and `CustomPainter`, the latter of which implements your algorithm to draw to
 the canvas.
 
 To learn how to implement a signature painter in Flutter, see Collin's answer on
-[StackOverflow](https://stackoverflow.com/questions/46241071/create-signature-area-
-for-mobile-app-in-dart-flutter).
+[StackOverflow][].
+
+[StackOverflow]: https://stackoverflow.com/questions/46241071/create-signature-area-for-mobile-app-in-dart-flutter
 
 <!-- skip -->
 {% prettify dart %}
@@ -1378,9 +1379,10 @@ the user, is not responding to user input, but is running in the background.
 * `suspending` — The application is suspended momentarily. This event is Android
 only.
 
-For more details on the meaning of these states, see
-[`AppLifecycleStatus`
-documentation](https://docs.flutter.io/flutter/dart-ui/AppLifecycleState-class.html).
+For more details on the meaning of these states, see [`AppLifecycleStatus`
+documentation][].
+
+[`AppLifecycleStatus` documentation]: https://docs.flutter.io/flutter/dart-ui/AppLifecycleState-class.html
 
 ## Layouts
 


### PR DESCRIPTION
- Contributes to #1413, by fixing all 404 errors. All we are left with now are connection failures (https://github.com/filiph/linkcheck/issues/29).
- Fixes #1475

Staged at https://ng2-io.firebaseapp.com