### PR TITLE
fix copying command in "MacOS install > Get the Flutter SDK"

### DIFF
--- a/src/docs/get-started/install/_get-sdk.md
+++ b/src/docs/get-started/install/_get-sdk.md
@@ -48,7 +48,7 @@
     (e.g., hermetic build environments, intermittent network availability), iOS
     and Android binaries can be downloaded ahead of time by running:
 
-    ```
+    ```terminal
     $ flutter precache
     ```
 


### PR DESCRIPTION
otherwise, it would copy 
```$ flutter precache```
instead of 
```flutter precache```

This is what I believe is the problem. The issue appears on Chrome v37 on macOS 