### PR TITLE
Revert "Fix homepage stretched logos (#1750) (#2466)"

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -228,26 +228,14 @@ description: >
             <div class="homepage__card-graphic col-lg-7 order-lg-1">
                 <div>
                     <div class="landing-page__card-graphic__logo-row row align-items-center">
-                      <div class="col-4">
-                        {% asset homepage/logo-alibaba.png alt='Alibaba logo' %}
-                      </div>
-                      <div class="col-4">
-                        {% asset homepage/logo-hamilton.png alt='Hamilton logo' %}
-                      </div>
-                      <div class="col-4">
-                        {% asset homepage/logo-google.svg alt='Google logo' %}
-                      </div>
+                        {% asset homepage/logo-alibaba.png alt='Alibaba logo' class="col-4" %}
+                        {% asset homepage/logo-hamilton.png alt='Hamilton logo' class="col-4" %}
+                        {% asset homepage/logo-google.svg alt='Google logo' class="col-4" %}
                     </div>
                     <div class="landing-page__card-graphic__logo-row row align-items-center">
-                      <div class="col-4">
-                        {% asset homepage/logo-tencent.png alt='Tencent logo' %}
-                      </div>
-                      <div class="col-4">
-                        {% asset homepage/logo-abbey_road_studios.png alt='Abbey Road Studios logo' %}
-                      </div>
-                      <div class="col-4">
-                        {% asset homepage/logo-google_ads.png alt='Google AdWords logo' %}
-                      </div>
+                        {% asset homepage/logo-tencent.png alt='Tencent logo' class="col-4" %}
+                        {% asset homepage/logo-abbey_road_studios.png alt='Abbey Road Studios logo' class="col-4" %}
+                        {% asset homepage/logo-google_ads.png alt='Google AdWords logo' class="col-4" %}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This reverts commit 1957c7ab060e2e16ac64de446b2d04f7204c0471.

The attempted fix added in #2466 made the images overflow outside their containers on all browsers, I'll reopen #1750 to fix in the future.