### PR TITLE
Drop field with invalid link from catalog/index.json data

### DIFF
--- a/src/_data/catalog/index.json
+++ b/src/_data/catalog/index.json
@@ -25,8 +25,7 @@
         "name": "Information displays"
       },
       {
-        "name": "Layout",
-        "description": "See also Flutter's <a href=\"/widgets/catalog/layout/\">general layout widgets</a> (such as row, column, and more)."
+        "name": "Layout"
       }
     ],
     "id":"material"
@@ -111,5 +110,5 @@
     "name": "Accessibility",
     "description": "Make your app accessible.",
     "id":"accessibility"
-  },
+  }
 ]


### PR DESCRIPTION
Subcategory descriptions aren't currently used, and one such subcategory description contains an invalid link, so this PR simply drops that description field.

cc @sfshaza2 