### PR TITLE
Correcting Swift error in platform-channel.md

### DIFF
--- a/src/docs/development/platform-integration/platform-channels.md
+++ b/src/docs/development/platform-integration/platform-channels.md
@@ -591,7 +591,7 @@ batteryChannel.setMethodCallHandler({
     result(FlutterMethodNotImplemented)
     return
   }
-  self.receiveBatteryLevel(result: result)
+  self?.receiveBatteryLevel(result: result)
 })
 ```
 


### PR DESCRIPTION
Correct example code in bottom of the section [**'Step 4b: Add an iOS platform-specific implementation using Swift'**](https://flutter.dev/docs/development/platform-integration/platform-channels#step-4b-add-an-ios-platform-specific-implementation-using-swift), to prevent this error on build: 

> Chain the optional using '?' to access member 'receiveBatteryLevel' only for non-'nil' base values 

This affects both simulated and physical iOS devices in Swift-based apps.