### PR TITLE
Layout row example - fix code excerpt

### DIFF
--- a/examples/layout/row/lib/main.dart
+++ b/examples/layout/row/lib/main.dart
@@ -6,42 +6,27 @@ void main() {
   runApp(MyApp());
 }
 
-// #docregion MyApp
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter layout demo',
-      home: MyHomePage(title: 'Flutter layout demo'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key, this.title}) : super(key: key);
-
-  final String title;
-
-  @override
-  _MyHomePageState createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.title),
-      ),
-      body: Center(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            Image.asset('images/pic1.jpg'),
-            Image.asset('images/pic2.jpg'),
-            Image.asset('images/pic3.jpg'),
-          ],
+      home: Scaffold(
+        appBar: AppBar(
+          title: Text('Flutter layout demo'),
         ),
+        // #docregion body
+        body: Center(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              Image.asset('images/pic1.jpg'),
+              Image.asset('images/pic2.jpg'),
+              Image.asset('images/pic3.jpg'),
+            ],
+          ),
+        ),
+        // #enddocregion body
       ),
     );
   }

--- a/examples/layout/row/test/widget_test.dart
+++ b/examples/layout/row/test/widget_test.dart
@@ -15,5 +15,6 @@ void main() {
     await tester.pumpWidget(MyApp());
 
     expect(find.text('Flutter layout demo'), findsOneWidget);
+    // TODO: test more app features.
   });
 }

--- a/src/docs/development/ui/layout/index.md
+++ b/src/docs/development/ui/layout/index.md
@@ -308,7 +308,7 @@ classes offer a variety of constants for controlling alignment.
   you need to update the pubspec file to access them&mdash;this
   example uses `Image.asset` to display the images.  For more information,
   see this example's [pubspec.yaml
-  file]({{code}}/layout/row/pubspec.yaml),
+  file]({{examples}}/layout/row/pubspec.yaml),
   or [Adding Assets and Images in Flutter](/docs/development/ui/assets-and-images).
   You don't need to do this if you're referencing online images using
   `Image.network`.
@@ -320,15 +320,27 @@ so setting the main axis alignment to `spaceEvenly` divides the free
 horizontal space evenly between, before, and after each image.
 
 <div class="row">
-<div class="col-lg-8">
-  {% include includelines filename="code/layout/row/main.dart" start=40 count=8 %}
+<div class="col-lg-8" markdown="1">
+  <?code-excerpt "layout/row/lib/main.dart (body)"?>
+  ```dart
+  body: Center(
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        Image.asset('images/pic1.jpg'),
+        Image.asset('images/pic2.jpg'),
+        Image.asset('images/pic3.jpg'),
+      ],
+    ),
+  ),
+  ```
 </div>
 <div class="col-lg-4" markdown="1">
   {% asset ui/layout/row-spaceevenly-visual.png class="mw-100" alt="Row with 3 evenly spaced images" %}
 
-  **Dart code:** [main.dart]({{code}}/layout/row/main.dart)<br>
-  **Images:** [images]({{code}}/layout/row/images)<br>
-  **Pubspec:** [pubspec.yaml]({{code}}/layout/row/pubspec.yaml)
+  **Dart code:** [main.dart]({{examples}}/layout/row/lib/main.dart)<br>
+  **Images:** [images]({{examples}}/layout/row/images)<br>
+  **Pubspec:** [pubspec.yaml]({{examples}}/layout/row/pubspec.yaml)
 </div>
 </div>
 


### PR DESCRIPTION
Contributes to #2233 

Before (code inclusion used to be line base, but somehow the line numbers must have changed, since the excerpt is incomplete):

> <img width="767" alt="screen shot 2019-01-28 at 12 22 45" src="https://user-images.githubusercontent.com/4140793/51854063-d8bc5b00-22f7-11e9-9e42-6463d5685e48.png">

After (using named code regions ensures that we dont' run into this problem again):

> <img width="764" alt="screen shot 2019-01-28 at 12 22 56" src="https://user-images.githubusercontent.com/4140793/51854062-d8bc5b00-22f7-11e9-9e82-c4878ccaac7a.png">

cc @sfshaza2 