### PR TITLE
Snackbar component, deprecated pages

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -5,7 +5,8 @@
     "staging-1": "flutter-io-staging-1",
     "staging-2": "flutter-io-staging-2",
     "pc2": "ng2-io",
-    "sz" :  "sz-flutter",
-    "sz2" : "sz-flutter-2"
+    "sz": "sz-flutter",
+    "sz2": "sz-flutter-2",
+    "ft": "flutter-web-staging"
   }
 }

--- a/src/_assets/css/_bootstrap_adjust.scss
+++ b/src/_assets/css/_bootstrap_adjust.scss
@@ -51,7 +51,7 @@ a.card {
 .btn {
   font-family: $site-font-family-alt;
   font-weight: 500;
-  padding: bs-spacer(2) bs-spacer(10);
+  padding: bs-spacer(2);
 }
 
 .btn-link:hover,

--- a/src/_assets/css/_snackbar.scss
+++ b/src/_assets/css/_snackbar.scss
@@ -1,0 +1,25 @@
+.snackbar {
+  align-items: center;
+  bottom: $site-snackbar-padding;
+  display: flex;
+  justify-content: center;
+  left: $site-snackbar-padding;
+  position: fixed;
+  right: $site-snackbar-padding;
+  z-index: $site-z-snackbar;
+
+  &__container {
+    align-items: center;
+    background-color: #323232;
+    color: $site-color-white;
+    display: inline-flex;
+    justify-content: space-between;
+    padding: bs-spacer(2) bs-spacer(4);
+  }
+
+  &__action {
+    margin-left: bs-spacer(4);
+    position: relative;
+    top: 1px;
+  }
+}

--- a/src/_assets/css/_variables.scss
+++ b/src/_assets/css/_variables.scss
@@ -27,10 +27,12 @@ $site-content-top-padding: 40px;
 $site-content-max-width: 960px;
 $site-sidebar-side-padding: 16px;
 $site-nav-mobile-side-padding: 20px;
+$site-snackbar-padding: 20px;
 
 // Layer stack
 $site-z-header: 100;
 $site-z-footer: 99;
+$site-z-snackbar: 150;
 $hero-layer-1-z: 40;
 $hero-layer-2-z: 41;
 $hero-layer-3-z: 42;

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -20,6 +20,7 @@
 @import '_material_colors';
 @import '_tabs';
 @import '_code_pre';
+@import '_snackbar';
 
 // page types
 @import '_landing-page';

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -15,6 +15,7 @@ $(function () {
   initFixedColumns();
   initVideoModal();
   initCarousel();
+  initSnackbar();
   prettyPrint();
 
   // New (dash) tabs
@@ -139,4 +140,17 @@ function initCarousel() {
   carousel.on('slid.bs.carousel', function (e) {
     carousel.find(CAROUSEL_ITEM_SELECTOR).eq(e.from).removeClass('transition-out');
   });
+}
+
+function initSnackbar() {
+  var SNACKBAR_SELECTOR ='.snackbar';
+  var SNACKBAR_ACTION_SELECTOR = '.snackbar__action';
+  var snackbars = $(SNACKBAR_SELECTOR);
+
+  snackbars.each(function () {
+    var snackbar = $(this);
+    snackbar.find(SNACKBAR_ACTION_SELECTOR).click(function () {
+      snackbar.fadeOut();
+    });
+  })
 }

--- a/src/_includes/snackbar.html
+++ b/src/_includes/snackbar.html
@@ -1,0 +1,10 @@
+<div class="snackbar {{ include.class }}">
+  <div class="snackbar__container">
+    <div class="snackbar__label">
+      {{ include.label }}
+    </div>
+    {% if include.action -%}
+    <button class="snackbar__action btn btn-link">{{ include.action }}</button>
+    {% endif -%}
+  </div>
+</div>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -20,6 +20,9 @@ layout: base
     {% endif -%}
     <main class="site-content {{main-col}}" role="main">
       <div class="container">
+        {% if page.deprecated %}
+          {% include snackbar.html class="snackbar--dismissible" label="This page has been deprecated and it's content may be out of date." action="Dismiss" %}
+        {% endif %}
         {% include next-prev-nav.html %}
         <header class="site-content__title">
           {% include shared/page-github-links.html %}

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -21,7 +21,7 @@ layout: base
     <main class="site-content {{main-col}}" role="main">
       <div class="container">
         {% if page.deprecated %}
-          {% include snackbar.html class="snackbar--dismissible" label="This page has been deprecated and it's content may be out of date." action="Dismiss" %}
+          {% include snackbar.html class="snackbar--dismissible" label="This page is deprecated and its content may be out of date." action="Dismiss" %}
         {% endif %}
         {% include next-prev-nav.html %}
         <header class="site-content__title">

--- a/src/docs/catalog/samples/AnimatedList.md
+++ b/src/docs/catalog/samples/AnimatedList.md
@@ -1,6 +1,7 @@
 ---
 title: AnimatedList Sample Apps
 description: Examples that use AnimatedList.
+deprecated: true
 ---
 
 All of the sample apps listed here use the Flutter AnimatedList class in

--- a/src/docs/catalog/samples/AnimatedListState.md
+++ b/src/docs/catalog/samples/AnimatedListState.md
@@ -1,6 +1,7 @@
 ---
 title: AnimatedListState Sample Apps
 description: Examples that use AnimatedListState.
+deprecated: true
 ---
 
 All of the sample apps listed here use the Flutter AnimatedListState

--- a/src/docs/catalog/samples/AppBar.md
+++ b/src/docs/catalog/samples/AppBar.md
@@ -1,6 +1,7 @@
 ---
 title: AppBar Sample Apps
 description: Examples that use AppBars.
+deprecated: true
 ---
 
 All of the sample apps listed here use the Flutter AppBar class in an

--- a/src/docs/catalog/samples/DefaultTabController.md
+++ b/src/docs/catalog/samples/DefaultTabController.md
@@ -1,6 +1,7 @@
 ---
 title: DefaultTabController Sample Apps
 description: Examples that use a DefaultTabController.
+deprecated: true
 ---
 
 All of the sample apps listed here use the Flutter DefaultTabController class

--- a/src/docs/catalog/samples/ExpansionTile.md
+++ b/src/docs/catalog/samples/ExpansionTile.md
@@ -1,6 +1,7 @@
 ---
 title: ExpansionTile Sample Apps
 description: Examples that use Expansion Tiles.
+deprecated: true
 ---
 
 All of the sample apps listed here use the Flutter ExpansionTile class in

--- a/src/docs/catalog/samples/IconButton.md
+++ b/src/docs/catalog/samples/IconButton.md
@@ -1,6 +1,7 @@
 ---
 title: IconButton Sample Apps
 description: Examples that use IconButtons.
+deprecated: true
 ---
 
 All of the sample apps listed here use the Flutter IconButton class in

--- a/src/docs/catalog/samples/ListView.md
+++ b/src/docs/catalog/samples/ListView.md
@@ -1,6 +1,7 @@
 ---
 title: ListView Sample Apps
 description: Examples of apps that use ListView.
+deprecated: true
 ---
 
 All of the sample apps listed here use the Flutter ListView class in an

--- a/src/docs/catalog/samples/PopupMenuButton.md
+++ b/src/docs/catalog/samples/PopupMenuButton.md
@@ -1,6 +1,7 @@
 ---
 title: PopupMenuButton Sample Apps
 description: Examples that use PopupMenuButtons.
+deprecated: true
 ---
 
 All of the sample apps listed here use the Flutter PopupMenuButton class

--- a/src/docs/catalog/samples/PreferredSize.md
+++ b/src/docs/catalog/samples/PreferredSize.md
@@ -1,6 +1,7 @@
 ---
 title: PreferredSize Sample Apps
 description: Examples that use PreferredSize.
+deprecated: true
 ---
 
 All of the sample apps listed here use the Flutter PreferredSize class

--- a/src/docs/catalog/samples/Scaffold.md
+++ b/src/docs/catalog/samples/Scaffold.md
@@ -1,6 +1,7 @@
 ---
 title: Scaffold Sample Apps
 description: Examples that use Scaffolds.
+deprecated: true
 ---
 
 All of the sample apps listed here use the Flutter Scaffold class in

--- a/src/docs/catalog/samples/TabBar.md
+++ b/src/docs/catalog/samples/TabBar.md
@@ -1,6 +1,7 @@
 ---
 title: TabBar Sample Apps
 description: Examples that use TabBars.
+deprecated: true
 ---
 
 All of the sample apps listed here use the Flutter TabBar class in

--- a/src/docs/catalog/samples/TabBarView.md
+++ b/src/docs/catalog/samples/TabBarView.md
@@ -1,6 +1,7 @@
 ---
 title: TabBarView Sample Apps
 description: Examples that use TabBarView.
+deprecated: true
 ---
 
 All of the sample apps listed here use the Flutter TabBarView class in

--- a/src/docs/catalog/samples/TabController.md
+++ b/src/docs/catalog/samples/TabController.md
@@ -1,6 +1,7 @@
 ---
 title: TabController Sample Apps
 description: Examples that use TabController.
+deprecated: true
 ---
 
 All of the sample apps listed here use the Flutter TabController class

--- a/src/docs/catalog/samples/animated-list.md
+++ b/src/docs/catalog/samples/animated-list.md
@@ -1,6 +1,7 @@
 ---
 title: AnimatedList
 description: An example that uses AnimatedList.
+deprecated: true
 ---
 
 An AnimatedList that displays a list of cards that stay in sync

--- a/src/docs/catalog/samples/app-bar-bottom.md
+++ b/src/docs/catalog/samples/app-bar-bottom.md
@@ -1,6 +1,7 @@
 ---
 title: AppBar with a custom bottom widget
 description: An example that uses an AppBar at the bottom of the page.
+deprecated: true
 ---
 
 Any widget with a PreferredSize can appear at the bottom of an AppBar.

--- a/src/docs/catalog/samples/basic-app-bar.md
+++ b/src/docs/catalog/samples/basic-app-bar.md
@@ -1,6 +1,7 @@
 ---
 title: AppBar Basics
 description: An example that implements a basic AppBar.
+deprecated: true
 ---
 
 A typical AppBar with a title, actions, and an overflow dropdown menu.

--- a/src/docs/catalog/samples/expansion-tile-sample.md
+++ b/src/docs/catalog/samples/expansion-tile-sample.md
@@ -1,6 +1,7 @@
 ---
 title: ExpansionTile
 description: An example that uses ExpansionTiles.
+deprecated: true
 ---
 
 ExpansionTiles can used to produce two-level or multi-level lists.

--- a/src/docs/catalog/samples/index.md
+++ b/src/docs/catalog/samples/index.md
@@ -2,6 +2,7 @@
 title: Sample App Catalog
 description: A list of samples that demonstrate some common mobile design patterns.
 toc: false
+deprecated: true
 ---
 
 This catalog lists applications that demonstrate how to implement common

--- a/src/docs/catalog/samples/tabbed-app-bar.md
+++ b/src/docs/catalog/samples/tabbed-app-bar.md
@@ -1,6 +1,7 @@
 ---
 title: Tabbed AppBar
 description: An example that uses a TabBar for its AppBar.
+deprecated: true
 ---
 
 An AppBar with a TabBar as its bottom widget.


### PR DESCRIPTION
- Implements snackbar component and styles
- Adds deprecated metadata to catalog sample pages
- Adds a snackbar when a doc is deprecated

Staging links:
- https://flutter-web-staging.firebaseapp.com/docs/catalog/samples
- https://flutter-web-staging.firebaseapp.com/docs/catalog/samples/animated-list

Fixes: #1492 