### PR TITLE
Remove Flutter Create contest banner on April 7

### DIFF
--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -8,8 +8,5 @@
       <a href="{{fl_url}}" target="_blank" rel="noopener">Learn more</a>.
     </p>
 {% endcomment %}
-    <p>
-      Try our Flutter Create contest. <a href="/create">Learn more</a>.
-    </p>
   </div>
 {% endif -%}


### PR DESCRIPTION
The banner is supposed to be taken down on April 7, when the contest ends! See #2415.

Cc: @maguinis 