### PR TITLE
Correct markup on reactive programing item, in bloc section

### DIFF
--- a/src/docs/development/data-and-backend/state-mgmt/options.md
+++ b/src/docs/development/data-and-backend/state-mgmt/options.md
@@ -55,7 +55,7 @@ Learn more at the following links, many of which have been contributed by the Fl
 * [Architect your Flutter project using BLoC pattern]({{site.medium}}/flutterpub/architecting-your-flutter-project-bd04e144a8f1),
   by Sagar Suri
 * [Bloc Library](https://felangel.github.io/bloc), by Felix Angelov
-* [Reactive Programming - Streams - BLoC - Practical Use Cases] (https://www.didierboelens.com/2018/12/reactive-programming---streams---bloc---practical-use-cases/), by Didier Boelens 
+* [Reactive Programming - Streams - BLoC - Practical Use Cases](https://www.didierboelens.com/2018/12/reactive-programming---streams---bloc---practical-use-cases), by Didier Boelens
 
 ## MobX
 


### PR DESCRIPTION
Correct markup on reactive programing item, in bloc section. There are a space between markup. Remove it.