### PR TITLE
New internationalization tutorial example: add_language

### DIFF
--- a/examples/internationalization/add_language/lib/main.dart
+++ b/examples/internationalization/add_language/lib/main.dart
@@ -248,6 +248,10 @@ class Home extends StatelessWidget {
       body: Center(
         child: RaisedButton(
           onPressed: () {
+            // This would fail if localizations were not provided for the
+            // app's locale. Although only a few Material widgets display
+            // localized strings, many expect to be able to find localized
+            // values for tooltips and other strings related to accessibility.
             showDialog(
               context: context,
               builder: (BuildContext context) => Dialog(child: Center(child: Text('Hello World'))),

--- a/examples/internationalization/add_language/lib/main.dart
+++ b/examples/internationalization/add_language/lib/main.dart
@@ -1,0 +1,275 @@
+import 'dart:async';
+
+import 'package:intl/intl.dart' as intl;
+import 'package:intl/date_symbol_data_local.dart' as intl;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+class _BeMaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocalizations> {
+  const _BeMaterialLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => locale.languageCode == 'be';
+
+  @override
+  Future<MaterialLocalizations> load(Locale locale) async {
+    final String localeName = intl.Intl.canonicalizedLocale(locale.toString());
+    await intl.initializeDateFormatting(localeName, null);
+    return SynchronousFuture<MaterialLocalizations>(
+      BeMaterialLocalizations(
+        localeName: localeName,
+        fullYearFormat: intl.DateFormat('y', localeName),
+        mediumDateFormat: intl.DateFormat('EEE, MMM d', localeName),
+        longDateFormat: intl.DateFormat('EEEE, MMMM d, y', localeName),
+        yearMonthFormat: intl.DateFormat('MMMM y', localeName),
+        decimalFormat: intl.NumberFormat('#,##0.###', localeName),
+        twoDigitZeroPaddedFormat: intl.NumberFormat('00', localeName),
+      ),
+    );
+  }
+
+  @override
+  bool shouldReload(_BeMaterialLocalizationsDelegate old) => false;
+}
+
+class BeMaterialLocalizations extends GlobalMaterialLocalizations {
+  const BeMaterialLocalizations({
+    String localeName = 'be',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+    localeName: localeName,
+    fullYearFormat: fullYearFormat,
+    mediumDateFormat: mediumDateFormat,
+    longDateFormat: longDateFormat,
+    yearMonthFormat: yearMonthFormat,
+    decimalFormat: decimalFormat,
+    twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+  );
+
+  @override
+  String get aboutListTileTitleRaw => r'About $applicationName';
+
+  @override
+  String get alertDialogLabel => r'Alert';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'Back';
+
+  @override
+  String get cancelButtonLabel => r'CANCEL';
+
+  @override
+  String get closeButtonLabel => r'CLOSE';
+
+  @override
+  String get closeButtonTooltip => r'Close';
+
+  @override
+  String get collapsedIconTapHint => r'Expand';
+
+  @override
+  String get continueButtonLabel => r'CONTINUE';
+
+  @override
+  String get copyButtonLabel => r'COPY';
+
+  @override
+  String get cutButtonLabel => r'CUT';
+
+  @override
+  String get deleteButtonTooltip => r'Delete';
+
+  @override
+  String get dialogLabel => r'Dialog';
+
+  @override
+  String get drawerLabel => r'Navigation menu';
+
+  @override
+  String get expandedIconTapHint => r'Collapse';
+
+  @override
+  String get hideAccountsLabel => r'Hide accounts';
+
+  @override
+  String get licensesPageTitle => r'Licenses';
+
+  @override
+  String get modalBarrierDismissLabel => r'Dismiss';
+
+  @override
+  String get nextMonthTooltip => r'Next month';
+
+  @override
+  String get nextPageTooltip => r'Next page';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  String get openAppDrawerTooltip => r'Open navigation menu';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow of $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw => r'$firstRow–$lastRow of about $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'PASTE';
+
+  @override
+  String get popupMenuLabel => r'Popup menu';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'Previous month';
+
+  @override
+  String get previousPageTooltip => r'Previous page';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'Refresh';
+
+  @override
+  String get remainingTextFieldCharacterCountFew => null;
+
+  @override
+  String get remainingTextFieldCharacterCountMany => null;
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'1 character remaining';
+
+  @override
+  String get remainingTextFieldCharacterCountOther => r'$remainingCount characters remaining';
+
+  @override
+  String get remainingTextFieldCharacterCountTwo => null;
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'No characters remaining';
+
+  @override
+  String get reorderItemDown => r'Move down';
+
+  @override
+  String get reorderItemLeft => r'Move left';
+
+  @override
+  String get reorderItemRight => r'Move right';
+
+  @override
+  String get reorderItemToEnd => r'Move to the end';
+
+  @override
+  String get reorderItemToStart => r'Move to the start';
+
+  @override
+  String get reorderItemUp => r'Move up';
+
+  @override
+  String get rowsPerPageTitle => r'Rows per page:';
+
+  @override
+  ScriptCategory get scriptCategory => ScriptCategory.englishLike;
+
+  @override
+  String get searchFieldLabel => r'Search';
+
+  @override
+  String get selectAllButtonLabel => r'SELECT ALL';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 item selected';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount items selected';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => r'No items selected';
+
+  @override
+  String get showAccountsLabel => r'Show accounts';
+
+  @override
+  String get showMenuTooltip => r'Show menu';
+
+  @override
+  String get signedInLabel => r'Signed in';
+
+  @override
+  String get tabLabelRaw => r'Tab $tabIndex of $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.h_colon_mm_space_a;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Select hours';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Select minutes';
+
+  @override
+  String get viewLicensesButtonLabel => r'VIEW LICENSES';
+
+  @override
+  List<String> get narrowWeekdays =>  const <String>['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+
+  @override
+  int get firstDayOfWeekIndex => 0;
+
+  static const LocalizationsDelegate<MaterialLocalizations> delegate = _BeMaterialLocalizationsDelegate();
+}
+
+class Home extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: RaisedButton(
+          onPressed: () {
+            showDialog(
+              context: context,
+              builder: (BuildContext context) => Dialog(child: Center(child: Text('Hello World'))),
+            );
+          },
+          child: const Text('Show Dialog'),
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  runApp(
+    MaterialApp(
+      localizationsDelegates: [
+        GlobalWidgetsLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        BeMaterialLocalizations.delegate,
+      ],
+      supportedLocales: [ const Locale('be', 'BY') ],
+      home: Home(),
+    ),
+  );
+}

--- a/examples/internationalization/pubspec.yaml
+++ b/examples/internationalization/pubspec.yaml
@@ -1,0 +1,16 @@
+name: add_language
+description: An i18n app example that adds a supported language
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  intl: 0.15.8
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
This will be referred to by a new [i18n tutorial section](https://github.com/flutter/website/blob/master/src/docs/development/accessibility-and-localization/internationalization.md) called "Adding support for new languages".