### PR TITLE
Minor fix: Change subcategory of Expanded widget to Single-child in widgets.json closes #3191

### DIFF
--- a/src/_data/catalog/widgets.json
+++ b/src/_data/catalog/widgets.json
@@ -731,7 +731,7 @@
     "name": "Expanded",
     "categories": [],
     "subcategories": [
-      "Multi-child layout widgets"
+      "Single-child layout widgets"
     ],
     "description": "A widget that expands a child of a Row, Column, or Flex.",
     "link": "https://api.flutter.dev/flutter/widgets/Expanded-class.html",


### PR DESCRIPTION

Closes #3191

Changes subcategory of Expanded widget from "Multi-child" to "Single-child in widgets.json

`  "name": "Expanded",
    "categories": [],
    "subcategories": [
      "Single-child layout widgets"
    ],`