### PR TITLE
Add next/prev links to cookbook pages

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -412,7 +412,7 @@ packages:
     source: hosted
     version: "1.0.9"
   yaml:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: yaml
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ dev_dependencies:
   code_excerpt_updater: any
   code_excerpter: any
   linkcheck: ^2.0.6
+  yaml: ^2.1.15
 
 dependency_overrides:
   code_excerpt_updater:

--- a/src/docs/cookbook/animation/opacity-animation.md
+++ b/src/docs/cookbook/animation/opacity-animation.md
@@ -1,7 +1,7 @@
 ---
 title: Fade a Widget in and out
 next:
-  title: "Add a Drawer to a screen"
+  title: Add a Drawer to a screen
   path: /docs/cookbook/design/drawer
 ---
 

--- a/src/docs/cookbook/animation/opacity-animation.md
+++ b/src/docs/cookbook/animation/opacity-animation.md
@@ -1,5 +1,8 @@
 ---
 title: Fade a Widget in and out
+next:
+  title: "Add a Drawer to a screen"
+  path: /docs/cookbook/design/drawer
 ---
 
 As UI developers, we often need to show and hide elements on screen. However,

--- a/src/docs/cookbook/design/drawer.md
+++ b/src/docs/cookbook/design/drawer.md
@@ -1,5 +1,11 @@
 ---
 title: Add a Drawer to a screen
+prev:
+  title: "Fade a Widget in and out"
+  path: /docs/cookbook/animation/opacity-animation
+next:
+  title: "Displaying SnackBars"
+  path: /docs/cookbook/design/snackbars
 ---
 
 In apps that employ Material Design, there are two primary options for

--- a/src/docs/cookbook/design/drawer.md
+++ b/src/docs/cookbook/design/drawer.md
@@ -1,10 +1,10 @@
 ---
 title: Add a Drawer to a screen
 prev:
-  title: "Fade a Widget in and out"
+  title: Fade a Widget in and out
   path: /docs/cookbook/animation/opacity-animation
 next:
-  title: "Displaying SnackBars"
+  title: Displaying SnackBars
   path: /docs/cookbook/design/snackbars
 ---
 

--- a/src/docs/cookbook/design/fonts.md
+++ b/src/docs/cookbook/design/fonts.md
@@ -2,6 +2,12 @@
 title: Using custom fonts
 short-title: Custom fonts
 description: How to use custom fonts.
+prev:
+  title: "Using Themes to share colors and font styles"
+  path: /docs/cookbook/design/themes
+next:
+  title: "Working with Tabs"
+  path: /docs/cookbook/design/tabs
 ---
 
 While Android and iOS offer high quality system fonts, one of the most common

--- a/src/docs/cookbook/design/fonts.md
+++ b/src/docs/cookbook/design/fonts.md
@@ -3,10 +3,10 @@ title: Using custom fonts
 short-title: Custom fonts
 description: How to use custom fonts.
 prev:
-  title: "Using Themes to share colors and font styles"
+  title: Using Themes to share colors and font styles
   path: /docs/cookbook/design/themes
 next:
-  title: "Working with Tabs"
+  title: Working with Tabs
   path: /docs/cookbook/design/tabs
 ---
 

--- a/src/docs/cookbook/design/orientation.md
+++ b/src/docs/cookbook/design/orientation.md
@@ -1,10 +1,10 @@
 ---
 title: Updating the UI based on orientation
 prev:
-  title: "Exporting fonts from a package"
+  title: Exporting fonts from a package
   path: /docs/cookbook/design/package-fonts
 next:
-  title: "Using Themes to share colors and font styles"
+  title: Using Themes to share colors and font styles
   path: /docs/cookbook/design/themes
 ---
 

--- a/src/docs/cookbook/design/orientation.md
+++ b/src/docs/cookbook/design/orientation.md
@@ -1,5 +1,11 @@
 ---
 title: Updating the UI based on orientation
+prev:
+  title: "Exporting fonts from a package"
+  path: /docs/cookbook/design/package-fonts
+next:
+  title: "Using Themes to share colors and font styles"
+  path: /docs/cookbook/design/themes
 ---
 
 In certain cases, it can be handy to update the design of an app when the user

--- a/src/docs/cookbook/design/package-fonts.md
+++ b/src/docs/cookbook/design/package-fonts.md
@@ -1,10 +1,10 @@
 ---
 title: Exporting fonts from a package
 prev:
-  title: "Displaying SnackBars"
+  title: Displaying SnackBars
   path: /docs/cookbook/design/snackbars
 next:
-  title: "Updating the UI based on orientation"
+  title: Updating the UI based on orientation
   path: /docs/cookbook/design/orientation
 ---
 

--- a/src/docs/cookbook/design/package-fonts.md
+++ b/src/docs/cookbook/design/package-fonts.md
@@ -1,5 +1,11 @@
 ---
 title: Exporting fonts from a package
+prev:
+  title: "Displaying SnackBars"
+  path: /docs/cookbook/design/snackbars
+next:
+  title: "Updating the UI based on orientation"
+  path: /docs/cookbook/design/orientation
 ---
 
 Rather than declaring a font as part of our app, we can declare a font as part

--- a/src/docs/cookbook/design/snackbars.md
+++ b/src/docs/cookbook/design/snackbars.md
@@ -3,10 +3,10 @@ title: Displaying SnackBars
 short-title: SnackBars
 description: How to implement a SnackBar to display messages.
 prev:
-  title: "Add a Drawer to a screen"
+  title: Add a Drawer to a screen
   path: /docs/cookbook/design/drawer
 next:
-  title: "Exporting fonts from a package"
+  title: Exporting fonts from a package
   path: /docs/cookbook/design/package-fonts
 ---
 

--- a/src/docs/cookbook/design/snackbars.md
+++ b/src/docs/cookbook/design/snackbars.md
@@ -2,6 +2,12 @@
 title: Displaying SnackBars
 short-title: SnackBars
 description: How to implement a SnackBar to display messages.
+prev:
+  title: "Add a Drawer to a screen"
+  path: /docs/cookbook/design/drawer
+next:
+  title: "Exporting fonts from a package"
+  path: /docs/cookbook/design/package-fonts
 ---
 
 In some cases, it can be handy to briefly inform our users when certain actions

--- a/src/docs/cookbook/design/tabs.md
+++ b/src/docs/cookbook/design/tabs.md
@@ -1,10 +1,10 @@
 ---
 title: Working with Tabs
 prev:
-  title: "Using custom fonts"
+  title: Using custom fonts
   path: /docs/cookbook/design/fonts
 next:
-  title: "Building a form with validation"
+  title: Building a form with validation
   path: /docs/cookbook/forms/validation
 ---
 

