### PR TITLE
Fix code-block spacing, and drop the few manual adjustments

### DIFF
--- a/src/_assets/css/_code.scss
+++ b/src/_assets/css/_code.scss
@@ -1,5 +1,10 @@
 @import '_code_pre';
 
+// Give code blocks the same margin-bottom as regular paragraphs.
+div.highlighter-rouge {
+  margin-bottom: bs-spacer(4);
+}
+
 pre > span.strike { text-decoration: line-through; }
 
 .numbered-code-notes {
@@ -22,11 +27,14 @@ pre > span.strike { text-decoration: line-through; }
   }
 }
 
-.code-excerpt {
-  border: $border-width solid $border-color;
-  margin-bottom: bs-spacer(4);
+@mixin code-excerpt-border($side: '') {
+  border#{$side}: $border-width solid $border-color;
+}
 
+.code-excerpt {
   &__code {
+    @include code-excerpt-border;
+    margin-bottom: bs-spacer(4);
     position: relative;
 
     pre {
@@ -48,7 +56,9 @@ pre > span.strike { text-decoration: line-through; }
 
   &__header {
     background-color: $gray-200;
-    border-bottom: $border-width solid $border-color;
+    @include code-excerpt-border('-top');
+    @include code-excerpt-border('-left');
+    @include code-excerpt-border('-right');
     font-size: $site-spacer * .875;
     font-weight: $font-weight-bold;
     padding-top: bs-spacer(3);

--- a/src/docs/development/accessibility-and-localization/accessibility.md
+++ b/src/docs/development/accessibility-and-localization/accessibility.md
@@ -57,7 +57,7 @@ The following two screenshots show the standard Flutter app template rendered
 with the default iOS font setting, and with the largest font setting selected in
 iOS accessibility settings.
 
-<div class="row mb-4">
+<div class="row">
   <div class="col-md-6">
     {% include app-figure.md image="a18n/app-regular-fonts.png" caption="Default font setting" img-class="border" %}
   </div>

--- a/src/docs/get-started/test-drive/_try-hot-reload.md
+++ b/src/docs/get-started/test-drive/_try-hot-reload.md
@@ -13,16 +13,16 @@ want to hot reload, and see the change in your simulator, emulator, or device.
 
  1. Open `lib/main.dart`.
  1. Change the string
+
     {% prettify dart %}
       'You have [[strike]]pushed[[/strike]] the button this many times'
     {% endprettify %}
-    {:.mb-3}
 
     to
+
     {% prettify dart %}
       'You have [!clicked!] the button this many times'
     {% endprettify %}
-    {:.mb-2}
 
     {{site.alert.important}}
       Do _not_ stop your app. Let your app run.


### PR DESCRIPTION
Fixes #2242. See the issue for before screenshots

### After

> <img width="835" alt="screen shot 2019-01-18 at 17 54 32" src="https://user-images.githubusercontent.com/4140793/51417026-2e4f7580-1b4a-11e9-9306-1b4a54175c13.png">

> <img width="651" alt="screen shot 2019-01-18 at 17 54 16" src="https://user-images.githubusercontent.com/4140793/51417027-2e4f7580-1b4a-11e9-94f2-71142c162f52.png">

cc @kwalrath 