### PR TITLE
Fix example validator functions on "Building a form with validation" page

### DIFF
--- a/src/docs/cookbook/forms/validation.md
+++ b/src/docs/cookbook/forms/validation.md
@@ -100,6 +100,7 @@ TextFormField(
     if (value.isEmpty) {
       return 'Please enter some text';
     }
+    return null;
   },
 );
 ```
@@ -198,6 +199,7 @@ class MyCustomFormState extends State<MyCustomForm> {
               if (value.isEmpty) {
                 return 'Please enter some text';
               }
+              return null;
             },
           ),
           Padding(


### PR DESCRIPTION
According to FormFieldValidator docs, validator function should return an error string to display if the input is invalid, or null otherwise.