### PR TITLE
Update link to the sample with newly landed url

### DIFF
--- a/src/docs/development/data-and-backend/state-mgmt/simple.md
+++ b/src/docs/development/data-and-backend/state-mgmt/simple.md
@@ -420,7 +420,7 @@ rebuild when `notifyListeners` is called.
 ## Putting it all together
 
 You can [check out the
-example]({{site.github}}/filiph/samples/tree/provider-shopper/provider_shopper)
+example]({{site.github}}flutter/samples/tree/master/provider_shopper)
 covered in this article. If you want something simpler,
 you can see how the simple Counter app looks like when [built with
 `provider`](https://github.com/flutter/samples/tree/master/provider_counter).

--- a/src/docs/development/data-and-backend/state-mgmt/simple.md
+++ b/src/docs/development/data-and-backend/state-mgmt/simple.md
@@ -420,7 +420,7 @@ rebuild when `notifyListeners` is called.
 ## Putting it all together
 
 You can [check out the
-example]({{site.github}}flutter/samples/tree/master/provider_shopper)
+example]({{site.github}}/flutter/samples/tree/master/provider_shopper)
 covered in this article. If you want something simpler,
 you can see how the simple Counter app looks like when [built with
 `provider`](https://github.com/flutter/samples/tree/master/provider_counter).


### PR DESCRIPTION
Thanks to https://github.com/flutter/samples/pull/87, we can now link to flutter/samples instead of filiph/samples.