### PR TITLE
Ensure `Get started > Test drive` page is mobile friendly

### DIFF
--- a/src/_assets/css/_code.scss
+++ b/src/_assets/css/_code.scss
@@ -1,5 +1,7 @@
 @import '_code_pre';
 
+pre > span.strike { text-decoration: line-through; }
+
 .numbered-code-notes {
   list-style-type: none;
   padding-left: 0;

--- a/src/docs/get-started/test-drive/_androidstudio.md
+++ b/src/docs/get-started/test-drive/_androidstudio.md
@@ -18,7 +18,7 @@ contains a simple demo app that uses [Material Components][].
 ## Run the app
 
  1. Locate the main Android Studio toolbar:<br>
-    ![Main IntelliJ toolbar][]
+    ![Main IntelliJ toolbar][]{:.mw-100}
  1. In the **target selector**, select an Android device for running the app.
     If none are listed as available, select **Tools> Android > AVD Manager** and
     create one there. For details, see [Managing AVDs][].

--- a/src/docs/get-started/test-drive/_try-hot-reload.md
+++ b/src/docs/get-started/test-drive/_try-hot-reload.md
@@ -13,13 +13,16 @@ want to hot reload, and see the change in your simulator, emulator, or device.
 
  1. Open `lib/main.dart`.
  1. Change the string
-    <code class="text-nowrap">
-    'You have <del>pushed</del> the button this many times'
-    </code>
+    {% prettify dart %}
+      'You have [[strike]]pushed[[/strike]] the button this many times'
+    {% endprettify %}
+    {:.mb-3}
+
     to
-    <code class="text-nowrap">
-      'You have <ins>clicked</ins> the button this many times'
-    </code>.
+    {% prettify dart %}
+      'You have [!clicked!] the button this many times'
+    {% endprettify %}
+    {:.mb-2}
 
     {{site.alert.important}}
       Do _not_ stop your app. Let your app run.


### PR DESCRIPTION
Fixes #1794
Contributes to #1951

Staged at https://flutter-io-staging-2.firebaseapp.com/docs/get-started/test-drive