### PR TITLE
Android tip for camera plugin

### DIFF
--- a/src/docs/cookbook/plugins/picture-using-camera.md
+++ b/src/docs/cookbook/plugins/picture-using-camera.md
@@ -40,6 +40,9 @@ dependencies:
   path_provider:
   path:
 ```
+{{site.alert.tip}}
+  - For android, You must have to update `minSdkVersion` to 21 (or higher).
+{{site.alert.end}}
 
 ## 2. Get a list of the available cameras
 


### PR DESCRIPTION
Fixes #3199 
I think just after updating `minSdkVersion` it's working fine.