### PR TITLE
Fixed the get-started urls by add docs/

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -43,7 +43,7 @@
       <a  class="nav-item nav-link" href="{{site.repo.organization}}"><i class="fab fa-github fa-lg"></i></a>
     </div>
     {% if page.show-nav-get-started-button -%}
-      <a class="site-header__cta btn btn-primary" href="/get-started/install/">Get started</a>
+      <a class="site-header__cta btn btn-primary" href="/docs/get-started/install/">Get started</a>
     {% endif -%}
   </nav>
 </header>

--- a/src/docs/development/packages-and-plugins/developing-packages.md
+++ b/src/docs/development/packages-and-plugins/developing-packages.md
@@ -119,7 +119,7 @@ experience.
 #### Step 2a: Define the package API (.dart)
 
 The API of the plugin package is defined in Dart code. Open the main `hello/`
-folder in your favorite [Flutter editor](/get-started/editor). Locate the file
+folder in your favorite [Flutter editor](/docs/get-started/editor). Locate the file
 `lib/hello.dart`.
 
 #### Step 2b: Add Android platform code (.java/.kt)

--- a/src/docs/development/tools/android-studio.md
+++ b/src/docs/development/tools/android-studio.md
@@ -14,7 +14,7 @@ description: How to develop Flutter apps in Android Studio or other IntelliJ pro
 
 ## Installation and setup
 
-Follow the [Set up an editor](/get-started/editor?ide=androidstudio)
+Follow the [Set up an editor](/docs/get-started/editor?ide=androidstudio)
 instructions to install the Dart and Flutter plugins.
 
 ### Updating the plugins<a name="updating"/>

--- a/src/docs/development/tools/formatting.md
+++ b/src/docs/development/tools/formatting.md
@@ -15,7 +15,7 @@ time may be better spent on code behavior rather than code style.
 
 ## Automatically formatting code in Android Studio and IntelliJ
 
-Install the `Dart` plugin (see [Editor setup](/get-started/editor))
+Install the `Dart` plugin (see [Editor setup](/docs/get-started/editor))
 to get automatic formatting of code in Android Studio and IntelliJ.
 
 To automatically format the code in the current source code window, right-click
@@ -25,7 +25,7 @@ Preferences.
 
 ## Automatically formatting code in VS Code
 
-Install the `Flutter` extension (see [Editor setup](/get-started/editor))
+Install the `Flutter` extension (see [Editor setup](/docs/get-started/editor))
 to get automatic formatting of code in VS Code.
 
 To automatically format the code in the current source code window, right-click

--- a/src/docs/development/tools/hot-reload.md
+++ b/src/docs/development/tools/hot-reload.md
@@ -12,7 +12,7 @@ of your changes.
 
 To hot reload a Flutter app:
 
- 1. Run the app from a supported [Flutter editor](/get-started/editor)
+ 1. Run the app from a supported [Flutter editor](/docs/get-started/editor)
     or a terminal window. Either a physical or virtual device can be the target.
     Only Flutter apps in debug mode can be hot reloaded.
  1. Modify one of the Dart files in your project. Most types of code changes can

--- a/src/docs/development/tools/inspector.md
+++ b/src/docs/development/tools/inspector.md
@@ -20,7 +20,7 @@ these widget trees. It can be helpful when:
 ## Getting started with the inspector
 
 The inspector is currently available in [the Flutter
-plugin](/get-started/editor) for Android Studio, or IntelliJ IDEA.
+plugin](/docs/get-started/editor) for Android Studio, or IntelliJ IDEA.
 
 To start click "Select widget" on the Flutter inspector toolbar, and then click
 on the device to select a widget. The selected widget is then highlighted

--- a/src/docs/development/tools/vs-code.md
+++ b/src/docs/development/tools/vs-code.md
@@ -15,7 +15,7 @@ description: How to develop Flutter apps in Visual Studio Code.
 
 ## Installation and setup
 
-Follow the [Set up an editor](/get-started/editor?ide=vscode) instructions to
+Follow the [Set up an editor](/docs/get-started/editor?ide=vscode) instructions to
 install the Dart and Flutter extensions (also called plugins).
 
 ### Updating the extension {#updating}

