### PR TITLE
Assets hint

### DIFF
--- a/src/docs/development/platform-integration/platform-channels.md
+++ b/src/docs/development/platform-integration/platform-channels.md
@@ -519,7 +519,7 @@ and returns a response for both the success and error cases using
 the `result` argument. If an unknown method is called, report that instead.
 
 ```objectivec
-__weak typeof(self) weakSelf = self
+__weak typeof(self) weakSelf = self;
 [batteryChannel setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
   // Note: this method is invoked on the UI thread.
   if ([@"getBatteryLevel" isEqualToString:call.method]) {

--- a/src/docs/development/ui/layout/tutorial.md
+++ b/src/docs/development/ui/layout/tutorial.md
@@ -360,6 +360,10 @@ Add the image file to the example:
   +  assets:
   +    - images/lake.jpg
   ```
+  {{site.alert.tip}}
+    - Note that `pubspec.yaml` is case sensitive. So, you should write `assets: ` and 
+      `image address` as above shown format.
+    - For `image address` proper indentation must be there.
 
 Now you can reference the image from your code:
 

--- a/src/docs/resources/platform-adaptations.md
+++ b/src/docs/resources/platform-adaptations.md
@@ -315,7 +315,7 @@ When using the Material package,
 certain icons automatically show different
 graphics depending on the platform.
 For instance, the overflow button's three dots
-are vertical on iOS and horizontal on Android.
+are horizontal on iOS and vertical on Android.
 The back button is a simple chevron on iOS and
 has a stem/shaft on Android.
 


### PR DESCRIPTION
Fixes #3055 
Added some hints for proper indentation and case sensitiveness of `pubspec.yaml` file.
Fixes #3170 
Corrected the Direction name as given in the image.
Fixes #3152 
Corrected Objective C code by adding a semicolon.