### PR TITLE
Fix internal links

### DIFF
--- a/src/docs/development/data-and-backend/state-mgmt/simple.md
+++ b/src/docs/development/data-and-backend/state-mgmt/simple.md
@@ -236,7 +236,7 @@ model itself and its business logic.
 
 `ChangeNotifier` is part of `flutter:foundation` and doesn't depend on 
 any higher-level classes in Flutter. It's easily testable (you don't even need
-to use [widget testing](/docs/testing#widget-testing) for it). For example,
+to use [widget testing](/docs/testing#widget-tests) for it). For example,
 here's a simple unit test of `CartModel`:
 
 <?code-excerpt "state_mgmt/simple/test/model_test.dart (test)"?>

--- a/src/docs/development/packages-and-plugins/developing-packages.md
+++ b/src/docs/development/packages-and-plugins/developing-packages.md
@@ -53,14 +53,14 @@ specialized content:
 * `lib/hello.dart`:
    - The Dart code for the package.
 * `test/hello_test.dart`:
-   - The [unit tests](/docs/testing#unit-testing) for the package.
+   - The [unit tests](/docs/testing#unit-tests) for the package.
 
 ### Step 2: Implement the package
 
 For pure Dart packages, simply add the functionality inside the main
 `lib/<package name>.dart` file, or in several files in the `lib` directory.
 
-To test the package, add [unit tests](/docs/testing#unit-testing)
+To test the package, add [unit tests](/docs/testing#unit-tests)
 in a `test` directory.
 
 For additional details on how to organize the package contents, see the

--- a/src/docs/testing/build-modes.md
+++ b/src/docs/testing/build-modes.md
@@ -7,7 +7,7 @@ The Flutter tooling supports three modes when compiling your app,
 and a headless mode for testing.
 This doc explains the three modes and tells you when to use which.
 For more information on headless testing, see
-[Unit testing.](/docs/testing#unit-testing)
+[Unit testing.](/docs/testing#unit-tests)
 
 You choose the compilation mode depending on where you are in
 the development cycle. Are you debugging your code? Do you

--- a/src/docs/testing/ui-performance/index.md
+++ b/src/docs/testing/ui-performance/index.md
@@ -476,7 +476,7 @@ and debugging in Flutter:
 [Flutter API]: {{site.api}}
 [UIKit]: https://developer.apple.com/documentation/uikit
 [MainThread]: {{site.android-dev}}/reference/android/support/annotation/MainThread
-[Integration testing]: /docs/testing#integration-testing
+[Integration testing]: /docs/testing#integration-tests
 [Architecture notes]: {{site.github}}/flutter/engine/wiki#architecture-notes
 [Widget inspector]: /docs/development/tools/inspector
 [Flutter Inspector talk]: https://www.youtube.com/watch?v=JIcmJNT9DNI


### PR DESCRIPTION
Some anchored internal links were broken because of changes in subtitles in the testing docs.