### PR TITLE
Fix a small typo in the Flutter 1.7 information

### DIFF
--- a/src/docs/index.md
+++ b/src/docs/index.md
@@ -31,7 +31,7 @@ Google group.
 
 Flutter 1.7 is live!
 
-For more information, see [Announcing Futter
+For more information, see [Announcing Flutter
 1.7]({{site.flutter-medium}}/announcing-flutter-1-7-9cab4f34eacf)
 on the [Flutter Medium Publication]({{site.flutter-medium}}),
 and the [1.7.8 release


### PR DESCRIPTION
minor typo - change "Futter" to "Flutter"