### PR TITLE
Make the spinning curve more natural

### DIFF
--- a/src/_packages/dartpad_picker/web/dartpad_picker_main.dart
+++ b/src/_packages/dartpad_picker/web/dartpad_picker_main.dart
@@ -138,7 +138,7 @@ class _MyAppState extends State<MyApp>
     );
     animation = Tween(begin: 0.0, end: 4 * pi)
       .animate(CurvedAnimation(
-        curve: Curves.easeInOut,
+        curve: Curves.easeInOutCubic,
         parent: controller,
     ));
   }


### PR DESCRIPTION
`easeInOutCubic` looks better, especially at the end of the animation.

From the API doc of [easeInOutCubic](https://api.flutter.dev/flutter/animation/Curves/easeInOutCubic-constant.html):

> The result is a safe sweet spot when choosing a curve for a widget whose initial and final positions are both within the viewport.