### PR TITLE
Fixed Reference-Link declaration on VS Code page

### DIFF
--- a/src/docs/development/tools/vs-code.md
+++ b/src/docs/development/tools/vs-code.md
@@ -286,4 +286,4 @@ When filing new issues, include [flutter doctor][] output.
 [let us know]: {{site.github}}/flutter/website/issues/new
 [issue tracker]: {{site.github}}/Dart-Code/Dart-Code/issues
 [Running DevTools from VS Code]: /docs/development/tools/devtools/vscode
-[Set up an editor](/docs/get-started/editor?tab=vscode)
+[Set up an editor]: /docs/get-started/editor?tab=vscode


### PR DESCRIPTION
Fixed incorrect Reference-Link declaration for the "Set up an editor" link in the "Tools & Techniques -> Visual Studio Code" tab