### PR TITLE
change order of forms cookbook section

### DIFF
--- a/src/docs/cookbook/forms/focus.md
+++ b/src/docs/cookbook/forms/focus.md
@@ -1,11 +1,11 @@
 ---
 title: Focus and text fields
 prev:
-  title: Create and style a text field
-  path: /docs/cookbook/forms/text-input
+  title: Retrieve the value of a text field
+  path: /docs/cookbook/forms/retrieve-input
 next:
-  title: Handle changes to a text field
-  path: /docs/cookbook/forms/text-field-changes
+  title: Add Material touch ripples
+  path: /docs/cookbook/gestures/ripples
 ---
 
 When a text field is selected and accepting input,

--- a/src/docs/cookbook/forms/retrieve-input.md
+++ b/src/docs/cookbook/forms/retrieve-input.md
@@ -4,8 +4,8 @@ prev:
   title: Handle changes to a text field
   path: /docs/cookbook/forms/text-field-changes
 next:
-  title: Add Material touch ripples
-  path: /docs/cookbook/gestures/ripples
+  title: Focus and text fields
+  path: /docs/cookbook/forms/focus
 ---
 
 In this recipe,

--- a/src/docs/cookbook/forms/text-field-changes.md
+++ b/src/docs/cookbook/forms/text-field-changes.md
@@ -1,8 +1,8 @@
 ---
 title: Handle changes to a text field
 prev:
-  title: Focus and text fields
-  path: /docs/cookbook/forms/focus
+  title: Create and style a text field
+  path: /docs/cookbook/forms/text-input
 next:
   title: Retrieve the value of a text field
   path: /docs/cookbook/forms/retrieve-input

--- a/src/docs/cookbook/forms/text-input.md
+++ b/src/docs/cookbook/forms/text-input.md
@@ -4,8 +4,8 @@ prev:
   title: Build a form with validation
   path: /docs/cookbook/forms/validation
 next:
-  title: Focus and text fields
-  path: /docs/cookbook/forms/focus
+  title: Handle changes to a text field
+  path: /docs/cookbook/forms/text-field-changes
 ---
 
 Text fields allow users to type text into an app.
@@ -38,6 +38,9 @@ TextField(
   ),
 );
 ```
+
+To retrieve the value when it changes, see the [Handle changes to a text
+field](/docs/cookbook/forms/text-field-changes/) recipe.
 
 ## `TextFormField`
 


### PR DESCRIPTION
- also adds a reference retrieve-input article
- does not change the order in the TOC, since that is alphabetical.

closes #2953