### PR TITLE
Code_excerpt plugin with a functional copy code button

### DIFF
--- a/src/_assets/css/_code.scss
+++ b/src/_assets/css/_code.scss
@@ -19,3 +19,32 @@
     }
   }
 }
+
+.code-excerpt {
+  border: $border-width solid $border-color;
+  margin-bottom: bs-spacer(4);
+
+  &__code {
+    position: relative;
+
+    pre {
+      background-color: $gray-100;
+      margin-bottom: 0;
+    }
+  }
+
+  &__copy-btn {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: $code-color;
+    margin-top: bs-spacer(2);
+    position: absolute;
+    right: 0;
+  }
+
+  &__header {
+    background-color: $gray-200;
+    padding: bs-spacer(3);
+  }
+}

--- a/src/_assets/css/_code.scss
+++ b/src/_assets/css/_code.scss
@@ -1,0 +1,21 @@
+@import '_code_pre';
+
+.numbered-code-notes {
+  list-style-type: none;
+  padding-left: 0;
+  display: table;
+  li {
+    counter-increment: code-note-counter;
+    display: table-row;
+    padding-left: 8px;
+    &:before {
+      font-family: $font-family-monospace;
+      content: '/*' counter(code-note-counter) '*/' ;
+      display: table-cell;
+      text-align: right;
+      color: $teal;
+      padding-right: $font-size-base / 2;
+      // background-color: lightyellow;
+    }
+  }
+}

--- a/src/_assets/css/main.scss
+++ b/src/_assets/css/main.scss
@@ -19,7 +19,7 @@
 @import '_bootstrap_adjust';
 @import '_material_colors';
 @import '_tabs';
-@import '_code_pre';
+@import '_code';
 @import '_snackbar';
 
 // page types
@@ -30,24 +30,3 @@
 @import '_404';
 
 @import 'site_overrides';
