### PR TITLE
Fixes numbered list in androidx-compatibility

### DIFF
--- a/src/docs/development/packages-and-plugins/androidx-compatibility.md
+++ b/src/docs/development/packages-and-plugins/androidx-compatibility.md
@@ -74,58 +74,62 @@ instructions on how to do this. Below are some steps that you'll likely need to 
 
 1. In `android/gradle/wrapper/gradle-wrapper.properties` change the line starting with `distributionUrl` like this:
 
-`distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip`
+  ```
+  distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+  ```
 
 2. In `android/build.gradle`, replace:
 
-```gradle
-dependencies {
-    classpath 'com.android.tools.build:gradle:3.2.1'
-}
-```
+  ```gradle
+  dependencies {
+      classpath 'com.android.tools.build:gradle:3.2.1'
+  }
+  ```
 
-by
+  by
 
-```gradle
-dependencies {
-    classpath 'com.android.tools.build:gradle:3.3.0'
-}
-```
+  ```gradle
+  dependencies {
+      classpath 'com.android.tools.build:gradle:3.3.0'
+  }
+  ```
 
 3. In `android/gradle.properties`, append
 
-```
-android.enableJetifier=true
-android.useAndroidX=true
-```
+  ```
+  android.enableJetifier=true
+  android.useAndroidX=true
+  ```
 
-4. In `android/app/build.gradle`:
-
-Under `android {`, make sure `compileSdkVersion` and `targetSdkVersion` are at least 28.
+4. In `android/app/build.gradle`, under `android {`, make sure `compileSdkVersion` and `targetSdkVersion` are at least 28.
 
 5. Replace all deprecated libraries with the AndroidX equivalents. For instance, if you're using the default `.gradle` files make the following changes:
 
-In `android/app/build.gradle`
+  In `android/app/build.gradle`
 
-`testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"`
+  ```gradle
+  testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+  ```
 
-by
+  by
 
-`testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"`
+  ```gradle
+  testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+  ```
 
-Finally, under `dependencies {`, replace
+  Finally, under `dependencies {`, replace
 
-```gradle
-androidTestImplementation 'com.android.support.test:runner:1.0.2'
-androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-```
+  ```gradle
+  androidTestImplementation 'com.android.support.test:runner:1.0.2'
+  androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+  ```
 
-by
+  by
 
-```gradle
-androidTestImplementation 'androidx.test.runner:1.1.1'
-androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
-```
+  ```gradle
+  androidTestImplementation 'androidx.test.runner:1.1.1'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+  ```
 
 ### Avoiding AndroidX
 

--- a/src/docs/development/packages-and-plugins/androidx-compatibility.md
+++ b/src/docs/development/packages-and-plugins/androidx-compatibility.md
@@ -101,7 +101,7 @@ android.useAndroidX=true
 
 4. In `android/app/build.gradle`:
 
-Replace version `27` by `28` (`compileSdkVersion` and `targetSdkVersion` under `android {`).
+Under `android {`, make sure `compileSdkVersion` and `targetSdkVersion` are at least 28.
 
 Also, replace
 

--- a/src/docs/development/packages-and-plugins/androidx-compatibility.md
+++ b/src/docs/development/packages-and-plugins/androidx-compatibility.md
@@ -103,7 +103,9 @@ android.useAndroidX=true
 
 Under `android {`, make sure `compileSdkVersion` and `targetSdkVersion` are at least 28.
 
-Also, replace
+5. Replace all deprecated libraries with the AndroidX equivalents. For instance, if you're using the default `.gradle` files make the following changes:
+
+In `android/app/build.gradle`
 
 `testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"`
 

--- a/src/docs/development/packages-and-plugins/androidx-compatibility.md
+++ b/src/docs/development/packages-and-plugins/androidx-compatibility.md
@@ -68,6 +68,10 @@ Use the following instructions:
 
 #### Not recommended: Manually migrate your app
 
+See [Migrating to
+AndroidX]({{site.android-dev}}/jetpack/androidx/migrate) for more detailed
+instructions on how to do this. Below are some steps that you'll likely need to go through as part of this process, listed here for reference. However the specific things you need to do will depend on your build configuration and could differ from the example changes suggested here.
+
 1. In `android/gradle/wrapper/gradle-wrapper.properties` change the line starting with `distributionUrl` like this:
 
 `distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip`
@@ -120,10 +124,6 @@ by
 androidTestImplementation 'androidx.test.runner:1.1.1'
 androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
 ```
-
-See [Migrating to
-AndroidX]({{site.android-dev}}/jetpack/androidx/migrate) for more detailed
-instructions on how to do this.
 
 ### Avoiding AndroidX
 

--- a/src/docs/development/packages-and-plugins/androidx-compatibility.md
+++ b/src/docs/development/packages-and-plugins/androidx-compatibility.md
@@ -68,8 +68,61 @@ Use the following instructions:
 
 #### Not recommended: Manually migrate your app
 
+1. In `android/gradle/wrapper/gradle-wrapper.properties` change the line starting with `distributionUrl` like this:
+
+`distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip`
+
+2. In `android/build.gradle`, replace:
+
+```gradle
+dependencies {
+    classpath 'com.android.tools.build:gradle:3.2.1'
+}
+```
+
+by
+
+```gradle
+dependencies {
+    classpath 'com.android.tools.build:gradle:3.3.0'
+}
+```
+
+3. In `android/gradle.properties`, append
+
+```
+android.enableJetifier=true
+android.useAndroidX=true
+```
+
+4. In `android/app/build.gradle`:
+
+Replace version `27` by `28` (`compileSdkVersion` and `targetSdkVersion` under `android {`).
+
+Also, replace
+
+`testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"`
+
+by
+
+`testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"`
+
+Finally, under `dependencies {`, replace
+
+```gradle
+androidTestImplementation 'com.android.support.test:runner:1.0.2'
+androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+```
+
+by
+
+```gradle
+androidTestImplementation 'androidx.test.runner:1.1.1'
+androidTestImplementation 'andoridx.test.espresso:espresso-core:3.1.1'
+```
+
 See [Migrating to
-AndroidX]({{site.android-dev}}/jetpack/androidx/migrate) for detailed
+AndroidX]({{site.android-dev}}/jetpack/androidx/migrate) for more detailed
 instructions on how to do this.
 
 ### Avoiding AndroidX

--- a/src/docs/development/packages-and-plugins/androidx-compatibility.md
+++ b/src/docs/development/packages-and-plugins/androidx-compatibility.md
@@ -118,7 +118,7 @@ by
 
 ```gradle
 androidTestImplementation 'androidx.test.runner:1.1.1'
-androidTestImplementation 'andoridx.test.espresso:espresso-core:3.1.1'
+androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
 ```
 
 See [Migrating to


### PR DESCRIPTION
After merging #2454, all steps in the numbered list in https://flutter.dev/docs/development/packages-and-plugins/androidx-compatibility appear as "1." This wasn't noticeable on GitHub since it's valid GitHub-flavored Markdown.

I've added padding to fix it. (And triple backticks to all Gradle code fragments for consistency).

Note: I haven't built the site yet to confirm steps appear as they should