### PR TITLE
issue 35703 documentation fix

### DIFF
--- a/src/docs/development/packages-and-plugins/developing-packages.md
+++ b/src/docs/development/packages-and-plugins/developing-packages.md
@@ -280,7 +280,7 @@ $ flutter pub pub publish --dry-run
 Finally, run the actual publish command:
 
 ```terminal
-$ flutter pub publish
+$ flutter pub pub publish
 ```
 
 For details on publishing, see the


### PR DESCRIPTION
Issue: https://github.com/flutter/flutter/issues/35703

> Documentation lists the command `flutter pub publish` but that command will never print `Looks great! Are you ready to upload your package (y/n)?`. Using `flutter pub pub publish` solved it for me as well.
> Link to the doc page: ://flutter.dev/docs/development/packages-and-plugins/developing-packages