### PR TITLE
Small grammar fix in Adding interactivity: Step 3

### DIFF
--- a/src/docs/development/ui/interactive.md
+++ b/src/docs/development/ui/interactive.md
@@ -207,7 +207,7 @@ class _FavoriteWidgetState extends State<FavoriteWidget> {
 The `_toggleFavorite()` method, which is called when the `IconButton` is
 pressed, calls `setState()`. Calling `setState()` is critical, because this
 tells the framework that the widget’s state has changed and that the widget
-should be redraw. The function argument to `setState()` toggles the UI between
+should be redrawn. The function argument to `setState()` toggles the UI between
 these two states:
 
 - A `star` icon and the number 41


### PR DESCRIPTION
This is a small grammar fix to the paragraph about `_toggleFavorite()` and `setState()` in Step 3 of the Adding interactivity tutorial.