### PR TITLE
Updated placeholder syntax

### DIFF
--- a/src/docs/cookbook/images/cached-images.md
+++ b/src/docs/cookbook/images/cached-images.md
@@ -30,7 +30,7 @@ placeholder. In this example, you'll display a spinner while the image loads.
 <!-- skip -->
 ```dart
 CachedNetworkImage(
-  placeholder: CircularProgressIndicator(),
+  placeholder: (context, url) => CircularProgressIndicator(),
   imageUrl: 'https://picsum.photos/250?image=9',
 );
 ```
@@ -59,7 +59,7 @@ class MyApp extends StatelessWidget {
         ),
         body: Center(
           child: CachedNetworkImage(
-            placeholder: CircularProgressIndicator(),
+            placeholder: (context, url) => CircularProgressIndicator(),
             imageUrl:
                 'https://picsum.photos/250?image=9',
           ),


### PR DESCRIPTION
As of version 0.8.0, the syntax for the placeholder has changed to a builder pattern: https://pub.dev/packages/cached_network_image