### PR TITLE
Fix some typos in the "Introduction to integration testing" and "Rend…

### DIFF
--- a/src/docs/cookbook/testing/integration/index.md
+++ b/src/docs/cookbook/testing/integration/index.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction to Integration testing
+title: Introduction to integration testing
 ---
 
 Unit tests and Widget tests are handy for testing individual classes, functions,
@@ -158,7 +158,7 @@ Now, we can instrument the app. This will involve two steps:
   1. Enable the flutter driver extensions
   2. Run the app
 
-We will add this code inside the `flutter_driver/app.dart` file.
+We will add this code inside the `test_driver/app.dart` file.
 
 <!-- skip -->
 ```dart

--- a/src/docs/resources/rendering.md
+++ b/src/docs/resources/rendering.md
@@ -62,7 +62,7 @@ render tree:
    model).
 
  * Finally, subclasses of `RenderObject` can override the default, do-nothing
-   implemenations of `handleEvent` and `rotate` to respond to user input and
+   implementations of `handleEvent` and `rotate` to respond to user input and
    screen rotation, respectively.
 
 The base model also provides two mixins for common child models:


### PR DESCRIPTION
…ering in Flutter" pages

* "implemenations" => "implementations"
* Adjust the capitalization of the "Introduction to integration
  testing" page for consistency with other pages.
* "flutter_driver/app.dart" => "test_driver/app.dart"

Fixes #1736.