### PR TITLE
Fix an incorrect link on https://flutter.dev/docs/cookbook/testing/widget/finders

### DIFF
--- a/src/docs/cookbook/testing/widget/finders.md
+++ b/src/docs/cookbook/testing/widget/finders.md
@@ -24,7 +24,7 @@ consult the
 [`CommonFinders` documentation]({{api}}/flutter_driver/CommonFinders-class.html).
 
 If you're unfamiliar with Widget testing and the role of `Finder` classes,
-review the [Introduction to Widget testing](/docs/cookbook/testing/integration) recipe.
+review the [Introduction to Widget testing](/docs/cookbook/testing/widget/introduction) recipe.
 
 ### Directions
 

--- a/src/docs/cookbook/testing/widget/finders.md
+++ b/src/docs/cookbook/testing/widget/finders.md
@@ -24,7 +24,7 @@ consult the
 [`CommonFinders` documentation]({{api}}/flutter_driver/CommonFinders-class.html).
 
 If you're unfamiliar with Widget testing and the role of `Finder` classes,
-review the [Introduction to Widget testing](/docs/cookbook/testing/widget/introduction) recipe.
+review the [Introduction to widget testing](/docs/cookbook/testing/widget/introduction) recipe.
 
 ### Directions
 


### PR DESCRIPTION
The "Introduction to Widget testing" link instead went to a table of
contents for integration testing.