### PR TITLE
correctly attribute which chart is which thread

### DIFF
--- a/src/docs/testing/ui-performance/index.md
+++ b/src/docs/testing/ui-performance/index.md
@@ -143,7 +143,7 @@ The following screenshot shows the performance overlay running on the Flutter
 Gallery example:
 
 <center><img src="/docs/testing/ui-performance/images/performance-overlay-green.png" alt="screenshot of performance overlay showing zero jank"></center>
-<center>Performance overlay showing the GPU thread (top), and UI thread (bottom).
+<center>Performance overlay showing the UI thread (top), and GPU thread (bottom).
 	The vertical green bars represent the current frame.</center><br>
 
 Flutter uses several threads to do its work. All your Dart code runs on

--- a/src/docs/testing/ui-performance/index.md
+++ b/src/docs/testing/ui-performance/index.md
@@ -143,7 +143,7 @@ The following screenshot shows the performance overlay running on the Flutter
 Gallery example:
 
 <center><img src="/docs/testing/ui-performance/images/performance-overlay-green.png" alt="screenshot of performance overlay showing zero jank"></center>
-<center>Performance overlay showing the UI thread (top), and GPU thread (bottom).
+<center>Performance overlay showing the GPU thread (top), and UI thread (bottom).
 	The vertical green bars represent the current frame.</center><br>
 
 Flutter uses several threads to do its work. All your Dart code runs on
@@ -167,7 +167,7 @@ your actions on the UI thread have performance consequences on other threads.
    a _layer tree_, a lightweight object containing device-agnostic
    painting commands, and sends the layer tree to the GPU thread to
    be rendered on the device. _Don't block this thread!_
-   Shown in the top row of the performance overlay.
+   Shown in the bottom row of the performance overlay.
 
 1. GPU thread<br>
    The GPU thread takes the layer tree and displays it by talking
@@ -176,7 +176,7 @@ your actions on the UI thread have performance consequences on other threads.
    it's a result of something you've done in the Dart code.
    Skia, the graphics library, runs on this thread, which is sometimes
    called the _rasterizer_ thread.
-   Shown in the bottom row of the performance overlay.
+   Shown in the top row of the performance overlay.
 
 1. I/O thread<br>
    Performs expensive tasks (mostly I/O) that would otherwise block


### PR DESCRIPTION
The text under the image contradicts the details in the bullet points about which graph shows the UI thread and GPU thread.