### PR TITLE
Add a copy-code button to every code excerpt

### DIFF
--- a/src/_assets/css/_code.scss
+++ b/src/_assets/css/_code.scss
@@ -37,8 +37,9 @@
     background: transparent;
     border: none;
     cursor: pointer;
-    color: $code-color;
+    color: lighten($code-color, 20%); // Offers better contrast on dark bg
     margin-top: bs-spacer(2);
+    outline: none !important;
     position: absolute;
     right: 0;
   }

--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -16,7 +16,8 @@ $(function () {
   initVideoModal();
   initCarousel();
   initSnackbar();
-  prettyPrint();
+
+  addCopyCodeButtonsEverywhere(); // Must be before tooltip activation.
   $('[data-toggle="tooltip"]').tooltip();
   setupClipboardJS();
 
@@ -25,6 +26,8 @@ $(function () {
   // Old tabs
   setupToolsTabs($('#tab-set-install'), 'tab-install-', 'io.flutter.tool-id');
   setupToolsTabs($('#tab-set-os'), 'tab-os-', null, getOS());
+
+  prettyPrint();
 });
 
 // TODO(chalin): Copied (& tweaked) from site-www, consider moving into site-shared
@@ -189,4 +192,27 @@ function _changeTooltip(target, text) {
   if (!$(target).is(":hover")) {
     $(target).tooltip('hide'); // ... but hide it if it isn't being hovered over
   }
+}
+
+function addCopyCodeButtonsEverywhere() {
+  var elts = $('pre');
+  elts.wrap(function (i) {
+    return $(this).parent('div.code-excerpt__code').length === 0
+      ? '<div class="code-excerpt__code"></div>'
+      : '';
+  });
+  elts.wrap(function (i) {
+    return '<div id="code-excerpt-' + i + '"></div>'
+  });
+
+  elts.parent() // === div#code-excerpt-X
+    .parent() // === div.code-excerpt__code
+    .prepend(function (i) {
+      return '' +
+        '<button class="code-excerpt__copy-btn" type="button"' +
+        '    data-toggle="tooltip" title="Copy code"' +
+        '    data-clipboard-target="#code-excerpt-' + i + '">' +
+        '  <i class="material-icons">content_copy</i>' +
+        '</button>';
+    });
 }

--- a/src/_plugins/code_excerpt.rb
+++ b/src/_plugins/code_excerpt.rb
@@ -21,23 +21,31 @@ module Jekyll
       end
 
       def render(context)
-        # TODO: autogenerate id
+        # Don't add a copy button here since we're currently adding
+        # it dynamically to all <pre> elements.
+        #
+        # id = 'code-excerpt-1' # TODO: autogenerate id
+        #
+        # Extra template code was:
+        #
+        # <button class="code-excerpt__copy-btn" type="button"
+        #     data-toggle="tooltip" title="Copy code"
+        #     data-clipboard-target="##{id}">
+        #   <i class="material-icons">content_copy</i>
+        # </button>
+        # <div id="#{id}">
+        # #{super(context)}
+        # </div>
+
         # TODO: only add header if there is a title
-        id = 'code-excerpt-1'
+
         %(
 <div class="code-excerpt">
 <div class="code-excerpt__header">
   #{CGI.escapeHTML(@argv1)}
 </div>
 <div class="code-excerpt__code">
-<button class="code-excerpt__copy-btn" type="button"
-    data-toggle="tooltip" title="Copy code"
-    data-clipboard-target="##{id}">
-  <i class="material-icons">content_copy</i>
-</button>
-<div id="#{id}">
 #{super(context)}
-</div>
 </div>
 </div>).strip
       end


### PR DESCRIPTION
Dynamically add a copy-code button to all code excerpts (this excludes diffs because diffs contain much more than just code).

Fixes #1756 

Staged, e.g., see https://flutter-io-staging-2.firebaseapp.com/docs/get-started/codelab#step-2-use-an-external-package

### Screenshot

> <img width="656" alt="screen shot 2019-01-08 at 20 06 33" src="https://user-images.githubusercontent.com/4140793/50869353-a3b88a80-1381-11e9-95ea-f9b3166b2248.png">

cc @galeyang 