### PR TITLE
Allow check-code.sh to check code again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     - JEKYLL_ENV=production
     - TZ=US/Pacific # normalize build timestamp
   matrix:
-    - TASK="./tool/check-code.sh"
+    - TASK="./tool/check-code.sh --no-check-code"
     - TASK="bundle exec jekyll build"
 
 before_install:

--- a/tool/check-code.sh
+++ b/tool/check-code.sh
@@ -15,4 +15,4 @@ if [[ $1 == --help || $1 == -h ]]; then
   exit 0
 fi
 
-exec ./tool/build_check_deploy.sh --no-build --no-check-links --no-check-code $*
+exec ./tool/build_check_deploy.sh --no-build --no-check-links $*


### PR DESCRIPTION
Currently `check-code.sh` doesn't pretty much nothing. Move the `--no-check-code` option from the check-code.sh script into Travis config so that we can run `check-code.sh` manually over a local repo and have it actually check code once again. This PR has no net change relative to the Travis build.

This PR is a small step toward reinstating CI code checks.

cc @johnpryan 