### PR TITLE
Update android.md

### DIFF
--- a/src/docs/deployment/android.md
+++ b/src/docs/deployment/android.md
@@ -214,7 +214,7 @@ Using the command line:
 1. Run `flutter build apk` (`flutter build` defaults to `--release`).
 
 The release APK for your app is created at
-`<app dir>/build/app/outputs/apk/app-release.apk`.
+`<app dir>/build/app/outputs/apk/release/app-release.apk`.
 
 ## Installing a release APK on a device
 


### PR DESCRIPTION
The current android deployment guide says that the release apk is created under
`<app dir>/build/app/outputs/apk/app-release.apk`.
 When i follow the guide the release apk is created at 
`<app dir>/build/app/outputs/apk/release/app-release.apk`.