### PR TITLE
Use a consistent border for DartPad embeddings

### DIFF
--- a/src/_assets/css/_content.scss
+++ b/src/_assets/css/_content.scss
@@ -81,4 +81,9 @@
 
     &:hover > .anchor > .octicon-link { opacity: 1 }
   }
+
+  // Embedded DartPad
+  iframe {
+    border: 1px solid #ccc;
+  }
 }


### PR DESCRIPTION
iframes use a browser-defined border by default, so this replaces that with a border consistent with DartPad's style