### PR TITLE
Fixes #2013 - Remove unnecessary `async` keyword.

### DIFF
--- a/src/docs/cookbook/persistence/reading-writing-files.md
+++ b/src/docs/cookbook/persistence/reading-writing-files.md
@@ -218,7 +218,7 @@ class _FlutterDemoState extends State<FlutterDemo> {
     });
   }
 
-  Future<File> _incrementCounter() async {
+  Future<File> _incrementCounter() {
     setState(() {
       _counter++;
     });


### PR DESCRIPTION
After review, the reported issue was correct, and the `async` keyword isn't doing any harm but also doesn't add any value here. It's been removed to keep things simple!