### PR TITLE
update swift samples to Swift 5

### DIFF
--- a/src/docs/development/platform-integration/platform-channels.md
+++ b/src/docs/development/platform-integration/platform-channels.md
@@ -575,7 +575,7 @@ a `FlutterMethodChannel` tied to the channel name
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
     let controller : FlutterViewController = window?.rootViewController as! FlutterViewController
     let batteryChannel = FlutterMethodChannel(name: "samples.flutter.dev/battery",
@@ -602,7 +602,7 @@ Add the following as a new method at the bottom of `AppDelegate.swift`:
 private func receiveBatteryLevel(result: FlutterResult) {
   let device = UIDevice.current
   device.isBatteryMonitoringEnabled = true
-  if device.batteryState == UIDeviceBatteryState.unknown {
+  if device.batteryState == UIDevice.BatteryState.unknown {
     result(FlutterError(code: "UNAVAILABLE",
                         message: "Battery info unavailable",
                         details: nil))


### PR DESCRIPTION
Updates the sample code in https://flutter.dev/docs/development/platform-integration/platform-channels to use Swift 5. I think this is the only article that needs updating.

Related to https://github.com/flutter/flutter/issues/41231

closes #2982