### PR TITLE
Update reading-writing-files.md: getTemporaryDirectory returns NSCachesDirectory

### DIFF
--- a/src/docs/cookbook/persistence/reading-writing-files.md
+++ b/src/docs/cookbook/persistence/reading-writing-files.md
@@ -37,7 +37,7 @@ two file system locations:
 
   * *Temporary directory:* A temporary directory (cache) that the system can
     clear at any time. On iOS, this corresponds to the
-    [`NSCachesDirectory`](https://developer.apple.com/documentation/foundation/nssearchpathdirectory/nscachesdirectory?language=occ). On Android, this is the value that
+    [`NSCachesDirectory`](https://developer.apple.com/documentation/foundation/nssearchpathdirectory/nscachesdirectory). On Android, this is the value that
     [`getCacheDir()`]({{site.android-dev}}/reference/android/content/Context#getCacheDir())
     returns.
   * *Documents directory:* A directory for the app to store files that only

--- a/src/docs/cookbook/persistence/reading-writing-files.md
+++ b/src/docs/cookbook/persistence/reading-writing-files.md
@@ -36,9 +36,8 @@ device's file system. The plugin currently supports access to
 two file system locations:
 
   * *Temporary directory:* A temporary directory (cache) that the system can
-    clear at any time. On iOS, this corresponds to the value that
-    [`NSTemporaryDirectory()`](https://developer.apple.com/reference/foundation/1409211-nstemporarydirectory)
-    returns. On Android, this is the value that
+    clear at any time. On iOS, this corresponds to the
+    [`NSCachesDirectory`](https://developer.apple.com/documentation/foundation/nssearchpathdirectory/nscachesdirectory?language=occ). On Android, this is the value that
     [`getCacheDir()`]({{site.android-dev}}/reference/android/content/Context#getCacheDir())
     returns.
   * *Documents directory:* A directory for the app to store files that only


### PR DESCRIPTION
path_provider.getTemporaryDirecory not return NSTemporaryDirectory.
Correctly NSCachesDirectory.

Source: https://github.com/flutter/plugins/blob/ed53cab392dda8495d927ff8a703fad4e59bdfea/packages/path_provider/ios/Classes/PathProviderPlugin.m#L52