### PR TITLE
Fix 2438 and 2399 : Remove broken link in bloc section 

### DIFF
--- a/src/docs/development/data-and-backend/state-mgmt/options.md
+++ b/src/docs/development/data-and-backend/state-mgmt/options.md
@@ -50,8 +50,6 @@ Learn more at the following links, many of which have been contributed by the Fl
 
 ## BLoC / Rx
 
-* [State Management Using BLoC pattern in Flutter](https://hk.saowen.com/a/fbb6e484de022173fe85248875286060ce40d069c97420bc0be49d838e19e372), 
-  by Saowen
 * [Architect your Flutter project using BLoC pattern]({{site.medium}}/flutterpub/architecting-your-flutter-project-bd04e144a8f1),
   by Sagar Suri
 * [Bloc Library](https://felangel.github.io/bloc), by Felix Angelov


### PR DESCRIPTION
Remove broken link in bloc section.

Fix : https://github.com/flutter/website/issues/2438 and https://github.com/flutter/website/issues/2399

State Management Using BLoC pattern in Flutter, by Saowen
https://hk.saowen.com/a/fbb6e484de022173fe85248875286060ce40d069c97420bc0be49d838e19e372