### PR TITLE
Fix typo in path so copy/paste will work.

### DIFF
--- a/src/docs/get-started/install/_path-mac-linux.md
+++ b/src/docs/get-started/install/_path-mac-linux.md
@@ -16,7 +16,7 @@ a new window. For example:
     the path where you cloned Flutter's git repo:
 
     ```terminal
-    $ export PATH=$PATH:[PATH_TO_FLUTTER_GIT_DIRECTORY]/flutter/bin
+    $ export PATH=$PATH:[PATH_TO_FLUTTER_GIT_DIRECTORY]/bin
     ```
  4. Run `source $HOME/.bash_profile` to refresh the current window.
  5. Verify that the `flutter/bin` directory is now in your PATH by running:


### PR DESCRIPTION
[PATH_TO_FLUTTER_GIT_DIRECTORY] usually contains "flutter" so it will be duplicated; this change corrects that so that you the instructions work.