### PR TITLE
Trim VSCode install instructions in editor.md

### DIFF
--- a/src/docs/get-started/editor.md
+++ b/src/docs/get-started/editor.md
@@ -72,7 +72,6 @@ VS Code is a light-weight editor with Flutter app execution and debug support.
  1. Type "install", and select **Extensions: Install Extensions**.
  1. Type "flutter" in the extensions search field, select **Flutter** in the list,
     and click **Install**. This also installs the required Dart plugin.
- 1. Click **Reload to Activate** to reload VS Code.
 
 ## Validate your setup with the Flutter Doctor
 


### PR DESCRIPTION
Visual Studio Code no longer needs to be reloaded to activate extensions as of the January 2019 release (v1.31), so removing that step.