### PR TITLE
Fix documentation on JavaScript to Dart comparison

### DIFF
--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -261,10 +261,14 @@ used to wait for a `Promise`.
 class Example {
   async _getIPAddress() {
     const url = "https://httpbin.org/ip";
-    const response = await fetch(url);
-    const responseJson = await response.json();
-    const ip = responseJson.origin;
-    console.log(ip);
+    try {
+      const response = await fetch(url);
+      const responseJson = await response.json();
+      const ip = responseJson.origin;
+      console.log(ip);
+    } catch (error) {
+      console.error(error);
+    }
   }
 }
 
@@ -285,9 +289,13 @@ import 'package:http/http.dart' as http;
 class Example {
   _getIPAddress() async {
     final url = 'https://httpbin.org/ip';
-    final response = await http.get(url);
-    String ip = json.decode(response.body)['origin'];
-    print(ip);
+    try {
+      final response = await http.get(url);
+      String ip = json.decode(response.body)['origin'];
+      print(ip);
+    } catch (error) {
+      print(error);
+    }
   }
 }
 

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -212,17 +212,18 @@ class Example {
     return fetch(url)
       .then(response => response.json())
       .then(responseJson => {
-        console.log(responseJson.origin);
+        const ip = responseJson.origin;
+        return ip;
       })
       .catch(error => {
         console.error(error);
       });
-  };
+  }
 }
 
 function main() {
   const example = new Example();
-  example._getIPAddress();
+  example._getIPAddress().then(ip => console.log(ip));
 }
 
 main();
