### PR TITLE
Test-drive / VS Code: make mobile-friendly

### DIFF
--- a/src/docs/get-started/test-drive/_vscode.md
+++ b/src/docs/get-started/test-drive/_vscode.md
@@ -17,7 +17,7 @@ contains a simple demo app that uses [Material Components][].
 ## Run the app
 
  1. Locate the VS Code status bar (the blue bar at the bottom of the
-    window):<br> ![status bar][]{:width="450px"}
+    window):<br> ![status bar][]{:.mw-100}
  1. Select a device from the **Device Selector** area.
     For details, see [Quickly switching between Flutter devices][].
     - If no device is available and you want to use a device simulator,


### PR DESCRIPTION
Contributes to #1951

### Screenshots

Before:
<img width="500" alt="screen shot 2019-01-25 at 13 52 31" src="https://user-images.githubusercontent.com/4140793/51766408-7cafc780-20a8-11e9-90f8-3214aafe5ee6.png">

After:
<img width="500" alt="screen shot 2019-01-25 at 13 52 12" src="https://user-images.githubusercontent.com/4140793/51766410-7cafc780-20a8-11e9-9210-374b252f793d.png">

cc @sfshaza2 