### PR TITLE
fix typo: react native example async await

### DIFF
--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -274,7 +274,7 @@ class Example {
     const response = await fetch(url);
     const json = await response.json();
     const data = await json.origin;
-    console.log(data);
+    return data;
   }
 }
 


### PR DESCRIPTION
the `_getIPAddress` function must return `data`, isn't it ?