### PR TITLE
Tutorial sources: link to GitHub page rather than raw content

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -65,9 +65,9 @@
             - title: Introduction
               permalink: /docs/development/ui/animations
               match-page-url-exactly: true
-            - title: Animations overview
+            - title: Overview
               permalink: /docs/development/ui/animations/overview
-            - title: Animations tutorial
+            - title: Tutorial
               permalink: /docs/development/ui/animations/tutorial
             - title: Hero animations
               permalink: /docs/development/ui/animations/hero-animations

--- a/src/docs/catalog/samples/animated-list.md
+++ b/src/docs/catalog/samples/animated-list.md
@@ -251,4 +251,4 @@ void main() {
   [Components-Lists: Controls](https://material.io/guidelines/components/lists-controls.html#)
   section of the [Material Design](https://material.io) specification:
 * The source code in
-  [examples/catalog/lib/animated_list.dart](https://raw.githubusercontent.com/flutter/flutter/master/examples/catalog/lib/animated_list.dart).
+  [examples/catalog/lib/animated_list.dart]({{site.repo.flutter}}/tree/{{site.branch}}/examples/catalog/lib/animated_list.dart).

--- a/src/docs/catalog/samples/app-bar-bottom.md
+++ b/src/docs/catalog/samples/app-bar-bottom.md
@@ -164,4 +164,4 @@ void main() {
 * The [Components-Tabs](https://material.io/guidelines/components/tabs.html)
   section of the [Material Design](https://material.io) specification.
 * The source code in
-  [examples/catalog/lib/app_bar_bottom.dart](https://raw.githubusercontent.com/flutter/flutter/master/examples/catalog/lib/animated_list.dart).
+  [examples/catalog/lib/app_bar_bottom.dart]({{site.repo.flutter}}/tree/{{site.branch}}/examples/catalog/lib/animated_list.dart).

--- a/src/docs/catalog/samples/basic-app-bar.md
+++ b/src/docs/catalog/samples/basic-app-bar.md
@@ -146,4 +146,4 @@ void main() {
 
 * The Material [App bars: top](https://material.io/design/components/app-bars-top.html) component page.
 * The source code in
-  [examples/catalog/lib/basic_app_bar.dart](https://raw.githubusercontent.com/flutter/flutter/master/examples/catalog/lib/basic_app_bar.dart).
+  [examples/catalog/lib/basic_app_bar.dart]({{site.repo.flutter}}/tree/{{site.branch}}/examples/catalog/lib/basic_app_bar.dart).

--- a/src/docs/catalog/samples/expansion-tile-sample.md
+++ b/src/docs/catalog/samples/expansion-tile-sample.md
@@ -142,4 +142,4 @@ void main() {
 
 * The Material [Lists](https://material.io/design/components/lists.html) component page.
 * The source code in
-  [examples/catalog/lib/expansion_tile_sample.dart](https://raw.githubusercontent.com/flutter/flutter/master/examples/catalog/lib/expansion_tile_sample.dart).
+  [examples/catalog/lib/expansion_tile_sample.dart]({{site.repo.flutter}}/tree/{{site.branch}}/examples/catalog/lib/expansion_tile_sample.dart).

--- a/src/docs/development/ui/animations/staggered-animations/index.md
+++ b/src/docs/development/ui/animations/staggered-animations/index.md
@@ -194,7 +194,7 @@ The stateful widget creates the controller, plays the animation,
 and builds the non-animating portion of the widget tree.
 The animation begins when a tap is detected anywhere in the screen.
 
-[Full code for basic_staggered_animation's main.dart](https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/animation/basic_staggered_animation/main.dart)
+[Full code for basic_staggered_animation's main.dart]({{site.repo.this}}/tree/{{site.branch}}/src/_includes/code/animation/basic_staggered_animation/main.dart)
 
 ### Stateless widget: StaggerAnimation
 

--- a/src/docs/development/ui/animations/tutorial.md
+++ b/src/docs/development/ui/animations/tutorial.md
@@ -136,7 +136,7 @@ The presence of `vsync` prevents offscreen animations from consuming
 unnecessary resources. You can use your stateful object as the vsync
 by adding SingleTickerProviderStateMixin to the class definition.
 You can see an example of this in
-[animate1](https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/animation/animate1/main.dart)
+[animate1]({{site.repo.this}}/tree/{{site.branch}}/src/_includes/code/animation/animate1/main.dart)
 on GitHub.
 {% comment %}
 The `vsync` object ties the ticking of the animation controller to
@@ -359,7 +359,7 @@ memory leaks.
 
 With these few changes, you’ve created your first animation in Flutter!
 You can find the source for this example,
-[animate1.](https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/animation/animate1/main.dart)
+[animate1.]({{site.repo.this}}/tree/{{site.branch}}/src/_includes/code/animation/animate1/main.dart)
 
 <aside class="alert alert-success" markdown="1">
 **Dart language tricks**
@@ -481,7 +481,7 @@ LogoApp passes the Animation object to the base class and uses
 it works exactly the same as before.
 
 You can find the source for this example,
-[animate2,](https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/animation/animate2/main.dart)
+[animate2,]({{site.repo.this}}/tree/{{site.branch}}/src/_includes/code/animation/animate2/main.dart)
 on GitHub.
 
 <a name="monitoring"></a>
@@ -502,7 +502,7 @@ It’s often helpful to know when an animation changes state,
 such as finishing, moving forward, or reversing.
 You can get notifications for this with `addStatusListener()`.
 The following code modifies the
-[animate1](https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/animation/animate1/main.dart)
+[animate1]({{site.repo.this}}/tree/{{site.branch}}/src/_includes/code/animation/animate1/main.dart)
 example so that it listens for a state change and prints an update.
 The highlighted line shows the change:
 
@@ -561,7 +561,7 @@ class _LogoAppState extends State<LogoApp> with SingleTickerProviderStateMixin {
 {% endprettify %}
 
 You can find the source for this example,
-[animate3,](https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/animation/animate3/main.dart)
+[animate3,]({{site.repo.this}}/tree/{{site.branch}}/src/_includes/code/animation/animate3/main.dart)
 on GitHub.
 
 ### Refactoring with AnimatedBuilder
@@ -583,7 +583,7 @@ on GitHub.
 </div>
 
 One problem with the code in the
-[animate3](https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/animation/animate3/main.dart)
+[animate3]({{site.repo.this}}/tree/{{site.branch}}/src/_includes/code/animation/animate3/main.dart)
 example, is that changing
 the animation required changing the widget that renders the logo.
 A better solution is to separate responsibilities into different
@@ -601,7 +601,7 @@ the widget tree dirty as necessary, so you don't need to call
 `addListener()`.
 
 The widget tree for the
-[animate5](https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/animation/animate5/main.dart)
+[animate5]({{site.repo.this}}/tree/{{site.branch}}/src/_includes/code/animation/animate5/main.dart)
 example looks like this:
 
 {% asset 'ui/AnimatedBuilder-WidgetTree.png' alt="Widget tree" %}
@@ -663,7 +663,7 @@ class GrowTransition extends StatelessWidget {
 
 Finally, the code to initialize the animation looks very similar to
 the first example,
-[animate1.](https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/animation/animate1/main.dart)
+[animate1.]({{site.repo.this}}/tree/{{site.branch}}/src/_includes/code/animation/animate1/main.dart)
 The `initState()` method creates an AnimationController
 and a Tween, then binds them with `animate()`. The magic happens in the
 `build()` method, which returns a GrowTransition object with a
@@ -707,7 +707,7 @@ void main() {
 {% endprettify %}
 
 You can find the source for this example,
-[animate4,](https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/animation/animate4/main.dart)
+[animate4,]({{site.repo.this}}/tree/{{site.branch}}/src/_includes/code/animation/animate4/main.dart)
 on GitHub.
 
 ### Simultaneous animations
@@ -724,7 +724,7 @@ on GitHub.
 
 In this section, you'll build on the example from [monitoring
 the progress of the animation](#monitoring)
-([animate3](https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/animation/animate3/main.dart)),
+([animate3]({{site.repo.this}}/tree/{{site.branch}}/src/_includes/code/animation/animate3/main.dart)),
 which used AnimatedWidget to animate in and out continuously. Consider the case
 where you want to animate in and out while the opacity animates from
 transparent to opaque.
@@ -834,7 +834,7 @@ void main() {
 {% endprettify %}
 
 You can find the source for this example,
-[animate5,](https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/animation/animate5/main.dart)
+[animate5,]({{site.repo.this}}/tree/{{site.branch}}/src/_includes/code/animation/animate5/main.dart)
 on GitHub.
 
 ## Next steps

--- a/src/docs/development/ui/interactive/index.md
+++ b/src/docs/development/ui/interactive/index.md
@@ -26,13 +26,13 @@ skip to the next section.
 * Make sure you've [set up](/docs/get-started/install) your environment.
 * [Create a basic Flutter app.](/docs/get-started/test-drive/#create-app)
 * Replace the `lib/main.dart` file with
-  [`main.dart`](https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/layout/lakes/main.dart)
+  [main.dart]({{site.repo.this}}/tree/{{site.branch}}/src/_includes/code/layout/lakes/main.dart)
   from GitHub.
 * Replace the `pubspec.yaml` file with
-  [`pubspec.yaml`](https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/layout/lakes/pubspec.yaml)
+  [pubspec.yaml]({{site.repo.this}}/tree/{{site.branch}}/src/_includes/code/layout/lakes/pubspec.yaml)
   from GitHub.
 * Create an `images` directory in your project, and add
-  [`lake.jpg`.](https://github.com/flutter/website/blob/master/src/_includes/code/layout/lakes/images/lake.jpg)
+  [lake.jpg.](https://github.com/flutter/website/tree/master/src/_includes/code/layout/lakes/images/lake.jpg)
 
 Once you have a connected and enabled device, or you've launched the [iOS
 simulator](/docs/get-started/install/macos#set-up-the-ios-simulator)
@@ -305,9 +305,9 @@ If you can't get your code to run, look in your IDE for possible errors.
 If you still can't find the problem,
 check your code against the interactive Lakes example on GitHub.
 
-* [`lib/main.dart`](https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/layout/lakes-interactive/main.dart)
-* [`pubspec.yaml`](https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/layout/lakes-interactive/pubspec.yaml)&mdash;no changes to this file
-* [`lakes.jpg`](https://github.com/flutter/website/blob/master/src/_includes/code/layout/lakes-interactive/images/lake.jpg)&mdash;no changes to this file
+* [lib/main.dart]({{site.repo.this}}/tree/{{site.branch}}/src/_includes/code/layout/lakes-interactive/main.dart)
+* [pubspec.yaml]({{site.repo.this}}/tree/{{site.branch}}/src/_includes/code/layout/lakes-interactive/pubspec.yaml)&mdash;no changes to this file
+* [lakes.jpg](https://github.com/flutter/website/tree/master/src/_includes/code/layout/lakes-interactive/images/lake.jpg)&mdash;no changes to this file
 
 If you still have questions, refer to [Get support.](/community)
 

--- a/src/docs/development/ui/layout/index.md
+++ b/src/docs/development/ui/layout/index.md
@@ -11,11 +11,11 @@ diff2html: true
 {% endcomment -%}
 
 {% assign api = 'https://docs.flutter.io/flutter' -%}
-{% assign code = 'https://raw.githubusercontent.com/flutter/website/master/src/_includes/code' -%}
-{% assign file = 'https://github.com/flutter/website/tree/master/src/_includes/code' -%}
-{% assign examples = 'https://github.com/flutter/website/tree/master/examples' -%}
-{% assign exFile = 'https://raw.githubusercontent.com/flutter/website/master/examples' -%}
-{% assign demo = 'https://github.com/flutter/flutter/blob/master/examples/flutter_gallery/lib/demo' -%}
+
+{% capture code -%} {{site.repo.this}}/tree/{{site.branch}}/src/_includes/code {%- endcapture -%}
+{% capture examples -%} {{site.repo.this}}/tree/{{site.branch}}/examples {%- endcapture -%}
+{% assign rawExFile = 'https://raw.githubusercontent.com/flutter/website/master/examples' -%}
+{% capture demo -%} {{site.repo.flutter}}/tree/{{site.branch}}/examples/flutter_gallery/lib/demo {%- endcapture -%}
 
 <style>dl, dd { margin-bottom: 0; }</style>
 
@@ -341,7 +341,7 @@ Three of the four column elements are now complete, leaving only the image.
 Add the image file to the example:
 
 * Create an `images` directory at the top of the project.
-* Add [`lake.jpg`]({{exFile}}/layout/lakes/step5/images/lake.jpg).
+* Add [`lake.jpg`]({{rawExFile}}/layout/lakes/step5/images/lake.jpg).
 
   {{site.alert.info}}
     Note that `wget` doesn't work for saving this binary file. The original image
@@ -770,7 +770,7 @@ horizontal space evenly between, before, and after each image.
   {% asset ui/layout/row-spaceevenly-visual.png class="mw-100" alt="Row with 3 evenly spaced images" %}
 
   **Dart code:** [main.dart]({{code}}/layout/row/main.dart)<br>
-  **Images:** [images]({{file}}/layout/row/images)<br>
+  **Images:** [images]({{code}}/layout/row/images)<br>
   **Pubspec:** [pubspec.yaml]({{code}}/layout/row/pubspec.yaml)
 </div>
 </div>
@@ -786,7 +786,7 @@ space evenly between, above, and below each image.
   {% include includelines filename="code/layout/column/main.dart" start=40 count=8 %}
 
   **Dart code:** [main.dart]({{code}}/layout/column/main.dart)<br>
-  **Images:** [images]({{file}}/layout/column/images)<br>
+  **Images:** [images]({{code}}/layout/column/images)<br>
   **Pubspec:** [pubspec.yaml]({{code}}/layout/column/pubspec.yaml)
 </div>
 <div class="col-lg-4 text-center">
@@ -829,7 +829,7 @@ as wide as the other two widgets, set the flex factor on the middle widget to 2:
       alt="Row of 3 images with the middle image twice as wide as the others" %}
 
   **Dart code:** [main.dart]({{code}}/layout/row-expanded/main.dart)<br>
-  **Images:** [images]({{file}}/layout/row-expanded/images)<br>
+  **Images:** [images]({{code}}/layout/row-expanded/images)<br>
   **Pubspec:** [pubspec.yaml]({{code}}/layout/row-expanded/pubspec.yaml)
 </div>
 </div>
@@ -849,7 +849,7 @@ the row to each widget.
       alt="Row of 3 images that are too wide, but each is constrained to take only 1/3 of the space" %}
 
   **Dart code:** [main.dart]({{code}}/layout/row-expanded-2/main.dart)<br>
-  **Images:** [images]({{file}}/layout/row-expanded-2/images)<br>
+  **Images:** [images]({{code}}/layout/row-expanded-2/images)<br>
   **Pubspec:** [pubspec.yaml]({{code}}/layout/row-expanded-2/pubspec.yaml)
 </div>
 </div>
@@ -1092,7 +1092,7 @@ body: Center(
 <div class="row">
 <div class="col-lg-3" markdown="1">
   **Dart code:** [main.dart]({{code}}/layout/pavlova/main.dart)<br>
-  **Images:** [images]({{file}}/layout/pavlova/images)<br>
+  **Images:** [images]({{code}}/layout/pavlova/images)<br>
   **Pubspec:** [pubspec.yaml]({{code}}/layout/pavlova/pubspec.yaml)
 </div>
 <div class="col-lg-9" markdown="1">
@@ -1180,7 +1180,7 @@ Gallery][].
   uses a Container to change the background color to a lighter grey.
 
   **Dart code:** [main.dart]({{code}}/layout/container/main.dart), snippet below<br>
-  **Images:** [images]({{file}}/layout/container/images)<br>
+  **Images:** [images]({{code}}/layout/container/images)<br>
   **Pubspec:** [pubspec.yaml]({{code}}/layout/container/pubspec.yaml)
 </div>
 <div class="col-lg-6 text-center">
@@ -1282,7 +1282,7 @@ it automatically scrolls.
   Uses `GridView.extent` to create a grid with tiles a maximum 150 pixels wide.
 
   **Dart code:** [main.dart]({{code}}/layout/grid/main.dart), snippet below<br>
-  **Images:** [images]({{file}}/layout/grid/images)<br>
+  **Images:** [images]({{code}}/layout/grid/images)<br>
   **Pubspec:** [pubspec.yaml]({{code}}/layout/grid/pubspec.yaml)
 </div>
 <div class="col-lg-6" markdown="1">
@@ -1457,7 +1457,7 @@ The widgets can completely or partially overlap the base widget.
   Alignments.
 
   **Dart code:** [main.dart]({{code}}/layout/stack/main.dart), snippet below<br>
-  **Image:** [images]({{file}}/layout/stack/images)<br>
+  **Image:** [images]({{code}}/layout/stack/images)<br>
   **Pubspec:** [pubspec.yaml]({{code}}/layout/stack/pubspec.yaml)
 </div>
 <div class="col-lg-5" markdown="1">


### PR DESCRIPTION
Fixes #2154 

I've checked that the new links are valid.

Staged, e.g., see:
- https://flutter-io-staging-2.firebaseapp.com/docs/development/ui/layout