### PR TITLE
Add background color example

### DIFF
--- a/src/docs/get-started/flutter-for/web-devs.md
+++ b/src/docs/get-started/flutter-for/web-devs.md
@@ -114,7 +114,9 @@ The CSS examples use the hex color equivalents to the Material color palette.
     ),
     width: 320.0,
     height: 240.0,
-[[highlight]]    color: Colors.grey[300],[[/highlight]]
+    [[highlight]]decoration: BoxDecoration(
+      color: Colors.grey[300],
+    ),[[/highlight]]
   );
 {% endprettify %}
 </div>


### PR DESCRIPTION
The current example for the [`Setting background color`](https://flutter.dev/docs/get-started/flutter-for/web-devs#setting-background-color) section doesn't contain the `decoration` property referenced in the explanatory text, so I updated it based on a later example.