### PR TITLE
Do not modify global defaultLocale

### DIFF
--- a/examples/internationalization/intl_example/lib/main.dart
+++ b/examples/internationalization/intl_example/lib/main.dart
@@ -44,13 +44,14 @@ import 'package:intl/intl.dart';
 import 'l10n/messages_all.dart';
 
 class DemoLocalizations {
+  DemoLocalizations(this.localeName);
+
   static Future<DemoLocalizations> load(Locale locale) {
     final String name = locale.countryCode.isEmpty ? locale.languageCode : locale.toString();
     final String localeName = Intl.canonicalizedLocale(name);
 
     return initializeMessages(localeName).then((_) {
-      Intl.defaultLocale = localeName;
-      return DemoLocalizations();
+      return DemoLocalizations(localeName);
     });
   }
 
@@ -58,11 +59,14 @@ class DemoLocalizations {
     return Localizations.of<DemoLocalizations>(context, DemoLocalizations);
   }
 
+  final String localeName;
+
   String get title {
     return Intl.message(
       'Hello World',
       name: 'title',
       desc: 'Title for the Demo application',
+      locale: localeName,
     );
   }
 }
@@ -88,7 +92,18 @@ class DemoApp extends StatelessWidget {
         title: Text(DemoLocalizations.of(context).title),
       ),
       body: Center(
-        child: Text(DemoLocalizations.of(context).title),
+        child: Column(
+          children: <Widget>[
+            Text(DemoLocalizations.of(context).title),
+            Text(MaterialLocalizations.of(context).alertDialogLabel),
+            RaisedButton(
+              onPressed: () {
+                showLicensePage(context: context);
+              },
+              child: Text('License'),
+            )
+          ],
+        ),
       ),
     );
   }

--- a/examples/internationalization/intl_example/lib/main.dart
+++ b/examples/internationalization/intl_example/lib/main.dart
@@ -92,18 +92,7 @@ class DemoApp extends StatelessWidget {
         title: Text(DemoLocalizations.of(context).title),
       ),
       body: Center(
-        child: Column(
-          children: <Widget>[
-            Text(DemoLocalizations.of(context).title),
-            Text(MaterialLocalizations.of(context).alertDialogLabel),
-            RaisedButton(
-              onPressed: () {
-                showLicensePage(context: context);
-              },
-              child: Text('License'),
-            )
-          ],
-        ),
+        child: Text(DemoLocalizations.of(context).title),
       ),
     );
   }

--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -300,7 +300,7 @@ class DemoLocalizations {
     final String name = locale.countryCode.isEmpty ? locale.languageCode : locale.toString();
     final String localeName = Intl.canonicalizedLocale(name);
     return initializeMessages(localeName).then((_) {
-      return DemoLocalizations();
+      return DemoLocalizations(localeName);
     });
   }
 

--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -48,7 +48,7 @@ support for other languages, an application must specify additional
 MaterialApp properties, and include a separate package called
 `flutter_localizations`.  As of April 2019, this package supports about
 52 languages.
-If you want your app to work smoothly on iOS then you have to add the 
+If you want your app to work smoothly on iOS then you have to add the
 package 'flutter_cupertino_localizations' as well.
 
 To use flutter_localizations, add the package as a dependency to your
@@ -235,7 +235,7 @@ different delegate of the same base type is specified with the app's
 The flutter_localizations package includes multi-language
 implementations of the localizations interfaces called
 [GlobalMaterialLocalizations]({{site.api}}/flutter/flutter_localizations/GlobalMaterialLocalizations-class.html)
