### PR TITLE
Fix GitHub Actions link

### DIFF
--- a/src/docs/deployment/cd.md
+++ b/src/docs/deployment/cd.md
@@ -180,6 +180,6 @@ The following are some other options available to help automate the delivery of 
   in the [flutter_redux library]({{site.github}}/brianegan/flutter_redux).
 * [Codemagic CI/CD for Flutter](https://blog.codemagic.io/getting-started-with-codemagic/)
 * [Flutter CI/CD with Bitrise](https://devcenter.bitrise.io/getting-started/getting-started-with-flutter-apps/)
-* [Github Actions- CI/CD on Github] (https://github.com/features/actions) Get
+* [Github Actions- CI/CD on GitHub](https://github.com/features/actions) Get
   [Example Project](https://github.com/nabilnalakath/flutter-githubaction)
 


### PR DESCRIPTION
Super small PR, but I was reading the CD docs and noticed this line not rendering properly on https://flutter.dev/docs/deployment/cd because the markdown had an extra space in it.