### PR TITLE
Fix broken floating action button theme

### DIFF
--- a/src/docs/cookbook/design/themes.md
+++ b/src/docs/cookbook/design/themes.md
@@ -188,7 +188,10 @@ class MyHomePage extends StatelessWidget {
         ),
       ),
       floatingActionButton: Theme(
-        data: Theme.of(context).copyWith(accentColor: Colors.yellow),
+        data: Theme.of(context).copyWith(
+          colorScheme:
+              Theme.of(context).colorScheme.copyWith(secondary: Colors.yellow),
+        ),
         child: FloatingActionButton(
           onPressed: null,
           child: Icon(Icons.add),


### PR DESCRIPTION
Fix issue #2688

The reason for this issue is because the resolving of `backgroundColor` in `FloatingActionButton`  widget looks like that:
```
final Color backgroundColor = this.backgroundColor
      ?? floatingActionButtonTheme.backgroundColor
      ?? theme.colorScheme.secondary;
```

LMK if this is the best solution for this.