### PR TITLE
Ensure that intermediate breadcrumb TOC pages have content

### DIFF
--- a/src/_layouts/toc.html
+++ b/src/_layouts/toc.html
@@ -5,30 +5,27 @@ toc: false
 
 {% assign url = page.url | regex_replace: '/index$|/index.html$|/$' -%}
 {% assign path_parts = url | split: '/' -%}
-{% assign num_parts = path_parts | size -%}
+{% assign topics = site.data.sidenav -%}
 
-{% if num_parts == 2 -%}
+{% comment %}
+  - path_parts[0] == '' because page.url always starts with '/'
+  - (path_parts | size) > 2 since we don't use this layout at
+    the top level, nor at the second level (under our current IA)
+{% endcomment -%}
 
-  {% assign topics = site.data.sidenav -%}
-
-{% else -%}
-
-  {% assign path1 = '/' | append: path_parts[1] -%}
-
-  {% assign topics = site.data.sidenav | where: "permalink", path1 -%}
-
-  {% if num_parts > 3 -%}
-    {% assign path2 = path1 | append: '/' | append: path_parts[2] -%}
-    {% assign topics = topics[0].children | where: "permalink", path2 -%}
+{% for path_part in path_parts -%}
+  {% if forloop.first == true -%}
+    {% assign path = '' -%}
+  {% else -%}
+    {% assign path = path | append: '/' | append: path_part -%}
   {% endif -%}
-
-  {% assign topics = topics[0].children -%}
-
+  {% if forloop.index0 > 1 -%}
+    {% assign topics = topics | where: "permalink", path -%}
+    {% assign topics = topics[0].children -%}
   {% endif -%}
+{% endfor -%}
 
-{% assign topics = topics | where: "title", page.title -%}
-{% assign entries = topics[0].children -%}
-
+{% assign entries = topics -%}
 {% capture md %}{% include mini-toc.md %}{% endcapture %}
 {{ md | markdownify }}
 

--- a/src/docs/development/index.md
+++ b/src/docs/development/index.md
@@ -1,5 +1,4 @@
 ---
 layout: toc
 title: Development
-show_breadcrumbs: false
 ---


### PR DESCRIPTION
Fixes #1810 

Staged, see:

- https://flutter-io-staging-2.firebaseapp.com/docs/development
- https://flutter-io-staging-2.firebaseapp.com/docs/development/ui
- etc

## Screenshots

> <img width="395" alt="screen shot 2018-12-05 at 19 41 26" src="https://user-images.githubusercontent.com/4140793/49553485-df18f280-f8c5-11e8-93e7-b1aa23319399.png">

---

> <img width="394" alt="screen shot 2018-12-05 at 19 41 36" src="https://user-images.githubusercontent.com/4140793/49553484-df18f280-f8c5-11e8-9806-5758777d3d96.png">

---

> <img width="381" alt="screen shot 2018-12-05 at 19 41 44" src="https://user-images.githubusercontent.com/4140793/49553483-df18f280-f8c5-11e8-9c05-a32c65fc8110.png">

---

> <img width="400" alt="screen shot 2018-12-05 at 19 41 52" src="https://user-images.githubusercontent.com/4140793/49553482-df18f280-f8c5-11e8-9073-f4541bb488ec.png">
