### PR TITLE
size docs for bitcode

### DIFF
--- a/src/docs/perf/app-size.md
+++ b/src/docs/perf/app-size.md
@@ -90,9 +90,11 @@ The resulting IPA file for the `example/helloworld` app
 
 A closer result can be obtained by creating a release archive as described in
 the [iOS create build archive instructions][]. If bitcode is enabled on your
-project, you will also have the option to rebuild from bitcode. You can also
-select app thinning for a specific phone architecture, which should be very
-close to the final IPA size from the store for that device.
+project, you will also have the option to rebuild from bitcode. This option
+should be selected if it is available, to more closely match what the App Store
+will produce for your application. You can also select app thinning for a
+specific phone architecture, which should be very close to the final IPA size
+from the store for that device.
 
 To measure an iOS app exactly,
 you have to upload a release IPA to Apple’s

--- a/src/docs/perf/app-size.md
+++ b/src/docs/perf/app-size.md
@@ -88,6 +88,12 @@ The resulting IPA file for the `example/helloworld` app
 -rw-r--r--  1 userName  primarygroup   8.3M Oct 25 13:47 build/app.ipa
 ```
 
+A closer result can be obtained by creating a release archive as described in
+the [iOS create build archive instructions][]. If bitcode is enabled on your
+project, you will also have the option to rebuild from bitcode. You can also
+select app thinning for a specific phone architecture, which should be very
+close to the final IPA size from the store for that device.
+
 To measure an iOS app exactly,
 you have to upload a release IPA to Apple’s
 App Store Connect ([instructions][])
@@ -112,4 +118,4 @@ are:
 [instructions]: /docs/deployment/ios
 [Test drive]: /docs/get-started/test-drive
 [Write your first Flutter app]: /docs/get-started/codelab
-
+[iOS create build archive instructions]: /docs/deployment/ios#create-a-build-archive

--- a/src/docs/resources/faq.md
+++ b/src/docs/resources/faq.md
@@ -371,6 +371,16 @@ binaries within the IPA, making the compression less efficient
 (see the [iOS App Store Specific Considerations][]
 section of Apple’s [QA1795][]).
 
+Since Flutter has started bundling bitcode, the size of the release
+Flutter.framework has vastly increased. This is because the release binary now
+contains a large blob of LLVM IR (bitcode). This is used by later process in
+Xcode and Apple's App Store to produce a final binary with the latest compiler
+optimizations and features. The profile and debug frameworks contain only
+"bitcode marker", and are more representative of the engine's actual binary
+size. Whether you ship with bitcode or not, the increased size of the release
+framework is stripped out during the final steps of the build. These steps
+happen after archiving your app and shipping it to the store.
+
 Of course, YMMV, and we recommend that you measure your own app.
 To measure an Android app, run `flutter build apk` (using the new
 `--split-per-abi` option in version 1.7.8+hotfix.3 and later)

--- a/src/docs/resources/faq.md
+++ b/src/docs/resources/faq.md
@@ -371,17 +371,16 @@ binaries within the IPA, making the compression less efficient
 (see the [iOS App Store Specific Considerations][]
 section of Apple’s [QA1795][]).
 
-Since Flutter has started bundling bitcode, the size of the release
-Flutter.framework has vastly increased. This is because the release binary now
-contains a large blob of LLVM IR (bitcode). This is used by later process in
-Xcode and Apple's App Store to produce a final binary with the latest compiler
-optimizations and features. The profile and debug frameworks contain only
-"bitcode marker", and are more representative of the engine's actual binary
-size. Whether you ship with bitcode or not, the increased size of the release
-framework is stripped out during the final steps of the build. These steps
-happen after archiving your app and shipping it to the store.
+As of Flutter SDK 1.12, the release engine binary now includes LLVM IR
+(bitcode). Xcode uses this bitcode to produce a final binary for the App Store
+containing the latest compiler optimizations and features.
+The profile and debug frameworks contain only a _bitcode marker_,
+and are more representative of the engine's actual binary size.
+Whether you ship with bitcode or not, the increased size of the release
+framework is stripped out during the final steps of the build.
+These steps happen after archiving your app and shipping it to the store.
 
-Of course, YMMV, and we recommend that you measure your own app.
+Of course, we recommend that you measure your own app.
 To measure an Android app, run `flutter build apk` (using the new
 `--split-per-abi` option in version 1.7.8+hotfix.3 and later)
 and load the APK


### PR DESCRIPTION
Helps give a canonical answer for why the release `Flutter.framework` is so big now, and additional details on measuring final app size for iOS.

/cc @timsneath @eseidelGoogle 