### PR TITLE
Homepage: add Reflectly description, and fix layout

### DIFF
--- a/src/_assets/css/_homepage.scss
+++ b/src/_assets/css/_homepage.scss
@@ -319,11 +319,17 @@
       margin-bottom: bs-spacer(4);
 
       @include media-breakpoint-up(sm) {
-        bottom: 0;
+        font-size: smaller;
+        bottom: bs-spacer(8);
+        margin-right: 2rem;
+        left: 340px;
         position: absolute;
-        right: bs-spacer(6);
-        text-align: center;
+        text-align: left;
       }
+      @include media-breakpoint-up(md) { left: 430px; font-size: inherit; }
+      @include media-breakpoint-up(lg) { left: 380px; }
+      @include media-breakpoint-up(xl) { left: 450px; bottom: bs-spacer(10); }
+      @include media-breakpoint-up(xxl){ left: 530px; }
     }
   }
 

--- a/src/index.html
+++ b/src/index.html
@@ -144,7 +144,7 @@ description: >
                 <div>
                     <div class="homepage__beautiful-uis__app-info">
                         <h5>Reflectly</h5>
-                        <p>A journal and mindfulness app.</p>
+                        <p>An award winning mindfulness app built with Flutter.</p>
                         <small>
                         Download: <a href="https://itunes.apple.com/us/app/reflectly-mindfulness-journal/id1241229134" target="_blank">iOS</a>, <a href="https://play.google.com/store/apps/details?id=com.reflectlyApp&e=-EnableAppDetailsPageRedesign" target="_blank">Android</a><br>
                         <a href="https://reflect.ly" target="blank">Learn more</a>

--- a/src/index.html
+++ b/src/index.html
@@ -144,6 +144,7 @@ description: >
                 <div>
                     <div class="homepage__beautiful-uis__app-info">
                         <h5>Reflectly</h5>
+                        <p>A journal and mindfulness app.</p>
                         <small>
                         Download: <a href="https://itunes.apple.com/us/app/reflectly-mindfulness-journal/id1241229134" target="_blank">iOS</a>, <a href="https://play.google.com/store/apps/details?id=com.reflectlyApp&e=-EnableAppDetailsPageRedesign" target="_blank">Android</a><br>
                         <a href="https://reflect.ly" target="blank">Learn more</a>


### PR DESCRIPTION
Fixes #2092. (It was a bit tricky to implement because the video and the text are overlaid because the video is about 2.5 times wider than the phone width.)

Staged at https://ng2-io.firebaseapp.com

cc @maguinis @sfshaza2 

---

### Screenshots at various widths

<img width="1105" alt="screen shot 2018-12-22 at 18 30 15" src="https://user-images.githubusercontent.com/4140793/50379475-ae9cbc80-0618-11e9-91ef-b1656e236acd.png">
<img width="688" alt="screen shot 2018-12-22 at 18 29 47" src="https://user-images.githubusercontent.com/4140793/50379476-ae9cbc80-0618-11e9-88dd-0bdbdc7df0f5.png">
<img width="475" alt="screen shot 2018-12-22 at 18 29 36" src="https://user-images.githubusercontent.com/4140793/50379477-ae9cbc80-0618-11e9-9cb1-f77355c43889.png">
