### PR TITLE
Clarification of 'onTap on 'Taps, drags, and other gestures' page

### DIFF
--- a/src/docs/development/ui/advanced/gestures.md
+++ b/src/docs/development/ui/advanced/gestures.md
@@ -50,7 +50,8 @@ lifecycle of the gesture (e.g., drag start, drag update, and drag end):
     particular location.
   - `onTapUp` A pointer that will trigger a tap has stopped contacting the screen
     at a particular location.
-  - `onTap` A tap has occurred.
+  - `onTap` The pointer that previously triggered the `onTapDown` has also 
+    triggered `onTapUp` will end up causing a tap.
   - `onTapCancel` The pointer that previously triggered the `onTapDown` will not
     end up causing a tap.
 - Double tap


### PR DESCRIPTION
Fixes #3051 
Added Proper Definition for onTap Event.