### PR TITLE
Eliminate example ambiguity

### DIFF
--- a/src/docs/cookbook/navigation/navigate-with-arguments.md
+++ b/src/docs/cookbook/navigation/navigate-with-arguments.md
@@ -115,28 +115,21 @@ arguments.
 ```dart
 // A button that navigates to a named route. The named route
 // extracts the arguments by itself.
-RaisedButton(
-  child: Text("Navigate to screen that extracts arguments"),
-  onPressed: () {
-    // When the user taps the button, navigate to the specific route
-    // and provide the arguments as part of the RouteSettings.
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (context) => ExtractArgumentsScreen(),
-        // Pass the arguments as part of the RouteSettings. The
-        // ExtractArgumentScreen reads the arguments from these
-        // settings.
-        settings: RouteSettings(
-          arguments: ScreenArguments(
-            'Extract Arguments Screen',
-            'This message is extracted in the build method.',
-          ),
-        ),
-      ),
-    );
-  },
-),
+RaisedButton(                                                   
+  child: Text("Navigate to screen that extracts arguments"),    
+  onPressed: () {                                               
+    // When the user taps the button, navigate to a named route 
+    // and provide the arguments as an optional parameter.      
+    Navigator.pushNamed(                                        
+      context,                                                  
+      ExtractArgumentsScreen.routeName,                         
+      arguments: ScreenArguments(                               
+        'Extract Arguments Screen',                              
+        'This message is extracted in the build method.',       
+      ),                                                                                                                 
+    );                                                          
+  },                                                            
+),                                                                                                                           
 ```
 
 ## Alternatively, extract the arguments using `onGenerateRoute`
@@ -187,30 +180,33 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      // Provide a function to handle named routes. Use this function to
-      // identify the named route being pushed, and create the correct
-      // Screen.
-      onGenerateRoute: (settings) {
-        // If you push the PassArguments route
-        if (settings.name == PassArgumentsScreen.routeName) {
-          // Cast the arguments to the correct type: ScreenArguments.
-          final ScreenArguments args = settings.arguments;
+        // Provide a function to handle named routes. Use this function to
+        // identify the named route being pushed, and create the correct
+        // Screen.
+        onGenerateRoute: (settings) {
+          // If you push the PassArguments route
+          if (settings.name == PassArgumentsScreen.routeName) {
+            // Cast the arguments to the correct type: ScreenArguments.
+            final ScreenArguments args = settings.arguments;
 
-          // Then, extract the required data from the arguments and
-          // pass the data to the correct screen.
-          return MaterialPageRoute(
-            builder: (context) {
-              return PassArgumentsScreen(
-                title: args.title,
-                message: args.message,
-              );
-            },
-          );
-        }
-      },
-      title: 'Navigation with Arguments',
-      home: HomeScreen(),
-    );
+            // Then, extract the required data from the arguments and
+            // pass the data to the correct screen.
+            return MaterialPageRoute(
+              builder: (context) {
+                return PassArgumentsScreen(
+                  title: args.title,
+                  message: args.message,
+                );
+              },
+            );
+          }
+        },
+        title: 'Navigation with Arguments',
+        home: HomeScreen(),
+        routes: {
+          ExtractArgumentsScreen.routeName: (context) =>
+              ExtractArgumentsScreen(),
+        });
   }
 }
 
@@ -230,21 +226,14 @@ class HomeScreen extends StatelessWidget {
             RaisedButton(
               child: Text("Navigate to screen that extracts arguments"),
               onPressed: () {
-                // When the user taps the button, navigate to the specific route
-                // and provide the arguments as part of the RouteSettings.
-                Navigator.push(
+                // When the user taps the button, navigate to a named route
+                // and provide the arguments as an optional parameter.
+                Navigator.pushNamed(
                   context,
-                  MaterialPageRoute(
-                    builder: (context) => ExtractArgumentsScreen(),
-                    // Pass the arguments as part of the RouteSettings. The
-                    // ExtractArgumentScreen reads the arguments from these
-                    // settings.
-                    settings: RouteSettings(
-                      arguments: ScreenArguments(
-                        'Extract Arguments Screen',
-                        'This message is extracted in the build method.',
-                      ),
-                    ),
+                  ExtractArgumentsScreen.routeName,
+                  arguments: ScreenArguments(
+                    'Extract Arguments Screen',
+                    'This message is extracted in the build method.',
                   ),
                 );
               },


### PR DESCRIPTION
As described in the fourth step: Finally, navigate to the `ExtractArgumentsScreen` when a user taps a button using `Navigator.pushNamed()`..., but the example use `Navigator.push()`, this is not related to named route. Also the Complete example miss the third step.