### PR TITLE
Add note on `Form.of` to validation recipe. Fixes #2479

### DIFF
--- a/src/docs/cookbook/forms/validation.md
+++ b/src/docs/cookbook/forms/validation.md
@@ -68,6 +68,13 @@ class MyCustomFormState extends State<MyCustomForm> {
 }
 ```
 
+{{site.alert.tip}}
+Using a `GlobalKey` is the recommended way to access a form. However, if you
+have a more complex widget tree, you can use the
+[`Form.of`](https://docs.flutter.io/flutter/widgets/Form/of.html) method to
+access the form within nested widgets.
+{{site.alert.end}}
+
 ## 2. Add a `TextFormField` with validation logic
 
 We have our `Form` in place, but we haven't provided a way for our users to


### PR DESCRIPTION
Addresses #2479.

For this recipe, we cannot use `Form.of`, because the `Form` is part of the `build` method -- it is not in the `context` provided to the `build` method.

Therefore, I've put a note in here that you might consider using `Form.of` in more advanced cases where passing around the GlobalKey becomes cumbersome.

Please let me know your thoughts!