### PR TITLE
Update instructions to install CocoaPods version 1.7.5

### DIFF
--- a/src/docs/get-started/install/_ios-setup.md
+++ b/src/docs/get-started/install/_ios-setup.md
@@ -85,7 +85,10 @@ to set up physical device deployment in Xcode.
     $ sudo gem install cocoapods -v 1.7.5
     $ pod setup
     ```
-    {{site.alert.warning}} Versions of CocoaPods greater than 1.7.5 are not compatible with the most recent stable version of Flutter. See [this issue](https://github.com/flutter/flutter/issues/41253) for details and a forthcoming fix. {{site.alert.end}}
+    {{site.alert.note}}
+      The `pod setup` command fails for versions of CocoaPods greater
+      than 1.7.5.   For more information, see [issue 41252][].
+    {{site.alert.end}}
 
  1. Follow the Xcode signing flow to provision your project:
 

--- a/src/docs/get-started/install/_ios-setup.md
+++ b/src/docs/get-started/install/_ios-setup.md
@@ -82,9 +82,10 @@ to set up physical device deployment in Xcode.
  1. Install and set up CocoaPods by running the following commands:
 
     ```terminal
-    $ sudo gem install cocoapods
+    $ sudo gem install cocoapods -v 1.7.5
     $ pod setup
     ```
+    {{site.alert.warning}} Versions of CocoaPods greater than 1.7.5 are not compatible with the most recent stable version of Flutter. See [this issue](https://github.com/flutter/flutter/issues/41253) for details and a forthcoming fix. {{site.alert.end}}
 
  1. Follow the Xcode signing flow to provision your project:
 


### PR DESCRIPTION
Temporary note to install CocoaPods 1.7.5 until https://github.com/flutter/flutter/issues/41253 makes it to stable.