--- a/src/docs/cookbook/design/tabs.md
+++ b/src/docs/cookbook/design/tabs.md
@@ -1,5 +1,11 @@
 ---
 title: Working with Tabs
+prev:
+  title: "Using custom fonts"
+  path: /docs/cookbook/design/fonts
+next:
+  title: "Building a form with validation"
+  path: /docs/cookbook/forms/validation
 ---
 
 Working with tabs is a common pattern in apps following the Material Design

--- a/src/docs/cookbook/design/themes.md
+++ b/src/docs/cookbook/design/themes.md
@@ -3,10 +3,10 @@ title: Using Themes to share colors and font styles
 short-title: Themes
 description: How to share colors and font styles throughout an app using Themes.
 prev:
-  title: "Updating the UI based on orientation"
+  title: Updating the UI based on orientation
   path: /docs/cookbook/design/orientation
 next:
-  title: "Using custom fonts"
+  title: Using custom fonts
   path: /docs/cookbook/design/fonts
 ---
 

--- a/src/docs/cookbook/design/themes.md
+++ b/src/docs/cookbook/design/themes.md
@@ -2,6 +2,12 @@
 title: Using Themes to share colors and font styles
 short-title: Themes
 description: How to share colors and font styles throughout an app using Themes.
+prev:
+  title: "Updating the UI based on orientation"
+  path: /docs/cookbook/design/orientation
+next:
+  title: "Using custom fonts"
+  path: /docs/cookbook/design/fonts
 ---
 
 In order to share colors and font styles throughout our app, we can take

--- a/src/docs/cookbook/forms/focus.md
+++ b/src/docs/cookbook/forms/focus.md
@@ -1,10 +1,10 @@
 ---
 title: Focus on a Text Field
 prev:
-  title: "Create and style a text field"
+  title: Create and style a text field
   path: /docs/cookbook/forms/text-input
 next:
-  title: "Handling changes to a text field"
+  title: Handling changes to a text field
   path: /docs/cookbook/forms/text-field-changes
 ---
 

--- a/src/docs/cookbook/forms/focus.md
+++ b/src/docs/cookbook/forms/focus.md
@@ -1,5 +1,11 @@
 ---
 title: Focus on a Text Field
+prev:
+  title: "Create and style a text field"
+  path: /docs/cookbook/forms/text-input
+next:
+  title: "Handling changes to a text field"
+  path: /docs/cookbook/forms/text-field-changes
 ---
 
 When a text field is selected and accepting input, it is said to have "focus."

--- a/src/docs/cookbook/forms/retrieve-input.md
+++ b/src/docs/cookbook/forms/retrieve-input.md
@@ -1,10 +1,10 @@
 ---
 title: Retrieve the value of a text field
 prev:
-  title: "Handling changes to a text field"
+  title: Handling changes to a text field
   path: /docs/cookbook/forms/text-field-changes
 next:
-  title: "Adding Material Touch Ripples"
+  title: Adding Material Touch Ripples
   path: /docs/cookbook/gestures/ripples
 ---
 

--- a/src/docs/cookbook/forms/retrieve-input.md
+++ b/src/docs/cookbook/forms/retrieve-input.md
@@ -1,5 +1,11 @@
 ---
 title: Retrieve the value of a text field
+prev:
+  title: "Handling changes to a text field"
+  path: /docs/cookbook/forms/text-field-changes
+next:
+  title: "Adding Material Touch Ripples"
+  path: /docs/cookbook/gestures/ripples
 ---
 
 In this recipe, we'll see how to retrieve the text a user has typed into a text

--- a/src/docs/cookbook/forms/text-field-changes.md
+++ b/src/docs/cookbook/forms/text-field-changes.md
@@ -1,10 +1,10 @@
 ---
 title: Handling changes to a text field
 prev:
-  title: "Focus on a Text Field"
+  title: Focus on a Text Field
   path: /docs/cookbook/forms/focus
 next:
-  title: "Retrieve the value of a text field"
+  title: Retrieve the value of a text field
   path: /docs/cookbook/forms/retrieve-input
 ---
 

--- a/src/docs/cookbook/forms/text-field-changes.md
+++ b/src/docs/cookbook/forms/text-field-changes.md
@@ -1,5 +1,11 @@
 ---
 title: Handling changes to a text field
+prev:
+  title: "Focus on a Text Field"
+  path: /docs/cookbook/forms/focus
+next:
+  title: "Retrieve the value of a text field"
+  path: /docs/cookbook/forms/retrieve-input
 ---
 
 In some cases, it can be handy to run a callback function every time the text

--- a/src/docs/cookbook/forms/text-input.md
+++ b/src/docs/cookbook/forms/text-input.md
@@ -1,10 +1,10 @@
 ---
 title: Create and style a text field
 prev:
-  title: "Building a form with validation"
+  title: Building a form with validation
   path: /docs/cookbook/forms/validation
 next:
-  title: "Focus on a Text Field"
+  title: Focus on a Text Field
   path: /docs/cookbook/forms/focus
 ---
 

--- a/src/docs/cookbook/forms/text-input.md
+++ b/src/docs/cookbook/forms/text-input.md
@@ -1,5 +1,11 @@
 ---
 title: Create and style a text field
+prev:
+  title: "Building a form with validation"
+  path: /docs/cookbook/forms/validation
+next:
+  title: "Focus on a Text Field"
+  path: /docs/cookbook/forms/focus
 ---
 
 Text fields allow users to type text into our apps. Text fields can be used to

--- a/src/docs/cookbook/forms/validation.md
+++ b/src/docs/cookbook/forms/validation.md
@@ -1,10 +1,10 @@
 ---
 title: Building a form with validation
 prev:
-  title: "Working with Tabs"
+  title: Working with Tabs
   path: /docs/cookbook/design/tabs
 next:
-  title: "Create and style a text field"
+  title: Create and style a text field
   path: /docs/cookbook/forms/text-input
 ---
 

--- a/src/docs/cookbook/forms/validation.md
+++ b/src/docs/cookbook/forms/validation.md
@@ -1,5 +1,11 @@
 ---
 title: Building a form with validation
+prev:
+  title: "Working with Tabs"
+  path: /docs/cookbook/design/tabs
+next:
+  title: "Create and style a text field"
+  path: /docs/cookbook/forms/text-input
 ---
 
 Apps often require users to enter information into a text field. For

--- a/src/docs/cookbook/gestures/dismissible.md
+++ b/src/docs/cookbook/gestures/dismissible.md
@@ -1,5 +1,11 @@
 ---
 title: Implement Swipe to Dismiss
