### PR TITLE
Flutter for React Native: fix Dartpad code excerpt

### DIFF
--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -200,6 +200,7 @@ For more information, see the documentation on
 [functions](https://www.dartlang.org/guides/language/language-tour#functions).
 
 ### Asynchronous programming
+
 #### Futures
 
 Like JavaScript, Dart supports single-threaded execution. In JavaScript,
@@ -239,7 +240,7 @@ _getIPAddress() {
 ```
 
 Try it out in
-[DartPad](https://dartpad.dartlang.org/b68eb981456c5eec03daa3c05ee59486).
+[DartPad](https://dartpad.dartlang.org/5a0017d09b6823d0248d965b93133e2e).
 
 For more information, see the documentation on
 [Futures](https://www.dartlang.org/tutorials/language/futures).


### PR DESCRIPTION
Fixes #1880 

I renamed to `json` and dropped the `dart:async` import, which is unnecessary as of 2.1.

cc @sfshaza2 @kwalrath 