### PR TITLE
fixed unknown backgroundColor parameter

### DIFF
--- a/src/docs/get-started/flutter-for/web-devs.md
+++ b/src/docs/get-started/flutter-for/web-devs.md
@@ -894,7 +894,7 @@ var container = Container( // grey box
         ),
       ), [[/highlight]]
       decoration: BoxDecoration(
-        backgroundColor: Colors.red[400],
+        color: Colors.red[400],
       ),
       padding: EdgeInsets.all(16),
     ),
@@ -956,7 +956,7 @@ var container = Container( // grey box
         maxLines: 1, [[/highlight]]
       ),
       decoration: BoxDecoration(
-        backgroundColor: Colors.red[400],
+        color: Colors.red[400],
       ),
       padding: EdgeInsets.all(16),
     ),


### PR DESCRIPTION
Fixed 2 unknown parameters in the getting started guide for web devs: https://flutter.dev/docs/get-started/flutter-for/web-devs

The correct parameter is **color** instead of backgroundColor for BoxDecoration widget: https://api.flutter.dev/flutter/painting/BoxDecoration/color.html