### PR TITLE
update test execution speed claims

### DIFF
--- a/src/docs/testing/index.md
+++ b/src/docs/testing/index.md
@@ -8,12 +8,12 @@ you publish it, while retaining your feature and bug fix velocity.
 
 Automated testing falls into a few categories:
 
-* A [_unit test_](#unit-tests) tests a single function, method, or class. 
+* A [_unit test_](#unit-tests) tests a single function, method, or class.
 * A [_widget test_](#widget-tests) (in other UI frameworks referred to
-  as _component test_) tests a single widget. 
+  as _component test_) tests a single widget.
 * An [_integration test_](#integration-tests)
   tests a complete app or a large part of an app.
-  
+
 Generally speaking, a well-tested app has many unit and widget tests, tracked by
 [code coverage](https://en.wikipedia.org/wiki/Code_coverage), plus enough
 integration tests to cover all the important use cases. This advice is based on
@@ -25,8 +25,8 @@ below.
 | **Confidence**       | Low    | Higher | Highest     |
 | **Maintenance cost** | Low    | Higher | Highest     |
 | **Dependencies**     | Few    | More   | Most        |
-| **Execution speed**  | Quick  | Slower | Slowest     |
-{:.table.table-striped} 
+| **Execution speed**  | Quick  | Quick  | Slow        |
+{:.table.table-striped}
 
 
 ## Unit tests
@@ -40,7 +40,7 @@ running the test.
 
 ### Recipes
 
-{% include testing_toc.md type='unit' %} 
+{% include testing_toc.md type='unit' %}
 
 ## Widget tests
 
@@ -50,15 +50,15 @@ widget's UI looks and interacts as expected. Testing a widget involves
 multiple classes and requires a test environment that provides the
 appropriate widget lifecycle context.
 
-For example, the Widget being tested should be able to receive and 
-respond to user actions and events, perform layout, and instantiate child 
+For example, the Widget being tested should be able to receive and
+respond to user actions and events, perform layout, and instantiate child
 widgets. A widget test is therefore more comprehensive than a unit test.
 However, like a unit test, a widget test's environment is replaced with
 an implementation much simpler than a full-blown UI system.
 
 ### Recipes
 
-{% include testing_toc.md type='widget' %} 
+{% include testing_toc.md type='widget' %}
 
 ## Integration tests
 
@@ -74,7 +74,7 @@ from the test driver code to avoid skewing the results.
 ### Recipes
 
 {% include testing_toc.md type='integration' %}
-  
+
 ## Continuous integration services
 
 Continuous integration (CI) services allow you to run your tests automatically
@@ -82,7 +82,7 @@ when pushing new code changes. This provides timely feedback on whether the code
 changes work as expected and do not introduce bugs.
 
 For information on running tests on various continuous integration services,
-see the following: 
+see the following:
 
 * [Continuous delivery using fastlane with
   Flutter](/docs/deployment/cd#fastlane)
@@ -91,7 +91,7 @@ see the following:
 * [Test Flutter apps on Cirrus](https://cirrus-ci.org/examples/#flutter)
 * [GitLab Continuous Integration
   (GitLab CI/CD)](https://docs.gitlab.com/ee/ci/README.html#doc-nav).
-  You'll need to create and configure a `.gitlab-ci.yml` file. You can 
+  You'll need to create and configure a `.gitlab-ci.yml` file. You can
   [find an example](https://raw.githubusercontent.com/brianegan/flutter_redux/master/.gitlab-ci.yml)
   in the [flutter_redux library]({{site.github}}/brianegan/flutter_redux).
 * [Codemagic CI/CD for Flutter](https://blog.codemagic.io/getting-started-with-codemagic/)


### PR DESCRIPTION
Because we run unit tests and widget tests in the same test environment (`flutter_tester`) our execution speed is quick both for unit tests and widget tests. Suggesting that widget test execution speed is slower might discourage developers from writing more widget tests. Instead, we should encourage more widget tests.