### PR TITLE
Check code-excerpt freshness

### DIFF
--- a/tool/refresh-code-excerpts.sh
+++ b/tool/refresh-code-excerpts.sh
@@ -68,7 +68,7 @@ LOG_FILE="$TMP/refresh-code-excerpts-log.txt"
   "$SRC" 2>&1 | tee $LOG_FILE
 LOG=$(cat $LOG_FILE)
 
-[[ $LOG == *" 0 out of"* && $LOG != *Error* ]]
-
 echo "Cleaning up .dart_tool/"
 rm -r "$rootDir/.dart_tool/"
+
+[[ $LOG == *" 0 out of"* && $LOG != *Error* ]]


### PR DESCRIPTION
Closes #3075

- tool/refresh-code-excerpts.sh: exit with 1 if code excerpts were refreshed
  (Readjustment following #2353.)
- tool/check-code.sh: also check code excerpt freshness

The code-excerpt freshness check will fail (it is a known failure), but the code check is currently allowed to fail so that's ok. (And, by having a known failure, we're testing that the script is working for that scenario.)

I'll refresh the code excerpts in a followup PR before or after we decide how to address #3073.
