### PR TITLE
Fix Flutter Create Byte Count Command Code

### DIFF
--- a/src/create/index.html
+++ b/src/create/index.html
@@ -135,7 +135,7 @@ body_class: landing-page create
                <code>.dart</code>. The total size of all Dart files in the ZIP
                file, excluding unit tests that are not executed, must be no
                more than 5,120 bytes as (for example) measured by the
-               command <code>find . -name "*.dart" | xargs cat | wc -c.</code></p>
+               command <code>find . -name "*.dart" | xargs cat | wc -c</code>.</p>
             <p>The application may use Flutter packages that are a) published
                on <a href="https://pub.dartlang.org">pub.dartlang.org</a>;
                b) have broad applicability (e.g. not written solely for the


### PR DESCRIPTION
`$ find . -name "*.dart" | xargs cat | wc -c` is correct.
But now, a trailling period is included in `<code>`.
It will be confusing, so I fixed it.