### PR TITLE
Fixed the wrong title at the docs nav.

### DIFF
--- a/src/docs/cookbook/animation/animated-container.md
+++ b/src/docs/cookbook/animation/animated-container.md
@@ -1,7 +1,7 @@
 ---
 title: Animate the properties of a container
 prev:
-  title: Animate a page route transition
+  title: Animate a widget using a physics simulation
   path: /docs/cookbook/animation/physics-simulation
 next:
   title: Fade a widget in and out


### PR DESCRIPTION
We change the URL, but left the title text behind ;-)
cc/ @sfshaza2 

Thanks!