### PR TITLE
Change twitter card to card with large image

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -18,7 +18,7 @@
   <meta name="description" content="{{desc}}">
   <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
 
-  <meta name="twitter:card" content="summary">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@flutterio">
 
   <meta property="og:title" content="{{ page.title }}">


### PR DESCRIPTION
**IMPORTANT**: this will change the twitter card type for all pages in flutter.dev

The current card type is hard coded as `summary`, although I have no context why it was hard coded this way, the default social share image is a 2:1 ratio image, which doesn't work for a card of type `summary`, it works for cards of type `summary_large_image`.

I think this change is safe to make since currently, sharing the top level flutter.dev site on twitter renders something like this: 
![image](https://user-images.githubusercontent.com/2965170/53272062-1b7a1480-36a5-11e9-9b05-c31652e8ef32.png)
