### PR TITLE
Fix analyzer warning for listenable in Animation Tutorial

### DIFF
--- a/examples/animation/animate2/lib/main.dart
+++ b/examples/animation/animate2/lib/main.dart
@@ -9,7 +9,7 @@ class AnimatedLogo extends AnimatedWidget {
       : super(key: key, listenable: animation);
 
   Widget build(BuildContext context) {
-    final Animation<double> animation = listenable;
+    final Animation<double> animation = listenable as Animation<double>;
     return Center(
       child: Container(
         margin: EdgeInsets.symmetric(vertical: 10),

--- a/examples/animation/animate3/lib/main.dart
+++ b/examples/animation/animate3/lib/main.dart
@@ -8,7 +8,7 @@ class AnimatedLogo extends AnimatedWidget {
       : super(key: key, listenable: animation);
 
   Widget build(BuildContext context) {
-    final Animation<double> animation = listenable;
+    final Animation<double> animation = listenable as Animation<double>;
     return Center(
       child: Container(
         margin: EdgeInsets.symmetric(vertical: 10),

--- a/examples/animation/animate5/lib/main.dart
+++ b/examples/animation/animate5/lib/main.dart
@@ -17,7 +17,7 @@ class AnimatedLogo extends AnimatedWidget {
       : super(key: key, listenable: animation);
 
   Widget build(BuildContext context) {
-    final Animation<double> animation = listenable;
+    final Animation<double> animation = listenable as Animation<double>;
     return Center(
       child: Opacity(
         opacity: _opacityTween.evaluate(animation),


### PR DESCRIPTION
Fix for https://github.com/flutter/flutter/issues/32772 where the Dart analyzer is giving this error:

`A value of type 'Listenable' can't be assigned to a variable of type 'Animation<double>'.
Try changing the type of the variable, or casting the right-hand type to 'Animation<double>'.
dart(invalid_assignment)`