### PR TITLE
Fix Code Problems in TabBar

### DIFF
--- a/src/docs/cookbook/design/tabs.md
+++ b/src/docs/cookbook/design/tabs.md
@@ -110,14 +110,14 @@ class TabBarDemo extends StatelessWidget {
           appBar: AppBar(
             title: Text('Tabs Demo'),
             bottom: PreferredSize(
-            preferredSize: Size(200,50),
-              child: TabBar(
-            tabs: [
-              Tab(icon: Icon(Icons.directions_car)),
-              Tab(icon: Icon(Icons.directions_transit)),
-              Tab(icon: Icon(Icons.directions_bike)),
-            ],
-          )),
+                preferredSize: Size(200, 50),
+                child: TabBar(
+                  tabs: [
+                    Tab(icon: Icon(Icons.directions_car)),
+                    Tab(icon: Icon(Icons.directions_transit)),
+                    Tab(icon: Icon(Icons.directions_bike)),
+                  ],
+                )),
           ),
           body: TabBarView(
             children: [

--- a/src/docs/cookbook/design/tabs.md
+++ b/src/docs/cookbook/design/tabs.md
@@ -108,6 +108,7 @@ class TabBarDemo extends StatelessWidget {
         length: 3,
         child: Scaffold(
           appBar: AppBar(
+            title: Text('Tabs Demo'),
             bottom: PreferredSize(
             preferredSize: Size(double.infinity,50),
               child: TabBar(
@@ -117,6 +118,7 @@ class TabBarDemo extends StatelessWidget {
               Tab(icon: Icon(Icons.directions_bike)),
             ],
           )),
+          ),
           body: TabBarView(
             children: [
               Icon(Icons.directions_car),

--- a/src/docs/cookbook/design/tabs.md
+++ b/src/docs/cookbook/design/tabs.md
@@ -69,8 +69,7 @@ DefaultTabController(
 
 By default, the `TabBar` looks up the Widget tree for the nearest
 `DefaultTabController`. If you're manually creating a `TabController`, you'll
-need to pass it to the `TabBar` into `PreferredSize`.
-
+need to pass it to the `TabBar`. also you will need to wrap `TabBar` with `PreferredSize`
 ## 3. Create content for each tab
 
 Now that we have tabs, we'll want to display content when a tab is selected.

--- a/src/docs/cookbook/design/tabs.md
+++ b/src/docs/cookbook/design/tabs.md
@@ -54,7 +54,7 @@ DefaultTabController(
   child: Scaffold(
     appBar: AppBar(
       bottom: PreferredSize(
-            preferredSize: Size(double.infinity,50),
+            preferredSize: Size(200,50),
               child: TabBar(
             tabs: [
               Tab(icon: Icon(Icons.directions_car)),
@@ -64,7 +64,7 @@ DefaultTabController(
       )),
     ),
   ),
-);
+)
 ```
 
 By default, the `TabBar` looks up the Widget tree for the nearest
@@ -110,7 +110,7 @@ class TabBarDemo extends StatelessWidget {
           appBar: AppBar(
             title: Text('Tabs Demo'),
             bottom: PreferredSize(
-            preferredSize: Size(double.infinity,50),
+            preferredSize: Size(200,50),
               child: TabBar(
             tabs: [
               Tab(icon: Icon(Icons.directions_car)),

--- a/src/docs/cookbook/design/tabs.md
+++ b/src/docs/cookbook/design/tabs.md
@@ -53,13 +53,15 @@ DefaultTabController(
   length: 3,
   child: Scaffold(
     appBar: AppBar(
-      bottom: TabBar(
-        tabs: [
-          Tab(icon: Icon(Icons.directions_car)),
-          Tab(icon: Icon(Icons.directions_transit)),
-          Tab(icon: Icon(Icons.directions_bike)),
-        ],
-      ),
+      bottom: PreferredSize(
+            preferredSize: Size(double.infinity,50),
+              child: TabBar(
+            tabs: [
+              Tab(icon: Icon(Icons.directions_car)),
+              Tab(icon: Icon(Icons.directions_transit)),
+              Tab(icon: Icon(Icons.directions_bike)),
+         ],
+      )),
     ),
   ),
 );
@@ -67,7 +69,7 @@ DefaultTabController(
 
 By default, the `TabBar` looks up the Widget tree for the nearest
 `DefaultTabController`. If you're manually creating a `TabController`, you'll
-need to pass it to the `TabBar`.
+need to pass it to the `TabBar` into `PreferredSize`.
 
 ## 3. Create content for each tab
 
@@ -106,15 +108,15 @@ class TabBarDemo extends StatelessWidget {
         length: 3,
         child: Scaffold(
           appBar: AppBar(
-            bottom: TabBar(
-              tabs: [
-                Tab(icon: Icon(Icons.directions_car)),
-                Tab(icon: Icon(Icons.directions_transit)),
-                Tab(icon: Icon(Icons.directions_bike)),
-              ],
-            ),
-            title: Text('Tabs Demo'),
-          ),
+            bottom: PreferredSize(
+            preferredSize: Size(double.infinity,50),
+              child: TabBar(
+            tabs: [
+              Tab(icon: Icon(Icons.directions_car)),
+              Tab(icon: Icon(Icons.directions_transit)),
+              Tab(icon: Icon(Icons.directions_bike)),
+            ],
+          )),
           body: TabBarView(
             children: [
               Icon(Icons.directions_car),


### PR DESCRIPTION
In new versions in Flutter there is some changes in AppBar in bottom argument it can't take anything except PreferredSize so we need to wrap TabBar with PreferredSize