### PR TITLE
Redirect old widget catalog page links to development/ui/widgets

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -96,8 +96,8 @@
       { "source": "/using-ide-vscode", "destination": "/docs/development/tools/vs-code", "type": 301 },
       { "source": "/using-packages", "destination": "/docs/development/packages-and-plugins/using-packages", "type": 301 },
       { "source": "/web-analogs", "destination": "/docs/get-started/flutter-for/web-devs", "type": 301 },
-      { "source": "/widgets", "destination": "/docs/reference/widgets/catalog", "type": 301 },
-      { "source": "/widgets/:rest*", "destination": "/docs/reference/widgets/:rest*", "type": 301 },
+      { "source": "/widgets", "destination": "/docs/development/ui/widgets/catalog", "type": 301 },
+      { "source": "/widgets/:rest*", "destination": "/docs/development/ui/widgets/:rest*", "type": 301 },
       { "source": "/widgets-intro", "destination": "/docs/development/ui/widgets-intro", "type": 301 }
     ]
   }


### PR DESCRIPTION
Fixes #1801 

Staged at https://ng2-io.firebaseapp.com

 - https://ng2-io.firebaseapp.com/widgets redirects to the catalog (under UI)
 - https://ng2-io.firebaseapp.com/widgets/layout redirects to development/ui/widgets