### PR TITLE
Fixed typo in "package fonts" documentation

### DIFF
--- a/src/docs/cookbook/design/package-fonts.md
+++ b/src/docs/cookbook/design/package-fonts.md
@@ -139,10 +139,10 @@ class MyHomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      // The AppBar uses the app-default Raleway font.
+      // The AppBar uses the app-default RobotoMono font.
       appBar: AppBar(title: Text('Package Fonts')),
       body: Center(
-        // This Text widget uses the RobotoMono font.
+        // This Text widget uses the Raleway font.
         child: Text(
           'Using the Raleway font from the awesome_package',
           style: TextStyle(


### PR DESCRIPTION
The documentation switched up the two different font types in the comments. Code is self-explanatory, but fixed comments for clarity.