### PR TITLE
Add "Icon" widget to Widget catalog

### DIFF
--- a/src/_data/catalog/widgets.json
+++ b/src/_data/catalog/widgets.json
@@ -70,7 +70,7 @@
       "Information displays"
     ],
     "link": "https://api.flutter.dev/flutter/widgets/Icon-class.html",
-    "image": "<img alt='' src='https://raw.githubusercontent.com/flutter/assets-for-api-docs/master/assets/widgets/icon.png'>"
+    "image": "<img alt='' src='https://flutter.github.io/assets-for-api-docs/assets/widgets/icon.png'>"
   },
   {
     "name": "RaisedButton",

--- a/src/_data/catalog/widgets.json
+++ b/src/_data/catalog/widgets.json
@@ -70,7 +70,7 @@
       "Information displays"
     ],
     "link": "https://api.flutter.dev/flutter/widgets/Icon-class.html",
-    "image": "<img alt='' src='/images/catalog-widget-placeholder.png'>"
+    "image": "<img alt='' src='https://raw.githubusercontent.com/flutter/assets-for-api-docs/master/assets/widgets/icon.png'>"
   },
   {
     "name": "RaisedButton",


### PR DESCRIPTION
Replace the Icon Widget's "Placeholder" icon in the Widget Catalog with an icon generated by the assets-for-api-docs tool.