### PR TITLE
Fixes #1887: Hide any previous snackbars and show the latest result

### DIFF
--- a/src/docs/cookbook/navigation/returning-data.md
+++ b/src/docs/cookbook/navigation/returning-data.md
@@ -171,8 +171,11 @@ _navigateAndDisplaySelection(BuildContext context) async {
     MaterialPageRoute(builder: (context) => SelectionScreen()),
   );
 
-  // After the Selection Screen returns a result, show it in a Snackbar!
-  Scaffold.of(context).showSnackBar(SnackBar(content: Text("$result")));
+  // After the Selection Screen returns a result, hide any previous snackbars
+  // and show the new result!
+  Scaffold.of(context)
+    ..removeCurrentSnackBar()
+    ..showSnackBar(SnackBar(content: Text("$result")));
 }
 ```
 
@@ -221,8 +224,11 @@ class SelectionButton extends StatelessWidget {
       MaterialPageRoute(builder: (context) => SelectionScreen()),
     );
 
-    // After the Selection Screen returns a result, show it in a Snackbar!
-    Scaffold.of(context).showSnackBar(SnackBar(content: Text("$result")));
+    // After the Selection Screen returns a result, hide any previous snackbars
+    // and show the new result!
+    Scaffold.of(context)
+      ..removeCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text("$result")));
   }
 }
 


### PR DESCRIPTION
Currently, the recipe simply adds a new Snackbar to the queue, which may be displayed immediately if nothing is in the queue, or might be delayed if other items are already in the queue. This makes it appear as though the app is not working correctly.

This fix removes any previously displayed Snackbars before showing the new result.