### PR TITLE
Closes #2577 Removed formatting typo.

### DIFF
--- a/src/docs/development/ui/animations/hero-animations.md
+++ b/src/docs/development/ui/animations/hero-animations.md
@@ -603,7 +603,7 @@ class RadialExpansion extends StatelessWidget {
   final Widget child;
 
   @override
-  Widget build(BuildContext context) {[[/highlight]]
+  Widget build(BuildContext context) 
     return [[highlight]]ClipOval([[/highlight]]
       child: [[highlight]]Center([[/highlight]]
         child: [[highlight]]SizedBox([[/highlight]]


### PR DESCRIPTION
See https://github.com/flutter/website/issues/2577

Before:
![before](https://user-images.githubusercontent.com/5550175/56062783-6d90fb00-5d22-11e9-9e20-c27a7a8b0438.png)

After:
![after](https://user-images.githubusercontent.com/5550175/56062788-7386dc00-5d22-11e9-83a6-affa80ee0cb6.png)
