### PR TITLE
 Add a link to the Flutter App Highlight Reel

### DIFF
--- a/src/showcase/index.html
+++ b/src/showcase/index.html
@@ -48,7 +48,9 @@ body_class: landing-page showcase
                 <h2>Made with Flutter</h2>
                 <p>
                 Flutter is used by Google and developers and organizations around the world to deliver beautiful native apps on
-                iOS and Android. Here is a small selection of apps made with Flutter.
+                iOS and Android. Watch the
+                <a href="https://youtu.be/REJDzio_h7o">Flutter App Highlight Reel</a>,
+                or see below for a small selection of apps made with Flutter.
                 </p>
             </div>
         </div>

--- a/src/showcase/index.html
+++ b/src/showcase/index.html
@@ -48,8 +48,10 @@ body_class: landing-page showcase
                 <h2>Made with Flutter</h2>
                 <p>
                 Flutter is used by Google and developers and organizations around the world to deliver beautiful native apps on
-                iOS and Android. Watch the
-                <a href="https://youtu.be/REJDzio_h7o">Flutter App Highlight Reel</a>,
+                iOS and Android.
+                </p>
+                <p>
+                Watch the <a href="https://youtu.be/REJDzio_h7o">Flutter App Highlight Reel</a>,
                 or see below for a small selection of apps made with Flutter.
                 </p>
             </div>

--- a/src/showcase/index.html
+++ b/src/showcase/index.html
@@ -48,11 +48,8 @@ body_class: landing-page showcase
                 <h2>Made with Flutter</h2>
                 <p>
                 Flutter is used by Google and developers and organizations around the world to deliver beautiful native apps on
-                iOS and Android.
-                </p>
-                <p>
-                Watch the <a href="https://youtu.be/REJDzio_h7o">Flutter App Highlight Reel</a>,
-                or see below for a small selection of apps made with Flutter.
+                iOS and Android. Here's a small selection of apps made with Flutter. Also see the
+                <a href="https://youtu.be/REJDzio_h7o">Flutter App Highlight Reel</a>.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
How's this as a fix for #1929?

(**Edit: updated screenshot to reflect latest PR commits**)
<img width="407" alt="screen shot 2018-12-07 at 18 49 21" src="https://user-images.githubusercontent.com/4140793/49678247-06e89180-fa51-11e8-8971-40b6d8777023.png">

Staged at https://flutter-io-staging-2.firebaseapp.com/showcase

Closes #1929 
