### PR TITLE
Adding a page on FFI

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -125,6 +125,8 @@
     - title: Platform integration
       permalink: /docs/development/platform-integration
       children:
+        - title: C and C++ interop
+          permalink: /docs/development/platform-integration/c-interop
         - title: Web FAQ
           permalink: /docs/development/platform-integration/web
         - title: Writing platform-specific code

--- a/src/docs/development/platform-integration/c-interop.md
+++ b/src/docs/development/platform-integration/c-interop.md
@@ -92,7 +92,7 @@ the application binary of any downstream app.
 ### Closed-source third-party library
 
 Add a `vendored_frameworks` field to the `.podspec`
-of the Flutter plugin. See the [CocoaPods Example][].
+of the Flutter plugin. See the [CocoaPods example][].
 
 Note that binary code should not be uploaded to
 Pub directly but rather downloaded from a trusted
@@ -138,11 +138,11 @@ not included in your Flutter package.
 
 [Add C and C++ code to your project]: {{site.android-dev}}/studio/projects/add-native-code
 [Android NDK Native APIs]: {{site.android-dev}}/ndk/guides/stable_apis
-[CocoaPods Example]: {{site.github}}/CocoaPods/CocoaPods/blob/master/examples/Vendored%20Framework%20Example/Example%20Pods/VendoredFrameworkExample.podspec
-[Dart API reference documentation]: {{site.dart-api}}/dev/
-[`DynamicLibrary.executable`]: {{site.dart-api}}/dev/dart-ffi/DynamicLibrary/DynamicLibrary.executable.html
-[`DynamicLibrary.open`]: {{site.dart-api}}/dev/dart-ffi/DynamicLibrary/DynamicLibrary.open.html
-[`DynamicLibrary.process`]: {{site.dart-api}}/dev/dart-ffi/DynamicLibrary/DynamicLibrary.process.html
+[CocoaPods example]: {{site.github}}/CocoaPods/CocoaPods/blob/master/examples/Vendored%20Framework%20Example/Example%20Pods/VendoredFrameworkExample.podspec
+[Dart API reference documentation]: {{site.dart.api}}/dev/
+[`DynamicLibrary.executable`]: {{site.dart.api}}/dev/dart-ffi/DynamicLibrary/DynamicLibrary.executable.html
+[`DynamicLibrary.open`]: {{site.dart.api}}/dev/dart-ffi/DynamicLibrary/DynamicLibrary.open.html
+[`DynamicLibrary.process`]: {{site.dart.api}}/dev/dart-ffi/DynamicLibrary/DynamicLibrary.process.html
 [FFI]: https://en.wikipedia.org/wiki/Foreign_function_interface
 [ffi issue]: {{site.github}}/dart-lang/sdk/issues/34452
 [Upgrading Flutter]: /docs/development/tools/sdk/upgrading

--- a/src/docs/development/platform-integration/c-interop.md
+++ b/src/docs/development/platform-integration/c-interop.md
@@ -3,7 +3,7 @@ title: "Binding to native code using dart:ffi"
 description: "To use C code in your Flutter program, use the dart:ffi library (currently in preview)."
 ---
 
-Flutter mobile can use the dart:ffi library
+Flutter mobile can use the [dart:ffi][] library
 to call native C APIs. The _ffi_ acronym stands for
 [_foreign function interface._][FFI]
 Other terms for similar functionality include
@@ -33,113 +33,166 @@ API documentation is available from the Dart dev channel:
 
 Dynamically linked libraries are automatically loaded by
 the dynamic linker when the app starts. Their constituent
-symbols can be resolved via [`DynamicLibrary.process`][].
+symbols can be resolved using [`DynamicLibrary.process`][].
 You can also get a handle to the library with
 [`DynamicLibrary.open`][] to restrict the scope of
 symbol resolution, but it's unclear how Apple's
 review process handles this.
+(**Question: I find this, and the next paragraph, to be
+ confusing. Why does the developer care about this?
+ Can we find a better/more compelling way to word it?**)
 
 Symbols statically linked into the application binary
-can be resolved via [`DynamicLibrary.executable`][] or
+can be resolved using [`DynamicLibrary.executable`][] or
 [`DynamicLibrary.process`][].
 
-### Platform library
+### Link to a system library shipped with a target device
 