+prev:
+  title: "Handling Taps"
+  path: /docs/cookbook/gestures/handling-taps
+next:
+  title: "Display images from the internet"
+  path: /docs/cookbook/images/network-image
 ---
 
 The "Swipe to dismiss" pattern is common in many mobile apps. For example, if

--- a/src/docs/cookbook/gestures/dismissible.md
+++ b/src/docs/cookbook/gestures/dismissible.md
@@ -1,10 +1,10 @@
 ---
 title: Implement Swipe to Dismiss
 prev:
-  title: "Handling Taps"
+  title: Handling Taps
   path: /docs/cookbook/gestures/handling-taps
 next:
-  title: "Display images from the internet"
+  title: Display images from the internet
   path: /docs/cookbook/images/network-image
 ---
 

--- a/src/docs/cookbook/gestures/handling-taps.md
+++ b/src/docs/cookbook/gestures/handling-taps.md
@@ -1,5 +1,11 @@
 ---
 title: Handling Taps
+prev:
+  title: "Adding Material Touch Ripples"
+  path: /docs/cookbook/gestures/ripples
+next:
+  title: "Implement Swipe to Dismiss"
+  path: /docs/cookbook/gestures/dismissible
 ---
 
 We not only want to display information to our users, we want our users to

--- a/src/docs/cookbook/gestures/handling-taps.md
+++ b/src/docs/cookbook/gestures/handling-taps.md
@@ -1,10 +1,10 @@
 ---
 title: Handling Taps
 prev:
-  title: "Adding Material Touch Ripples"
+  title: Adding Material Touch Ripples
   path: /docs/cookbook/gestures/ripples
 next:
-  title: "Implement Swipe to Dismiss"
+  title: Implement Swipe to Dismiss
   path: /docs/cookbook/gestures/dismissible
 ---
 

--- a/src/docs/cookbook/gestures/ripples.md
+++ b/src/docs/cookbook/gestures/ripples.md
@@ -1,10 +1,10 @@
 ---
 title: Adding Material Touch Ripples
 prev:
-  title: "Retrieve the value of a text field"
+  title: Retrieve the value of a text field
   path: /docs/cookbook/forms/retrieve-input
 next:
-  title: "Handling Taps"
+  title: Handling Taps
   path: /docs/cookbook/gestures/handling-taps
 ---
 

--- a/src/docs/cookbook/gestures/ripples.md
+++ b/src/docs/cookbook/gestures/ripples.md
@@ -1,5 +1,11 @@
 ---
 title: Adding Material Touch Ripples
+prev:
+  title: "Retrieve the value of a text field"
+  path: /docs/cookbook/forms/retrieve-input
+next:
+  title: "Handling Taps"
+  path: /docs/cookbook/gestures/handling-taps
 ---
 
 While designing an app that should follow the Material Design Guidelines, we'll

--- a/src/docs/cookbook/images/cached-images.md
+++ b/src/docs/cookbook/images/cached-images.md
@@ -1,5 +1,11 @@
 ---
 title: Working with cached images
+prev:
+  title: "Fade in images with a placeholder"
+  path: /docs/cookbook/images/fading-in-images
+next:
+  title: "Basic List"
+  path: /docs/cookbook/lists/basic-list
 ---
 
 In some cases, it can be handy to cache images as they're downloaded from the

--- a/src/docs/cookbook/images/cached-images.md
+++ b/src/docs/cookbook/images/cached-images.md
@@ -1,10 +1,10 @@
 ---
 title: Working with cached images
 prev:
-  title: "Fade in images with a placeholder"
+  title: Fade in images with a placeholder
   path: /docs/cookbook/images/fading-in-images
 next:
-  title: "Basic List"
+  title: Basic List
   path: /docs/cookbook/lists/basic-list
 ---
 

--- a/src/docs/cookbook/images/fading-in-images.md
+++ b/src/docs/cookbook/images/fading-in-images.md
@@ -1,5 +1,11 @@
 ---
 title: Fade in images with a placeholder
+prev:
+  title: "Display images from the internet"
+  path: /docs/cookbook/images/network-image
+next:
+  title: "Working with cached images"
+  path: /docs/cookbook/images/cached-images
 ---
 
 When displaying images using the default `Image` widget, you might notice they

--- a/src/docs/cookbook/images/fading-in-images.md
+++ b/src/docs/cookbook/images/fading-in-images.md
@@ -1,10 +1,10 @@
 ---
 title: Fade in images with a placeholder
 prev:
-  title: "Display images from the internet"
+  title: Display images from the internet
   path: /docs/cookbook/images/network-image
 next:
-  title: "Working with cached images"
+  title: Working with cached images
   path: /docs/cookbook/images/cached-images
 ---
 

--- a/src/docs/cookbook/images/network-image.md
+++ b/src/docs/cookbook/images/network-image.md
@@ -1,5 +1,11 @@
 ---
 title: Display images from the internet
+prev:
+  title: "Implement Swipe to Dismiss"
+  path: /docs/cookbook/gestures/dismissible
+next:
+  title: "Fade in images with a placeholder"
+  path: /docs/cookbook/images/fading-in-images
 ---
 
 Displaying images is fundamental for most mobile apps. Flutter provides the

--- a/src/docs/cookbook/images/network-image.md
+++ b/src/docs/cookbook/images/network-image.md
@@ -1,10 +1,10 @@
 ---
 title: Display images from the internet
 prev:
-  title: "Implement Swipe to Dismiss"
+  title: Implement Swipe to Dismiss
   path: /docs/cookbook/gestures/dismissible
 next:
-  title: "Fade in images with a placeholder"
+  title: Fade in images with a placeholder
   path: /docs/cookbook/images/fading-in-images
 ---
 

--- a/src/docs/cookbook/lists/basic-list.md
+++ b/src/docs/cookbook/lists/basic-list.md
@@ -1,10 +1,10 @@
 ---
 title: Basic List
 prev:
-  title: "Working with cached images"
+  title: Working with cached images
   path: /docs/cookbook/images/cached-images
 next:
-  title: "Create a horizontal list"
+  title: Create a horizontal list
   path: /docs/cookbook/lists/horizontal-list
 ---
 

--- a/src/docs/cookbook/lists/basic-list.md
+++ b/src/docs/cookbook/lists/basic-list.md
@@ -1,5 +1,11 @@
 ---
 title: Basic List
+prev:
+  title: "Working with cached images"
+  path: /docs/cookbook/images/cached-images
+next:
+  title: "Create a horizontal list"
+  path: /docs/cookbook/lists/horizontal-list
 ---
 
 Displaying lists of data is a fundamental pattern for mobile apps. Flutter

--- a/src/docs/cookbook/lists/grid-lists.md
+++ b/src/docs/cookbook/lists/grid-lists.md
@@ -1,10 +1,10 @@
 ---
 title: Creating a Grid List
 prev:
