### PR TITLE
Minor correction to Flutter widget test cookbook

### DIFF
--- a/src/docs/cookbook/testing/widget/introduction.md
+++ b/src/docs/cookbook/testing/widget/introduction.md
@@ -41,7 +41,7 @@ together throughout this recipe, which uses the following steps:
   3. Create a `testWidgets` test.
   4. Build the widget using the `WidgetTester`.
   5. Search for the widget using a `Finder`.
-  6. Verify that the widget uses a `Matcher`.
+  6. Verify the widget using a `Matcher`.
 
 ### 1. Add the `flutter_test` dependency
 
@@ -181,7 +181,7 @@ void main() {
 }
 ```
 
-### 6. Verify that the widget uses a `Matcher`
+### 6. Verify the widget using a `Matcher`
 
 Finally, verify the title and message `Text` widgets appear on screen
 using the `Matcher` constants provided by `flutter_test`.


### PR DESCRIPTION
The headline for one of the steps in the widget test cookbook article is "Verify that the Widget uses a Matcher," which I don't believe is correct. What the code example shows is a Matcher being used to verify the behavior of a widget. I've tweaked the headline to reflect this.