### PR TITLE
Move position of "Try Flutter" section further up on landing page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -126,7 +126,6 @@ js:
     </div>
 </section>
 
-
 <!-- Do not show DartPad on Safari -->
 <section id="dartpad-landing-page" class="landing-page__cta card text-center">
     <div class="card-body">
@@ -139,7 +138,6 @@ js:
         </div>
     </div>
 </section>
-
 
 <section class="homepage__hot-reload card">
     <div class="card-body">
@@ -303,7 +301,6 @@ js:
         </div>
     </div>
 </div>
-
 
 <section class="landing-page__cta card text-center">
     <div class="card-body">

--- a/src/index.html
+++ b/src/index.html
@@ -126,6 +126,21 @@ js:
     </div>
 </section>
 
+
+<!-- Do not show DartPad on Safari -->
+<section id="dartpad-landing-page" class="landing-page__cta card text-center">
+    <div class="card-body">
+        <div class="dash-dartpad">
+            <a name="try-dart"></a>
+            <h2>Try Flutter in your browser</h2>
+            <select id="dartpad-select"></select>
+            <div id="dartpad-host"></div>
+            <h3>Want more practice? <a href="/codelabs">Try a codelab</a>.</h3>
+        </div>
+    </div>
+</section>
+
+
 <section class="homepage__hot-reload card">
     <div class="card-body">
         <div class="row">
@@ -289,19 +304,6 @@ js:
     </div>
 </div>
 
-
-<!-- Do not show DartPad on Safari -->
-<section id="dartpad-landing-page" class="landing-page__cta card text-center">
-    <div class="card-body">
-        <div class="dash-dartpad">
-            <a name="try-dart"></a>
-            <h2>Try Flutter in your browser</h2>
-            <select id="dartpad-select"></select>
-            <div id="dartpad-host"></div>
-            <h3>Want more practice? <a href="/codelabs">Try a codelab</a>.</h3>
-        </div>
-    </div>
-</section>
 
 <section class="landing-page__cta card text-center">
     <div class="card-body">


### PR DESCRIPTION
Per product + UX recent insights, move DartPad section further up the page on flutter.dev landing page to increase visibility and usage of DartPad. 

Will review key metrics ~2 weeks from now to track effect.