-  title: "Create a horizontal list"
+  title: Create a horizontal list
   path: /docs/cookbook/lists/horizontal-list
 next:
-  title: "Creating lists with different types of items"
+  title: Creating lists with different types of items
   path: /docs/cookbook/lists/mixed-list
 ---
 

--- a/src/docs/cookbook/lists/grid-lists.md
+++ b/src/docs/cookbook/lists/grid-lists.md
@@ -1,5 +1,11 @@
 ---
 title: Creating a Grid List
+prev:
+  title: "Create a horizontal list"
+  path: /docs/cookbook/lists/horizontal-list
+next:
+  title: "Creating lists with different types of items"
+  path: /docs/cookbook/lists/mixed-list
 ---
 
 In some cases, you might want to display your items as a Grid rather than

--- a/src/docs/cookbook/lists/horizontal-list.md
+++ b/src/docs/cookbook/lists/horizontal-list.md
@@ -1,5 +1,11 @@
 ---
 title: Create a horizontal list
+prev:
+  title: "Basic List"
+  path: /docs/cookbook/lists/basic-list
+next:
+  title: "Creating a Grid List"
+  path: /docs/cookbook/lists/grid-lists
 ---
 
 At times, you may want to create a List that scrolls horizontally rather than

--- a/src/docs/cookbook/lists/horizontal-list.md
+++ b/src/docs/cookbook/lists/horizontal-list.md
@@ -1,10 +1,10 @@
 ---
 title: Create a horizontal list
 prev:
-  title: "Basic List"
+  title: Basic List
   path: /docs/cookbook/lists/basic-list
 next:
-  title: "Creating a Grid List"
+  title: Creating a Grid List
   path: /docs/cookbook/lists/grid-lists
 ---
 

--- a/src/docs/cookbook/lists/long-lists.md
+++ b/src/docs/cookbook/lists/long-lists.md
@@ -1,10 +1,10 @@
 ---
 title: Working with long lists
 prev:
-  title: "Creating lists with different types of items"
+  title: Creating lists with different types of items
   path: /docs/cookbook/lists/mixed-list
 next:
-  title: "Report errors to a service"
+  title: Report errors to a service
   path: /docs/cookbook/maintenance/error-reporting
 ---
 

--- a/src/docs/cookbook/lists/long-lists.md
+++ b/src/docs/cookbook/lists/long-lists.md
@@ -1,5 +1,11 @@
 ---
 title: Working with long lists
