### PR TITLE
Add Android Studio workaround

### DIFF
--- a/src/docs/development/androidx-migration.md
+++ b/src/docs/development/androidx-migration.md
@@ -1,5 +1,5 @@
 ---
-title: AndroidX Migration 
+title: AndroidX Migration
 description: How to migrate existing Flutter projects to AndroidX.
 ---
 
@@ -8,35 +8,35 @@ description: How to migrate existing Flutter projects to AndroidX.
   doesn't use AndroidX.
 {{site.alert.end}}
 
-[AndroidX](https://developer.android.com/jetpack/androidx) is a major improvement 
+[AndroidX](https://developer.android.com/jetpack/androidx) is a major improvement
 to the original Android Support Library.
 
-It provides the `androidx.*` package libraries, unbundled from the platform API. 
-This means that it offers backward compatibility and is updated more frequently 
+It provides the `androidx.*` package libraries, unbundled from the platform API.
+This means that it offers backward compatibility and is updated more frequently
 than the Android platform.
 
 ## Common Questions
 
 ### How do I migrate my existing app, plugin or host-editable module project to AndroidX?
 
-_You will need Android Studio 3.2 or higher. If you don’t have it installed, 
-you can download the latest version from 
+_You will need Android Studio 3.2 or higher. If you don’t have it installed,
+you can download the latest version from
 [developer.android.com/studio](https://developer.android.com/studio)_.
 
 1. Open Android Studio.
 2. Select **Open an existing Android Studio Project**.
 3. Open the `android` directory within your app.
-4. Wait until the project has been synced successfully. 
+4. Wait until the project has been synced successfully.
   (This happens automatically once you open the project, but if it doesn’t,
    select **Sync Project with Gradle Files** from the **File** menu).
-5. Select **Migrate to AndroidX** from the Refactor menu. 
-6. If you are asked to backup the project before proceeding, 
-   check **Backup project as Zip file**, then click **Migrate**. Lastly, save 
+5. Select **Migrate to AndroidX** from the Refactor menu.
+6. If you are asked to backup the project before proceeding,
+   check **Backup project as Zip file**, then click **Migrate**. Lastly, save
    the zip file in your location of preference.
   <img
       width="500"
       style="border-radius: 12px;"
-      src="/images/androidx/migrate_prompt.png" 
+      src="/images/androidx/migrate_prompt.png"
       class="figure-img img-fluid"
       alt="Select backup project as zip file" />
 7. The refactoring preview shows the list of changes. Finally, click **Do Refactor**:
@@ -46,10 +46,21 @@ you can download the latest version from
       src="/images/androidx/do_androidx_refactor.png"
       class="figure-img img-fluid"
       alt="An animation of the bottom-up page transition on Android" />
-8. That is it! You successfully migrated your project to AndroidX. 
+8. That is it! You successfully migrated your project to AndroidX.
 
-Finally, if you migrated a plugin, publish the new AndroidX version to pub and update 
+Finally, if you migrated a plugin, publish the new AndroidX version to pub and update
 your `CHANGELOG.md` to indicate that this new version is compatible with AndroidX.
+
+### What about if I can't use Android Studio
+
+You can create a new project using the Flutter tool and then move the Dart code and
+assets to the new project.
+
+To create a new project run:
+
+```bash
+flutter create --androidx -t <project-type> <new-project-path>
+```
 
 ### How do I migrate my existing module project to AndroidX?
 
@@ -64,14 +75,13 @@ line to `pubspec.yml`:
 
 Finally, run `flutter clean`.
 
-If your module contains an `android` directory instead, then follow the 
+If your module contains an `android` directory instead, then follow the
 steps in previous section.
-
 
 ### How do I know if my project is using AndroidX?
 
 * **Apps and Modules**
-  Your project uses AndroidX if the file `android/gradle.properties` or 
+  Your project uses AndroidX if the file `android/gradle.properties` or
   `.android/gradle.properties`contains:
 
   ```
@@ -85,15 +95,15 @@ steps in previous section.
 
 ### What if I don’t migrate my app or module to AndroidX?
 
-Your app may continue to work. However, combining AndroidX and Support artifacts 
-is generally not recommended because it can result in dependency conflicts or 
+Your app may continue to work. However, combining AndroidX and Support artifacts
+is generally not recommended because it can result in dependency conflicts or
 other kind of Gradle failures. As a result, as more plugins migrate to AndroidX,
 plugins depending on Android core libraries are likely to cause build failures.
 
 ### What if my app is migrated to AndroidX, but not all of the plugins I use?
 
-The Flutter tool uses Jetifier to automatically migrate Flutter plugins using 
-the Support Library to AndroidX, so you can use the same plugins even if they 
+The Flutter tool uses Jetifier to automatically migrate Flutter plugins using
+the Support Library to AndroidX, so you can use the same plugins even if they
 haven’t been migrated to AndroidX yet.
 
 ### I'm having issues migrating to AndroidX


### PR DESCRIPTION
This section adds a workaround for the migration in case the app doesn't support AndroidX.  It also trims trailing whitespaces.