### PR TITLE
Use whereArgs to prevent SQLite injection attacks

### DIFF
--- a/src/docs/cookbook/persistence/sqlite.md
+++ b/src/docs/cookbook/persistence/sqlite.md
@@ -239,7 +239,9 @@ Future<void> updateDog(Dog dog) async {
     'dogs',
     dog.toMap(),
     // Ensure we only update the Dog with a matching id
-    where: "id = ${dog.id}",
+    where: "id = ?",
+    // Pass the Dog's id through as a whereArg to prevent SQL injection
+    whereArgs: [dog.id],
   );
 }
 
@@ -253,6 +255,14 @@ await updateDog(Dog(
 // And you could print the updated results
 print(await dogs()); // Prints Fido with age 42.
 ```
+
+{{site.alert.warning}}
+Always use `whereArgs` to pass arguments to a `where` statement. This 
+helps safeguard against SQL injection attacks. 
+
+Do not use string interpolation, such as `where: "id = ${dog.id}"`!
+{{site.alert.end}}
+
 
 ## 8. Delete a `Dog` from the database
 
@@ -275,7 +285,9 @@ Future<void> deleteDog(int id) async {
   await db.delete(
     'dogs',
     // Use a `where` clause to delete a specific dog
-    where: "id = $id",
+    where: "id = ?",
+    // Pass the Dog's id through as a whereArg to prevent SQL injection
+    whereArgs: [id],
   );
 }
 ```
@@ -352,7 +364,9 @@ void main() async {
       'dogs',
       dog.toMap(),
       // Ensure we only update the Dog with a matching id
-      where: "id = ${dog.id}",
+      where: "id = ?",
+      // Pass the Dog's id through as a whereArg to prevent SQL injection
+      whereArgs: [dog.id],
     );
   }
 
@@ -364,7 +378,9 @@ void main() async {
     await db.delete(
       'dogs',
       // Use a `where` clause to delete a specific dog
-      where: "id = $id",
+      where: "id = ?",
+      // Pass the Dog's id through as a whereArg to prevent SQL injection
+      whereArgs: [id],
     );
   }
 


### PR DESCRIPTION
The old recipe used String interpolation to make it simpler for newcomers, but that was a bad idea: It opens users up to SQL injection. 

This fixes that issues and adds a warning to let folks know they should always use whereArgs.