### PR TITLE
Added links to 'mobile', 'web', and 'desktop'

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -51,7 +51,7 @@ description: >
             <div class="col-md-12 col-lg-8 offset-lg-2">
                 <span class="homepage__intro__partner">Made by {% asset homepage/logo-google.svg alt='Google logo' %}</span>
                 <p class="homepage__intro__statement text-center">
-                    Flutter is Google’s portable UI toolkit for building beautiful, natively-compiled applications for mobile, web, and desktop from a single codebase.
+                    Flutter is Google’s portable UI toolkit for building beautiful, natively-compiled applications for <a href="https://flutter.dev/docs">mobile</a>, <a href="https://flutter.dev/web">web</a>, and <a href="https://flutter.dev/desktop">desktop</a> from a single codebase.
                 </p>
 
                 <div class="homepage__intro__buttons">


### PR DESCRIPTION
Added links to 'mobile', 'web', and 'desktop' on homepage so users can quickly read about or navigate to each of the three

[note: mobile just links to docs for now but we could make a flutter.dev/mobile to talk about how mobile is stable, etc...]

*please review this for accuracy and to make sure links work*