### PR TITLE
Support for code excerpts with titles

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -90,10 +90,10 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "51d2db87b61146587973c08d949013b466fa3ae0"
+      resolved-ref: "07f2bc30285fc66f7723820e9ba8b4d1316dd707"
       url: "https://github.com/chalin/code_excerpt_updater.git"
     source: git
-    version: "0.16.0"
+    version: "0.16.1"
   code_excerpter:
     dependency: "direct dev"
     description:
@@ -249,7 +249,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.1.7"
   mime:
     dependency: transitive
     description:
@@ -291,7 +291,7 @@ packages:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.6"
+    version: "1.4.0"
   pub_semver:
     dependency: transitive
     description:
@@ -305,7 +305,7 @@ packages:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   quiver:
     dependency: transitive
     description:
@@ -333,7 +333,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.1"
+    version: "1.5.0"
   stack_trace:
     dependency: transitive
     description:
@@ -362,6 +362,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
+  term_glyph:
+    dependency: transitive
+    description:
+      name: term_glyph
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   timing:
     dependency: transitive
     description:

--- a/src/_assets/css/_bootstrap_config.scss
+++ b/src/_assets/css/_bootstrap_config.scss
@@ -77,3 +77,5 @@ $grid-gutter-width: 50px;
 
 $nav-tabs-link-active-color: $site-color-body;
 $nav-tabs-link-active-border-color: transparent transparent $site-color-primary;
+
+$tooltip-bg: #343a40 // $gray-800; // So we can see against black terminal bg

--- a/src/_assets/css/_code.scss
+++ b/src/_assets/css/_code.scss
@@ -46,6 +46,12 @@
 
   &__header {
     background-color: $gray-200;
-    padding: bs-spacer(3);
+    border-bottom: $border-width solid $border-color;
+    font-size: $site-spacer * .875;
+    font-weight: $font-weight-bold;
+    padding-top: bs-spacer(3);
+    padding-left: bs-spacer(4);
+    padding-right: bs-spacer(2);
+    padding-bottom: 0.67rem;
   }
 }

--- a/src/_plugins/code_excerpt_framer.rb
+++ b/src/_plugins/code_excerpt_framer.rb
@@ -1,0 +1,42 @@
+module DartSite
+
+  # Takes the given code excerpt (with the given attributes) and creates
+  # some framing HTML: e.g., a div with possible excerpt title in a header.
+  class CodeExcerptFramer
+    def frame_code(title, classes, attrs, escaped_code, indent)
+      _unindented_template(title, classes, attrs, escaped_code)
+    end
+
+    private
+    # @param [String] div_classes, in the form "foo bar"
+    # @param [Hash] attrs: attributes as attribute-name/value pairs.
+    def _unindented_template(title, _div_classes, attrs, escaped_code)
+      div_classes = ['code-excerpt']
+      div_classes << _div_classes if _div_classes
+
+      pre_classes = attrs[:class] || []
+      pre_classes.unshift("lang-#{attrs[:lang]}") if attrs[:lang]
+      pre_classes.unshift('prettyprint')
+
+      # Was:             <code>escaped_code</code>!n
+      # Also had: <copy-container></copy-container>
+
+      # Ensure that the template starts and ends with a blank line.
+      # We're rendering to markdown, and we don't want the frame HTML
+      # to be adjacent to any text, otherwise the text might not be rendered
+      # as a paragraph (e.g., esp. if inside an <li>).
+      <<~TEMPLATE.gsub(/!n\s*/,'').sub(/\bescaped_code\b/,escaped_code)
+      
+        <div class="#{div_classes * ' '}">
+        #{title ? "<div class=\"code-excerpt__header\">#{title}</div>" : '!n'}
+        <div class="code-excerpt__code">!n
+          <pre class="#{pre_classes * ' '}">!n
+            escaped_code!n
+          </pre>!n
+        </div>
+        </div>
+
+      TEMPLATE
+    end
+  end
+end

