### PR TITLE
fixed typo in link

### DIFF
--- a/src/docs/resources/faq.md
+++ b/src/docs/resources/faq.md
@@ -956,4 +956,4 @@ deployed to Apple's App Store.
 [built into Android Studio]: {{site.android-dev}}/studio/build/apk-analyzer
 [Android Studio instructions]: {{site.android-dev}}/studio/build/apk-analyzer
 [iOS instructions]: /docs/deployment/ios
-[web instructions]: {{site.github}}/flutter/flutter-web
+[web instructions]: {{site.github}}/flutter/flutter_web


### PR DESCRIPTION
the repo was called "flutter-web" instead of "flutter_web". This lead to a 404 page