### PR TITLE
Don't check links twice and don't deploy from a cron build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ script: $TASK
 
 after_script:
   - if [[ $TASK == *build* ]]; then ./tool/shared/check-links.sh || travis_terminate 1; fi
-  - if [[ $TASK == *build* ]]; then ./tool/shared/check-links.sh --external; fi
 
 deploy:
   - provider: script
@@ -53,7 +52,7 @@ deploy:
     on:
       repo: flutter/website
       branch: master
-      condition: $TASK == *build*
+      condition: $TASK == *build* && $TRAVIS_EVENT_TYPE == push
 
 # Only run Travis jobs for named branches (to avoid double builds for each PR)
 branches:


### PR DESCRIPTION
Not checking links twice will make regular builds a bit faster.

Contributes to #3079
Closes #3127

cc @johnpryan 