### PR TITLE
Drop self-referential canonical links in site page heads

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -27,8 +27,6 @@
   {% assign og_image_path = page.image | default: layout.image | default: '/images/flutter-logo-sharing.png' %}
   <meta property="og:image" content="{{og_image_path | absolute_url}}">
 
-  <link rel="canonical" href="{{ page_url | absolute_url }}">
-
   <link href="https://fonts.googleapis.com/css?family=Google+Sans:400,500|Roboto:300,400,500|Roboto+Mono:400,700|Material+Icons" rel="stylesheet">
   {% asset main.css %}
   {% for css in page.css -%}


### PR DESCRIPTION
Followup to #1738 and #1739.