### PR TITLE
Replaced example code with code that is less fraught with peril.

### DIFF
--- a/src/docs/development/ui/assets-and-images.md
+++ b/src/docs/development/ui/assets-and-images.md
@@ -209,17 +209,7 @@ declarations above:
 
 ```dart
 Widget build(BuildContext context) {
-  // ...
-  return DecoratedBox(
-    decoration: BoxDecoration(
-      image: DecorationImage(
-        image: AssetImage('graphics/background.png'),
-        // ...
-      ),
-      // ...
-    ),
-  );
-  // ...
+  return Image(image: AssetImage('graphics/background.png'));
 }
 ```
 


### PR DESCRIPTION
Relevant Issue: https://github.com/flutter/website/issues/1826

If users are learning how to display images here they will get stuck with a widget that has zero width and height.  The Image widget is more straightforward than the DecoratedBox.