### PR TITLE
Make flutter-for/react-native tables more mobile-friendly

### DIFF
--- a/src/_assets/css/_base.scss
+++ b/src/_assets/css/_base.scss
@@ -156,3 +156,7 @@ dd {
 }
 
 .fa-macos { @extend .fa-apple; }
+
+.table-wrapper {
+  overflow-x: auto;
+}

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -2173,6 +2173,7 @@ In Flutter, if you are using an IDE, you can use the IDE tools. If you start
 your application using `flutter run` you can also access the menu by typing `h`
 in the terminal window, or type the following shortcuts:
 
+<div class="table-wrapper" markdown="1">
 | Action| Terminal Shortcut| Debug functions and properties|
 | :------- | :------: | :------ |
 | Widget hierarchy of the app| `w`| debugDumpApp()|
@@ -2185,8 +2186,9 @@ in the terminal window, or type the following shortcuts:
 | To display the performance overlay | `P` | WidgetsApp. showPerformanceOverlay|
 | To save a screenshot to flutter. png| `s` ||
 | To quit| `q` ||
+{:.table.table-striped}
+</div>
 
-<br>
 ### How do I perform a hot reload?
 
 Flutter’s hot reload feature helps you quickly and easily experiment, build UIs,
@@ -2407,6 +2409,7 @@ child: Dismissible(
 The following table lists commonly-used React Native components mapped to the
 corresponding Flutter widget and common widget properties.
 
+<div class="table-wrapper" markdown="1">
 | React Native Component                                                                    | Flutter Widget                                                                                             | Description                                                                                                                            |
 | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | [Button](https://facebook.github.io/react-native/docs/button.html)                        | [Raised Button](https://docs.flutter.io/flutter/material/RaisedButton-class.html)                           | A basic raised button.                                                                              |
@@ -2477,3 +2480,4 @@ corresponding Flutter widget and common widget properties.
 |                                                                                         | value [required]                                                                                          | [ double ] The current value of the slider.                                                                                                                                                                           |
 |                                                                                         | onChanged [required]                                                                                      | Called when the user selects a new value for the slider.                                                                                                                                                      |
 {:.table.table-striped}
+</div>


### PR DESCRIPTION
Followup to #1790, but this PR tackles the two tables. With this PR the page no longer scrolls horizontally.

Staged at https://flutter-io-staging-2.firebaseapp.com/docs/get-started/flutter-for/react-native-devs

The tables are under these sections:

- https://flutter-io-staging-2.firebaseapp.com/docs/get-started/flutter-for/react-native-devs#how-do-i-access-the-in-app-developer-menu
- https://flutter-io-staging-2.firebaseapp.com/docs/get-started/flutter-for/react-native-devs#react-native-and-flutter-widget-equivalent-components