### PR TITLE
Widget catalog: list widget categories in alphabetical order

### DIFF
--- a/src/docs/development/ui/widgets/index.md
+++ b/src/docs/development/ui/widgets/index.md
@@ -8,7 +8,8 @@ platform, and interactive widgets. In addition to browsing widgets by category,
 you can also see all the widgets in the [widget index](/docs/reference/widgets).
 
 <div class="card-deck card-deck--responsive">
-{% for section in site.data.catalog.index %}
+{% assign categories = site.data.catalog.index | sort: 'name' -%}
+{% for section in categories %}
     <div class="card">
         <div class="card-body">
             <a href="{{page.url}}{{section.id}}"><header class="card-title">{{section.name}}</header></a>


### PR DESCRIPTION
Fixes #1895 

### Before

> <img width="939" alt="screen shot 2019-01-16 at 11 28 04" src="https://user-images.githubusercontent.com/4140793/51263422-38bf1300-1982-11e9-9c4b-4d92745279fe.png">

### After

> <img width="922" alt="screen shot 2019-01-16 at 11 30 31" src="https://user-images.githubusercontent.com/4140793/51263406-3066d800-1982-11e9-8eb3-cc4ffd1a3c21.png">
