### PR TITLE
Added info about Google Ads on Android app page

### DIFF
--- a/src/docs/deployment/android.md
+++ b/src/docs/deployment/android.md
@@ -377,6 +377,17 @@ From the command line:
 For detailed instructions on publishing your app to the Google Play Store,
 see the [Google Play launch][play] documentation.
 
+Now that you’ve created your app, attract more users with Google Ads. App campaigns use machine learning to drive more installs and make the most of your budget. 
+
+Get your campaign running in a few steps
+1. Create your ad - we’ll help create your ad from your app information
+2. Choose your budget - set your target cost-per-install (tCPI) and daily budget cap 
+3. Select your location - let us know where you’d like your ads to run
+4. Decide what action you want users to take - choose installs, in-app actions, or target return on ad spend (ROAS) 
+
+<a href = "https://ads.google.com/lp/appcampaigns/?modal_active=none&subid=ww-ww-et-aw-a-flutter1!o1#?modal_active=none"> Get $75 app advertising credit when you spend $25 </a>
+
+
 ## Android release FAQ
 
 Here are some commonly asked questions about deployment for


### PR DESCRIPTION
used HTML (a href =) for linking. @Sfshaza let me know if there is a different required way as I did not see this used anywhere else on the page.