### PR TITLE
Fix images in Image widget of Sizing widgets example not fit full width

### DIFF
--- a/src/_includes/code/layout/row-expanded-2/main.dart
+++ b/src/_includes/code/layout/row-expanded-2/main.dart
@@ -45,13 +45,22 @@ class _MyHomePageState extends State<MyHomePage> {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             Expanded(
-              child: Image.asset('images/pic1.jpg'),
+              child: Image.asset(
+                'images/pic1.jpg',
+                fit: BoxFit.fitWidth,
+              ),
             ),
             Expanded(
-              child: Image.asset('images/pic2.jpg'),
+              child: Image.asset(
+                'images/pic2.jpg',
+                fit: BoxFit.fitWidth,
+              ),
             ),
             Expanded(
-              child: Image.asset('images/pic3.jpg'),
+              child: Image.asset(
+                'images/pic3.jpg',
+                fit: BoxFit.fitWidth,
+              ),
             ),
           ],
         ),

--- a/src/_includes/code/layout/row-expanded/main.dart
+++ b/src/_includes/code/layout/row-expanded/main.dart
@@ -45,14 +45,23 @@ class _MyHomePageState extends State<MyHomePage> {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             Expanded(
-              child: Image.asset('images/pic1.jpg'),
+              child: Image.asset(
+                'images/pic1.jpg',
+                fit: BoxFit.fitWidth,
+              ),
             ),
             Expanded(
               flex: 2,
-              child: Image.asset('images/pic2.jpg'),
+              child: Image.asset(
+                'images/pic2.jpg',
+                fit: BoxFit.fitWidth,
+              ),
             ),
             Expanded(
-              child: Image.asset('images/pic3.jpg'),
+              child: Image.asset(
+                'images/pic3.jpg',
+                fit: BoxFit.fitWidth,
+              ),
             ),
           ],
         ),


### PR DESCRIPTION
[https://flutter.io/docs/development/ui/layout#sizing-widgets](https://flutter.io/docs/development/ui/layout#sizing-widgets)

In this example, the middle widget is not twice as wide as the other two widgets because of `BoxFit.scaleDown`. 