### PR TITLE
Homepage: fix use-case and news spacing

### DIFF
--- a/src/_assets/css/_homepage.scss
+++ b/src/_assets/css/_homepage.scss
@@ -327,6 +327,16 @@
     }
   }
 
+  &__headline-after-image {
+    margin-top: bs-spacer(6) !important;
+    margin-bottom: bs-spacer(2);
+
+    @include media-breakpoint-up(md) {
+      margin-top: 0;
+      margin-bottom: bs-spacer(4);
+    }
+  }
+
   &__use-cases {
     .homepage__card-graphic {
       align-items: center;

--- a/src/_assets/css/_landing-page.scss
+++ b/src/_assets/css/_landing-page.scss
@@ -84,7 +84,7 @@
 
     &__logo-row {
       &:not(:last-child) {
-        margin-bottom: bs-spacer(12);
+        margin-bottom: bs-spacer(2);
       }
     }
   }

--- a/src/index.html
+++ b/src/index.html
@@ -202,13 +202,13 @@ description: >
                 </div>
             </div>
             <div class="col-lg-4">
-                <h2>Learn from developers</h2>
+                <h2 class="homepage__headline-after-image">Learn from developers</h2>
 
                 <p>
                 Watch these videos to learn from Google and developers as you build with Flutter.
                 </p>
 
-                <a href="https://www.youtube.com/playlist?list=PLOU2XLYxmsIJ7dsVN4iRuA7BT8XHzGtCr">Visit our YouTube playlist.</a>
+                <a href="https://www.youtube.com/playlist?list=PLOU2XLYxmsIJ7dsVN4iRuA7BT8XHzGtCr">Visit our YouTube playlist</a>
             </div>
         </div>
     </div>
@@ -219,12 +219,12 @@ description: >
         <div class="row">
             <div class="homepage__card-graphic col-lg-7 order-lg-1">
                 <div>
-                    <div class="homepage__card-graphic__logo-row row align-items-center">
+                    <div class="landing-page__card-graphic__logo-row row align-items-center">
                         {% asset homepage/logo-alibaba.png alt='Alibaba logo' class="col-4" %}
                         {% asset homepage/logo-hamilton.png alt='Hamilton logo' class="col-4" %}
                         {% asset homepage/logo-google.svg alt='Google logo' class="col-4" %}
                     </div>
-                    <div class="homepage__card-graphic__logo-row row align-items-center">
+                    <div class="landing-page__card-graphic__logo-row row align-items-center">
                         {% asset homepage/logo-tencent.png alt='Tencent logo' class="col-4" %}
                         {% asset homepage/logo-abbey_road_studios.png alt='Abbey Road Studios logo' class="col-4" %}
                         {% asset homepage/logo-google_ads.png alt='Google AdWords logo' class="col-4" %}
@@ -232,7 +232,7 @@ description: >
                 </div>
             </div>
             <div class="col-lg-5">
-                <h2>Who's using Flutter?</h2>
+                <h2 class="homepage__headline-after-image">Who's using Flutter?</h2>
 
                 <p>
                 Organizations around the world are building apps with Flutter.


### PR DESCRIPTION
Fix spacing:

- Before and after headings ("Learn from devs" and "Who's using Flutter?") under mobile.
- Between rows of logos under "Who's using Flutter?" (mobile and desktop)

Staged at https://flutter-io-staging-2.firebaseapp.com

cc @fertolg 

## Screenshot (before PR)

<img width="526" alt="screen shot 2018-12-06 at 18 17 32" src="https://user-images.githubusercontent.com/4140793/49617805-164dd900-f984-11e8-8d7f-abf20f85ab34.png">

## Screenshot (with this PR)

The adjusted spacing is shown in red in the left margin:

<img width="526" alt="screen shot 2018-12-06 at 18 19 45" src="https://user-images.githubusercontent.com/4140793/49618015-f834a880-f984-11e8-975d-ab4c8daf1913.png">