--- a/src/_plugins/markdown_converter.rb
+++ b/src/_plugins/markdown_converter.rb
@@ -1,0 +1,30 @@
+require_relative '../_shared/_plugins/markdown_with_code_excerpts'
+require_relative 'code_excerpt_framer'
+
+module Jekyll
+  module Converters
+
+    # Kramdown plugin extension.
+    #
+    # Converts markdown code blocks preceded by a processing instruction (PI) of the form
+    # <?code-excerpt?> into:
+    #
+    # - <code-example> elements suitable for use in Angular docs.
+    # - diff2html elements
+    #
+    class DartSiteMarkdown < Converter
+      priority :high
+
+      include MarkdownWithCodeExcerptsConverterMixin
+
+      def initialize(config = {})
+        super(config)
+        @cec = MarkdownWithCodeExcerpts.new(config, DartSite::CodeExcerptFramer.new)
+      end
+
+      def convert(content)
+        @cec.convert(content)
+      end
+    end
+  end
+end

--- a/src/_plugins/ng_markdown.rb
+++ b/src/_plugins/ng_markdown.rb
@@ -1,1 +1,0 @@
-../_shared/_plugins/ng_markdown.rb

--- a/src/docs/development/ui/layout/index.md
+++ b/src/docs/development/ui/layout/index.md
@@ -113,7 +113,8 @@ in variables and functions.
 First, you'll build the left column in the title section. Add the following code
 at the top of the `build()` method of the `MyApp` class:
 
-{% code_excerpt "lib/main.dart (titleSection)" %}
+<?code-excerpt "lib/main.dart (titleSection)" title?>
+```dart
 Widget titleSection = Container(
   padding: const EdgeInsets.all(32.0),
   child: Row(
@@ -151,7 +152,7 @@ Widget titleSection = Container(
     ],
   ),
 );
-{% endcode_excerpt %}
+```
 
 {:.numbered-code-notes}
  1. Putting a Column inside an Expanded widget stretches the column to use all
@@ -201,6 +202,8 @@ Add the title section to the app body like this:
 
 ### Step 3: Implement the button row
 
+<?code-excerpt path-base="layout/lakes/step3"?>
+
 The button section contains 3 columns that use the same layout&mdash;an
 icon over a row of text. The columns in this row are evenly spaced,
 and the text and icons are painted with the primary color.
@@ -210,7 +213,7 @@ helper method named `buildButtonColumn()`, which takes a color, an Icon and
 Text, and returns a column with its widgets painted in the given color.
 
 <!-- skip -->
-<?code-excerpt "step3/lib/main.dart (_buildButtonColumn)"?>
+<?code-excerpt "lib/main.dart (_buildButtonColumn)" title?>
 ```dart
 class MyApp extends StatelessWidget {
   @override
@@ -251,7 +254,7 @@ between, and after each column. Add the following code just below the
 `titleSection` declaration inside the `build()` method:
 
 <!-- skip -->
-<?code-excerpt "step3/lib/main.dart (buttonSection)"?>
+<?code-excerpt "lib/main.dart (buttonSection)" title?>
 ```dart
 Color color = Theme.of(context).primaryColor;
 
