### PR TITLE
The command line of build_runner build

### DIFF
--- a/src/docs/development/data-and-backend/json.md
+++ b/src/docs/development/data-and-backend/json.md
@@ -321,7 +321,7 @@ There are two ways of running the code generator.
 
 #### One-time code generation
 
-By running `flutter pub run build_runner build` in the project root,
+By running `flutter packages pub run build_runner build` in the project root,
 you generate JSON serialization code for your models whenever they are needed.
 This triggers a one-time build that goes through the source files, picks the
 relevant ones, and generates the necessary serialization code for them.
@@ -334,7 +334,7 @@ build manually every time you make changes in your model classes.
 A _watcher_ makes our source code generation process more convenient. It
 watches changes in our project files and automatically builds the necessary
 files when needed. Start the watcher by running
-`flutter pub run build_runner watch` in the project root.
+`flutter packages pub run build_runner watch` in the project root.
 
 It is safe to start the watcher once and leave it running in the background.
 
@@ -406,7 +406,7 @@ class User {
 }
 ```
 
-Running `flutter pub run build_runner build` in the terminal creates
+Running `flutter packages pub run build_runner build` in the terminal creates
 the `*.g.dart` file, but the private `_$UserToJson()` function
 looks something like the following:
 


### PR DESCRIPTION
We've found an issue here cfug/flutter.cn/issues/425 from the Flutter China community about the command line of build_runner build, we tried `flutter pub run build_runner build` and got errors, but `flutter packages pub run build_runner build` got works, I was wondering if there are any issues about the document, I just add `packages` in the command line.

cc/ @t496971418 @Vadaski @Realank, let me know if you have any updates.
cc/ @sfshaza2