### PR TITLE
Add instructions for updating the version number

### DIFF
--- a/src/docs/deployment/android.md
+++ b/src/docs/deployment/android.md
@@ -387,6 +387,22 @@ Get your campaign running in a few steps
 
 <a href = "https://ads.google.com/lp/appcampaigns/?modal_active=none&subid=ww-ww-et-aw-a-flutter1!o1#?modal_active=none"> Get $75 app advertising credit when you spend $25 </a>
 
+## Updating the version of the app
+
+The default version number of the app is `1.0.0`. To update it, navigate to the `pubspec.yaml` file and update the following line:
+`version: 1.0.0+1`
+
+The version number is three numbers separated by dots, like `1.0.0` in the example above, followed by an optional build number such as `1` in the example above, separated by a `+`.
+
+Both the version and the builder number may be overridden in flutter
+build by specifying --build-name and --build-number, respectively.
+
+In Android, build-name is used as versionName while build-number used as versionCode.
+Read more about Android versioning at https://developer.android.com/studio/publish/versioning
+
+In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
+Read more about iOS versioning at
+https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 
 ## Android release FAQ
 


### PR DESCRIPTION
A lot of Flutter users are publishing their apps to the Play store but finding a way to update the version number and name isn't straightforward. 

Hence, this answer is gaining more attention every week: https://stackoverflow.com/a/56970752/5066615

Even though the instructions are directly available in `pubspec.yaml`, most users like me couldn't find it easily initially.  

Hence, this PR uses the same words from the `pubspec.yaml` on updating the version number of the app.