### PR TITLE
Remove instructions to install CocoaPods version 1.7.5

### DIFF
--- a/src/docs/get-started/install/_ios-setup.md
+++ b/src/docs/get-started/install/_ios-setup.md
@@ -88,13 +88,9 @@ to set up physical device deployment in Xcode.
  1. Install and set up CocoaPods by running the following commands:
 
     ```terminal
-    $ sudo gem install cocoapods -v 1.7.5
+    $ sudo gem install cocoapods
     $ pod setup
     ```
-    {{site.alert.note}}
-      The `pod setup` command fails for versions of CocoaPods greater
-      than 1.7.5.   For more information, see [issue 41253][].
-    {{site.alert.end}}
 
  1. Follow the Xcode signing flow to provision your project:
 
@@ -146,7 +142,6 @@ to set up physical device deployment in Xcode.
 
 [Check the app's Bundle ID]: /images/setup/xcode-unique-bundle-id.png
 [Choosing a Membership]: https://developer.apple.com/support/compare-memberships
-[issue 41253]: {{site.github}}/flutter/flutter/issues/41253
 [Mac App Store]: https://itunes.apple.com/us/app/xcode/id497799835
 [Trust Mac]: /images/setup/trust-computer.png
 [web download]: https://developer.apple.com/xcode/


### PR DESCRIPTION
[Fix](https://github.com/flutter/flutter/issues/41253) has been hotfixed to stable as v1.9.1+hotfix.5.  Remove instructions to install 1.7.5.