### PR TITLE
fix typo

### DIFF
--- a/src/docs/development/platform-integration/platform-channels.md
+++ b/src/docs/development/platform-integration/platform-channels.md
@@ -469,7 +469,7 @@ as was used on the Flutter client side.
   FlutterViewController* controller = (FlutterViewController*)self.window.rootViewController;
 
   FlutterMethodChannel* batteryChannel = [FlutterMethodChannel
-                                          methodChannelWithName:@"samples.flutter.de/battery"
+                                          methodChannelWithName:@"samples.flutter.dev/battery"
                                           binaryMessenger:controller];
 
   [batteryChannel setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {


### PR DESCRIPTION
samples.flutter.de/battery -> samples.flutter.dev/battery