### PR TITLE
Add back the link to JD Finance iOS app, but don't check it

### DIFF
--- a/src/_data/showcases.yml
+++ b/src/_data/showcases.yml
@@ -79,6 +79,5 @@
   logo_src: showcase/logo-jd.png
   learn_more_cta: Developer website
   learn_more_link: https://jr.jd.com/
-  # FIXME(2018/12/06): link gives 404 - https://github.com/flutter/website/issues/1877
-  # app_store_link: https://itunes.apple.com/cn/app/id895682747
+  app_store_link: https://itunes.apple.com/cn/app/id895682747
   play_store_link: https://m.jr.jd.com/spe/downloadApp/index.html?id=1024

--- a/tool/config/linkcheck-skip-list.txt
+++ b/tool/config/linkcheck-skip-list.txt
@@ -8,10 +8,11 @@
 https://github.com
 
 # -----------------------------------------------------------------------------
-# Valid external links that result in connetion failures too often:
+# Valid external links that result in connection failures too often:
 
 https://developers.google.com/events/flutter-live
 https://hk.saowen.com/a/fbb6e484de022173fe85248875286060ce40d069c97420bc0be49d838e19e372
+https://itunes.apple.com/cn/app/id895682747
 https://now.qq.com
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
We won't check the AppStore link since it has disappeared (404) and returned (200) within the scope of a day already.