@@ -235,17 +236,18 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 class Example {
-  _getIPAddress() {
+  Future<String> _getIPAddress() {
     final url = 'https://httpbin.org/ip';
-    http.get(url).then((response) {
-      print(jsonDecode(response.body)['origin']);
+    return http.get(url).then((response) {
+      String ip = jsonDecode(response.body)['origin'];
+      return ip;
     }).catchError((error) => print(error));
   }
 }
 
 main() {
   final example = new Example();
-  example._getIPAddress();
+  example._getIPAddress().then((ip) => print(ip));
 }
 ```
 
@@ -271,7 +273,7 @@ class Example {
       const response = await fetch(url);
       const responseJson = await response.json();
       const ip = responseJson.origin;
-      console.log(ip);
+      return ip;
     } catch (error) {
       console.error(error);
     }
@@ -280,7 +282,8 @@ class Example {
 
 async function main() {
   const example = new Example();
-  await example._getIPAddress();
+  const ip = await example._getIPAddress();
+  console.log(ip);
 }
 
 main();
@@ -297,21 +300,23 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 class Example {
-  _getIPAddress() async {
+  Future<String> _getIPAddress() async {
     final url = 'https://httpbin.org/ip';
     try {
       final response = await http.get(url);
       String ip = jsonDecode(response.body)['origin'];
-      print(ip);
+      return ip;
     } catch (error) {
       print(error);
+      return "";
     }
   }
 }
 
 main() async {
   final example = new Example();
-  await example._getIPAddress();
+  final ip = await example._getIPAddress();
+  print(ip);
 }
 ```
 

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -224,11 +224,13 @@ const example = {
 <!-- skip -->
 ```dart
 // Dart
-_getIPAddress() {
-  final url = 'https://httpbin.org/ip';
-  HttpRequest.request(url).then((value) {
-      print(json.decode(value.responseText)['origin']);
-  }).catchError((error) => print(error));
+class Example {
+  _getIPAddress() {
+    final url = 'https://httpbin.org/ip';
+    HttpRequest.request(url).then((value) {
+        print(json.decode(value.responseText)['origin']);
+    }).catchError((error) => print(error));
+  }
 }
 ```
 
@@ -265,11 +267,13 @@ scheduled for execution later. The `await` operator is used to wait for a
 <!-- skip -->
 ```dart
 // Dart
-_getIPAddress() async {
-  final url = 'https://httpbin.org/ip';
-  var request = await HttpRequest.request(url);
-  String ip = json.decode(request.responseText)['origin'];
-  print(ip);
+class Example {
+  _getIPAddress() async {
+    final url = 'https://httpbin.org/ip';
+    var request = await HttpRequest.request(url);
+    String ip = json.decode(request.responseText)['origin'];
+    print(ip);
+  }
 }
 ```
 

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -206,17 +206,19 @@ objects to handle this.
 
 ```js
 // JavaScript
-_getIPAddress() {
-  const url = "https://httpbin.org/ip";
-  return fetch(url)
-    .then(response => response.json())
-    .then(responseJson => {
-      console.log(responseJson.origin);
-    })
-    .catch(error => {
-      console.error(error);
-    });
-};
+const example = {
+  _getIPAddress() {
+    const url = "https://httpbin.org/ip";
+    return fetch(url)
+      .then(response => response.json())
+      .then(responseJson => {
+        console.log(responseJson.origin);
+      })
+      .catch(error => {
+        console.error(error);
+      });
+  };
+}
 ```
 
 <!-- skip -->
@@ -245,12 +247,14 @@ used to wait for a `Promise`.
 
 ```js
 // JavaScript
-async _getIPAddress() {
-  const url = "https://httpbin.org/ip";
-  const response = await fetch(url);
-  const responseJson = await response.json();
-  const ip = responseJson.origin;
-  console.log(ip);
+const example = {
+  async _getIPAddress() {
+    const url = "https://httpbin.org/ip";
+    const response = await fetch(url);
+    const responseJson = await response.json();
+    const ip = responseJson.origin;
+    console.log(ip);
+  }
 }
 ```
 

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -206,7 +206,7 @@ objects to handle this.
 
 ```js
 // JavaScript
-const example = {
+class Example {
   _getIPAddress() {
     const url = "https://httpbin.org/ip";
     return fetch(url)
@@ -249,7 +249,7 @@ used to wait for a `Promise`.
 
 ```js
 // JavaScript
-const example = {
+class Example {
   async _getIPAddress() {
     const url = "https://httpbin.org/ip";
     const response = await fetch(url);

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -214,16 +214,16 @@ class Example {
       .then(responseJson => {
         const ip = responseJson.origin;
         return ip;
-      })
-      .catch(error => {
-        console.error(error);
       });
   }
 }
 
 function main() {
   const example = new Example();
-  example._getIPAddress().then(ip => console.log(ip));
+  example
+    ._getIPAddress()
+    .then(ip => console.log(ip))
+    .catch(error => console.error(error));
 }
 
 main();
@@ -241,13 +241,16 @@ class Example {
     return http.get(url).then((response) {
       String ip = jsonDecode(response.body)['origin'];
       return ip;
-    }).catchError((error) => print(error));
+    });
   }
 }
 
 main() {
   final example = new Example();
-  example._getIPAddress().then((ip) => print(ip));
+  example
+      ._getIPAddress()
+      .then((ip) => print(ip))
+      .catchError((error) => print(error));
 }
 ```
 
@@ -269,21 +272,21 @@ used to wait for a `Promise`.
 class Example {
   async _getIPAddress() {
     const url = 'https://httpbin.org/ip';
-    try {
-      const response = await fetch(url);
-      const responseJson = await response.json();
-      const ip = responseJson.origin;
-      return ip;
-    } catch (error) {
-      console.error(error);
-    }
+    const response = await fetch(url);
+    const responseJson = await response.json();
+    const ip = responseJson.origin;
+    return ip;
   }
 }
 
 async function main() {
   const example = new Example();
-  const ip = await example._getIPAddress();
-  console.log(ip);
+  try {
+    const ip = await example._getIPAddress();
+    console.log(ip);
+  } catch (error) {
+    console.error(error);
+  }
 }
 
 main();
@@ -302,21 +305,20 @@ import 'package:http/http.dart' as http;
 class Example {
   Future<String> _getIPAddress() async {
     final url = 'https://httpbin.org/ip';
-    try {
-      final response = await http.get(url);
-      String ip = jsonDecode(response.body)['origin'];
-      return ip;
-    } catch (error) {
-      print(error);
-      return "";
-    }
+    final response = await http.get(url);
+    String ip = jsonDecode(response.body)['origin'];
+    return ip;
   }
 }
 
 main() async {
   final example = new Example();
-  final ip = await example._getIPAddress();
-  print(ip);
+  try {
+    final ip = await example._getIPAddress();
+    print(ip);
+  } catch (error) {
+    print(error);
+  }
 }
 ```
 

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -238,7 +238,7 @@ class Example {
   _getIPAddress() {
     final url = 'https://httpbin.org/ip';
     http.get(url).then((response) {
-      print(json.decode(response.body)['origin']);
+      print(jsonDecode(response.body)['origin']);
     }).catchError((error) => print(error));
   }
 }
@@ -301,7 +301,7 @@ class Example {
     final url = 'https://httpbin.org/ip';
     try {
       final response = await http.get(url);
-      String ip = json.decode(response.body)['origin'];
+      String ip = jsonDecode(response.body)['origin'];
       print(ip);
     } catch (error) {
       print(error);
@@ -1997,7 +1997,7 @@ _getIPAddress() async {
   var request = await httpClient.getUrl(url);
   var response = await request.close();
   var responseBody = await response.transform(utf8.decoder).join();
-  String ip = json.decode(responseBody)['origin'];
+  String ip = jsonDecode(responseBody)['origin'];
   setState(() {
     _ipAddress = ip;
   });

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -206,8 +206,8 @@ objects to handle this.
 
 ```js
 // JavaScript
-_getIPAddress = () => {
-  const url="https://httpbin.org/ip";
+_getIPAddress() {
+  const url = "https://httpbin.org/ip";
   return fetch(url)
     .then(response => response.json())
     .then(responseJson => {
@@ -246,11 +246,11 @@ used to wait for a `Promise`.
 ```js
 // JavaScript
 async _getIPAddress() {
-  const url="https://httpbin.org/ip";
+  const url = "https://httpbin.org/ip";
   const response = await fetch(url);
-  const json = await response.json();
-  const data = await json.origin;
-  console.log(data);
+  const responseJson = await response.json();
+  const ip = responseJson.origin;
+  console.log(ip);
 }
 ```
 

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -227,6 +227,9 @@ example._getIPAddress();
 <!-- skip -->
 ```dart
 // Dart
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
 class Example {
   _getIPAddress() {
     final url = 'https://httpbin.org/ip';
@@ -276,6 +279,9 @@ scheduled for execution later. The `await` operator is used to wait for a
 <!-- skip -->
 ```dart
 // Dart
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
 class Example {
   _getIPAddress() async {
     final url = 'https://httpbin.org/ip';

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -59,7 +59,7 @@ To print to the console in Dart, use `print()`.
 
 ```js
 // JavaScript
-console.log("Hello world!");
+console.log('Hello world!');
 ```
 
 <!-- skip -->
@@ -87,7 +87,7 @@ typed or the type system must infer the proper type automatically.
 
 ```js
 // JavaScript
-var name = "JavaScript";
+var name = 'JavaScript';
 ```
 
 <!-- skip -->
@@ -138,11 +138,11 @@ In JavaScript, values of 1 or any non-null objects are treated as true.
 // JavaScript
 var myNull = null;
 if (!myNull) {
-  console.log("null is treated as false");
+  console.log('null is treated as false');
 }
 var zero = 0;
 if (!zero) {
-  console.log("0 is treated as false");
+  console.log('0 is treated as false');
 }
 ```
 In Dart, only the boolean value `true` is treated as true.
@@ -208,7 +208,7 @@ objects to handle this.
 // JavaScript
 class Example {
   _getIPAddress() {
-    const url = "https://httpbin.org/ip";
+    const url = 'https://httpbin.org/ip';
     return fetch(url)
       .then(response => response.json())
       .then(responseJson => {
@@ -266,7 +266,7 @@ used to wait for a `Promise`.
 // JavaScript
 class Example {
   async _getIPAddress() {
-    const url = "https://httpbin.org/ip";
+    const url = 'https://httpbin.org/ip';
     try {
       const response = await fetch(url);
       const responseJson = await response.json();
@@ -366,8 +366,8 @@ In React Native, you need to import each required component.
 
 ```js
 //React Native
-import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
 ```
 
 In Flutter, to use widgets from the Material Design library, import the `material.dart` package. To use iOS style widgets, import the Cupertino library. To use a more basic widget set, import the Widgets library. Or, you can write your own widget library and import that.
@@ -391,8 +391,8 @@ implements the render method by returning a view component.
 
 ```js
 // React Native
-import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
 
 export default class App extends React.Component {
   render() {
@@ -407,9 +407,9 @@ export default class App extends React.Component {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#fff",
-    alignItems: "center",
-    justifyContent: "center"
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center'
   }
 });
 ```
@@ -604,7 +604,7 @@ Flutter app.
 ```dart
 // Dart
 void main(){
- print("Hello, this is the main function.");
+ print('Hello, this is the main function.');
 }
 ```
 
@@ -672,7 +672,7 @@ In React Native, you would add a static image by placing the image file in a
 source code directory and referencing it.
 
 ```js
-<Image source={require("./my-icon.png")} />
+<Image source={require('./my-icon.png')} />
 ```
 
 In Flutter, add a static image to your app using the `AssetImage` class in a
@@ -837,8 +837,8 @@ In React Native, canvas components aren't present so third party libraries like 
 ```js
 // React Native
 handleCanvas = canvas => {
-  const ctx = canvas.getContext("2d");
-  ctx.fillStyle = "skyblue";
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = 'skyblue';
   ctx.beginPath();
   ctx.arc(75, 75, 50, 0, 2 * Math.PI);
   ctx.fillRect(150, 100, 300, 300);
@@ -912,9 +912,9 @@ components in a column, you would specify a prop such as:
 <View
   style={%raw%}{{
     flex: 1,
-    flexDirection: "column",
-    justifyContent: "space-between",
-    alignItems: "center"
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    alignItems: 'center'
   }}{%endraw%}
 >
 ```
@@ -986,7 +986,7 @@ Stack(
   children: <Widget>[
     CircleAvatar(
       backgroundImage: NetworkImage(
-        "https://avatars3.githubusercontent.com/u/14101776?v=4"),
+        'https://avatars3.githubusercontent.com/u/14101776?v=4'),
     ),
     Container(
       decoration: BoxDecoration(
@@ -1017,7 +1017,7 @@ components.
 ```js
 // React Native
 <View style={styles.container}>
-  <Text style={%raw%}{{ fontSize: 32, color: "cyan", fontWeight: "600" }}{%endraw%}>
+  <Text style={%raw%}{{ fontSize: 32, color: 'cyan', fontWeight: '600' }}{%endraw%}>
     This is a sample text
   </Text>
 </View>
@@ -1025,9 +1025,9 @@ components.
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#fff",
-    alignItems: "center",
-    justifyContent: "center"
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center'
   }
 });
 ```
@@ -1200,7 +1200,7 @@ of stateless widgets which subclass
 // Flutter
 import 'package:flutter/material.dart';
 
-void main() => runApp(MyStatelessWidget(text: "StatelessWidget Example to show immutable data"));
+void main() => runApp(MyStatelessWidget(text: 'StatelessWidget Example to show immutable data'));
 
 class MyStatelessWidget extends StatelessWidget {
   final String text;
@@ -1426,7 +1426,7 @@ class CustomCard extends React.Component {
       <View>
         <Text> Card {this.props.index} </Text>
         <Button
-          title="Press"
+          title='Press'
           onPress={() => this.props.onPress(this.props.index)}
         />
       </View>
@@ -1436,7 +1436,7 @@ class CustomCard extends React.Component {
 class App extends React.Component {
 
   onPress = index => {
-    console.log("Card ", index);
+    console.log('Card ', index);
   };
 
   render() {
@@ -1507,8 +1507,8 @@ global to the app.
 
 ```js
 // React Native
-await AsyncStorage.setItem( "counterkey", json.stringify(++this.state.counter));
-AsyncStorage.getItem("counterkey").then(value => {
+await AsyncStorage.setItem( 'counterkey', json.stringify(++this.state.counter));
+AsyncStorage.getItem('counterkey').then(value => {
   if (value != null) {
     this.setState({ counter: value });
   }
@@ -1575,7 +1575,7 @@ and DrawerNavigator. Each provides a way to configure and define the screens.
 // React Native
 const MyApp = TabNavigator(
   { Home: { screen: HomeScreen }, Notifications: { screen: tabNavScreen } },
-  { tabBarOptions: { activeTintColor: "#e91e63" } }
+  { tabBarOptions: { activeTintColor: '#e91e63' } }
 );
 const SimpleApp = StackNavigator({
   Home: { screen: MyApp },
@@ -1673,7 +1673,7 @@ import { createBottomTabNavigator } from 'react-navigation';
 
 const MyApp = TabNavigator(
   { Home: { screen: HomeScreen }, Notifications: { screen: tabNavScreen } },
-  { tabBarOptions: { activeTintColor: "#e91e63" } }
+  { tabBarOptions: { activeTintColor: '#e91e63' } }
 );
 ```
 
@@ -1802,7 +1802,7 @@ Drawer(
     leading: Icon(Icons.change_history),
     title: Text('Screen2'),
     onTap: () {
-      Navigator.of(context).pushNamed("/b");
+      Navigator.of(context).pushNamed('/b');
     },
   ),
   elevation: 20.0,
@@ -1825,13 +1825,13 @@ Widget build(BuildContext context) {
         leading: Icon(Icons.change_history),
         title: Text('Screen2'),
         onTap: () {
-          Navigator.of(context).pushNamed("/b");
+          Navigator.of(context).pushNamed('/b');
         },
       ),
       elevation: 20.0,
     ),
     appBar: AppBar(
-      title: Text("Home"),
+      title: Text('Home'),
     ),
     body: Container(),
   );
@@ -1858,10 +1858,10 @@ the `Touchable` components.
 // React Native
 <TouchableOpacity
   onPress={() => {
-    console.log("Press");
+    console.log('Press');
   }}
   onLongPress={() => {
-    console.log("Long Press");
+    console.log('Long Press');
   }}
 >
   <Text>Tap or Long Press</Text>
@@ -1911,7 +1911,7 @@ to any widget by wrapping it in a
 GestureDetector(
   child: Scaffold(
     appBar: AppBar(
-      title: Text("Gestures"),
+      title: Text('Gestures'),
     ),
     body: Center(
       child: Column(
@@ -1956,7 +1956,7 @@ and then receive the response to get the data.
 ```js
 // React Native
 _getIPAddress = () => {
-  fetch("https://httpbin.org/ip")
+  fetch('https://httpbin.org/ip')
     .then(response => response.json())
     .then(responseJson => {
       this.setState({ _ipAddress: responseJson.origin });
@@ -2045,7 +2045,7 @@ final TextEditingController _controller = TextEditingController();
 TextField(
   controller: _controller,
   decoration: InputDecoration(
-    hintText: 'Type something', labelText: "Text Field "
+    hintText: 'Type something', labelText: 'Text Field '
   ),
 ),
 RaisedButton(
@@ -2145,12 +2145,12 @@ In React Native, the following implementation would be used:
 
 ```js
 // React Native
-if (Platform.OS === "ios") {
-  return "iOS";
-} else if (Platform.OS === "android") {
-  return "android";
+if (Platform.OS === 'ios') {
+  return 'iOS';
+} else if (Platform.OS === 'android') {
+  return 'android';
 } else {
-  return "not recognised";
+  return 'not recognised';
 }
 ```
 In Flutter, use the following implementation:
@@ -2158,13 +2158,13 @@ In Flutter, use the following implementation:
 ```dart
 // Flutter
 if (Theme.of(context).platform == TargetPlatform.iOS) {
-  return "iOS";
+  return 'iOS';
 } else if (Theme.of(context).platform == TargetPlatform.android) {
-  return "android";
+  return 'android';
 } else if (Theme.of(context).platform == TargetPlatform.fuchsia) {
-  return "fuchsia";
+  return 'fuchsia';
 } else {
-  return "not recognised ";
+  return 'not recognised ';
 }
 ```
 

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -230,8 +230,8 @@ example._getIPAddress();
 class Example {
   _getIPAddress() {
     final url = 'https://httpbin.org/ip';
-    HttpRequest.request(url).then((value) {
-        print(json.decode(value.responseText)['origin']);
+    http.get(url).then((response) {
+      print(json.decode(response.body)['origin']);
     }).catchError((error) => print(error));
   }
 }
@@ -279,8 +279,8 @@ scheduled for execution later. The `await` operator is used to wait for a
 class Example {
   _getIPAddress() async {
     final url = 'https://httpbin.org/ip';
-    var request = await HttpRequest.request(url);
-    String ip = json.decode(request.responseText)['origin'];
+    final response = await http.get(url);
+    String ip = json.decode(response.body)['origin'];
     print(ip);
   }
 }

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -239,8 +239,10 @@ class Example {
   }
 }
 
-final example = new Example();
-example._getIPAddress();
+main() {
+  final example = new Example();
+  example._getIPAddress();
+}
 ```
 
 Try it out in
@@ -299,8 +301,10 @@ class Example {
   }
 }
 
-final example = new Example();
-example._getIPAddress();
+main() async {
+  final example = new Example();
+  await example._getIPAddress();
+}
 ```
 
 Try it out in

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -219,6 +219,9 @@ class Example {
       });
   };
 }
+
+const example = new Example();
+example._getIPAddress();
 ```
 
 <!-- skip -->
@@ -232,6 +235,9 @@ class Example {
     }).catchError((error) => print(error));
   }
 }
+
+final example = new Example();
+example._getIPAddress();
 ```
 
 Try it out in
@@ -258,6 +264,9 @@ class Example {
     console.log(ip);
   }
 }
+
+const example = new Example();
+example._getIPAddress();
 ```
 
 In Dart, an `async` function returns a `Future`, and the body of the function is
@@ -275,6 +284,9 @@ class Example {
     print(ip);
   }
 }
+
+final example = new Example();
+example._getIPAddress();
 ```
 
 Try it out in

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -254,9 +254,6 @@ main() {
 }
 ```
 
-Try it out in
-[DartPad]({{site.dartpad}}/5a0017d09b6823d0248d965b93133e2e).
-
 For more information, see the documentation on
 [Futures]({{site.dart-site}}/tutorials/language/futures).
 
@@ -321,9 +318,6 @@ main() async {
   }
 }
 ```
-
-Try it out in
-[DartPad]({{site.dartpad}}/04bb4334985107cddcd021322398c918).
 
 For more information, see the documentation for [`async` and
 `await`]({{site.dart-site}}/guides/language/language-tour#asynchrony-support).

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -220,8 +220,12 @@ class Example {
   };
 }
 
-const example = new Example();
-example._getIPAddress();
+function main() {
+  const example = new Example();
+  example._getIPAddress();
+}
+
+main();
 ```
 
 <!-- skip -->
@@ -274,8 +278,12 @@ class Example {
   }
 }
 
-const example = new Example();
-example._getIPAddress();
+async function main() {
+  const example = new Example();
+  await example._getIPAddress();
+}
+
+main();
 ```
 
 In Dart, an `async` function returns a `Future`, and the body of the function is


### PR DESCRIPTION
Remove unnecessary arrow syntax on the Promise-based `_getIPAddress` function.
Fix formatting on `url` variable declaration.
Remove unnecessary `await` in accessing object field in javascript.
Rename `json` to `responseJson` to better match the previous Promise-based example, since they have the same semantics.
Rename `data` to `ip` to better match the Dart example.