### PR TITLE
Replace broken (possibly old?) Step #4

### DIFF
--- a/src/docs/cookbook/navigation/navigate-with-arguments.md
+++ b/src/docs/cookbook/navigation/navigate-with-arguments.md
@@ -120,16 +120,23 @@ RaisedButton(
   onPressed: () {
     // When the user taps the button, navigate to the specific route
     // and provide the arguments as part of the RouteSettings.
-    Navigator.pushNamed(
+    Navigator.push(
       context,
-      ExtractArgumentsScreen.routeName,
-      arguments: ScreenArguments(
-        'Extract Arguments Screen',
-        'This message is extracted in the build method.',
+      MaterialPageRoute(
+        builder: (context) => ExtractArgumentsScreen(),
+        // Pass the arguments as part of the RouteSettings. The
+        // ExtractArgumentScreen reads the arguments from these
+        // settings.
+        settings: RouteSettings(
+          arguments: ScreenArguments(
+            'Extract Arguments Screen',
+            'This message is extracted in the build method.',
+          ),
+        ),
       ),
     );
   },
-);
+)
 ```
 
 ## Alternatively, extract the arguments using `onGenerateRoute`


### PR DESCRIPTION
Replace broken (possibly old?) Step #4 with a correct version from the completed example. No code added, just fixing an internal consistency on the page.

I've tested the completed example in Android Studio and it runs with no errors.

From the Cookbooks, so it's a high-visibility doc.
Fixes #3209