-To link against a platform library,
-open `Runner.xcodeproj` in Xcode, select the target,
-click **+** in the **Linked Frameworks and Libraries**
-section, and select the platform library to link against.
+To link against a platform's system library,
+use the following instructions:
 
-### First-party library
+1. In Xcode, open `Runner.xcodeproj`.
+1. Select the target platform.
+1. Click **+** in the **Linked Frameworks and Libraries**
+   section.
+1. Select the system library to link against.
 
-A first-party native library can be included either as
-source or as a (signed) `.framework`.
-It's probably possible to include statically linked
-archives as well, but this should be tested.
+### Link directly to source code
 
-#### Source
+To link directly to source code,
+use the following instructions:
 
-Add the C/C++/Objective-C/Swift sources to the Xcode
-project, and add the following prefix to the exported
-symbol declarations to ensure they are visible to Dart:
+<ol markdown="1">
+<li markdown="1">In Xcode, open `Runner.xcodeprof`.
+</li>
+<li markdown="1">Add the C/C++/Objective-C/Swift
+    source files to the Xcode project.
+    (**Question: Is this added to Runner.xcodeproj?
+     I'm assuming so. Also, do we have an example?**)
+</li>
+<li markdown="1">Add the following prefix to the
+    exported symbol declarations to ensure they
+    are visible to Dart:
+    (**Question: Is "exported symbol declarations" in the same file?**)
 
 **C/C++/Objective-C**
 
-```
+```objective-c
 extern "C" /* <= C++ only */ __attribute__((visibility("default"))) __attribute((used))
 ```
 
 **Swift**
 
-```
+```swift
 @_cdecl("myFunctionName")
 ```
+</li>
+</ol>
 
-#### Compiled (dynamic library)
+### Link to a compiled library
 
-If a (properly signed) `Framework` file is present,
-add it to the **Embedded Binaries** and
-**Linked Frameworks & Libraries** section of the
-target in Xcode.
+To link to a compiled dynamic library,
+use the following instructions:
 
-### Open-source third-party library
+1. If a properly signed `Framework` file is present,
+   open `Runner.xcodeproj` and add it to
+   it to the **Embedded Binaries** section.
+1. Also add it to the **Linked Frameworks & Libraries**
+   section of the target in Xcode.
 
-Simply add the native code to the `source_files`
-field of the `.podspec` in the Flutter plugin.
-The native code will be statically linked into
-the application binary of any downstream app.
+(**Question: If no Framework file is present, or if it IS
+ present, but not properly signed, what then?**)
 
-### Closed-source third-party library
+### Create a plugin containing Dart and native code
 
-Add a `vendored_frameworks` field to the `.podspec`
-of the Flutter plugin. See the [CocoaPods example][].
+To create a Flutter plugin that includes both
+C/C++/Objective-C _and_ Dart code,
+use the following instructions:
 
-Note that binary code should not be uploaded to
-Pub directly but rather downloaded from a trusted
-third-party as in the example.
+1. In your plugin project,
+   open `ios/<myproject>.podspec`.
+1. Add the native code to the `source_files`
+   field.
+
+The native code is then statically linked into
+the application binary of any app that uses
+this plugin.
+
+### Create a plugin distributed in binary form
+
+To create a Flutter plugin that includes Dart
+source code, but distribute the C/C++ library
+in binary form, use the following instructions:
+
+1. In your plugin project,
+   open `ios/<myproject>.podspec`.
+1. Add a `vendored_frameworks` field.
+   See the [CocoaPods example][].
+
+**Do not** upload this plugin
+(or any plugin containing binary code)
+to Pub. Instead, this plugin should be downloaded
+from a trusted third-party,
+as shown in the CocoaPods example.
 
 ## Android
 
-### Platform library
+### Link to a system library shipped with a target device
 
-See [Android NDK Native APIs][] in the
-Android docs for a list of stable native APIs.
+To link against a platform's system library,
+use the following instructions:
 
-[`DynamicLibrary.open`][] can be used to load
-a library from the list.
-For example, to load OpenGL ES (v3):
+1. Find the desired library in the
+   [Android NDK Native APIs][]
+   list in the Android docs.
+   This lists stable native APIs.
+   (**Question: What if it's not in the list?
+   Are you then unable to make it work?**)
+1. Load the library using
+   [`DynamicLibrary.open`][].
+   For example, to load OpenGL ES (v3):
 
-```
-DynamicLibrary.open("libGLES_v3.so");
-```
+   ```dart
+   DynamicLibrary.open('libGLES_v3.so');
+   ```
 
 You might need to update the Android manifest
 file of the app or plugin if indicated by
 the documentation.
 
-### First-party library
-
-The process for including native code in source
-or binary form is the same for an app or plugin.
-
-### Open-source third-party library
+### Create a plugin containing Dart and native code
 
 Follow the [Add C and C++ code to your project][]
 instructions in the Android docs to
 add native code and support for the native
 code toolchain (either CMake or `ndk-build`).
+(**Comment: Wow, the instructions on that page are
+ long and complex. It's rather intimidating.**)
 
-### Closed-source third-party library
+### Create a plugin distributed in binary form
 
-Add the AAR artifact as a dependency in your `build.gradle`.
-It should be downloaded from a repository such as JCenter,
-not included in your Flutter package.
+To create a Flutter plugin that includes Dart
+source code, but distribute the C/C++ library
+in binary form, use the following instructions:
+
+1. Open the `android/build.gradle` file for your
+   project.
+1. Add the AAR artifact as a dependency.
+   **Don't** include the artifact in your
+   Flutter package. Instead, it should be
+   downloaded from a repository, such as
+   JCenter.
+
+## Web
+
+Plugins are not yet supported for web apps.
 
 
 [Add C and C++ code to your project]: {{site.android-dev}}/studio/projects/add-native-code
 [Android NDK Native APIs]: {{site.android-dev}}/ndk/guides/stable_apis
 [CocoaPods example]: {{site.github}}/CocoaPods/CocoaPods/blob/master/examples/Vendored%20Framework%20Example/Example%20Pods/VendoredFrameworkExample.podspec
 [Dart API reference documentation]: {{site.dart.api}}/dev/
+[dart:ffi]: {{site.dart.api}}/dev/dart-ffi/dart-ffi-library.html
 [`DynamicLibrary.executable`]: {{site.dart.api}}/dev/dart-ffi/DynamicLibrary/DynamicLibrary.executable.html
 [`DynamicLibrary.open`]: {{site.dart.api}}/dev/dart-ffi/DynamicLibrary/DynamicLibrary.open.html
 [`DynamicLibrary.process`]: {{site.dart.api}}/dev/dart-ffi/DynamicLibrary/DynamicLibrary.process.html

--- a/src/docs/development/platform-integration/c-interop.md
+++ b/src/docs/development/platform-integration/c-interop.md
@@ -166,7 +166,9 @@ the auto-generated "example" app (`example/lib/main.dart`):
         ),
 ```
 
-## iOS and macOS
+## Other use cases
+
+### iOS and macOS
 
 Dynamically linked libraries are automatically loaded by
 the dynamic linker when the app starts. Their constituent
@@ -180,7 +182,7 @@ Symbols statically linked into the application binary
 can be resolved using [`DynamicLibrary.executable`][] or
 [`DynamicLibrary.process`][].
 
-### Platform library
+#### Platform library
 
 To link against a platform library,
 use the following instructions:
@@ -191,14 +193,14 @@ use the following instructions:
    section.
 1. Select the system library to link against.
 
-### First-party library
+#### First-party library
 
 A first-party native library can be included either
 as source or as a (signed) `.framework` file.
 It's probably possible to include statically linked
 archives as well, but it requires testing.
 
-### Source code
+#### Source code
 
 To link directly to source code,
 use the following instructions:
@@ -227,7 +229,7 @@ extern "C" /* <= C++ only */ __attribute__((visibility("default"))) __attribute(
 </li>
 </ol>
 
-### Compiled (dynamic) library
+#### Compiled (dynamic) library
 
 To link to a compiled dynamic library,
 use the following instructions:
@@ -239,7 +241,7 @@ use the following instructions:
 1. Also add it to the **Linked Frameworks & Libraries**
    section of the target in Xcode.
 
-### Open-source third-party library
+#### Open-source third-party library
 
 To create a Flutter plugin that includes both
 C/C++/Objective-C _and_ Dart code,
@@ -254,7 +256,7 @@ The native code is then statically linked into
 the application binary of any app that uses
 this plugin.
 
-### Closed-source third-party library
+#### Closed-source third-party library
 
 To create a Flutter plugin that includes Dart
 source code, but distribute the C/C++ library
@@ -271,9 +273,9 @@ to Pub. Instead, this plugin should be downloaded
 from a trusted third-party,
 as shown in the CocoaPods example.
 
-## Android
+### Android
 
-### Platform library
+#### Platform library
 
 To link against a platform library,
 use the following instructions:
@@ -294,20 +296,20 @@ You might need to update the Android manifest
 file of the app or plugin if indicated by
 the documentation.
 
-### First-party library
+#### First-party library
 
 The process for including native code in source
 code or binary form is the same for an app or
 plugin.
 
-### Open-source third-party
+#### Open-source third-party
 
 Follow the [Add C and C++ code to your project][]
 instructions in the Android docs to
 add native code and support for the native
 code toolchain (either CMake or `ndk-build`).
 
-### Closed-source third-party library
+#### Closed-source third-party library
 
 To create a Flutter plugin that includes Dart
 source code, but distribute the C/C++ library
@@ -321,7 +323,7 @@ in binary form, use the following instructions:
    downloaded from a repository, such as
    JCenter.
 
-## Web
+### Web
 
 Plugins are not yet supported for web apps.
 

--- a/src/docs/development/platform-integration/c-interop.md
+++ b/src/docs/development/platform-integration/c-interop.md
@@ -1,0 +1,149 @@
+---
+title: "Binding to native code using dart:ffi"
+description: "To use C code in your Flutter program, use the dart:ffi library (currently in preview)."
+---
+
+Flutter mobile can use the dart:ffi library
+to call native C APIs. The _ffi_ acronym stands for
+[_foreign function interface._][FFI]
+Other terms for similar functionality include
+_native interface_ and _language bindings._
+
+{{ site.alert.note }}
+  The dart:ffi library is [in active development][ffi issue]
+  and isn't complete yet. Note that the API is likely to have
+  breaking changes between now and its completion.
+
+  Using the feature requires a Flutter 1.10.x
+  dev channel build. To switch to the dev channel and
+  upload the latest dev version, do the following:
+
+  ```terminal
+  $ flutter channel dev
+  $ flutter upgrade
+  ```
+  For more information on Flutter's channels,
+  see [Upgrading Flutter][].
+{{ site.alert.end }}
+
+API documentation is available from the Dart dev channel:
+[Dart API reference documentation][].
+
+## iOS and macOS
+
+Dynamically linked libraries are automatically loaded by
+the dynamic linker when the app starts. Their constituent
+symbols can be resolved via [`DynamicLibrary.process`][].
+You can also get a handle to the library with
+[`DynamicLibrary.open`][] to restrict the scope of
+symbol resolution, but it's unclear how Apple's
+review process handles this.
+
+Symbols statically linked into the application binary
+can be resolved via [`DynamicLibrary.executable`][] or
+[`DynamicLibrary.process`][].
+
+### Platform library
+
+To link against a platform library,
+open `Runner.xcodeproj` in Xcode, select the target,
+click **+** in the **Linked Frameworks and Libraries**
+section, and select the platform library to link against.
+
+### First-party library
+
+A first-party native library can be included either as
+source or as a (signed) `.framework`.
+It's probably possible to include statically linked
+archives as well, but this should be tested.
+
+#### Source
+
+Add the C/C++/Objective-C/Swift sources to the Xcode
+project, and add the following prefix to the exported
+symbol declarations to ensure they are visible to Dart:
+
+**C/C++/Objective-C**
+
+```
+extern "C" /* <= C++ only */ __attribute__((visibility("default"))) __attribute((used))
+```
+
+**Swift**
+
+```
+@_cdecl("myFunctionName")
+```
+
+#### Compiled (dynamic library)
+
+If a (properly signed) `Framework` file is present,
+add it to the **Embedded Binaries** and
+**Linked Frameworks & Libraries** section of the
+target in Xcode.
+
+### Open-source third-party library
+
+Simply add the native code to the `source_files`
+field of the `.podspec` in the Flutter plugin.
+The native code will be statically linked into
+the application binary of any downstream app.
+
+### Closed-source third-party library
+
+Add a `vendored_frameworks` field to the `.podspec`
+of the Flutter plugin. See the [CocoaPods Example][].
+
+Note that binary code should not be uploaded to
+Pub directly but rather downloaded from a trusted
+third-party as in the example.
+
+## Android
+
+### Platform library
+
+See [Android NDK Native APIs][] in the
+Android docs for a list of stable native APIs.
+
+[`DynamicLibrary.open`][] can be used to load
+a library from the list.
+For example, to load OpenGL ES (v3):
+
+```
+DynamicLibrary.open("libGLES_v3.so");
+```
+
+You might need to update the Android manifest
+file of the app or plugin if indicated by
+the documentation.
+
+### First-party library
+
+The process for including native code in source
+or binary form is the same for an app or plugin.
+
+### Open-source third-party library
+
+Follow the [Add C and C++ code to your project][]
+instructions in the Android docs to
+add native code and support for the native
+code toolchain (either CMake or `ndk-build`).
+
+### Closed-source third-party library
+
+Add the AAR artifact as a dependency in your `build.gradle`.
+It should be downloaded from a repository such as JCenter,
+not included in your Flutter package.
+
+
+[Add C and C++ code to your project]: {{site.android-dev}}/studio/projects/add-native-code
+[Android NDK Native APIs]: {{site.android-dev}}/ndk/guides/stable_apis
+[CocoaPods Example]: {{site.github}}/CocoaPods/CocoaPods/blob/master/examples/Vendored%20Framework%20Example/Example%20Pods/VendoredFrameworkExample.podspec
+[Dart API reference documentation]: {{site.dart-api}}/dev/
+[`DynamicLibrary.executable`]: {{site.dart-api}}/dev/dart-ffi/DynamicLibrary/DynamicLibrary.executable.html
+[`DynamicLibrary.open`]: {{site.dart-api}}/dev/dart-ffi/DynamicLibrary/DynamicLibrary.open.html
+[`DynamicLibrary.process`]: {{site.dart-api}}/dev/dart-ffi/DynamicLibrary/DynamicLibrary.process.html
+[FFI]: https://en.wikipedia.org/wiki/Foreign_function_interface
+[ffi issue]: {{site.github}}/dart-lang/sdk/issues/34452
+[Upgrading Flutter]: /docs/development/tools/sdk/upgrading
+

--- a/src/docs/index.md
+++ b/src/docs/index.md
@@ -49,10 +49,14 @@ but more will be coming.
 New and updated docs on the site include:
 
 * The Flutter layout codelab has been rewritten and
-  uses the updated DartPad, the browser-based tool for running
-  Dart code. DartPad now supports Flutter!
+  uses the updated DartPad, the browser-based tool for
+  running Dart code. DartPad now supports Flutter!
   [Try it out](/docs/codelabs/layout-basics)
   and let us know what you think.
+* A new page on [using the dart:ffi
+  library](/docs/development/platform-integration/c-interop)
+  to bind your app to native code (a feature currently under
+  development).
 * The Performance view tool, which allows you to record
   and profile a session from your Dart/Flutter application,
   has been enabled in DevTools. For more information,
@@ -80,6 +84,15 @@ Other relevant docs:
   you how to migrate to the flutter package:
   [Upgrading from package:flutter_web to the Flutter
   SDK](https://github.com/flutter/flutter/wiki/Upgrading-from-package:flutter_web-to-the-Flutter-SDK).
+* A new [ToggleButtons]({{site.api}}/flutter/material/ToggleButtons-class.html)
+  widget, described in the API docs.
+  [ToggleButtons demo]({{site.github}}/csells/flutter_toggle_buttons)
+* A new [ColorFiltered]({{site.api}}/flutter/widgets/ColorFiltered-class.html)
+  widget, also described in the API docs.
+  [ColorFiltered demo]({{site.github}}/csells/flutter_color_filter)
+* New behavior for the
+  [SelectableText]({{site.api}}/flutter/material/SelectableText-class.html)
+  widget.
 
 Happy Fluttering!
 


### PR DESCRIPTION
Staged: https://sz-flutter.firebaseapp.com/docs/development/platform-integration/c-interop

Fixes https://github.com/flutter/website/issues/2941

I was asked to migrate a page from the Flutter wiki to our site. This is not a topic I know much about, so please help me clarify any confusion, errors, or omissions. Once this page is live, we can forward the old page.

Another question: Will this also work with web?

Thanks!

cc @kwalrath @mit-mit 