### PR TITLE
Fix small markdown rendering error

### DIFF
--- a/src/docs/development/ui/layout/index.md
+++ b/src/docs/development/ui/layout/index.md
@@ -347,7 +347,7 @@ setting the main axis alignment to `spaceEvenly` divides the free vertical
 space evenly between, above, and below each image.
 
 <div class="row">
-<div class="col-lg-8">
+<div class="col-lg-8" markdown="1">
   <?code-excerpt "layout/row_column/lib/main.dart (Column)" replace="/Column/[!$&!]/g"?>
   {% prettify dart context="html" %}
   [!Column!](


### PR DESCRIPTION
There is a link in the [docs](https://flutter.io/docs/development/ui/layout#aligning-widgets) (see bottom of section) which is not rendered properly. It appears that the `markdown` attribute is missing and causing this issue.