+prev:
+  title: "Creating lists with different types of items"
+  path: /docs/cookbook/lists/mixed-list
+next:
+  title: "Report errors to a service"
+  path: /docs/cookbook/maintenance/error-reporting
 ---
 
 The standard [`ListView`](https://docs.flutter.io/flutter/widgets/ListView-class.html)

--- a/src/docs/cookbook/lists/mixed-list.md
+++ b/src/docs/cookbook/lists/mixed-list.md
@@ -1,10 +1,10 @@
 ---
 title: Creating lists with different types of items
 prev:
-  title: "Creating a Grid List"
+  title: Creating a Grid List
   path: /docs/cookbook/lists/grid-lists
 next:
-  title: "Working with long lists"
+  title: Working with long lists
   path: /docs/cookbook/lists/long-lists
 ---
 

--- a/src/docs/cookbook/lists/mixed-list.md
+++ b/src/docs/cookbook/lists/mixed-list.md
@@ -1,5 +1,11 @@
 ---
 title: Creating lists with different types of items
+prev:
+  title: "Creating a Grid List"
+  path: /docs/cookbook/lists/grid-lists
+next:
+  title: "Working with long lists"
+  path: /docs/cookbook/lists/long-lists
 ---
 
 We often need to create lists that display different types of content. For

--- a/src/docs/cookbook/maintenance/error-reporting.md
+++ b/src/docs/cookbook/maintenance/error-reporting.md
@@ -1,5 +1,11 @@
 ---
 title: Report errors to a service
+prev:
+  title: "Working with long lists"
+  path: /docs/cookbook/lists/long-lists
+next:
+  title: "Animating a Widget across screens"
+  path: /docs/cookbook/navigation/hero-animations
 ---
 
 While we always do our best to create apps that are free of bugs, they're sure

--- a/src/docs/cookbook/maintenance/error-reporting.md
+++ b/src/docs/cookbook/maintenance/error-reporting.md
@@ -1,10 +1,10 @@
 ---
 title: Report errors to a service
 prev:
-  title: "Working with long lists"
+  title: Working with long lists
   path: /docs/cookbook/lists/long-lists
 next:
-  title: "Animating a Widget across screens"
+  title: Animating a Widget across screens
   path: /docs/cookbook/navigation/hero-animations
 ---
 

--- a/src/docs/cookbook/navigation/hero-animations.md
+++ b/src/docs/cookbook/navigation/hero-animations.md
@@ -1,10 +1,10 @@
 ---
 title: Animating a Widget across screens
 prev:
-  title: "Report errors to a service"
+  title: Report errors to a service
   path: /docs/cookbook/maintenance/error-reporting
 next:
-  title: "Navigate to a new screen and back"
+  title: Navigate to a new screen and back
   path: /docs/cookbook/navigation/navigation-basics
 ---
 

--- a/src/docs/cookbook/navigation/hero-animations.md
+++ b/src/docs/cookbook/navigation/hero-animations.md
@@ -1,5 +1,11 @@
 ---
 title: Animating a Widget across screens
+prev:
+  title: "Report errors to a service"
+  path: /docs/cookbook/maintenance/error-reporting
+next:
+  title: "Navigate to a new screen and back"
+  path: /docs/cookbook/navigation/navigation-basics
 ---
 
 It's often helpful to guide users through our apps as they navigate from screen

--- a/src/docs/cookbook/navigation/named-routes.md
+++ b/src/docs/cookbook/navigation/named-routes.md
@@ -1,10 +1,10 @@
 ---
 title: Navigate with named routes
 prev:
-  title: "Navigate to a new screen and back"
+  title: Navigate to a new screen and back
   path: /docs/cookbook/navigation/navigation-basics
 next:
-  title: "Return data from a screen"
+  title: Return data from a screen
   path: /docs/cookbook/navigation/returning-data
 ---
 

--- a/src/docs/cookbook/navigation/named-routes.md
+++ b/src/docs/cookbook/navigation/named-routes.md
@@ -1,5 +1,11 @@
 ---
 title: Navigate with named routes
+prev:
+  title: "Navigate to a new screen and back"
+  path: /docs/cookbook/navigation/navigation-basics
+next:
+  title: "Return data from a screen"
+  path: /docs/cookbook/navigation/returning-data
 ---
 
 In the

--- a/src/docs/cookbook/navigation/navigation-basics.md
+++ b/src/docs/cookbook/navigation/navigation-basics.md
@@ -2,10 +2,10 @@
 title: Navigate to a new screen and back
 description: How to navigate between routes
 prev:
-  title: "Animating a Widget across screens"
+  title: Animating a Widget across screens
   path: /docs/cookbook/navigation/hero-animations
 next:
-  title: "Navigate with named routes"
+  title: Navigate with named routes
   path: /docs/cookbook/navigation/named-routes
 ---
 

--- a/src/docs/cookbook/navigation/navigation-basics.md
+++ b/src/docs/cookbook/navigation/navigation-basics.md
@@ -1,6 +1,12 @@
 ---
 title: Navigate to a new screen and back
 description: How to navigate between routes
+prev:
+  title: "Animating a Widget across screens"
+  path: /docs/cookbook/navigation/hero-animations
+next:
+  title: "Navigate with named routes"
+  path: /docs/cookbook/navigation/named-routes
 ---
 
 Most apps contain several screens for displaying different types of information.
@@ -30,7 +36,7 @@ using these steps:
 
 ## 1. Create two routes
 
-First, create two routes to work with. Since this is a basic example, 
+First, create two routes to work with. Since this is a basic example,
 each route contains only a single button. Tapping the button on the
 first route navigates to the second route. Tapping the button on the
 second route returns to the first route.

--- a/src/docs/cookbook/navigation/passing-data.md
+++ b/src/docs/cookbook/navigation/passing-data.md
@@ -1,5 +1,11 @@
 ---
 title: Send data to a new screen
+prev:
+  title: "Return data from a screen"
+  path: /docs/cookbook/navigation/returning-data
+next:
+  title: "Fetch data from the internet"
+  path: /docs/cookbook/networking/fetch-data
 ---
 
 Oftentimes, we not only want to navigate to a new screen, but also pass some

--- a/src/docs/cookbook/navigation/passing-data.md
+++ b/src/docs/cookbook/navigation/passing-data.md
@@ -1,10 +1,10 @@
 ---
 title: Send data to a new screen
 prev:
-  title: "Return data from a screen"
+  title: Return data from a screen
   path: /docs/cookbook/navigation/returning-data
 next:
-  title: "Fetch data from the internet"
+  title: Fetch data from the internet
   path: /docs/cookbook/networking/fetch-data
 ---
 

--- a/src/docs/cookbook/navigation/returning-data.md
+++ b/src/docs/cookbook/navigation/returning-data.md
@@ -1,10 +1,10 @@
 ---
 title: Return data from a screen
 prev:
-  title: "Navigate with named routes"
+  title: Navigate with named routes
   path: /docs/cookbook/navigation/named-routes
 next:
-  title: "Send data to a new screen"
+  title: Send data to a new screen
   path: /docs/cookbook/navigation/passing-data
 ---
 

--- a/src/docs/cookbook/navigation/returning-data.md
+++ b/src/docs/cookbook/navigation/returning-data.md
@@ -1,5 +1,11 @@
 ---
 title: Return data from a screen
+prev:
+  title: "Navigate with named routes"
+  path: /docs/cookbook/navigation/named-routes
+next:
+  title: "Send data to a new screen"
+  path: /docs/cookbook/navigation/passing-data
 ---
 
 In some cases, we might want to return data from a new screen. For example, say

--- a/src/docs/cookbook/networking/authenticated-requests.md
+++ b/src/docs/cookbook/networking/authenticated-requests.md
@@ -1,10 +1,10 @@
 ---
 title: Making authenticated requests
 prev:
-  title: "Fetch data from the internet"
+  title: Fetch data from the internet
   path: /docs/cookbook/networking/fetch-data
 next:
-  title: "Parsing JSON in the background"
+  title: Parsing JSON in the background
   path: /docs/cookbook/networking/background-parsing
 ---
 

--- a/src/docs/cookbook/networking/authenticated-requests.md
+++ b/src/docs/cookbook/networking/authenticated-requests.md
@@ -1,5 +1,11 @@
 ---
 title: Making authenticated requests
+prev:
+  title: "Fetch data from the internet"
+  path: /docs/cookbook/networking/fetch-data
+next:
+  title: "Parsing JSON in the background"
+  path: /docs/cookbook/networking/background-parsing
 ---
 
 In order to fetch data from many web services, you need to provide

--- a/src/docs/cookbook/networking/background-parsing.md
+++ b/src/docs/cookbook/networking/background-parsing.md
@@ -1,5 +1,11 @@
 ---
 title: Parsing JSON in the background
+prev:
+  title: "Making authenticated requests"
+  path: /docs/cookbook/networking/authenticated-requests
+next:
+  title: "Working with WebSockets"
+  path: /docs/cookbook/networking/web-sockets
 ---
 
 By default, Dart apps do all of their work on a single thread. In many cases,

--- a/src/docs/cookbook/networking/background-parsing.md
+++ b/src/docs/cookbook/networking/background-parsing.md
@@ -1,10 +1,10 @@
 ---
 title: Parsing JSON in the background
 prev:
-  title: "Making authenticated requests"
+  title: Making authenticated requests
   path: /docs/cookbook/networking/authenticated-requests
 next:
-  title: "Working with WebSockets"
+  title: Working with WebSockets
   path: /docs/cookbook/networking/web-sockets
 ---
 

--- a/src/docs/cookbook/networking/fetch-data.md
+++ b/src/docs/cookbook/networking/fetch-data.md
@@ -1,5 +1,11 @@
 ---
 title: Fetch data from the internet
+prev:
+  title: "Send data to a new screen"
+  path: /docs/cookbook/navigation/passing-data
+next:
+  title: "Making authenticated requests"
+  path: /docs/cookbook/networking/authenticated-requests
 ---
 
 Fetching data from the internet is necessary for most apps. Luckily, Dart and

--- a/src/docs/cookbook/networking/fetch-data.md
+++ b/src/docs/cookbook/networking/fetch-data.md
@@ -1,10 +1,10 @@
 ---
 title: Fetch data from the internet
 prev:
-  title: "Send data to a new screen"
+  title: Send data to a new screen
   path: /docs/cookbook/navigation/passing-data
 next:
-  title: "Making authenticated requests"
+  title: Making authenticated requests
   path: /docs/cookbook/networking/authenticated-requests
 ---
 

--- a/src/docs/cookbook/networking/web-sockets.md
+++ b/src/docs/cookbook/networking/web-sockets.md
@@ -1,5 +1,11 @@
 ---
 title: Working with WebSockets
+prev:
+  title: "Parsing JSON in the background"
+  path: /docs/cookbook/networking/background-parsing
+next:
+  title: "Reading and Writing Files"
+  path: /docs/cookbook/persistence/reading-writing-files
 ---
 
 In addition to normal HTTP requests, we can connect to servers using WebSockets.

--- a/src/docs/cookbook/networking/web-sockets.md
+++ b/src/docs/cookbook/networking/web-sockets.md
@@ -1,10 +1,10 @@
 ---
 title: Working with WebSockets
 prev:
-  title: "Parsing JSON in the background"
+  title: Parsing JSON in the background
   path: /docs/cookbook/networking/background-parsing
 next:
-  title: "Reading and Writing Files"
+  title: Reading and Writing Files
   path: /docs/cookbook/persistence/reading-writing-files
 ---
 

--- a/src/docs/cookbook/persistence/key-value.md
+++ b/src/docs/cookbook/persistence/key-value.md
@@ -1,5 +1,11 @@
 ---
 title: Storing key-value data on disk
+prev:
+  title: "Reading and Writing Files"
+  path: /docs/cookbook/persistence/reading-writing-files
+next:
+  title: "An introduction to integration testing"
+  path: /docs/cookbook/testing/integration/introduction
 ---
 
 If we have a relatively small collection of key-values that we'd like to save,

--- a/src/docs/cookbook/persistence/key-value.md
+++ b/src/docs/cookbook/persistence/key-value.md
@@ -1,10 +1,10 @@
 ---
 title: Storing key-value data on disk
 prev:
-  title: "Reading and Writing Files"
+  title: Reading and Writing Files
   path: /docs/cookbook/persistence/reading-writing-files
 next:
-  title: "An introduction to integration testing"
+  title: An introduction to integration testing
   path: /docs/cookbook/testing/integration/introduction
 ---
 

--- a/src/docs/cookbook/persistence/reading-writing-files.md
+++ b/src/docs/cookbook/persistence/reading-writing-files.md
@@ -1,5 +1,11 @@
 ---
 title: Reading and Writing Files
+prev:
+  title: "Working with WebSockets"
+  path: /docs/cookbook/networking/web-sockets
+next:
+  title: "Storing key-value data on disk"
+  path: /docs/cookbook/persistence/key-value
 ---
 
 In some cases, it can be handy to read and write files to disk. This can be

--- a/src/docs/cookbook/persistence/reading-writing-files.md
+++ b/src/docs/cookbook/persistence/reading-writing-files.md
@@ -1,10 +1,10 @@
 ---
 title: Reading and Writing Files
 prev:
-  title: "Working with WebSockets"
+  title: Working with WebSockets
   path: /docs/cookbook/networking/web-sockets
 next:
-  title: "Storing key-value data on disk"
+  title: Storing key-value data on disk
   path: /docs/cookbook/persistence/key-value
 ---
 

--- a/src/docs/cookbook/testing/integration/introduction.md
+++ b/src/docs/cookbook/testing/integration/introduction.md
@@ -1,6 +1,12 @@
 ---
 title: An introduction to integration testing
 short-title: Introduction
+prev:
+  title: "Storing key-value data on disk"
+  path: /docs/cookbook/persistence/key-value
+next:
+  title: "Performance profiling"
+  path: /docs/cookbook/testing/integration/profiling
 ---
 
 Unit tests and Widget tests are handy for testing individual classes, functions,

--- a/src/docs/cookbook/testing/integration/introduction.md
+++ b/src/docs/cookbook/testing/integration/introduction.md
@@ -2,10 +2,10 @@
 title: An introduction to integration testing
 short-title: Introduction
 prev:
-  title: "Storing key-value data on disk"
+  title: Storing key-value data on disk
   path: /docs/cookbook/persistence/key-value
 next:
-  title: "Performance profiling"
+  title: Performance profiling
   path: /docs/cookbook/testing/integration/profiling
 ---
 

--- a/src/docs/cookbook/testing/integration/profiling.md
+++ b/src/docs/cookbook/testing/integration/profiling.md
@@ -1,10 +1,10 @@
 ---
 title: Performance profiling
 prev:
-  title: "An introduction to integration testing"
+  title: An introduction to integration testing
   path: /docs/cookbook/testing/integration/introduction
 next:
-  title: "Scrolling"
+  title: Scrolling
   path: /docs/cookbook/testing/integration/scrolling
 ---
 

--- a/src/docs/cookbook/testing/integration/profiling.md
+++ b/src/docs/cookbook/testing/integration/profiling.md
@@ -1,5 +1,11 @@
 ---
 title: Performance profiling
+prev:
+  title: "An introduction to integration testing"
+  path: /docs/cookbook/testing/integration/introduction
+next:
+  title: "Scrolling"
+  path: /docs/cookbook/testing/integration/scrolling
 ---
 
 When it comes to mobile apps, performance is critical to user experience. Users

--- a/src/docs/cookbook/testing/integration/scrolling.md
+++ b/src/docs/cookbook/testing/integration/scrolling.md
@@ -1,5 +1,11 @@
 ---
 title: Scrolling
+prev:
+  title: "Performance profiling"
+  path: /docs/cookbook/testing/integration/profiling
+next:
+  title: "An introduction to unit testing"
+  path: /docs/cookbook/testing/unit/introduction
 ---
 
 Many apps feature lists of content, from email clients to music apps and beyond.

--- a/src/docs/cookbook/testing/integration/scrolling.md
+++ b/src/docs/cookbook/testing/integration/scrolling.md
@@ -1,10 +1,10 @@
 ---
 title: Scrolling
 prev:
-  title: "Performance profiling"
+  title: Performance profiling
   path: /docs/cookbook/testing/integration/profiling
 next:
-  title: "An introduction to unit testing"
+  title: An introduction to unit testing
   path: /docs/cookbook/testing/unit/introduction
 ---
 

--- a/src/docs/cookbook/testing/unit/introduction.md
+++ b/src/docs/cookbook/testing/unit/introduction.md
@@ -2,10 +2,10 @@
 title: An introduction to unit testing
 short-title: Introduction
 prev:
-  title: "Scrolling"
+  title: Scrolling
   path: /docs/cookbook/testing/integration/scrolling
 next:
-  title: "Mock dependencies using Mockito"
+  title: Mock dependencies using Mockito
   path: /docs/cookbook/testing/unit/mocking
 ---
 

--- a/src/docs/cookbook/testing/unit/introduction.md
+++ b/src/docs/cookbook/testing/unit/introduction.md
@@ -1,6 +1,12 @@
 ---
 title: An introduction to unit testing
 short-title: Introduction
+prev:
+  title: "Scrolling"
+  path: /docs/cookbook/testing/integration/scrolling
+next:
+  title: "Mock dependencies using Mockito"
+  path: /docs/cookbook/testing/unit/mocking
 ---
 
 How can we ensure that our apps continue to work as we add more features or

--- a/src/docs/cookbook/testing/unit/mocking.md
+++ b/src/docs/cookbook/testing/unit/mocking.md
@@ -2,10 +2,10 @@
 title: Mock dependencies using Mockito
 short-title: Mocking
 prev:
-  title: "An introduction to unit testing"
+  title: An introduction to unit testing
   path: /docs/cookbook/testing/unit/introduction
 next:
-  title: "An introduction to widget testing"
+  title: An introduction to widget testing
   path: /docs/cookbook/testing/widget/introduction
 ---
 

--- a/src/docs/cookbook/testing/unit/mocking.md
+++ b/src/docs/cookbook/testing/unit/mocking.md
@@ -1,6 +1,12 @@
 ---
 title: Mock dependencies using Mockito
 short-title: Mocking
+prev:
+  title: "An introduction to unit testing"
+  path: /docs/cookbook/testing/unit/introduction
+next:
+  title: "An introduction to widget testing"
+  path: /docs/cookbook/testing/widget/introduction
 ---
 
 In certain cases, unit tests may depend on classes that fetch data from live

--- a/src/docs/cookbook/testing/widget/finders.md
+++ b/src/docs/cookbook/testing/widget/finders.md
@@ -1,10 +1,10 @@
 ---
 title: Finding widgets
 prev:
-  title: "An introduction to widget testing"
+  title: An introduction to widget testing
   path: /docs/cookbook/testing/widget/introduction
 next:
-  title: "Tapping, dragging and entering text"
+  title: Tapping, dragging and entering text
   path: /docs/cookbook/testing/widget/tap-drag
 ---
 

--- a/src/docs/cookbook/testing/widget/finders.md
+++ b/src/docs/cookbook/testing/widget/finders.md
@@ -1,5 +1,11 @@
 ---
 title: Finding widgets
+prev:
+  title: "An introduction to widget testing"
+  path: /docs/cookbook/testing/widget/introduction
+next:
+  title: "Tapping, dragging and entering text"
+  path: /docs/cookbook/testing/widget/tap-drag
 ---
 
 {% assign api = site.api | append: '/flutter' -%}

--- a/src/docs/cookbook/testing/widget/introduction.md
+++ b/src/docs/cookbook/testing/widget/introduction.md
@@ -2,10 +2,10 @@
 title: An introduction to widget testing
 short-title: Introduction
 prev:
-  title: "Mock dependencies using Mockito"
+  title: Mock dependencies using Mockito
   path: /docs/cookbook/testing/unit/mocking
 next:
-  title: "Finding widgets"
+  title: Finding widgets
   path: /docs/cookbook/testing/widget/finders
 ---
 

--- a/src/docs/cookbook/testing/widget/introduction.md
+++ b/src/docs/cookbook/testing/widget/introduction.md
@@ -1,6 +1,12 @@
 ---
 title: An introduction to widget testing
 short-title: Introduction
+prev:
+  title: "Mock dependencies using Mockito"
+  path: /docs/cookbook/testing/unit/mocking
+next:
+  title: "Finding widgets"
+  path: /docs/cookbook/testing/widget/finders
 ---
 
 {% assign api = site.api | append: '/flutter' -%}

--- a/src/docs/cookbook/testing/widget/tap-drag.md
+++ b/src/docs/cookbook/testing/widget/tap-drag.md
@@ -1,7 +1,7 @@
 ---
 title: Tapping, dragging and entering text
 prev:
-  title: "Finding widgets"
+  title: Finding widgets
   path: /docs/cookbook/testing/widget/finders
 ---
 

--- a/src/docs/cookbook/testing/widget/tap-drag.md
+++ b/src/docs/cookbook/testing/widget/tap-drag.md
@@ -1,5 +1,8 @@
 ---
 title: Tapping, dragging and entering text
+prev:
+  title: "Finding widgets"
+  path: /docs/cookbook/testing/widget/finders
 ---
 
 {% assign api = site.api | append: '/flutter' -%}

--- a/tool/next_prev.dart
+++ b/tool/next_prev.dart
@@ -5,6 +5,7 @@ import 'package:yaml/yaml.dart';
 
 const frontMatterMarker = '---';
 
+/// Update the frontmatter entries for next/prev page links of all cookbook pages.
 void main(List<String> args) {
   if (!File('pubspec.yaml').existsSync()) {
     _warn('This tool must be run from the project root.');
@@ -35,14 +36,12 @@ List<Page> _getPageList() {
   return pages.toList();
 }
 
-List<Page> _sortPageList(List<Page> pageList) {
-  final list = pageList
-    ..sort((a, b) {
-      var dirComp = a.dir.compareTo(b.dir);
-      return dirComp != 0 ? dirComp : a.title.compareTo(b.title);
-    });
-  return list.toList(); // .getRange(0, 3)
-}
+List<Page> _sortPageList(List<Page> pageList) => pageList
+  ..sort((a, b) {
+    var dirComp = a.dir.compareTo(b.dir);
+    return dirComp != 0 ? dirComp : a.title.compareTo(b.title);
+  })
+  ..toList(); // .getRange(0, 3)
 
 void _doublyLinkPages(List<Page> orderedPageList) {
   Page prev;

--- a/tool/next_prev.dart
+++ b/tool/next_prev.dart
@@ -5,7 +5,7 @@ import 'package:yaml/yaml.dart';
 
 const frontMatterMarker = '---';
 
-/// Update the frontmatter entries for next/prev page links of all cookbook pages.
+/// Update the front matter next/prev entries of all cookbook pages.
 void main(List<String> args) {
   if (!File('pubspec.yaml').existsSync()) {
     _warn('This tool must be run from the project root.');
@@ -41,7 +41,7 @@ List<Page> _sortPageList(List<Page> pageList) => pageList
     var dirComp = a.dir.compareTo(b.dir);
     return dirComp != 0 ? dirComp : a.title.compareTo(b.title);
   })
-  ..toList(); // .getRange(0, 3)
+  ..toList();
 
 void _doublyLinkPages(List<Page> orderedPageList) {
   Page prev;
@@ -55,8 +55,6 @@ void _doublyLinkPages(List<Page> orderedPageList) {
 }
 
 void _updatePageLinks(Page page) {
-  print('>> processing ${page.path}');
-
   yamlRemoveKey(page.frontMatter, 'prev');
   yamlRemoveKey(page.frontMatter, 'next');
 
@@ -80,8 +78,10 @@ void yamlRemoveKey(List<String> frontMatter, String key) {
 void yamlAppendKey(List<String> frontMatter, String key, Page page) {
   // Add the key
   var i = frontMatter.length;
+  var title = page.title;
+  if (title.contains('"')) title = '"' + title + '"';
   frontMatter.insert(i++, '$key:');
-  frontMatter.insert(i++, '  title: "${page.title}"');
+  frontMatter.insert(i++, '  title: $title');
   frontMatter.insert(i++, '  path: ${page.path}');
 }
 
@@ -98,7 +98,7 @@ class Page {
   Page(this.file) {
     dir = p.dirname(file.path);
     path = file.path.substring('src'.length); // Skip 'src' prefix
-    path = path.substring(0, path.length - '.md'.length);
+    path = path.substring(0, path.length - '.md'.length); // Drop '.md' suffix
     _readAndParsePage();
   }
 

--- a/tool/next_prev.dart
+++ b/tool/next_prev.dart
@@ -108,14 +108,14 @@ class Page {
 
     if (lines[0] != frontMatterMarker) {
       _warn('Jekyll frontmatter expected but none found: ${file.path}');
-      return null;
+      return;
     }
 
     final endOfFrontMatterIndex = lines.indexOf(frontMatterMarker, 1);
     if (endOfFrontMatterIndex < 0) {
       _warn(
           'Jekyll frontmatter has no ending "$frontMatterMarker" marker: ${file.path}');
-      return null;
+      return;
     }
 
     frontMatter = lines.getRange(1, endOfFrontMatterIndex).toList();

--- a/tool/next_prev.dart
+++ b/tool/next_prev.dart
@@ -1,0 +1,139 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+const frontMatterMarker = '---';
+
+void main(List<String> args) {
+  if (!File('pubspec.yaml').existsSync()) {
+    _warn('This tool must be run from the project root.');
+    exit(1);
+  }
+
+  final pageList = _getPageList();
+  final orderedPageList = _sortPageList(pageList);
+
+  _doublyLinkPages(orderedPageList);
+  orderedPageList.forEach(_updatePageLinks);
+
+  print('Processed ${orderedPageList.length} pages.');
+}
+
+List<Page> _getPageList() {
+  final basePath = 'src/docs/cookbook';
+
+  Iterable<FileSystemEntity> files = Directory(basePath)
+      .listSync(recursive: true)
+      .where((FileSystemEntity entity) =>
+          entity is File &&
+          entity.path.endsWith('.md') &&
+          !entity.path.contains('index.md'));
+
+  Iterable<Page> pages = files.map((e) => Page(e)).where((p) => p.rest != null);
+
+  return pages.toList();
+}
+
+List<Page> _sortPageList(List<Page> pageList) {
+  final list = pageList
+    ..sort((a, b) {
+      var dirComp = a.dir.compareTo(b.dir);
+      return dirComp != 0 ? dirComp : a.title.compareTo(b.title);
+    });
+  return list.toList(); // .getRange(0, 3)
+}
+
+void _doublyLinkPages(List<Page> orderedPageList) {
+  Page prev;
+  for (final page in orderedPageList) {
+    if (prev != null) {
+      prev.next = page;
+      page.prev = prev;
+    }
+    prev = page;
+  }
+}
+
+void _updatePageLinks(Page page) {
+  print('>> processing ${page.path}');
+
+  yamlRemoveKey(page.frontMatter, 'prev');
+  yamlRemoveKey(page.frontMatter, 'next');
+
+  if (page.prev != null) yamlAppendKey(page.frontMatter, 'prev', page.prev);
+  if (page.next != null) yamlAppendKey(page.frontMatter, 'next', page.next);
+
+  page.file.writeAsStringSync(page.content);
+}
+
+void _warn(String msg) => print("WARNING: $msg");
+
+void yamlRemoveKey(List<String> frontMatter, String key) {
+  var i = frontMatter.indexOf('$key:');
+  if (i < 0) return;
+  frontMatter.removeAt(i);
+  while (i < frontMatter.length && frontMatter[i].startsWith(' ')) {
+    frontMatter.removeAt(i);
+  }
+}
+
+void yamlAppendKey(List<String> frontMatter, String key, Page page) {
+  // Add the key
+  var i = frontMatter.length;
+  frontMatter.insert(i++, '$key:');
+  frontMatter.insert(i++, '  title: "${page.title}"');
+  frontMatter.insert(i++, '  path: ${page.path}');
+}
+
+class Page {
+  final File file;
+  String title;
+  String path;
+  String dir;
+
+  // @nullable
+  Page prev, next;
+  List<String> frontMatter, rest;
+
+  Page(this.file) {
+    dir = p.dirname(file.path);
+    path = file.path.substring('src'.length); // Skip 'src' prefix
+    path = path.substring(0, path.length - '.md'.length);
+    _readAndParsePage();
+  }
+
+  void _readAndParsePage() {
+    final content = file.readAsStringSync();
+    final lines = content.split('\n');
+
+    if (lines[0] != frontMatterMarker) {
+      _warn('Jekyll frontmatter expected but none found: ${file.path}');
+      return null;
+    }
+
+    final endOfFrontMatterIndex = lines.indexOf(frontMatterMarker, 1);
+    if (endOfFrontMatterIndex < 0) {
+      _warn(
+          'Jekyll frontmatter has no ending "$frontMatterMarker" marker: ${file.path}');
+      return null;
+    }
+
+    frontMatter = lines.getRange(1, endOfFrontMatterIndex).toList();
+    rest = lines.getRange(endOfFrontMatterIndex + 1, lines.length).toList();
+
+    final yaml = loadYaml(frontMatter.join('\n'));
+    title = yaml['title'];
+  }
+
+  String get content {
+    final output = [frontMatterMarker];
+    output.addAll(frontMatter);
+    output.add(frontMatterMarker);
+    output.addAll(rest);
+    return output.join('\n');
+  }
+
+  @override
+  String toString() => '$path';
+}

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -1,7 +1,0 @@
-name: prdeployer
-version: 0.0.1
-dependencies:
-  firebase: ^3.0.0
-  github:
-    git: git://github.com/FaisalAbid/github.dart.git
-


### PR DESCRIPTION
Fixes #1370. All cookbook pages are linked together now, even across sections.

The cookbook page front matter is updated using `tool/next_prev.dart`.

Followup:
- Run `dart tool/next_prev.dart` as part of CI or a pre-commit check #2217

Staged, e.g., see https://flutter-io-staging-2.firebaseapp.com/docs/cookbook

### Screenshot

> <img width="799" alt="screen shot 2019-01-16 at 09 36 08" src="https://user-images.githubusercontent.com/4140793/51256270-022dcc00-1973-11e9-84fd-f8552d044e63.png">

cc @brianegan 