### PR TITLE
Correct VS Code shortcut for quick-fixes

### DIFF
--- a/src/docs/development/tools/ide/vs-code.md
+++ b/src/docs/development/tools/ide/vs-code.md
@@ -143,7 +143,7 @@ To open Observatory:
 Assists are code changes related to a certain code identifier. A number of these
 are available when the cursor is placed on a Flutter widget identifier, as
 indicated by the yellow lightbulb icon. The assist can be invoked by clicking
-the lightbulb, or by using the keyboard shortcut `Ctrl`+`.` (`Cmd`+`.` on macOS), as
+the lightbulb, or by using the keyboard shortcut `Ctrl`+`.` (`Cmd`+`.` on Mac), as
 illustrated here:
 
 ![Code Assists]({% asset tools/vs-code/assists.png @path %}){:width="467px"}

--- a/src/docs/development/tools/ide/vs-code.md
+++ b/src/docs/development/tools/ide/vs-code.md
@@ -143,8 +143,8 @@ To open Observatory:
 Assists are code changes related to a certain code identifier. A number of these
 are available when the cursor is placed on a Flutter widget identifier, as
 indicated by the yellow lightbulb icon. The assist can be invoked by clicking
-the lightbulb, or by using the keyboard shortcut `Ctrl`+`Enter`, as illustrated
-here:
+the lightbulb, or by using the keyboard shortcut `Ctrl`+`.` (`Cmd`+`.` on macOS), as
+illustrated here:
 
 ![Code Assists]({% asset tools/vs-code/assists.png @path %}){:width="467px"}
 


### PR DESCRIPTION
The quick-fix shortcut seems to be wrong on the site, it's `Cmd`(/`Ctrl`)+`.`.

https://code.visualstudio.com/docs/getstarted/keybindings#_rich-languages-editing

<img width="731" alt="screen shot 2018-11-21 at 12 59 22 pm" src="https://user-images.githubusercontent.com/1078012/48842911-742bcf80-ed8d-11e8-889d-60d7ebd20ce9.png">

Fixes https://github.com/Dart-Code/Dart-Code/issues/1317.