### PR TITLE
Update build-modes.md

### DIFF
--- a/src/docs/testing/build-modes.md
+++ b/src/docs/testing/build-modes.md
@@ -100,4 +100,4 @@ For more information on the build modes, see
 [Android]: /docs/deployment/android
 [hot reload]: /docs/development/tools/hot-reload
 [DevTools]: /docs/development/tools/devtools
-[Flutter's build modes]: ({{site.github}}/flutter/flutter/wiki/Flutter%27s-modes)
+[Flutter's build modes]: {{site.github}}/flutter/flutter/wiki/Flutter%27s-modes


### PR DESCRIPTION
remove unnecessary parentheses for the hyperlink declaration of Flutter's build modes.