### PR TITLE
Updating the video page and fixing a bug in the Android Release page.

### DIFF
--- a/src/docs/deployment/android.md
+++ b/src/docs/deployment/android.md
@@ -68,6 +68,9 @@ Alternatively, if you want to do it manually, here's how:
 
 ## Signing the app
 
+To publish on the iTunes store, you need to give your app a digital
+signature. Use the following instructions to sign your app.
+
 ### Create a keystore
 If you have an existing keystore, skip to the next step. If not, create one
 by running the following at the command line:

--- a/src/docs/deployment/android.md
+++ b/src/docs/deployment/android.md
@@ -68,7 +68,7 @@ Alternatively, if you want to do it manually, here's how:
 
 ## Signing the app
 
-To publish on the iTunes store, you need to give your app a digital
+To publish on the Play store, you need to give your app a digital
 signature. Use the following instructions to sign your app.
 
 ### Create a keystore

--- a/src/docs/resources/videos.md
+++ b/src/docs/resources/videos.md
@@ -23,14 +23,21 @@ Coding mistakes, solutions, and snazzy intro music included.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/yr8F2S3Amas?rel=0" frameborder="1" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 Episode One: The Boring Flutter Show<br>
-[The Boring Flutter Show playlist](https://www.youtube.com/watch?v=yr8F2S3Amas&list=PLOU2XLYxmsIK0r_D-zWcmJ1plIcDNnRkK)
+[The Boring Flutter Show playlist](https://www.youtube.com/playlist?list=PLOU2XLYxmsIK0r_D-zWcmJ1plIcDNnRkK)
 
 ### Flutter Widget of the Week
 
 Do you have 60 seconds? Each one-minute video highlights a Flutter widget.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/lkF0TQJO0bA?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
-[Flutter Widget of the Week playlist](https://www.youtube.com/watch?v=lkF0TQJO0bA&list=PLOU2XLYxmsIL0pH0zWe_ZOHgGhZ7UasUE)
+[Flutter Widget of the Week playlist](https://www.youtube.com/playlist?list=PLOU2XLYxmsIL0pH0zWe_ZOHgGhZ7UasUE)
+
+### Flutter Widgets 101
+
+Five-to-ten minute videos on how to use Flutter widgets.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/wE7khGHVkYY?list=PLOU2XLYxmsIJyiwUPCou_OVTpRIn_8UMd" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+[Flutter Widgets 101 playlist](https://www.youtube.com/playlist?list=PLOU2XLYxmsIJyiwUPCou_OVTpRIn_8UMd)
 
 ### Flutter Challenge series by Fluttery
 
@@ -45,16 +52,21 @@ Each episode solves a different design challenge.
 Weekly episodes, released on Sunday, feature Flutter widgets.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/aVZ5rsA4Yx8?rel=0" frameborder="1" allow="autoplay; encrypted-media" allowfullscreen></iframe>
-[Flutter Weekly Widgets playlist](https://www.youtube.com/watch?v=aVZ5rsA4Yx8&list=PLR2qQy0Zxs_Wot7YfLeeKdMlJ9838C_w0)
+[Flutter Weekly Widgets playlist](https://www.youtube.com/playlist?list=PLR2qQy0Zxs_Wot7YfLeeKdMlJ9838C_w0)
 
 ---
+
+{% comment %}
+Comment this out until we have a working Conference playlist link. 
 
 ## Conference talks
 
 Here are a few recent Flutter talks given at various conferences, listed by newist first.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/p4yLzYwy_4g?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
-[Conference Talks playlist](https://www.youtube.com/playlist?list=PLOU2XLYxmsIKVFj6DCJHTwvSzUBa2R8Ec)
+[Conference Talks playlist]()
+
+{% endcomment %}
 
 ## Flutter DevBytes
 

--- a/src/docs/resources/videos.md
+++ b/src/docs/resources/videos.md
@@ -34,7 +34,9 @@ Do you have 60 seconds? Each one-minute video highlights a Flutter widget.
 
 ### Flutter Widgets 101
 
-Five-to-ten minute videos on how to use Flutter widgets.
+Five-to-ten minute videos on StatelessWidget, StatefulWidget, and
+other buiding-block widgets that every Flutter developer needs
+to know about.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/wE7khGHVkYY?list=PLOU2XLYxmsIJyiwUPCou_OVTpRIn_8UMd" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 [Flutter Widgets 101 playlist](https://www.youtube.com/playlist?list=PLOU2XLYxmsIJyiwUPCou_OVTpRIn_8UMd)
@@ -61,7 +63,8 @@ Comment this out until we have a working Conference playlist link.
 
 ## Conference talks
 
-Here are a few recent Flutter talks given at various conferences, listed by newist first.
+Here are a few recent Flutter talks given at various conferences,
+listed by newest first.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/p4yLzYwy_4g?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 [Conference Talks playlist]()


### PR DESCRIPTION
On the Android release page, a level 2 header had no text, so the cursor was hopping up and down between the h2 and h3 labels. I've added text to fix this.

