### PR TITLE
Make tutorials more easily discoverable

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -27,7 +27,7 @@
     - title: "Dart language overview"
       permalink: https://www.dartlang.org/guides/language
 
-- title: Samples & codelabs
+- title: Samples & tutorials
   children:
     - title: Sample apps on GitHub
       permalink: https://github.com/flutter/samples/blob/master/INDEX.md
@@ -35,6 +35,8 @@
       permalink: /docs/cookbook
     - title: Codelabs
       permalink: /docs/codelabs
+    - title: Tutorials
+      permalink: /docs/reference/tutorials
 
 - title: Development
   expanded: true
@@ -185,8 +187,6 @@
 - title: Reference
   expanded: true
   children:
-    - title: Tutorials
-      permalink: /docs/reference/tutorials
     - title: Widget index
       permalink: /docs/reference/widgets
     - title: API reference


### PR DESCRIPTION
Fixed #2110 

@galeyang - note that this PR simply changes the location of the Tutorials index page in the sidenav. The page URL doesn't change (so that there is no need for a Firebase redirect rule).

cc @sfshaza2 

<img width="903" alt="screen shot 2018-12-26 at 16 39 01" src="https://user-images.githubusercontent.com/4140793/50457881-fa0edd80-092c-11e9-92f8-20c8ab5cfd29.png">
