### PR TITLE
chore: site alert style fixes due to fontawesome icon changes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -85,18 +85,18 @@ os-list: [Windows, macOS, Linux]
 alert:
   important: >-
     <aside class="alert alert-warning" role="alert" markdown="1">
-    <i class="fa fa-warning"></i> **Important:**
+    <i class="fas fa-exclamation-circle"></i> **Important:**
   note: >-
     <aside class="alert alert-info" role="alert" markdown="1">
-    <i class="fa fa-info-circle"></i> **Note:**
+    <i class="fas fa-info-circle"></i> **Note:**
   secondary: >-
     <aside class="alert alert-secondary" role="alert" markdown="1">
   tip: >-
     <aside class="alert alert-success" role="alert" markdown="1">
     <i class="far fa-lightbulb"></i> **Tip:**
   warning: >-
-    <aside class="alert alert-danger" role="alert" markdown="1">
-    <i class="fa fa-exclamation-circle"></i> **Warning:**
+    <aside class="alert alert-warning" role="alert" markdown="1">
+    <i class="fas fa-exclamation-triangle"></i> **Warning:**
   end: </aside>
 
   # callout_danger: '<div class="bs-callout bs-callout-danger">'


### PR DESCRIPTION
Fix the following problems:

- The "important" alert icon wasn't showing.
- The "warning" alert used the "danger" color scheme.

### Screenshots

<img width="730" alt="screen shot 2018-12-11 at 18 21 58" src="https://user-images.githubusercontent.com/4140793/49836761-dca91380-fd71-11e8-8562-3b2280202cbf.png">
<img width="716" alt="screen shot 2018-12-11 at 18 21 48" src="https://user-images.githubusercontent.com/4140793/49836762-dca91380-fd71-11e8-8230-e184fd1453cd.png">

cc @kwalrath 