@@ -269,6 +272,7 @@ Widget buttonSection = Container(
 
 Add the button section to the body:
 
+<?code-excerpt path-base="layout/lakes"?>
 <?code-excerpt "step2/lib/main.dart" diff-with="step3/lib/main.dart" from="return MaterialApp" to="}"?>
 ```diff
 --- step2/lib/main.dart
@@ -291,12 +295,14 @@ Add the button section to the body:
 
 ### Step 4: Implement the text section
 
+<?code-excerpt path-base="layout/lakes/step4"?>
+
 Define the text section as a variable. Put the text in a Container and add
 padding along each edge. Add the following code just below the `buttonSection`
 declaration:
 
 <!-- skip -->
-<?code-excerpt "step4/lib/main.dart (textSection)"?>
+<?code-excerpt "lib/main.dart (textSection)" title?>
 ```dart
 Widget textSection = Container(
   padding: const EdgeInsets.all(32.0),
@@ -317,6 +323,7 @@ wrapping at a word boundary.
 
 Add the text section to the body:
 
+<?code-excerpt path-base="layout/lakes"?>
 <?code-excerpt "step3/lib/main.dart" diff-with="step4/lib/main.dart" from="return MaterialApp"?>
 ```diff
 --- step3/lib/main.dart
@@ -368,24 +375,24 @@ Add the image file to the example:
 
 Now you can reference the image from your code:
 
-  <?code-excerpt "step4/lib/main.dart" diff-with="step5/lib/main.dart"?>
-  ```diff
-  --- step4/lib/main.dart
-  +++ step5/lib/main.dart
-  @@ -77,6 +77,12 @@
-           ),
-           body: Column(
-             children: [
-  +            Image.asset(
-  +              'images/lake.jpg',
-  +              width: 600.0,
-  +              height: 240.0,
-  +              fit: BoxFit.cover,
-  +            ),
-               titleSection,
-               buttonSection,
-               textSection,
-  ```
+<?code-excerpt "step4/lib/main.dart" diff-with="step5/lib/main.dart"?>
+```diff
+--- step4/lib/main.dart
++++ step5/lib/main.dart
+@@ -77,6 +77,12 @@
+         ),
+         body: Column(
+           children: [
++            Image.asset(
++              'images/lake.jpg',
++              width: 600.0,
++              height: 240.0,
++              fit: BoxFit.cover,
++            ),
+             titleSection,
+             buttonSection,
+             textSection,
+```
 
 `BoxFit.cover` tells the framework that the image should be as small as
 possible but cover its entire render box.

--- a/src/docs/get-started/codelab.md
+++ b/src/docs/get-started/codelab.md
@@ -419,7 +419,7 @@ lazily, on demand.
     Also, add a `_biggerFont` variable for making the font size larger.
 
     <!-- skip -->
-    <?code-excerpt "lib/main.dart (RandomWordsState var)" title region="RWS-var" indent-by="2" replace="/final .*/[!$&!]/g"?>
+    <?code-excerpt "lib/main.dart" title region="RWS-var" indent-by="2" replace="/final .*/[!$&!]/g"?>
     ```dart
       class RandomWordsState extends State<RandomWords> {
         [!final _suggestions = <WordPair>[];!]

--- a/src/docs/get-started/codelab.md
+++ b/src/docs/get-started/codelab.md
@@ -13,7 +13,6 @@ diff2html: true
 {% assign code-url = 'https://raw.githubusercontent.com/flutter/codelabs/master' -%}
 
 {% asset get-started/startup-namer-part-1 alt="The app that you'll be building" class='site-image-right' %}
-<?code-excerpt path-base="codelabs/startup_namer"?>
 
 {%- comment %}
   Code highlights in this page are green, to match diff additions.
@@ -77,6 +76,8 @@ The animated GIF shows how the app works at the completion of part 1.
 
 ## Step 1: Create the starter Flutter app
 
+<?code-excerpt path-base="codelabs/startup_namer/1-base"?>
+
 Create a simple, templated Flutter app, using the instructions in
 [Getting Started with your first Flutter app.](/docs/get-started/test-drive#create-app)
 Name the project **startup_namer** (instead of _myapp_).
@@ -95,7 +96,7 @@ where the Dart code lives.
     Replace with the following code, which displays "Hello World" in the center
     of the screen.
 
-    <?code-excerpt "1-base/lib/main.dart"?>
+    <?code-excerpt "lib/main.dart" title?>
     ```dart
     import 'package:flutter/material.dart';
 
@@ -180,6 +181,7 @@ packages, on [the Package site](https://pub.dartlang.org/flutter).
     `pubspec.yaml`, add `english_words` (3.1.0 or higher) to the dependencies
     list:
 
+    <?code-excerpt path-base="codelabs/startup_namer"?>
     <?code-excerpt "1-base/pubspec.yaml" diff-with="2-use-package/pubspec.yaml" diff-u="4" from="dependencies" to="english"?>
     ```diff
     --- 1-base/pubspec.yaml
@@ -209,11 +211,12 @@ packages, on [the Package site](https://pub.dartlang.org/flutter).
  3. In `lib/main.dart`, import the new package:
 
     <!-- skip -->
-    <?code-excerpt "2-use-package/lib/main.dart" retain="/^import/" replace="/import.*?english.*/[!$&!]/g" indent-by="2"?>
-    {% prettify dart %}
+    <?code-excerpt path-base="codelabs/startup_namer/2-use-package"?>
+    <?code-excerpt "lib/main.dart" title retain="/^import/" replace="/import.*?english.*/[!$&!]/g" indent-by="2"?>
+    ```dart
       import 'package:flutter/material.dart';
       [!import 'package:english_words/english_words.dart';!]
-    {% endprettify %}
+    ```
 
     As you type, Android Studio gives you suggestions for libraries to import.
     It then renders the import string in gray, letting you know that the
@@ -222,6 +225,7 @@ packages, on [the Package site](https://pub.dartlang.org/flutter).
  4. Use the English words package to generate the text instead of
     using the string "Hello World":
 
+    <?code-excerpt path-base="codelabs/startup_namer"?>
     <?code-excerpt "1-base/lib/main.dart" diff-with="2-use-package/lib/main.dart" from="class"?>
     ```diff
     --- 1-base/lib/main.dart
@@ -276,6 +280,8 @@ use the code at the following links to get back on track.
 
 ## Step 3: Add a Stateful widget
 
+<?code-excerpt path-base="codelabs/startup_namer/3-stateful-widget"?>
+
 State<em>less</em> widgets are immutable, meaning that their
 properties can’t change&mdash;all values are final.
 
@@ -294,12 +300,12 @@ a child inside the existing `MyApp` stateless widget.
     of `main.dart`:
 
     <!-- skip -->
-    <?code-excerpt "3-stateful-widget/lib/main.dart (RWS-class-only)" plaster="// TODO Add build() method" indent-by="2"?>
-    {% prettify dart %}
+    <?code-excerpt "lib/main.dart (RandomWordsState)" title region="RWS-class-only" plaster="// TODO Add build() method" indent-by="2"?>
+    ```dart
       class RandomWordsState extends State<RandomWords> {
         // TODO Add build() method
       }
-    {% endprettify %}
+    ```
 
     Notice the declaration `State<RandomWords>`. This indicates that we're
     using the generic
@@ -317,13 +323,13 @@ a child inside the existing `MyApp` stateless widget.
     The `RandomWords` widget does little else beside creating its State class:
 
     <!-- skip -->
-    <?code-excerpt "3-stateful-widget/lib/main.dart (RandomWords)" indent-by="2"?>
-    {% prettify dart %}
+    <?code-excerpt "lib/main.dart (RandomWords)" title indent-by="2"?>
+    ```dart
       class RandomWords extends StatefulWidget {
         @override
         RandomWordsState createState() => new RandomWordsState();
       }
-    {% endprettify %}
+    ```
 
     After adding the state class, the IDE complains that
     the class is missing a build method. Next, you'll add a basic
@@ -333,8 +339,8 @@ a child inside the existing `MyApp` stateless widget.
  3. Add the `build()` method to `RandomWordsState`:
 
     <!-- skip -->
-    <?code-excerpt "3-stateful-widget/lib/main.dart (RandomWordsState)" indent-by="2" replace="/(\n  )(.*)/$1[!$2!]/g"?>
-    {% prettify dart %}
+    <?code-excerpt "lib/main.dart (RandomWordsState)" title indent-by="2" replace="/(\n  )(.*)/$1[!$2!]/g"?>
+    ```dart
       class RandomWordsState extends State<RandomWords> {
         [!@override!]
         [!Widget build(BuildContext context) {!]
@@ -342,11 +348,12 @@ a child inside the existing `MyApp` stateless widget.
         [!  return Text(wordPair.asPascalCase);!]
         [!}!]
       }
-    {% endprettify %}
+    ```
 
  4. Remove the word generation code from `MyApp` by making the changes shown in
     the following diff:
 
+    <?code-excerpt path-base="codelabs/startup_namer"?>
     <?code-excerpt "2-use-package/lib/main.dart" diff-with="3-stateful-widget/lib/main.dart" to="}"?>
     ```diff
     --- 2-use-package/lib/main.dart
@@ -399,6 +406,8 @@ at the following link to get back on track.
 
 ## Step 4: Create an infinite scrolling ListView
 
+<?code-excerpt path-base="codelabs/startup_namer/4-infinite-list"?>
+
 In this step, you'll expand `RandomWordsState` to generate
 and display a list of word pairings. As the user scrolls, the list
 displayed in a `ListView` widget, grows infinitely. `ListView`'s
@@ -410,14 +419,14 @@ lazily, on demand.
     Also, add a `_biggerFont` variable for making the font size larger.
 
     <!-- skip -->
-    <?code-excerpt "4-infinite-list/lib/main.dart (RWS-var)" indent-by="2" replace="/final .*/[!$&!]/g"?>
-    {% prettify dart %}
+    <?code-excerpt "lib/main.dart (RandomWordsState var)" title region="RWS-var" indent-by="2" replace="/final .*/[!$&!]/g"?>
+    ```dart
       class RandomWordsState extends State<RandomWords> {
         [!final _suggestions = <WordPair>[];!]
         [!final _biggerFont = const TextStyle(fontSize: 18.0);!]
         // ···
       }
-    {% endprettify %}
+    ```
 
     {{site.alert.note}}
       Prefixing an identifier with an underscore [enforces
@@ -440,8 +449,8 @@ lazily, on demand.
  2. Add a `_buildSuggestions()` function to the `RandomWordsState` class:
 
     <!-- skip -->
-    <?code-excerpt "4-infinite-list/lib/main.dart (_buildSuggestions)" indent-by="2"?>
-    {% prettify dart %}
+    <?code-excerpt "lib/main.dart (_buildSuggestions)" title indent-by="2"?>
+    ```dart
       Widget _buildSuggestions() {
         return ListView.builder(
             padding: const EdgeInsets.all(16.0),
@@ -455,7 +464,7 @@ lazily, on demand.
               return _buildRow(_suggestions[index]);
             });
       }
-    {% endprettify %}
+    ```
 
     {:.numbered-code-notes}
      1. The `itemBuilder` callback is called once per suggested word pairing,
@@ -478,8 +487,8 @@ lazily, on demand.
  3. Add a `_buildRow()` function to `RandomWordsState`:
 
     <!-- skip -->
-    <?code-excerpt "4-infinite-list/lib/main.dart (_buildRow)" indent-by="2"?>
-    {% prettify dart %}
+    <?code-excerpt "lib/main.dart (_buildRow)" title indent-by="2"?>
+    ```dart
       Widget _buildRow(WordPair pair) {
         return ListTile(
           title: Text(
@@ -488,7 +497,7 @@ lazily, on demand.
           ),
         );
       }
-    {% endprettify %}
+    ```
 
  4. In the `RandomWordsState` class, update the `build()` method to use
     `_buildSuggestions()`, rather than directly calling the word
@@ -498,8 +507,8 @@ lazily, on demand.
     Replace the method body with the highlighted code:
 
     <!-- skip -->
-    <?code-excerpt "4-infinite-list/lib/main.dart (RWS-build)" replace="/(\n  )(return.*|  .*|\);)/$1[!$2!]/g" indent-by="2"?>
-    {% prettify dart %}
+    <?code-excerpt "lib/main.dart (build)" title region="RWS-build" replace="/(\n  )(return.*|  .*|\);)/$1[!$2!]/g" indent-by="2"?>
+    ```dart
       @override
       Widget build(BuildContext context) {
         [!return Scaffold(!]
@@ -509,11 +518,12 @@ lazily, on demand.
         [!  body: _buildSuggestions(),!]
         [!);!]
       }
-    {% endprettify %}
+    ```
 
  5. In the `MyApp` class, update the `build()` method by changing the title, and
     changing the home to be a `RandomWords` widget:
 
+    <?code-excerpt path-base="codelabs/startup_namer"?>
     <?code-excerpt "3-stateful-widget/lib/main.dart" diff-with="4-infinite-list/lib/main.dart" diff-u="4" from="class MyApp" to="}"?>
     ```diff
     --- 3-stateful-widget/lib/main.dart

--- a/tool/extract.dart
+++ b/tool/extract.dart
@@ -57,9 +57,7 @@ int _processFile(File file) {
     } else if (lines[index].trim().startsWith('<!--')) {
       // Look for <!-- comment sections.
       int startIndex = index;
-      while (!lines[index].trim().endsWith('-->')) {
-        index++;
-      }
+      while (!lines[index].trim().endsWith('-->')) index++;
 
       lastComment = lines.sublist(startIndex, index + 1).join('\n').trim();
       lastComment = lastComment.substring(4);
@@ -68,6 +66,8 @@ int _processFile(File file) {
         lastComment = lastComment.substring(1);
       }
       lastComment = lastComment.substring(0, lastComment.length - 3);
+    } else if (lines[index].contains('<?code-') || lines[index].trim().isEmpty) {
+      // Carry on. In particular, don't reset lastComment.
     } else {
       lastComment = null;
     }
@@ -98,15 +98,11 @@ void _extractSnippet(
   print('  ${lines.length} line snippet ==> $path');
 }
 
-String _removeMarkup(String source) {
-  List<String> tags = ['strike', 'highlight', 'note', 'red'];
+final highlightRE = RegExp(r'\[\[/?(highlight|note|red|strike)\]\]');
+final abbreviatedHighlightRE = RegExp(r'\[!|!\]');
 
-  tags.forEach((String tag) {
-    source = source.replaceAll('\[\[$tag\]\]', '');
-    source = source.replaceAll('\[\[/$tag\]\]', '');
-  });
-  return source;
-}
+String _removeMarkup(String source) =>
+    source.replaceAll(highlightRE, '').replaceAll(abbreviatedHighlightRE, '');
 
 void clean() {
   var exampleDir = Directory(generatedExampleDirPath);


### PR DESCRIPTION
Support code-excerpt headers (containing the file as the text), simply by adding the `title` attribute to the `code-excerpt` processing instruction like this:

    <?code-excerpt "lib/main.dart (textSection)" title?>

This PR also:

- I've added titles to all code excerpts in the codelab and the layout "tutorial".
- Fixes spacing issues before/after code excerpts
- Fixes the contrast of the copy-code button tooltip (so that it doesn't blend in with terminal code excerpts).

Staged, e.g., see:

- https://flutter-io-staging-2.firebaseapp.com/docs/get-started/codelab#step-2-use-an-external-package
- https://flutter-io-staging-2.firebaseapp.com/docs/development/ui/layout#step-4-implement-the-text-section

### Screenshots

> <img width="560" alt="screen shot 2019-01-11 at 17 24 51" src="https://user-images.githubusercontent.com/4140793/51062728-0306dc80-15c6-11e9-92ac-7351c5b4896d.png">

> <img width="777" alt="screen shot 2019-01-11 at 17 25 13" src="https://user-images.githubusercontent.com/4140793/51062727-0306dc80-15c6-11e9-9483-7c85f58420ba.png">

### How it was before:

> <img width="582" alt="screen shot 2019-01-11 at 17 29 13" src="https://user-images.githubusercontent.com/4140793/51062901-a0faa700-15c6-11e9-8c6d-a0b9802a29e7.png">


cc @kwalrath 