### PR TITLE
travis ci: make link checker skip codelab

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,4 +197,3 @@ Also check out the site-shared
 [Repo on Travis]: https://travis-ci.org/flutter/website
 [rvm]: https://rvm.io/rvm/install#installation
 [this repo]: https://github.com/flutter/website
-

--- a/README.md
+++ b/README.md
@@ -197,3 +197,4 @@ Also check out the site-shared
 [Repo on Travis]: https://travis-ci.org/flutter/website
 [rvm]: https://rvm.io/rvm/install#installation
 [this repo]: https://github.com/flutter/website
+

--- a/tool/config/linkcheck-skip-list.txt
+++ b/tool/config/linkcheck-skip-list.txt
@@ -14,6 +14,7 @@ https://dart-pub.mirrors.sjtug.sjtu.edu.cn
 https://hk.saowen.com/a/fbb6e484de022173fe85248875286060ce40d069c97420bc0be49d838e19e372
 https://itunes.apple.com/cn/app/id895682747
 https://now.qq.com
+https://codelabs.developers.google.com/codelabs/google-photos-sharing
 
 # -----------------------------------------------------------------------------
 # Links with "anchors" that aren't really anchors


### PR DESCRIPTION
There doesn't seem to be anything wrong with https://codelabs.developers.google.com/codelabs/google-photos-sharing but this seems to be the culprit so I think we should skip it when we test external links