-
-
-.numbered-code-notes {
-  list-style-type: none;
-  padding-left: 0;
-  display: table;
-  li {
-    counter-increment: code-note-counter;
-    display: table-row;
-    padding-left: 8px;
-    &:before {
-      font-family: $font-family-monospace;
-      content: '/*' counter(code-note-counter) '*/' ;
-      display: table-cell;
-      text-align: right;
-      color: $teal;
-      padding-right: $font-size-base / 2;
-      // background-color: lightyellow;
-    }
-  }
-}

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -17,13 +17,15 @@ $(function () {
   initCarousel();
   initSnackbar();
   prettyPrint();
+  $('[data-toggle="tooltip"]').tooltip();
+  setupClipboardJS();
 
   // New (dash) tabs
   setupTabs($('#editor-setup'), 'io.flutter.tool-id');
   // Old tabs
   setupToolsTabs($('#tab-set-install'), 'tab-install-', 'io.flutter.tool-id');
   setupToolsTabs($('#tab-set-os'), 'tab-os-', null, getOS());
-})
+});
 
 // TODO(chalin): Copied (& tweaked) from site-www, consider moving into site-shared
 function adjustToc() {
@@ -31,7 +33,7 @@ function adjustToc() {
 
   var tocId = '#site-toc--side';
   var tocWrapper = $(tocId);
-  $(tocWrapper).find('.site-toc--button__page-top').click(function() {
+  $(tocWrapper).find('.site-toc--button__page-top').click(function () {
     $('html, body').animate({ scrollTop: 0 }, 'fast');
   })
 
@@ -143,7 +145,7 @@ function initCarousel() {
 }
 
 function initSnackbar() {
-  var SNACKBAR_SELECTOR ='.snackbar';
+  var SNACKBAR_SELECTOR = '.snackbar';
   var SNACKBAR_ACTION_SELECTOR = '.snackbar__action';
   var snackbars = $(SNACKBAR_SELECTOR);
 
@@ -153,4 +155,38 @@ function initSnackbar() {
       snackbar.fadeOut();
     });
   })
+}
+
+function setupClipboardJS() {
+  var clipboard = new ClipboardJS('.code-excerpt__copy-btn'); // [data-clipboard-target]
+  clipboard.on('success', _copiedFeedback);
+}
+
+function _copiedFeedback(e) {
+  // e.action === 'copy'
+  // e.text === copied text
+  e.clearSelection(); // Unselect copied code
+
+  var copied = 'Copied';
+  var target = e.trigger;
+  var title = target.getAttribute('title') || target.getAttribute('data-original-title')
+  var savedTitle;
+
+  if (title === copied) return;
+
+  savedTitle = title;
+  setTimeout(function () {
+    _changeTooltip(target, savedTitle);
+  }, 1500);
+
+  _changeTooltip(target, copied);
+}
+
+function _changeTooltip(target, text) {
+  target.setAttribute('title', text);
+  $(target).tooltip('dispose'); // Dispose of tip with old title
+  $(target).tooltip('show'); // Recreate tip with new title ...
+  if (!$(target).is(":hover")) {
+    $(target).tooltip('hide'); // ... but hide it if it isn't being hovered over
+  }
 }

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -32,6 +32,10 @@
   {% for css in page.css -%}
     {% asset '{{css}}' %}
   {% endfor %}
+  {% comment %}
+    TODO: use a local copy of clipboard.js rather than CDN
+  {% endcomment -%}
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js"></script>
   {% asset main.js %}
   {% for js in page.js -%}
     <script {% if js.defer %}defer{% endif %} src="{{js.url | default: js}}"></script>

--- a/src/_plugins/code_excerpt.rb
+++ b/src/_plugins/code_excerpt.rb
@@ -1,0 +1,48 @@
+# Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
+require 'cgi'
+require 'liquid/tag/parser' # https://github.com/envygeeks/liquid-tag-parser
+require_relative 'prettify'
+
+module Jekyll
+
+  module Tags
+
+    # A Ruby plugin equivalent of the <?code-excerpt?> instruction.
+    class CodeExcerpt < Prettify
+
+      def initialize(tag_name, string_of_args, tokens)
+        super
+        @args = Liquid::Tag::Parser.new(string_of_args).args
+        @argv1 = @args[:argv1]
+        @lang = 'dart' # TODO: set dynamically
+      end
+
+      def render(context)
+        # TODO: autogenerate id
+        # TODO: only add header if there is a title
+        id = 'code-excerpt-1'
+        %(
+<div class="code-excerpt">
+<div class="code-excerpt__header">
+  #{CGI.escapeHTML(@argv1)}
+</div>
+<div class="code-excerpt__code">
+<button class="code-excerpt__copy-btn" type="button"
+    data-toggle="tooltip" title="Copy code"
+    data-clipboard-target="##{id}">
+  <i class="material-icons">content_copy</i>
+</button>
+<div id="#{id}">
+#{super(context)}
+</div>
+</div>
+</div>).strip
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag('code_excerpt', Jekyll::Tags::CodeExcerpt)

--- a/src/docs/development/ui/layout/index.md
+++ b/src/docs/development/ui/layout/index.md
@@ -108,13 +108,12 @@ in variables and functions.
 
 ### Step 2: Implement the title row
 
-<?code-excerpt path-base="layout/lakes"?>
+<?code-excerpt path-base="layout/lakes/step2"?>
 
 First, you'll build the left column in the title section. Add the following code
 at the top of the `build()` method of the `MyApp` class:
 
-<?code-excerpt "step2/lib/main.dart (titleSection)"?>
-```dart
+{% code_excerpt "lib/main.dart (titleSection)" %}
 Widget titleSection = Container(
   padding: const EdgeInsets.all(32.0),
   child: Row(
@@ -152,7 +151,7 @@ Widget titleSection = Container(
     ],
   ),
 );
-```
+{% endcode_excerpt %}
 
 {:.numbered-code-notes}
  1. Putting a Column inside an Expanded widget stretches the column to use all
@@ -166,6 +165,7 @@ Widget titleSection = Container(
 
 Add the title section to the app body like this:
 
+<?code-excerpt path-base="layout/lakes"?>
 <?code-excerpt "step0/lib/main.dart" diff-with="step2/lib/main.dart" from="return MaterialApp"?>
 {% diff %}
 --- step0/lib/main.dart


### PR DESCRIPTION
Base support for a copy code button, integrated with a new code_excerpt Jekyll block plugin.

The copy button has a "Copy code" tooltip. When the button is pressed, the tooltip temporarily changes to "Copied".

Staged at: https://flutter-io-staging-2.firebaseapp.com/docs/development/ui/layout#step-2-implement-the-title-row

### Screenshots

<img width="544" alt="screen shot 2019-01-05 at 13 32 21" src="https://user-images.githubusercontent.com/4140793/50863845-1455ac00-136e-11e9-945f-c749415f5175.png">

<img width="561" alt="screen shot 2019-01-05 at 13 38 35" src="https://user-images.githubusercontent.com/4140793/50863843-1455ac00-136e-11e9-9880-5dd8b4d1341f.png">
