### PR TITLE
Add xcodebuild -runFirstLaunch command to iOS setup instructions

### DIFF
--- a/src/docs/get-started/install/_ios-setup.md
+++ b/src/docs/get-started/install/_ios-setup.md
@@ -12,6 +12,7 @@ To develop Flutter apps for iOS, you need a Mac with Xcode.
 
     ```terminal
     $ sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+    $ sudo xcodebuild -runFirstLaunch
     ```
 
     This is the correct path for most cases,


### PR DESCRIPTION
Add command to install Xcode command-line tools without opening the app.

Fixes https://github.com/flutter/website/issues/3100.