-and 
+and
 [GlobalWidgetsLocalizations]({{site.api}}/flutter/flutter_localizations/GlobalWidgetsLocalizations-class.html).
 International apps must specify localization delegates for
 these classes as described in [Setting up an internationalized
@@ -294,11 +294,12 @@ to look them up.
 
 {% prettify dart %}
 class DemoLocalizations {
+  DemoLocalizations(this.localeName);
+
   static Future<DemoLocalizations> load(Locale locale) {
     final String name = locale.countryCode.isEmpty ? locale.languageCode : locale.toString();
     final String localeName = Intl.canonicalizedLocale(name);
     return initializeMessages(localeName).then((_) {
-      Intl.defaultLocale = localeName;
       return DemoLocalizations();
     });
   }
@@ -307,11 +308,14 @@ class DemoLocalizations {
     return Localizations.of<DemoLocalizations>(context, DemoLocalizations);
   }
 
+  final String localeName;
+
   String get title {
     return Intl.message(
       'Hello World',
       name: 'title',
       desc: 'Title for the Demo application',
+      locale: localeName,
     );
   }
 }
@@ -446,11 +450,11 @@ language.
 A new GlobalMaterialLocalizations subclass defines the
 localizations that the Material library depends on.
 A new LocalizationsDelegate subclass, which serves
-as factory for the GlobalMaterialLocalizations subclass, 
+as factory for the GlobalMaterialLocalizations subclass,
 must also be defined.
 
 Here's [the source code for a complete example](
-{{site.github}}/flutter/website/tree/master/examples/internationalization/add_language/lib/main.dart), 
+{{site.github}}/flutter/website/tree/master/examples/internationalization/add_language/lib/main.dart),
 less the actual Belarusan translations, of an app that includes support for a new language.
 
 The locale-specific GlobalMaterialLocalizations subclass is called
@@ -476,14 +480,14 @@ String get closeButtonLabel => r'CLOSE';
 // etc..
 {% endprettify %}
 
-These are the English translations of course. To complete the job you 
-need to change the return value of each getter to an appropriate 
+These are the English translations of course. To complete the job you
+need to change the return value of each getter to an appropriate
 Belarusan string.
 
 The getters return "raw" Dart strings that have an r prefix, like
 `r'About $applicationName'`, because sometimes the strings contain
-variables with a `$` prefix. The variables are expanded by parameterized 
-localization methods: 
+variables with a `$` prefix. The variables are expanded by parameterized
+localization methods:
 {% prettify dart %}
 @override
 String get aboutListTileTitleRaw => r'About $applicationName';
@@ -495,14 +499,14 @@ String aboutListTileTitle(String applicationName) {
 }
 {% endprettify %}
 
-For more information about localization strings, see the 
+For more information about localization strings, see the
 [flutter_localizations README](
 {{site.github}}/flutter/flutter/blob/master/packages/flutter_localizations/lib/src/l10n/README.md).
 
-Once you've implemented your language-specific subclasses of 
-GlobalMaterialLocalizations and LocalizationsDelegate, you just 
-need to add the language and a delegate instance to your app. 
-Here's some code that sets the app's language to Belarusan and 
+Once you've implemented your language-specific subclasses of
+GlobalMaterialLocalizations and LocalizationsDelegate, you just
+need to add the language and a delegate instance to your app.
+Here's some code that sets the app's language to Belarusan and
 adds the BeMaterialLocalizations delegate instance to the app's
 localizationsDelegates list:
 


### PR DESCRIPTION
Prior to this change we were telling people to modify the global `Intl.defaultLocale` when their custom `Localizations` for a new locale are loaded. That's a bad idea because Flutter allows that different parts of the same app use different localizations. For example, let's say your global locale is `de`. Now you have one screen in the app that uses a locale of `en` via the `Localizations.override` widget. When the first locale is loaded, `Intl.defaultLocale` is set to `de` and everything in your app appears in German as expected. When you navigate to the screen that has the `Localizations.override`, the `en` local is loaded and `Intl.defaultLocale` is set to `en` forcing the entire (!) app to English, even the parts outside of the `Localizations.override`.

This change no longer recommends the usage of `Intl.defaultLocale` and instead holds on to the locale applicable to the current Localizations instance in an instance variable.

Fixes https://github.com/flutter/flutter/issues/40353.