### PR TITLE
Updated Testing Index.md Documentation

### DIFF
--- a/src/docs/testing/index.md
+++ b/src/docs/testing/index.md
@@ -203,6 +203,7 @@ To use `flutter_driver`, you must add the following block to your `pubspec.yaml`
 
 ```yaml
 dev_dependencies:
+  test:
   flutter_driver:
     sdk: flutter
 ```

--- a/src/docs/testing/index.md
+++ b/src/docs/testing/index.md
@@ -83,6 +83,7 @@ In addition, you must add the following block to your `pubspec.yaml`:
 
 ```yaml
 dev_dependencies:
+  test:
   flutter_test:
     sdk: flutter
 ```

--- a/src/docs/testing/index.md
+++ b/src/docs/testing/index.md
@@ -83,9 +83,9 @@ In addition, you must add the following block to your `pubspec.yaml`:
 
 ```yaml
 dev_dependencies:
-  test:
   flutter_test:
     sdk: flutter
+  test: ^1.5.1
 ```
 
 {{site.alert.note}}
@@ -204,9 +204,11 @@ To use `flutter_driver`, you must add the following block to your `pubspec.yaml`
 
 ```yaml
 dev_dependencies:
-  test:
   flutter_driver:
     sdk: flutter
+  flutter_test:
+    sdk: flutter
+  test: ^1.5.1
 ```
 
 ### Creating instrumented Flutter apps


### PR DESCRIPTION
The examples provided in Testing Index.md are missing the dart `test` dev dependency. This fixes that documentation.

Fixes #2167 , #2165