### PR TITLE
Remove unnecessary VS Code relaunch step.

### DIFF
--- a/src/docs/get-started/editor.md
+++ b/src/docs/get-started/editor.md
@@ -72,7 +72,6 @@ VS Code is a light-weight editor with Flutter app execution and debug support.
  1. Type "install", and select **Extensions: Install Extensions**.
  1. Type "flutter" in the extensions search field, select **Flutter** in the list,
     and click **Install**. This also installs the required Dart plugin.
- 1. Click **Reload to Activate** to reload VS Code.
 
 ## Validate your setup with the Flutter Doctor
 


### PR DESCRIPTION
[VS Code no longer requires a relaunch after an extension is installed/uninstalled/enabled/disabled](https://code.visualstudio.com/updates/v1_31), so the **Reload to Activate** button is no longer shown.