### PR TITLE
Don't use raw github repo images in examples

### DIFF
--- a/src/docs/cookbook/images/cached-images.md
+++ b/src/docs/cookbook/images/cached-images.md
@@ -19,7 +19,7 @@ placeholders and fading images in as they're loaded!
 <!-- skip -->
 ```dart
 CachedNetworkImage(
-  imageUrl: 'https://github.com/flutter/website/blob/master/src/_includes/code/layout/lakes/images/lake.jpg?raw=true',
+  imageUrl: 'https://picsum.photos/250?image=9',
 );
 ```
 
@@ -32,7 +32,7 @@ In this example, we'll display a spinner while the image loads.
 ```dart
 CachedNetworkImage(
   placeholder: CircularProgressIndicator(),
-  imageUrl: 'https://github.com/flutter/website/blob/master/src/_includes/code/layout/lakes/images/lake.jpg?raw=true',
+  imageUrl: 'https://picsum.photos/250?image=9',
 );
 ```
 
@@ -62,7 +62,7 @@ class MyApp extends StatelessWidget {
           child: CachedNetworkImage(
             placeholder: CircularProgressIndicator(),
             imageUrl:
-                'https://github.com/flutter/website/blob/master/src/_includes/code/layout/lakes/images/lake.jpg?raw=true',
+                'https://picsum.photos/250?image=9',
           ),
         ),
       ),

--- a/src/docs/cookbook/images/fading-in-images.md
+++ b/src/docs/cookbook/images/fading-in-images.md
@@ -59,8 +59,7 @@ class MyApp extends StatelessWidget {
             Center(
               child: FadeInImage.memoryNetwork(
                 placeholder: kTransparentImage,
-                image:
-                    'https://picsum.photos/250?image=9',
+                image: 'https://picsum.photos/250?image=9',
               ),
             ),
           ],

--- a/src/docs/cookbook/images/fading-in-images.md
+++ b/src/docs/cookbook/images/fading-in-images.md
@@ -119,8 +119,7 @@ class MyApp extends StatelessWidget {
         body: Center(
           child: FadeInImage.assetNetwork(
             placeholder: 'assets/loading.gif',
-            image:
-                'https://picsum.photos/250?image=9',
+            image: 'https://picsum.photos/250?image=9',
           ),
         ),
       ),

--- a/src/docs/cookbook/images/fading-in-images.md
+++ b/src/docs/cookbook/images/fading-in-images.md
@@ -28,7 +28,7 @@ package for a simple transparent placeholder.
 ```dart
 FadeInImage.memoryNetwork(
   placeholder: kTransparentImage,
-  image: 'https://github.com/flutter/website/blob/master/src/_includes/code/layout/lakes/images/lake.jpg?raw=true',
+  image: 'https://picsum.photos/250?image=9',
 );
 ```
 
@@ -60,7 +60,7 @@ class MyApp extends StatelessWidget {
               child: FadeInImage.memoryNetwork(
                 placeholder: kTransparentImage,
                 image:
-                    'https://github.com/flutter/website/blob/master/src/_includes/code/layout/lakes/images/lake.jpg?raw=true',
+                    'https://picsum.photos/250?image=9',
               ),
             ),
           ],
@@ -93,7 +93,7 @@ constructor:
 ```dart
 FadeInImage.assetNetwork(
   placeholder: 'assets/loading.gif',
-  image: 'https://github.com/flutter/website/blob/master/src/_includes/code/layout/lakes/images/lake.jpg?raw=true',
+  image: 'https://picsum.photos/250?image=9',
 );
 ```
 
@@ -121,7 +121,7 @@ class MyApp extends StatelessWidget {
           child: FadeInImage.assetNetwork(
             placeholder: 'assets/loading.gif',
             image:
-                'https://github.com/flutter/website/blob/master/src/_includes/code/layout/lakes/images/lake.jpg?raw=true',
+                'https://picsum.photos/250?image=9',
           ),
         ),
       ),

--- a/src/docs/cookbook/images/network-image.md
+++ b/src/docs/cookbook/images/network-image.md
@@ -18,7 +18,7 @@ constructor.
 <!-- skip -->
 ```dart
 Image.network(
-  'https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/layout/lakes/images/lake.jpg',
+  'https://picsum.photos/250?image=9',
 )
 ```
 
@@ -63,7 +63,7 @@ class MyApp extends StatelessWidget {
           title: Text(title),
         ),
         body: Image.network(
-          'https://github.com/flutter/website/blob/master/src/_includes/code/layout/lakes/images/lake.jpg?raw=true',
+          'https://picsum.photos/250?image=9',
         ),
       ),
     );

--- a/src/docs/cookbook/navigation/hero-animations.md
+++ b/src/docs/cookbook/navigation/hero-animations.md
@@ -48,7 +48,7 @@ class MainScreen extends StatelessWidget {
           }));
         },
         child: Image.network(
-          'https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/layout/lakes/images/lake.jpg',
+          'https://picsum.photos/250?image=9',
         ),
       ),
     );
@@ -65,7 +65,7 @@ class DetailScreen extends StatelessWidget {
         },
         child: Center(
           child: Image.network(
-            'https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/layout/lakes/images/lake.jpg',
+            'https://picsum.photos/250?image=9',
           ),
         ),
       ),
@@ -89,7 +89,7 @@ requires two arguments:
 Hero(
   tag: 'imageHero',
   child: Image.network(
-    'https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/layout/lakes/images/lake.jpg',
+    'https://picsum.photos/250?image=9',
   ),
 );
 ```
@@ -108,7 +108,7 @@ screens will work!
 Hero(
   tag: 'imageHero',
   child: Image.network(
-    'https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/layout/lakes/images/lake.jpg',
+    'https://picsum.photos/250?image=9',
   ),
 );
 ```
@@ -145,7 +145,7 @@ class MainScreen extends StatelessWidget {
         child: Hero(
           tag: 'imageHero',
           child: Image.network(
-            'https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/layout/lakes/images/lake.jpg',
+            'https://picsum.photos/250?image=9',
           ),
         ),
         onTap: () {
@@ -167,7 +167,7 @@ class DetailScreen extends StatelessWidget {
           child: Hero(
             tag: 'imageHero',
             child: Image.network(
-              'https://raw.githubusercontent.com/flutter/website/master/src/_includes/code/layout/lakes/images/lake.jpg',
+              'https://picsum.photos/250?image=9',
             ),
           ),
         ),


### PR DESCRIPTION
Some code referred to an image in the repo (via github.com or raw.githubusercontent.com), but that image doesn't exist anymore. Instead, we're now using an image from https://picsum.photos.

cc @brianegan 