### PR TITLE
Fix spelling of 'verification' in cookbook

### DIFF
--- a/src/docs/cookbook/testing/widget/introduction.md
+++ b/src/docs/cookbook/testing/widget/introduction.md
@@ -154,7 +154,7 @@ which is particularly useful while testing.
 
 With a widget in the test environment, search
 through the widget tree for the `title` and `message`
-Text widgets using a `Finder`. This allow verifification that
+Text widgets using a `Finder`. This allow verification that
 the widgets are displaying correctly.
 
 For this purpose, use the top-level


### PR DESCRIPTION
Fixes the spelling of 'verification' in the cookbook 'An introduction to widget testing' under the '5. Search for our widget using a Finder'