### PR TITLE
Remove confusing provider article

### DIFF
--- a/src/docs/development/data-and-backend/state-mgmt/options.md
+++ b/src/docs/development/data-and-backend/state-mgmt/options.md
@@ -84,7 +84,3 @@ by the Flutter community:
 * [MobX.dart, Hassle free state-management for your Dart and Flutter apps](https://github.com/mobxjs/mobx.dart)
 * [Getting started with MobX.dart](https://mobx.pub/getting-started)
 * [Flutter: State Management with Mobx](https://developer.school/posts/flutter-state-management-with-mobx/) by Paul Halliday
-
-## Provider
-
-* [Getting Started with Provider](https://developer.school/posts/flutter-provider-and-bloc-in-5-minutes/) by Paul Halliday


### PR DESCRIPTION
The article article describes the use of the Provider package with a ChangeNotifier while calling this the BLoC pattern. As this will confuse a lot of people I would prefer to remove the article while we wait for it to be fixed (https://github.com/developer-school/flutter_bloc_provider/issues/2).