### PR TITLE
flutter_test no longer includes dart test

### DIFF
--- a/src/docs/cookbook/testing/unit/introduction.md
+++ b/src/docs/cookbook/testing/unit/introduction.md
@@ -44,10 +44,8 @@ dev_dependencies:
   test: <latest_version>
 ```
 
-If you're working on a package that will only be used for Flutter apps, or if
-we need to write Widget tests, depend on the `flutter_test` package instead.
-It includes everything from the `test` package, as well as
-additional utilities for testing Widgets.
+If you need to write Widget tests, depend on the `flutter_test` package as well.
+It includes additional utilities for testing Widgets.
 
 ```yaml
 dev_dependencies:


### PR DESCRIPTION
Both `flutter_test` and dart `test` are required. See https://github.com/flutter/flutter/issues/24384 and https://groups.google.com/forum/#!topic/flutter-dev/EppJpBk9eqQ for discussion.

> As part of an ongoing effort to reduce versioning friction and make it easier to upgrade flutter versions, I've landed a recent change in master that drastically shrinks the set of transitive dependencies of flutter_test.

Previously, docs said:

> If you’re working on a package that will only be used for Flutter apps, or if we need to write Widget tests, depend on the flutter_test package instead. It includes everything from the test package, as well as additional utilities for testing Widgets.

Which is no longer the case.