### PR TITLE
remove Xcode 9 reference, as version 10.2 is now the minimum version

### DIFF
--- a/src/docs/get-started/install/_ios-setup.md
+++ b/src/docs/get-started/install/_ios-setup.md
@@ -104,7 +104,7 @@ to set up physical device deployment in Xcode.
      1. In the `Runner` target settings page,
         make sure your Development Team is selected.
         The UI varies depending on your version of Xcode.
-        * For Xcode 9 & 10, look under **General > Signing > Team**.
+        * For Xcode 10, look under **General > Signing > Team**.
         * For Xcode 11 and newer, look under
         **Signing & Capabilities > Team**.
 


### PR DESCRIPTION
The minimum version of Xcode that the flutter tool will allow is [currently 10.2](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/macos/xcode.dart#L15). Thus, this PR removes a reference to version 9. Ideally, we would want everyone to be on the latest, and we don't want to reference 9, making users think it is supported.