### PR TITLE
Re-sync non-add-to-app changes to master

### DIFF
--- a/src/docs/development/packages-and-plugins/developing-packages.md
+++ b/src/docs/development/packages-and-plugins/developing-packages.md
@@ -17,20 +17,18 @@ minimal package consists of:
 
 {{site.alert.note}}
   For a list of dos and don'ts when writing an effective plugin,
-  see [Writing a good
-  plugin]({{site.flutter-medium}}/writing-a-good-flutter-plugin-1a561b986c9c)
-  on Medium.
+  see [Writing a good plugin][] on Medium.
 {{site.alert.end}}
 
 ### Package types {#types}
 
 Packages can contain several kinds of content:
 
-* *Dart packages*: General packages written in Dart, for example the
-  [`path`]({{site.pub}}/packages/path) package. Some of these might
+* *Dart packages*: General packages written in Dart,
+  for example the [`path`][] package. Some of these might
   contain Flutter specific functionality and thus have a dependency on the
-  Flutter framework, restricting their use to Flutter only, for example the
-  [`fluro`]({{site.pub}}/packages/fluro) package.
+  Flutter framework, restricting their use to Flutter only,
+  for example the [`fluro`][] package.
 
 * *Plugin packages*: A specialized Dart package which contains an API written in
   Dart code combined with a platform-specific implementation for Android (using
@@ -60,7 +58,7 @@ specialized content:
 For pure Dart packages, simply add the functionality inside the main
 `lib/<package name>.dart` file, or in several files in the `lib` directory.
 
-To test the package, add [unit tests](/docs/testing#unit-tests)
+To test the package, add [unit tests][]
 in a `test` directory.
 
 For additional details on how to organize the package contents, see the
@@ -273,10 +271,8 @@ Prior to publishing, make sure to review the `pubspec.yaml`, `README.md`, and
 Next, run the dry-run command to see if everything passes analysis:
 
 ```terminal
-$ flutter pub pub publish --dry-run
+$ flutter pub publish --dry-run
 ```
-
-(Note the redundant `pub pub`, which is needed until [issue #33302](https://github.com/flutter/flutter/issues/33302) is resolved).
 
 Finally, run the actual publish command:
 

--- a/src/docs/development/packages-and-plugins/using-packages.md
+++ b/src/docs/development/packages-and-plugins/using-packages.md
@@ -62,7 +62,7 @@ To add the package, `css_colors`, to an app:
 The [Installing tab][], available on any package page on pub.dev,
 is a handy reference for these steps.
 
-For a complete example, see the [css_colors example](#css-example) below.
+For a complete example, see the [css_colors example][] below.
 
 ### Conflict resolution
 
@@ -134,9 +134,8 @@ specify a version range in the pubspec file.
 All packages have a version number, specified in the
 package's `pubspec.yaml` file. The current version of a package
 is displayed next to its name (for example,
-see the [url_launcher]({{site.pub-pkg}}/url_launcher) package), as
-well as a list of all prior versions ([url_launcher
-versions]({{site.pub-pkg}}/url_launcher#-versions-tab-)).
+see the [`url_launcher`][] package), as
+well as a list of all prior versions ([url_launcher versions][]).
 
 When a package is added to `pubspec.yaml`, the shorthand form `plugin1:`
 means that any version of the plugin1 package can be used.
@@ -150,8 +149,7 @@ specify a version range using one of the following formats:
     url_launcher: '>=0.1.2 <0.2.0'
   ```
 
-* Range constraints with [*caret
-  syntax*]({{site.dart-site}}/tools/pub/dependencies#caret-syntax)
+* Range constraints with [*caret syntax*][]
   are similar to regular range constraints:
 
   ```yaml
@@ -159,8 +157,7 @@ specify a version range using one of the following formats:
     collection: '^0.1.2'
   ```
 
-For additional details, see the [package versioning
-guide]({{site.dart-site}}/tools/pub/versioning).
+For additional details, see the [package versioning guide][].
 
 ### Updating package dependencies
 
@@ -179,7 +176,7 @@ that is allowed by the version constraint specified in
 
 ### Dependencies on unpublished packages
 
-Packages can be used even when not published on the Pub site.
+Packages can be used even when not published on pub.dev.
 For private plugins, or for packages not ready for publishing,
 additional dependency options are available:
 
@@ -219,7 +216,7 @@ additional dependency options are available:
 
   Finally, use the `ref` argument to pin the dependency to a
   specific git commit, branch, or tag. For more details, see
-  [Package dependencies]({{site.dart-site}}/tools/pub/dependencies).
+  [Package dependencies][].
 
 ## Examples
 
@@ -228,7 +225,7 @@ using packages.
 
 ### Example: Using the css_colors package {#css-example}
 
-The [`css_colors`]({{site.pub-pkg}}/css_colors) package
+The [`css_colors`][] package
 defines color constants for CSS colors, so use the constants
 wherever the Flutter framework expects the `Color` type.
 


### PR DESCRIPTION
updated the last bits of non-add-to-app files to master so when we merge this whole staging branch to master one day, we don't end up with non-add-to-app bits.