### PR TITLE
Update flutter packages link to 'https'

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -132,7 +132,7 @@
         - title: Background processes
           permalink: /docs/development/packages-and-plugins/background-processes
         - title: Package site
-          permalink: http://pub.dartlang.org/flutter
+          permalink: https://pub.dartlang.org/flutter
     - title: Tools & techniques
       permalink: /docs/development/tools
       children:


### PR DESCRIPTION
Hail Mary to fix flutter.dev being identified as malware, regardless we should always link to https when available.