### PR TITLE
Adjust the step by step to the same file name

### DIFF
--- a/src/docs/get-started/flutter-for/android-devs.md
+++ b/src/docs/get-started/flutter-for/android-devs.md
@@ -1220,7 +1220,7 @@ assets:
 You can then access your images using `AssetImage`:
 
 {% prettify dart %}
-return AssetImage("images/a_dot_burr.jpeg");
+return AssetImage("images/my_icon.jpeg");
 {% endprettify %}
 
 or directly in an `Image` widget:


### PR DESCRIPTION
Doesn't make more sense to keep using `my_icon` for the file name since we are following a step by step?