### PR TITLE
Adjust links to main cookbook unit testing page

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -21,7 +21,7 @@
       { "source": "/docs/cookbook/testing/integration-test-profiling", "destination": "/docs/cookbook/testing/integration/profiling", "type": 301 },
       { "source": "/docs/cookbook/testing/integration-test-scrolling", "destination": "/docs/cookbook/testing/integration/scrolling", "type": 301 },
       { "source": "/docs/cookbook/testing/mocking", "destination": "/docs/cookbook/testing/unit/mocking", "type": 301 },
-      { "source": "/docs/cookbook/testing/unit-test", "destination": "/docs/cookbook/testing/unit", "type": 301 },
+      { "source": "/docs/cookbook/testing/unit-test", "destination": "/docs/cookbook/testing/unit/introduction", "type": 301 },
       { "source": "/docs/cookbook/testing/widget-test-finders", "destination": "/docs/cookbook/testing/widget/finders", "type": 301 },
       { "source": "/docs/cookbook/testing/widget-test-introduction", "destination": "/docs/cookbook/testing/widget", "type": 301 },
       { "source": "/docs/cookbook/testing/widget-test-tap-drag", "destination": "/docs/cookbook/testing/widget/tap-drag", "type": 301 },

--- a/src/docs/cookbook/networking/fetch-data.md
+++ b/src/docs/cookbook/networking/fetch-data.md
@@ -209,7 +209,7 @@ class _MyAppState extends State<MyApp> {
 For information on how to test this functionality, please see the following
 recipes:
 
-  * [Introduction to unit testing](/docs/cookbook/testing/unit)
+  * [Introduction to unit testing](/docs/cookbook/testing/unit/introduction)
   * [Mock dependencies using Mockito](/docs/cookbook/testing/unit/mocking)
 
 ## Complete example

--- a/src/docs/cookbook/testing/unit/mocking.md
+++ b/src/docs/cookbook/testing/unit/mocking.md
@@ -92,7 +92,7 @@ Future<Post> fetchPost(http.Client client) async {
 
 Next, we'll need to create our test file along with a `MockClient` class.
 Following the advice in the
-[Introduction to unit testing](/docs/cookbook/testing/unit/) recipe, we will
+[Introduction to unit testing](/docs/cookbook/testing/unit/introduction) recipe, we will
 create a file called `fetch_post_test.dart` file in the root `test` folder.
 
 The `MockClient` class will implement the `http.Client` class. This will allow
@@ -167,7 +167,7 @@ $ flutter test test/counter_test.dart
 
 You can also run tests inside your favorite editor by following the instructions
 in the
-[Introduction to unit testing](/docs/cookbook/testing/unit#run-tests-using-intellij-or-vscode)
+[Introduction to unit testing](/docs/cookbook/testing/unit/introduction#run-tests-using-intellij-or-vscode)
 recipe.
 
 ### Summary

--- a/src/docs/cookbook/testing/widget/introduction.md
+++ b/src/docs/cookbook/testing/widget/introduction.md
@@ -11,7 +11,7 @@ next:
 
 {% assign api = site.api | append: '/flutter' -%}
 
-In the [introduction to unit testing](/docs/cookbook/testing/unit) recipe, we
+In the [introduction to unit testing](/docs/cookbook/testing/unit/introduction) recipe, we
 learned how to test Dart classes using the `test` package. In order to test
 Widget classes, we'll need a few additional tools provided by the
 [`flutter_test`]({{api}}/flutter_test/flutter_test-library.html)


### PR DESCRIPTION
The main page used to be in `index.md` but it was recently changed (back) to `introduction.md`. The index page is now only used as a destination for the breadcrumb "Unit" crumb target.