### PR TITLE
Updated firebase project for publishing to .dev domain

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,6 +1,7 @@
 {
   "projects": {
-    "default": "sweltering-fire-2088",
+    "default": "flutter-dev-230821",
+    "flutter-dev": "flutter-dev-230821"
     "flutter-io": "sweltering-fire-2088",
     "staging-1": "flutter-io-staging-1",
     "staging-2": "flutter-io-staging-2",

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: Flutter
 # description: TBC
 email: flutter-dev@googlegroups.com
-url: https://flutter.io
+url: https://flutter.dev
 port: 4002
 github_username: flutter
 repo:

--- a/firebase.json
+++ b/firebase.json
@@ -103,6 +103,7 @@
       { "source": "/widgets", "destination": "/docs/development/ui/widgets/catalog", "type": 301 },
       { "source": "/widgets/:rest*", "destination": "/docs/development/ui/widgets/:rest*", "type": 301 },
       { "source": "/widgets-intro", "destination": "/docs/development/ui/widgets-intro", "type": 301 }
+      { "source": "/youtube", "destination": "youtube.com/flutterdev", "type": 301 }
     ]
   }
 }


### PR DESCRIPTION
Migrate the firebase project to the one hosting flutter.dev instead of flutter.io. 

cc @gspencergoog @Sfshaza for our work this week.