### PR TITLE
Add Expanded widget as a "Layout helper"

### DIFF
--- a/src/_data/catalog/index.json
+++ b/src/_data/catalog/index.json
@@ -46,9 +46,6 @@
       {
         "name": "Multi-child layout widgets",
         "description":"These widgets take multiple children and arrange them in different ways."
-      },
-      {
-        "name": "Layout helpers"
       }
     ],
     "id":"layout"

--- a/src/_data/catalog/widgets.json
+++ b/src/_data/catalog/widgets.json
@@ -939,7 +939,7 @@
     "categories": [
     ],
     "subcategories": [
-      "Layout helpers"
+      "Multi-child layout widgets"
     ],
     "link": "https://docs.flutter.io/flutter/widgets/LayoutBuilder-class.html",
     "image": "<img alt='' src='/images/catalog-widget-placeholder.png'>"
@@ -1634,9 +1634,9 @@
     "categories": [
     ],
     "subcategories": [
-      "Layout helpers"
+      "Multi-child layout widgets"
     ],
-    "description": "A widget that expands a child of a Row, Column, or Flex..",
+    "description": "A widget that expands a child of a Row, Column, or Flex.",
     "link": "https://docs.flutter.io/flutter/widgets/Expanded-class.html",
     "image": "<img alt='' src='/images/catalog-widget-placeholder.png'>"
   },

--- a/src/_data/catalog/widgets.json
+++ b/src/_data/catalog/widgets.json
@@ -1630,6 +1630,17 @@
     "image": "<img alt='' src='/images/catalog-widget-placeholder.png'>"
   },
   {
+    "name": "Expanded",
+    "categories": [
+    ],
+    "subcategories": [
+      "Layout helpers"
+    ],
+    "description": "A widget that expands a child of a Row, Column, or Flex..",
+    "link": "https://docs.flutter.io/flutter/widgets/Expanded-class.html",
+    "image": "<img alt='' src='/images/catalog-widget-placeholder.png'>"
+  },
+  {
     "name": "PageView",
     "description": "A scrollable list that works page by page.",
     "categories": [


### PR DESCRIPTION
Fixes #1856 

@Hixie - do you agree with the `subcategories` attribution? This results in two helpers:

> <img width="465" alt="screen shot 2018-12-05 at 14 30 41" src="https://user-images.githubusercontent.com/4140793/49538880-6486ad80-f89a-11e8-9b8e-018c189999c6.png">


cc @sfshaza2 @kwalrath 