### PR TITLE
Revert to "toc:false" for pages with tabbed content

### DIFF
--- a/src/docs/development/tools/sdk/archive.md
+++ b/src/docs/development/tools/sdk/archive.md
@@ -2,6 +2,7 @@
 title: Flutter SDK archive
 short-title: Archive
 description: Flutter SDK archive
+toc: false
 ---
 
 <style>

--- a/src/docs/get-started/editor.md
+++ b/src/docs/get-started/editor.md
@@ -6,6 +6,7 @@ prev:
 next:
   title: Test drive
   path: /docs/get-started/test-drive
+toc: false
 ---
 
 You can build apps with Flutter using any text editor combined with our

--- a/src/docs/get-started/test-drive/index.md
+++ b/src/docs/get-started/test-drive/index.md
@@ -6,6 +6,7 @@ prev:
 next:
   title: Write your first Flutter app
   path: /docs/get-started/codelab
+toc: false
 ---
 
 This page describes how to create a new Flutter app from templates, run it, and experience "hot reload" after you make changes to the app.


### PR DESCRIPTION
At least until #1404 is fixed. (Followup to #2127)