### PR TITLE
Added the missing link of Flutter’s build modes

### DIFF
--- a/src/docs/testing/build-modes.md
+++ b/src/docs/testing/build-modes.md
@@ -100,3 +100,4 @@ For more information on the build modes, see
 [Android]: /docs/deployment/android
 [hot reload]: /docs/development/tools/hot-reload
 [DevTools]: /docs/development/tools/devtools
+[Flutter's build modes]: ({{site.github}}/flutter/flutter/wiki/Flutter%27s-modes)


### PR DESCRIPTION
Found this issue while I am doing the sync/localization works on this, please have a review.

Thanks!