--- a/src/docs/development/ui/animations/hero-animations/index.md
+++ b/src/docs/development/ui/animations/hero-animations/index.md
@@ -298,7 +298,7 @@ to specify the new route, the image flies along a curved path,
 as described by the [Material Design motion
 spec.](https://material.io/guidelines/motion/movement.html)
 
-[Create a new Flutter example](/get-started/test-drive) and
+[Create a new Flutter example](/docs/get-started/test-drive) and
 update it using the files from the
 [GitHub directory.](https://github.com/flutter/website/tree/master/src/_includes/code/animation/hero_animation/)
 
@@ -517,7 +517,7 @@ rectangular clips yield a rectangle that's the same size as the hero
 widget. In other words, at the end of the transition the image is no
 longer clipped.
 
-[Create a new Flutter example](/get-started/test-drive) and
+[Create a new Flutter example](/docs/get-started/test-drive) and
 update it using the files from the
 [GitHub directory.](https://github.com/flutter/website/tree/master/src/_includes/code/animation/radial_hero_animation)
 

--- a/src/docs/development/ui/interactive/index.md
+++ b/src/docs/development/ui/interactive/index.md
@@ -23,8 +23,8 @@ If you've already built the layout in
 [Building Layouts in Flutter](/docs/development/ui/layout),
 skip to the next section.
 
-* Make sure you've [set up](/get-started/install) your environment.
-* [Create a basic Flutter app.](/get-started/test-drive/#create-app)
+* Make sure you've [set up](/docs/get-started/install) your environment.
+* [Create a basic Flutter app.](/docs/get-started/test-drive/#create-app)
 * Replace the `lib/main.dart` file with
   [`main.dart`](https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/layout/lakes/main.dart)
   from GitHub.
@@ -35,7 +35,7 @@ skip to the next section.
   [`lake.jpg`.](https://github.com/flutter/website/blob/master/src/_includes/code/layout/lakes/images/lake.jpg)
 
 Once you have a connected and enabled device, or you've launched the [iOS
-simulator](/get-started/install/macos#set-up-the-ios-simulator)
+simulator](/docs/get-started/install/macos#set-up-the-ios-simulator)
 (part of the Flutter install),
 you are good to go!
 

--- a/src/docs/development/ui/layout/index.md
+++ b/src/docs/development/ui/layout/index.md
@@ -38,8 +38,8 @@ start with [Flutter's approach to layout](#flutters-approach-to-layout).
 
 First, get the code:
 
-* Make sure you've [set up](/get-started/install) your environment.
-* [Create a basic Flutter app](/get-started/test-drive#create-app).
+* Make sure you've [set up](/docs/get-started/install) your environment.
+* [Create a basic Flutter app](/docs/get-started/test-drive#create-app).
 
 Next, add the image to the example:
 
@@ -1586,7 +1586,7 @@ The following resources may help when writing layout code.
 
 * [Widget Overview](/docs/development/ui/widgets)
 : Describes many of the widgets available in Flutter.
-* [HTML/CSS Analogs in Flutter](/get-started/flutter-for/web-devs)
+* [HTML/CSS Analogs in Flutter](/docs/get-started/flutter-for/web-devs)
 : For those familiar with web programming, this page maps HTML/CSS functionality
   to Flutter features.
 * [Flutter Gallery][]

--- a/src/docs/get-started/codelab.md
+++ b/src/docs/get-started/codelab.md
@@ -3,10 +3,10 @@ title: Write your first Flutter app, part 1
 short-title: Write your first app
 prev:
   title: Test drive
-  path: /get-started/test-drive
+  path: /docs/get-started/test-drive
 next:
   title: Learn more
-  path: /get-started/learn-more
+  path: /docs/get-started/learn-more
 diff2html: true
 ---
 

--- a/src/docs/get-started/codelab.md
+++ b/src/docs/get-started/codelab.md
@@ -62,7 +62,7 @@ The animated GIF shows how the app works at the completion of part 1.
   <h4 class="no_toc">What you'll use</h4>
 
   You need two pieces of software to complete this lab: the
-  [Flutter SDK](/get-started/install) and [an editor](/get-started/editor).
+  [Flutter SDK](/docs/get-started/install) and [an editor](/docs/get-started/editor).
   This codelab assumes Android Studio, but you can use your preferred
   editor.
 
@@ -78,13 +78,13 @@ The animated GIF shows how the app works at the completion of part 1.
 ## Step 1: Create the starter Flutter app
 
 Create a simple, templated Flutter app, using the instructions in
-[Getting Started with your first Flutter app.](/get-started/test-drive#create-app)
+[Getting Started with your first Flutter app.](/docs/get-started/test-drive#create-app)
 Name the project **startup_namer** (instead of _myapp_).
 
 {{site.alert.tip}}
   If you don't see "New Flutter Project" as an option in your IDE, make
   sure you have the [plugins installed for Flutter and
-  Dart](/get-started/editor).
+  Dart](/docs/get-started/editor).
 {{site.alert.end}}
 
 In this codelab, you'll mostly be editing **lib/main.dart**,
@@ -129,7 +129,7 @@ where the Dart code lives.
       * Terminal: Run `flutter format <filename>`.
     {{site.alert.end}}
 
- 2. [Run the app](/get-started/test-drive#androidstudio) by clicking
+ 2. [Run the app](/docs/get-started/test-drive#androidstudio) by clicking
     the green arrow in the IDE.
     You should see either Android or iOS output, depending on your device.
 

--- a/src/docs/get-started/editor.md
+++ b/src/docs/get-started/editor.md
@@ -16,7 +16,7 @@ highlighting, widget editing assists, run & debug support, and more.
 
 Follow the steps below to add an editor plugin for Android Studio, IntelliJ, or
 VS Code. If you want to use a different editor, that's OK, skip ahead to the
-[next step: Test drive](/get-started/test-drive).
+[next step: Test drive](/docs/get-started/test-drive).
 
 {% comment %} Nav tabs {% endcomment -%}
 <ul class="nav nav-tabs" id="editor-setup" role="tablist">

--- a/src/docs/get-started/editor.md
+++ b/src/docs/get-started/editor.md
@@ -2,10 +2,10 @@
 title: Set up an editor
 prev:
   title: Install
-  path: /get-started/install
+  path: /docs/get-started/install
 next:
   title: Test drive
-  path: /get-started/test-drive
+  path: /docs/get-started/test-drive
 toc: false
 ---
 

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -307,7 +307,7 @@ To create an app in Flutter, do one of the following:
 $ flutter create <projectname>
 {% endprettify%}
 
-For more information, see [Getting Started](/get-started), which
+For more information, see [Getting Started](/docs/get-started), which
 walks you through creating a button-click counter app. Creating a Flutter
 project builds all the files that you need to run a sample app on both Android
 and iOS devices.
@@ -324,7 +324,7 @@ In React Native, you would run `npm run` or `yarn run` from the project
 
  Your app runs on a connected device, the iOS emulator, or the Android simulator.
 
-For more information, see the Flutter [Getting Started](/get-started) documentation.
+For more information, see the Flutter [Getting Started](/docs/get-started) documentation.
 
 ### How do I import widgets?
 

--- a/src/docs/get-started/install/index.md
+++ b/src/docs/get-started/install/index.md
@@ -2,7 +2,7 @@
 title: Install
 next:
   title: Set up an editor
-  path: /get-started/editor
+  path: /docs/get-started/editor
 toc: false
 ---
 

--- a/src/docs/get-started/install/index.md
+++ b/src/docs/get-started/install/index.md
@@ -10,7 +10,7 @@ Select the operating system on which you are installing Flutter:
 
 <div class="card-deck mb-8">
 {% for os in site.os-list %}
-  <a class="card" href="/get-started/install/{{os | downcase}}">
+  <a class="card" href="/docs/get-started/install/{{os | downcase}}">
     <div class="card-body">
       <header class="card-title text-center m-0">
         {{os}}

--- a/src/docs/get-started/install/linux.md
+++ b/src/docs/get-started/install/linux.md
@@ -4,7 +4,7 @@ short-title: Linux
 # js: [{defer: true, url: /assets/archive.js}]
 next:
   title: Set up an editor
-  path: /get-started/editor
+  path: /docs/get-started/editor
 ---
 
 {% assign os = 'linux' -%}

--- a/src/docs/get-started/install/linux.md
+++ b/src/docs/get-started/install/linux.md
@@ -28,4 +28,4 @@ To install and run Flutter, your development environment must meet these minimum
 
 ## Next step
 
-[Next step: Configure Editor](/get-started/editor)
+[Next step: Configure Editor](/docs/get-started/editor)

--- a/src/docs/get-started/install/macos.md
+++ b/src/docs/get-started/install/macos.md
@@ -3,7 +3,7 @@ title: MacOS install
 short-title: MacOS
 next:
   title: Set up an editor
-  path: /get-started/editor
+  path: /docs/get-started/editor
 ---
 
 {% assign os = 'macos' -%}

--- a/src/docs/get-started/install/macos.md
+++ b/src/docs/get-started/install/macos.md
@@ -33,4 +33,4 @@ first Flutter app.
 
 ## Next step
 
-[Next step: Configure Editor](/get-started/editor)
+[Next step: Configure Editor](/docs/get-started/editor)

--- a/src/docs/get-started/install/windows.md
+++ b/src/docs/get-started/install/windows.md
@@ -28,7 +28,7 @@ To install and run Flutter, your development environment must meet these minimum
 
 ## Next step
 
-[Next step: Configure Editor](/get-started/editor)
+[Next step: Configure Editor](/docs/get-started/editor)
 
 [Git for Windows]: https://git-scm.com/download/win
 [Windows PowerShell 5.0]: https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell

--- a/src/docs/get-started/install/windows.md
+++ b/src/docs/get-started/install/windows.md
@@ -4,7 +4,7 @@ short-title: Windows
 # js: [{defer: true, url: /assets/archive.js}]
 next:
   title: Set up an editor
-  path: /get-started/editor
+  path: /docs/get-started/editor
 ---
 
 {% assign os = 'windows' -%}

--- a/src/docs/get-started/learn-more.md
+++ b/src/docs/get-started/learn-more.md
@@ -9,11 +9,11 @@ toc: false
 
 Learn more about the Flutter framework:
 
-* [Flutter for Android developers](/get-started/flutter-for/android-devs)
-* [Flutter for iOS developers](/get-started/flutter-for/ios-devs)
-* [Flutter for React Native developers](/get-started/flutter-for/react-native-devs)
-* [Flutter for Xamarin.Forms developers](/get-started/flutter-for/xamarin-forms-devs)
-* [Flutter for web developers](/get-started/flutter-for/web-devs)
+* [Flutter for Android developers](/docs/get-started/flutter-for/android-devs)
+* [Flutter for iOS developers](/docs/get-started/flutter-for/ios-devs)
+* [Flutter for React Native developers](/docs/get-started/flutter-for/react-native-devs)
+* [Flutter for Xamarin.Forms developers](/docs/get-started/flutter-for/xamarin-forms-devs)
+* [Flutter for web developers](/docs/get-started/flutter-for/web-devs)
 * [Building layouts in Flutter](/docs/development/ui/layout) tutorial
 * [Add interactivity](/docs/development/ui/interactive) tutorial
 * [Introduction to widgets](/docs/development/ui/widgets-intro)

--- a/src/docs/get-started/learn-more.md
+++ b/src/docs/get-started/learn-more.md
@@ -3,7 +3,7 @@ title: Learn more
 description: More resources to help you learn Flutter.
 prev:
   title: Write your first Flutter app
-  path: /get-started/codelab
+  path: /docs/get-started/codelab
 toc: false
 ---
 

--- a/src/docs/get-started/test-drive/_terminal.md
+++ b/src/docs/get-started/test-drive/_terminal.md
@@ -37,5 +37,5 @@ contains a simple demo app that uses
 
 {% include_relative _try-hot-reload.md save_changes=save_changes %}
 
-[Install]: /get-started/install
+[Install]: /docs/get-started/install
 </div>

--- a/src/docs/get-started/test-drive/_vscode.md
+++ b/src/docs/get-started/test-drive/_vscode.md
@@ -35,7 +35,7 @@ contains a simple demo app that uses [Material Components][].
 
 {% include_relative _try-hot-reload.md save_changes=save_changes %}
 
-[Install]: /get-started/install
+[Install]: /docs/get-started/install
 [Material Components]: https://material.io/guidelines
 [Quickly switching between Flutter devices]: https://dartcode.org/docs/quickly-switching-between-flutter-devices
 [status bar]: {% asset tools/vs-code/device_status_bar.png @path %}

--- a/src/docs/get-started/test-drive/index.md
+++ b/src/docs/get-started/test-drive/index.md
@@ -2,10 +2,10 @@
 title: Test drive
 prev:
   title: Set up an editor
-  path: /get-started/editor
+  path: /docs/get-started/editor
 next:
   title: Write your first Flutter app
-  path: /get-started/codelab
+  path: /docs/get-started/codelab
 toc: false
 ---
 

--- a/src/docs/resources/faq.md
+++ b/src/docs/resources/faq.md
@@ -144,7 +144,7 @@ Studio](https://developer.android.com/studio/),
 [IntelliJ IDEA](https://www.jetbrains.com/idea/),
 and [VS Code](https://code.visualstudio.com/).
 
-See [editor configuration](/get-started/editor) for setup details, and
+See [editor configuration](/docs/get-started/editor) for setup details, and
 ['Developing Flutter apps in an IDE'](/docs/development/tools/android-studio)
 for tips on how to use the plugins.
 

--- a/src/docs/resources/technical-overview.md
+++ b/src/docs/resources/technical-overview.md
@@ -194,7 +194,7 @@ to start developing and iterating.
 
 Next steps:
 
-1.  [Follow the Flutter Getting Started guide](/get-started).
+1.  [Follow the Flutter Getting Started guide](/docs/get-started).
 1.  Try [Building Layouts in Flutter](/docs/development/ui/layout) and
     [Adding Interactivity to Your Flutter App](/docs/development/ui/interactive).
 1.  Follow a detailed example in [Tour of the Widget

--- a/src/docs/testing/debugging.md
+++ b/src/docs/testing/debugging.md
@@ -15,7 +15,7 @@ applications.
 Before running your applications, test your code with `flutter analyze`. This
 tool (which is a wrapper around the `dartanalyzer` tool) analyzes your code
 and helps you find possible mistakes. If you're using a
-[Flutter enabled IDE/editor](/get-started/editor/),
+[Flutter enabled IDE/editor](/docs/get-started/editor/),
 this is already happening for you.
 
 The Dart analyzer makes heavy use of type annotations that you put in
@@ -30,7 +30,7 @@ If you started your application using `flutter run`, then,
 while it is running, you can open the Web page at the Observatory URL printed
 to the console (e.g., `Observatory listening on http://127.0.0.1:8100/`), to
 connect to your application directly with a statement-level single-stepping
-debugger. If you're using a [Flutter enabled IDE/editor](/get-started/editor/),
+debugger. If you're using a [Flutter enabled IDE/editor](/docs/get-started/editor/),
 you can also debug your application using its built-in debugger.
 
 Observatory also supports profiling, examining the heap, etc. For more

--- a/src/docs/testing/oem-debuggers.md
+++ b/src/docs/testing/oem-debuggers.md
@@ -32,7 +32,7 @@ plugins installed and configured.
 ### Dart debugger
 
 * Open your project in Android Studio. If you don't have a project yet,
-  create one using the instructions in [Test drive](/get-started/test-drive).
+  create one using the instructions in [Test drive](/docs/get-started/test-drive).
 
 * Simultaneously bring up the Debug pane and run the app in the Console
   view by clicking the bug icon

--- a/src/showcase/index.html
+++ b/src/showcase/index.html
@@ -101,7 +101,7 @@ body_class: landing-page showcase
     <div class="card-body">
         <h2 class="landing-page__cta__headline">Try Flutter today.</h2>
         <p class="landing-page__cta__body">It’s free and open source.</p>
-        <a class="landing-page__cta__button btn btn-primary btn-cta" href="/get-started/install">Get started</a>
+        <a class="landing-page__cta__button btn btn-primary btn-cta" href="/docs/get-started/install">Get started</a>
     </div>
 </section>
 


### PR DESCRIPTION
Please consider this PR, since not everyone will deploy Flutter docs by using Firebase (could set 301 to custom url / path), trying to use the full URL (add "docs/" before "get-started") will be great, thanks! 