### PR TITLE
Add NestedScrollView description

### DIFF
--- a/src/_data/catalog/widgets.json
+++ b/src/_data/catalog/widgets.json
@@ -1202,7 +1202,7 @@
   },
   {
     "name": "NestedScrollView",
-    "description": "",
+    "description": "A scrolling view inside of which can be nested other scrolling views, with their scroll positions being intrinsically linked.",
     "categories": [
       "Scrolling"
     ],


### PR DESCRIPTION
All of widgets' description are described except for NestedScrollView, so I copied [NestedScrollView class - widgets library - Dart API](https://docs.flutter.io/flutter/widgets/NestedScrollView-class.html)' s first paragraph to NestedScrollView's description.

There is not description for NestedScrollView currently:

<img width="251" alt="image" src="https://user-images.githubusercontent.com/1255062/53295352-c244e900-383c-11e9-95ee-3a91334d9a5c.png">

[Flutter widget index - Flutter](https://flutter.dev/docs/reference/widgets)