### PR TITLE
Add release notes for 1.9.2 and prior releases to the web site.

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -211,6 +211,17 @@
               permalink: /docs/development/tools/sdk/archive
             - title: Breaking changes
               permalink: /docs/release/breaking-changes
+            - title: Release notes
+              permalink: /docs/development/tools/sdk/release-notes
+              children:
+                - title: 1.9.1
+                  permalink: /docs/development/tools/sdk/release-notes/release-notes-1.9.1.md
+                - title: 1.7.8
+                  permalink: /docs/development/tools/sdk/release-notes/release-notes-1.7.8.md
+                - title: 1.5.4
+                  permalink: /docs/development/tools/sdk/release-notes/release-notes-1.5.4.md
+                - title: 1.2.1
+                  permalink: /docs/development/tools/sdk/release-notes/release-notes-1.2.1.md
         - title: Hot reload
           permalink: /docs/development/tools/hot-reload
         - title: Code formatting

--- a/src/docs/development/tools/sdk/release-notes/changelogs/changelog-1.2.1.md
+++ b/src/docs/development/tools/sdk/release-notes/changelogs/changelog-1.2.1.md
@@ -1,0 +1,1988 @@
+---
+title: Change log for Flutter 1.2.2 
+short-title: 1.2.2 change log
+description: Change log for Flutter 1.2.2 containing a list of all PRs merged for this release.
+---
+
+
+## PRs closed in this release of flutter/flutter
+
+From Fri Nov 29 19:41:00 2018 -0800 to Thu Feb 21 20:22:00 2019 -0800
+
+
+[21157](https://github.com/flutter/flutter/pull/21157) Swap scope with gesture (cla: yes, f: scrolling, framework)
+
+[22139](https://github.com/flutter/flutter/pull/22139) move INTERNET permission to debug/AndroidManifest.xml (cla: yes, tool, ▣ platform-android)
+
+[23118](https://github.com/flutter/flutter/pull/23118) Setting icon color to first ListTile in ExpansionTile. Fixes #23053 (cla: yes, f: material design, framework)
+
+[23188](https://github.com/flutter/flutter/pull/23188) Check for duplicative Flutter.framework emeddings when building for Xcode 10 (cla: yes, tool, ⌺‬ platform-ios)
+
+[23424](https://github.com/flutter/flutter/pull/23424) Teach drag start behaviors to DragGestureRecognizer (a: text input, cla: yes, d: examples, f: cupertino, f: date/time picker, f: gestures, f: material design, f: scrolling, framework)
+
+[23506](https://github.com/flutter/flutter/pull/23506) Create slider with editable numerical value in gallery (cla: yes, f: material design, framework)
+
+[23531](https://github.com/flutter/flutter/pull/23531) [O] Remove many timeouts. (a: tests, cla: yes, t: gradle, team, tool)
+
+[23677](https://github.com/flutter/flutter/pull/23677) Add animation tests for changes to the FloatingActionButtonLocation (cla: yes, f: material design, framework)
+
+[23759](https://github.com/flutter/flutter/pull/23759) Adds CupertinoTheme (cla: yes, f: cupertino, f: material design, framework, team: gallery)
+
+[23782](https://github.com/flutter/flutter/pull/23782) Add flutter_shared assets to module artifact (a: assets, t: gradle, tool)
+
+[23817](https://github.com/flutter/flutter/pull/23817) Fix project directory has spaces lead to compile error (a: existing-apps, cla: yes, tool, ▣ platform-android)
+
+[23860](https://github.com/flutter/flutter/pull/23860) Clearing pendingImages when the cache is cleared or evicted. (cla: yes, framework)
+
+[23889](https://github.com/flutter/flutter/pull/23889) Flutter doctor error message lookup (cla: yes, t: flutter doctor, tool)
+
+[23919](https://github.com/flutter/flutter/pull/23919) Allow detection of taps on TabBar (cla: yes, f: material design, framework)
+
+[24156](https://github.com/flutter/flutter/pull/24156) [Material] Bottom app bar theme (cla: yes, f: material design, framework)
+
+[24169](https://github.com/flutter/flutter/pull/24169) [Material] Theme-able elevation on dialogs. (cla: yes, f: material design, framework)
+
+[24209](https://github.com/flutter/flutter/pull/24209) Do not ignore pubspec.lock in project templates (cla: yes, tool)
+
+[24440](https://github.com/flutter/flutter/pull/24440) Adding support for android app bundle - Issue #17829 (cla: no, t: gradle, tool, ▣ platform-android)
+
+[24449](https://github.com/flutter/flutter/pull/24449) Text field style merge (cla: yes, f: material design, framework)
+
+[24457](https://github.com/flutter/flutter/pull/24457) Revise Android and iOS gestures on Material TextField (a: text input, cla: yes, f: cupertino, f: material design, framework)
+
+[24511](https://github.com/flutter/flutter/pull/24511) [H] Undeprecate BigInteger support, but document what it actually does. (cla: yes, framework)
+
+[24513](https://github.com/flutter/flutter/pull/24513) Add some basic tests for evaluating expressions in `flutter test` (a: debugging, a: tests, cla: yes, tool)
+
+[24515](https://github.com/flutter/flutter/pull/24515) Add some a basic debug stepping tests (a: debugging, cla: yes, tool)
+
+[24527](https://github.com/flutter/flutter/pull/24527) obscureText and enableInteractiveSelection defaults (a: text input, cla: yes, framework)
+
+[24537](https://github.com/flutter/flutter/pull/24537) Add ipv6 and observatory port support to the attach command. (cla: yes, customer: dream (g3), tool)
+
+[24551](https://github.com/flutter/flutter/pull/24551) Add consumedScrollExtent to SliverConstraints as reported by Viewport (cla: yes, f: scrolling, framework)
+
+[24554](https://github.com/flutter/flutter/pull/24554) Adds force press gesture detector and recognizer (cla: yes, f: gestures, framework)
+
+[24580](https://github.com/flutter/flutter/pull/24580) Remove code signing special casing for Googlers round 2 (cla: yes, tool, ⌺‬ platform-ios)
+
+[24581](https://github.com/flutter/flutter/pull/24581) [OR] Cleanup device lab test and remove a timeout. (cla: yes, t: hot reload, tool)
+
+[24587](https://github.com/flutter/flutter/pull/24587) Validate style in TextField (cla: yes, f: material design, framework)
+
+[24632](https://github.com/flutter/flutter/pull/24632) Include error message in crash reports (cla: yes, tool)
+
+[24635](https://github.com/flutter/flutter/pull/24635) TextFormField cursor params (a: text input, cla: yes, f: material design, framework)
+
+[24643](https://github.com/flutter/flutter/pull/24643) [H] Some minor tweaks to InputDecoration (mainly docs). (cla: yes, f: material design, framework)
+
+[24669](https://github.com/flutter/flutter/pull/24669) Ensure that cache dirs and files have appropriate permissions (cla: yes, tool)
+
+[24728](https://github.com/flutter/flutter/pull/24728) [H] Support setting the elevation of disabled floating action buttons (cla: yes, f: material design, framework)
+
+[24736](https://github.com/flutter/flutter/pull/24736) [H] Provide some more locations for the FAB. (cla: yes, f: material design, framework)
+
+[24744](https://github.com/flutter/flutter/pull/24744) drop/restore focus when app becomes invisible/visible (a: text input, cla: yes, framework)
+
+[24746](https://github.com/flutter/flutter/pull/24746) Change the required version of adb, as older versions break hot reload. (cla: yes, tool, ▣ platform-android)
+
+[24752](https://github.com/flutter/flutter/pull/24752) Replace platform check with switch (cla: yes, f: material design)
+
+[24754](https://github.com/flutter/flutter/pull/24754) Replace Android-specific check with switch (cla: yes, framework, team)
+
+[24761](https://github.com/flutter/flutter/pull/24761) Adds support for floating cursor (a: text input, cla: yes, framework)
+
+[24767](https://github.com/flutter/flutter/pull/24767) [H] Improved positioning of leading and trailing widgets in overflowing ListTiles (cla: yes, f: material design, framework)
+
+[24779](https://github.com/flutter/flutter/pull/24779) Skip formatters if text has not changed (a: text input, cla: yes, framework)
+
+[24797](https://github.com/flutter/flutter/pull/24797) Iterate through potential grapheme cluster lengths in text painter (a: text input, a: typography, cla: yes, framework)
+
+[24816](https://github.com/flutter/flutter/pull/24816) [H] ClipPath.shape and related fixes (cla: yes, f: material design, framework)
+
+[24830](https://github.com/flutter/flutter/pull/24830) Implement hover support for mouse pointers. (cla: yes, f: gestures, framework, ⎊ platform-chromebook, ▣ platform-android)
+
+[24848](https://github.com/flutter/flutter/pull/24848) [H] Handle errors in `compute()` by propagating them to the Future. (cla: yes, framework)
+
+[24862](https://github.com/flutter/flutter/pull/24862) Fix semantics compiler for offstage children (a: accessibility, cla: yes, framework, severe: crash)
+
+[24868](https://github.com/flutter/flutter/pull/24868) Clarify dart:ui dependencies in foundation library (cla: yes, d: api docs, framework)
+
+[24876](https://github.com/flutter/flutter/pull/24876) Adds a fade in and out, rounds corners, fixes offset and fixes height of cursor on iOS (a: text input, cla: yes, f: cupertino, f: material design, framework)
+
+[24878](https://github.com/flutter/flutter/pull/24878) Add a flutter-attach entry point for fuchsia (cla: yes, tool)
+
+[24881](https://github.com/flutter/flutter/pull/24881) Remove offstage wording from KeepAlive (cla: yes, framework)
+
+[24889](https://github.com/flutter/flutter/pull/24889) Update AUTHORS (cla: yes, team)
+
+[24890](https://github.com/flutter/flutter/pull/24890) Remove deprecated lint "prefer_bool_in_asserts". (cla: yes, team)
+
+[24892](https://github.com/flutter/flutter/pull/24892) Handle a TabBarView special case: last tab deleted before animation ends (cla: yes, f: material design, framework)
+
+[24930](https://github.com/flutter/flutter/pull/24930) Run flutter tests through mini test engine when run directly (flutter run -t test_file) (a: tests, cla: yes, framework)
+
+[24932](https://github.com/flutter/flutter/pull/24932) Fixed Typography null factory constructor (cla: yes, f: material design, framework)
+
+[24941](https://github.com/flutter/flutter/pull/24941) Update Switch doc: disabled state (cla: yes, f: material design, framework)
+
+[24942](https://github.com/flutter/flutter/pull/24942) Fix debugPrint(null) to not crash (cla: yes, framework, severe: crash)
+
+[24944](https://github.com/flutter/flutter/pull/24944) Fix flutter root error message string interpolation (cla: yes, tool)
+
+[24953](https://github.com/flutter/flutter/pull/24953) Fuchsia multiple devices and target (cla: yes, customer: fuchsia, tool)
+
+[24976](https://github.com/flutter/flutter/pull/24976) Support TextField multi-line hint text #20941 (cla: yes, f: material design, framework)
+
+[24989](https://github.com/flutter/flutter/pull/24989) Add documentation for how to use annotated region (cla: yes, d: api docs, framework)
+
+[24993](https://github.com/flutter/flutter/pull/24993) Add InputDecoration alignLabelWithHint parameter (cla: yes, f: material design, framework)
+
+[24994](https://github.com/flutter/flutter/pull/24994) Add polling module discovery for Fuchsia (cla: yes, tool, ○ platform-fuchsia)
+
+[24999](https://github.com/flutter/flutter/pull/24999) Remove TextField.noMaxLength, use maxLength = -1 instead (cla: yes, f: material design, framework)
+
+[25003](https://github.com/flutter/flutter/pull/25003) Fix typo in documentation (cla: yes, d: api docs, framework)
+
+[25007](https://github.com/flutter/flutter/pull/25007) Warn when building on master channel (cla: yes, tool)
+
+[25008](https://github.com/flutter/flutter/pull/25008) [Slider] Custom track, ticker, and overlay shape painters (cla: yes, f: material design, framework)
+
+[25013](https://github.com/flutter/flutter/pull/25013) Adds a small fix to the Cupertino Navigation demo (cla: yes, team: gallery)
+
+[25046](https://github.com/flutter/flutter/pull/25046) Add a check for build methods that return context.widget (cla: yes, framework)
+
+[25048](https://github.com/flutter/flutter/pull/25048) Don't crash if pinned & floating AppBar has less than minExtent remainingPaintExtent (cla: yes, framework, severe: crash)
+
+[25049](https://github.com/flutter/flutter/pull/25049) Fix behavior of handleDrawFrame() in benchmark mode. (a: tests, cla: yes, framework)
+
+[25051](https://github.com/flutter/flutter/pull/25051) Do not fade out text for pinned & floating AppBar (cla: yes, f: material design, framework)
+
+[25055](https://github.com/flutter/flutter/pull/25055) Include cursor in textfield intrinsic width measurement (a: text input, cla: yes, framework)
+
+[25058](https://github.com/flutter/flutter/pull/25058) ensure lastBuildTimestamp is set before early return (cla: yes, tool)
+
+[25076](https://github.com/flutter/flutter/pull/25076) fix: cuertino dialog action background blur effect (cla: yes, f: cupertino, framework)
+
+[25079](https://github.com/flutter/flutter/pull/25079) Fix Podfile issue #24342 (cla: yes, tool, waiting for tree to go green, ⌺‬ platform-ios)
+
+[25091](https://github.com/flutter/flutter/pull/25091) Add animations to SliverAppBar doc (cla: yes, d: api docs, f: material design, framework)
+
+[25094](https://github.com/flutter/flutter/pull/25094) Include empty config message in 'flutter config' output (cla: yes, tool)
+
+[25095](https://github.com/flutter/flutter/pull/25095) InputDecorator Count Widget (cla: yes, f: material design, framework)
+
+[25096](https://github.com/flutter/flutter/pull/25096) Change network image URL in doc (cla: yes, d: api docs, framework)
+
+[25120](https://github.com/flutter/flutter/pull/25120) Replace deprecated link (to design-principles page) in comment (cla: yes, d: api docs, f: material design, framework)
+
+[25125](https://github.com/flutter/flutter/pull/25125) Add reverse functionality to repeat() of AnimationController (a: animation, cla: yes, framework)
+
+[25126](https://github.com/flutter/flutter/pull/25126) Fix error message and other typos (cla: yes, framework)
+
+[25154](https://github.com/flutter/flutter/pull/25154) Don't require the AVD folder to exist in order to run `flutter emulators` (cla: yes, tool, ▣ platform-android)
+
+[25159](https://github.com/flutter/flutter/pull/25159) fix #25143 Successive calls to `precacheImage()` throw an exception (cla: yes, framework, waiting for tree to go green)
+
+[25168](https://github.com/flutter/flutter/pull/25168) Fixed an InheritedWidget code sample typo (cla: yes, framework)
+
+[25178](https://github.com/flutter/flutter/pull/25178) Adds favicon to Dash/Zeal docset, adds OpenSearch metadata. (cla: yes, team)
+
+[25183](https://github.com/flutter/flutter/pull/25183) Add navigatorKey to CupertinoTabView (cla: yes, f: cupertino, framework)
+
+[25184](https://github.com/flutter/flutter/pull/25184) Add imports section to sample code templates, and more docs. (cla: yes, team)
+
+[25186](https://github.com/flutter/flutter/pull/25186) Temporarily add back filtered bintray ExoPlayer repository (cla: yes, team: gallery)
+
+[25217](https://github.com/flutter/flutter/pull/25217) Fixed Spelling. (cla: yes, framework)
+
+[25221](https://github.com/flutter/flutter/pull/25221) Support ANDROID_SDK_ROOT in addition to ANDROID_HOME (cla: yes, tool, ▣ platform-android)
+
+[25228](https://github.com/flutter/flutter/pull/25228) IntrinsicWidth stepWidth or stepHeight == 0.0 (cla: yes, framework)
+
+[25229](https://github.com/flutter/flutter/pull/25229) Right aligned backspace bug (a: text input, cla: yes, framework)
+
+[25237](https://github.com/flutter/flutter/pull/25237) Fix typo (a: text input, cla: yes, d: api docs, framework)
+
+[25238](https://github.com/flutter/flutter/pull/25238) [OR] Update links for China help (cla: yes, tool)
+
+[25239](https://github.com/flutter/flutter/pull/25239) Call mark* methods before attaching child (cla: yes, framework, severe: crash)
+
+[25240](https://github.com/flutter/flutter/pull/25240) Revert "Ensure that cache dirs and files have appropriate permissions" (cla: yes, tool)
+
+[25243](https://github.com/flutter/flutter/pull/25243) Allow snippets tool to be run from arbitrary CWDs (cla: yes, d: api docs, team)
+
+[25269](https://github.com/flutter/flutter/pull/25269) Make doctor output consistent between VS Code/IntelliJ/Android Studio when plugins are missing (cla: yes, t: flutter doctor, tool)
+
+[25288](https://github.com/flutter/flutter/pull/25288) Revert "Add ipv6 and observatory port support to the attach command." (cla: yes, tool)
+
+[25300](https://github.com/flutter/flutter/pull/25300) Remove uses-material-design from hello_world example (a: size, cla: yes, d: examples)
+
+[25301](https://github.com/flutter/flutter/pull/25301) Flutter tool support for automatic saving of JIT compilation trace (cla: yes, framework, tool)
+
+[25303](https://github.com/flutter/flutter/pull/25303) Add ipv6 and observatory port support to the attach command (cla: yes, tool)
+
+[25305](https://github.com/flutter/flutter/pull/25305) Use stderr instead of stdout to contain errors in flutter attach test (a: tests, cla: yes)
+
+[25332](https://github.com/flutter/flutter/pull/25332) [fuchsia] Get Dart VM service ports from The Hub (cla: yes, tool, ○ platform-fuchsia)
+
+[25335](https://github.com/flutter/flutter/pull/25335) Revert "obscureText and enableInteractiveSelection defaults" (a: text input, cla: yes, framework)
+
+[25339](https://github.com/flutter/flutter/pull/25339) [Material] Theme-able TextStyles for AlertDialog (cla: yes, f: material design, framework)
+
+[25342](https://github.com/flutter/flutter/pull/25342) Revert "Revert "obscureText and enableInteractiveSelection defaults"" (a: text input, cla: yes, f: material design, framework)
+
+[25344](https://github.com/flutter/flutter/pull/25344) Add fuchsia devices to daemon command (cla: yes, customer: fuchsia, tool)
+
+[25345](https://github.com/flutter/flutter/pull/25345) assert(elevation >= 0.0) and doc clarifications (cla: yes, customer: fuchsia, f: material design, framework)
+
+[25352](https://github.com/flutter/flutter/pull/25352) Revert "Adds support for floating cursor" (a: text input, cla: yes, f: cupertino, f: material design, framework)
+
+[25380](https://github.com/flutter/flutter/pull/25380) Revert "Use stderr instead of stdout to contain errors in flutter attach test" (a: tests, cla: yes)
+
+[25381](https://github.com/flutter/flutter/pull/25381) Add cull opacity perf test to device lab (a: tests, cla: yes, framework, severe: performance)
+
+[25382](https://github.com/flutter/flutter/pull/25382) Revert "Call mark* methods before attaching child (#25239)" (cla: yes, framework, severe: crash)
+
+[25384](https://github.com/flutter/flutter/pull/25384) Adds support for floating cursor (a: text input, cla: yes, f: cupertino, f: material design, framework)
+
+[25390](https://github.com/flutter/flutter/pull/25390) Revert "drop/restore focus when app becomes invisible/visible" (a: text input, cla: yes, framework)
+
+[25394](https://github.com/flutter/flutter/pull/25394) Update localizations (a: internationalization, cla: yes, framework)
+
+[25395](https://github.com/flutter/flutter/pull/25395) Reland "Call mark* methods before attaching child (#25239)" (cla: yes, framework, severe: crash)
+
+[25413](https://github.com/flutter/flutter/pull/25413) Added key.properties and *.jks to .gitignore (cla: yes, tool, waiting for tree to go green)
+
+[25416](https://github.com/flutter/flutter/pull/25416) try disabling flutter run test (cla: yes, team)
+
+[25440](https://github.com/flutter/flutter/pull/25440) don't warn for non-matching device discoverers (cla: yes, tool)
+
+[25443](https://github.com/flutter/flutter/pull/25443) fix the daemon device.getDevices call (cla: yes, tool)
+
+[25470](https://github.com/flutter/flutter/pull/25470) Support Java 1.8 (cla: yes, t: gradle, tool)
+
+[25472](https://github.com/flutter/flutter/pull/25472) Read correct cached VM snapshot in dynamic mode (PRODUCT vs RELEASE) (cla: yes, tool)
+
+[25473](https://github.com/flutter/flutter/pull/25473) TextField.onChanged() doc update (a: text input, cla: yes, d: api docs, framework)
+
+[25474](https://github.com/flutter/flutter/pull/25474) fix some formatting issues (a: animation, cla: yes, f: cupertino, framework, team)
+
+[25477](https://github.com/flutter/flutter/pull/25477) TransitionRoute.canTransitionFrom,To() doc update (cla: yes, d: api docs, f: routes, framework)
+
+[25479](https://github.com/flutter/flutter/pull/25479) Depend on the goldens repo through git. (a: tests, cla: yes, tool)
+
+[25482](https://github.com/flutter/flutter/pull/25482) Mark flaky tests as such (a: tests, cla: yes)
+
+[25483](https://github.com/flutter/flutter/pull/25483) Update examples to match the new version of generated build.gradle (cla: yes, d: examples)
+
+[25484](https://github.com/flutter/flutter/pull/25484) Fix gradle local.properties tests that were never excersized (cla: yes, t: gradle, tool)
+
+[25488](https://github.com/flutter/flutter/pull/25488) Transition Curve Fix (a: animation, cla: yes, f: cupertino, framework)
+
+[25489](https://github.com/flutter/flutter/pull/25489) Video demo instrumentation (a: tests, cla: yes, team: gallery)
+
+[25512](https://github.com/flutter/flutter/pull/25512) Fix failed assert when running `flutter test` with `--start-paused` (cla: yes, tool)
+
+[25513](https://github.com/flutter/flutter/pull/25513) make "See also" sections uniform (cla: yes, team)
+
+[25514](https://github.com/flutter/flutter/pull/25514) fix typo (cla: yes, team)
+
+[25515](https://github.com/flutter/flutter/pull/25515) Write snippets index file when generating docs (cla: yes, d: api docs, team)
+
+[25516](https://github.com/flutter/flutter/pull/25516) Change flutter create to use master-docs.flutter.io instead of firebase URL. (cla: yes, tool)
+
+[25520](https://github.com/flutter/flutter/pull/25520) Fix flutter tool to actually honor --build-number/--build-name flags (cla: yes, t: gradle, tool)
+
+[25521](https://github.com/flutter/flutter/pull/25521) fix indentation in doc comments (cla: yes, team)
+
+[25563](https://github.com/flutter/flutter/pull/25563) Revert "Update examples to match the new version of generated build.gradle (#25483)" (cla: yes, d: examples, t: gradle, team, team: gallery)
+
+[25568](https://github.com/flutter/flutter/pull/25568) Fix the build (a: tests, cla: yes, team)
+
+[25569](https://github.com/flutter/flutter/pull/25569) Reland: Update examples to match the new version of generated build.gradle (#25483) (cla: yes, d: examples, t: gradle, team)
+
+[25573](https://github.com/flutter/flutter/pull/25573) Update DayPicker,DatePicker doc "see also" sections (cla: yes, d: api docs, f: date/time picker, f: material design, framework)
+
+[25574](https://github.com/flutter/flutter/pull/25574) Use full textspan tree instead of top level textspan (cla: yes, framework)
+
+[25576](https://github.com/flutter/flutter/pull/25576) Flutter tool support for building dynamic patches on Android (cla: yes, t: gradle, tool)
+
+[25579](https://github.com/flutter/flutter/pull/25579) fix doc-comment snippets (cla: yes, team)
+
+[25582](https://github.com/flutter/flutter/pull/25582) Add missing dependency to fix the build (cla: yes, team, team: gallery)
+
+[25584](https://github.com/flutter/flutter/pull/25584) Fix material reference in CupertinoPicker doc (cla: yes, d: api docs, f: cupertino, framework)
+
+[25585](https://github.com/flutter/flutter/pull/25585) Expose font fallback API in TextStyle, Roll engine 54a3577c0139..215ca1560088 (8 commits) (a: typography, cla: yes, f: material design, framework)
+
+[25586](https://github.com/flutter/flutter/pull/25586) Report devfs stats (cla: yes, tool)
+
+[25593](https://github.com/flutter/flutter/pull/25593) Let CupertinoTabScaffold handle keyboard insets too (cla: yes, f: cupertino, framework)
+
+[25594](https://github.com/flutter/flutter/pull/25594) Switch over to the new name for compilation trace native function (cla: yes, framework)
+
+[25595](https://github.com/flutter/flutter/pull/25595) Don't parse APK unless explicitly requested (cla: yes, tool)
+
+[25604](https://github.com/flutter/flutter/pull/25604) no period after an alone reference in see also section (cla: yes, d: api docs, framework)
+
+[25631](https://github.com/flutter/flutter/pull/25631) Default baseline build options (cla: yes, tool)
+
+[25642](https://github.com/flutter/flutter/pull/25642) Revert dependency upgrade to see if it helps with build times and APK size (cla: yes, team, team: gallery)
+
+[25645](https://github.com/flutter/flutter/pull/25645) Friendlier flags for Dart compilation training. (cla: yes, tool)
+
+[25646](https://github.com/flutter/flutter/pull/25646) Revert "[O] Remove many timeouts." (a: tests, cla: yes, t: flutter driver, tool)
+
+[25670](https://github.com/flutter/flutter/pull/25670) 3D SemanticsTree (a: accessibility, cla: yes, f: material design, framework)
+
+[25674](https://github.com/flutter/flutter/pull/25674) Updated Shrine demo (a: tests, cla: yes, team, team: gallery)
+
+[25678](https://github.com/flutter/flutter/pull/25678) Pin the goldens repo to a specific commit in the android_views test. (a: tests, cla: yes)
+
+[25682](https://github.com/flutter/flutter/pull/25682) Move runner directory messages to the user messages class (a: internationalization, cla: yes, tool)
+
+[25683](https://github.com/flutter/flutter/pull/25683) Selects a word on force tap (a: text input, cla: yes, f: cupertino, f: material design, framework)
+
+[25718](https://github.com/flutter/flutter/pull/25718) Fix merge conflict. (cla: yes, f: material design, framework)
+
+[25788](https://github.com/flutter/flutter/pull/25788) Add Robert Penner’s easing functions (a: animation, cla: yes, framework)
+
+[25790](https://github.com/flutter/flutter/pull/25790) Clarify doc for AnimatedContainer (a: animation, cla: yes, d: api docs, framework)
+
+[25792](https://github.com/flutter/flutter/pull/25792) Actively reject UiKitView gestures. (a: platform-views, cla: yes, f: gestures, framework)
+
+[25796](https://github.com/flutter/flutter/pull/25796) Allow dynamic patches without a patch number. (cla: yes, t: gradle, tool)
+
+[25798](https://github.com/flutter/flutter/pull/25798) remove early-stage from Gallery's About screen (cla: yes, team, team: gallery)
+
+[25799](https://github.com/flutter/flutter/pull/25799) Make LicensePage respect the notch (cla: yes, f: material design, framework)
+
+[25815](https://github.com/flutter/flutter/pull/25815) Flutter engine roll with dart roll (cla: yes)
+
+[25817](https://github.com/flutter/flutter/pull/25817) fix flutter run in dev/manual_tests (a: tests, cla: yes, team)
+
+[25849](https://github.com/flutter/flutter/pull/25849) Roll engine to f0a1d6f91 (cla: yes)
+
+[25854](https://github.com/flutter/flutter/pull/25854) Fix analyzer "prefer const" warning. (cla: yes, team)
+
+[25857](https://github.com/flutter/flutter/pull/25857) Mark flutter_gallery__back_button_memory as flaky. (a: tests, cla: yes, team, team: gallery)
+
+[25863](https://github.com/flutter/flutter/pull/25863) Friendlier messages when using dynamic patching (cla: yes, tool)
+
+[25864](https://github.com/flutter/flutter/pull/25864) Make decodeImageFromList mockable (cla: yes, framework)
+
+[25865](https://github.com/flutter/flutter/pull/25865) [H] Add ImageStreamCompleter.hasListeners (and cleanup) (cla: yes, f: material design, framework)
+
+[25872](https://github.com/flutter/flutter/pull/25872) Optimize cocoapods logic in flutter doctor. (cla: yes, customer: gold, tool, waiting for tree to go green, ⌺‬ platform-ios)
+
+[25888](https://github.com/flutter/flutter/pull/25888) Extract TestBorder into a utility file (a: tests, cla: yes)
+
+[25922](https://github.com/flutter/flutter/pull/25922) update lint list (cla: yes, team)
+
+[25974](https://github.com/flutter/flutter/pull/25974) Add a validator to ensure NO_PROXY is set correctly if HTTP_PROXY is set (cla: yes, t: flutter doctor, tool)
+
+[25977](https://github.com/flutter/flutter/pull/25977) Add didSendFirstFrameEvent service extension. (cla: yes, framework)
+
+[25980](https://github.com/flutter/flutter/pull/25980) Ensure all errors thrown by image providers can be caught by developers. (cla: yes, framework)
+
+[25984](https://github.com/flutter/flutter/pull/25984) use RRect to draw avatar check on chip (cla: yes, f: material design, framework)
+
+[25988](https://github.com/flutter/flutter/pull/25988) Add Golden test for background painting order. (a: tests, cla: yes, engine)
+
+[25992](https://github.com/flutter/flutter/pull/25992) Add docs to TextStyle for fontFamilyFallback/Custom font fallback (cla: yes, d: api docs, framework)
+
+[25994](https://github.com/flutter/flutter/pull/25994) Simplify ImageStream(Completer).removeListener (cla: yes, framework)
+
+[25995](https://github.com/flutter/flutter/pull/25995) Address code review comment. (cla: yes, team)
+
+[26001](https://github.com/flutter/flutter/pull/26001) Add long-press-drag cursor move support for text fields (a: text input, cla: yes, f: cupertino, f: material design, framework, severe: API break)
+
+[26015](https://github.com/flutter/flutter/pull/26015) [fuchsia] Fix flutter_gallery BUILD.gn (cla: yes, team, team: gallery)
+
+[26017](https://github.com/flutter/flutter/pull/26017) Fix recursive link resulted `flutter doctor` stucking.  (cla: yes, customer: gold, tool, ▣ platform-android)
+
+[26021](https://github.com/flutter/flutter/pull/26021) Fix SliverAppBar title opacity and test all cases (cla: yes, f: material design, framework)
+
+[26024](https://github.com/flutter/flutter/pull/26024) Workaround the Gradle crash due to non ASCII characters. (cla: yes, team)
+
+[26030](https://github.com/flutter/flutter/pull/26030) Turn clipping on for Card Demo (cla: yes, team, team: gallery)
+
+[26031](https://github.com/flutter/flutter/pull/26031) Clean gallery about page post-1.0 (cla: yes, team, team: gallery)
+
+[26039](https://github.com/flutter/flutter/pull/26039) Report hot reload statistics. (cla: yes, t: hot reload, tool)
+
+[26041](https://github.com/flutter/flutter/pull/26041) Update dartdoc to 0.27.0 (cla: yes, d: api docs, team)
+
+[26042](https://github.com/flutter/flutter/pull/26042) Update material spec references in BottomSheet et al., Scaffold (cla: yes, d: api docs, f: material design, framework)
+
+[26069](https://github.com/flutter/flutter/pull/26069) Improve the intergrity checking for "gradle wrapper". (cla: yes, t: gradle, tool)
+
+[26084](https://github.com/flutter/flutter/pull/26084) Improve message when saving compilation training data (cla: yes, tool)
+
+[26088](https://github.com/flutter/flutter/pull/26088) Fix typos introduced with the TextField.onTap PR, udpated debugFillProperties (cla: yes, f: material design, framework)
+
+[26089](https://github.com/flutter/flutter/pull/26089) Explain that BoxDecoration doesn't do clip. (cla: yes, d: api docs, framework)
+
+[26090](https://github.com/flutter/flutter/pull/26090) Replace netls and netaddr with dev_finder (cla: yes, tool, ○ platform-fuchsia)
+
+[26101](https://github.com/flutter/flutter/pull/26101) Fix a floating snapping SliverAppBar crash (cla: yes, f: material design, framework)
+
+[26104](https://github.com/flutter/flutter/pull/26104) Put correct VM snapshot in APK when using cached engine (cla: yes, tool)
+
+[26107](https://github.com/flutter/flutter/pull/26107) Better error messages for flutter tool --dynamic flag. (cla: yes, tool)
+
+[26143](https://github.com/flutter/flutter/pull/26143) Fix DropDownButton with no items resulting in RenderFlex overflow (cla: yes, f: material design, framework)
+
+[26153](https://github.com/flutter/flutter/pull/26153) Remove the cc @Hixie from no-response template (cla: yes, team)
+
+[26192](https://github.com/flutter/flutter/pull/26192) [FAB] Adding FAB as class in tests. (cla: yes, f: material design, framework)
+
+[26199](https://github.com/flutter/flutter/pull/26199) Fix tristate checkbox false to null transition, test ALL transitions (cla: yes, f: material design, framework)
+
+[26201](https://github.com/flutter/flutter/pull/26201) Prevent calls to view.uiIsolate.flutterExit on devices which do not support it (cla: yes, tool, ○ platform-fuchsia)
+
+[26203](https://github.com/flutter/flutter/pull/26203) Add support for reverse to ReorderableListView (cla: yes, f: material design, framework)
+
+[26209](https://github.com/flutter/flutter/pull/26209) Revert "Teach drag start behaviors to DragGestureRecognizer (#23424)" (a: text input, cla: yes, d: examples, f: cupertino, f: gestures, f: material design, f: scrolling, framework, team: gallery)
+
+[26227](https://github.com/flutter/flutter/pull/26227) Give integration tests unique temp folder names (a: tests, cla: yes)
+
+[26235](https://github.com/flutter/flutter/pull/26235) rev the min dart sdk dep in the templates to 2.1.0 (cla: yes, tool)
+
+[26238](https://github.com/flutter/flutter/pull/26238) Remove long-deprecated TwoLevelList (cla: yes, f: material design, framework, severe: API break)
+
+[26239](https://github.com/flutter/flutter/pull/26239) Force DatePicker value to stay within firstDate and lastDate upon year change (cla: yes, f: date/time picker, framework)
+
+[26244](https://github.com/flutter/flutter/pull/26244) move analysis_options to package (cla: yes, team)
+
+[26246](https://github.com/flutter/flutter/pull/26246) Teach drag start behaviors to DragGestureRecognizer (cla: yes, f: gestures, f: scrolling, framework)
+
+[26249](https://github.com/flutter/flutter/pull/26249) Revert "Replace netls and netaddr with dev_finder" (cla: yes, tool, ○ platform-fuchsia)
+
+[26250](https://github.com/flutter/flutter/pull/26250) Reland: Switch to dev_finder (cla: yes, tool, ○ platform-fuchsia)
+
+[26252](https://github.com/flutter/flutter/pull/26252) Manual engine roll with analyzer fixes (cla: yes)
+
+[26257](https://github.com/flutter/flutter/pull/26257) Add link to Flutter brand guidelines (cla: yes, f: material design, framework)
+
+[26259](https://github.com/flutter/flutter/pull/26259) Deprecate Scaffold resizeToAvoidBottomPadding, now resizeToAvoidBottomInset (cla: yes, f: material design, framework)
+
+[26260](https://github.com/flutter/flutter/pull/26260) Fixed typo (cla: yes, d: api docs, f: material design, framework)
+
+[26262](https://github.com/flutter/flutter/pull/26262) Declare a system message channel for Skia configuration (cla: yes, dependency: skia, framework)
+
+[26265](https://github.com/flutter/flutter/pull/26265) Add support for detecting which modifier keys have been pressed on RawKeyboardEvents (a: text input, cla: yes, framework)
+
+[26266](https://github.com/flutter/flutter/pull/26266) [flutter_driver] Move Fuchsia logging code. (cla: yes, t: flutter driver, tool, ○ platform-fuchsia)
+
+[26269](https://github.com/flutter/flutter/pull/26269) Update docs for editable_text (TextField) (a: text input, cla: yes, d: api docs, f: cupertino, f: material design, framework, waiting for tree to go green)
+
+[26270](https://github.com/flutter/flutter/pull/26270) Fix red tree (Android module) (cla: yes, t: gradle, tool)
+
+[26271](https://github.com/flutter/flutter/pull/26271) Add compileOptions to android_host_app (a: existing-apps, a: tests, cla: yes)
+
+[26274](https://github.com/flutter/flutter/pull/26274) Add source line to snippet metadata file (cla: yes, d: api docs)
+
+[26285](https://github.com/flutter/flutter/pull/26285) Wrap lines at 80 characters (cla: yes, team)
+
+[26290](https://github.com/flutter/flutter/pull/26290) Add new curve animations to class documentation (a: animation, cla: yes, d: api docs, framework, waiting for tree to go green)
+
+[26295](https://github.com/flutter/flutter/pull/26295) Added the superellipse (a.k.a. squircle) shape to flutter. (a: fidelity, cla: yes, f: cupertino, framework)
+
+[26297](https://github.com/flutter/flutter/pull/26297) Added 'physics' prop to Stepper. (cla: yes, f: material design, framework)
+
+[26300](https://github.com/flutter/flutter/pull/26300) Allow bundle identifier to be surrounded with quotes. (cla: yes, tool)
+
+[26303](https://github.com/flutter/flutter/pull/26303) Adds a type parameter to invokeMethod (and additional utility methods) (cla: yes, framework, p: framework, plugin, team)
+
+[26309](https://github.com/flutter/flutter/pull/26309) Fix descenders cutoff in TextField (a: text input, cla: yes, framework)
+
+[26312](https://github.com/flutter/flutter/pull/26312) Add logic for creating rollback dynamic patches. (cla: yes, t: gradle, tool, ▣ platform-android)
+
+[26313](https://github.com/flutter/flutter/pull/26313) Fix Listenable.merge to not leak (cla: yes, framework)
+
+[26315](https://github.com/flutter/flutter/pull/26315) Ensure that Dart SDK dirs have appropriate permissions (cla: yes, tool)
+
+[26332](https://github.com/flutter/flutter/pull/26332) Integrate Strut: Add StrutStyle, expose Strut API, wire up strut with dart:ui, Roll engine 31a7f4d..e7eb1c8 (7 commits) (a: text input, a: typography, cla: yes, framework, severe: API break)
+
+[26333](https://github.com/flutter/flutter/pull/26333) Add back lost gallery theme code (cla: yes, team, team: gallery, waiting for tree to go green)
+
+[26334](https://github.com/flutter/flutter/pull/26334) mark tests as not flaky (a: tests, cla: yes, team)
+
+[26337](https://github.com/flutter/flutter/pull/26337) chromebot recipe instructions missing a step (cla: yes, team)
+
+[26339](https://github.com/flutter/flutter/pull/26339) Revert "Check for duplicative Flutter.framework emeddings when building for Xcode 10" (cla: yes, t: xcode, tool, ⌺‬ platform-ios)
+
+[26376](https://github.com/flutter/flutter/pull/26376) removed image with 404 (cla: yes, team)
+
+[26377](https://github.com/flutter/flutter/pull/26377) Restore ignore for *.lock files (cla: yes)
+
+[26378](https://github.com/flutter/flutter/pull/26378) Friendlier flutter tool messages for dynamic mode (cla: yes, tool)
+
+[26385](https://github.com/flutter/flutter/pull/26385) Deprecate the animated image frame cache (a: tests, cla: yes, framework)
+
+[26386](https://github.com/flutter/flutter/pull/26386) Check response code, retry when downloading docs (cla: yes, team)
+
+[26388](https://github.com/flutter/flutter/pull/26388) fix #26207 .gitignore only include project root build directory (cla: yes, tool)
+
+[26389](https://github.com/flutter/flutter/pull/26389) Make sure package cache prepare does not end up creating projects inside the cloned Flutter repo (a: tests, cla: yes, team)
+
+[26392](https://github.com/flutter/flutter/pull/26392) Avoid use of ParagraphConstrains const ctor (cla: yes, framework, team)
+
+[26395](https://github.com/flutter/flutter/pull/26395) Emit more of HTTP error response bodies (cla: yes, team)
+
+[26402](https://github.com/flutter/flutter/pull/26402) Let the packaging recipe use gsutil.py (cla: yes, team)
+
+[26403](https://github.com/flutter/flutter/pull/26403) Re-enable compute credites for macOS PRs only. (cla: yes, team)
+
+[26422](https://github.com/flutter/flutter/pull/26422) Create an injectable factory for application packages. (cla: yes, tool)
+
+[26426](https://github.com/flutter/flutter/pull/26426) Send ServiceExtensionToggled event when service extension is set. (cla: yes, f: inspector, framework)
+
+[26430](https://github.com/flutter/flutter/pull/26430) Roll engine e5ec3cf3ea5c..b7f6bf0192d1 (28 commits) (cla: yes)
+
+[26436](https://github.com/flutter/flutter/pull/26436) Revert "move analysis_options to package" (cla: yes, team)
+
+[26440](https://github.com/flutter/flutter/pull/26440) [fuchsia] Add BUILD.gn for flutter_localizations (a: internationalization, cla: yes, framework)
+
+[26441](https://github.com/flutter/flutter/pull/26441) Fix some doc references (cla: yes, d: api docs, f: cupertino, framework)
+
+[26444](https://github.com/flutter/flutter/pull/26444) Update compileSdkVersion in the Android app templates to Android P (cla: yes, tool, ▣ platform-android)
+
+[26449](https://github.com/flutter/flutter/pull/26449) Add asserts for @required parameters (cla: yes, framework, team)
+
+[26450](https://github.com/flutter/flutter/pull/26450) Add a manifest for profile builds that enables INTERNET permission (cla: yes, tool, ▣ platform-android)
+
+[26454](https://github.com/flutter/flutter/pull/26454) Cleanup temporary catchError. (cla: yes, framework)
+
+[26456](https://github.com/flutter/flutter/pull/26456) `flutter create --template=plugin` now includes flutter (dart) unit test (cla: yes, tool)
+
+[26482](https://github.com/flutter/flutter/pull/26482) Grammatical fix: "places" to "placed" (cla: yes, d: api docs, framework)
+
+[26511](https://github.com/flutter/flutter/pull/26511) desktop workflow, devices, and test (cla: yes, tool, ⌘‬ platform-mac, ❖ platform-windows, 🐧 platform-linux)
+
+[26519](https://github.com/flutter/flutter/pull/26519) Skip `flutter test` expression eval tests (a: tests, cla: yes, tool)
+
+[26533](https://github.com/flutter/flutter/pull/26533) [Material] TabBarTheme text style parameters (cla: yes, f: material design, framework)
+
+[26537](https://github.com/flutter/flutter/pull/26537) Report overall and transfer timings as part of hot reload statistics,… (cla: yes, t: hot reload, tool)
+
+[26539](https://github.com/flutter/flutter/pull/26539) Narrow regexp for import search in bot's analyze script. (cla: yes, team)
+
+[26545](https://github.com/flutter/flutter/pull/26545) remove ignore_for_file lints (cla: yes, team)
+
+[26546](https://github.com/flutter/flutter/pull/26546) Update dartdoc to 0.28.0 and add flags to constrain warnings (cla: yes, d: api docs, team)
+
+[26550](https://github.com/flutter/flutter/pull/26550) Remove incorrect Coveralls badge. (cla: yes, team)
+
+[26559](https://github.com/flutter/flutter/pull/26559) add type parameter back to PageRouteFactory (cla: yes, team)
+
+[26562](https://github.com/flutter/flutter/pull/26562) Remove todo from Podhelpr.rb (cla: yes, team)
+
+[26565](https://github.com/flutter/flutter/pull/26565) Emulator support for dynamic mode on Intel architecture (cla: yes, tool, ▣ platform-android)
+
+[26579](https://github.com/flutter/flutter/pull/26579) Fix+unskip `flutter test` expression eval tests (cla: yes, tool)
+
+[26586](https://github.com/flutter/flutter/pull/26586) Added Sample code for Stack widget (cla: yes, d: api docs, framework)
+
+[26589](https://github.com/flutter/flutter/pull/26589) Do not exit tool if parts of fuchsia workflow fail (cla: yes, tool, ○ platform-fuchsia)
+
+[26592](https://github.com/flutter/flutter/pull/26592) Prevent crash when calling lerp for IconThemeData with null arguments (cla: yes, framework)
+
+[26593](https://github.com/flutter/flutter/pull/26593) Support running macOS prebuilt application (cla: yes, tool, ⌘‬ platform-mac)
+
+[26596](https://github.com/flutter/flutter/pull/26596) Roll engine to 5983e34a3c0e1217da7e8bbe9f2fe685048fe259 (cla: yes)
+
+[26597](https://github.com/flutter/flutter/pull/26597) [Material] Implement App Bar Theme (cla: yes, f: material design, framework)
+
+[26598](https://github.com/flutter/flutter/pull/26598) Add tests for getOffsetToReveal on RenderSlivers (a: tests, cla: yes, framework, severe: crash)
+
+[26604](https://github.com/flutter/flutter/pull/26604) Adding a shutdown hook to HotRunnerConfig (cla: yes, tool)
+
+[26605](https://github.com/flutter/flutter/pull/26605) Implemented Dark Mode for Android (#25525) (cla: yes, f: material design, framework, ▣ platform-android)
+
+[26611](https://github.com/flutter/flutter/pull/26611) IconButton backgroundColor doc sample (cla: yes, d: api docs, f: material design, framework)
+
+[26612](https://github.com/flutter/flutter/pull/26612) Remove TODO, reduce tech debt (cla: yes, team)
+
+[26613](https://github.com/flutter/flutter/pull/26613) Updated AlertDialog content doc (cla: yes, f: material design, framework)
+
+[26629](https://github.com/flutter/flutter/pull/26629) [HX] Quick fix for tap-to-show-keyboard regression (a: text input, cla: yes, f: gestures, f: material design, framework, ⚠ TODAY)
+
+[26630](https://github.com/flutter/flutter/pull/26630) Move flutter_assets to App.framework (a: existing-apps, cla: yes, t: xcode, tool, ⌺‬ platform-ios)
+
+[26642](https://github.com/flutter/flutter/pull/26642) Fix --build-shared-library on newer NDKs (cla: yes, tool, ▣ platform-android)
+
+[26644](https://github.com/flutter/flutter/pull/26644) Revert "Add flutter_shared assets to module artifact (#23782)" (a: assets, cla: yes, t: gradle, tool)
+
+[26650](https://github.com/flutter/flutter/pull/26650) Wrap dart:convert to track utf8 decode failures (cla: yes, tool)
+
+[26652](https://github.com/flutter/flutter/pull/26652) Fix rounding error in build tests (a: tests, a: text input, cla: yes, framework)
+
+[26659](https://github.com/flutter/flutter/pull/26659) Adds fix for NAN value and pressure values outside of device reported min and max (a: text input, cla: yes, f: gestures, framework, waiting for tree to go green)
+
+[26663](https://github.com/flutter/flutter/pull/26663) Make getOffsetToReveal work with nested Viewports (cla: yes, f: scrolling, framework)
+
+[26668](https://github.com/flutter/flutter/pull/26668) [Gradle] Copy ICU data to flutter_shared only when building an AAR module (cla: yes, t: gradle, tool)
+
+[26669](https://github.com/flutter/flutter/pull/26669) Register hotRestart service in flutter_tools. (cla: yes, tool)
+
+[26675](https://github.com/flutter/flutter/pull/26675) Revert "Move flutter_assets to App.framework (#26630)" (a: existing-apps, cla: yes, t: xcode, tool)
+
+[26680](https://github.com/flutter/flutter/pull/26680) [frdp] Adds paths for `find` and `ls` for Fuchsia execution. (cla: yes, team, tool, ○ platform-fuchsia)
+
+[26690](https://github.com/flutter/flutter/pull/26690) Doc fix: SliverChildBuilderDelegate is the lazy one (cla: yes, d: api docs, f: scrolling, framework)
+
+[26693](https://github.com/flutter/flutter/pull/26693) Add another test to ImageStream (a: tests, cla: yes, framework, waiting for tree to go green)
+
+[26694](https://github.com/flutter/flutter/pull/26694) Roll engine back to 1e93a8eb39d79f643952737aa4fc31e1787a5a17 (cla: yes, engine, team)
+
+[26702](https://github.com/flutter/flutter/pull/26702) Update test temp folder name to be more consistent with others (a: tests, cla: yes, tool)
+
+[26713](https://github.com/flutter/flutter/pull/26713) Roll engine to 05fee4eeee0ff6b219b1fcc394371e5f6963cc46 (a: assets, cla: yes, tool, ⌺‬ platform-ios)
+
+[26715](https://github.com/flutter/flutter/pull/26715) Experimental flags in flutter (cla: yes, tool)
+
+[26716](https://github.com/flutter/flutter/pull/26716) Fix missing const analyzer warning (a: tests, cla: yes, team)
+
+[26720](https://github.com/flutter/flutter/pull/26720) Allow attaching to profile builds (cla: yes, tool)
+
+[26721](https://github.com/flutter/flutter/pull/26721) Respect EditableText.keyboardAppearance (a: text input, cla: yes, f: cupertino, framework)
+
+[26722](https://github.com/flutter/flutter/pull/26722) [Material] Refactor _build<Widget> methods in BottomNavBar (cla: yes, f: material design, framework)
+
+[26727](https://github.com/flutter/flutter/pull/26727) Roll engine to d470fc65ea1cb91ae66706b320d82c4536a4da8b (cla: yes)
+
+[26734](https://github.com/flutter/flutter/pull/26734) Reverts default DragStartBehavior to DragStartBehavior.down (a: text input, cla: yes, f: cupertino, f: material design, f: scrolling, framework)
+
+[26736](https://github.com/flutter/flutter/pull/26736) [O] Removing all timeouts (mark II) (a: tests, cla: yes, framework, t: flutter driver, team, tool)
+
+[26737](https://github.com/flutter/flutter/pull/26737) Use Cirrus image's fastlane instead of freezing our own set of gem dependencies (cla: yes, team, team: gallery)
+
+[26763](https://github.com/flutter/flutter/pull/26763) Close the Scaffold drawer in scroll_perf_test.dart (cla: yes, team)
+
+[26764](https://github.com/flutter/flutter/pull/26764) Fix lerp in textTheme to allow for null parameters (cla: yes, f: material design, framework)
+
+[26765](https://github.com/flutter/flutter/pull/26765) [Material] Inline the single Theme.of(context) call in BAB (cla: yes, f: material design, framework)
+
+[26766](https://github.com/flutter/flutter/pull/26766) Report early error if appropriate host local engine is not found. (cla: yes, tool)
+
+[26770](https://github.com/flutter/flutter/pull/26770) Revert switch drag behavior (cla: yes, f: material design, framework)
+
+[26774](https://github.com/flutter/flutter/pull/26774) [cupertino_icons] add car, bus, train, paw, controller, and flask icons. (cla: yes, f: cupertino, framework)
+
+[26778](https://github.com/flutter/flutter/pull/26778) Better ListTile leading/trailing widget alignment (cla: yes, f: material design, framework)
+
+[26790](https://github.com/flutter/flutter/pull/26790) Rev Android Platform to 28 for bots (cla: yes, t: gradle, team)
+
+[26793](https://github.com/flutter/flutter/pull/26793) Fill editable_text.dart test coverage (a: tests, a: text input, cla: yes, framework)
+
+[26795](https://github.com/flutter/flutter/pull/26795) Update VERSION_LINUX_SDK (cla: yes, team, 🐧 platform-linux)
+
+[26796](https://github.com/flutter/flutter/pull/26796) [Material] Theme data type for cards (cla: yes, f: material design, framework)
+
+[26797](https://github.com/flutter/flutter/pull/26797) Update VERSION_WIN_SDK (cla: yes, team, ❖ platform-windows)
+
+[26798](https://github.com/flutter/flutter/pull/26798) targetSdkVersion 28 (cla: yes, d: examples, team, ▣ platform-android)
+
+[26807](https://github.com/flutter/flutter/pull/26807) #19060 Update material.google.com links to material.io (cla: yes, d: api docs, f: material design, framework, team)
+
+[26808](https://github.com/flutter/flutter/pull/26808) Add Checkbox checkIcon color parameter (cla: yes, f: material design, framework)
+
+[26809](https://github.com/flutter/flutter/pull/26809) Fix test expectations per change made in #26736 (cla: yes, team)
+
+[26819](https://github.com/flutter/flutter/pull/26819) Refactor android launchable activity extractor logic (cla: yes, customer: gold, tool, waiting for tree to go green, ▣ platform-android)
+
+[26826](https://github.com/flutter/flutter/pull/26826) Avoid calling `cancel` on `AnsiSpinner` more than once when building for iOS (cla: yes, tool, ⌘‬ platform-mac, ⌺‬ platform-ios)
+
+[26840](https://github.com/flutter/flutter/pull/26840) Support using flutter with specific version (cla: yes, tool)
+
+[26883](https://github.com/flutter/flutter/pull/26883) Move Circle CI badge next to heading in Readme (cla: yes, team)
+
+[26896](https://github.com/flutter/flutter/pull/26896) Add uiMode to android:configChanges (cla: yes, team, tool, ▣ platform-android)
+
+[26898](https://github.com/flutter/flutter/pull/26898) make FDE opt-in via the environment variable (cla: yes, tool)
+
+[26900](https://github.com/flutter/flutter/pull/26900) Make reassemble public (cla: yes, framework)
+
+[26901](https://github.com/flutter/flutter/pull/26901) Add Dismissible.confirmDismiss callback (cla: yes, f: material design, framework)
+
+[26904](https://github.com/flutter/flutter/pull/26904) Fix immediately overriding the user's chosen AM/PM selection (cla: yes, f: cupertino, f: date/time picker, framework, waiting for tree to go green)
+
+[26911](https://github.com/flutter/flutter/pull/26911) Dismissible not dismissable (cla: yes, team, team: gallery)
+
+[26913](https://github.com/flutter/flutter/pull/26913) Upgrade the Gradle script to Android plugin version 3.3.0 (cla: yes, team)
+
+[26921](https://github.com/flutter/flutter/pull/26921) fix some bad indentations (cla: yes, team)
+
+[26926](https://github.com/flutter/flutter/pull/26926) Roll engine to 10eb972fc15b8a3f97ed7c26032cae03b10fca2c (cla: yes)
+
+[26932](https://github.com/flutter/flutter/pull/26932) Make UriMapper and StdoutHandler public and add test cases (cla: yes, tool)
+
+[26938](https://github.com/flutter/flutter/pull/26938) Fix gradle verbose error. (cla: yes, customer: gold, t: gradle, tool, waiting for tree to go green)
+
+[26942](https://github.com/flutter/flutter/pull/26942) Detect Android SDK 28/28.0.3 (a: first hour, cla: yes, t: flutter doctor, tool, waiting for tree to go green, ▣ platform-android)
+
+[26944](https://github.com/flutter/flutter/pull/26944) Use mDNS to discover the device port (cla: yes, tool, ⌺‬ platform-ios)
+
+[26964](https://github.com/flutter/flutter/pull/26964) Refactor logic to get plugins path for android studio in mac (cla: yes, customer: gold, t: gradle, tool, waiting for tree to go green, ▣ platform-android)
+
+[26967](https://github.com/flutter/flutter/pull/26967) Use site-shared as canonical source for Flutter logo (cla: yes, team)
+
+[26970](https://github.com/flutter/flutter/pull/26970) Fix a problem that: `PODS_ROOT` not defined because that Debug.xcconfig misses Flutter environment (cla: yes, customer: gold, t: xcode, tool, waiting for tree to go green, ⌺‬ platform-ios)
+
+[26978](https://github.com/flutter/flutter/pull/26978) Add flutter_build package for codegen and version sync with tool (cla: yes, tool)
+
+[26988](https://github.com/flutter/flutter/pull/26988) Experimental flags for hot reloads (cla: yes, t: hot reload, tool)
+
+[26989](https://github.com/flutter/flutter/pull/26989) Add experimentalBuildEnabled flag and initial shim for build_runner (cla: yes, tool)
+
+[26990](https://github.com/flutter/flutter/pull/26990) Re-enable use of ParagraphConstrains const ctor (cla: yes, framework, team)
+
+[26991](https://github.com/flutter/flutter/pull/26991) Assert when calling a method that tries to use the ticker unsafely after dispose (a: animation, a: debugging, cla: yes, framework, waiting for tree to go green)
+
+[26993](https://github.com/flutter/flutter/pull/26993) Add WorkspaceSettings.xcsettings for stocks app (cla: yes, d: examples)
+
+[26996](https://github.com/flutter/flutter/pull/26996) Explain font platform inconsistency (cla: yes, d: api docs, framework)
+
+[27003](https://github.com/flutter/flutter/pull/27003) Add more RenderEditable test coverage (a: tests, a: text input, cla: yes, framework)
+
+[27032](https://github.com/flutter/flutter/pull/27032) Pass --verify-entry-points in debug mode. (cla: yes, tool)
+
+[27037](https://github.com/flutter/flutter/pull/27037) Revert "Experimental flags for hot reloads" (cla: yes, t: hot reload, tool)
+
+[27039](https://github.com/flutter/flutter/pull/27039) Improve documentation on decodeSyslog (cla: yes, tool, ⌺‬ platform-ios)
+
+[27042](https://github.com/flutter/flutter/pull/27042) Updated DropdownButton docs (cla: yes, f: material design, framework)
+
+[27043](https://github.com/flutter/flutter/pull/27043) Experimental flags for hot reloads, fixed (cla: yes, t: hot reload, tool)
+
+[27045](https://github.com/flutter/flutter/pull/27045) Revert "Upgrade the Gradle script to Android plugin version 3.3.0 (#26913)" (cla: yes, t: gradle, team)
+
+[27046](https://github.com/flutter/flutter/pull/27046) Update packages (cla: yes, team)
+
+[27049](https://github.com/flutter/flutter/pull/27049) Roll engine to 31c79171796c7d24d5f81033db77e25f95c45a64 (cla: yes)
+
+[27053](https://github.com/flutter/flutter/pull/27053) Modify offline docs platform family for Dash/Zeal (cla: yes, team)
+
+[27054](https://github.com/flutter/flutter/pull/27054) Update flutter clean to remove .dart_tool directory (cla: yes, tool)
+
+[27058](https://github.com/flutter/flutter/pull/27058) Add arguments for pushing named routes (cla: yes, d: examples, f: routes, framework, waiting for tree to go green)
+
+[27059](https://github.com/flutter/flutter/pull/27059) Revert "Experimental flags for hot reloads, fixed" (cla: yes, t: hot reload, tool)
+
+[27093](https://github.com/flutter/flutter/pull/27093) Update readmes for stocks/gallery (cla: yes, d: examples, team, team: gallery)
+
+[27096](https://github.com/flutter/flutter/pull/27096) Revert "Warn when building on master channel (#25007)" (cla: yes, tool)
+
+[27097](https://github.com/flutter/flutter/pull/27097) Typo fixes for notched_shapes.dart (cla: yes, framework)
+
+[27111](https://github.com/flutter/flutter/pull/27111) format initializer list of constructors (cla: yes, team)
+
+[27112](https://github.com/flutter/flutter/pull/27112) prevent _computeColumnWidths from getting stuck due to double precision (cla: yes, framework)
+
+[27113](https://github.com/flutter/flutter/pull/27113) Fix gsutil.py call for windows (cla: yes, team)
+
+[27114](https://github.com/flutter/flutter/pull/27114) Adds haptic vibration to Cupertino switch (cla: yes, f: cupertino, framework)
+
+[27116](https://github.com/flutter/flutter/pull/27116) Add some instructions to the README for packaging archives locally (cla: yes, team)
+
+[27122](https://github.com/flutter/flutter/pull/27122) Add module checking (cla: yes, tool)
+
+[27140](https://github.com/flutter/flutter/pull/27140) Add docs and sample for takeException (a: tests, cla: yes, d: api docs)
+
+[27154](https://github.com/flutter/flutter/pull/27154) Add2App: Fix crash resulted from hard-code module 'app'  (a: existing-apps, cla: yes, customer: gold, t: gradle, tool)
+
+[27169](https://github.com/flutter/flutter/pull/27169)  Update an IconButton sample, add RaisedButton sample (cla: yes, d: api docs, f: material design, framework)
+
+[27181](https://github.com/flutter/flutter/pull/27181) Change "Starting Xcode build" status text to "Running xcode build" (cla: yes, t: xcode, tool, ⌘‬ platform-mac)
+
+[27186](https://github.com/flutter/flutter/pull/27186) Improve unsupported text (cla: yes, tool)
+
+[27191](https://github.com/flutter/flutter/pull/27191) Revert f9e6242db (#26944) (cla: yes, tool)
+
+[27195](https://github.com/flutter/flutter/pull/27195) PopupMenuDivider.represents() paramter must be void, not Null (cla: yes, f: material design, framework)
+
+[27197](https://github.com/flutter/flutter/pull/27197) Add default values for optional parameters. (cla: yes, team)
+
+[27199](https://github.com/flutter/flutter/pull/27199) Remove obsolete ignore: (cla: yes, framework, team)
+
+[27207](https://github.com/flutter/flutter/pull/27207) Add support for multiroot scheme to PackageUriMapper (cla: yes, tool)
+
+[27208](https://github.com/flutter/flutter/pull/27208) Add a flag to enable tracing to systrace. (cla: yes, tool, ▣ platform-android)
+
+[27211](https://github.com/flutter/flutter/pull/27211) Inject KernelCompiler via KernelCompilerFactory (cla: yes, tool)
+
+[27252](https://github.com/flutter/flutter/pull/27252) Add support for experimental flags during hot reload. (cla: yes, t: hot reload, tool)
+
+[27253](https://github.com/flutter/flutter/pull/27253) [flutter_tool,doctor] Fix and test gen_snapshot failure message (cla: yes, tool)
+
+[27256](https://github.com/flutter/flutter/pull/27256) Update additionalTime in TestWidgetsFlutterBinding.runAsync() to 1000. (a: tests, cla: yes, team)
+
+[27257](https://github.com/flutter/flutter/pull/27257) Add basic codegen app to be used for integration testing and benchmarks (a: tests, cla: yes, tool)
+
+[27260](https://github.com/flutter/flutter/pull/27260) Update Align docs (cla: yes, framework, waiting for tree to go green)
+
+[27261](https://github.com/flutter/flutter/pull/27261) format parameter list (cla: yes, team)
+
+[27271](https://github.com/flutter/flutter/pull/27271) Remove all obsolete "// ignore:" (cla: yes, team, waiting for tree to go green)
+
+[27272](https://github.com/flutter/flutter/pull/27272) Fix asserts for initialDateTime in CupertinoDatePicker (cla: yes, f: cupertino, f: date/time picker, framework, waiting for tree to go green)
+
+[27274](https://github.com/flutter/flutter/pull/27274) Add missing comma to fix build (cla: yes, d: api docs, framework)
+
+[27277](https://github.com/flutter/flutter/pull/27277) Use flutter_tools to generate build_script (cla: yes, tool)
+
+[27278](https://github.com/flutter/flutter/pull/27278) Make version documentation clearer. (cla: yes, tool)
+
+[27295](https://github.com/flutter/flutter/pull/27295) Handle missing curl (cla: yes, tool)
+
+[27297](https://github.com/flutter/flutter/pull/27297) Add Material/Card borderOnForeground flag to allow border to be painted behind the child widget (cla: yes, f: material design, framework)
+
+[27305](https://github.com/flutter/flutter/pull/27305) Outline for survey implementation (cla: yes, d: api docs, team)
+
+[27316](https://github.com/flutter/flutter/pull/27316) Add elevation to Chips to allow for more flexibility (cla: yes, f: material design, framework)
+
+[27319](https://github.com/flutter/flutter/pull/27319) Don't send accept/reject if compilation never started. (cla: yes, tool)
+
+[27322](https://github.com/flutter/flutter/pull/27322) Fix typo in WrapAlignment documentation (cla: yes, d: api docs, framework, waiting for tree to go green)
+
+[27323](https://github.com/flutter/flutter/pull/27323) don't pass the --packages-dir flag (cla: yes, tool)
+
+[27365](https://github.com/flutter/flutter/pull/27365) Updated focus handling for nested FocusScopes (cla: yes)
+
+[27367](https://github.com/flutter/flutter/pull/27367) Update shrine login screen so that cancel dismisses the route (cla: yes, team, team: gallery)
+
+[27374](https://github.com/flutter/flutter/pull/27374) Lazily download artifacts: The Phantom Menace  (cla: yes, tool)
+
+[27376](https://github.com/flutter/flutter/pull/27376) Material.border type is now BorderRadiusGeometry (cla: yes, f: material design, framework)
+
+[27378](https://github.com/flutter/flutter/pull/27378) Make the deviceDiscovery API overridable (cla: yes, tool)
+
+[27381](https://github.com/flutter/flutter/pull/27381) Fix bug in UnconstrainedBox class debugFillProperties (a: debugging, cla: yes, framework)
+
+[27387](https://github.com/flutter/flutter/pull/27387) Track InheritedElement dependencies in diagnostic properties (cla: yes, framework)
+
+[27389](https://github.com/flutter/flutter/pull/27389) Enable dependency injection of Window instead of using static property (cla: yes)
+
+[27399](https://github.com/flutter/flutter/pull/27399) Add elevation/pressElevation to ChipThemeData (cla: yes, f: material design, framework)
+
+[27400](https://github.com/flutter/flutter/pull/27400) Ensure Shrine app respects the platform toggle from Gallery options (cla: yes, team, team: gallery)
+
+[27409](https://github.com/flutter/flutter/pull/27409) Ensure all curves return 0 and 1 in .transform(t) when t=0/1 (a: animation, cla: yes, framework, waiting for tree to go green)
+
+[27410](https://github.com/flutter/flutter/pull/27410) Disable usage of bare instructions in AOT (cla: yes, tool)
+
+[27413](https://github.com/flutter/flutter/pull/27413) Fix typo "when when" (cla: yes, d: api docs, framework)
+
+[27424](https://github.com/flutter/flutter/pull/27424) [H] Expose "center" on CustomScrollView (cla: yes, f: date/time picker, f: scrolling)
+
+[27425](https://github.com/flutter/flutter/pull/27425) [HR] Clean up matters related to "offstageness". (cla: yes, framework)
+
+[27432](https://github.com/flutter/flutter/pull/27432) Remove leftover of GlobalKey removal listeners (cla: yes, framework)
+
+[27433](https://github.com/flutter/flutter/pull/27433) Fix issue where SliverPersistentHeader that is both floating and pinned would scroll down when scrolling past the beginning of the ScrollView (cla: yes, f: scrolling, framework, waiting for tree to go green)
+
+[27471](https://github.com/flutter/flutter/pull/27471) Refactor ios bundleid/android application process logic. (cla: yes, tool)
+
+[27477](https://github.com/flutter/flutter/pull/27477) [H] Tabs (cla: yes, f: material design, framework)
+
+[27481](https://github.com/flutter/flutter/pull/27481) Move Brightness to dart:ui in the engine (#27479). (cla: yes, framework)
+
+[27487](https://github.com/flutter/flutter/pull/27487) [H] Make NotchedShape more practical to use (cla: yes, f: material design, framework)
+
+[27501](https://github.com/flutter/flutter/pull/27501) Update docs for initstate(), didUpdateWidget(), dispose() (cla: yes, d: api docs, framework)
+
+[27502](https://github.com/flutter/flutter/pull/27502) Make a kReleaseMode constant that is public. (cla: yes, framework)
+
+[27504](https://github.com/flutter/flutter/pull/27504) Added support for the Galician language (material_es_GL.arb) (a: internationalization, cla: yes, framework)
+
+[27505](https://github.com/flutter/flutter/pull/27505) Remove icudtl.dat from APK asset size checks (cla: yes, team)
+
+[27506](https://github.com/flutter/flutter/pull/27506) Added support for Swahili (material_sw.arb) (a: internationalization, cla: yes, framework)
+
+[27509](https://github.com/flutter/flutter/pull/27509) Removed double the (cla: yes, d: api docs, f: material design, framework)
+
+[27510](https://github.com/flutter/flutter/pull/27510) [Material] Allow slider shapes to be easily resized (cla: yes, f: material design, framework)
+
+[27511](https://github.com/flutter/flutter/pull/27511) Update dartdoc to 0.28.1+1 and add parameters for source-code linking (cla: yes, team)
+
+[27513](https://github.com/flutter/flutter/pull/27513) Add scroll performance test for flutter_gallery (cla: yes, team)
+
+[27519](https://github.com/flutter/flutter/pull/27519) Update OutlineButton on-pressed fill color (cla: yes, f: material design, framework)
+
+[27528](https://github.com/flutter/flutter/pull/27528) Fixed Cupertino Switch Demo (cla: yes, f: cupertino, framework, waiting for tree to go green)
+
+[27531](https://github.com/flutter/flutter/pull/27531) Print 50000$ monopoly money (cla: yes, tool, waiting for tree to go green)
+
+[27532](https://github.com/flutter/flutter/pull/27532) Add @isTest to Flutter's wrappers over group/test (a: tests, cla: yes)
+
+[27534](https://github.com/flutter/flutter/pull/27534) Stop using SelectionChangedCause internally to show the text selection toolbar (a: text input, cla: yes, f: cupertino, f: material design, framework, severe: API break)
+
+[27553](https://github.com/flutter/flutter/pull/27553) Use CP_REPOS_DIR if it's set (cla: yes, tool, ⌺‬ platform-ios)
+
+[27556](https://github.com/flutter/flutter/pull/27556) update flutter and flutter.bat command to suggest stable branch (cla: yes, tool)
+
+[27559](https://github.com/flutter/flutter/pull/27559) Update dartdoc to 0.28.1+2 and fix search text alignment (cla: yes, team)
+
+[27564](https://github.com/flutter/flutter/pull/27564) Fix window bug in _sendPlatformMessage() (#27541). (cla: yes, framework, p: framework)
+
+[27566](https://github.com/flutter/flutter/pull/27566) Warn when gradle builds fail because of AndroidX (cla: yes, t: gradle, tool)
+
+[27568](https://github.com/flutter/flutter/pull/27568) Fix initial scroll of TabBar in release mode (cla: yes, f: material design, f: scrolling, framework)
+
+[27569](https://github.com/flutter/flutter/pull/27569) Bugfix: Add platformBrightness to TestWindow. (a: tests, cla: yes)
+
+[27570](https://github.com/flutter/flutter/pull/27570) Small cleanup in CupertinoSliverRefreshControl (cla: yes, f: cupertino, framework)
+
+[27573](https://github.com/flutter/flutter/pull/27573) Let text selection toolbar buttons be independent from theme (cla: yes, f: cupertino, framework)
+
+[27575](https://github.com/flutter/flutter/pull/27575) Update OutlineButton default border width and highlight elevation (cla: yes, f: material design, framework)
+
+[27576](https://github.com/flutter/flutter/pull/27576) Handle CupertinoTabScaffold rebuilds with deleted tabs (cla: yes, f: cupertino, framework)
+
+[27577](https://github.com/flutter/flutter/pull/27577) [flutter_driver] Use async call to run SSH cmds w/o deadlock. (cla: yes, t: flutter driver, tool, ○ platform-fuchsia)
+
+[27588](https://github.com/flutter/flutter/pull/27588) CupertinoSliverRefreshControl inactive overscroll behavior (cla: yes, f: cupertino, framework, waiting for tree to go green)
+
+[27596](https://github.com/flutter/flutter/pull/27596) Check powershell version. (cla: yes, tool, waiting for tree to go green, ❖ platform-windows)
+
+[27604](https://github.com/flutter/flutter/pull/27604) Update material Galician (gl) translations filename (a: internationalization, cla: yes, framework)
+
+[27607](https://github.com/flutter/flutter/pull/27607) Remove build runner from injection (cla: yes, tool)
+
+[27613](https://github.com/flutter/flutter/pull/27613) [Material] Simple API for skipping over certain Slider shapes (cla: yes, f: material design, framework)
+
+[27615](https://github.com/flutter/flutter/pull/27615) fix list devices throwing on junk input (cla: yes, tool, ○ platform-fuchsia)
+
+[27616](https://github.com/flutter/flutter/pull/27616) minor doc fixes for overlay (cla: yes, framework)
+
+[27620](https://github.com/flutter/flutter/pull/27620) Add a keyboard key code generator. (cla: yes, tool)
+
+[27623](https://github.com/flutter/flutter/pull/27623) Make FlexibleSpaceBar title padding configurable (cla: yes, f: material design, framework)
+
+[27627](https://github.com/flutter/flutter/pull/27627) Adding support for logical and physical key events (cla: yes, framework)
+
+[27632](https://github.com/flutter/flutter/pull/27632) Null check logic for datatable. (cla: yes, f: material design, framework)
+
+[27647](https://github.com/flutter/flutter/pull/27647) Fixed #27621: CupertinoTimerPicker breaks if minuteInterval > 1 (cla: yes, f: cupertino, framework)
+
+[27648](https://github.com/flutter/flutter/pull/27648) Make sample analyzer more friendly for running locally. (cla: yes, team)
+
+[27659](https://github.com/flutter/flutter/pull/27659) fix small typo (cla: yes, framework, waiting for tree to go green)
+
+[27661](https://github.com/flutter/flutter/pull/27661) Add build_runner_core to flutter_tools BUILD.gn (cla: yes, tool)
+
+[27663](https://github.com/flutter/flutter/pull/27663) TextField should only set EditableText.cursorOffset for iOS (a: text input, cla: yes, f: material design, framework)
+
+[27665](https://github.com/flutter/flutter/pull/27665) Add desktop devices to daemon behind flag (cla: yes, tool)
+
+[27668](https://github.com/flutter/flutter/pull/27668) Wire dart2js through flutter tool, add compilation test (cla: yes, tool)
+
+[27672](https://github.com/flutter/flutter/pull/27672) Support for building dynamic patches in AOT mode. (cla: yes, tool)
+
+[27687](https://github.com/flutter/flutter/pull/27687) Add android studio process logic for JetBrainsToolbox (cla: yes, customer: gold, tool, ▣ platform-android, ⚠ TODAY)
+
+[27690](https://github.com/flutter/flutter/pull/27690) remove super_goes_last (cla: yes, team)
+
+[27691](https://github.com/flutter/flutter/pull/27691) Fix Xcode_backend.sh for flavors (cla: yes, t: xcode, tool, waiting for tree to go green, ⌺‬ platform-ios)
+
+[27697](https://github.com/flutter/flutter/pull/27697) Cupertino TextField Cursor Fix (a: text input, cla: yes, f: cupertino, framework)
+
+[27699](https://github.com/flutter/flutter/pull/27699) [Material] Update the card demo in the Gallery to demonstrate different uses of the Card widget (cla: yes, f: material design, framework, team, team: gallery)
+
+[27703](https://github.com/flutter/flutter/pull/27703) Add builder parameter to showDatePicker, showTimePicker (cla: yes, f: date/time picker, f: material design, framework)
+
+[27705](https://github.com/flutter/flutter/pull/27705) Revert "Lazily download artifacts" (cla: yes, tool)
+
+[27708](https://github.com/flutter/flutter/pull/27708) remove build_runner_core import from flutter_tools (cla: yes, tool)
+
+[27709](https://github.com/flutter/flutter/pull/27709) Increase our build budget to 16ms (cla: yes, t: flutter driver, tool)
+
+[27717](https://github.com/flutter/flutter/pull/27717) Refactor "no ios devices attached" logic. (cla: yes, tool, ⌺‬ platform-ios)
+
+[27735](https://github.com/flutter/flutter/pull/27735) Lazily download artifacts (Part II): The Clone Wars (cla: yes, tool)
+
+[27743](https://github.com/flutter/flutter/pull/27743) Refactor build-number/build-name logic. (cla: yes, t: gradle, t: xcode, tool)
+
+[27752](https://github.com/flutter/flutter/pull/27752) Adding horizontal and vertical scale parameter to ScaleUpdateDetails. (cla: yes, f: gestures, framework, waiting for tree to go green)
+
+[27754](https://github.com/flutter/flutter/pull/27754) Add support for binary compression of dynamic patches by the flutter tool. (cla: yes, t: gradle, tool)
+
+[27765](https://github.com/flutter/flutter/pull/27765) Refactor local engine logic (cla: yes, t: xcode, tool, ⌺‬ platform-ios)
+
+[27773](https://github.com/flutter/flutter/pull/27773) DatePicker noon/midnight overflow fix (cla: yes, f: cupertino, f: date/time picker, framework)
+
+[27789](https://github.com/flutter/flutter/pull/27789) Revert "Disable usage of bare instructions in AOT (#27410)" (cla: yes, tool)
+
+[27793](https://github.com/flutter/flutter/pull/27793) Remove remaining "### Sample code" segments, and fix the snippet generator. (cla: yes, d: api docs, team)
+
+[27800](https://github.com/flutter/flutter/pull/27800) Prevent tests from importing other tests. (a: tests, cla: yes, team)
+
+[27803](https://github.com/flutter/flutter/pull/27803) Added sample code to AnimatedWidget (a: animation, cla: yes, d: api docs, framework, waiting for tree to go green)
+
+[27808](https://github.com/flutter/flutter/pull/27808) Manual Engine roll for flutter/engine#7791 - Add trailing whitespace tracking. (a: text input, cla: yes, framework)
+
+[27812](https://github.com/flutter/flutter/pull/27812) Pass method used to start flutter application (cla: yes, tool)
+
+[27817](https://github.com/flutter/flutter/pull/27817) Optimize flutter run logic for iOS by "ONLY_ACTIVE_ARCH=YES" if possible (cla: yes)
+
+[27818](https://github.com/flutter/flutter/pull/27818) Fix Dashing rules to use new dartdoc CSS entity markers. (cla: yes, d: api docs, team)
+
+[27825](https://github.com/flutter/flutter/pull/27825) Deflake AnsiSpinner tests (a: tests, cla: yes, team, team: flakes, waiting for tree to go green)
+
+[27849](https://github.com/flutter/flutter/pull/27849) Revert "Roll engine 713fe130eb02..d48de7a3ec97 (1 commits)" (cla: yes)
+
+[27851](https://github.com/flutter/flutter/pull/27851) Fixes a cursor offset mistake for Material on iOS (a: text input, cla: yes, framework, ⌺‬ platform-ios)
+
+[27853](https://github.com/flutter/flutter/pull/27853) Hook up character events and unmodified code points to Android raw key event handling. (cla: yes, framework)
+
+[27855](https://github.com/flutter/flutter/pull/27855) Reland "Roll engine 713fe130eb02..d48de7a3ec97 (1 commits)" (cla: yes)
+
+[27861](https://github.com/flutter/flutter/pull/27861) Temporarily disable inconsistent strut golden tests due to test fonts (a: tests, a: typography, cla: yes, framework)
+
+[27864](https://github.com/flutter/flutter/pull/27864) Fix crash when disposing nested Scrollables while holding in overscroll position (cla: yes, f: scrolling, framework, severe: crash)
+
+[27865](https://github.com/flutter/flutter/pull/27865) Add Armenian translations (a: internationalization, cla: yes, framework)
+
+[27866](https://github.com/flutter/flutter/pull/27866) Handle back swipe completed->completed or completed->dismissed transitions (cla: yes, f: cupertino, f: routes, framework)
+
+[27873](https://github.com/flutter/flutter/pull/27873) Don't cache result for homeDirPath. (cla: yes, tool)
+
+[27892](https://github.com/flutter/flutter/pull/27892) Fix overflow clipping/fading for text (cla: yes, framework)
+
+[27895](https://github.com/flutter/flutter/pull/27895) Revert "Lazily download artifacts (Part II)" (cla: yes, tool)
+
+[27900](https://github.com/flutter/flutter/pull/27900) Fixes switch vibration (cla: yes, f: cupertino, framework)
+
+[27902](https://github.com/flutter/flutter/pull/27902) update packages and supress lint (cla: yes, framework, tool, waiting for tree to go green)
+
+[27908](https://github.com/flutter/flutter/pull/27908) Reland automatic discovery of observatory port for iOS (cla: yes, tool, waiting for tree to go green, ⌘‬ platform-mac, ⌺‬ platform-ios)
+
+[27914](https://github.com/flutter/flutter/pull/27914) fix multiroot scheme (cla: yes, tool)
+
+[27915](https://github.com/flutter/flutter/pull/27915) Revert "[HR] Clean up matters related to "offstageness"." (cla: yes, f: scrolling, framework)
+
+[27919](https://github.com/flutter/flutter/pull/27919) Revert "Ensure all curves return 0 and 1 in .transform(t) when t=0/1" (a: animation, cla: yes, framework)
+
+[27929](https://github.com/flutter/flutter/pull/27929) Use double literals where a double type is expected (a: animation, cla: yes, framework, team)
+
+[27945](https://github.com/flutter/flutter/pull/27945) Fixes crossAxisSpacing overflow in RTL (a: internationalization, cla: yes, f: scrolling, framework, waiting for tree to go green)
+
+[27953](https://github.com/flutter/flutter/pull/27953) Add outer try block for obtainKey errors. Add docs. (cla: yes, framework, waiting for tree to go green)
+
+[27955](https://github.com/flutter/flutter/pull/27955) Adds media query check in editable_text (a: text input, cla: yes, framework, waiting for tree to go green)
+
+[27966](https://github.com/flutter/flutter/pull/27966) Revert "Fix overflow clipping/fading for text" (a: typography, cla: yes, framework)
+
+[27968](https://github.com/flutter/flutter/pull/27968) Sample code for Icon class (cla: yes, d: api docs, framework)
+
+[27969](https://github.com/flutter/flutter/pull/27969) Do not draw Slider tick marks if they are too dense (cla: yes, f: material design, framework)
+
+[27970](https://github.com/flutter/flutter/pull/27970) Make sure the selection is still painted under the text (a: text input, cla: yes, framework)
+
+[27973](https://github.com/flutter/flutter/pull/27973) Add extendBody parameter to Scaffold, body MediaQuery reflects BAB height (cla: yes, f: material design, framework)
+
+[27980](https://github.com/flutter/flutter/pull/27980) Reapply "Fix overflow clipping/fading for text (#27892)" (a: typography, cla: yes, framework)
+
+[27983](https://github.com/flutter/flutter/pull/27983) Test text paint orders by color (a: tests, a: text input, cla: yes, framework)
+
+[27987](https://github.com/flutter/flutter/pull/27987) add ui.Window fallback to TestViewConfiguration (a: tests, cla: yes, tool)
+
+[28006](https://github.com/flutter/flutter/pull/28006) Re-apply "Ensure all curves return 0 and 1 in .transform(t) when t=0/1" (a: animation, cla: yes, framework)
+
+[28011](https://github.com/flutter/flutter/pull/28011) Remove accidentally committed libs (cla: yes, tool)
+
+[28024](https://github.com/flutter/flutter/pull/28024) Disable prefer_collection_literals in the analyzer until we can update to using set literals (cla: yes, team)
+
+[28027](https://github.com/flutter/flutter/pull/28027) Remove extra slash from builder that is not handled on windows (cla: yes, tool)
+
+[28031](https://github.com/flutter/flutter/pull/28031) Revert "Add support for binary compression of dynamic patches by the flutter tool. (#27754)" (cla: yes, t: gradle, tool, ▣ platform-android)
+
+[28032](https://github.com/flutter/flutter/pull/28032) Revert 26001 (a: text input, cla: yes, f: cupertino, f: material design, framework, severe: API break)
+
+[28040](https://github.com/flutter/flutter/pull/28040) Remove json_schema and cli_util deps from flutter_tool (cla: yes, team, tool, waiting for tree to go green)
+
+[28101](https://github.com/flutter/flutter/pull/28101) Remove unused --packages argument to gen_snapshot. (cla: yes, tool)
+
+[28178](https://github.com/flutter/flutter/pull/28178) Roll engine to f45572e95f93edb89b6750a4f36ad8ed7c0a2560 (cla: yes)
+
+[28182](https://github.com/flutter/flutter/pull/28182) Add TextOverflow.visible (a: typography, cla: yes, framework, waiting for tree to go green)
+
+[28183](https://github.com/flutter/flutter/pull/28183) Rename SuperellipseShare ContinuousRectangleBorder (cla: yes, f: material design, framework)
+
+[28216](https://github.com/flutter/flutter/pull/28216) Fix 'to to' (cla: yes, f: material design, framework)
+
+[28222](https://github.com/flutter/flutter/pull/28222) Manual engine roll to 6d7eb52185b117a3972cac4e23625f97198114d9 (cla: yes)
+
+[28224](https://github.com/flutter/flutter/pull/28224) Adds a template for Pull Requests (cla: yes, team, waiting for tree to go green)
+
+[28235](https://github.com/flutter/flutter/pull/28235) Remove line breaks from PR template (cla: yes, team)
+
+[28238](https://github.com/flutter/flutter/pull/28238) Remove set literal syntax (cla: yes, team)
+
+[28265](https://github.com/flutter/flutter/pull/28265) Revert "Remove unused --packages argument to gen_snapshot." (cla: yes, tool)
+
+[28272](https://github.com/flutter/flutter/pull/28272) Make logcat less chatty on perf tests (cla: yes, team)
+
+
+## PRs closed in this release of flutter/engine
+
+From Fri Nov 29 19:41:00 2018 -0800 to Thu Feb 21 20:22:00 2019 -0800
+
+
+[6399](https://github.com/flutter/engine/pull/6399) System Channels, Plugins, Dart Entrypoint, FlutterFragment (cla: yes)
+
+[6558](https://github.com/flutter/engine/pull/6558) Retained rendering in Fuchsia PhysicalShapeLayer (cla: yes)
+
+[6719](https://github.com/flutter/engine/pull/6719) Add onStart hook to FlutterFragmentActivity (cla: yes)
+
+[6805](https://github.com/flutter/engine/pull/6805) [OR] Offset.fromDirection and Size.aspectRatio (cla: yes)
+
+[6879](https://github.com/flutter/engine/pull/6879) Allow FlutterViewController to be released when not initialized with an engine (cla: yes)
+
+[6903](https://github.com/flutter/engine/pull/6903) [H] Undeprecate BigInteger support, but document what it actually does. (cla: yes)
+
+[6913](https://github.com/flutter/engine/pull/6913) Support real fonts in 'flutter test' (cla: yes)
+
+[6918](https://github.com/flutter/engine/pull/6918) Announce in/out of list (cla: yes)
+
+[6919](https://github.com/flutter/engine/pull/6919) Reland "Compile libcxx and libcxxabi for Android (#6886)" (cla: yes, size)
+
+[6922](https://github.com/flutter/engine/pull/6922) Verify RunConfiguration is valid before running (cla: yes)
+
+[6923](https://github.com/flutter/engine/pull/6923) Compute cull_rect and optimize in Layer::Preroll (cla: yes)
+
+[6926](https://github.com/flutter/engine/pull/6926) Roll buildtools to bac220c15490dcf7b7d8136f75100bbc77e8d217 (cla: yes, size)
+
+[6927](https://github.com/flutter/engine/pull/6927) Support overriding font leading in TextStyle and LibTxt (affects: text input, brand new feature, cla: yes)
+
+[6936](https://github.com/flutter/engine/pull/6936) Return real null instead of null string when locale has not been set in locale closure. (cla: yes)
+
+[6945](https://github.com/flutter/engine/pull/6945) Adds force cursor support (cla: yes)
+
+[6961](https://github.com/flutter/engine/pull/6961) Add hover event support to the engine (cla: yes)
+
+[6967](https://github.com/flutter/engine/pull/6967) Eliminate obsolete FlutterDartProject initializers (cla: yes)
+
+[6973](https://github.com/flutter/engine/pull/6973) Eliminate main_dart_file_path, package_file_path (cla: yes)
+
+[6977](https://github.com/flutter/engine/pull/6977) Rename dart-non-checked-mode: disable-dart-asserts (cla: yes)
+
+[6985](https://github.com/flutter/engine/pull/6985) Fix keyboard not showing for targetSdk 28 (cla: yes)
+
+[6989](https://github.com/flutter/engine/pull/6989) Japanese Clear Text Crash (cla: yes)
+
+[6991](https://github.com/flutter/engine/pull/6991) MInor Docs to runtime controller WindowData (cla: yes)
+
+[7002](https://github.com/flutter/engine/pull/7002) Support querying display refresh rate in engine (cla: yes)
+
+[7012](https://github.com/flutter/engine/pull/7012) Merge latest from master => 21008 staging branch (cla: yes)
+
+[7024](https://github.com/flutter/engine/pull/7024) Roll Skia to 57d29eaf2ed7518983d9e91fd5219f4cfc181f88 (cla: yes)
+
+[7031](https://github.com/flutter/engine/pull/7031) Pass operator_new_alignment value through gn script into GN args. (cla: yes)
+
+[7048](https://github.com/flutter/engine/pull/7048) Only overflow the cache for one required frame (cla: yes)
+
+[7068](https://github.com/flutter/engine/pull/7068)  SK_SUPPORT_LEGACY_TEXTENCODINGENUM (cla: yes)
+
+[7087](https://github.com/flutter/engine/pull/7087) Wire up support for external OpenGL textures for the embedder. (cla: yes)
+
+[7097](https://github.com/flutter/engine/pull/7097) Simplify conversion of numeric types in the message codec on iOS (cla: yes)
+
+[7098](https://github.com/flutter/engine/pull/7098) Android embedding refactor PR1: JNI Extraction to FlutterJNI.java (cla: yes)
+
+[7102](https://github.com/flutter/engine/pull/7102) Prepare for upcoming fuchsia vulkan driver changes (cla: yes)
+
+[7108](https://github.com/flutter/engine/pull/7108) Fix destruction of the child object list in the iOS accessibility bridge (cla: yes)
+
+[7146](https://github.com/flutter/engine/pull/7146) Revert "Reland "Compile libcxx and libcxxabi for Android (#6886)"" (cla: yes, size)
+
+[7151](https://github.com/flutter/engine/pull/7151) Generalize runFromBundle to support multiple bundlePaths (cla: yes)
+
+[7152](https://github.com/flutter/engine/pull/7152) Add native for fetching compilation trace as a memory buffer, for use in automated tools (cla: yes)
+
+[7158](https://github.com/flutter/engine/pull/7158) Minor comments fix and add TODO (cla: yes)
+
+[7160](https://github.com/flutter/engine/pull/7160)  Reland "Compile libcxx and libcxxabi for Android (#6886)" (cla: yes, size)
+
+[7161](https://github.com/flutter/engine/pull/7161) Handle null bundlePaths in FlutterRunArguments (cla: yes)
+
+[7162](https://github.com/flutter/engine/pull/7162) Merge master branch into skia-master (cla: no)
+
+[7163](https://github.com/flutter/engine/pull/7163) Merge skia-master branch into master (cla: no)
+
+[7164](https://github.com/flutter/engine/pull/7164) Add empty metrics to account for truncated whitespace for GetRectsForRange. (cla: yes)
+
+[7179](https://github.com/flutter/engine/pull/7179) Fixed Spelling. (cla: yes)
+
+[7185](https://github.com/flutter/engine/pull/7185) Check for empty line before adding empty 'padding' metrics (cla: yes)
+
+[7187](https://github.com/flutter/engine/pull/7187) Revert "Support overriding font leading in TextStyle and LibTxt (#6927)" (cla: yes)
+
+[7189](https://github.com/flutter/engine/pull/7189) Remove unnecessary includes of Skia headers. (cla: yes)
+
+[7194](https://github.com/flutter/engine/pull/7194) Roll buildroot to 4cb5a74c9612b71b917997f46e97da6d1051eab4 (cla: yes, size)
+
+[7195](https://github.com/flutter/engine/pull/7195) Roll buildroot to 8e538639660413490ea9261eee84864005e240f4 (cla: yes, size)
+
+[7202](https://github.com/flutter/engine/pull/7202) Add .woff file to binary format (cla: yes)
+
+[7207](https://github.com/flutter/engine/pull/7207) Downloading and installation of dynamic updates on Android (cla: yes)
+
+[7208](https://github.com/flutter/engine/pull/7208) Fallback font match caching to fix emoji lag. (cla: yes)
+
+[7213](https://github.com/flutter/engine/pull/7213) Roll Dart to version e15e8609aa8610f8c432f1caf2ab89358e2fce50 (cla: yes)
+
+[7214](https://github.com/flutter/engine/pull/7214) [Fuchsia] Depend on libtrace when that is what's really meant (cla: yes)
+
+[7221](https://github.com/flutter/engine/pull/7221) [vulkan] Fix Fuchsia build (cla: yes)
+
+[7227](https://github.com/flutter/engine/pull/7227) Compile embedder unit test Dart to kernel (cla: yes)
+
+[7230](https://github.com/flutter/engine/pull/7230) Revert "Compile embedder unit test Dart to kernel (#7227)" (cla: yes)
+
+[7231](https://github.com/flutter/engine/pull/7231) Compile embedder unit test Dart to kernel (re-land) (cla: yes)
+
+[7234](https://github.com/flutter/engine/pull/7234) Fix misspelling in doc comments (cla: yes)
+
+[7235](https://github.com/flutter/engine/pull/7235) Fix settings.advisory_script_uri in iOS createShell (cla: yes)
+
+[7237](https://github.com/flutter/engine/pull/7237) Allow inferred types using diamond syntax (cla: yes)
+
+[7238](https://github.com/flutter/engine/pull/7238) Clarify TextAffinity docs (cla: yes)
+
+[7239](https://github.com/flutter/engine/pull/7239) Simplify nested try-with-resources statements (cla: yes)
+
+[7240](https://github.com/flutter/engine/pull/7240) Fix linter errors in ResourceUpdater (cla: yes)
+
+[7241](https://github.com/flutter/engine/pull/7241) Support user-provided font-fallback. (cla: yes)
+
+[7242](https://github.com/flutter/engine/pull/7242) Revert spelling correction in licence matcher (cla: yes)
+
+[7244](https://github.com/flutter/engine/pull/7244) iOS A11y memory leak (cla: yes)
+
+[7245](https://github.com/flutter/engine/pull/7245) Roll buildroot to support Android SDK 28 (cla: yes)
+
+[7246](https://github.com/flutter/engine/pull/7246) Update iOS unit test for the removal of hex string encoding of uint64 data (cla: yes)
+
+[7248](https://github.com/flutter/engine/pull/7248) Update terminology to match that of the flutter tool (cla: yes)
+
+[7250](https://github.com/flutter/engine/pull/7250) Extract function to collect licenses for component (cla: yes)
+
+[7254](https://github.com/flutter/engine/pull/7254) Fix javadoc for Android-28 (cla: yes)
+
+[7256](https://github.com/flutter/engine/pull/7256) Document native functions for compilation trace (cla: yes)
+
+[7257](https://github.com/flutter/engine/pull/7257) Add a system message channel for controlling the Skia resource cache size (cla: yes)
+
+[7258](https://github.com/flutter/engine/pull/7258) Remove unused GrContext in AndroidSurfaceGL (cla: yes)
+
+[7260](https://github.com/flutter/engine/pull/7260) Re-run license tool on all source when it changes (cla: yes)
+
+[7261](https://github.com/flutter/engine/pull/7261) Update usage of some Android APIs that are deprecated in API level 28 (cla: yes)
+
+[7266](https://github.com/flutter/engine/pull/7266) Eliminate use of new keyword in license tool (cla: yes)
+
+[7267](https://github.com/flutter/engine/pull/7267) Mark all unreassigned locals final in license tool (cla: yes)
+
+[7269](https://github.com/flutter/engine/pull/7269) [License] Eliminate duplicate case in switch (cla: yes)
+
+[7270](https://github.com/flutter/engine/pull/7270) [License] Assert license filename is non-null, non-empty (cla: yes)
+
+[7272](https://github.com/flutter/engine/pull/7272) Make IOManager own resource context (cla: yes)
+
+[7273](https://github.com/flutter/engine/pull/7273) [License] Sync analysis_options.yaml from framework (cla: yes)
+
+[7274](https://github.com/flutter/engine/pull/7274) TextAffinity Docs Improvement (cla: yes)
+
+[7275](https://github.com/flutter/engine/pull/7275) [License] Enable avoid_positional_boolean_parameters lint (cla: yes)
+
+[7276](https://github.com/flutter/engine/pull/7276) Remove unused native function dumpCompilationTrace() (cla: yes)
+
+[7281](https://github.com/flutter/engine/pull/7281) TextInputType.number default fix (cla: yes)
+
+[7282](https://github.com/flutter/engine/pull/7282) Add elevation and thickness to SemanticsNode (accessibility, cla: yes)
+
+[7283](https://github.com/flutter/engine/pull/7283) Revert "Roll Dart to version e15e8609aa8610f8c432f1caf2ab89358e2fce50" (cla: yes)
+
+[7284](https://github.com/flutter/engine/pull/7284) Roll buildroot and update method of getting android SDK and support libs (cla: yes)
+
+[7286](https://github.com/flutter/engine/pull/7286) Roll version of Dart to d1817ddc91fd3aea061647b2e21860c47a5a5180 (cla: yes)
+
+[7287](https://github.com/flutter/engine/pull/7287) Paint all backgrounds first to prevent overlap (cla: yes)
+
+[7307](https://github.com/flutter/engine/pull/7307) Only reject gestures to embedded UIViews when the framework says so. (cla: yes)
+
+[7308](https://github.com/flutter/engine/pull/7308) Support loading flutter assets from dynamic patch (cla: yes)
+
+[7309](https://github.com/flutter/engine/pull/7309) Allow dynamic patches without a patch number. (cla: yes)
+
+[7313](https://github.com/flutter/engine/pull/7313) Revert "Only reject gestures to embedded UIViews when the framework s… (cla: yes)
+
+[7315](https://github.com/flutter/engine/pull/7315)  Reland "Only reject gestures to embedded UIViews when the framework sa… (cla: yes)
+
+[7316](https://github.com/flutter/engine/pull/7316) Roll dart to 88e6fe0f67 (cla: yes)
+
+[7317](https://github.com/flutter/engine/pull/7317) Recreate the overlay rendering surfaces if the GrContext was changed. (cla: yes)
+
+[7322](https://github.com/flutter/engine/pull/7322) Roll buildroot (cla: yes)
+
+[7324](https://github.com/flutter/engine/pull/7324) Update GetCallbackHandle to use Dart_IsTearOff instead of a string comparison (cla: yes)
+
+[7325](https://github.com/flutter/engine/pull/7325) Minor refactoring of dynamic patching code. (cla: yes)
+
+[7327](https://github.com/flutter/engine/pull/7327) Give more control over when dynamic patches get downloaded and installed. (cla: yes)
+
+[7346](https://github.com/flutter/engine/pull/7346) Make `ParagraphConstraints` have const constructor (cla: yes)
+
+[7354](https://github.com/flutter/engine/pull/7354) Preparing to remove SK_SUPPORT_LEGACY_PAINT_TEXTMEASURE (cla: yes)
+
+[7360](https://github.com/flutter/engine/pull/7360) Fix typo clas -> class (cla: yes)
+
+[7363](https://github.com/flutter/engine/pull/7363) Roll Dart to version ec86471ccc47a62df8b4009e1fb37c66ff9dc91b (cla: yes)
+
+[7370](https://github.com/flutter/engine/pull/7370) [HR] Documentation cleanup (cla: yes)
+
+[7371](https://github.com/flutter/engine/pull/7371) Test SDK roll (cla: yes)
+
+[7374](https://github.com/flutter/engine/pull/7374) Revert "Test SDK roll" (cla: yes)
+
+[7387](https://github.com/flutter/engine/pull/7387) Improve TextAffinity Docs (cla: yes)
+
+[7398](https://github.com/flutter/engine/pull/7398) Replace Java code with equivalent, more concise code. (cla: yes)
+
+[7401](https://github.com/flutter/engine/pull/7401) Reset ParagraphBuilder after build() (cla: yes)
+
+[7403](https://github.com/flutter/engine/pull/7403) Dart SDK roll for 2019-01-07 (cla: yes)
+
+[7404](https://github.com/flutter/engine/pull/7404) fix up analysis for Dart in Engine (cla: yes)
+
+[7405](https://github.com/flutter/engine/pull/7405) Dart SDK roll for 2019-01-07 (cla: yes)
+
+[7409](https://github.com/flutter/engine/pull/7409) Cleanup dead code (cla: yes)
+
+[7410](https://github.com/flutter/engine/pull/7410) Refactor shared code into separate function to simplify further work. (cla: yes)
+
+[7411](https://github.com/flutter/engine/pull/7411) Dart SDK roll for 2019-01-08 (cla: yes)
+
+[7413](https://github.com/flutter/engine/pull/7413) remove deprecated updateNode argument (cla: yes)
+
+[7414](https://github.com/flutter/engine/pull/7414) Strut implementation (cla: yes)
+
+[7416](https://github.com/flutter/engine/pull/7416) Dart SDK roll for 2019-01-08 (cla: yes)
+
+[7417](https://github.com/flutter/engine/pull/7417) Dart SDK roll for 2019-01-09 (cla: yes)
+
+[7419](https://github.com/flutter/engine/pull/7419) Dart SDK roll for 2019-01-09 (cla: yes)
+
+[7421](https://github.com/flutter/engine/pull/7421) Dart SDK roll for 2019-01-09 (cla: yes)
+
+[7426](https://github.com/flutter/engine/pull/7426) Refactor dynamic patching to use clearer naming and structure. (cla: yes)
+
+[7427](https://github.com/flutter/engine/pull/7427) Allow embedders to add per shell idle notification callbacks. (cla: yes)
+
+[7428](https://github.com/flutter/engine/pull/7428) Download dynamic patch to separate file to avoid races (cla: yes)
+
+[7429](https://github.com/flutter/engine/pull/7429) Eliminate unused import of ZipException (cla: yes)
+
+[7431](https://github.com/flutter/engine/pull/7431) Dart SDK roll for 2019-01-09 (cla: yes)
+
+[7432](https://github.com/flutter/engine/pull/7432) Improve 404 handling when downloading dynamic patches. (cla: yes)
+
+[7433](https://github.com/flutter/engine/pull/7433) Eliminate std::string using directive (cla: yes)
+
+[7435](https://github.com/flutter/engine/pull/7435) Add Ahem to LibTxt testing fonts. (cla: yes)
+
+[7436](https://github.com/flutter/engine/pull/7436) Clear the font collection's cache when a font is dynamically loaded (cla: yes)
+
+[7437](https://github.com/flutter/engine/pull/7437) Temporary revert of Dart SDK rolls made since 2019/01/08 (cla: yes)
+
+[7439](https://github.com/flutter/engine/pull/7439) Remove legacy and deprecated defaultClipBehavior (cla: yes)
+
+[7442](https://github.com/flutter/engine/pull/7442) Move Picture.toImage rasterization to the GPU thread (cla: yes)
+
+[7443](https://github.com/flutter/engine/pull/7443) Avg ms/frame instead of FPS in performance overlay (cla: yes)
+
+[7444](https://github.com/flutter/engine/pull/7444) Pass deadline to embedder idle notification callback (cla: yes)
+
+[7445](https://github.com/flutter/engine/pull/7445) Use anti-aliasing when drawing text in the performance overlay (cla: yes)
+
+[7446](https://github.com/flutter/engine/pull/7446) Reland Dart SDK rolls made since 2019/01/08 (cla: yes)
+
+[7447](https://github.com/flutter/engine/pull/7447) Make SetLocales more consistent with other RuntimeController methods (cla: yes)
+
+[7449](https://github.com/flutter/engine/pull/7449) Dart SDK roll for 2019-01-11 (cla: yes)
+
+[7450](https://github.com/flutter/engine/pull/7450) Stop pumping frames in applicationWillResignActive (cla: yes)
+
+[7451](https://github.com/flutter/engine/pull/7451) Dart SDK roll for 2019-01-11 (cla: yes)
+
+[7459](https://github.com/flutter/engine/pull/7459) add ColorFilter matrix support (cla: yes)
+
+[7461](https://github.com/flutter/engine/pull/7461) Dart SDK roll for 2019-01-14 (cla: yes)
+
+[7463](https://github.com/flutter/engine/pull/7463) Dart SDK roll for 2019-01-14 (cla: yes)
+
+[7464](https://github.com/flutter/engine/pull/7464) update site to use SkFont for text fields (cla: yes)
+
+[7476](https://github.com/flutter/engine/pull/7476) Log errors returned from method channel invocations in the text input plugin (cla: yes)
+
+[7480](https://github.com/flutter/engine/pull/7480) Switch to Skia's new SkColorSpace factory (cla: yes)
+
+[7483](https://github.com/flutter/engine/pull/7483) Revert "Add elevation and thickness to SemanticsNode" (cla: yes)
+
+[7484](https://github.com/flutter/engine/pull/7484) Reland "Add elevation and thickness to SemanticsNode (#7282)" (accessibility, cla: yes)
+
+[7485](https://github.com/flutter/engine/pull/7485) Execute Picture.toImage on the current thread in the test environment (cla: yes)
+
+[7488](https://github.com/flutter/engine/pull/7488) Implemented Dark Mode for Android (#25525) (cla: yes)
+
+[7492](https://github.com/flutter/engine/pull/7492) Cleanup Dart sticky errors API and roll tonic to 4634b29a24ccfc0fcfafcc8196ef30131185ad88 (cla: yes)
+
+[7493](https://github.com/flutter/engine/pull/7493) Add runttime unittest that loads and runs an isolate from the kernel. (cla: yes)
+
+[7495](https://github.com/flutter/engine/pull/7495) Add unittest that runs Dart code synchronously. (cla: yes)
+
+[7496](https://github.com/flutter/engine/pull/7496) Validate dynamic patches before attempting to install (cla: yes)
+
+[7497](https://github.com/flutter/engine/pull/7497) Deprecate FlutterProjectArgs.main_path, packages_path (cla: yes)
+
+[7500](https://github.com/flutter/engine/pull/7500) Introduced a number of Java system channels in io/flutter/embedding/engine/systemchannels/ (cla: yes)
+
+[7503](https://github.com/flutter/engine/pull/7503) Edit the bundleid so that it conform to UIT specifications. (cla: yes)
+
+[7511](https://github.com/flutter/engine/pull/7511) Remove unused headers (cla: yes)
+
+[7512](https://github.com/flutter/engine/pull/7512) Wrap the user entrypoint function in a zone with native exception callback. (cla: yes)
+
+[7516](https://github.com/flutter/engine/pull/7516) Fixes Android pressure range (cla: yes)
+
+[7518](https://github.com/flutter/engine/pull/7518) Update default flutter_assets path for iOS embedding (cla: yes)
+
+[7522](https://github.com/flutter/engine/pull/7522) Revert "Wrap the user entrypoint function in a zone with native exception callback. (#7512)" (cla: yes)
+
+[7525](https://github.com/flutter/engine/pull/7525) Support custom kernel blob path in test fixtures (cla: yes)
+
+[7528](https://github.com/flutter/engine/pull/7528) Ensure the ResourceContext is not ripped out from under dart (cla: yes)
+
+[7530](https://github.com/flutter/engine/pull/7530) Fix suspicious typo "painted" to "paint" (cla: yes)
+
+[7532](https://github.com/flutter/engine/pull/7532) Mark new unavailable for those init marked unavailable (cla: yes)
+
+[7533](https://github.com/flutter/engine/pull/7533) Configure the embedder for AOT in "profile" and "release" runtime modes. (cla: yes)
+
+[7537](https://github.com/flutter/engine/pull/7537) Add mock capability to PerformanceOverlayLayer (cla: yes)
+
+[7538](https://github.com/flutter/engine/pull/7538) Allow embedders to specify AOT snapshot buffers. (cla: yes)
+
+[7539](https://github.com/flutter/engine/pull/7539) IWYU to get SkFontMetrics (cla: yes)
+
+[7544](https://github.com/flutter/engine/pull/7544) Keep engine alive if VC is not deallocated (cla: yes)
+
+[7545](https://github.com/flutter/engine/pull/7545) IWYU, esp. since SkFontMetrics.h is leaving SkPaint.h (cla: yes)
+
+[7548](https://github.com/flutter/engine/pull/7548) Remove SkColorSpaceXformCanvas, use color-managed SkSurfaces instead (cla: yes)
+
+[7549](https://github.com/flutter/engine/pull/7549) Remove the shell build target's dependency on the embedder library (cla: yes)
+
+[7551](https://github.com/flutter/engine/pull/7551) Re-land "Wrap the user entrypoint function in a zone with native exception callback. (#7512)" (cla: yes)
+
+[7558](https://github.com/flutter/engine/pull/7558) Fix UIButton selector doesn't work in iOS platformview (cla: yes)
+
+[7563](https://github.com/flutter/engine/pull/7563) Fix typos in Fuchsia (cla: yes)
+
+[7566](https://github.com/flutter/engine/pull/7566) Avoid unnecessarily creating/destroying the PlatformView (cla: yes)
+
+[7567](https://github.com/flutter/engine/pull/7567) Rename FlutterResult in embedder.h (cla: yes)
+
+[7576](https://github.com/flutter/engine/pull/7576) Allow generating coverage reports for all unit-tests in the engine. (cla: yes)
+
+[7577](https://github.com/flutter/engine/pull/7577) [embedder] Avoid looking for the kernel binary in AOT builds. (cla: yes)
+
+[7579](https://github.com/flutter/engine/pull/7579) Add lcov coverage file generation. (cla: yes)
+
+[7588](https://github.com/flutter/engine/pull/7588) Embed ICU data inside libflutter.so on Android (cla: yes)
+
+[7591](https://github.com/flutter/engine/pull/7591) Roll buildroot to b4d21cb2a64d63218c8d99533d9c14e99201e8d8 (cla: yes)
+
+[7602](https://github.com/flutter/engine/pull/7602) Update buildtools to c9e5400c9e03a0cfb7313d14fde38525399a7715 (cla: yes)
+
+[7610](https://github.com/flutter/engine/pull/7610) Provide public api to allow FlutterEngine related context to be destoryed (affects: engine, cla: yes, customer: gold, platform-ios)
+
+[7611](https://github.com/flutter/engine/pull/7611) Update license to sync with flutter/flutter (cla: yes)
+
+[7617](https://github.com/flutter/engine/pull/7617) Allow the engine to redirect traces to systrace via settings. (cla: yes)
+
+[7621](https://github.com/flutter/engine/pull/7621) Improve PathMetrics (cla: yes)
+
+[7628](https://github.com/flutter/engine/pull/7628) Check in GEM_HOME for jazzy (cla: yes)
+
+[7633](https://github.com/flutter/engine/pull/7633) Revert buildtools roll back to bac220c (cla: yes)
+
+[7634](https://github.com/flutter/engine/pull/7634) Expose the Flutter engine, Dart and Skia versions to Dart. (cla: yes)
+
+[7642](https://github.com/flutter/engine/pull/7642) Initial import of FDE macOS framework (cla: yes)
+
+[7643](https://github.com/flutter/engine/pull/7643) Respect default goma path on Windows (cla: yes)
+
+[7645](https://github.com/flutter/engine/pull/7645) Fix dynamic array -> vector (cla: yes)
+
+[7647](https://github.com/flutter/engine/pull/7647) Update the verify_exported script to include the symbols for ICU data (cla: yes)
+
+[7648](https://github.com/flutter/engine/pull/7648) [embedder] Document make_resource_current on FlutterOpenGLRendererConfig and warn if the callback is not set. (cla: yes)
+
+[7649](https://github.com/flutter/engine/pull/7649) Fix two typos in embedder docs (cla: yes)
+
+[7651](https://github.com/flutter/engine/pull/7651) Add FlutterProjectArgs::root_isolate_create_callback (cla: yes)
+
+[7658](https://github.com/flutter/engine/pull/7658) Use the Wuffs GIF decoder (cla: yes)
+
+[7659](https://github.com/flutter/engine/pull/7659) DCHECK that clip layer's behavior isn't none (cla: yes)
+
+[7660](https://github.com/flutter/engine/pull/7660) Add kernel-worker and dart2js to BUILD.gn (cla: yes)
+
+[7678](https://github.com/flutter/engine/pull/7678) Move Brightness definition to dart:ui (#27479) (cla: yes)
+
+[7686](https://github.com/flutter/engine/pull/7686) Replace hb_face_reference_table with hb_ot_color_has_png in isColorBitmapFont (cla: yes)
+
+[7687](https://github.com/flutter/engine/pull/7687) Lower the threshold to raster cache pictures (cla: yes)
+
+[7689](https://github.com/flutter/engine/pull/7689) Revert "Disable the persistent cache (#6835)" (cla: yes)
+
+[7691](https://github.com/flutter/engine/pull/7691) Don't warn for Async texture uploads on Fuchsia (cla: yes)
+
+[7692](https://github.com/flutter/engine/pull/7692) Ensure dart2js and kernel worker snapshots are copied out of gen dir (cla: yes)
+
+[7694](https://github.com/flutter/engine/pull/7694) Create stubbed dart:ui implementation, dart2js libraries file, copy rule (cla: yes)
+
+[7701](https://github.com/flutter/engine/pull/7701) Revert "Lower the threshold to raster cache pictures" (cla: yes)
+
+[7702](https://github.com/flutter/engine/pull/7702) Update snapshot build rules to generate .o files instead of .S files on Windows (Windows, cla: yes)
+
+[7708](https://github.com/flutter/engine/pull/7708) [fuchsia] Update scenic include (cla: yes)
+
+[7713](https://github.com/flutter/engine/pull/7713) Disable wuff on Windows (cla: yes)
+
+[7715](https://github.com/flutter/engine/pull/7715) Decode using the last cached required frame (cla: yes, crash)
+
+[7717](https://github.com/flutter/engine/pull/7717) Allow all entrypoints support by the command line VM. (cla: yes)
+
+[7718](https://github.com/flutter/engine/pull/7718) Roll buildroot to c82412bcdcd593f1385a478ae2c4b8eb9814f3b8 (cla: yes)
+
+[7719](https://github.com/flutter/engine/pull/7719) libtxt: support justification of RTL text (cla: yes)
+
+[7725](https://github.com/flutter/engine/pull/7725) Correct libraries.yaml path for stub_ui, add brightness, copy dart2js_platform.dill files (cla: yes)
+
+[7726](https://github.com/flutter/engine/pull/7726) Fix versions implementation (cla: yes)
+
+[7731](https://github.com/flutter/engine/pull/7731) [fuchsia] Update path to fuchsia.ui.scenic (cla: yes)
+
+[7733](https://github.com/flutter/engine/pull/7733) Update documentation for command line args in FlutterProjectArgs. (cla: yes)
+
+[7734](https://github.com/flutter/engine/pull/7734) Use all font managers to discover fonts for strut. (cla: yes)
+
+[7735](https://github.com/flutter/engine/pull/7735) Use correct flags on LUCI/legacy (cla: yes)
+
+[7737](https://github.com/flutter/engine/pull/7737) Provide a default pressure range if a MotionEvent does not have a device (cla: yes)
+
+[7738](https://github.com/flutter/engine/pull/7738) Android embedding refactor pr3 add remaining systemchannels (cla: yes)
+
+[7739](https://github.com/flutter/engine/pull/7739) Add onPlatformBrightnessChanged/platformBrightness to stub ui window. (cla: yes)
+
+[7740](https://github.com/flutter/engine/pull/7740) Rename macOS framework to FlutterMacOS.framework (cla: yes)
+
+[7741](https://github.com/flutter/engine/pull/7741) use full git hash for version (cla: yes)
+
+[7744](https://github.com/flutter/engine/pull/7744) Support for loading dynamic patches in AOT mode. (cla: yes)
+
+[7746](https://github.com/flutter/engine/pull/7746) Don't call OnAnimatorNotifyIdle if a frame is scheduled (cla: yes)
+
+[7751](https://github.com/flutter/engine/pull/7751) Create mipmaps for images when uploading them on the IO thread (cla: yes)
+
+[7753](https://github.com/flutter/engine/pull/7753) allow specifying out directory root (cla: yes)
+
+[7755](https://github.com/flutter/engine/pull/7755) Document GPUSurfaceGLDelegate methods and move it to its own file. (cla: yes)
+
+[7756](https://github.com/flutter/engine/pull/7756) Add flutter config to macOS targets (cla: yes)
+
+[7758](https://github.com/flutter/engine/pull/7758) Recommended implementation of combining characters implementation. (cla: yes)
+
+[7759](https://github.com/flutter/engine/pull/7759) Throttle picture raster cache (cla: yes)
+
+[7762](https://github.com/flutter/engine/pull/7762) Allow specifying the out directory prefix (cla: yes)
+
+[7764](https://github.com/flutter/engine/pull/7764) Add x bit to some python scripts (cla: yes)
+
+[7765](https://github.com/flutter/engine/pull/7765) Revert "Add mock capability to PerformanceOverlayLayer" (cla: yes)
+
+[7777](https://github.com/flutter/engine/pull/7777) Support for binary decompression of dynamic patches. (cla: yes)
+
+[7785](https://github.com/flutter/engine/pull/7785) Don't use WUFFs (cla: yes)
+
+[7786](https://github.com/flutter/engine/pull/7786) Update licenses for the switch away from the Wuffs GIF decoder (cla: yes)
+
+[7790](https://github.com/flutter/engine/pull/7790) Allow embedders to specify pointer device IDs. (cla: yes)
+
+[7791](https://github.com/flutter/engine/pull/7791) Add space metrics tracking for trailing whitespace "ghost" runs. (cla: yes)
+
+[7801](https://github.com/flutter/engine/pull/7801) Revert "Use all font managers to discover fonts for strut. (#7734)" (cla: yes)
+
+[7804](https://github.com/flutter/engine/pull/7804) Add support for new Scenic clip planes. (cla: yes)
+
+[7806](https://github.com/flutter/engine/pull/7806) Remove the Dart JIT snapshot data from AOT builds of the embedder library (cla: yes)
+
+[7807](https://github.com/flutter/engine/pull/7807) Add flow events connecting pointer events to frames (cla: yes)
+
+[7809](https://github.com/flutter/engine/pull/7809) Use newer Skia API for PathMeasure (cla: yes)
+
+[7811](https://github.com/flutter/engine/pull/7811) Add FFI to libraries.yaml. (cla: yes)
+
+[7813](https://github.com/flutter/engine/pull/7813) Expose more pointer phases in embedder.h (cla: yes)
+
+[7814](https://github.com/flutter/engine/pull/7814) Fix typo in painting.dart (cla: yes, waiting for tree to go green)
+
+[7815](https://github.com/flutter/engine/pull/7815) Allow specifying the buildtools path (cla: yes, waiting for tree to go green)
+
+[7819](https://github.com/flutter/engine/pull/7819) Fix tests that were committed after cirrus ran (cla: yes)
+
+[7826](https://github.com/flutter/engine/pull/7826) Pass flow id properly. (cla: yes)
+
+[7827](https://github.com/flutter/engine/pull/7827) Remove unnecessary entry-point closurization. (cla: yes)
+
+[7830](https://github.com/flutter/engine/pull/7830) Move up ndk version that is being downloaded(old one no longer available). (cla: yes)
+
+[7832](https://github.com/flutter/engine/pull/7832) Shut down and restart the Dart VM as needed. (cla: yes)
+
+[7834](https://github.com/flutter/engine/pull/7834) [fuchsia][SCN-1054] Map elevation onto -Z in Scenic (cla: yes)
+
+[7836](https://github.com/flutter/engine/pull/7836) Delete GL textures when they are released from the texture registry. (cla: yes)
+
+[7837](https://github.com/flutter/engine/pull/7837) Fix NullPointerException in SurfaceTextureRegistryEntry (cla: yes)
+
+[7838](https://github.com/flutter/engine/pull/7838) Fix NullPointerException in ResourceCleaner (cla: yes)
+
+[7839](https://github.com/flutter/engine/pull/7839) Ensure to pass dill file after VM options for gen_snapshot (cla: yes)
+
+[7841](https://github.com/flutter/engine/pull/7841) Don't call static method from instance variable (cla: yes)
+
+[7843](https://github.com/flutter/engine/pull/7843) Add support for calling into other plugins from a background context on iOS (cla: yes)
+
+[7845](https://github.com/flutter/engine/pull/7845) Add fml::FileExists implementation for Windows (cla: yes)
+
+[7846](https://github.com/flutter/engine/pull/7846) Update buildroot to 7f64ff4928e to unblock Mac builds. (cla: yes)
+
+[7849](https://github.com/flutter/engine/pull/7849) Revert "Android embedding refactor pr3 add remaining systemchannels (… (cla: yes)
+
+[7853](https://github.com/flutter/engine/pull/7853) Revert "Support for binary decompression of dynamic patches. (#7777)" (cla: yes)
+
+[7862](https://github.com/flutter/engine/pull/7862) Reland "Lower the threshold to raster cache pictures (#7687)" (cla: yes)
+
+[7863](https://github.com/flutter/engine/pull/7863) Reland PerformanceOverlayLayer golden test (cla: yes)
+
+[7874](https://github.com/flutter/engine/pull/7874) Android embedding refactor pr3 add remaining systemchannels (cla: yes)
+
+[7875](https://github.com/flutter/engine/pull/7875) Fix caret being at left edge when newline pressed on centered text (cla: yes)
+
+[7876](https://github.com/flutter/engine/pull/7876) Revert "Remove unnecessary entry-point closurization." (cla: yes)
+
+[7877](https://github.com/flutter/engine/pull/7877) Revert "Shut down and restart the Dart VM as needed." (cla: yes)
+
+[7878](https://github.com/flutter/engine/pull/7878) Android embedding refactor pr5 add flutterengine impl (cla: yes)
+
+[7880](https://github.com/flutter/engine/pull/7880) Test profile and release build and unit tests (cla: yes)
+
+[7882](https://github.com/flutter/engine/pull/7882) Fix minor typos in accessibility action docs (cla: yes)
+
+[7883](https://github.com/flutter/engine/pull/7883) Correct onAccessibilityFeaturesChanged docs (cla: yes)
+
+[7886](https://github.com/flutter/engine/pull/7886) Revert "Android embedding refactor pr3 add remaining systemchannels" (cla: yes)
+
+[7891](https://github.com/flutter/engine/pull/7891) Add accessibility semantics support to embedder (cla: yes)
+
+[7892](https://github.com/flutter/engine/pull/7892) Android embedding refactor pr3 add remaining systemchannels (cla: yes)
+
+[7893](https://github.com/flutter/engine/pull/7893) Respect the custom GL proc table when creating the resource context on the IO thread. (cla: yes)
+
+[7895](https://github.com/flutter/engine/pull/7895) Revert "Reland PerformanceOverlayLayer golden test (#7863)" (cla: yes)
+
+[7899](https://github.com/flutter/engine/pull/7899) Eliminate .member = foo struct initialization (cla: yes)
+
+[7904](https://github.com/flutter/engine/pull/7904) Reland "Remove unnecessary entry-point closurization." (cla: yes)
+
+
+
+## PRs closed in this release of flutter/plugins
+
+From Fri Nov 29 19:41:00 2018 -0800 to Thu Feb 21 20:22:00 2019 -0800
+
+
+[690](https://github.com/flutter/plugins/pull/690) [video_player] Fix aspect ratio (cla: yes)
+
+[842](https://github.com/flutter/plugins/pull/842) Remove base detector class and change detection method name (cla: yes, flutterfire)
+
+[895](https://github.com/flutter/plugins/pull/895) [connectivity] Added getWifiIP() (cla: yes)
+
+[896](https://github.com/flutter/plugins/pull/896) [firebase-analytics] Enable setAnalyticsCollectionEnabled support for iOS (cla: no, flutterfire, submit queue)
+
+[926](https://github.com/flutter/plugins/pull/926) Remove firebase_auth dependency from android_alarm_manager library and add initialize step to readme (cla: yes, documentation, submit queue)
+
+[936](https://github.com/flutter/plugins/pull/936) Fixed typo `BarcodeValueType` (cla: yes)
+
+[947](https://github.com/flutter/plugins/pull/947) fix: url_launcher can't launcher for Android (cla: yes)
+
+[949](https://github.com/flutter/plugins/pull/949) Fixes: 'webview_flutter/WebviewFlutterPlugin.h' file not found (cla: yes)
+
+[950](https://github.com/flutter/plugins/pull/950) Show https://flutter.io in the webview_flutter example. (cla: yes)
+
+[954](https://github.com/flutter/plugins/pull/954) add new plugins reference to README.md (cla: yes)
+
+[956](https://github.com/flutter/plugins/pull/956) Make the description for webview_flutter longer. (cla: yes)
+
+[957](https://github.com/flutter/plugins/pull/957) fix message structure from intent (cla: yes)
+
+[959](https://github.com/flutter/plugins/pull/959) Add navigation methods to webview_flutter (cla: yes)
+
+[960](https://github.com/flutter/plugins/pull/960) Fail call when trying to recover auth with backgrounded app (cla: yes)
+
+[961](https://github.com/flutter/plugins/pull/961) Control the GoogleMap options with widget parameters. (cla: yes)
+
+[965](https://github.com/flutter/plugins/pull/965) Add byte streaming capability for the camera  (cla: yes)
+
+[967](https://github.com/flutter/plugins/pull/967) Fix initialUrl null check for webview_flutter (cla: yes)
+
+[971](https://github.com/flutter/plugins/pull/971) Add the ability for ML Kit to create image from bytes (cla: yes)
+
+[972](https://github.com/flutter/plugins/pull/972) Fix typo in WebView's "initWithWithFrame". (cla: yes)
+
+[974](https://github.com/flutter/plugins/pull/974) Implemented reload method in webview_flutter (cla: yes)
+
+[976](https://github.com/flutter/plugins/pull/976) [camera] Fix issue with crash when the physical device's orientation is unknown on Android. (cla: yes)
+
+[977](https://github.com/flutter/plugins/pull/977) Temporarily add exoplayer repo accidentally deleted from jcenter (cla: yes)
+
+[992](https://github.com/flutter/plugins/pull/992) Add currentUrl accessor to WebView plugin. (cla: yes)
+
+[993](https://github.com/flutter/plugins/pull/993) Allow user to handle PlatformExceptions caught by FirebaseAnalyticsObserver._sendScreenView(). (cla: yes)
+
+[995](https://github.com/flutter/plugins/pull/995) Bump webview_flutter's version. (cla: yes)
+
+[997](https://github.com/flutter/plugins/pull/997) closeWebView fixes for url_launcher (cla: yes)
+
+[1002](https://github.com/flutter/plugins/pull/1002) Fixed local_auth crash with API < 24 #24339 (cla: yes)
+
+[1006](https://github.com/flutter/plugins/pull/1006) Bump android_alarm_manager version to 0.2.3 (cla: yes)
+
+[1021](https://github.com/flutter/plugins/pull/1021) javascript evaluation ios/android (cla: yes, feature, webview)
+
+[1024](https://github.com/flutter/plugins/pull/1024) Doc and build script updates to the IAP plugin (cla: yes)
+
+[1025](https://github.com/flutter/plugins/pull/1025) Fix CI analyzer errors (cla: yes)
+
+[1031](https://github.com/flutter/plugins/pull/1031) Workaround the Gradle crash due to non ASCII characters. (cla: yes)
+
+[1034](https://github.com/flutter/plugins/pull/1034) Remove comments from license file (cla: yes)
+
+[1037](https://github.com/flutter/plugins/pull/1037) Save photo orientation on iOS (cla: yes)
+
+[1040](https://github.com/flutter/plugins/pull/1040) Rev version to publish 0.3.1 to pub (cla: yes)
+
+[1042](https://github.com/flutter/plugins/pull/1042) Remove scary message (cla: yes)
+
+[1046](https://github.com/flutter/plugins/pull/1046) Fix Crash When StartPreview Error (cla: yes)
+
+[1051](https://github.com/flutter/plugins/pull/1051) Fix image picker crash on IOS (cla: yes)
+
+[1057](https://github.com/flutter/plugins/pull/1057) [IAP] Check if the payment processor is available (cla: yes)
+
+[1058](https://github.com/flutter/plugins/pull/1058) Update dart doc for forceSafariVC for the usage of universal links on iOS (cla: yes)
+
+[1060](https://github.com/flutter/plugins/pull/1060) Bump camera plugin version and update changelog. (cla: yes)
+
+[1062](https://github.com/flutter/plugins/pull/1062) Url launcher ios universallinksonly (cla: yes)
+
+[1065](https://github.com/flutter/plugins/pull/1065) Supress `strong_mode_implicit_dynamic_method` for `invokeMethod` calls. (cla: yes)
+
+[1068](https://github.com/flutter/plugins/pull/1068) Iap productlist ios (cla: yes)
+
+[1072](https://github.com/flutter/plugins/pull/1072) adding nil check (cla: yes)
+
+[1076](https://github.com/flutter/plugins/pull/1076) Fix `Manifest versionCode not found` (cla: yes)
+
+[1082](https://github.com/flutter/plugins/pull/1082) [IAP] Clean up Dart unit tests (cla: yes)
+
+[1083](https://github.com/flutter/plugins/pull/1083) [IAP] Add missing license headers (cla: yes)
+
+[1084](https://github.com/flutter/plugins/pull/1084) [IAP] Fetch SkuDetails from Google Play (cla: yes)
+
+[1085](https://github.com/flutter/plugins/pull/1085) Url launcher refactor (cla: yes)
+
+[1086](https://github.com/flutter/plugins/pull/1086) Enable compute credits for commits, and for macOS PRs (cla: yes)
+
+[1087](https://github.com/flutter/plugins/pull/1087) cirrues update to mojave-xcode-10.1 (cla: yes)
+
+[1088](https://github.com/flutter/plugins/pull/1088) add deprecated_member_use_from_same_package to pass analyzer (cla: yes)
+
+[1089](https://github.com/flutter/plugins/pull/1089) Fix a crash when selecting downloaded images on certain devices (cla: yes)
+
+[1090](https://github.com/flutter/plugins/pull/1090) [IAP] Generate boilerplate serializers (cla: yes)
+
+[1092](https://github.com/flutter/plugins/pull/1092) Fix broken documentation link to AndroidBuildVersionCodes (cla: yes)
+
+[1093](https://github.com/flutter/plugins/pull/1093) [image_picker] Fixed a crash that would occur when called in quick succession on Android (cla: yes)
+
+[1102](https://github.com/flutter/plugins/pull/1102) cleanup (cla: yes)
+
+[1103](https://github.com/flutter/plugins/pull/1103) Migrate independent plugins to AndroidX (cla: yes)
+
+[1104](https://github.com/flutter/plugins/pull/1104) Include Android SDK 27 in the docker image and accept licenses (cla: yes)
+
+[1105](https://github.com/flutter/plugins/pull/1105) update change log for url launcher (cla: yes)
+
+[1106](https://github.com/flutter/plugins/pull/1106) [firebase_ml_vision] Set minimum iOS to 8 (cla: yes)
+
+[1108](https://github.com/flutter/plugins/pull/1108) Remove 'init' static method (cla: yes)
+
+[1109](https://github.com/flutter/plugins/pull/1109) Update all plugins to minimum iOS 8.0 (cla: yes)
+
+[1112](https://github.com/flutter/plugins/pull/1112) [IAP] Update README (cla: yes)
+
+[1115](https://github.com/flutter/plugins/pull/1115) Migrate remaining plugins to AndroidX (cla: yes)
+
+[1116](https://github.com/flutter/plugins/pull/1116) Add WebView JavaScript channels (Dart side). (cla: yes)
+
+[1117](https://github.com/flutter/plugins/pull/1117) [firebase_auth] Update a broken dependency. (cla: yes)
+
+[1118](https://github.com/flutter/plugins/pull/1118) [IAP] Update dev deps to match flutter_driver (cla: yes)
+
+[1120](https://github.com/flutter/plugins/pull/1120) A few additional Androix dependencies (cla: yes)
+
+[1124](https://github.com/flutter/plugins/pull/1124) Updated `launch` to use async and await, fixed the incorrect return value by `launch` method. (cla: yes)
+
+[1125](https://github.com/flutter/plugins/pull/1125) Fixed image picker crash when used with android alarm manager (cla: yes)
+
+[1126](https://github.com/flutter/plugins/pull/1126) [In_app_purchase] add payment translators in objc (cla: yes)
+
+[1127](https://github.com/flutter/plugins/pull/1127) Revert AndroidX changes for 1.0.0 plugins (cla: yes)
+
+[1128](https://github.com/flutter/plugins/pull/1128) Migrate to AndroidX forward roll (cla: yes)
+
+[1129](https://github.com/flutter/plugins/pull/1129) android_alarm_manager background execution bug fixes (bugfix, cla: yes, submit queue)
+
+[1130](https://github.com/flutter/plugins/pull/1130) WebView JavasScript channels Android implementation. (cla: yes, feature, webview)
+
+[1132](https://github.com/flutter/plugins/pull/1132) Use string to save double for shared_preference(Android). (bugfix, cla: yes, needs love, submit queue)
+
+[1133](https://github.com/flutter/plugins/pull/1133) Added support for persisting alarms across reboots (cla: yes, feature)
+
+[1134](https://github.com/flutter/plugins/pull/1134) Updated connectivity to singleton (cla: yes)
+
+[1135](https://github.com/flutter/plugins/pull/1135) FIx issue with calculating iOS image orientation in certain special c… (cla: yes)
+
+[1138](https://github.com/flutter/plugins/pull/1138) Add a gradle warning to the AndroidX plugins (cla: yes)
+
+[1139](https://github.com/flutter/plugins/pull/1139) WebView JavaScript channels - iOS implementation. (cla: yes)
+
+[1140](https://github.com/flutter/plugins/pull/1140) Change iOS video format back to bgra8888 (cla: yes)
+
+[1147](https://github.com/flutter/plugins/pull/1147) [In_app_purchase] Use json serializer for skproduct wrapper and related classes. (cla: yes)
+
+[1148](https://github.com/flutter/plugins/pull/1148) Update NSNull check with directly checking the expected type.  (cla: yes)
+
+[1149](https://github.com/flutter/plugins/pull/1149) Allow clearing cookies for FlutterWebView (cla: yes)
+
+[1155](https://github.com/flutter/plugins/pull/1155) Updating the example to match the new API (cla: yes, documentation, flutterfire, submit queue)
+
+[1156](https://github.com/flutter/plugins/pull/1156) Add capability of using single plane buffers (cla: yes)
+
+[1157](https://github.com/flutter/plugins/pull/1157) Workaround to fix the camera positioning issue on the google map view (cla: yes)
+
+[1161](https://github.com/flutter/plugins/pull/1161) Add Swift example to README.md for google_maps_flutter (cla: yes)
+
+[1162](https://github.com/flutter/plugins/pull/1162) [In_app_purchase] Expose nslocale and expose currencySymbol instead of currencyCode to match android (cla: yes)
+
+[1163](https://github.com/flutter/plugins/pull/1163) Change from Rectangle<num>/Point<num> to Rect/Offset for ui convenience (cla: yes)
+
+[1169](https://github.com/flutter/plugins/pull/1169) [In_app_purchase] getproductlist basic draft (cla: yes)
+
+[1170](https://github.com/flutter/plugins/pull/1170) Remove ML models from ML Kit Vision plugin (cla: yes)
+
+[1171](https://github.com/flutter/plugins/pull/1171) Revert "IAP add payment translators in objc (#1126)" (cla: yes)
+
+[1172](https://github.com/flutter/plugins/pull/1172) [In_app_purchase] add payment objc translators (cla: yes)
+
+[1173](https://github.com/flutter/plugins/pull/1173) Fix biometrics check error below ios11. (cla: yes)
+
+[1175](https://github.com/flutter/plugins/pull/1175) Add unit tests to connectivity plugin (cla: yes)
+
+[1176](https://github.com/flutter/plugins/pull/1176) Fix Firebase phone auth on Android (cla: yes)
+
+[1177](https://github.com/flutter/plugins/pull/1177) Fix bug causing black screen on some Android devices (cla: yes)
+
+[1178](https://github.com/flutter/plugins/pull/1178) [In_app_purchase] iOS add payment dart wrappers (cla: yes)
+
+[1180](https://github.com/flutter/plugins/pull/1180) Expose exception on the signIn method in Google sign in. (cla: yes)
+
+[1185](https://github.com/flutter/plugins/pull/1185) remove extra space (cla: yes)
+
+[1193](https://github.com/flutter/plugins/pull/1193) Mark some packages as unpublishable (cla: yes)
+
+[1194](https://github.com/flutter/plugins/pull/1194) [In_app_purchase] Fix the param map passed down to the platform channel when calling querySkuDetails (cla: yes)
+
+[1195](https://github.com/flutter/plugins/pull/1195) Fix bug where HttpMetric/Trace dictionaries weren't being initialized on iOS (cla: yes)
+
+[1199](https://github.com/flutter/plugins/pull/1199) [In_app_purchase] fix requesthandler crash (cla: yes)
+
+[1200](https://github.com/flutter/plugins/pull/1200) WebView controller let's you clear cache (cla: yes)
+
+[1202](https://github.com/flutter/plugins/pull/1202) Fix IllegalStateException for cloud_firestore transactions (cla: yes)
+
+[1203](https://github.com/flutter/plugins/pull/1203) Don’t send empty cloud_firestore snapshots on iOS when encountering errors (cla: yes)
+
+[1204](https://github.com/flutter/plugins/pull/1204) Remove assertion for firebase_core that can interfere with hot-restart (cla: yes)
+
+[1205](https://github.com/flutter/plugins/pull/1205) Introduce CODEOWNERS (cla: yes)
+
+[1206](https://github.com/flutter/plugins/pull/1206) Fix iOS transactions when getting a snapshot that doesn't exist (cla: yes)
+
+[1207](https://github.com/flutter/plugins/pull/1207) Fix cloud_firestore dates on some iOS devices (cla: yes)
+
+[1209](https://github.com/flutter/plugins/pull/1209) fix firestore multiple app support for DocumentSnapshot and transactions (cla: yes)
+
+[1210](https://github.com/flutter/plugins/pull/1210) cloud functions multiple app support (cla: yes)
+
+[1212](https://github.com/flutter/plugins/pull/1212) Change version webview flutter (cla: yes)
+
+[1213](https://github.com/flutter/plugins/pull/1213) Set GoogleAppMeasurement dependency version (cla: yes)
+
+[1214](https://github.com/flutter/plugins/pull/1214) Video player supported formats (cla: yes)
+
+[1215](https://github.com/flutter/plugins/pull/1215) Bump video_player version to 0.10.0+2 (cla: yes)
+
+[1217](https://github.com/flutter/plugins/pull/1217) [android_alarm_manager] Include missing dependency (cla: yes)
+
+[1220](https://github.com/flutter/plugins/pull/1220) remove the blank line in CODEOWNER (cla: yes)
+
+[1221](https://github.com/flutter/plugins/pull/1221) Remove the method channel's reference to webview/maps on dispose. (cla: yes)
+
+[1222](https://github.com/flutter/plugins/pull/1222) [In_app_purchase]remove categories (cla: yes)
+
+[1225](https://github.com/flutter/plugins/pull/1225) Rotate image file based on Exif data (cla: yes, submit queue)
+
+[1226](https://github.com/flutter/plugins/pull/1226) Remove categories (cla: yes)
+
+[1230](https://github.com/flutter/plugins/pull/1230) [IAP] Add Java call for launchBillingFlow (cla: yes)
+
+[1231](https://github.com/flutter/plugins/pull/1231) [in_app_purchase] make payment objc (cla: yes)
+
+[1232](https://github.com/flutter/plugins/pull/1232) [IAP] Add the Dart API for launchBillingFlow (cla: yes)
+
+[1238](https://github.com/flutter/plugins/pull/1238) [Camera] remove extra space in CHANGELOG (cla: yes)
+
+[1242](https://github.com/flutter/plugins/pull/1242) Bugfix documents: webview_flutter JavascriptChannel, Example is not updated. (cla: yes)
+
+[1246](https://github.com/flutter/plugins/pull/1246) Collection literals ignores in webview flutter plugin (cla: yes)
+
+[1248](https://github.com/flutter/plugins/pull/1248) Remove left over conflict marker (cla: yes)

--- a/src/docs/development/tools/sdk/release-notes/changelogs/changelog-1.5.4.md
+++ b/src/docs/development/tools/sdk/release-notes/changelogs/changelog-1.5.4.md
@@ -1,0 +1,2330 @@
+---
+title: Change log for Flutter 1.5.4 
+short-title: 1.5.4 change log
+description: Change log for Flutter 1.5.4 containing a list of all PRs merged for this release.
+---
+
+## PRs closed in this release of flutter/flutter
+
+From Thu Feb 21 20:22:00 2019 -0800 to Wed May 1 16:56:00 2019 -0700
+
+
+[21834](https://github.com/flutter/flutter/pull/21834)  Add shapeBorder option on App Bar (cla: yes, f: material design, framework)
+
+[21896](https://github.com/flutter/flutter/pull/21896) Bottom sheet scrolling (a: animation, cla: yes, f: material design, f: routes, framework)
+
+[22762](https://github.com/flutter/flutter/pull/22762) Add support for scrollwheels (cla: yes, f: gestures, framework)
+
+[22810](https://github.com/flutter/flutter/pull/22810) build the gallery on PRs (cla: yes, team)
+
+[24476](https://github.com/flutter/flutter/pull/24476) Fix text selection handles showing outside the visible text region (a: text input, cla: yes, framework)
+
+[25164](https://github.com/flutter/flutter/pull/25164) Pan and zoom gallery demo (cla: yes, team, team: gallery)
+
+[25202](https://github.com/flutter/flutter/pull/25202) fix #19175 How should addTime be used from a test? (a: tests, cla: yes, framework, team: gallery, waiting for tree to go green)
+
+[26438](https://github.com/flutter/flutter/pull/26438) Breaks the moveBy call from drag and dragFrom into two separate calls and changes the default behavior of DragStartBehavior to DragStartBehavior.start (cla: yes, f: gestures, framework, severe: API break)
+
+[26785](https://github.com/flutter/flutter/pull/26785) Document that SearchDelegate.buildResults can be called multiple time… (cla: yes, d: api docs, f: material design, framework, team: flakes, team: gallery)
+
+[27034](https://github.com/flutter/flutter/pull/27034) Updated package template .gitignore file (cla: yes, tool)
+
+[27205](https://github.com/flutter/flutter/pull/27205) Fix TextField height issues (a: text input, cla: no, framework)
+
+[27217](https://github.com/flutter/flutter/pull/27217) Fix Shrine overscroll glow indicator (cla: yes, f: material design, framework, team, team: gallery)
+
+[27435](https://github.com/flutter/flutter/pull/27435) Add lerping between LinearGradients with arbitrary number of colors and stops (cla: yes, framework, waiting for tree to go green)
+
+[27572](https://github.com/flutter/flutter/pull/27572) Remove the flutter_shared assets directory from the Gradle script (cla: yes, tool)
+
+[27612](https://github.com/flutter/flutter/pull/27612)  Force line height in TextFields with strut (a: text input, a: typography, cla: yes, f: cupertino, f: material design, framework, severe: API break)
+
+[27660](https://github.com/flutter/flutter/pull/27660) Shader warm up (cla: yes, framework, severe: performance)
+
+[27711](https://github.com/flutter/flutter/pull/27711) Make extended FAB's icon optional (a: fidelity, cla: yes, f: material design, framework)
+
+[27712](https://github.com/flutter/flutter/pull/27712) add2app test (a: existing-apps, a: tests, cla: yes, engine, waiting for tree to go green)
+
+[27749](https://github.com/flutter/flutter/pull/27749) Switch flutter_tools from script to app-jit snapshot. (cla: yes, tool)
+
+[27751](https://github.com/flutter/flutter/pull/27751) Add Sample code for FlatButton #21136 (cla: yes, d: api docs, f: material design, framework)
+
+[27811](https://github.com/flutter/flutter/pull/27811) set literal conversions (cla: yes, framework, team)
+
+[27898](https://github.com/flutter/flutter/pull/27898) Add slight clarification to debugDeterministicCursor (a: text input, cla: yes, framework, waiting for tree to go green)
+
+[27903](https://github.com/flutter/flutter/pull/27903) Lazily download artifacts (III): The Revenge of the Sith (cla: yes, tool)
+
+[27904](https://github.com/flutter/flutter/pull/27904) Convert PointerEvent's toString to Diagnosticable (a: debugging, cla: yes, f: gestures, framework)
+
+[27944](https://github.com/flutter/flutter/pull/27944) Add tests (a: tests, cla: yes, tool)
+
+[27971](https://github.com/flutter/flutter/pull/27971) Run non-perf sensitive tests on Cirrus (a: tests, cla: yes, framework, team)
+
+[28001](https://github.com/flutter/flutter/pull/28001) CupertinoTextField: added ability to change placeholder color (a: text input, cla: yes, f: cupertino, framework, waiting for tree to go green)
+
+[28004](https://github.com/flutter/flutter/pull/28004) Paint backgroundColor in CircularProgressIndicator (cla: yes, f: material design, framework)
+
+[28013](https://github.com/flutter/flutter/pull/28013) [Material] Unit test for skipping Slider tick mark due to overdensity (cla: yes, f: material design, framework)
+
+[28017](https://github.com/flutter/flutter/pull/28017) Add more docs to BackdropFilter (cla: yes, d: api docs, framework)
+
+[28097](https://github.com/flutter/flutter/pull/28097) Allow for gradle downloading missing SDK assets (cla: yes, t: gradle, tool)
+
+[28125](https://github.com/flutter/flutter/pull/28125) [Gallery] Fortnightly demo moved from flutter/samples. (cla: yes, team, team: gallery)
+
+[28152](https://github.com/flutter/flutter/pull/28152) Improve hot reload performance (cla: yes, t: hot reload, tool)
+
+[28157](https://github.com/flutter/flutter/pull/28157) Add await to future to please analyzer (cla: yes, framework, team)
+
+[28159](https://github.com/flutter/flutter/pull/28159) [Material] Expand BottomNavigationBar API (reprise) (cla: no, f: material design, framework)
+
+[28163](https://github.com/flutter/flutter/pull/28163) [Material] Add ability to set shadow color and selected shadow color for chips and for chip themes (cla: yes, f: material design, framework)
+
+[28166](https://github.com/flutter/flutter/pull/28166) Add some more CupertinoPicker doc (cla: yes, d: api docs, f: cupertino, framework)
+
+[28168](https://github.com/flutter/flutter/pull/28168) [flutter_tool,fuchsia_tester] Only require a test source dir for coverage (a: tests, cla: yes, tool, ○ platform-fuchsia)
+
+[28169](https://github.com/flutter/flutter/pull/28169) Add/rewrite tests for FocusScope. (a: text input, cla: yes, framework)
+
+[28171](https://github.com/flutter/flutter/pull/28171) deploy to .dev firebase projects. (cla: yes, team)
+
+[28172](https://github.com/flutter/flutter/pull/28172) Add backgroundColor argument to TextStyle for convenience (cla: yes, framework)
+
+[28174](https://github.com/flutter/flutter/pull/28174) No shrinking for BackdropFilter's cull rect (cla: yes, framework, severe: API break, waiting for tree to go green)
+
+[28175](https://github.com/flutter/flutter/pull/28175) Only call Activity.reportFullyDrawn on Lollipop or above (cla: yes, team, team: gallery)
+
+[28193](https://github.com/flutter/flutter/pull/28193) Clean up flutter_gallery.cmx's sandbox (cla: yes, team, team: gallery)
+
+[28214](https://github.com/flutter/flutter/pull/28214) [Material] Add the ability to theme trailing app bar actions independently from leading (cla: yes, f: material design, framework)
+
+[28215](https://github.com/flutter/flutter/pull/28215) Minor UI tweaks to Cards demo based on internal feedback (cla: yes, team, team: gallery)
+
+[28242](https://github.com/flutter/flutter/pull/28242) Add long-press-move support for text fields 2 (a: text input, cla: yes, f: cupertino, f: gestures, f: material design, framework, severe: API break)
+
+[28245](https://github.com/flutter/flutter/pull/28245) [Typo] Update 'use' to 'user' (cla: yes, d: api docs, f: material design, framework)
+
+[28264](https://github.com/flutter/flutter/pull/28264) Fix the length of the valueHelp on the --sample option for the create command, and turn on wrapping. (cla: yes, d: examples, tool)
+
+[28280](https://github.com/flutter/flutter/pull/28280) [fuchsia] Fix paths to find and ls (cla: yes, tool, ○ platform-fuchsia)
+
+[28281](https://github.com/flutter/flutter/pull/28281) Reduce memory benchmark perf tests outer loop to 10. (cla: yes, team)
+
+[28290](https://github.com/flutter/flutter/pull/28290) Text selection via mouse (a: text input, cla: yes, f: gestures, framework)
+
+[28291](https://github.com/flutter/flutter/pull/28291) Reland #27754, now that bsdiff has moved to flutter/packages. (cla: yes, team)
+
+[28295](https://github.com/flutter/flutter/pull/28295) Revert "Allow for gradle downloading missing SDK assets" (cla: yes, tool, ▣ platform-android)
+
+[28296](https://github.com/flutter/flutter/pull/28296) Roll the engine to 5db4b377244bae48bc21e449e616417e68c9a6b9 (cla: yes)
+
+[28297](https://github.com/flutter/flutter/pull/28297) Test reporter (a: tests, cla: yes, team, waiting for tree to go green)
+
+[28302](https://github.com/flutter/flutter/pull/28302) Add basic web device and run support (cla: yes, tool)
+
+[28308](https://github.com/flutter/flutter/pull/28308) Roll engine to 043d92c48abdebdad926569bc204a59c5cf20a11 (cla: yes)
+
+[28309](https://github.com/flutter/flutter/pull/28309) Roll engine to cb0f7ece1f251c78a07550db89d0fcb3edf61e3c (cla: yes)
+
+[28315](https://github.com/flutter/flutter/pull/28315) Roll engine to 33bb91cc15916610261097eb971ec8a11b804d06 (cla: yes)
+
+[28334](https://github.com/flutter/flutter/pull/28334) Remove unused --packages argument to gen_snapshot. (cla: yes, team, tool)
+
+[28341](https://github.com/flutter/flutter/pull/28341) use deviceManager discovery in daemon protocol (cla: yes, tool)
+
+[28343](https://github.com/flutter/flutter/pull/28343) pass --skip-build-script-checks and remove module usage (cla: yes, team)
+
+[28346](https://github.com/flutter/flutter/pull/28346) [flutter_tool,fuchsia] Add missing dep to flutter_tool (cla: yes, team, tool)
+
+[28349](https://github.com/flutter/flutter/pull/28349) Dynamic patching support for native code libraries. (cla: yes, t: gradle, tool, ▣ platform-android)
+
+[28352](https://github.com/flutter/flutter/pull/28352) only perform multi-root mapping if there are multiple roots (cla: yes, tool)
+
+[28355](https://github.com/flutter/flutter/pull/28355) Reland "Allow for gradle downloading missing SDK assets" (#28097) (cla: yes, t: gradle, tool, waiting for tree to go green, ▣ platform-android)
+
+[28356](https://github.com/flutter/flutter/pull/28356) Log pub return code on failure on Windows (cla: yes, tool, ❖ platform-windows)
+
+[28369](https://github.com/flutter/flutter/pull/28369) Add LICENSE test to presubmit checks (cla: yes, team)
+
+[28370](https://github.com/flutter/flutter/pull/28370) Removed trailing whitespace from the end of the CI config (cla: yes, team)
+
+[28371](https://github.com/flutter/flutter/pull/28371) Ensure that the DropdownButton menu respects its parents bounds (cla: yes, f: material design, framework)
+
+[28372](https://github.com/flutter/flutter/pull/28372) V1.2.1 hotfix.1 --- cherry-pick  (cla: yes, team)
+
+[28373](https://github.com/flutter/flutter/pull/28373) Mark non-flaky test as such (a: tests, cla: yes, team)
+
+[28376](https://github.com/flutter/flutter/pull/28376) Revert "Shader warm up (#27660)" (cla: yes, team, team: flakes)
+
+[28386](https://github.com/flutter/flutter/pull/28386) remove personal repo and replace with trivial example for smoke test (cla: yes, tool)
+
+[28398](https://github.com/flutter/flutter/pull/28398) fix red build for analysis (a: typography, cla: yes, framework)
+
+[28400](https://github.com/flutter/flutter/pull/28400) update packages (cla: yes, team)
+
+[28431](https://github.com/flutter/flutter/pull/28431) [Gallery] Fix fortnightly analysis for consts. (cla: yes, team, team: gallery)
+
+[28470](https://github.com/flutter/flutter/pull/28470) Throw assertion error when a Hero has a Hero child. (cla: yes, framework, waiting for tree to go green)
+
+[28472](https://github.com/flutter/flutter/pull/28472) Add SHA256 checksums to published metadata (cla: yes, team)
+
+[28477](https://github.com/flutter/flutter/pull/28477) Fix backspace and clear length in AnsiStatus (cla: yes, tool)
+
+[28478](https://github.com/flutter/flutter/pull/28478) Support iOS devices reporting pressure data of 0 (cla: yes, f: cupertino, f: gestures, f: material design, ⚠ TODAY)
+
+[28480](https://github.com/flutter/flutter/pull/28480) increase timeout (a: tests, cla: yes, team, team: flakes)
+
+[28482](https://github.com/flutter/flutter/pull/28482) Fuschia -> Fuchsia (cla: yes, team)
+
+[28517](https://github.com/flutter/flutter/pull/28517) remove json_schema dep again (cla: yes)
+
+[28527](https://github.com/flutter/flutter/pull/28527) Be more strict about finding version number attached to a revision when packaging. (cla: yes, team)
+
+[28530](https://github.com/flutter/flutter/pull/28530) Fix type issue of the timelineEvents assignment (cla: yes)
+
+[28537](https://github.com/flutter/flutter/pull/28537) Reland "Shader warm up (#27660)" (cla: yes, framework, severe: performance)
+
+[28540](https://github.com/flutter/flutter/pull/28540) Add animation curve slowMiddle (a: animation, cla: yes, framework, severe: new feature)
+
+[28546](https://github.com/flutter/flutter/pull/28546) Call onTapCancel when down pointer gets cancelled (cla: yes, f: gestures, framework)
+
+[28555](https://github.com/flutter/flutter/pull/28555) disable dart2js test (a: tests, cla: yes, team)
+
+[28558](https://github.com/flutter/flutter/pull/28558) Fix typo (a: text input, cla: yes, d: api docs, f: material design)
+
+[28597](https://github.com/flutter/flutter/pull/28597) Adjust remaining Cupertino route animations to match native (a: fidelity, cla: yes, f: cupertino, f: routes, waiting for tree to go green)
+
+[28598](https://github.com/flutter/flutter/pull/28598) TextField Snippet for API Docs (cla: yes)
+
+[28602](https://github.com/flutter/flutter/pull/28602) Allow PointerEnterEvent and PointerExitEvents to be created from any PointerEvent (a: desktop, cla: yes, f: gestures, framework, severe: API break)
+
+[28603](https://github.com/flutter/flutter/pull/28603) select ResidentCompiler during FlutterDevice initialization (cla: yes, tool)
+
+[28604](https://github.com/flutter/flutter/pull/28604) Add warnings and an example to the TextEditingController docs (a: text input, cla: yes, d: api docs, framework)
+
+[28607](https://github.com/flutter/flutter/pull/28607) Roll engine to 3e4e6f5c54db7a705e6d50f7f3bddfa2ac0d6612 (cla: yes)
+
+[28608](https://github.com/flutter/flutter/pull/28608) Roll engine to 4434a39c7d545ed47186b2f4d98cd09c8366e720 (cla: yes)
+
+[28614](https://github.com/flutter/flutter/pull/28614) Add convex path and non-AA paint to shader warm-up (cla: yes, framework, p: firebase_performance)
+
+[28619](https://github.com/flutter/flutter/pull/28619) Updated gallery light and dark themes (cla: yes, team, team: gallery)
+
+[28629](https://github.com/flutter/flutter/pull/28629) Make sure everything in the Cupertino page transition can be linear when back swiping (cla: yes, f: cupertino, f: routes, framework)
+
+[28638](https://github.com/flutter/flutter/pull/28638) Fix the test annotation used for test groups (a: tests, cla: yes, framework)
+
+[28653](https://github.com/flutter/flutter/pull/28653) Fix ink highlight effect of RawChip (cla: yes)
+
+[28657](https://github.com/flutter/flutter/pull/28657) Fix spelling errors. (cla: yes, framework)
+
+[28658](https://github.com/flutter/flutter/pull/28658) Include git output into error message from channel command (cla: yes, team, tool)
+
+[28661](https://github.com/flutter/flutter/pull/28661) Use a simpler implementation of Diagnosticable.toString when running in profile/release mode (cla: yes, framework)
+
+[28663](https://github.com/flutter/flutter/pull/28663) Update TabController.indexIsChanging doc (cla: yes, framework)
+
+[28666](https://github.com/flutter/flutter/pull/28666) Make RenderUiKitView reject absorbed touch events (cla: yes, framework)
+
+[28669](https://github.com/flutter/flutter/pull/28669) Drive-by fix for TODO (cla: yes)
+
+[28672](https://github.com/flutter/flutter/pull/28672) Support hotfix version numbers (cla: yes, tool)
+
+[28673](https://github.com/flutter/flutter/pull/28673) Add missing trailing commas (cla: yes, team)
+
+[28675](https://github.com/flutter/flutter/pull/28675) Update docs for ancestorWidgetOfExactType (cla: yes, d: api docs, framework, waiting for tree to go green)
+
+[28679](https://github.com/flutter/flutter/pull/28679) Shader warm-up doc fixes (cla: yes)
+
+[28681](https://github.com/flutter/flutter/pull/28681) Expanded Snippet for API Docs (cla: yes, d: api docs, d: examples)
+
+[28683](https://github.com/flutter/flutter/pull/28683) Remove the old HaTS implementation on API docs (cla: yes, d: api docs)
+
+[28684](https://github.com/flutter/flutter/pull/28684) Add capability to run build_runner tests for tool (cla: yes)
+
+[28687](https://github.com/flutter/flutter/pull/28687) Make shader warm-up async so it can handle image (cla: yes)
+
+[28688](https://github.com/flutter/flutter/pull/28688) Initialize the lifecycle state with initial state in window. Roll engine (19 commits) (cla: yes, customer: mulligan (g3), framework)
+
+[28698](https://github.com/flutter/flutter/pull/28698) Roll engine to 99f3f7a9c246f1ebedc6eefd867cde250b370380 (cla: yes)
+
+[28709](https://github.com/flutter/flutter/pull/28709) improve error messages on Text constructors (cla: yes, framework)
+
+[28734](https://github.com/flutter/flutter/pull/28734) Update README.md (cla: yes)
+
+[28735](https://github.com/flutter/flutter/pull/28735) [Material] Create a FloatingActionButton ThemeData and honor it within the FloatingActionButton (cla: yes, f: material design, framework)
+
+[28736](https://github.com/flutter/flutter/pull/28736) Avoid the overhead of instantiating a generator in paintImage (cla: yes, framework)
+
+[28746](https://github.com/flutter/flutter/pull/28746) Remove timeout from add2app test for iOS (a: tests, cla: yes, team, ⌺‬ platform-ios)
+
+[28747](https://github.com/flutter/flutter/pull/28747) Part 1: Improve Overlay API (cla: yes, framework)
+
+[28748](https://github.com/flutter/flutter/pull/28748) Revert "Remove the old HaTS implementation on API docs" (cla: yes, d: api docs, team)
+
+[28749](https://github.com/flutter/flutter/pull/28749) Add minimum time gap requirement to double tap (cla: yes, f: gestures, framework)
+
+[28751](https://github.com/flutter/flutter/pull/28751) Expose decorationThickness in TextStyle. Roll engine (12 commits) (a: typography, cla: yes, framework)
+
+[28752](https://github.com/flutter/flutter/pull/28752) FAB Snippet for API Docs (cla: yes, d: api docs, d: examples, f: material design, framework)
+
+[28756](https://github.com/flutter/flutter/pull/28756) Handle Cupertino back gesture interrupted by Navigator push (cla: yes, f: cupertino, framework)
+
+[28759](https://github.com/flutter/flutter/pull/28759) switch tool tests to build runner (cla: yes)
+
+[28799](https://github.com/flutter/flutter/pull/28799) Add semantics label to FadeInImage. (cla: yes, framework)
+
+[28809](https://github.com/flutter/flutter/pull/28809) fix some formatting issues (cla: yes, framework, team)
+
+[28821](https://github.com/flutter/flutter/pull/28821) [fuchsia] Permit relative entries to the fuchsia_tester (cla: yes, tool)
+
+[28845](https://github.com/flutter/flutter/pull/28845) [Material] Fix radio ink ripple to be centered (cla: yes, f: material design, framework)
+
+[28852](https://github.com/flutter/flutter/pull/28852) Update macOS version in tests (a: tests, cla: yes, team)
+
+[28855](https://github.com/flutter/flutter/pull/28855) Move material iOS back swipe test to material (cla: yes, f: cupertino, framework)
+
+[28857](https://github.com/flutter/flutter/pull/28857) Form Snippet for API Docs (cla: yes, d: api docs, d: examples, framework)
+
+[28863](https://github.com/flutter/flutter/pull/28863) Fall-back to platform tools in Android SDK detection logic. (cla: yes, tool, waiting for tree to go green)
+
+[28866](https://github.com/flutter/flutter/pull/28866) Add build script invalidation and snapshotting logic (cla: yes, tool)
+
+[28873](https://github.com/flutter/flutter/pull/28873) Remove extra build_runner modes, remove flutter_build (cla: yes, tool)
+
+[28888](https://github.com/flutter/flutter/pull/28888) Changed flutter.io to flutter.dev on each link on readme file (cla: yes, team)
+
+[28899](https://github.com/flutter/flutter/pull/28899) Roll engine 4f54a1dd9...e6a5201f0 (cla: yes)
+
+[28900](https://github.com/flutter/flutter/pull/28900) Add key support to cupertino button (cla: yes, f: cupertino, framework, waiting for tree to go green)
+
+[28919](https://github.com/flutter/flutter/pull/28919) Always composite PhysicalModels (cla: yes, framework, severe: API break)
+
+[28922](https://github.com/flutter/flutter/pull/28922) Fix crash on flutter update-packages (cla: yes)
+
+[28933](https://github.com/flutter/flutter/pull/28933) Fix indentations of statements in BlockFunctionBody (cla: yes, framework, team)
+
+[28938](https://github.com/flutter/flutter/pull/28938) Add a `flutter create --list-samples` command (cla: yes, tool)
+
+[28944](https://github.com/flutter/flutter/pull/28944) fix missing variable name (cla: yes, framework, waiting for tree to go green)
+
+[28951](https://github.com/flutter/flutter/pull/28951) Quick fix for shader warm up (cla: yes, framework)
+
+[28953](https://github.com/flutter/flutter/pull/28953) Include platformViewId in semantics tree (cla: yes, framework, severe: API break)
+
+[28955](https://github.com/flutter/flutter/pull/28955) Add more doc pointing to the EditableText's rudimentary nature around gesture handling (cla: yes, framework)
+
+[28963](https://github.com/flutter/flutter/pull/28963) Fix for post submit on cirrus (cla: yes)
+
+[28970](https://github.com/flutter/flutter/pull/28970) Fix coverage shard and print summary after test run (cla: yes, waiting for tree to go green)
+
+[28975](https://github.com/flutter/flutter/pull/28975) Revert "Roll engine f4951df193a7..471a2c89a689 (11 commits)" (cla: yes)
+
+[28990](https://github.com/flutter/flutter/pull/28990) Fix MouseTracker annotation leak (cla: yes, f: gestures, framework, waiting for tree to go green)
+
+[29008](https://github.com/flutter/flutter/pull/29008) Update CupertinoTextField (cla: yes, f: cupertino, framework, waiting for tree to go green)
+
+[29010](https://github.com/flutter/flutter/pull/29010) re-enable dart2js test (cla: yes, tool)
+
+[29012](https://github.com/flutter/flutter/pull/29012) Remove doc references to obsolete SemanticsSortOrder (cla: yes)
+
+[29016](https://github.com/flutter/flutter/pull/29016) make coverage work again (cla: yes)
+
+[29020](https://github.com/flutter/flutter/pull/29020) Add integration to all targets (cla: yes)
+
+[29023](https://github.com/flutter/flutter/pull/29023) update readme for LUCI (cla: yes)
+
+[29024](https://github.com/flutter/flutter/pull/29024) Fix CupertinoTabView tree re-shape on view inset change (cla: yes, ⚠ TODAY)
+
+[29025](https://github.com/flutter/flutter/pull/29025) print system time on all mac builds (a: tests, cla: yes, team)
+
+[29030](https://github.com/flutter/flutter/pull/29030) Revert "re-enable dart2js test" (cla: yes)
+
+[29048](https://github.com/flutter/flutter/pull/29048) Use async execution for xcodebuild commands (cla: yes, tool)
+
+[29051](https://github.com/flutter/flutter/pull/29051) fix block formatting (cla: yes, framework, team)
+
+[29053](https://github.com/flutter/flutter/pull/29053) Update to Container Sample Code in API Docs (cla: yes, d: api docs, d: examples, framework)
+
+[29054](https://github.com/flutter/flutter/pull/29054) Deprecate profile() (cla: yes, framework, waiting for tree to go green)
+
+[29056](https://github.com/flutter/flutter/pull/29056) add heartbeat (cla: yes)
+
+[29057](https://github.com/flutter/flutter/pull/29057) Fix Flex class docs by replacing 'vertical space' with 'space on its main axis' so that the language fits both column and row. (cla: yes, framework, waiting for tree to go green)
+
+[29062](https://github.com/flutter/flutter/pull/29062) fix windows codegen (cla: yes, tool)
+
+[29064](https://github.com/flutter/flutter/pull/29064) Revert "Lazily download artifacts (III)" (cla: yes)
+
+[29069](https://github.com/flutter/flutter/pull/29069) Heroes and nested Navigators (a: animation, cla: yes, framework)
+
+[29072](https://github.com/flutter/flutter/pull/29072) Update to ListView Sample Code in API Docs (cla: yes, d: api docs, d: examples, framework)
+
+[29073](https://github.com/flutter/flutter/pull/29073) Make sure test reporter prints out stderr, and disables Bigquery for non-contributors (a: tests, cla: yes, team)
+
+[29093](https://github.com/flutter/flutter/pull/29093) Revert "Fix TextField height issues" (cla: yes)
+
+[29126](https://github.com/flutter/flutter/pull/29126) Cause `flutter analyze` to fail if the analysis server experienced an error. (cla: yes, team, tool)
+
+[29129](https://github.com/flutter/flutter/pull/29129) Update .cirrus.yml (cla: yes)
+
+[29134](https://github.com/flutter/flutter/pull/29134) Properly escape Android SDK Manager path in error message (cla: yes, tool, waiting for tree to go green)
+
+[29138](https://github.com/flutter/flutter/pull/29138) Update DropdownButton underline to be customizable (cla: yes, f: material design)
+
+[29156](https://github.com/flutter/flutter/pull/29156) Fix typo in RefreshIndicator constructor API doc (cla: yes)
+
+[29165](https://github.com/flutter/flutter/pull/29165) Docs edit for Tab Label Color (cla: yes, d: api docs, f: material design, framework)
+
+[29171](https://github.com/flutter/flutter/pull/29171) Only run codegen at start of flutter_test (cla: yes, tool)
+
+[29175](https://github.com/flutter/flutter/pull/29175) Ensure that animated pairs of Tabs TextStyles have matching inherited values (cla: yes, f: material design, framework)
+
+[29179](https://github.com/flutter/flutter/pull/29179) No image shader caching in default shader warm-up (cla: yes, framework)
+
+[29183](https://github.com/flutter/flutter/pull/29183) Implement labelPadding configuration in TabBarTheme  (cla: yes, f: material design, framework)
+
+[29188](https://github.com/flutter/flutter/pull/29188) Fix 25807: implement move in sliver multibox widget (cla: yes, f: material design, framework, severe: API break)
+
+[29189](https://github.com/flutter/flutter/pull/29189) MaterialButton shape should override ButtonTheme shape (cla: yes, f: material design, framework)
+
+[29192](https://github.com/flutter/flutter/pull/29192) Update upgrade to rebase and stash local changes. (cla: yes, tool)
+
+[29195](https://github.com/flutter/flutter/pull/29195) Add sample to forEachTween (a: animation, cla: yes, framework)
+
+[29196](https://github.com/flutter/flutter/pull/29196) Detect and cleanup leaky processes (a: tests, cla: yes, team: flakes)
+
+[29200](https://github.com/flutter/flutter/pull/29200) Cupertino localization step 1: add an English arb file (a: internationalization, cla: yes, f: cupertino, framework)
+
+[29229](https://github.com/flutter/flutter/pull/29229) Install JDK and Android SDK only for integration tests (cla: yes, team, waiting for tree to go green)
+
+[29231](https://github.com/flutter/flutter/pull/29231) Adds macOS raw keyboard mapping (a: desktop, cla: yes, framework)
+
+[29236](https://github.com/flutter/flutter/pull/29236) Add skip to group in test_compat (a: tests, cla: yes, framework)
+
+[29245](https://github.com/flutter/flutter/pull/29245) Fix DartDoc for UniqueKey (cla: yes, d: api docs, framework, waiting for tree to go green)
+
+[29247](https://github.com/flutter/flutter/pull/29247) Update flutter_localizations translations (cla: yes)
+
+[29250](https://github.com/flutter/flutter/pull/29250) Text field height attempt 2 (cla: yes, f: cupertino, f: material design, framework)
+
+[29258](https://github.com/flutter/flutter/pull/29258) Add dump-shader-skp flag to flutter tools (cla: yes, tool)
+
+[29273](https://github.com/flutter/flutter/pull/29273) Speculative fix for #29262 (a: tests, cla: yes, team)
+
+[29304](https://github.com/flutter/flutter/pull/29304) Include platformViewId in semantics tree for iOS (a: accessibility, a: platform-views, cla: yes, framework, ⌺‬ platform-ios)
+
+[29314](https://github.com/flutter/flutter/pull/29314) Revert "Always composite PhysicalModels" (cla: yes)
+
+[29319](https://github.com/flutter/flutter/pull/29319) Revert "Speculative fix for #29262" (cla: yes)
+
+[29321](https://github.com/flutter/flutter/pull/29321) add option for --verbose-system-logs (cla: yes)
+
+[29329](https://github.com/flutter/flutter/pull/29329) Error message when TextSelectionOverlay finds no Overlay (cla: yes, framework)
+
+[29330](https://github.com/flutter/flutter/pull/29330) Revert "Roll engine 31b289f277c6..b1b388f1c235 (7 commits)", Roll to 8b1a299ed instead. (cla: yes)
+
+[29332](https://github.com/flutter/flutter/pull/29332) add assert if length of TabController and number of tabs do not match (cla: yes, f: material design, framework)
+
+[29340](https://github.com/flutter/flutter/pull/29340) guard new formatter behind env var (a: tests, cla: yes, team)
+
+[29342](https://github.com/flutter/flutter/pull/29342) Add semantic label finders (a: accessibility, a: tests, cla: yes, t: flutter driver)
+
+[29363](https://github.com/flutter/flutter/pull/29363) Manual engine roll with goldens (cla: yes)
+
+[29369](https://github.com/flutter/flutter/pull/29369) Update README.md (cla: yes, waiting for tree to go green)
+
+[29374](https://github.com/flutter/flutter/pull/29374) Revert "Manual engine roll with goldens" (cla: yes)
+
+[29377](https://github.com/flutter/flutter/pull/29377) Roll engine to 403337ebb893380101d1fa9cc435ce9b6cfeb22c (cla: yes)
+
+[29383](https://github.com/flutter/flutter/pull/29383) --verbose-logging to verbose-logging in android (cla: yes)
+
+[29385](https://github.com/flutter/flutter/pull/29385) Skip Dialog interaction on macos (cla: yes)
+
+[29386](https://github.com/flutter/flutter/pull/29386) Use fs.identical to compare paths when finding the engine source path (cla: yes)
+
+[29387](https://github.com/flutter/flutter/pull/29387) Make it easier to ensure semantics in widgetTests (a: accessibility, a: tests, cla: yes)
+
+[29389](https://github.com/flutter/flutter/pull/29389) Update SDK constraints to reflect the fact that set literals are being used (cla: yes)
+
+[29390](https://github.com/flutter/flutter/pull/29390) Make expansion panel optionally toggle its state by tapping its header. (cla: yes, f: material design, framework, severe: new feature)
+
+[29395](https://github.com/flutter/flutter/pull/29395) Fix text selection when user is dragging in the opposite direction (a: text input, cla: yes, framework)
+
+[29399](https://github.com/flutter/flutter/pull/29399) Enable code generation features in tool (via opt-in) (cla: yes, tool)
+
+[29403](https://github.com/flutter/flutter/pull/29403) Disable widget inspector scroll test (cla: yes)
+
+[29404](https://github.com/flutter/flutter/pull/29404) Improve flutter test startup time (cla: yes, tool)
+
+[29407](https://github.com/flutter/flutter/pull/29407) [cupertino_icons] Add circle and circle_filled, for radio buttons. (cla: yes, f: cupertino, framework, waiting for tree to go green)
+
+[29413](https://github.com/flutter/flutter/pull/29413) Fix MaterialApp's _navigatorObserver when only builder used (cla: yes, f: material design, framework)
+
+[29434](https://github.com/flutter/flutter/pull/29434) Add builders and engine hash to fingerprint (cla: yes, tool)
+
+[29442](https://github.com/flutter/flutter/pull/29442) Align Snippet for API Docs (cla: yes, d: api docs, d: examples, framework)
+
+[29445](https://github.com/flutter/flutter/pull/29445) Add doc about MediaQuery to Chip (cla: yes, d: api docs, f: material design, framework)
+
+[29451](https://github.com/flutter/flutter/pull/29451) Added opacity to cupertino switch when disabled (cla: yes, f: cupertino)
+
+[29452](https://github.com/flutter/flutter/pull/29452) some spaces formatting (cla: yes, framework, team)
+
+[29454](https://github.com/flutter/flutter/pull/29454) Update another SDK constraint (cla: yes, customer: fuchsia, team)
+
+[29456](https://github.com/flutter/flutter/pull/29456) Fix for sometimes packages file is an APK (cla: yes)
+
+[29461](https://github.com/flutter/flutter/pull/29461) Remove explicit frame schedule (cla: yes, tool)
+
+[29463](https://github.com/flutter/flutter/pull/29463) Make real JSON in arb (cla: yes, f: cupertino, framework)
+
+[29467](https://github.com/flutter/flutter/pull/29467) prevent stream notifications from interfering with reload (a: tests, cla: yes, team)
+
+[29469](https://github.com/flutter/flutter/pull/29469) fix asset reloading (cla: yes, tool)
+
+[29474](https://github.com/flutter/flutter/pull/29474) Let CupertinoTextField's clear button also call onChanged (cla: yes, f: cupertino, framework, waiting for tree to go green)
+
+[29494](https://github.com/flutter/flutter/pull/29494) initial work on coverage generating script for tool (cla: yes, tool)
+
+[29499](https://github.com/flutter/flutter/pull/29499) Set custom flutter_assets by add FLTAssetsPath to AppFrameworkInfo.plist (cla: yes, tool, waiting for tree to go green)
+
+[29528](https://github.com/flutter/flutter/pull/29528) Ensure that assumed formatting of properties file is correct (cla: yes, tool)
+
+[29532](https://github.com/flutter/flutter/pull/29532) Reland composite physical layers on all platforms (cla: yes, customer: dream (g3), customer: fuchsia, framework)
+
+[29540](https://github.com/flutter/flutter/pull/29540) Improve Navigator documentation (cla: yes)
+
+[29563](https://github.com/flutter/flutter/pull/29563) Avoid flickering while dragging to select text (cla: yes, f: material design, framework)
+
+[29564](https://github.com/flutter/flutter/pull/29564) Update progress indicator API docs (cla: yes, f: material design, framework)
+
+[29566](https://github.com/flutter/flutter/pull/29566) Manually roll engine to 5088735e5f (a: tests, cla: yes, framework)
+
+[29568](https://github.com/flutter/flutter/pull/29568) make build runner configurable (cla: yes, team)
+
+[29572](https://github.com/flutter/flutter/pull/29572) DropdownButton Icon customizability (cla: yes, f: material design, framework)
+
+[29604](https://github.com/flutter/flutter/pull/29604) added friendlier error for invalid AndroidManifest.xml (cla: yes, tool, ▣ platform-android)
+
+[29619](https://github.com/flutter/flutter/pull/29619) make literals const for @immutable constructors (cla: yes, team)
+
+[29621](https://github.com/flutter/flutter/pull/29621) Update PULL_REQUEST_TEMPLATE.md (cla: yes, team)
+
+[29623](https://github.com/flutter/flutter/pull/29623) Revert "Reland composite physical layers on all platforms" (cla: yes, framework)
+
+[29625](https://github.com/flutter/flutter/pull/29625) Fix typo in flutter_tools (cla: yes, tool)
+
+[29627](https://github.com/flutter/flutter/pull/29627) Manual engine roll for 2019-03-19 (cla: yes)
+
+[29630](https://github.com/flutter/flutter/pull/29630) Add heart shapes to CupertinoIcons (cla: yes, f: cupertino, framework)
+
+[29632](https://github.com/flutter/flutter/pull/29632) Enable platform views for Flutter Gallery on iOS. (cla: yes, team, team: gallery)
+
+[29633](https://github.com/flutter/flutter/pull/29633) Download secondary SDK (cla: yes, tool)
+
+[29638](https://github.com/flutter/flutter/pull/29638) Fix transition to stock details (cla: yes, team, team: gallery)
+
+[29641](https://github.com/flutter/flutter/pull/29641) Fix links on homepage of API docs (cla: yes, d: api docs, framework)
+
+[29644](https://github.com/flutter/flutter/pull/29644) Cupertino localization step 3: in-place move some material tools around to make room for cupertino (cla: yes, f: cupertino, f: material design, framework)
+
+[29650](https://github.com/flutter/flutter/pull/29650) Cupertino localization step 4: let generated date localization combine material and cupertino locales (cla: yes, f: cupertino, f: material design, framework)
+
+[29654](https://github.com/flutter/flutter/pull/29654) Include brackets on OutlineButton doc (cla: yes, d: api docs, f: material design, framework)
+
+[29669](https://github.com/flutter/flutter/pull/29669) Speed up CI via mojave-flutter image (a: tests, cla: yes, team)
+
+[29677](https://github.com/flutter/flutter/pull/29677) Fix calculation of hero rectTween when Navigator isn't fullscreen (a: animation, cla: yes, customer: solaris, framework, waiting for tree to go green)
+
+[29684](https://github.com/flutter/flutter/pull/29684) Revert last 2 engine rolls. (cla: yes)
+
+[29693](https://github.com/flutter/flutter/pull/29693) Use source list from the compiler to track invalidated files for hot reload. (cla: yes, t: hot reload, tool)
+
+[29697](https://github.com/flutter/flutter/pull/29697) Embedding new diagrams for API Docs (cla: yes, d: api docs, d: examples, framework)
+
+[29699](https://github.com/flutter/flutter/pull/29699) Fix more tests for ANSI terminals (cla: yes, tool)
+
+[29701](https://github.com/flutter/flutter/pull/29701) Reland composite physical layers for all platforms (cla: yes, framework)
+
+[29708](https://github.com/flutter/flutter/pull/29708) Cupertino localization step 5: add french arb as translated example (cla: yes, f: cupertino, framework)
+
+[29721](https://github.com/flutter/flutter/pull/29721) Use Dart version in script cache check (cla: yes, tool)
+
+[29747](https://github.com/flutter/flutter/pull/29747) Allowing adding/updating packages during hot reload (cla: yes)
+
+[29754](https://github.com/flutter/flutter/pull/29754) Revert "Enable platform views for Flutter Gallery on iOS." (cla: yes)
+
+[29758](https://github.com/flutter/flutter/pull/29758) Linking Higher & Lower Class Docs (cla: yes, d: api docs, framework)
+
+[29760](https://github.com/flutter/flutter/pull/29760) some formatting of map, parameters and spaces (cla: yes, framework, team)
+
+[29764](https://github.com/flutter/flutter/pull/29764) update fuchsia-attach to configure dev_finder location (cla: yes, tool)
+
+[29767](https://github.com/flutter/flutter/pull/29767) Cupertino localization step 6: add a GlobalCupertinoLocalizations base class with date time formatting (cla: yes, f: cupertino)
+
+[29768](https://github.com/flutter/flutter/pull/29768) Directly depend on frontend_server tool in fuchsia_attach (cla: yes, tool)
+
+[29769](https://github.com/flutter/flutter/pull/29769) Add support for text selection via mouse to Cupertino text fields (cla: yes, f: cupertino, framework)
+
+[29771](https://github.com/flutter/flutter/pull/29771) Set Max Height for ListTile trailing and leading widgets (cla: yes, f: material design, framework)
+
+[29779](https://github.com/flutter/flutter/pull/29779) Removes unnecessary "new" in documentation (cla: yes)
+
+[29780](https://github.com/flutter/flutter/pull/29780) Revert "Update upgrade to rebase and stash local changes." (cla: yes)
+
+[29783](https://github.com/flutter/flutter/pull/29783) Fix cache location, artifacts, and re-enable dart2js test (cla: yes, tool)
+
+[29785](https://github.com/flutter/flutter/pull/29785) Lazy cache 4: A New Hope (cla: yes, tool)
+
+[29786](https://github.com/flutter/flutter/pull/29786) Update upgrade to stash local changes and reset off of hotfix branches (cla: yes, tool)
+
+[29811](https://github.com/flutter/flutter/pull/29811) TextField Validator Height Docs (cla: yes, f: material design, framework)
+
+[29817](https://github.com/flutter/flutter/pull/29817) roll engine to 5f8ae420c1ac61bbbb26e61251d129c879fc788d (cla: yes)
+
+[29818](https://github.com/flutter/flutter/pull/29818) dont fail build if codegen fails (cla: yes, tool)
+
+[29821](https://github.com/flutter/flutter/pull/29821) Cupertino localization step 1.5: fix a resource mismatch in cupertino_en.arb (cla: yes, f: cupertino, framework)
+
+[29822](https://github.com/flutter/flutter/pull/29822) Cupertino localization step 7: modularize material specific things out of gen_localizations.dart (cla: yes, f: cupertino, framework)
+
+[29824](https://github.com/flutter/flutter/pull/29824) Cupertino localization step 8: create a gen_cupertino_localizations and generate one for cupertino english and french (cla: yes, f: cupertino, framework)
+
+[29860](https://github.com/flutter/flutter/pull/29860) Move binarySearch to foundation. (cla: yes, framework)
+
+[29861](https://github.com/flutter/flutter/pull/29861) Wrap Timeline calls in assert for material/about.dart (cla: yes)
+
+[29883](https://github.com/flutter/flutter/pull/29883) Watch wildcard directories in addition to asset bundle (cla: yes, tool)
+
+[29885](https://github.com/flutter/flutter/pull/29885) ensure packages file is updated when using build_runner (cla: yes, tool)
+
+[29908](https://github.com/flutter/flutter/pull/29908) Update Twitter handle @flutterio -> @FlutterDev (cla: yes, team, team: gallery)
+
+[29928](https://github.com/flutter/flutter/pull/29928) Limit the semantic nodes ID range to 2^16 (cla: yes, framework)
+
+[29929](https://github.com/flutter/flutter/pull/29929) Remove tranparent paint hack from BackdropFilter (cla: yes, framework)
+
+[29938](https://github.com/flutter/flutter/pull/29938) Pass FLUTTER_TOOL_ARGS to snapshot command. (cla: yes, tool)
+
+[29942](https://github.com/flutter/flutter/pull/29942) [fuchsia] Fix flutter_tool BUILD.gn deps (cla: yes, tool)
+
+[29943](https://github.com/flutter/flutter/pull/29943) Remove unwanted gap between navigation bar and safe area's child (cla: yes, f: cupertino, framework)
+
+[29946](https://github.com/flutter/flutter/pull/29946) Let CupertinoPageScaffold have tap status bar to scroll to top (cla: yes, f: cupertino)
+
+[29980](https://github.com/flutter/flutter/pull/29980) Fix issue with account drawer header arrow rotating when setState is called (cla: yes, f: material design)
+
+[29985](https://github.com/flutter/flutter/pull/29985) Revert "Lazy cache 4" (cla: yes)
+
+[29986](https://github.com/flutter/flutter/pull/29986) Lazy cache 5: The Empire Strikes Back (cla: yes, tool)
+
+[29987](https://github.com/flutter/flutter/pull/29987) update CupertinoSwitch documentation (cla: yes, d: api docs, f: cupertino, framework)
+
+[29989](https://github.com/flutter/flutter/pull/29989) Avoid overwriting task result for non-leak checkers (a: tests, cla: yes, team, tool)
+
+[29993](https://github.com/flutter/flutter/pull/29993) Adds the keyboard mapping for Linux (a: desktop, cla: yes, framework)
+
+[29998](https://github.com/flutter/flutter/pull/29998) Fix edge cases of PointerEventConverter (cla: yes, framework, waiting for tree to go green)
+
+[30019](https://github.com/flutter/flutter/pull/30019) Update to latest matcher (cla: yes, team)
+
+[30032](https://github.com/flutter/flutter/pull/30032) Introduce --report-timings flag for flutter build aot command. (cla: yes, tool)
+
+[30040](https://github.com/flutter/flutter/pull/30040) Implement focus traversal for desktop platforms, shoehorn edition. (a: desktop, cla: yes, framework, severe: API break)
+
+[30048](https://github.com/flutter/flutter/pull/30048) Document that Hero needs to be present on destination page's zero frame (cla: yes, d: api docs, f: material design, framework)
+
+[30053](https://github.com/flutter/flutter/pull/30053) Make timeout durations configurable (cla: yes, tool)
+
+[30055](https://github.com/flutter/flutter/pull/30055) Change -c to --enable-asserts (cla: yes)
+
+[30058](https://github.com/flutter/flutter/pull/30058) Draggable Scrollable sheet (cla: yes, framework)
+
+[30059](https://github.com/flutter/flutter/pull/30059) Added link to Hero animation docs from Hero docs (cla: yes, d: api docs, f: material design, framework)
+
+[30071](https://github.com/flutter/flutter/pull/30071) Move spinner `_defaultSlowWarning` message to a new line (cla: yes, tool)
+
+[30075](https://github.com/flutter/flutter/pull/30075) Ensure that flutter run/drive/test/update_packages only downloads required artifacts (cla: yes, tool)
+
+[30078](https://github.com/flutter/flutter/pull/30078) Add more test coverage to image handling (cla: yes, framework)
+
+[30082](https://github.com/flutter/flutter/pull/30082) skip .dart_tool folders when running update-packages (cla: yes)
+
+[30115](https://github.com/flutter/flutter/pull/30115) Forward missing pub commands (cla: yes, tool)
+
+[30123](https://github.com/flutter/flutter/pull/30123) Fix OutlineInputBorder crash (cla: yes, f: material design, framework)
+
+[30129](https://github.com/flutter/flutter/pull/30129) Fix refresh control in the gallery demo, update comments  (cla: yes, f: cupertino, framework)
+
+[30139](https://github.com/flutter/flutter/pull/30139) Intercept errors thrown by synchronous Completers in image resolution. (cla: yes)
+
+[30141](https://github.com/flutter/flutter/pull/30141) Fix a misuse of matchesGoldenFile() in the physical_model_test. (cla: yes)
+
+[30145](https://github.com/flutter/flutter/pull/30145) Error message for setting shaderWarmUp too late (cla: yes)
+
+[30153](https://github.com/flutter/flutter/pull/30153) Allow disabling experimental commands, devices on stable branch (cla: yes, tool)
+
+[30160](https://github.com/flutter/flutter/pull/30160) Cupertino localization 1.9: add needed singular resource for cupertino_en.arb (cla: yes, f: cupertino, framework)
+
+[30194](https://github.com/flutter/flutter/pull/30194) Change order of studies in flutter_gallery (cla: yes)
+
+[30195](https://github.com/flutter/flutter/pull/30195) V1.4.5 hotfixes again (cla: yes)
+
+[30198](https://github.com/flutter/flutter/pull/30198) roll engine to 82765aa77db9621dfbc50801ee2709aa0a00e04d (cla: yes)
+
+[30201](https://github.com/flutter/flutter/pull/30201) update sample code analyzer regexp & test case (cla: yes, d: api docs, team, tool)
+
+[30204](https://github.com/flutter/flutter/pull/30204) disable jit snapshot (cla: yes)
+
+[30205](https://github.com/flutter/flutter/pull/30205) Add missing test case and handle wildcard removal (cla: yes)
+
+[30206](https://github.com/flutter/flutter/pull/30206) Made the showMenu() position parameter required  (cla: yes)
+
+[30212](https://github.com/flutter/flutter/pull/30212) Added assert to prevent complete ListTile trailing/leading horizontal expansion (cla: yes, f: material design, framework)
+
+[30215](https://github.com/flutter/flutter/pull/30215) Check for invalid elevations (cla: yes, customer: dream (g3), customer: fuchsia, framework, severe: customer critical, ○ platform-fuchsia)
+
+[30216](https://github.com/flutter/flutter/pull/30216) make sure flutter test asks for cache upgrades (cla: yes)
+
+[30218](https://github.com/flutter/flutter/pull/30218) [fuchsia_tester] Plumb through the location of icudtl (cla: yes, tool)
+
+[30219](https://github.com/flutter/flutter/pull/30219) Added helpful Material assert message (cla: yes, f: material design, framework)
+
+[30222](https://github.com/flutter/flutter/pull/30222) Add coverage benchmark (cla: yes)
+
+[30227](https://github.com/flutter/flutter/pull/30227) Simplify logic of TapGestureRecognizer (cla: yes, framework)
+
+[30228](https://github.com/flutter/flutter/pull/30228) Make heroes fly on pushReplacement (cla: yes, f: routes, framework)
+
+[30232](https://github.com/flutter/flutter/pull/30232) Revert "Ensure that flutter run/drive/test/update_packages only downloads required artifacts" (cla: yes)
+
+[30235](https://github.com/flutter/flutter/pull/30235) Warn on uncomitted changes (cla: yes, tool)
+
+[30254](https://github.com/flutter/flutter/pull/30254) Reland: Ensure that flutter run/drive/test/update_packages only downloads required artifacts  (cla: yes, tool)
+
+[30275](https://github.com/flutter/flutter/pull/30275) Implement compute for async function (#16265) (cla: yes, framework)
+
+[30276](https://github.com/flutter/flutter/pull/30276) Random trivial fixes in the animation packages (a: animation, cla: yes, framework, waiting for tree to go green)
+
+[30304](https://github.com/flutter/flutter/pull/30304) no need .toList() before .join() (cla: yes, framework)
+
+[30305](https://github.com/flutter/flutter/pull/30305) shorter nullable list duplications (cla: yes, framework, waiting for tree to go green)
+
+[30327](https://github.com/flutter/flutter/pull/30327) Add "feature request" issue template (cla: yes, team)
+
+[30339](https://github.com/flutter/flutter/pull/30339) Add buttons to gestures (a: desktop, cla: yes, framework)
+
+[30343](https://github.com/flutter/flutter/pull/30343) ExpansionPanelList and ExpansionPanelList.radio documentation (cla: yes, d: api docs, f: material design, framework)
+
+[30346](https://github.com/flutter/flutter/pull/30346) Make sure _handleAppFrame is only registered once per frame (cla: yes, framework)
+
+[30348](https://github.com/flutter/flutter/pull/30348) RaisedButton Sample Code Update for Diagrams (cla: yes, d: api docs, d: examples, framework)
+
+[30353](https://github.com/flutter/flutter/pull/30353) Fix minor typo (cla: yes, f: material design, framework)
+
+[30390](https://github.com/flutter/flutter/pull/30390) [Material] Update slider and slider theme with new sizes, shapes, and color mappings (cla: yes, f: material design, framework)
+
+[30398](https://github.com/flutter/flutter/pull/30398) Embedding new raised button diagram. (cla: yes, d: api docs, d: examples, framework, waiting for tree to go green)
+
+[30414](https://github.com/flutter/flutter/pull/30414) Remove pressure customization from some pointer events (cla: yes, framework, severe: API break)
+
+[30415](https://github.com/flutter/flutter/pull/30415) Add 29 Widget of the Week videos (cla: yes, d: api docs, framework)
+
+[30422](https://github.com/flutter/flutter/pull/30422) Commit a navigator.pop as soon as the back swipe is lifted (cla: yes, framework)
+
+[30428](https://github.com/flutter/flutter/pull/30428) Update repair command for Arch Linux (cla: yes, tool)
+
+[30451](https://github.com/flutter/flutter/pull/30451) Bump dartdocs to 0.28.3 (cla: yes, d: api docs, framework)
+
+[30452](https://github.com/flutter/flutter/pull/30452) Moar Videos (cla: yes, d: api docs, framework)
+
+[30453](https://github.com/flutter/flutter/pull/30453) Updating sample code for BottomNavigationBar class for diagram. (cla: yes, d: api docs, d: examples, framework, waiting for tree to go green)
+
+[30455](https://github.com/flutter/flutter/pull/30455) Prevent vertical scroll in shrine by ensuring card size fits the screen (cla: yes, f: material design, framework, team, team: gallery, waiting for tree to go green)
+
+[30456](https://github.com/flutter/flutter/pull/30456) make shellcheck (linter) changes to bin/flutter bash script (cla: yes, tool)
+
+[30457](https://github.com/flutter/flutter/pull/30457) Touching the screen adds `0x01` to buttons (cla: yes, framework)
+
+[30458](https://github.com/flutter/flutter/pull/30458) [fuchsia] Fix isolate filter (cla: yes, customer: fuchsia, tool)
+
+[30460](https://github.com/flutter/flutter/pull/30460) Fix gallery API doc URL launcher (cla: yes, team, team: gallery)
+
+[30461](https://github.com/flutter/flutter/pull/30461) Be more explicit when ValueNotifier notifies (cla: yes, d: api docs, framework, waiting for tree to go green)
+
+[30463](https://github.com/flutter/flutter/pull/30463) Revert "Error message for setting shaderWarmUp too late (#30145)" (cla: yes, framework, waiting for tree to go green)
+
+[30468](https://github.com/flutter/flutter/pull/30468) Embedding diagram for BottomNavigationBar. (cla: yes, d: api docs, d: examples, framework)
+
+[30470](https://github.com/flutter/flutter/pull/30470) Fixed Table flex column layout error #30437 (cla: yes, framework)
+
+[30475](https://github.com/flutter/flutter/pull/30475) Trackpad mode crash fix (cla: yes, f: material design, framework, ⌺‬ platform-ios)
+
+[30497](https://github.com/flutter/flutter/pull/30497) Add confirmDismiss example to flutter_gallery (cla: yes, f: material design, team: gallery)
+
+[30513](https://github.com/flutter/flutter/pull/30513) Fix issue 21640: Assertion Error : '_listenerAttached': is not true (cla: yes, framework)
+
+[30521](https://github.com/flutter/flutter/pull/30521) Provide a default IconTheme in CupertinoTheme (cla: yes, f: cupertino, framework)
+
+[30525](https://github.com/flutter/flutter/pull/30525) Fix cursor outside of input width (cla: yes, f: material design, framework)
+
+[30527](https://github.com/flutter/flutter/pull/30527) Cupertino localization step 11: add more translation clarifications in the instructions (cla: yes, f: cupertino, framework)
+
+[30530](https://github.com/flutter/flutter/pull/30530) Let docker image install fastlane too for Linux (cla: yes)
+
+[30531](https://github.com/flutter/flutter/pull/30531) Correct MaterialButton disabledColor (cla: yes)
+
+[30535](https://github.com/flutter/flutter/pull/30535) Correctly synthesise event buttons (cla: yes, waiting for tree to go green)
+
+[30537](https://github.com/flutter/flutter/pull/30537) Embedded images and added variations to ListTile sample code (cla: yes, d: api docs, f: material design, framework)
+
+[30562](https://github.com/flutter/flutter/pull/30562) Replace flutter.io with flutter.dev (a: first hour, a: quality, cla: yes)
+
+[30563](https://github.com/flutter/flutter/pull/30563) Fixed a typo in the Expanded API doc (cla: yes, d: api docs, framework)
+
+[30570](https://github.com/flutter/flutter/pull/30570) Bump dartdocs to 0.28.3+1 (cla: yes)
+
+[30572](https://github.com/flutter/flutter/pull/30572) [Material] Adaptive Slider constructor (cla: yes, f: material design, framework)
+
+[30578](https://github.com/flutter/flutter/pull/30578) Mark ios-deploy version 2.0.0 as bad (cla: yes, tool)
+
+[30579](https://github.com/flutter/flutter/pull/30579) PointerDownEvent and PointerMoveEvent default `buttons` to 1 (a: desktop, cla: yes, framework, severe: API break)
+
+[30594](https://github.com/flutter/flutter/pull/30594) Update README.md (a: first hour, a: quality, cla: yes)
+
+[30612](https://github.com/flutter/flutter/pull/30612) Added required parameters to FlexibleSpaceBarSettings (cla: yes, f: material design, framework)
+
+[30626](https://github.com/flutter/flutter/pull/30626) Add sample for ValueListenable (cla: yes, d: api docs, framework)
+
+[30640](https://github.com/flutter/flutter/pull/30640) Add `const Border.uniformSide()` (cla: yes, framework)
+
+[30643](https://github.com/flutter/flutter/pull/30643) Add Form.onSaved (a: desktop, cla: yes, framework)
+
+[30644](https://github.com/flutter/flutter/pull/30644) Make FormField._validate() return void (cla: yes, framework)
+
+[30645](https://github.com/flutter/flutter/pull/30645) Add docs to FormFieldValidator (cla: yes, framework)
+
+[30648](https://github.com/flutter/flutter/pull/30648) Allow downloading of desktop embedding artifacts (a: desktop, cla: yes, tool)
+
+[30667](https://github.com/flutter/flutter/pull/30667) Fix additional @mustCallSuper indirect overrides and mixins (cla: yes, framework)
+
+[30746](https://github.com/flutter/flutter/pull/30746) Baseline Aligned Row (cla: yes, f: material design, framework)
+
+[30747](https://github.com/flutter/flutter/pull/30747) Print warning if flutter drive is run in debug (a: tests, cla: yes, t: flutter driver)
+
+[30754](https://github.com/flutter/flutter/pull/30754) [Material] Fix showDialog crasher caused by old contexts (cla: yes, f: material design, framework)
+
+[30755](https://github.com/flutter/flutter/pull/30755) Register Gradle wrapper as universal artifact (cla: yes)
+
+[30760](https://github.com/flutter/flutter/pull/30760) fix cast NPE in invokeListMethod and invokeMapMethod (cla: yes, framework)
+
+[30767](https://github.com/flutter/flutter/pull/30767) Mark cubic_bezier_perf__timeline_summary nonflaky (cla: yes)
+
+[30792](https://github.com/flutter/flutter/pull/30792) Rename Border.uniform() -> Border.fromSide() (cla: yes, framework)
+
+[30793](https://github.com/flutter/flutter/pull/30793) Revert "Add Form.onSaved" (cla: yes, f: material design, framework)
+
+[30796](https://github.com/flutter/flutter/pull/30796) Unbounded TextField width error (cla: yes, f: material design, framework)
+
+[30800](https://github.com/flutter/flutter/pull/30800) Update ListTile sample snippets to use Material Scaffold Template (cla: yes, d: api docs, f: material design, framework)
+
+[30805](https://github.com/flutter/flutter/pull/30805) Update ExpansionPanelList Samples with Scaffold Template (cla: yes, d: api docs, f: material design, framework)
+
+[30809](https://github.com/flutter/flutter/pull/30809)  Fix issue 23527: Exception: RenderViewport exceeded its maximum numb… (cla: yes, framework)
+
+[30811](https://github.com/flutter/flutter/pull/30811) Make coverage, like, really fast (cla: yes, tool)
+
+[30814](https://github.com/flutter/flutter/pull/30814) Fix StatefulWidget and StatelessWidget Sample Documentation (cla: yes, d: api docs, framework)
+
+[30815](https://github.com/flutter/flutter/pull/30815) Make CupertinoNavigationBarBackButton correctly return an assert error (cla: yes, f: cupertino)
+
+[30818](https://github.com/flutter/flutter/pull/30818) New flag to `flutter drive` to skip installing fresh app on device (cla: yes, tool)
+
+[30828](https://github.com/flutter/flutter/pull/30828) add golden tests for CupertinoDatePicker (cla: yes, f: cupertino, f: date/time picker, framework)
+
+[30829](https://github.com/flutter/flutter/pull/30829) Keep hover annotation layers in sync with the mouse detector. (a: desktop, cla: yes, framework)
+
+[30832](https://github.com/flutter/flutter/pull/30832) Bump Android build tools to 28.0.3 in Dockerfile (cla: yes, team)
+
+[30837](https://github.com/flutter/flutter/pull/30837) Add semanticsLabel parameter to TextSpan (cla: yes)
+
+[30857](https://github.com/flutter/flutter/pull/30857) Added support for authentication codes for the VM service. (a: tests, cla: yes, tool)
+
+[30862](https://github.com/flutter/flutter/pull/30862) CupertinoDatePicker initialDateTime accounts for minuteInterval  (cla: yes, f: cupertino, framework)
+
+[30867](https://github.com/flutter/flutter/pull/30867) Add toggle for debugProfileWidgetBuilds (cla: yes, tool)
+
+[30871](https://github.com/flutter/flutter/pull/30871) Update the upload key which seems to have trouble for some reason (a: tests, cla: yes, team)
+
+[30873](https://github.com/flutter/flutter/pull/30873) Revert "Remove pressure customization from some pointer events" (cla: yes)
+
+[30876](https://github.com/flutter/flutter/pull/30876) Simplify toImage future handling (cla: yes, framework)
+
+[30880](https://github.com/flutter/flutter/pull/30880) Let `sliver.dart` `_createErrorWidget` work with other Widgets (cla: yes, framework)
+
+[30883](https://github.com/flutter/flutter/pull/30883) Fix iTunes Transporter quirk (cla: yes)
+
+[30884](https://github.com/flutter/flutter/pull/30884) [Material] Update TabController to support dynamic Tabs (cla: yes, f: material design, framework)
+
+[30886](https://github.com/flutter/flutter/pull/30886) Allow mouse hover to only respond to some mouse events but not all. (cla: yes)
+
+[30887](https://github.com/flutter/flutter/pull/30887) Add more dialog doc cross-reference (cla: yes, d: api docs)
+
+[30898](https://github.com/flutter/flutter/pull/30898) Check that ErrorWidget.builder is not modified after test (a: tests, cla: yes, framework, waiting for tree to go green)
+
+[30919](https://github.com/flutter/flutter/pull/30919) Manual engine roll with disabled service authentication codes (cla: yes)
+
+[30921](https://github.com/flutter/flutter/pull/30921) Use identical instead of '==' in a constant expression. (cla: yes)
+
+[30930](https://github.com/flutter/flutter/pull/30930) Revert "Manual engine roll with disabled service authentication codes" (cla: yes)
+
+[30932](https://github.com/flutter/flutter/pull/30932) 2d transforms UX improvements (cla: yes, framework, team: gallery)
+
+[30937](https://github.com/flutter/flutter/pull/30937) Backport fixes into v1.4.9 (cla: yes, team)
+
+[30938](https://github.com/flutter/flutter/pull/30938) Update keycodes, fix a comment. (a: desktop, cla: yes, framework)
+
+[30942](https://github.com/flutter/flutter/pull/30942) rectMoreOrLess equals, prep for 64bit rects (a: tests, cla: yes, f: material design, framework)
+
+[30946](https://github.com/flutter/flutter/pull/30946) Add some more cupertino icons (cla: yes, f: cupertino, framework)
+
+[30985](https://github.com/flutter/flutter/pull/30985) Add rrect contains microbenchmark (a: tests, cla: yes, severe: performance, waiting for tree to go green)
+
+[30990](https://github.com/flutter/flutter/pull/30990) Allow profile widget builds in profile mode (cla: yes, severe: performance, team)
+
+[30991](https://github.com/flutter/flutter/pull/30991) Use full height of the glyph for caret height on Android (a: fidelity, a: text input, a: typography, cla: yes, severe: API break)
+
+[30995](https://github.com/flutter/flutter/pull/30995) revert last 2 engine rolls (cla: yes)
+
+[30997](https://github.com/flutter/flutter/pull/30997) Fix the warning test by checking stderr (cla: yes)
+
+[30998](https://github.com/flutter/flutter/pull/30998) Revert "revert last 2 engine rolls" (cla: yes)
+
+[31000](https://github.com/flutter/flutter/pull/31000) Fix bugs in contrast guideline and improve heuristic (cla: yes)
+
+[31005](https://github.com/flutter/flutter/pull/31005) [scenic] Remove dead view_manager ref (cla: yes, customer: fuchsia, team: gallery, ○ platform-fuchsia)
+
+[31063](https://github.com/flutter/flutter/pull/31063) Download and handle product version of flutter patched sdk (cla: yes, tool)
+
+[31064](https://github.com/flutter/flutter/pull/31064) Add sorting to flutter version command (cla: yes, tool)
+
+[31073](https://github.com/flutter/flutter/pull/31073) Fuchsia step 1: add SDK version file and artifact download (cla: yes, tool)
+
+[31074](https://github.com/flutter/flutter/pull/31074) make flutterProject option of CoverageCollector optional (cla: yes, tool)
+
+[31088](https://github.com/flutter/flutter/pull/31088) Text field scroll physics (cla: yes, f: cupertino, f: material design, framework)
+
+[31092](https://github.com/flutter/flutter/pull/31092) Add null checks to coverage collection (cla: yes)
+
+[31093](https://github.com/flutter/flutter/pull/31093) Make the matchesGoldenFile docs link to an explanation of how to create golden image files (cla: yes, framework)
+
+[31097](https://github.com/flutter/flutter/pull/31097) Fix text field selection toolbar under Opacity (cla: yes, framework)
+
+[31109](https://github.com/flutter/flutter/pull/31109) Clarify various CupertinoTabView docs (cla: yes, f: cupertino, framework)
+
+[31148](https://github.com/flutter/flutter/pull/31148) Bump dartdoc to 0.28.3+2 (cla: yes)
+
+[31159](https://github.com/flutter/flutter/pull/31159) Revert "Use full height of the glyph for caret height on Android" (cla: yes, framework)
+
+[31171](https://github.com/flutter/flutter/pull/31171) Allow disabling all fingerprint caches via environment variable (cla: yes, tool)
+
+[31178](https://github.com/flutter/flutter/pull/31178) Add breadcrumb to docs (cla: yes)
+
+[31205](https://github.com/flutter/flutter/pull/31205) Add desktop projects and build commands (experimental) (a: desktop, cla: yes, tool)
+
+[31207](https://github.com/flutter/flutter/pull/31207) fix issue 12999: Make assets available during tests (cla: yes, framework, tool)
+
+[31210](https://github.com/flutter/flutter/pull/31210) Use full height of the glyph for caret height on Android v2 (a: text input, cla: yes, framework)
+
+[31216](https://github.com/flutter/flutter/pull/31216) Disable macOS integration tests (cla: yes)
+
+[31218](https://github.com/flutter/flutter/pull/31218) Add run capability for macOS target (a: desktop, cla: yes, ⌘‬ platform-mac)
+
+[31228](https://github.com/flutter/flutter/pull/31228) Fix ExpansionPanelList Duplicate Global Keys Exception (cla: yes, f: material design, framework, severe: crash)
+
+[31229](https://github.com/flutter/flutter/pull/31229) Add flutter run support for linux and windows (a: desktop, cla: yes, tool)
+
+[31262](https://github.com/flutter/flutter/pull/31262) Add track-widget-creation flag to attach command (cla: yes)
+
+[31267](https://github.com/flutter/flutter/pull/31267) remove the unused hintMessage and hintId fields from the reload results (cla: yes)
+
+[31273](https://github.com/flutter/flutter/pull/31273) add daemon.log to the daemon spec (cla: yes)
+
+[31275](https://github.com/flutter/flutter/pull/31275) Update SnackBar to allow for support of the new style from Material spec (cla: yes, f: material design, framework)
+
+[31277](https://github.com/flutter/flutter/pull/31277) pass track widget creation flag through to build script (a: desktop, cla: yes, tool)
+
+[31278](https://github.com/flutter/flutter/pull/31278) add --force flag to precache (cla: yes)
+
+[31279](https://github.com/flutter/flutter/pull/31279) Add flutter attach documentation (cla: yes)
+
+[31282](https://github.com/flutter/flutter/pull/31282) Stop precaching the artifacts for dynamic mode. (cla: yes, tool)
+
+[31283](https://github.com/flutter/flutter/pull/31283) Add desktop workflows to doctor (a: desktop, cla: yes, tool)
+
+[31291](https://github.com/flutter/flutter/pull/31291) Add some docs to StatefulBuilder (cla: yes, framework)
+
+[31294](https://github.com/flutter/flutter/pull/31294) Improve Radio Documentation with Example (cla: yes, d: api docs, f: material design, framework)
+
+[31295](https://github.com/flutter/flutter/pull/31295) Improve ThemeData.accentColor connection to secondary color (cla: yes, d: api docs, f: material design, framework)
+
+[31310](https://github.com/flutter/flutter/pull/31310) Updated flutter_driver to support auth codes (cla: yes)
+
+[31315](https://github.com/flutter/flutter/pull/31315) Fixed failing tests caused by introduction of authentication codes (cla: yes)
+
+[31316](https://github.com/flutter/flutter/pull/31316) Add InkWell docs on transitions and ink splash clipping (cla: yes, d: api docs, f: material design, framework)
+
+[31321](https://github.com/flutter/flutter/pull/31321) Fixed flutter_attach_test not respecting authentication codes (cla: yes)
+
+[31326](https://github.com/flutter/flutter/pull/31326) Add more shuffle cupertino icons (cla: yes, f: cupertino, framework)
+
+[31329](https://github.com/flutter/flutter/pull/31329) Add Xcode build script for macOS target (a: desktop, cla: yes, tool, ⌘‬ platform-mac)
+
+[31332](https://github.com/flutter/flutter/pull/31332) iOS selection handles are invisible (cla: yes, framework, ⌺‬ platform-ios)
+
+[31339](https://github.com/flutter/flutter/pull/31339) Revert "[Material] Update slider and slider theme with new sizes, shapes, and color mappings" (cla: yes)
+
+[31342](https://github.com/flutter/flutter/pull/31342) check if project exists before regenerating platform specific tooling (cla: yes, tool)
+
+[31359](https://github.com/flutter/flutter/pull/31359) Remove support for building dynamic patches on Android (cla: yes, tool)
+
+[31395](https://github.com/flutter/flutter/pull/31395) Roll engine ca31a7c57bad..206cab6e7013 (11 commits) (cla: yes)
+
+[31399](https://github.com/flutter/flutter/pull/31399) add ignorable track-widget-creation flag to build aot (cla: yes, tool)
+
+[31400](https://github.com/flutter/flutter/pull/31400) add printError messages and tool exit to android device (cla: yes, tool)
+
+[31404](https://github.com/flutter/flutter/pull/31404) throw toolExit instead of rethrowing on filesystem exceptions (cla: yes, tool)
+
+[31406](https://github.com/flutter/flutter/pull/31406) if there is no .ios or ios sub-project, don't attempt building for iOS (cla: yes, tool)
+
+[31419](https://github.com/flutter/flutter/pull/31419) Add a note about events coming from the server (cla: yes, tool)
+
+[31420](https://github.com/flutter/flutter/pull/31420) Add more breadcrumb docs to Transformation (cla: yes, framework)
+
+[31421](https://github.com/flutter/flutter/pull/31421) Add Widget of the Week video to SizedBox (cla: yes, framework)
+
+[31434](https://github.com/flutter/flutter/pull/31434) Add more context to flutter create sample (cla: yes)
+
+[31446](https://github.com/flutter/flutter/pull/31446) Allow filtering devices to only those supported by current project (cla: yes, tool)
+
+[31451](https://github.com/flutter/flutter/pull/31451) Set SYMROOT as absolute in Generated.xcconfig for macOS (cla: yes)
+
+[31452](https://github.com/flutter/flutter/pull/31452) Remove engine tests (a: tests, cla: yes, team, waiting for tree to go green)
+
+[31454](https://github.com/flutter/flutter/pull/31454) Improve docs to address flutter/flutter#31202 (cla: yes)
+
+[31456](https://github.com/flutter/flutter/pull/31456) Relax the string matching for path in test (cla: yes)
+
+[31461](https://github.com/flutter/flutter/pull/31461) Revert "Implement focus traversal for desktop platforms, shoehorn edition. (#30040)" (cla: yes)
+
+[31463](https://github.com/flutter/flutter/pull/31463) Disable all Dart fingerprinters (cla: yes)
+
+[31464](https://github.com/flutter/flutter/pull/31464) CupertinoPicker fidelity revision (a: fidelity, cla: yes, f: cupertino, f: date/time picker, framework)
+
+[31486](https://github.com/flutter/flutter/pull/31486) fix precedence issue (cla: yes, team: gallery)
+
+[31491](https://github.com/flutter/flutter/pull/31491) Allow adb stdout to contain the port number without failing (cla: yes, tool, ▣ platform-android)
+
+[31493](https://github.com/flutter/flutter/pull/31493) Keycode generation doc fix (a: desktop, cla: yes, d: api docs, framework)
+
+[31497](https://github.com/flutter/flutter/pull/31497) Revert "Fix 25807: implement move for sliver multibox widget (#29188)" (cla: yes, framework)
+
+[31502](https://github.com/flutter/flutter/pull/31502) Improve Tabs documentation (cla: yes, d: api docs, f: material design, framework)
+
+[31505](https://github.com/flutter/flutter/pull/31505) add desktop artifacts to run/target_platform selectors (cla: yes)
+
+[31515](https://github.com/flutter/flutter/pull/31515) Support local engine and asset sync for macOS (cla: yes, tool)
+
+[31520](https://github.com/flutter/flutter/pull/31520) Don't add empty OpacityLayer to the engine (cla: yes, engine, framework)
+
+[31526](https://github.com/flutter/flutter/pull/31526) replace no-op log reader with real implementation (cla: yes, tool)
+
+[31538](https://github.com/flutter/flutter/pull/31538) Fix typo in docs (cla: yes, f: material design, framework)
+
+[31561](https://github.com/flutter/flutter/pull/31561) Add support for Tooltip hover (cla: yes)
+
+[31562](https://github.com/flutter/flutter/pull/31562) Allow all tests to run with --update-goldens. (cla: yes)
+
+[31564](https://github.com/flutter/flutter/pull/31564) [Material] Update slider and slider theme with new sizes, shapes, and color mappings (2nd attempt) (cla: yes)
+
+[31566](https://github.com/flutter/flutter/pull/31566) TimePicker moves to minute mode after hour selection (cla: yes, f: material design, framework)
+
+[31567](https://github.com/flutter/flutter/pull/31567) Remove need for build/name scripts on Linux desktop (a: desktop, cla: yes)
+
+[31568](https://github.com/flutter/flutter/pull/31568) fix transform assert (cla: yes, framework)
+
+[31569](https://github.com/flutter/flutter/pull/31569) Roll engine to 3e47b4bb39bb4993f03a278ea7b1c11ee6459b06 (cla: yes)
+
+[31578](https://github.com/flutter/flutter/pull/31578) Add support for the Kazakh language (cla: yes)
+
+[31582](https://github.com/flutter/flutter/pull/31582) Issues/31511 (cla: yes)
+
+[31584](https://github.com/flutter/flutter/pull/31584) Capture JSON RPC errors that presently get swallowed (cla: yes)
+
+[31591](https://github.com/flutter/flutter/pull/31591) make sure we exit early if the Runner.xcodeproj file is missing (cla: yes, tool)
+
+[31600](https://github.com/flutter/flutter/pull/31600) Re-enable const (cla: yes, framework, waiting for tree to go green)
+
+[31614](https://github.com/flutter/flutter/pull/31614) [Re-Land] Implement focus traversal for desktop platforms. (cla: yes)
+
+[31616](https://github.com/flutter/flutter/pull/31616) Make FlutterPlatform public so we can start testing/refactoring it (cla: yes)
+
+[31619](https://github.com/flutter/flutter/pull/31619) Fix the documentation for UiKitView#creationParams (cla: yes, framework)
+
+[31621](https://github.com/flutter/flutter/pull/31621) Add check that xcode project configuration is not missing (cla: yes)
+
+[31622](https://github.com/flutter/flutter/pull/31622) refactor context to be implicit-downcast safe (cla: yes)
+
+[31623](https://github.com/flutter/flutter/pull/31623) fix edge swiping and dropping back at starting point (cla: yes, f: cupertino, framework)
+
+[31634](https://github.com/flutter/flutter/pull/31634) Improve canvas example in sample dart ui app (cla: yes, d: api docs, d: examples, framework)
+
+[31638](https://github.com/flutter/flutter/pull/31638) Fix doc link (cla: yes)
+
+[31642](https://github.com/flutter/flutter/pull/31642) Refactor the test compiler into a separate library (cla: yes)
+
+[31687](https://github.com/flutter/flutter/pull/31687) Center iOS caret, remove constant offsets that do not scale (a: text input, cla: yes, framework, ⌺‬ platform-ios)
+
+[31692](https://github.com/flutter/flutter/pull/31692) Revert "Add support for Tooltip hover (#31561)" (cla: yes)
+
+[31693](https://github.com/flutter/flutter/pull/31693) Adds a note to Radio's/RadioListTile's onChange (cla: yes, d: api docs, f: material design, framework)
+
+[31696](https://github.com/flutter/flutter/pull/31696) Attempt to reduce usage of runtimeType (cla: yes, framework)
+
+[31736](https://github.com/flutter/flutter/pull/31736) update packages and unpin build (cla: yes, tool)
+
+[31757](https://github.com/flutter/flutter/pull/31757) Make FlutterProject factories synchronous (cla: yes, tool)
+
+[31759](https://github.com/flutter/flutter/pull/31759) Remove deprecated commands (cla: yes, tool)
+
+[31761](https://github.com/flutter/flutter/pull/31761) Support clipBehavior changes in hot reload (cla: yes, framework)
+
+[31762](https://github.com/flutter/flutter/pull/31762) Remove trailing whitespace from README template (cla: yes)
+
+[31765](https://github.com/flutter/flutter/pull/31765) Initial sketch of tools testbed (cla: yes, tool)
+
+[31771](https://github.com/flutter/flutter/pull/31771) Fix a simple typo (cla: yes)
+
+[31795](https://github.com/flutter/flutter/pull/31795) Revert "update packages and unpin build" (cla: yes)
+
+[31800](https://github.com/flutter/flutter/pull/31800) Revert "Fix text field selection toolbar under Opacity" (cla: yes)
+
+[31801](https://github.com/flutter/flutter/pull/31801) Revert "Add buttons to gestures" (cla: yes)
+
+[31802](https://github.com/flutter/flutter/pull/31802) Reland "Fix text field selection toolbar under Opacity (#31097)" (cla: yes, framework)
+
+[31804](https://github.com/flutter/flutter/pull/31804) only build asset when there is asset declared in pubspec (cla: yes, framework, tool)
+
+[31807](https://github.com/flutter/flutter/pull/31807) Make const available for classes that override AssetBundle (cla: yes, tool)
+
+[31812](https://github.com/flutter/flutter/pull/31812) Fix #31764: Show appropriate error message when fonts pubspec.yaml isn't iterable (cla: yes, tool)
+
+[31815](https://github.com/flutter/flutter/pull/31815) remove assert (cla: yes)
+
+[31819](https://github.com/flutter/flutter/pull/31819) Redo: Add buttons to gestures (a: desktop, cla: yes, framework)
+
+[31832](https://github.com/flutter/flutter/pull/31832) Allow DSS to be dragged when its children do not fill extent (cla: yes, f: scrolling, framework, waiting for tree to go green)
+
+[31835](https://github.com/flutter/flutter/pull/31835) Cherry-pick ADB CrOS fix to beta (cla: yes, tool)
+
+[31860](https://github.com/flutter/flutter/pull/31860) Fix prefer_const_constructors (cla: yes)
+
+[31862](https://github.com/flutter/flutter/pull/31862) iOS selection handles are invisible (#31332) (cla: yes)
+
+[31868](https://github.com/flutter/flutter/pull/31868) Handle notification errors (cla: yes, tool, waiting for tree to go green)
+
+[31871](https://github.com/flutter/flutter/pull/31871) Pick up v1.5.4-hotfix-2 engine for flutter 1.5.4 hotfix branch (cla: yes)
+
+[31874](https://github.com/flutter/flutter/pull/31874) add stderr to log processor for desktop (cla: yes)
+
+[31876](https://github.com/flutter/flutter/pull/31876) Revert "fix edge swiping and dropping back at starting point" (cla: yes)
+
+[31886](https://github.com/flutter/flutter/pull/31886) Revert "Handle notification errors" (cla: yes)
+
+
+## PRs closed in this release of flutter/engine
+
+From Thu Feb 21 20:22:00 2019 -0800 to Wed May 1 16:56:00 2019 -0700
+
+
+[7494](https://github.com/flutter/engine/pull/7494) Add engine support for scrollwheel events (cla: yes)
+
+[7776](https://github.com/flutter/engine/pull/7776) Support ContextWrapper when instantiating a FlutterView. (cla: yes)
+
+[7783](https://github.com/flutter/engine/pull/7783) Refactor ios play input sound logic. (cla: yes)
+
+[7803](https://github.com/flutter/engine/pull/7803) [re-land] Use all font managers to discover fonts for strut. (cla: yes)
+
+[7828](https://github.com/flutter/engine/pull/7828) Revert Versions API (cla: yes)
+
+[7851](https://github.com/flutter/engine/pull/7851) Improve path metrics tests and docs (cla: yes)
+
+[7888](https://github.com/flutter/engine/pull/7888) Reland #7777 with proper LICENSE (cla: yes)
+
+[7896](https://github.com/flutter/engine/pull/7896) Android Embedding PR 6: Introduce FlutterView structure with FlutterSurfaceView and FlutterTextureView. (cla: yes)
+
+[7906](https://github.com/flutter/engine/pull/7906) Do not add ghost runs for trailing whitespace if the text is ellipsized (cla: yes)
+
+[7908](https://github.com/flutter/engine/pull/7908) Link dart:* sources into engine for debugger source support (affects: dev experience, affects: engine, cla: yes)
+
+[7911](https://github.com/flutter/engine/pull/7911) Reland "PerformanceOverlayLayer golden test (#7863)" (cla: yes)
+
+[7912](https://github.com/flutter/engine/pull/7912) Android PR 7: Introduce structure of FlutterActivity and FlutterFragment (cla: yes)
+
+[7913](https://github.com/flutter/engine/pull/7913) Revert dart rolls (cla: yes)
+
+[7914](https://github.com/flutter/engine/pull/7914) Allow embedder to specify a vsync waiter. (cla: yes)
+
+[7915](https://github.com/flutter/engine/pull/7915) Embedder API for setting the persistent cache path (cla: yes)
+
+[7916](https://github.com/flutter/engine/pull/7916) Revert "Revert "Revert "Reland PerformanceOverlayLayer golden test (#… (cla: yes)
+
+[7917](https://github.com/flutter/engine/pull/7917) Allow embedders to add events to the timeline. (cla: yes)
+
+[7919](https://github.com/flutter/engine/pull/7919) fix Memory leak when using PlatformView [IOS] #24714 (cla: yes)
+
+[7923](https://github.com/flutter/engine/pull/7923) Move canvas clear after preroll (cla: yes)
+
+[7925](https://github.com/flutter/engine/pull/7925) Make the layout of dynamic patch bundle similar to APK. (cla: yes)
+
+[7926](https://github.com/flutter/engine/pull/7926) Remove unused FML file export.h (cla: yes)
+
+[7927](https://github.com/flutter/engine/pull/7927) Dynamic patching support for native code libraries. (cla: yes)
+
+[7928](https://github.com/flutter/engine/pull/7928) New setting to decide whether we want the engine to load ICU mapping. (cla: yes)
+
+[7929](https://github.com/flutter/engine/pull/7929) Do not clear FlutterJNI state when a FlutterView is detached (cla: yes)
+
+[7937](https://github.com/flutter/engine/pull/7937) fix sendLocales on old android versions (cla: yes)
+
+[7942](https://github.com/flutter/engine/pull/7942) Correct FlutterSemanticsNode member name style (cla: yes)
+
+[7946](https://github.com/flutter/engine/pull/7946) Android Embedding PR 8: Add FlutterEngine attachment/detachment to FlutterView (cla: yes)
+
+[7947](https://github.com/flutter/engine/pull/7947) Android Embedding PR 9: Introduce an AndroidTouchProcessor to convert MotionEvents to Flutter touch data. (cla: yes)
+
+[7953](https://github.com/flutter/engine/pull/7953) libtxt: remove a debug log message in ComputeStrut (cla: yes)
+
+[7954](https://github.com/flutter/engine/pull/7954) Fixed an Android keyboard entry bug that was introduced by the embedding refactor. (#28438) (cla: yes)
+
+[7960](https://github.com/flutter/engine/pull/7960) Android Embedding PR 10: Add system channels to FlutterEngine. (cla: yes)
+
+[7964](https://github.com/flutter/engine/pull/7964) Fix cursor jumping when typing some special characters. (cla: yes)
+
+[7967](https://github.com/flutter/engine/pull/7967) Add api 21 check to LocalizationChannel.java (cla: yes)
+
+[7968](https://github.com/flutter/engine/pull/7968) Switch flutter's dart sdk to full and add dartdevc libraries (cla: yes)
+
+[7972](https://github.com/flutter/engine/pull/7972) Android Embedding PR 11: Add FlutterEngine to FlutterFragment. (cla: yes)
+
+[7973](https://github.com/flutter/engine/pull/7973) Suppress deprecation warning for usage of Configuration.locale (cla: yes)
+
+[7974](https://github.com/flutter/engine/pull/7974) Android Embedding PR 12: Add lifecycle methods to FlutterActivity. (cla: yes)
+
+[7975](https://github.com/flutter/engine/pull/7975) [macos] Add hover support to FLEViewController (cla: yes)
+
+[7978](https://github.com/flutter/engine/pull/7978) Refactor web configuration/ Add dartdevc (cla: yes)
+
+[7979](https://github.com/flutter/engine/pull/7979) Android Embedding PR 13: Integrated text input, keyevent input, and some other channel comms in FlutterView. (cla: yes)
+
+[7982](https://github.com/flutter/engine/pull/7982) Fix deleting text when the last character is some special characters on IOS (cla: yes)
+
+[7985](https://github.com/flutter/engine/pull/7985) Add async events to pipeline flows. (cla: yes)
+
+[7986](https://github.com/flutter/engine/pull/7986) Check for a null pressure range for motion events (cla: yes)
+
+[7988](https://github.com/flutter/engine/pull/7988) Provide batching for semantics updates (cla: yes)
+
+[7990](https://github.com/flutter/engine/pull/7990) Improve performance of Locale.toString (cla: yes)
+
+[7991](https://github.com/flutter/engine/pull/7991) Select MPL instead of LGPL (cla: yes)
+
+[7993](https://github.com/flutter/engine/pull/7993) Fix two typos in embedder.h (cla: yes)
+
+[7997](https://github.com/flutter/engine/pull/7997) Fix spelling errors in dartdocs (cla: yes)
+
+[7999](https://github.com/flutter/engine/pull/7999) Buffer lifecycle in WindowData (cla: yes)
+
+[8000](https://github.com/flutter/engine/pull/8000) Android Embedding PR 14: Almost done with FlutterFragment. (cla: yes)
+
+[8001](https://github.com/flutter/engine/pull/8001) Fix incorrect transformation matrix (cla: yes)
+
+[8005](https://github.com/flutter/engine/pull/8005) A11y callback (cla: yes)
+
+[8006](https://github.com/flutter/engine/pull/8006) Guard against using Android API not defined in API level 16 & 17 (cla: yes)
+
+[8007](https://github.com/flutter/engine/pull/8007) Add overloads for lookup that lets you specify a bundle (cla: yes)
+
+[8008](https://github.com/flutter/engine/pull/8008) Expose decorationThickness to dart:ui (cla: yes)
+
+[8010](https://github.com/flutter/engine/pull/8010) Revert "Buffer lifecycle in WindowData" (cla: yes)
+
+[8011](https://github.com/flutter/engine/pull/8011) Build engine for iOS on presubmit (cla: yes)
+
+[8023](https://github.com/flutter/engine/pull/8023) Start of linting Android embedding (cla: yes)
+
+[8024](https://github.com/flutter/engine/pull/8024) [fuchsia] Fix snapshot BUILD.gn file for Fuchsia roll (cla: yes)
+
+[8026](https://github.com/flutter/engine/pull/8026) [platform_views] Fix duplicated touch event pass down to flutter view from platform view.  (cla: yes)
+
+[8029](https://github.com/flutter/engine/pull/8029) Android Embedding PR15: Add Viewport Metrics to FlutterView (cla: yes)
+
+[8030](https://github.com/flutter/engine/pull/8030) Add missing kHasImplicitScrolling enum value (cla: yes)
+
+[8032](https://github.com/flutter/engine/pull/8032) Re-land "Buffer lifecycle in WindowData" (cla: yes)
+
+[8033](https://github.com/flutter/engine/pull/8033) Add missing values to semantics action enums (cla: yes)
+
+[8034](https://github.com/flutter/engine/pull/8034) Android Embedding PR 16: Add touch support to FlutterView. (cla: yes)
+
+[8036](https://github.com/flutter/engine/pull/8036) add lint script for Android with baseline (cla: yes)
+
+[8041](https://github.com/flutter/engine/pull/8041) [platform_views]remove an unnecessary extra statement. (cla: yes)
+
+[8043](https://github.com/flutter/engine/pull/8043) Minor cleanups to CONTRIBUTING.md (cla: yes)
+
+[8044](https://github.com/flutter/engine/pull/8044) Improve elevation bounds for physical shape layers (cla: yes)
+
+[8045](https://github.com/flutter/engine/pull/8045) Merge only gpu and platform threads for platform views, fix deadlock. (cla: yes)
+
+[8046](https://github.com/flutter/engine/pull/8046) Fix weak pointer use violations in shell and platform view. (cla: yes)
+
+[8047](https://github.com/flutter/engine/pull/8047) Add clang static analysis support to gn wrapper (cla: yes)
+
+[8048](https://github.com/flutter/engine/pull/8048) Guard against NewAPI failures (cla: yes)
+
+[8049](https://github.com/flutter/engine/pull/8049) Add read-only persistent cache (cla: yes)
+
+[8050](https://github.com/flutter/engine/pull/8050) Skip skp files in license check (cla: yes)
+
+[8051](https://github.com/flutter/engine/pull/8051) Used named conditionals for platform specific dependencies and suppress Android and Windows hooks on Mac. (cla: yes)
+
+[8052](https://github.com/flutter/engine/pull/8052) remove extra source files (cla: yes)
+
+[8053](https://github.com/flutter/engine/pull/8053) Remove redundant thread checker in FML. (cla: yes)
+
+[8054](https://github.com/flutter/engine/pull/8054) Correct URL for Cirrus CI build status badge (cla: yes)
+
+[8055](https://github.com/flutter/engine/pull/8055) Adds a platfromViewId to SemanticsNode (cla: yes)
+
+[8056](https://github.com/flutter/engine/pull/8056) Send scroll events from the macOS shell (cla: yes)
+
+[8061](https://github.com/flutter/engine/pull/8061) Android Embedding PR 17: Clarify AccessibilityBridge. (cla: yes)
+
+[8065](https://github.com/flutter/engine/pull/8065) add signal to pointer kinds (cla: yes)
+
+[8066](https://github.com/flutter/engine/pull/8066) Revert "add signal to pointer kinds" (cla: yes)
+
+[8071](https://github.com/flutter/engine/pull/8071) Only build a full Dart SDK when building for the host system (cla: yes)
+
+[8072](https://github.com/flutter/engine/pull/8072) Delay the vsync callback till the frame start time specified by embedder. (cla: yes)
+
+[8073](https://github.com/flutter/engine/pull/8073) Update a11y word forward/back enum names (cla: yes)
+
+[8074](https://github.com/flutter/engine/pull/8074) Add script to help generate PR messages (cla: yes, waiting for tree to go green)
+
+[8077](https://github.com/flutter/engine/pull/8077) Mark const extern (cla: yes)
+
+[8078](https://github.com/flutter/engine/pull/8078) only partial rule revert (cla: yes)
+
+[8079](https://github.com/flutter/engine/pull/8079) Fix text.dart height docs (cla: yes)
+
+[8080](https://github.com/flutter/engine/pull/8080) Only build full sdk on release to speed up bots (cla: yes)
+
+[8084](https://github.com/flutter/engine/pull/8084) Move android_sdk_downloader so I can more easily deprecate it (cla: yes)
+
+[8085](https://github.com/flutter/engine/pull/8085) Remove deprecated libraries from snapshot (cla: yes)
+
+[8087](https://github.com/flutter/engine/pull/8087) Drop android_sdk_downloader in favor of cipd (cla: yes)
+
+[8089](https://github.com/flutter/engine/pull/8089) Allow embedders to post tasks onto the render thread. (cla: yes)
+
+[8090](https://github.com/flutter/engine/pull/8090) Android linter prints to the console by default (cla: yes)
+
+[8093](https://github.com/flutter/engine/pull/8093) Clarify arguments to FlutterEngineOnVsync. (cla: yes)
+
+[8094](https://github.com/flutter/engine/pull/8094) Add support for trace counters with variable arguments and instrument the raster cache. (cla: yes)
+
+[8095](https://github.com/flutter/engine/pull/8095) Integrated AndroidTouchProcessor within the old FlutterView (cla: yes)
+
+[8096](https://github.com/flutter/engine/pull/8096) Log non-kSuccess returns from embedder API calls. (cla: yes)
+
+[8098](https://github.com/flutter/engine/pull/8098) Do not cache gclient sync (cla: yes)
+
+[8099](https://github.com/flutter/engine/pull/8099) Use right stream for Java, on mac try to autoselect Java 1.8 (cla: yes)
+
+[8102](https://github.com/flutter/engine/pull/8102) Fix typo (cla: yes)
+
+[8103](https://github.com/flutter/engine/pull/8103) Guard initialization of touch exploration listener (cla: yes)
+
+[8105](https://github.com/flutter/engine/pull/8105) Support dartdevc, dart2js with shared source files, dartdevc sdk (cla: yes)
+
+[8106](https://github.com/flutter/engine/pull/8106) Fix the Windows build (cla: yes)
+
+[8109](https://github.com/flutter/engine/pull/8109) Android Embedding PR 19: Add accessibility to new FlutterView. (cla: yes)
+
+[8114](https://github.com/flutter/engine/pull/8114) Improve shadow doc in PhysicalShapeLayer (cla: yes)
+
+[8115](https://github.com/flutter/engine/pull/8115) Add Views V2 support for Fuchsia (cla: yes)
+
+[8122](https://github.com/flutter/engine/pull/8122) Revert "Add support for trace counters with variable arguments and instrument the raster cache." (cla: yes)
+
+[8124](https://github.com/flutter/engine/pull/8124) Use final state passed to dart before initialization as the initial lifecycleState. (cla: yes)
+
+[8126](https://github.com/flutter/engine/pull/8126) Bugfix #29203: NPE in getAccessibilityProvider in old FlutterView. (cla: yes)
+
+[8139](https://github.com/flutter/engine/pull/8139) Look up ICU symbols based on the path to libflutter.so as a fallback (cla: yes)
+
+[8140](https://github.com/flutter/engine/pull/8140) Reland PerformanceOverlayLayer golden test (cla: yes)
+
+[8141](https://github.com/flutter/engine/pull/8141) Fix TextStyle decode misalignment (cla: yes)
+
+[8142](https://github.com/flutter/engine/pull/8142) Typo "fast an inline" to "fast and inline" (cla: yes)
+
+[8143](https://github.com/flutter/engine/pull/8143) Fix indexing error in dart:ui TextStyle.toString (cla: yes)
+
+[8145](https://github.com/flutter/engine/pull/8145) Reland "Add support for trace counters with variable arguments and instrument the raster cache." (cla: yes)
+
+[8147](https://github.com/flutter/engine/pull/8147) Add “full-dart-debug” that disabled optimizations in the Dart VM. (cla: yes)
+
+[8148](https://github.com/flutter/engine/pull/8148) Add dump-shader-skp switch to help ShaderWarmUp (cla: yes)
+
+[8149](https://github.com/flutter/engine/pull/8149) Encode scroll motion events in the Android touch processor (cla: yes)
+
+[8150](https://github.com/flutter/engine/pull/8150) Disable build_ios task due to lack of credits. (cla: yes)
+
+[8151](https://github.com/flutter/engine/pull/8151) [Skia] Rollback Skia to 29d5dec9a0783a033b921dc483fb98d565d684f6 (cla: yes)
+
+[8153](https://github.com/flutter/engine/pull/8153) Revert "Disable build_ios task due to lack of credits." (cla: yes)
+
+[8154](https://github.com/flutter/engine/pull/8154) Suppress deprecation warning for use of Build.CPU_ABI (cla: yes)
+
+[8155](https://github.com/flutter/engine/pull/8155) Ensure that typed data is released within SendPlatformMessage scope. (cla: yes)
+
+[8156](https://github.com/flutter/engine/pull/8156) Add a11y support for embedded iOS platform view (cla: yes)
+
+[8157](https://github.com/flutter/engine/pull/8157) Anti-Aliasing for shape layers (cla: yes)
+
+[8159](https://github.com/flutter/engine/pull/8159) Initial import of GLFW Linux shell from FDE (cla: yes)
+
+[8160](https://github.com/flutter/engine/pull/8160) Add a build dependencies script for Linux desktop (cla: yes)
+
+[8166](https://github.com/flutter/engine/pull/8166) Do not pass short-lived buffers as labels to Dart_TimelineEvent (cla: yes)
+
+[8168](https://github.com/flutter/engine/pull/8168) Add an allocator specific check to ensure that strings passed to the timeline are not heap allocated. (cla: yes)
+
+[8170](https://github.com/flutter/engine/pull/8170) Bugfix: Prevent crash when responding to a platform message after FlutterJNI detaches from native. (cla: yes)
+
+[8171](https://github.com/flutter/engine/pull/8171) Add docs for helpful commands to fix format (cla: yes)
+
+[8172](https://github.com/flutter/engine/pull/8172) Add frame and target time metadata to vsync events and connect platform vsync events using flows. (cla: yes)
+
+[8174](https://github.com/flutter/engine/pull/8174) [scenic][SCN-1054] Move back off of SetTranslationRH (cla: yes)
+
+[8175](https://github.com/flutter/engine/pull/8175) Keep overlays_gr_context_ in sync with the overlay surface (cla: yes)
+
+[8180](https://github.com/flutter/engine/pull/8180) Fix log level typo from ERROR to INFO (cla: yes)
+
+[8181](https://github.com/flutter/engine/pull/8181) Fix include of libzx. (cla: yes)
+
+[8182](https://github.com/flutter/engine/pull/8182) Ensure that Picture::RasterizeToImage destroys Dart persistent values on the UI thread (cla: yes)
+
+[8183](https://github.com/flutter/engine/pull/8183) Clip to clip_rect instead of paint bounds (cla: yes)
+
+[8185](https://github.com/flutter/engine/pull/8185) Simplify the fallback waiter and add traces for vsync scheduling overhead. (cla: yes)
+
+[8196](https://github.com/flutter/engine/pull/8196) Add --no-full-dart-sdk option to GN (cla: yes)
+
+[8202](https://github.com/flutter/engine/pull/8202) [platform_view] iOSP platformView composition optimize. (cla: yes, platform-ios)
+
+[8203](https://github.com/flutter/engine/pull/8203) Export FlutterSemanticsUpdateNotification and improve docs (cla: yes)
+
+[8204](https://github.com/flutter/engine/pull/8204) Disable build_ios due to large queue times. (cla: yes)
+
+[8206](https://github.com/flutter/engine/pull/8206) Define the dart_platform_sdk GN variable only on host targets (cla: yes)
+
+[8208](https://github.com/flutter/engine/pull/8208) Plumb a reference of PlatformViewsController and AccessibilityBridge to each other (cla: yes)
+
+[8210](https://github.com/flutter/engine/pull/8210) Correct greater than or equal logic in offset base (cla: yes)
+
+[8214](https://github.com/flutter/engine/pull/8214) libtxt: more accurate tracking of run positioning and width for justified text (cla: yes)
+
+[8217](https://github.com/flutter/engine/pull/8217) Allow exported __const on iOS (cla: yes)
+
+[8218](https://github.com/flutter/engine/pull/8218) [ios] Set contentsScale before we commit CATransaction (cla: yes)
+
+[8219](https://github.com/flutter/engine/pull/8219) Send macOS keyboard data to the engine (cla: yes)
+
+[8221](https://github.com/flutter/engine/pull/8221) Moved io.flutter.embedding.engine.android package to io.flutter.embedding.android (cla: yes)
+
+[8227](https://github.com/flutter/engine/pull/8227) Add the Linux desktop setup script to Dockerfile (cla: yes)
+
+[8229](https://github.com/flutter/engine/pull/8229) Have the AccessibilityBridge attach/detach itself to the (cla: yes)
+
+[8230](https://github.com/flutter/engine/pull/8230) Remove jsoncpp from desktop Linux shell setup (cla: yes)
+
+[8231](https://github.com/flutter/engine/pull/8231) Removed Activity reference from AccessibilityBridge by using a View for insets instead of the Activity (cla: yes)
+
+[8233](https://github.com/flutter/engine/pull/8233) Enable Linux shell build (cla: yes)
+
+[8234](https://github.com/flutter/engine/pull/8234) Use the GPU thread for Android surface on-screen context lifecycle operations (cla: yes)
+
+[8237](https://github.com/flutter/engine/pull/8237) Mirror Android platform views a11y tree in the Flutter a11y tree. (cla: yes)
+
+[8241](https://github.com/flutter/engine/pull/8241) fix video player dismiss when there is a iOS platform view (cla: yes)
+
+[8246](https://github.com/flutter/engine/pull/8246) Remove more forced crashes from FlutterJNI (cla: yes)
+
+[8247](https://github.com/flutter/engine/pull/8247) Fix incorrect vertices colors length check (cla: yes)
+
+[8249](https://github.com/flutter/engine/pull/8249) Allow specifying an alternate Mac host SDK. (cla: yes)
+
+[8250](https://github.com/flutter/engine/pull/8250) Delegate a11y events and action to/from embedded Android platform views. (cla: yes)
+
+[8251](https://github.com/flutter/engine/pull/8251) Fixed service isolate not being initialized correctly due to bad name (cla: yes)
+
+[8253](https://github.com/flutter/engine/pull/8253) Add platformViewId to stub_ui (cla: yes)
+
+[8254](https://github.com/flutter/engine/pull/8254) Do not drop the DartExecutor's message handler when a FlutterNativeView is detached from the FlutterView (cla: yes)
+
+[8256](https://github.com/flutter/engine/pull/8256) check that public API of dart:ui conforms to web implementation (cla: yes)
+
+[8265](https://github.com/flutter/engine/pull/8265) Linking Higher & Lower Class Docs (affects: docs, cla: yes)
+
+[8273](https://github.com/flutter/engine/pull/8273) Allow embedders to specify their own task runner interfaces. (cla: yes)
+
+[8274](https://github.com/flutter/engine/pull/8274) [ui] Add null check in FontWeight.lerp (Work in progress (WIP), cla: yes, prod: API break)
+
+[8276](https://github.com/flutter/engine/pull/8276) Make it easy to write embedder unit tests by creating a fixture and config builder. (cla: yes)
+
+[8277](https://github.com/flutter/engine/pull/8277) Roll buildroot to 9c7b023ff266ee58b00fe60326fa1db910a087f3 (cla: yes)
+
+[8293](https://github.com/flutter/engine/pull/8293) [vulkan] Add FUCHSIA external sem/mem extensions (cla: yes)
+
+[8295](https://github.com/flutter/engine/pull/8295) Fixing links between higher and lower classes. (affects: docs, cla: yes)
+
+[8296](https://github.com/flutter/engine/pull/8296) Migrate existing embedder unit tests to use the fixture. (cla: yes)
+
+[8297](https://github.com/flutter/engine/pull/8297) [fuchsia] Add missing trace macros (cla: yes)
+
+[8299](https://github.com/flutter/engine/pull/8299) Enable lambda like native callbacks in tests and add support for custom entrypoints. (cla: yes)
+
+[8308](https://github.com/flutter/engine/pull/8308) Map glfw into third_party, and roll buildroot (cla: yes)
+
+[8309](https://github.com/flutter/engine/pull/8309) Allow specification of std::functions as native entrypoints from Dart code. (cla: yes)
+
+[8312](https://github.com/flutter/engine/pull/8312) Revert "Allow specification of std::functions as native entrypoints from Dart code." (cla: yes)
+
+[8317](https://github.com/flutter/engine/pull/8317) Android Embedding PR22: Polish - FlutterActivity Intent factories, FlutterFragment control of render modes, FlutterSurfaceView transparent until rendering is ready. (cla: yes)
+
+[8318](https://github.com/flutter/engine/pull/8318) Reduce z-fighting on Scenic (cla: yes)
+
+[8319](https://github.com/flutter/engine/pull/8319) Fix "PointerEvent" flow end event (cla: yes)
+
+[8325](https://github.com/flutter/engine/pull/8325) [fuchsia] Disable FML_TRACE_COUNTER events to unblock roll (cla: yes)
+
+[8327](https://github.com/flutter/engine/pull/8327) Build GLFW from source for Linux shell (cla: yes)
+
+[8329](https://github.com/flutter/engine/pull/8329) Reland "Allow specification of std::functions as native entrypoints from Dart code." (cla: yes)
+
+[8330](https://github.com/flutter/engine/pull/8330) Create a new resource loading EGL context for each PlatformView instance on Android (cla: yes)
+
+[8331](https://github.com/flutter/engine/pull/8331) Build Windows shell (cla: yes)
+
+[8333](https://github.com/flutter/engine/pull/8333) Allow delegation of a11y events from nodes that were not yet traversed (cla: yes)
+
+[8334](https://github.com/flutter/engine/pull/8334) Remove use of epoxy from Linux shell (cla: yes)
+
+[8335](https://github.com/flutter/engine/pull/8335) Add super call in FLEView reshape (cla: yes)
+
+[8336](https://github.com/flutter/engine/pull/8336) Fix Windows build. (cla: yes)
+
+[8337](https://github.com/flutter/engine/pull/8337) Cleanups to run_tests.sh script (cla: yes)
+
+[8338](https://github.com/flutter/engine/pull/8338) Remove the standalone a11y test runners and merge its tests into embedder_unittests. (cla: yes)
+
+[8339](https://github.com/flutter/engine/pull/8339) Fix typos (cla: yes)
+
+[8343](https://github.com/flutter/engine/pull/8343) Reset min log levels on each engine launch. (cla: yes)
+
+[8345](https://github.com/flutter/engine/pull/8345) Build precompiled sdk and analyzer summary for dartdevc (cla: yes)
+
+[8346](https://github.com/flutter/engine/pull/8346) Introduce unit tests and refactor web dart:ui into "package" (cla: yes)
+
+[8353](https://github.com/flutter/engine/pull/8353) Revert "Build precompiled sdk and analyzer summary for dartdevc" (cla: yes)
+
+[8354](https://github.com/flutter/engine/pull/8354) Rename threshold to access_threshold (cla: yes)
+
+[8355](https://github.com/flutter/engine/pull/8355) Create ddc summary file and precompiled sdk (cla: yes)
+
+[8358](https://github.com/flutter/engine/pull/8358) Allow per-platform customization of the default Skia font manager (cla: yes)
+
+[8359](https://github.com/flutter/engine/pull/8359) update buildroot dep for PR #227 (cla: yes)
+
+[8360](https://github.com/flutter/engine/pull/8360) Remove old Fuchsia external mem,sem extensions (cla: yes)
+
+[8362](https://github.com/flutter/engine/pull/8362) Ensure OpacityLayer to have a single child (cla: yes)
+
+[8368](https://github.com/flutter/engine/pull/8368) libtxt: track the start and end x positions of glyph blobs for more accurate rendering of text decorations (cla: yes)
+
+[8369](https://github.com/flutter/engine/pull/8369) GN Format all files in the engine. (cla: yes)
+
+[8371](https://github.com/flutter/engine/pull/8371) Add a GN format presubmit. (cla: yes)
+
+[8373](https://github.com/flutter/engine/pull/8373) Move libdart selection into its own target in //flutter/runtime. (cla: yes)
+
+[8374](https://github.com/flutter/engine/pull/8374) [flutter_tester] Accept --icu-data-file-path (cla: yes)
+
+[8375](https://github.com/flutter/engine/pull/8375) Allow running runtime_unittests in AOT mode. (cla: yes)
+
+[8376](https://github.com/flutter/engine/pull/8376) Check for hover motion events in AndroidTouchProcessor (cla: yes)
+
+[8377](https://github.com/flutter/engine/pull/8377) Handle null values in TextInputConfiguration.actionLabel JSON (cla: yes)
+
+[8379](https://github.com/flutter/engine/pull/8379) Allow native entrypoint registration for runtime unittests. (cla: yes)
+
+[8380](https://github.com/flutter/engine/pull/8380) Delay platform view removal to submitFrame. (cla: yes)
+
+[8381](https://github.com/flutter/engine/pull/8381) Remove unused DartVM::IsKernelMapping (cla: yes)
+
+[8382](https://github.com/flutter/engine/pull/8382) Add missing import to functional for Windows. (cla: yes)
+
+[8387](https://github.com/flutter/engine/pull/8387) Make the resource context primary on iOS (cla: yes)
+
+[8393](https://github.com/flutter/engine/pull/8393) Don't access a11y APIs with reflection starting Android P. (cla: yes)
+
+[8397](https://github.com/flutter/engine/pull/8397) Separate the data required to bootstrap the VM into its own class. (cla: yes)
+
+[8400](https://github.com/flutter/engine/pull/8400) Make sure FlutterViewController flushs all pending touches when no longer active (cla: yes)
+
+[8402](https://github.com/flutter/engine/pull/8402) Enable shutting down all root isolates in a VM. (cla: yes)
+
+[8406](https://github.com/flutter/engine/pull/8406) Revert "Separate the data required to bootstrap the VM into its own class." (cla: yes)
+
+[8407](https://github.com/flutter/engine/pull/8407) [fuchsia] Exclude glfw from the Fuchsia host build (cla: yes)
+
+[8410](https://github.com/flutter/engine/pull/8410) [txt] Add back FontCollection::SetDefaultFontManager (cla: yes)
+
+[8411](https://github.com/flutter/engine/pull/8411) Added new Android embedding packages to javadoc generation. (cla: yes)
+
+[8412](https://github.com/flutter/engine/pull/8412) Pass environment defines to compile flutter platform step. (cla: yes)
+
+[8414](https://github.com/flutter/engine/pull/8414) Separate the data required to bootstrap the VM into its own class. (cla: yes)
+
+[8416](https://github.com/flutter/engine/pull/8416) Add scroll wheel support to desktop GLFW shell (cla: yes)
+
+[8417](https://github.com/flutter/engine/pull/8417) Remove use of DART_CHECK_VALID. (cla: yes)
+
+[8419](https://github.com/flutter/engine/pull/8419) Support message loops whose tasks are executed concurrently. (cla: yes)
+
+[8421](https://github.com/flutter/engine/pull/8421) dart:ui Locale: add toLanguageTag() (cla: yes)
+
+[8425](https://github.com/flutter/engine/pull/8425) Roll buildroot (cla: yes)
+
+[8427](https://github.com/flutter/engine/pull/8427) Eliminate unused displayBounds parameter (cla: yes)
+
+[8429](https://github.com/flutter/engine/pull/8429) Make AccessibilityViewEmbedder final (cla: yes)
+
+[8431](https://github.com/flutter/engine/pull/8431) Revert "Enable shutting down all root isolates in a VM." (cla: yes)
+
+[8435](https://github.com/flutter/engine/pull/8435) Add window title/icon support to GLFW shell (cla: yes)
+
+[8439](https://github.com/flutter/engine/pull/8439) update to use SkTileMode (cla: yes)
+
+[8442](https://github.com/flutter/engine/pull/8442) Build windows engine on GCE (cla: yes)
+
+[8446](https://github.com/flutter/engine/pull/8446) Add scripts that prepares our windows VM image (cla: yes)
+
+[8448](https://github.com/flutter/engine/pull/8448) Android Embedding PR24: Allow FlutterActivity to provide an engine, also adjust FlutterFragment timing to avoid Activity launch lag. (cla: yes)
+
+[8456](https://github.com/flutter/engine/pull/8456) More detailed comments for engine build windows VM (cla: yes)
+
+[8457](https://github.com/flutter/engine/pull/8457) Enable shutting down all root isolates in a VM. (cla: yes)
+
+[8460](https://github.com/flutter/engine/pull/8460) Android Embedding PR25: Prevent black rectangle when launching FlutterActivity (cla: yes)
+
+[8461](https://github.com/flutter/engine/pull/8461) Log the correct function on error in the embedder. (cla: yes)
+
+[8462](https://github.com/flutter/engine/pull/8462) Document the leak_vm flag. (cla: yes)
+
+[8465](https://github.com/flutter/engine/pull/8465) Android Embedding PR26: Offer an async version of FlutterMain's ensure initialization complete. (cla: yes)
+
+[8467](https://github.com/flutter/engine/pull/8467) Initialize OpacityLayer's matrix to identity (cla: yes)
+
+[8472](https://github.com/flutter/engine/pull/8472) [Docs] Correcting link to contributing guide. (affects: docs, cla: yes, easy fix)
+
+[8473](https://github.com/flutter/engine/pull/8473) Roll dart back to 907c514c8937cf76e (cla: yes)
+
+[8477](https://github.com/flutter/engine/pull/8477) Add trace events for creating minikin fonts (cla: yes)
+
+[8490](https://github.com/flutter/engine/pull/8490) Remove unused variable (cla: yes)
+
+[8496](https://github.com/flutter/engine/pull/8496) [scenic] Remove unused mozart.internal (cla: yes)
+
+[8497](https://github.com/flutter/engine/pull/8497) Wire up support for Dart fixtures in shell_unittests. (cla: yes)
+
+[8498](https://github.com/flutter/engine/pull/8498) Move constant definitions out embedder.h (cla: yes)
+
+[8499](https://github.com/flutter/engine/pull/8499) Route FlutterEventTracer events to Fuchsia tracing for Fuchsia (cla: yes)
+
+[8500](https://github.com/flutter/engine/pull/8500) Get rid of the macro for accessing the current test name. (cla: yes)
+
+[8503](https://github.com/flutter/engine/pull/8503) [scenic][SCN-1054] remove dangling uses of SetTranslationRH (cla: yes)
+
+[8504](https://github.com/flutter/engine/pull/8504) Android Embedding PR27: Fix SurfaceView flicker in Fragment transactions (cla: yes)
+
+[8511](https://github.com/flutter/engine/pull/8511) switch to newer APIs for shaders and filters (cla: yes)
+
+[8515](https://github.com/flutter/engine/pull/8515) Add windows host_debug_unopt build test (cla: yes)
+
+[8517](https://github.com/flutter/engine/pull/8517) Rename the blink namespace to flutter. (cla: yes)
+
+[8518](https://github.com/flutter/engine/pull/8518) Remove the unused EnableBlink flag. (cla: yes)
+
+[8520](https://github.com/flutter/engine/pull/8520) Rename the shell namespace to flutter. (cla: yes)
+
+[8523](https://github.com/flutter/engine/pull/8523) Remove redundant specification of the |flutter| namespace in the engine. (cla: yes)
+
+[8524](https://github.com/flutter/engine/pull/8524) Change Rect internal representation from Float32List to Float64List (cla: yes)
+
+[8525](https://github.com/flutter/engine/pull/8525) Merge flutter/synchronization contents into fml. (cla: yes)
+
+[8527](https://github.com/flutter/engine/pull/8527) Added support for authentication codes for the VM service (cla: yes)
+
+[8528](https://github.com/flutter/engine/pull/8528) Redo a fix for cull rect calculation on TransformLayers with a perspective transform (cla: yes)
+
+[8530](https://github.com/flutter/engine/pull/8530) Tight Paragraph Width (cla: yes)
+
+[8531](https://github.com/flutter/engine/pull/8531) Add an option to build the GLFW shell on macOS (cla: yes)
+
+[8534](https://github.com/flutter/engine/pull/8534) Use code cache dir for engine cache (#14704). (cla: yes)
+
+[8536](https://github.com/flutter/engine/pull/8536) Android Embedding PR28: Report app is active to Flutter in FlutterFragment.onResume() instead of onPostResume() forwarded from Activity. (cla: yes)
+
+[8537](https://github.com/flutter/engine/pull/8537) Correct nullability for FlutterStandardReader (cla: yes)
+
+[8538](https://github.com/flutter/engine/pull/8538) Add null check in FLETextInputPlugin (cla: yes)
+
+[8540](https://github.com/flutter/engine/pull/8540) Android Embedding PR29: Improve FlutterFragment construction API + engine config API. (cla: yes)
+
+[8541](https://github.com/flutter/engine/pull/8541) Eliminate unused write to local (cla: yes)
+
+[8545](https://github.com/flutter/engine/pull/8545) Revert "Change Rect internal representation from Float32List to Float64List (#8524)" (cla: yes)
+
+[8546](https://github.com/flutter/engine/pull/8546) [font_collection] Add missing semicolon (cla: yes)
+
+[8548](https://github.com/flutter/engine/pull/8548) Initialize OpacityLayer's matrix to identity (#8467) (cla: yes)
+
+[8549](https://github.com/flutter/engine/pull/8549) [fuchsia] Add flutter:: to scene_host.cc (cla: yes)
+
+[8550](https://github.com/flutter/engine/pull/8550) Export extern constants in embedder.h (cla: yes)
+
+[8551](https://github.com/flutter/engine/pull/8551) Android Embedding PR30: Make FlutterView focusable so that the keyboard can interact with it. (cla: yes)
+
+[8555](https://github.com/flutter/engine/pull/8555) Roll Dart 15b11b018364ce03...a8f3a5dae6203d10 (cla: yes)
+
+[8557](https://github.com/flutter/engine/pull/8557) Update README.md (cla: yes)
+
+[8562](https://github.com/flutter/engine/pull/8562) Add missing <memory> include to text_input_model.h (cla: yes)
+
+[8563](https://github.com/flutter/engine/pull/8563) Remove unused import in FlutterActivityDelegate (cla: yes)
+
+[8565](https://github.com/flutter/engine/pull/8565) Make Rect and RRect use 64 bit doubles, and make them const-able (cla: yes)
+
+[8581](https://github.com/flutter/engine/pull/8581) Remove the flutter_aot GN argument. (cla: yes)
+
+[8583](https://github.com/flutter/engine/pull/8583) Pipe Z bounds from ViewportMetrics to Flow (cla: yes)
+
+[8585](https://github.com/flutter/engine/pull/8585) Check that TransformLayer has a finite matrix (cla: yes)
+
+[8591](https://github.com/flutter/engine/pull/8591) Glitchiness with Tab Characters (cla: yes)
+
+[8592](https://github.com/flutter/engine/pull/8592) Variant type for C++ client wrapper (cla: yes)
+
+[8593](https://github.com/flutter/engine/pull/8593) Roll buildroot to ce7b5c786a12927c9e0b4543af267d48c52e0b3a (cla: yes)
+
+[8594](https://github.com/flutter/engine/pull/8594) Enable VM service authentication codes by default (cla: yes)
+
+[8598](https://github.com/flutter/engine/pull/8598) Implement StandardMethodCodec for C++ shells (cla: yes)
+
+[8600](https://github.com/flutter/engine/pull/8600) Add desktop shell unittests to test script (cla: yes)
+
+[8605](https://github.com/flutter/engine/pull/8605) Allow building without python2 (cla: yes)
+
+[8608](https://github.com/flutter/engine/pull/8608) [fuchsia] Fix SceneUpdateContext for new PaintContext field (cla: yes)
+
+[8611](https://github.com/flutter/engine/pull/8611) Add FLEPluginRegistry for macOS (cla: yes)
+
+[8612](https://github.com/flutter/engine/pull/8612) Remove call to SkFont::setLinearMetrics (cla: yes)
+
+[8615](https://github.com/flutter/engine/pull/8615) Rename flow namespace to flutter (cla: yes)
+
+[8616](https://github.com/flutter/engine/pull/8616) Add a unit test for PhysicalShapeLayer (cla: yes)
+
+[8617](https://github.com/flutter/engine/pull/8617) Fixes a typo in comment (affects: docs, cla: yes)
+
+[8618](https://github.com/flutter/engine/pull/8618) Test saving compilation traces. (cla: yes)
+
+[8621](https://github.com/flutter/engine/pull/8621) Avoid manually shutting down engine managed isolates. (cla: yes)
+
+[8622](https://github.com/flutter/engine/pull/8622) Assert that all VM launches in the process have the same opinion on whether the VM should be leaked in the process. (cla: yes)
+
+[8623](https://github.com/flutter/engine/pull/8623) Add an adjustment to the line width check in LineBreaker::addWordBreak (cla: yes)
+
+[8625](https://github.com/flutter/engine/pull/8625) Add support for authentication codes via MDNS on iOS (cla: yes)
+
+[8626](https://github.com/flutter/engine/pull/8626) Avoid leaking the VM in runtime_unittests and update failing tests. (cla: yes)
+
+[8627](https://github.com/flutter/engine/pull/8627) Revert "Add a unit test for PhysicalShapeLayer" (cla: yes)
+
+[8628](https://github.com/flutter/engine/pull/8628) Avoid leaking the VM in the shell unittests and assert VM state in existing tests. (cla: yes)
+
+[8633](https://github.com/flutter/engine/pull/8633) Reland elevation test (cla: yes)
+
+[8634](https://github.com/flutter/engine/pull/8634) Merge runtime lifecycle unittests into the base test target. (cla: yes)
+
+[8635](https://github.com/flutter/engine/pull/8635) Remove unnecessary DartIO::EntropySource wrapper (cla: yes)
+
+[8637](https://github.com/flutter/engine/pull/8637) Generate layer unique id for raster cache key (cla: yes)
+
+[8638](https://github.com/flutter/engine/pull/8638) Custom RTL handling for ghost runs, NotoNaskhArabic test font (cla: yes)
+
+[8640](https://github.com/flutter/engine/pull/8640) Remove DartSnapshotBuffer and dry up snapshot resolution logic. (cla: yes)
+
+[8642](https://github.com/flutter/engine/pull/8642) Remove unused Settings::ToString. (cla: yes)
+
+[8643](https://github.com/flutter/engine/pull/8643) Allow specifying the Mac SDK path as an environment variable to //flutter/tools/gn (cla: yes)
+
+[8644](https://github.com/flutter/engine/pull/8644) Revert "Remove DartSnapshotBuffer and dry up snapshot resolution logic." (cla: yes)
+
+[8645](https://github.com/flutter/engine/pull/8645) Reland "Remove DartSnapshotBuffer and dry up snapshot resolution logic". (cla: yes)
+
+[8646](https://github.com/flutter/engine/pull/8646) Disable auth codes for Observatory test (cla: yes)
+
+[8649](https://github.com/flutter/engine/pull/8649) Roll buildroot to 380d0ed5c3399d5a2aaac4a66d98e3a3fda77c31 (cla: yes)
+
+[8652](https://github.com/flutter/engine/pull/8652) Add factory methods to FileMapping that make it easy to create common mappings. (cla: yes)
+
+[8653](https://github.com/flutter/engine/pull/8653) Cleanup references to FLX archives from the engine. (cla: yes)
+
+[8656](https://github.com/flutter/engine/pull/8656) Only allow mappings for ICU initialization. (cla: yes)
+
+[8657](https://github.com/flutter/engine/pull/8657) Change Vertices.indices to use a Uint16 list to more accurately reflect Skia's API (cla: yes)
+
+[8658](https://github.com/flutter/engine/pull/8658) Allow native bindings in secondary isolates. (cla: yes)
+
+[8659](https://github.com/flutter/engine/pull/8659) Replace ThreadLocal with ThreadLocalUniquePtr<T> (cla: yes)
+
+[8661](https://github.com/flutter/engine/pull/8661) Put the testing lib in the flutter namespace. (cla: yes)
+
+[8663](https://github.com/flutter/engine/pull/8663) Remove support for downloading dynamic patches on Android (cla: yes)
+
+[8664](https://github.com/flutter/engine/pull/8664) Add framework test in engine presubmit checks (cla: yes)
+
+[8681](https://github.com/flutter/engine/pull/8681) Revert "Custom RTL handling for ghost runs, NotoNaskhArabic test font" (cla: yes)
+
+[8682](https://github.com/flutter/engine/pull/8682) Revert "Only allow mappings for ICU initialization." (cla: yes)
+
+[8683](https://github.com/flutter/engine/pull/8683) Custom RTL handling for ghost runs, NotoNaskhArabic test font (cla: yes)
+
+[8688](https://github.com/flutter/engine/pull/8688) fix toString (cla: yes)
+
+[8689](https://github.com/flutter/engine/pull/8689) Revert "Remove unused Settings::ToString. (#8642)" (cla: yes)
+
+[8690](https://github.com/flutter/engine/pull/8690) Revert Rect/RRect 64 bit (cla: yes)
+
+[8692](https://github.com/flutter/engine/pull/8692) Add tests from framework (cla: yes)
+
+[8695](https://github.com/flutter/engine/pull/8695) Reland const Rect/RRect (cla: yes)
+
+[8698](https://github.com/flutter/engine/pull/8698) Convert animated unpremul images to premul during decode (cla: yes)
+
+[8700](https://github.com/flutter/engine/pull/8700) Increase the memory usage estimate for EngineLayer (cla: yes)
+
+[8704](https://github.com/flutter/engine/pull/8704) Limit the size of VirtualDisplay we create in android (cla: yes)
+
+[8706](https://github.com/flutter/engine/pull/8706) Rename tightWidth to longestLine (cla: yes)
+
+[8707](https://github.com/flutter/engine/pull/8707) Document that OpacityLayer's children are nonempty (cla: yes)
+
+[8710](https://github.com/flutter/engine/pull/8710) Plumb arguments from Settings to Dart entrypoint (cla: yes)
+
+[8712](https://github.com/flutter/engine/pull/8712) [scenic] Purge references to Mozart (cla: yes)
+
+[8716](https://github.com/flutter/engine/pull/8716) Add Rect.fromCenter() constructor (cla: yes)
+
+[8721](https://github.com/flutter/engine/pull/8721) Fix header include guards for fml/thread_local.h (cla: yes)
+
+[8723](https://github.com/flutter/engine/pull/8723) Fix include paths in libtxt to prepare for upcoming Skia build change (cla: yes)
+
+[8735](https://github.com/flutter/engine/pull/8735) Fix reflective ctor invocation in FlutterFragment (cla: yes)
+
+[8738](https://github.com/flutter/engine/pull/8738) Revert "Increase the memory usage estimate for EngineLayer" (cla: yes)
+
+[8742](https://github.com/flutter/engine/pull/8742) Log the sticky error during isolate shutdown (cla: yes)
+
+[8747](https://github.com/flutter/engine/pull/8747) Fix crash when cursor ends up at invalid position (cla: yes)
+
+[8758](https://github.com/flutter/engine/pull/8758) Check the matrix in pushTransform (cla: yes)
+
+[8772](https://github.com/flutter/engine/pull/8772) colormatrix is now 0...1 (cla: yes)
+
+[8780](https://github.com/flutter/engine/pull/8780) VirtualDisplay size constraint - add a comment explaining the reason (cla: yes)
+
+[8789](https://github.com/flutter/engine/pull/8789) Roll to branched dart sdk with hotfix(dartbug.com/36772) for flutter 1.5.4 (cla: yes)
+
+[8790](https://github.com/flutter/engine/pull/8790) Roll to branched dart sdk with two more hotfixes for flutter 1.5.4. (cla: yes)
+
+[8792](https://github.com/flutter/engine/pull/8792) Re-create texture from pixel buffer onGrContextCreate (cla: yes)
+
+[8793](https://github.com/flutter/engine/pull/8793) Roll buildroot to pull in Fuchsia SDK related updates. (cla: yes)
+
+[8796](https://github.com/flutter/engine/pull/8796) Dart SDK roll for 2019-04-30 (cla: yes)
+
+
+## PRs closed in this release of flutter/plugins
+
+From Thu Feb 21 20:22:00 2019 -0800 to Wed May 1 16:56:00 2019 -0700
+
+
+[721](https://github.com/flutter/plugins/pull/721) [google_sign_in]Fix filename in google_sign_in docs, which leads to crash (bugfix, cla: yes, documentation)
+
+[742](https://github.com/flutter/plugins/pull/742) [image_picker]Fixed losing transparency of PNGs (bugfix, cla: yes, submit queue)
+
+[790](https://github.com/flutter/plugins/pull/790) [cloud_firestore]add sample to get specific document (cla: yes, documentation, flutterfire, submit queue)
+
+[793](https://github.com/flutter/plugins/pull/793) [video_player]Do not divide by zero (bugfix, cla: yes, submit queue)
+
+[815](https://github.com/flutter/plugins/pull/815) [google_maps_flutter] adds support for custom icon from a byte array (PNG) (cla: yes, feature, needs love)
+
+[927](https://github.com/flutter/plugins/pull/927) [firebase_admob]Fix typo in RewardedVideoAdd sample (bugfix, cla: yes, documentation, flutterfire, submit queue)
+
+[963](https://github.com/flutter/plugins/pull/963) Reduce Android compiler warnings, prevent NPE (cla: yes)
+
+[985](https://github.com/flutter/plugins/pull/985) [google_maps_flutter]add support for map tapping (cla: yes)
+
+[991](https://github.com/flutter/plugins/pull/991) [firebase_core]Fix firebase core registration and fix firestore document observer cleanup (cla: yes)
+
+[1008](https://github.com/flutter/plugins/pull/1008) [firebase_analytics] Add 'loginMethod' parameter to logLogin() (cla: yes, feature, flutterfire, submit queue)
+
+[1022](https://github.com/flutter/plugins/pull/1022) [camera] Add serial dispatch_queue for camera plugin to avoid blocking the UI (bugfix, cla: yes, submit queue)
+
+[1023](https://github.com/flutter/plugins/pull/1023) [camera]Fix CameraPreview freezes during startVideoRecording on iOS (cla: yes)
+
+[1049](https://github.com/flutter/plugins/pull/1049) [google_maps_flutter] Widget based polyline support for google maps. (cla: yes)
+
+[1080](https://github.com/flutter/plugins/pull/1080) [firebase_crashlytics]Firebase Crashlytics plugin (cla: yes)
+
+[1096](https://github.com/flutter/plugins/pull/1096) [firebase_database]Return error message from DatabaseError#toString() (cla: yes, submit queue)
+
+[1123](https://github.com/flutter/plugins/pull/1123) [video_player] Correctly report buffering status on Android (bugfix, cla: yes, submit queue)
+
+[1142](https://github.com/flutter/plugins/pull/1142) [firebase_dynamic_links] fix dynamic link crash when creating shortlink if warnings are null (bugfix, cla: yes, flutterfire, submit queue)
+
+[1154](https://github.com/flutter/plugins/pull/1154) [video_player] Upgrade ExoPlayer dependency to 2.9.4 (cla: yes, feature, submit queue)
+
+[1159](https://github.com/flutter/plugins/pull/1159) [firebase_auth] Enable passwordless sign in (cla: yes, feature, flutterfire, submit queue)
+
+[1182](https://github.com/flutter/plugins/pull/1182) [firebase_dynamic_links] sometimes got error NSPOSIXErrorDomain Code=53 in ios (bugfix, cla: yes, flutterfire, submit queue)
+
+[1192](https://github.com/flutter/plugins/pull/1192) Flutterfire apps no longer show a confusing log message about configuring default app (cla: yes)
+
+[1201](https://github.com/flutter/plugins/pull/1201) [connectivity] Update README.md (cla: yes, documentation, submit queue)
+
+[1208](https://github.com/flutter/plugins/pull/1208) [firebase_storage] Support for getReferenceFromUrl (cla: yes)
+
+[1219](https://github.com/flutter/plugins/pull/1219) [firebase_auth] update example app and README (cla: yes, documentation, feature, flutterfire)
+
+[1223](https://github.com/flutter/plugins/pull/1223) [firebase_ml_vision] Fix crash when scanning URL QR-code on iOS (bugfix, cla: yes, submit queue)
+
+[1229](https://github.com/flutter/plugins/pull/1229) [google_maps_flutter] Marker APIs are now widget based (Android) (bugfix, cla: yes, feature)
+
+[1236](https://github.com/flutter/plugins/pull/1236) [webview_flutter]Allow specifying a navigation delegate(Android and Dart). (cla: yes)
+
+[1237](https://github.com/flutter/plugins/pull/1237) [share] Changed compileSdkVersion of share plugin to 28 (cla: yes, submit queue)
+
+[1239](https://github.com/flutter/plugins/pull/1239) [google_maps_flutter] Marker APIs are now widget based (Dart Changes) (cla: yes, documentation)
+
+[1240](https://github.com/flutter/plugins/pull/1240) [google_maps_flutter] Marker APIs are now widget based (iOS Changes) (cla: yes, feature)
+
+[1241](https://github.com/flutter/plugins/pull/1241) [camera] 28180 fix exif data bug for first time camera use android (cla: yes, submit queue)
+
+[1249](https://github.com/flutter/plugins/pull/1249) [in_app_purchase] payment queue dart ios (bugfix, cla: yes, feature)
+
+[1250](https://github.com/flutter/plugins/pull/1250) [video_player] Cast the NSInteger to long and use %ld formatter (cla: yes, submit queue)
+
+[1251](https://github.com/flutter/plugins/pull/1251) Update android_alarm_manager with instructions on setting WAKE_LOCK permissions (cla: yes, documentation)
+
+[1252](https://github.com/flutter/plugins/pull/1252) [In_app_purchase]SKProduct related fixes (cla: yes)
+
+[1253](https://github.com/flutter/plugins/pull/1253) Disable analyzer error (cla: yes)
+
+[1255](https://github.com/flutter/plugins/pull/1255) Don't register the Maps and Camera plugin for background FlutterViews. (cla: yes)
+
+[1256](https://github.com/flutter/plugins/pull/1256) Skip Gradle's static permission check for the Maps MyLocation feature. (cla: yes)
+
+[1257](https://github.com/flutter/plugins/pull/1257) Suppress unchecked cast warning for the PlatformViewFactory creation … (cla: yes)
+
+[1259](https://github.com/flutter/plugins/pull/1259) [in_app_purchase] Java API for querying purchases (cla: yes)
+
+[1261](https://github.com/flutter/plugins/pull/1261) [camera] Fixes #28350 (bugfix, cla: yes, feature, submit queue)
+
+[1265](https://github.com/flutter/plugins/pull/1265) [image_picker] fix error if pick image from yandex disk(dropbox) (bugfix, cla: yes)
+
+[1266](https://github.com/flutter/plugins/pull/1266) [image_picker] update Uri Authority for GooglePhotos (bugfix, cla: yes, submit queue)
+
+[1268](https://github.com/flutter/plugins/pull/1268) [image_picker] remove unnecessary camera permmision (bugfix, cla: yes)
+
+[1269](https://github.com/flutter/plugins/pull/1269) [image_picker] set real extension instead always jpg (cla: yes, submit queue)
+
+[1270](https://github.com/flutter/plugins/pull/1270) [firebase_ml_vision] Incorrect link for including the ML Model pods into the example project (cla: yes, documentation, submit queue)
+
+[1271](https://github.com/flutter/plugins/pull/1271) [google_maps_flutter] Update the sample app in README.md (cla: yes)
+
+[1274](https://github.com/flutter/plugins/pull/1274) [cloud_firestore,firebase_database,firebase_storage] handling error nil on getFlutterError (cla: yes)
+
+[1275](https://github.com/flutter/plugins/pull/1275) [package_info] calling new method for BuildNumber in new android versions (bugfix, cla: yes, submit queue)
+
+[1277](https://github.com/flutter/plugins/pull/1277) [firebase_performance] Fix incorrect setting of Trace & HttpMetric attributes (cla: yes, flutterfire)
+
+[1278](https://github.com/flutter/plugins/pull/1278) [firebase_performance] remove deprecated trace counter API usage (cla: yes, flutterfire)
+
+[1279](https://github.com/flutter/plugins/pull/1279) [firebase_core][firebase_database]Add nil check for some static methods to avoid unwanted behaviors (cla: yes)
+
+[1281](https://github.com/flutter/plugins/pull/1281) [in_app_purchase] Fix CI formatting errors. (cla: yes)
+
+[1284](https://github.com/flutter/plugins/pull/1284) [in_app_purchase] Minor bugfixes and code cleanup (cla: yes)
+
+[1285](https://github.com/flutter/plugins/pull/1285) [shared_preferences] driver test using package:test on device (cla: yes)
+
+[1286](https://github.com/flutter/plugins/pull/1286) [in_app_purchase] Adds Dart BillingClient APIs for loading purchases (cla: yes)
+
+[1288](https://github.com/flutter/plugins/pull/1288) [image_picker] delete original file if scaled (cla: yes)
+
+[1289](https://github.com/flutter/plugins/pull/1289) Add missing license headers (cla: yes)
+
+[1291](https://github.com/flutter/plugins/pull/1291) Bugfix/account for nsnull (cla: yes)
+
+[1292](https://github.com/flutter/plugins/pull/1292) [firebase_auth] Make providerId 'const String' for easier use in switch statements (bugfix, cla: yes, flutterfire, submit queue)
+
+[1293](https://github.com/flutter/plugins/pull/1293) [google_maps_flutter] The FloatingActionButton requires an icon (cla: yes)
+
+[1294](https://github.com/flutter/plugins/pull/1294) Fix icon issue on ios and manifest on android (cla: yes)
+
+[1296](https://github.com/flutter/plugins/pull/1296) [image_picker] Update pub info for #742 (cla: yes)
+
+[1297](https://github.com/flutter/plugins/pull/1297) Update play-services-maps from 15.+ to 16.1.0 (cla: yes)
+
+[1299](https://github.com/flutter/plugins/pull/1299) [in_app_purchase]restore purchases (cla: yes)
+
+[1300](https://github.com/flutter/plugins/pull/1300) Add my name to firebase_performance and firebase_dynamic_links owners (cla: yes, submit queue)
+
+[1302](https://github.com/flutter/plugins/pull/1302) [google_maps_flutter]ChangeNotifier is replaced with granular callbacks (cla: yes)
+
+[1303](https://github.com/flutter/plugins/pull/1303) [in_app_purchase]retrieve receipt (cla: yes)
+
+[1306](https://github.com/flutter/plugins/pull/1306) [cloud_firestore] Update firebase-firestore to 18.2.0 (cla: yes, submit queue)
+
+[1309](https://github.com/flutter/plugins/pull/1309) [firebase_dynamic_links] Version bump for firebase_dynamic_links PR #1142 (bugfix, cla: yes, flutterfire, submit queue)
+
+[1311](https://github.com/flutter/plugins/pull/1311) [firebase_analytics] Add resetAnalyticsData method (cla: yes)
+
+[1314](https://github.com/flutter/plugins/pull/1314) trackCameraPosition is inferred from GoogleMap.onCameraMove (cla: yes)
+
+[1315](https://github.com/flutter/plugins/pull/1315) [image_picker] remove unnecessary file path for video. (bugfix, cla: yes, needs love, submit queue)
+
+[1316](https://github.com/flutter/plugins/pull/1316) [cloud_functions] Specify version for CocoaPod and handle null regions gracefully (cla: yes)
+
+[1322](https://github.com/flutter/plugins/pull/1322) [in_app_purchase] refactoring and tests (cla: yes)
+
+[1323](https://github.com/flutter/plugins/pull/1323) Allow specifying a navigation delegate (iOS implementation). (cla: yes)
+
+[1324](https://github.com/flutter/plugins/pull/1324) Exclude longPress from semantics (cla: yes)
+
+[1326](https://github.com/flutter/plugins/pull/1326) [image_picker] Update versioning for #1268 (cla: yes)
+
+[1327](https://github.com/flutter/plugins/pull/1327) Change build link in contributors site to cirrus (cla: yes)
+
+[1329](https://github.com/flutter/plugins/pull/1329) [firebase_messaging] Fix Changelog.md version for firebase_messaging (cla: yes, documentation, flutterfire)
+
+[1331](https://github.com/flutter/plugins/pull/1331) [connectivity] Enable fetching current Wi-Fi network's BSSID (cla: yes, feature)
+
+[1333](https://github.com/flutter/plugins/pull/1333) [firebase_auth] fixes Android linkWithCredential (cla: yes, flutterfire)
+
+[1335](https://github.com/flutter/plugins/pull/1335) [webview_flutter] Add a page loaded callback (cla: yes, feature, submit queue)
+
+[1337](https://github.com/flutter/plugins/pull/1337) [android_alarm_manager] Improve error message seen when an alarm fires and `AlarmService.setPluginRegistrant` has not been called. (bugfix, cla: yes)
+
+[1338](https://github.com/flutter/plugins/pull/1338) Add Kaushik to maps code owners (cla: yes)
+
+[1339](https://github.com/flutter/plugins/pull/1339) [cloud_firestore] ios check for nil snapshot in cloud_firestore error handling instead of checking for non-nil error (cla: yes)
+
+[1341](https://github.com/flutter/plugins/pull/1341) Removed dependency on Firebase for android_alarm_manager example (cla: yes)
+
+[1342](https://github.com/flutter/plugins/pull/1342) add driver test command to cirrus (cla: yes)
+
+[1343](https://github.com/flutter/plugins/pull/1343) [firebase_auth] fix error code in doc of createUserWithEmailAndPassword() (cla: yes)
+
+[1344](https://github.com/flutter/plugins/pull/1344) [shared_preferences] Update shared_preferences CHANGELOG for release (cla: yes)
+
+[1345](https://github.com/flutter/plugins/pull/1345) [cloud_firestore] fix NoSuchMethodError regression and add test (cla: yes)
+
+[1346](https://github.com/flutter/plugins/pull/1346) [cloud_functions] add a driver test (cla: yes)
+
+[1348](https://github.com/flutter/plugins/pull/1348) [firebase_auth] Add a driver test (cla: yes)
+
+[1350](https://github.com/flutter/plugins/pull/1350) [google_maps_flutter] add My location button enabled option (cla: yes)
+
+[1352](https://github.com/flutter/plugins/pull/1352) [google_maps_flutter] Add method getVisibleRegion (cla: yes)
+
+[1353](https://github.com/flutter/plugins/pull/1353) [firebase_messaging] Update example (cla: yes, submit queue)
+
+[1357](https://github.com/flutter/plugins/pull/1357) Disable Android emulator testing for now to fix tests (cla: yes)
+
+[1360](https://github.com/flutter/plugins/pull/1360) [webview_flutter] Create WebView client depending on version and hasDelegate (bugfix, cla: yes, webview)
+
+[1361](https://github.com/flutter/plugins/pull/1361) [webview_flutter] Update changelog and bump versions. (cla: yes, submit queue)
+
+[1364](https://github.com/flutter/plugins/pull/1364) [firebase_ml_vision] Update ImageDetector for iOS (bugfix, cla: yes, flutterfire)
+
+[1367](https://github.com/flutter/plugins/pull/1367) [firebase_ml_vision] Android side of upgrade to new ImageLabeler (bugfix, cla: yes, flutterfire)
+
+[1369](https://github.com/flutter/plugins/pull/1369) [webview_flutter] Refactor WebViewController to have a reference to the widget, to minimize necessary update calls. (cla: yes)
+
+[1372](https://github.com/flutter/plugins/pull/1372) [image_picker] fix "Cancel button not visible in gallery, if camera was accessed first" (bugfix, cla: yes)
+
+[1373](https://github.com/flutter/plugins/pull/1373) [shared_preferences] Add contains method (cla: yes, feature)
+
+[1374](https://github.com/flutter/plugins/pull/1374) Update CONTRIBUTING.md with test info (cla: yes)
+
+[1375](https://github.com/flutter/plugins/pull/1375) Add pull request template (cla: yes)
+
+[1377](https://github.com/flutter/plugins/pull/1377) [firebase_admob] Update documentation to add iOS Admob ID & add iOS Admob ID in example project (cla: yes, documentation, flutterfire)
+
+[1378](https://github.com/flutter/plugins/pull/1378) [firebase_crashlytics] Support compatibility with Swift plugins (cla: yes)
+
+[1379](https://github.com/flutter/plugins/pull/1379) [firebase_crashlytics] Upgrade dependencies (cla: yes)
+
+[1380](https://github.com/flutter/plugins/pull/1380) [in_app_purchase]load purchase (cla: yes, feature)
+
+[1381](https://github.com/flutter/plugins/pull/1381) [in_app_purchase] Iap refactor (cla: yes)
+
+[1384](https://github.com/flutter/plugins/pull/1384) Send success result for `AlarmService.initialized` method call (cla: yes)
+
+[1385](https://github.com/flutter/plugins/pull/1385) [firebase_crashlytics]Remove white spaces to make git happy (cla: yes)
+
+[1386](https://github.com/flutter/plugins/pull/1386) [google_maps_flutter] Add failing test verifying that only changed markers are updated (cla: yes)
+
+[1387](https://github.com/flutter/plugins/pull/1387) [cloud_firestore] Add metadata field to DocumentSnapshot (cla: yes, feature, flutterfire)
+
+[1388](https://github.com/flutter/plugins/pull/1388) [firebase_crashlytics] Add firebase_crashlytics for Readme. (cla: yes, documentation, flutterfire)
+
+[1393](https://github.com/flutter/plugins/pull/1393) [camera] Fixes (#29925) (bugfix, cla: yes)
+
+[1394](https://github.com/flutter/plugins/pull/1394) Add Crashlytics plugin to FlutterFire docs (cla: no, flutterfire, submit queue)
+
+[1395](https://github.com/flutter/plugins/pull/1395) Add Crashlytics plugin to opensource list (cla: yes, flutterfire, submit queue)
+
+[1398](https://github.com/flutter/plugins/pull/1398) [firebase_auth]Fix PhoneCodeAuthRetrievalTimeout callback never called (bugfix, cla: yes, flutterfire)
+
+[1404](https://github.com/flutter/plugins/pull/1404) Bump version to 0.4.1+5 (cla: yes)
+
+[1405](https://github.com/flutter/plugins/pull/1405) [firebase_messaging] Additional step for iOS (cla: yes, documentation, flutterfire)
+
+[1406](https://github.com/flutter/plugins/pull/1406) [webview_flutter] Add initial e2e tests (cla: yes, feature, webview)
+
+[1407](https://github.com/flutter/plugins/pull/1407) [firebase_crashlytics] Update README code example (cla: yes, documentation, flutterfire)
+
+[1409](https://github.com/flutter/plugins/pull/1409) [google_maps] Add initial google_maps tests (cla: yes)
+
+[1410](https://github.com/flutter/plugins/pull/1410) [android_alarm_manager] add type params for invokeMethod calls. (cla: yes)
+
+[1411](https://github.com/flutter/plugins/pull/1411) [android_intent] add type params for invokeMethod calls. (cla: yes, feature)
+
+[1412](https://github.com/flutter/plugins/pull/1412) [Battery]add type params for invokeMethod calls. (cla: yes)
+
+[1413](https://github.com/flutter/plugins/pull/1413) [Camera]add type params for invokeMethod calls. (cla: yes)
+
+[1414](https://github.com/flutter/plugins/pull/1414) [Cloud_firestore]add type params for invokeMethod calls. (cla: yes)
+
+[1416](https://github.com/flutter/plugins/pull/1416) [Connectivity]add type params for invokeMethod calls. (cla: yes, feature)
+
+[1418](https://github.com/flutter/plugins/pull/1418) [firebase_crashlytics] Rely on firebase_core to set up Firebase Analytics dependency (bugfix, cla: yes, flutterfire)
+
+[1420](https://github.com/flutter/plugins/pull/1420) [webview_flutter] Use a pumpWidget utility in e2e tests (cla: yes)
+
+[1421](https://github.com/flutter/plugins/pull/1421) [in_app_purchase]make payment unified APIs (cla: yes, feature)
+
+[1424](https://github.com/flutter/plugins/pull/1424) [google_maps_flutter] Add a key parameter to the GoogleMap widget (cla: yes)
+
+[1427](https://github.com/flutter/plugins/pull/1427) [firebase_crashlytics] Do not break debug log formatting. (cla: yes, flutterfire)
+
+[1428](https://github.com/flutter/plugins/pull/1428) [firebase_analytics] Added Navigator.pushReplacement screen tracking (bugfix, cla: yes, feature, flutterfire)
+
+[1429](https://github.com/flutter/plugins/pull/1429) Make sure to post javascript channel messages from the platform thread. (cla: yes)
+
+[1430](https://github.com/flutter/plugins/pull/1430) [google_maps] Maps zoom level tests (cla: yes)
+
+[1434](https://github.com/flutter/plugins/pull/1434) [google_map] Test zoom gestures enabled (cla: yes)
+
+[1435](https://github.com/flutter/plugins/pull/1435) [cloud_firestore] Remove usage of `invokeMapMethod` (cla: yes)
+
+[1436](https://github.com/flutter/plugins/pull/1436) Fix formatting in main.dart of firebase_database, firebase_storage, google_sign_in, shared_preference (cla: yes)
+
+[1437](https://github.com/flutter/plugins/pull/1437) [firebase_crashlytics] Fix to Initialize Fabric (cla: yes, submit queue)
+
+[1438](https://github.com/flutter/plugins/pull/1438) [google_sign_in] Handle `null` check in example app (cla: yes)
+
+[1439](https://github.com/flutter/plugins/pull/1439) [battery] Update example in README.md (cla: yes)
+
+[1440](https://github.com/flutter/plugins/pull/1440) [image_picker] Check camera permissions and return error (cla: yes)
+
+[1441](https://github.com/flutter/plugins/pull/1441) [google_maps] Update android gradle version (cla: yes)
+
+[1442](https://github.com/flutter/plugins/pull/1442) [google_maps] Add tests for rotate tilt and zoom gestures (cla: yes)
+
+[1443](https://github.com/flutter/plugins/pull/1443) [firebase_core] Use Gradle BoM with firebase_core (cla: yes, flutterfire)
+
+[1444](https://github.com/flutter/plugins/pull/1444) [firebase_crashlytics] Added a simple integration test (cla: yes)
+
+[1445](https://github.com/flutter/plugins/pull/1445) [Image_picker]Android: fix original image deleted after scaling. (cla: yes)
+
+[1447](https://github.com/flutter/plugins/pull/1447) Update changelog and pubspec for onTap (cla: yes)
+
+[1448](https://github.com/flutter/plugins/pull/1448) [in_app_purchase] Add references to the original object for PurchaseDetails and ProductDetails (cla: yes)
+
+[1453](https://github.com/flutter/plugins/pull/1453) [cloud_firestore] Use Gradle BoM with cloud_firestore (cla: yes)
+
+[1455](https://github.com/flutter/plugins/pull/1455) [connectivity]Added integration test. (cla: yes, submit queue)
+
+[1458](https://github.com/flutter/plugins/pull/1458) [firebase_auth] AuthCredential for email and link (cla: yes)
+
+[1462](https://github.com/flutter/plugins/pull/1462) Remove BoM to avoid Gradle issues (cla: yes)
+
+[1464](https://github.com/flutter/plugins/pull/1464) [firebase_core] fix BoM-related build incompatibility regression (cla: yes)
+
+[1465](https://github.com/flutter/plugins/pull/1465) Integration tests for cloud_firestore and firebase_database transactions (cla: yes, flutterfire)
+
+[1466](https://github.com/flutter/plugins/pull/1466) [cloud_firestore]remove white spaces. (cla: yes)
+
+[1467](https://github.com/flutter/plugins/pull/1467) [cloud_firestore]remove blank line. (cla: yes)
+
+[1468](https://github.com/flutter/plugins/pull/1468) Migrate firebase messaging plugin away from token (cla: yes)
+
+[1470](https://github.com/flutter/plugins/pull/1470) [video_player] Android: Added missing event.put("event", "completed"); (bugfix, cla: yes)
+
+[1471](https://github.com/flutter/plugins/pull/1471) [image_picker] Fix invalid path being returned from Google Photos (bugfix, cla: yes)
+
+[1472](https://github.com/flutter/plugins/pull/1472) [Google_map]Enable iOS a11y by default. (cla: yes)
+
+[1473](https://github.com/flutter/plugins/pull/1473) [package_info] Integration tests. (cla: yes)
+
+[1474](https://github.com/flutter/plugins/pull/1474) [in_app_purchase]remove SKDownloadWrapper and related code. (cla: yes)
+
+[1476](https://github.com/flutter/plugins/pull/1476) [cloud_firestore] support for pagination using startAtDocument, endAtDocument, etc. (cla: no, flutterfire)
+
+[1477](https://github.com/flutter/plugins/pull/1477) [camera] Remove activity lifecycle (cla: yes, submit queue)
+
+[1478](https://github.com/flutter/plugins/pull/1478) [google_maps_flutter] Add a bitmap descriptor that is aware of scale (cla: yes)
+
+[1479](https://github.com/flutter/plugins/pull/1479) Adding links to the firebase_analytics  example (cla: yes)
+
+[1483](https://github.com/flutter/plugins/pull/1483) [Image_picker] ios minimum deployment target to 8.0. (cla: yes)
+
+[1484](https://github.com/flutter/plugins/pull/1484) [video_player] Explicitly indicate that self should be retained (cla: yes)
+
+[1485](https://github.com/flutter/plugins/pull/1485) Fix unused vars and rename (cla: yes)
+
+[1486](https://github.com/flutter/plugins/pull/1486) [firebase_performance] Firebase Performance integration tests (cla: yes)
+
+[1487](https://github.com/flutter/plugins/pull/1487) [firebase_auth] Migrate FlutterAuthPlugin from deprecated APIs (cla: yes, flutterfire)
+
+[1488](https://github.com/flutter/plugins/pull/1488) [image_picker]version fix. (cla: yes)
+
+[1489](https://github.com/flutter/plugins/pull/1489) BitmapDescriptor#fromBytes should be consistent across platforms (cla: yes)
+
+[1490](https://github.com/flutter/plugins/pull/1490) [firebase_analytics] Fixes errors in firebase_analytics docs (cla: yes)
+
+[1491](https://github.com/flutter/plugins/pull/1491) [cloud_firestore] Support for atomic FieldValue.increment (cla: yes, feature, flutterfire)
+
+[1492](https://github.com/flutter/plugins/pull/1492) [firebase_analytics] Initial integration test (cla: yes, flutterfire)
+
+[1493](https://github.com/flutter/plugins/pull/1493) [android_alarm_manager] Added comments and refactored android_alarm_manager plugin for clarity. (cla: yes)
+
+[1495](https://github.com/flutter/plugins/pull/1495) [in_app_purchase ]add cyanglaz to code owner. (cla: yes)
+
+[1496](https://github.com/flutter/plugins/pull/1496) Add myself to video_player CODEOWNERS (cla: yes)
+
+[1501](https://github.com/flutter/plugins/pull/1501) [webview_flutter] Fixed documentation for usage example of JavaScript message (cla: yes)
+
+[1502](https://github.com/flutter/plugins/pull/1502) [connectivity] Fixes lint error by using getApplicationContext() (cla: yes)
+
+[1503](https://github.com/flutter/plugins/pull/1503) Update firebase_auth CocoaPod dependency (cla: yes)
+
+[1504](https://github.com/flutter/plugins/pull/1504) [firebase_storage] Return error when failing to read file (bugfix, cla: yes, flutterfire)
+
+[1505](https://github.com/flutter/plugins/pull/1505) [image_picker] Fix path of returned File objects when picking videos (bugfix, cla: yes)
+
+[1506](https://github.com/flutter/plugins/pull/1506) [firebase_ml_vision] Start of ML Kit integration tests (cla: yes)
+
+[1508](https://github.com/flutter/plugins/pull/1508) [firebase_auth] Increase iOS Firebase/Auth CocoaPods dependency to 5.19 (cla: yes)
+
+[1509](https://github.com/flutter/plugins/pull/1509) [Image_picker] Android: fix a crash when the MainActivity is destroyed after selecting the image/video.  (cla: yes)
+
+[1511](https://github.com/flutter/plugins/pull/1511) [webview_flutter]bugfix:webview example should be statefulWidget (cla: yes)
+
+[1512](https://github.com/flutter/plugins/pull/1512) [Image_picker] retrieve lost image. (cla: yes)
+
+[1513](https://github.com/flutter/plugins/pull/1513) [firebase_storage] Initial integration testing (cla: yes)
+
+[1514](https://github.com/flutter/plugins/pull/1514) [firebase_remote_config] Initial integration tests (cla: yes, flutterfire)
+
+[1516](https://github.com/flutter/plugins/pull/1516) [webview_flutter] controller headers loadurl (cla: yes)
+
+[1517](https://github.com/flutter/plugins/pull/1517) [in_app_purchase] Rename the unified API (cla: yes)
+
+[1519](https://github.com/flutter/plugins/pull/1519) [image_picker] request camera permission if need (cla: yes)
+
+[1520](https://github.com/flutter/plugins/pull/1520) [cloud_functions] update Dart API to replace call with getHttpsCallable (cla: yes, feature, flutterfire)
+
+[1523](https://github.com/flutter/plugins/pull/1523) [firebase_performance] Deprecate incrementCounter in favor of incrementMetric (cla: yes)
+
+[1527](https://github.com/flutter/plugins/pull/1527) Some additions to CODEOWNERS (cla: yes)
+
+[1528](https://github.com/flutter/plugins/pull/1528) [webview_flutter] Remove un-used method params (cla: yes)
+
+[1531](https://github.com/flutter/plugins/pull/1531) [image_picker] example app video load error fix. (bugfix, cla: yes)
+
+[1532](https://github.com/flutter/plugins/pull/1532) [firebase_messaging] remove obsolete docs instruction (cla: yes, flutterfire)
+
+[1533](https://github.com/flutter/plugins/pull/1533) [image_picker] version fix. (cla: yes)
+
+[1534](https://github.com/flutter/plugins/pull/1534) [webview_flutter] Skip loadUrlWithHeaders test (cla: yes)
+
+[1535](https://github.com/flutter/plugins/pull/1535) [webview_flutter] Test: wait for page to load before checking the content (cla: yes)
+
+[1536](https://github.com/flutter/plugins/pull/1536) [in_app_purchase] Minor doc updates (cla: yes)
+
+[1537](https://github.com/flutter/plugins/pull/1537) [in_app_purchase] Add auto-consume errors to PurchaseDetails (cla: yes)
+
+[1539](https://github.com/flutter/plugins/pull/1539) [firebase_ml_vision] Update Firebase ML Vision documentation (cla: yes, documentation, flutterfire, submit queue)
+
+[1540](https://github.com/flutter/plugins/pull/1540) [in_app_purchase] Only fetch owned purchases (cla: yes)
+
+[1541](https://github.com/flutter/plugins/pull/1541) [image_picker] correct suffix on android. (cla: yes)
+
+[1542](https://github.com/flutter/plugins/pull/1542) [video_player] Android: Fix ide warnings in video_player (cla: yes)
+
+[1543](https://github.com/flutter/plugins/pull/1543) [cloud_firestore] Fix wrong FieldValue (cla: yes)
+
+[1544](https://github.com/flutter/plugins/pull/1544) [image_picker]fix license format. (cla: yes)
+
+[1545](https://github.com/flutter/plugins/pull/1545) [firebase_ml_vision] [share] Fix analyzer warnings from const Rect constructor. (cla: yes)
+
+[1549](https://github.com/flutter/plugins/pull/1549) [google_maps_flutter] Support Color's alpha channel when converting to UIColor on iOS (cla: yes)
+
+[1552](https://github.com/flutter/plugins/pull/1552) [video_player] Fix player initialization and other warnings (cla: yes)

--- a/src/docs/development/tools/sdk/release-notes/changelogs/changelog-1.7.8.md
+++ b/src/docs/development/tools/sdk/release-notes/changelogs/changelog-1.7.8.md
@@ -1,0 +1,2605 @@
+---
+title: Change log for Flutter 1.7.8 
+short-title: 1.7.8 change log
+description: Change log for Flutter 1.7.8 containing a list of all PRs merged for this release.
+---
+
+
+## PRs closed in this release of flutter/flutter
+
+From Wed May 1 16:56:00 2019 -0700 to Thu Jul 18 08:04:00 2019 -0700
+
+
+[28808](https://github.com/flutter/flutter/pull/28808)  updated tearDownAll function (cla: yes, t: flutter driver, team, tool, waiting for tree to go green)
+
+[28834](https://github.com/flutter/flutter/pull/28834) Sliver animated list (cla: yes, framework, waiting for tree to go green)
+
+[29683](https://github.com/flutter/flutter/pull/29683) Show/hide toolbar and handles based on device kind (a: desktop, a: text input, cla: yes, framework, severe: API break)
+
+[29809](https://github.com/flutter/flutter/pull/29809) Fix text selection toolbar appearing under obstructions (cla: yes, f: cupertino, f: material design, framework)
+
+[29954](https://github.com/flutter/flutter/pull/29954) Cupertino localization step 9: add tests (cla: yes, f: cupertino, framework)
+
+[30076](https://github.com/flutter/flutter/pull/30076) Implements FocusTraversalPolicy and DefaultFocusTraversal features. (a: desktop, cla: yes, framework)
+
+[30224](https://github.com/flutter/flutter/pull/30224) Cupertino localization step 10: update the flutter_localizations README (cla: yes, f: cupertino, framework)
+
+[30388](https://github.com/flutter/flutter/pull/30388) Add hintStyle in SearchDelegate (cla: yes, f: material design, framework)
+
+[30406](https://github.com/flutter/flutter/pull/30406) Add binaryMessenger constructor argument to platform channels (cla: yes, framework, p: framework)
+
+[30874](https://github.com/flutter/flutter/pull/30874) Redo "Remove pressure customization from some pointer events" (cla: yes, framework, severe: API break)
+
+[30979](https://github.com/flutter/flutter/pull/30979) fix issue 30526: rounding error (cla: yes, framework, waiting for tree to go green)
+
+[30983](https://github.com/flutter/flutter/pull/30983) Refactor core uses of FlutterError. (cla: yes, framework)
+
+[30988](https://github.com/flutter/flutter/pull/30988) Tight Paragraph Width (cla: yes, framework)
+
+[31018](https://github.com/flutter/flutter/pull/31018) [Material] selected/unselected label styles + icon themes on BottomNavigationBar (cla: yes, f: material design, framework)
+
+[31025](https://github.com/flutter/flutter/pull/31025) added `scrimColor` property in Scaffold widget (cla: yes, f: material design, framework)
+
+[31028](https://github.com/flutter/flutter/pull/31028) Adds support for generating projects that use AndroidX support libraries (cla: yes, tool, waiting for tree to go green)
+
+[31039](https://github.com/flutter/flutter/pull/31039) Fix bundle id on iOS launch using flutter run (cla: yes, tool)
+
+[31095](https://github.com/flutter/flutter/pull/31095) Add buttons customization to WidgetController and related testing classes (cla: yes, framework)
+
+[31227](https://github.com/flutter/flutter/pull/31227) Adding CupertinoTabController (cla: yes, f: cupertino, framework, severe: API break)
+
+[31308](https://github.com/flutter/flutter/pull/31308) Added font bold when isDefaultAction is true in CupertinoDialogAction (cla: yes, f: cupertino)
+
+[31317](https://github.com/flutter/flutter/pull/31317) Add docs to AppBar (cla: yes, d: api docs, f: material design, framework)
+
+[31318](https://github.com/flutter/flutter/pull/31318) Add BottomSheetTheme to enable theming color, elevation, shape of BottomSheet (cla: yes, f: material design, framework)
+
+[31333](https://github.com/flutter/flutter/pull/31333) Clean up flutter_test/test/controller_test.dart (a: tests, cla: yes, framework)
+
+[31438](https://github.com/flutter/flutter/pull/31438) Implements focus handling and hover for Material buttons. (cla: yes, f: material design, framework)
+
+[31485](https://github.com/flutter/flutter/pull/31485) Prevent exception being thrown on hasScrolledBody (cla: yes, f: scrolling, framework)
+
+[31514](https://github.com/flutter/flutter/pull/31514) Date picker layout exceptions (cla: yes, f: material design, framework)
+
+[31574](https://github.com/flutter/flutter/pull/31574) Improve RadioListTile Callback Behavior Consistency (cla: yes, f: material design, framework, severe: API break)
+
+[31581](https://github.com/flutter/flutter/pull/31581) Fix Exception on Nested TabBarView disposal (cla: yes, f: material design, framework, severe: crash)
+
+[31631](https://github.com/flutter/flutter/pull/31631) Teach Linux to use local engine (cla: yes, tool)
+
+[31644](https://github.com/flutter/flutter/pull/31644) Cupertino localization step 12: push translation for all supported languages (a: internationalization, cla: yes, f: cupertino, f: material design, framework)
+
+[31662](https://github.com/flutter/flutter/pull/31662) added shape property to SliverAppBar (cla: yes, f: material design, framework)
+
+[31681](https://github.com/flutter/flutter/pull/31681) [Material] Create a themable Range Slider (continuous and discrete) (cla: yes, f: material design, framework)
+
+[31699](https://github.com/flutter/flutter/pull/31699) Re-land: Add support for Tooltip hover (cla: yes, f: material design, framework)
+
+[31701](https://github.com/flutter/flutter/pull/31701) Add more asserts to check matrix validity (cla: yes, framework)
+
+[31763](https://github.com/flutter/flutter/pull/31763) Fix ScrollbarPainter thumbExtent calculation and add padding  (cla: yes, d: api docs, f: cupertino, f: material design, f: scrolling, framework)
+
+[31798](https://github.com/flutter/flutter/pull/31798) Fix tab indentation (cla: yes, framework, tool, waiting for tree to go green)
+
+[31822](https://github.com/flutter/flutter/pull/31822) remove unnecessary artificial delay in catalog example (cla: yes, d: examples, framework)
+
+[31824](https://github.com/flutter/flutter/pull/31824) fix FlutterDriver timeout (cla: yes, framework, t: flutter driver)
+
+[31825](https://github.com/flutter/flutter/pull/31825) Fix missing return statements on function literals (cla: yes, team, tool)
+
+[31850](https://github.com/flutter/flutter/pull/31850) Make Gradle error message more specific (cla: yes, tool)
+
+[31851](https://github.com/flutter/flutter/pull/31851) Add documentation to Navigator (cla: yes, framework)
+
+[31852](https://github.com/flutter/flutter/pull/31852) Text selection handles are sometimes not interactive (cla: yes, f: cupertino, f: material design, framework)
+
+[31861](https://github.com/flutter/flutter/pull/31861) Add Horizontal Padding to Constrained Chip Label Calculations (cla: yes, f: material design, framework)
+
+[31873](https://github.com/flutter/flutter/pull/31873) Add basic desktop linux checks (cla: yes, tool)
+
+[31885](https://github.com/flutter/flutter/pull/31885) Fix commit message UTF issue for deploy_gallery shard too (cla: yes, team)
+
+[31889](https://github.com/flutter/flutter/pull/31889) Start abstracting platform logic builds behind a shared interface (cla: yes, tool)
+
+[31890](https://github.com/flutter/flutter/pull/31890) apply fp hack to Flex (cla: yes, framework)
+
+[31894](https://github.com/flutter/flutter/pull/31894) Introduce separate HitTestResults for Box and Sliver (cla: yes, framework)
+
+[31895](https://github.com/flutter/flutter/pull/31895) Report CompileTime metric in flutter build aot --report-timings. (cla: yes, tool)
+
+[31902](https://github.com/flutter/flutter/pull/31902) Updated primaryColor docs to refer to colorScheme properties (cla: yes, d: api docs, f: material design, framework)
+
+[31903](https://github.com/flutter/flutter/pull/31903) Extract TODO comment from Image.asset dardoc (cla: yes, d: api docs, framework)
+
+[31909](https://github.com/flutter/flutter/pull/31909) Change unfocus to unfocus the entire chain, not just the primary focus (cla: yes, framework)
+
+[31910](https://github.com/flutter/flutter/pull/31910) [fuchsia] Add support for the 'device' command using the SDK (cla: yes)
+
+[31912](https://github.com/flutter/flutter/pull/31912) Revert "Redo: Add buttons to gestures" (cla: yes)
+
+[31923](https://github.com/flutter/flutter/pull/31923) Reland #31623 - fix edge swiping and dropping back at starting point (cla: yes)
+
+[31925](https://github.com/flutter/flutter/pull/31925) Add commands to swap dart imports for local development (cla: yes)
+
+[31926](https://github.com/flutter/flutter/pull/31926) Avoid NPE (cla: yes)
+
+[31929](https://github.com/flutter/flutter/pull/31929) Sample Code & Animation for Flow Widget (cla: yes, d: api docs, d: examples, framework)
+
+[31935](https://github.com/flutter/flutter/pull/31935) Redo#2: Add buttons to gestures (a: desktop, cla: yes, framework)
+
+[31936](https://github.com/flutter/flutter/pull/31936) make windows/mac consistent with linux (cla: yes)
+
+[31938](https://github.com/flutter/flutter/pull/31938) Update scrimDrawerColor with proper const format (cla: yes, f: material design, framework)
+
+[31944](https://github.com/flutter/flutter/pull/31944) Performance issue template (cla: yes, team)
+
+[31947](https://github.com/flutter/flutter/pull/31947) Simplify drawer scrimColor defaults, update tests (cla: yes)
+
+[31954](https://github.com/flutter/flutter/pull/31954) Fix MediaQueryData.toString() to generate readable output (cla: yes)
+
+[31960](https://github.com/flutter/flutter/pull/31960) Fix bug handling cyclic diagnostics. (cla: yes)
+
+[31967](https://github.com/flutter/flutter/pull/31967) cherry-pick: fix edge swiping and dropping back at starting point (#31623) (cla: yes)
+
+[31978](https://github.com/flutter/flutter/pull/31978) Reland fix 25807 implement move for sliver multibox widget (cla: yes)
+
+[31979](https://github.com/flutter/flutter/pull/31979) Revert "Tight Paragraph Width" (cla: yes)
+
+[31987](https://github.com/flutter/flutter/pull/31987) Text wrap width (a: typography, cla: yes, framework)
+
+[31998](https://github.com/flutter/flutter/pull/31998) [flutter_tool] Pull the right Fuchsia SDK for the platform (cla: yes)
+
+[32003](https://github.com/flutter/flutter/pull/32003) Revert "Start abstracting platform logic builds behind a shared interface" (cla: yes)
+
+[32013](https://github.com/flutter/flutter/pull/32013) Cupertino Turkish Translation (a: internationalization, cla: yes, f: cupertino, framework)
+
+[32025](https://github.com/flutter/flutter/pull/32025) Make Hover Listener respect transforms (cla: yes, framework, waiting for tree to go green)
+
+[32041](https://github.com/flutter/flutter/pull/32041) Remove deprecated decodedCacheRatioCap (cla: yes, framework)
+
+[32043](https://github.com/flutter/flutter/pull/32043) Rollback caret change for Android (cla: yes)
+
+[32050](https://github.com/flutter/flutter/pull/32050) Test Material buttons against a11y contrast guidelines (cla: yes)
+
+[32053](https://github.com/flutter/flutter/pull/32053) Increase TimePicker touch targets (cla: yes, f: material design, framework)
+
+[32059](https://github.com/flutter/flutter/pull/32059) fix issue 14014 read only text field (a: text input, cla: yes, framework, severe: API break)
+
+[32060](https://github.com/flutter/flutter/pull/32060) make hotfix use a plus instead of minus (cla: yes, tool)
+
+[32066](https://github.com/flutter/flutter/pull/32066) update packages and unpin build (cla: yes)
+
+[32070](https://github.com/flutter/flutter/pull/32070) rename foreground and background to light and dark (a: tests, cla: yes, framework)
+
+[32071](https://github.com/flutter/flutter/pull/32071) [flutter_tool] In 'attach' use platform dill etc from the Fuchsia SDK (cla: yes, tool)
+
+[32072](https://github.com/flutter/flutter/pull/32072) don't NPE with empty pubspec (cla: yes, tool)
+
+[32086](https://github.com/flutter/flutter/pull/32086) Fix CupertinoSliverRefreshControl onRefresh callback (cla: yes, f: cupertino, framework)
+
+[32126](https://github.com/flutter/flutter/pull/32126) Bump multicast_dns version (cla: yes, tool)
+
+[32135](https://github.com/flutter/flutter/pull/32135) Revert "Sliver animated list" (cla: yes)
+
+[32142](https://github.com/flutter/flutter/pull/32142) Fix RenderPointerListener so that callbacks aren't called at the wrong time. (cla: yes, framework)
+
+[32147](https://github.com/flutter/flutter/pull/32147) Added state management docs/sample to SwitchListTile (cla: yes, d: api docs, f: material design, framework)
+
+[32155](https://github.com/flutter/flutter/pull/32155) Revert "added shape property to SliverAppBar" (cla: yes)
+
+[32177](https://github.com/flutter/flutter/pull/32177) Tab Animation Sample Video (cla: yes, d: api docs, f: material design, framework)
+
+[32192](https://github.com/flutter/flutter/pull/32192) Transform PointerEvents to the local coordinate system of the event receiver (cla: yes, framework)
+
+[32256](https://github.com/flutter/flutter/pull/32256) fix issue 32212 Text field keyboard selection crashes (cla: yes)
+
+[32266](https://github.com/flutter/flutter/pull/32266) Add reference to Runner-Bridging-Header.h to iOS profile config (cla: yes, t: xcode, waiting for tree to go green)
+
+[32302](https://github.com/flutter/flutter/pull/32302) Add geometry getters to Flutter Driver (cla: yes)
+
+[32328](https://github.com/flutter/flutter/pull/32328) Add breadcrumbs to TextOverflow (cla: yes, framework, waiting for tree to go green)
+
+[32335](https://github.com/flutter/flutter/pull/32335) Teach flutter msbuild for Windows (cla: yes, tool)
+
+[32340](https://github.com/flutter/flutter/pull/32340) make immutables const (cla: yes, framework)
+
+[32345](https://github.com/flutter/flutter/pull/32345) Add master channel to performance issue template (cla: yes, team)
+
+[32350](https://github.com/flutter/flutter/pull/32350) Fix nested listeners so that ancestor listeners can also receive enter/exit/move events. (cla: yes)
+
+[32360](https://github.com/flutter/flutter/pull/32360) Allow flutter web to be compiled with flutter (cla: yes, framework, tool)
+
+[32380](https://github.com/flutter/flutter/pull/32380) const everything in Driver (cla: yes, framework, t: flutter driver, waiting for tree to go green)
+
+[32404](https://github.com/flutter/flutter/pull/32404) Comment out .vscode/ in gitignore for templates (cla: yes, tool)
+
+[32406](https://github.com/flutter/flutter/pull/32406) Fix assignment in macos_build_flutter_assets.sh (cla: yes)
+
+[32408](https://github.com/flutter/flutter/pull/32408) More const conversions (cla: yes, framework)
+
+[32410](https://github.com/flutter/flutter/pull/32410) Add ancestor and descendant finders to Driver (cla: yes, framework, waiting for tree to go green)
+
+[32425](https://github.com/flutter/flutter/pull/32425) Fix benchmark regression in layer.find<S>(Offset) (cla: yes)
+
+[32434](https://github.com/flutter/flutter/pull/32434) Support for replacing the TabController, after disposing the old one (cla: yes, f: material design, framework)
+
+[32437](https://github.com/flutter/flutter/pull/32437) Add assert that the root widget has been attached. (a: tests, cla: yes, framework)
+
+[32444](https://github.com/flutter/flutter/pull/32444) Updated some links (cla: yes, framework, tool)
+
+[32469](https://github.com/flutter/flutter/pull/32469)  Let CupertinoNavigationBarBackButton take a custom onPressed (cla: yes, f: cupertino, framework)
+
+[32470](https://github.com/flutter/flutter/pull/32470) Revert "Cupertino localization step 12: push translation for all supported languages" (cla: yes)
+
+[32487](https://github.com/flutter/flutter/pull/32487) Add a more meaningful message to the assertion on children (cla: yes, framework)
+
+[32496](https://github.com/flutter/flutter/pull/32496) Revert "Add more asserts to check matrix validity" (cla: yes)
+
+[32499](https://github.com/flutter/flutter/pull/32499) Use precisionErrorTolerance (cla: yes)
+
+[32503](https://github.com/flutter/flutter/pull/32503) Add more missing returns (cla: yes, team, tool)
+
+[32511](https://github.com/flutter/flutter/pull/32511) Rendering errors with root causes in the widget layer should have a reference to the widget (cla: yes, customer: countless, customer: headline, framework)
+
+[32513](https://github.com/flutter/flutter/pull/32513) Cupertino localization step 12 try 2: push translation for all supported languages (a: internationalization, cla: yes, f: cupertino)
+
+[32515](https://github.com/flutter/flutter/pull/32515) Remove appbundle build steps that are required for APKs but not AABs (cla: yes)
+
+[32519](https://github.com/flutter/flutter/pull/32519) [flutter_tool] Build a Fuchsia package (cla: yes)
+
+[32520](https://github.com/flutter/flutter/pull/32520) Fixing accidental merge from working branch (cla: yes)
+
+[32521](https://github.com/flutter/flutter/pull/32521) Reland matrix check (cla: yes)
+
+[32527](https://github.com/flutter/flutter/pull/32527) Added 'enabled' property to the PopupMenuButton (cla: yes, f: material design, framework)
+
+[32528](https://github.com/flutter/flutter/pull/32528) Tapping a modal bottom sheet should not dismiss it by default (cla: yes, f: material design, framework)
+
+[32530](https://github.com/flutter/flutter/pull/32530) Add Actions to AppBar Sample Doc (cla: yes, d: api docs, f: material design, framework)
+
+[32535](https://github.com/flutter/flutter/pull/32535) Fix transforms for things with RenderPointerListeners (cla: yes)
+
+[32538](https://github.com/flutter/flutter/pull/32538) Adjust macOS build flow (cla: yes)
+
+[32620](https://github.com/flutter/flutter/pull/32620) Added ScrollController to TextField (cla: yes, f: cupertino, f: material design, f: scrolling, framework)
+
+[32638](https://github.com/flutter/flutter/pull/32638) Fix apidocs in _WidgetsAppState.basicLocaleListResolution (cla: yes, d: api docs, framework)
+
+[32641](https://github.com/flutter/flutter/pull/32641) Updating dart.dev related links (cla: yes, d: api docs, framework)
+
+[32654](https://github.com/flutter/flutter/pull/32654) Tabs code/doc cleanup (cla: yes, f: material design, framework)
+
+[32656](https://github.com/flutter/flutter/pull/32656) Add diagnostics around needsCompositing (cla: yes)
+
+[32686](https://github.com/flutter/flutter/pull/32686) enable lint prefer_null_aware_operators (cla: yes, framework)
+
+[32702](https://github.com/flutter/flutter/pull/32702) Revert "Show/hide toolbar and handles based on device kind" (cla: yes)
+
+[32703](https://github.com/flutter/flutter/pull/32703) Add Doc Samples For CheckboxListTile, RadioListTile and SwitchListTile (cla: yes, d: api docs, f: material design, framework)
+
+[32704](https://github.com/flutter/flutter/pull/32704) Redo: Show/hide toolbar and handles based on device kind (cla: yes)
+
+[32706](https://github.com/flutter/flutter/pull/32706) Change the way macOS app names are located (cla: yes)
+
+[32710](https://github.com/flutter/flutter/pull/32710) Ignore some JSON RPC errors (cla: yes)
+
+[32711](https://github.com/flutter/flutter/pull/32711) use null aware operators (cla: yes, framework)
+
+[32717](https://github.com/flutter/flutter/pull/32717) Fix RenderPointerListener needsCompositing propagation from child widgets. (cla: yes)
+
+[32724](https://github.com/flutter/flutter/pull/32724) Correct platform reference in UiKitViewController (cla: yes)
+
+[32726](https://github.com/flutter/flutter/pull/32726) Material should not prevent ScrollNotifications from bubbling upwards (cla: yes, f: material design, f: scrolling, framework)
+
+[32727](https://github.com/flutter/flutter/pull/32727) [Material] Remove inherit: false on default TextStyles in BottomNavigationBar (cla: yes)
+
+[32730](https://github.com/flutter/flutter/pull/32730) Add reverseDuration to AnimationController (a: animation, cla: yes, framework)
+
+[32773](https://github.com/flutter/flutter/pull/32773) Add a FocusNode for AndroidView widgets. (cla: yes)
+
+[32776](https://github.com/flutter/flutter/pull/32776) Text field focus and hover support. (cla: yes, f: material design, framework)
+
+[32783](https://github.com/flutter/flutter/pull/32783) Streamline Windows build process (cla: yes)
+
+[32787](https://github.com/flutter/flutter/pull/32787) Support 32 and 64 bit (cla: yes, dependency: dart, t: gradle, tool)
+
+[32816](https://github.com/flutter/flutter/pull/32816) Add initial implementation of flutter assemble (cla: yes, tool)
+
+[32817](https://github.com/flutter/flutter/pull/32817) Skip flaky date picker tests on Windows (cla: yes)
+
+[32823](https://github.com/flutter/flutter/pull/32823) Add enableInteractiveSelection to CupertinoTextField (a: text input, cla: yes, f: cupertino, framework)
+
+[32825](https://github.com/flutter/flutter/pull/32825) Remove debug logging in _handleSingleLongTapEnd (cla: yes)
+
+[32826](https://github.com/flutter/flutter/pull/32826) Fix Focus.of to not find FocusScope nodes. (cla: yes)
+
+[32832](https://github.com/flutter/flutter/pull/32832) Visual selection is not adjusted when changing text selection with Ta… (cla: yes)
+
+[32833](https://github.com/flutter/flutter/pull/32833) reduce retry attempts for flutter create --list-samples (cla: yes)
+
+[32834](https://github.com/flutter/flutter/pull/32834) Prepare for API addition to HttpClientResponse (cla: yes)
+
+[32838](https://github.com/flutter/flutter/pull/32838) Handles hidden by keyboard (a: text input, cla: yes, f: material design, framework)
+
+[32842](https://github.com/flutter/flutter/pull/32842) Allow "from" hero state to survive hero animation in a push transition (a: animation, cla: yes, f: scrolling, framework, severe: API break)
+
+[32843](https://github.com/flutter/flutter/pull/32843) Added a missing dispose of an AnimationController that was leaking a ticker. (cla: yes, f: date/time picker, f: material design, framework)
+
+[32849](https://github.com/flutter/flutter/pull/32849) [flutter_tool] Adds support for 'run' for Fuchsia devices (cla: yes, tool, ○ platform-fuchsia)
+
+[32853](https://github.com/flutter/flutter/pull/32853) Add onBytesReceived callback to consolidateHttpClientResponseBytes() (a: images, cla: yes, framework)
+
+[32857](https://github.com/flutter/flutter/pull/32857) Add debugNetworkImageHttpClientProvider (a: images, cla: yes, framework)
+
+[32904](https://github.com/flutter/flutter/pull/32904) Use reverseDuration on Tooltip and InkWell (cla: yes, f: material design, framework)
+
+[32909](https://github.com/flutter/flutter/pull/32909) Documentation fix for debugProfileBuildsEnabled (cla: yes, d: api docs, framework)
+
+[32911](https://github.com/flutter/flutter/pull/32911) Material Long Press Text Handle Flash (cla: yes, f: material design, framework)
+
+[32914](https://github.com/flutter/flutter/pull/32914) Make hover and focus not respond when buttons and fields are disabled. (cla: yes, f: material design, framework)
+
+[32936](https://github.com/flutter/flutter/pull/32936) Add some sanity to the ImageStream listener API (a: images, cla: yes, framework)
+
+[32950](https://github.com/flutter/flutter/pull/32950) Material allows "select all" when not collapsed (cla: yes, f: material design, ▣ platform-android)
+
+[32974](https://github.com/flutter/flutter/pull/32974) Fix disabled CupertinoTextField style (a: text input, cla: yes, f: cupertino, framework)
+
+[32982](https://github.com/flutter/flutter/pull/32982) Add widget of the week videos (cla: yes)
+
+[33026](https://github.com/flutter/flutter/pull/33026) fix bad lint commented out (cla: yes)
+
+[33041](https://github.com/flutter/flutter/pull/33041) Rename `flutter packages` to `flutter pub` (cla: yes, tool)
+
+[33058](https://github.com/flutter/flutter/pull/33058) Add more missing returns (cla: yes, framework)
+
+[33062](https://github.com/flutter/flutter/pull/33062) Turn off container focus highlight for filled text fields. (cla: yes)
+
+[33068](https://github.com/flutter/flutter/pull/33068) Revert "Add assert that the root widget has been attached." (cla: yes)
+
+[33073](https://github.com/flutter/flutter/pull/33073) SliverAppBar shape property (cla: yes, f: material design, framework)
+
+[33078](https://github.com/flutter/flutter/pull/33078) don't send crash reports if on a user branch (cla: yes, tool)
+
+[33080](https://github.com/flutter/flutter/pull/33080) Fixed several issues with confirmDismiss handling on the LeaveBehindItem demo. (cla: yes, f: material design, framework)
+
+[33083](https://github.com/flutter/flutter/pull/33083) Update enabled color for outlined text fields. (cla: yes)
+
+[33084](https://github.com/flutter/flutter/pull/33084) Re-apply "Add assert that the root widget has been attached" (cla: yes)
+
+[33090](https://github.com/flutter/flutter/pull/33090) [Material] Add support for hovered, pressed, and focused text color on Buttons. (cla: yes, f: material design, framework)
+
+[33092](https://github.com/flutter/flutter/pull/33092) Add support for ImageStreamListener.onChunk() (cla: yes)
+
+[33135](https://github.com/flutter/flutter/pull/33135) A minor bug fix and comment cleanups for focus (cla: yes)
+
+[33140](https://github.com/flutter/flutter/pull/33140) flutter/tests support (cla: yes, team)
+
+[33146](https://github.com/flutter/flutter/pull/33146) [flutter_tool] Don't look for Fuchsia artifacts on Windows (cla: yes, tool)
+
+[33148](https://github.com/flutter/flutter/pull/33148) ExpandIcon Custom Colors (cla: yes, f: material design, framework, severe: API break, severe: new feature)
+
+[33152](https://github.com/flutter/flutter/pull/33152) ModalRoute resumes previous focus on didPopNext (cla: yes, framework, waiting for tree to go green)
+
+[33157](https://github.com/flutter/flutter/pull/33157) Engine roll 75963dbb0ba6..135a140591f3 (cla: yes)
+
+[33163](https://github.com/flutter/flutter/pull/33163) Clean up some flutter_tools tests and roll dependencies (cla: yes)
+
+[33164](https://github.com/flutter/flutter/pull/33164) remove Layer.replaceWith due to no usage and no tests (cla: yes, framework, severe: API break)
+
+[33191](https://github.com/flutter/flutter/pull/33191) Remove colon from Gradle task name since it's deprecated (cla: yes, t: gradle, tool, ▣ platform-android)
+
+[33195](https://github.com/flutter/flutter/pull/33195) Slight clarification in the ImageCache docs (cla: yes, framework)
+
+[33197](https://github.com/flutter/flutter/pull/33197) Wire up hot restart and incremental rebuilds for web (cla: yes, tool, ☸ platform-web)
+
+[33198](https://github.com/flutter/flutter/pull/33198) Build macOS via workspace, rather than project (cla: yes)
+
+[33206](https://github.com/flutter/flutter/pull/33206) Revert "Clean up some flutter_tools tests and roll dependencies" (cla: yes)
+
+[33217](https://github.com/flutter/flutter/pull/33217) Fix ImageStreamListener's hashCode & operator== (cla: yes)
+
+[33224](https://github.com/flutter/flutter/pull/33224) manual engine roll (cla: yes)
+
+[33225](https://github.com/flutter/flutter/pull/33225) Reland "Clean up some flutter_tools tests and roll dependencies" (cla: yes, tool)
+
+[33226](https://github.com/flutter/flutter/pull/33226) Explain hairline rendering in BorderSide.width docs (cla: yes, d: api docs, framework)
+
+[33228](https://github.com/flutter/flutter/pull/33228) Make Paths absolute in settings.gradle (cla: yes, t: gradle, tool)
+
+[33230](https://github.com/flutter/flutter/pull/33230) Framework support for font features in text styles (cla: yes, framework)
+
+[33232](https://github.com/flutter/flutter/pull/33232) use the --disable-server-feature-completion cli arg to the analysis server (cla: yes)
+
+[33248](https://github.com/flutter/flutter/pull/33248) [ci] use Windows Container 2019 (cla: yes)
+
+[33260](https://github.com/flutter/flutter/pull/33260) Pass an async callback to testWidgets. (cla: yes, framework)
+
+[33263](https://github.com/flutter/flutter/pull/33263) [flutter_tool] Improve Fuchsia 'run' tests (cla: yes, tool)
+
+[33264](https://github.com/flutter/flutter/pull/33264) Add local overrides to testbed and provide more defaults (cla: yes, tool)
+
+[33267](https://github.com/flutter/flutter/pull/33267) Add unpublish_package script. (cla: yes, team)
+
+[33268](https://github.com/flutter/flutter/pull/33268) Add cast to prepare for package:file update (cla: yes)
+
+[33269](https://github.com/flutter/flutter/pull/33269) Mark non-flaky test as such (cla: yes)
+
+[33271](https://github.com/flutter/flutter/pull/33271) No longer necessary with ddc fix (cla: yes, tool)
+
+[33272](https://github.com/flutter/flutter/pull/33272) Add mustRunAfter on mergeAssets task to force task ordering (cla: yes, engine, t: gradle, tool, waiting for tree to go green)
+
+[33277](https://github.com/flutter/flutter/pull/33277) Implement macOS support in `flutter doctor` (cla: yes, tool)
+
+[33279](https://github.com/flutter/flutter/pull/33279) Fix a problem in first focus determination. (cla: yes, framework)
+
+[33281](https://github.com/flutter/flutter/pull/33281) Update TextStyle and StrutStyle height docs (a: typography, cla: yes, d: api docs, framework, severe: API break)
+
+[33282](https://github.com/flutter/flutter/pull/33282) [flutter_tool] Use product runner in Fuchsia release build (cla: yes, tool)
+
+[33283](https://github.com/flutter/flutter/pull/33283) Fix relative paths and snapshot logic in tool (cla: yes, tool)
+
+[33284](https://github.com/flutter/flutter/pull/33284) make sure we build test targets too (cla: yes, tool)
+
+[33285](https://github.com/flutter/flutter/pull/33285) disable flaky devfs test (cla: yes)
+
+[33287](https://github.com/flutter/flutter/pull/33287) Add macosPrefix to the pubspec schema for plugins (cla: yes)
+
+[33295](https://github.com/flutter/flutter/pull/33295) Add stateful_widget_animation snippet template (cla: yes)
+
+[33297](https://github.com/flutter/flutter/pull/33297) Instrument add to app flows (a: existing-apps, cla: yes, tool)
+
+[33298](https://github.com/flutter/flutter/pull/33298) Add actions and keyboard shortcut map support (a: desktop, cla: yes, framework)
+
+[33322](https://github.com/flutter/flutter/pull/33322) Correct typos (cla: yes)
+
+[33323](https://github.com/flutter/flutter/pull/33323) Americanise spellings (cla: yes)
+
+[33349](https://github.com/flutter/flutter/pull/33349) Compatibility pass on flutter/foundation tests for JavaScript compilation. (1) (a: tests, cla: yes, ☸ platform-web)
+
+[33350](https://github.com/flutter/flutter/pull/33350) Compatibility pass on flutter/scheduler tests for JavaScript compilation. (2) (a: tests, cla: yes, ☸ platform-web)
+
+[33352](https://github.com/flutter/flutter/pull/33352) Compatibility pass on flutter/painting tests for JavaScript compilation. (3) (a: tests, cla: yes, ☸ platform-web)
+
+[33354](https://github.com/flutter/flutter/pull/33354) Compatibility pass on flutter/services tests for JavaScript compilation. (4) (a: tests, cla: yes, ☸ platform-web)
+
+[33355](https://github.com/flutter/flutter/pull/33355) Compatibility pass on flutter/rendering tests for JavaScript compilation. (5) (a: tests, cla: yes, ☸ platform-web)
+
+[33359](https://github.com/flutter/flutter/pull/33359) Compatibility pass on flutter/physics tests for JavaScript compilation. (6) (a: tests, cla: yes, ☸ platform-web)
+
+[33360](https://github.com/flutter/flutter/pull/33360) Compatibility pass on flutter/semantics tests for JavaScript compilation. (7) (a: tests, cla: yes, ☸ platform-web)
+
+[33361](https://github.com/flutter/flutter/pull/33361) (trivial) Rename test file (a: tests, cla: yes, f: material design, framework)
+
+[33363](https://github.com/flutter/flutter/pull/33363) Add clarification in Animation's listener API docs (cla: yes)
+
+[33369](https://github.com/flutter/flutter/pull/33369) Add loading support to Image (cla: yes, framework)
+
+[33370](https://github.com/flutter/flutter/pull/33370) Update FadeInImage to use new Image APIs (cla: yes, framework, severe: API break)
+
+[33374](https://github.com/flutter/flutter/pull/33374) Devfs cleanup and testing (cla: yes, tool)
+
+[33377](https://github.com/flutter/flutter/pull/33377) Compatibility pass on flutter/widgets tests for JavaScript compilation. (8) (a: tests, cla: yes, ☸ platform-web)
+
+[33378](https://github.com/flutter/flutter/pull/33378) Compatibility pass on flutter/material tests for JavaScript compilation. (9) (a: tests, cla: yes, ☸ platform-web)
+
+[33403](https://github.com/flutter/flutter/pull/33403) Add blank newline after Dartdoc bulleted list. (cla: yes)
+
+[33406](https://github.com/flutter/flutter/pull/33406) Add web safe indirection to Platform.isPlatform getters (a: tests, cla: yes, framework)
+
+[33431](https://github.com/flutter/flutter/pull/33431) Expose service client and app isolate in driver (cla: yes, framework, t: flutter driver)
+
+[33442](https://github.com/flutter/flutter/pull/33442) fix GridView documentation (cla: yes, d: api docs, framework, waiting for tree to go green)
+
+[33443](https://github.com/flutter/flutter/pull/33443) Wrap Windows build invocation in a batch script (a: desktop, cla: yes, tool, ❖ platform-windows)
+
+[33444](https://github.com/flutter/flutter/pull/33444) Revert "Framework support for font features in text styles" (cla: yes)
+
+[33448](https://github.com/flutter/flutter/pull/33448) Use vswhere to find Visual Studio (cla: yes, tool)
+
+[33449](https://github.com/flutter/flutter/pull/33449) Revert "Instrument add to app flows" (cla: yes)
+
+[33450](https://github.com/flutter/flutter/pull/33450) Do not return null from IosProject.isSwift (a: existing-apps, cla: yes, tool)
+
+[33454](https://github.com/flutter/flutter/pull/33454) ensure unpack declares required artifacts (a: desktop, cla: yes, tool)
+
+[33458](https://github.com/flutter/flutter/pull/33458) Add to app measurement (cla: yes, tool)
+
+[33459](https://github.com/flutter/flutter/pull/33459) make sure version check includes hotfixes (a: tests, cla: yes, team)
+
+[33461](https://github.com/flutter/flutter/pull/33461) Various code cleanup improvements (cla: yes, framework, waiting for tree to go green)
+
+[33462](https://github.com/flutter/flutter/pull/33462) Fix text scaling of strut style (cla: yes, framework)
+
+[33463](https://github.com/flutter/flutter/pull/33463) Pin previous build_daemon (cla: yes)
+
+[33466](https://github.com/flutter/flutter/pull/33466) [flutter_tool] Misc. fixes for Fuchsia (cla: yes, tool)
+
+[33467](https://github.com/flutter/flutter/pull/33467) fixed 33347 fill the gap during performLayout in SliverGrid and Slive… (cla: yes, framework)
+
+[33468](https://github.com/flutter/flutter/pull/33468) Fix a missing_return analyzer error in a code example (cla: yes)
+
+[33472](https://github.com/flutter/flutter/pull/33472) add daemon command to enumerate supported platforms (cla: yes, tool)
+
+[33473](https://github.com/flutter/flutter/pull/33473) fix 23723 rounding error (cla: yes, framework)
+
+[33474](https://github.com/flutter/flutter/pull/33474) Fixed for DropdownButton crashing when a style was used that didn't include a fontSize (cla: yes, f: material design, framework)
+
+[33475](https://github.com/flutter/flutter/pull/33475) Move declaration of semantic handlers from detectors to recognizers (cla: yes, framework)
+
+[33477](https://github.com/flutter/flutter/pull/33477) Fix onExit calling when the mouse is removed. (cla: yes, framework)
+
+[33488](https://github.com/flutter/flutter/pull/33488) use toFixedAsString and DoubleProperty in diagnosticProperties (cla: yes, framework)
+
+[33489](https://github.com/flutter/flutter/pull/33489) Remove empty file (cla: yes, framework)
+
+[33525](https://github.com/flutter/flutter/pull/33525) Add capability to flutter test --platform=chrome (cla: yes, tool)
+
+[33526](https://github.com/flutter/flutter/pull/33526) Update Fuchsia SDK (cla: yes, tool)
+
+[33528](https://github.com/flutter/flutter/pull/33528) Build the solution on Windows (cla: yes)
+
+[33529](https://github.com/flutter/flutter/pull/33529) Revert "Wire up hot restart and incremental rebuilds for web" (cla: yes)
+
+[33531](https://github.com/flutter/flutter/pull/33531) Fixed broken link in debugProfileBuildsEnabled documentation (cla: yes, framework)
+
+[33533](https://github.com/flutter/flutter/pull/33533) Reland - Wire up hot restart and incremental rebuilds for web (cla: yes, tool)
+
+[33535](https://github.com/flutter/flutter/pull/33535) Custom height parameters for DataTable header and data rows (cla: yes, f: material design, framework, severe: new feature)
+
+[33539](https://github.com/flutter/flutter/pull/33539) Fix/update several HTML links (cla: yes, team)
+
+[33540](https://github.com/flutter/flutter/pull/33540) Pass local engine variables to Windows build (cla: yes, tool)
+
+[33549](https://github.com/flutter/flutter/pull/33549) Mark flutter_gallery__back_button_memory as flaky (cla: yes)
+
+[33554](https://github.com/flutter/flutter/pull/33554) Remove obsolete TODOs (cla: yes, team)
+
+[33595](https://github.com/flutter/flutter/pull/33595) Add DiagnosticableMixin (cla: yes)
+
+[33596](https://github.com/flutter/flutter/pull/33596) Un-mark uncaught_image_error_linux as flaky (cla: yes)
+
+[33602](https://github.com/flutter/flutter/pull/33602) Remove assert from Image._handleImageFrame() (cla: yes)
+
+[33608](https://github.com/flutter/flutter/pull/33608) Restructure macOS project files (cla: yes, tool)
+
+[33611](https://github.com/flutter/flutter/pull/33611) Use Dart's new direct ELF generator to package AOT blobs as shared libraries in Android APKs (cla: yes, tool)
+
+[33620](https://github.com/flutter/flutter/pull/33620) Document that offsets are returned in logical pixels (cla: yes, d: api docs, framework)
+
+[33624](https://github.com/flutter/flutter/pull/33624) CupertinoTabScaffold crash fix (cla: yes, f: cupertino)
+
+[33627](https://github.com/flutter/flutter/pull/33627) SliverFillRemaining flag for different use cases (cla: yes, f: scrolling, framework)
+
+[33628](https://github.com/flutter/flutter/pull/33628) DataTable Custom Horizontal Padding (cla: yes, f: material design, framework, severe: new feature)
+
+[33629](https://github.com/flutter/flutter/pull/33629) Add real-er restart for web using webkit inspection protocol (cla: yes, tool, ☸ platform-web)
+
+[33632](https://github.com/flutter/flutter/pull/33632) Update the keycodes from source (cla: yes, framework)
+
+[33634](https://github.com/flutter/flutter/pull/33634) Let there be scroll bars (a: fidelity, cla: yes, f: cupertino, f: material design, f: scrolling, framework, team: gallery)
+
+[33636](https://github.com/flutter/flutter/pull/33636) Implement plugin tooling support for macOS (a: desktop, cla: yes, tool, ⌘‬ platform-mac)
+
+[33653](https://github.com/flutter/flutter/pull/33653) Include advice about dispose in TextEditingController api  (cla: yes, d: api docs, f: cupertino, f: material design, framework)
+
+[33662](https://github.com/flutter/flutter/pull/33662) Prep for engine roll (cla: yes, engine, framework)
+
+[33663](https://github.com/flutter/flutter/pull/33663) Use conditional imports for flutter foundation libraries (cla: yes, framework)
+
+[33665](https://github.com/flutter/flutter/pull/33665) [Trivial] Move dropdownValue into State in DropdownButton sample docs (cla: yes, d: api docs, f: material design, framework)
+
+[33666](https://github.com/flutter/flutter/pull/33666) Change screenshot observatory port flag to a URI that can include the authentication code (cla: yes)
+
+[33673](https://github.com/flutter/flutter/pull/33673) Revert "Devfs cleanup and testing" (cla: yes)
+
+[33674](https://github.com/flutter/flutter/pull/33674) Add documentation to ImplicitlyAnimatedWidgetState (cla: yes, framework)
+
+[33676](https://github.com/flutter/flutter/pull/33676) Removing old golden checkout for integration test (a: tests, cla: yes, tool)
+
+[33677](https://github.com/flutter/flutter/pull/33677) Roll pub dependencies (cla: yes, team)
+
+[33684](https://github.com/flutter/flutter/pull/33684) Disable CocoaPods input and output paths in Xcode build phase and adopt new Xcode build system (cla: yes, t: xcode, tool, ⌺‬ platform-ios)
+
+[33688](https://github.com/flutter/flutter/pull/33688) Part 1: Skia Gold Testing (a: tests, cla: yes, framework)
+
+[33695](https://github.com/flutter/flutter/pull/33695) Add pseudo-key synonyms for keys like shift, meta, alt, and control. (a: desktop, cla: yes, framework)
+
+[33696](https://github.com/flutter/flutter/pull/33696) Generate ELF shared libraries and allow multi-abi libs in APKs and App bundles (cla: yes, t: gradle, tool, ▣ platform-android)
+
+[33697](https://github.com/flutter/flutter/pull/33697) Roll engine a32df2c92800..153416e554ef (2 commits) (#33680) (cla: yes)
+
+[33698](https://github.com/flutter/flutter/pull/33698) fix devicelab manfiest (cla: yes)
+
+[33703](https://github.com/flutter/flutter/pull/33703) Revert "Add real-er restart for web using webkit inspection protocol … (cla: yes)
+
+[33704](https://github.com/flutter/flutter/pull/33704) Default optional bool param to false (cla: yes)
+
+[33729](https://github.com/flutter/flutter/pull/33729) Update consolidateHttpClientResponseBytes() to use compressionState (a: images, cla: yes, framework)
+
+[33739](https://github.com/flutter/flutter/pull/33739) fixed cupertinoTextField placeholder textAlign (cla: yes, f: cupertino, framework)
+
+[33772](https://github.com/flutter/flutter/pull/33772) Remove ios_add2app Pods directory and add to gitignore (cla: yes)
+
+[33776](https://github.com/flutter/flutter/pull/33776) Revert "Add web safe indirection to Platform.isPlatform getters" (cla: yes)
+
+[33780](https://github.com/flutter/flutter/pull/33780) Add web safe indirection to Platform.isPlatform getters (2) (cla: yes)
+
+[33781](https://github.com/flutter/flutter/pull/33781) wire in fuchsiaApp (cla: yes)
+
+[33782](https://github.com/flutter/flutter/pull/33782) [flutter_tool] Log an Android X related failure to analytics (cla: yes)
+
+[33786](https://github.com/flutter/flutter/pull/33786) Add a real-er web restart, doctor, workflow (a: tests, cla: yes, t: flutter driver, team)
+
+[33787](https://github.com/flutter/flutter/pull/33787) Add chrome stable to dockerfile and web shard (cla: yes, team)
+
+[33790](https://github.com/flutter/flutter/pull/33790) Revert "Update consolidateHttpClientResponseBytes() to use compressionState" (cla: yes)
+
+[33792](https://github.com/flutter/flutter/pull/33792) Remove references to HttpClientResponseCompressionState (cla: yes)
+
+[33794](https://github.com/flutter/flutter/pull/33794) Text inline widgets, TextSpan rework (a: text input, a: typography, cla: yes, framework, severe: API break, severe: new feature)
+
+[33800](https://github.com/flutter/flutter/pull/33800) Revert "Add capability to flutter test --platform=chrome" (cla: yes)
+
+[33802](https://github.com/flutter/flutter/pull/33802) Double double tap toggles instead of error (a: text input, cla: yes, f: material design, framework)
+
+[33805](https://github.com/flutter/flutter/pull/33805) Fixing duplicate golden test names (a: tests, cla: yes, framework)
+
+[33808](https://github.com/flutter/flutter/pull/33808) fix ExpansionPanelList merge the header semantics when it is not nece… (a: accessibility, cla: yes, f: material design, framework)
+
+[33814](https://github.com/flutter/flutter/pull/33814) Added a benchmark for ImageCache (a: images, cla: yes, framework)
+
+[33815](https://github.com/flutter/flutter/pull/33815) Revert "ModalRoute resumes previous focus on didPopNext" (cla: yes)
+
+[33825](https://github.com/flutter/flutter/pull/33825) Revert "Use conditional imports for flutter foundation libraries" (cla: yes)
+
+[33828](https://github.com/flutter/flutter/pull/33828) Reland https://github.com/flutter/flutter/pull/33663 (cla: yes)
+
+[33842](https://github.com/flutter/flutter/pull/33842) Don't print warning message when running benchmarks test. (a: tests, cla: yes, framework)
+
+[33846](https://github.com/flutter/flutter/pull/33846) [flutter_tool] Fix 'q' for Fuchsia profile/debug mode (cla: yes, tool)
+
+[33851](https://github.com/flutter/flutter/pull/33851) Revert "Move declaration of semantic handlers from detectors to recognizers" (cla: yes)
+
+[33852](https://github.com/flutter/flutter/pull/33852) Disable CocoaPods input and output paths in Xcode build phase and adopt new Xcode build system (cla: yes, tool)
+
+[33859](https://github.com/flutter/flutter/pull/33859) Reland support flutter test on platform chrome (cla: yes, tool)
+
+[33861](https://github.com/flutter/flutter/pull/33861) Unmark flutter_gallery__back_button_memory as flaky (cla: yes, team)
+
+[33865](https://github.com/flutter/flutter/pull/33865) Correct version name for BottomNavigationBar golden test (a: tests, cla: yes, f: material design, framework, waiting for tree to go green)
+
+[33867](https://github.com/flutter/flutter/pull/33867) Remove environment variable guards for command line desktop and web (cla: yes, tool)
+
+[33868](https://github.com/flutter/flutter/pull/33868) Game controller button support (a: desktop, cla: yes, framework)
+
+[33872](https://github.com/flutter/flutter/pull/33872) Add 'doctor' support for Windows (cla: yes, tool)
+
+[33874](https://github.com/flutter/flutter/pull/33874) Prevent windows web doctor from launching chrome (cla: yes, tool)
+
+[33876](https://github.com/flutter/flutter/pull/33876) Reland "Framework support for font features in text styles" (cla: yes, framework)
+
+[33880](https://github.com/flutter/flutter/pull/33880) Splitting golden file versioning out as an argument of matchesGoldenFile (a: tests, cla: yes, framework, waiting for tree to go green)
+
+[33882](https://github.com/flutter/flutter/pull/33882) Revert "Disable CocoaPods input and output paths in Xcode build phase and adopt new Xcode build system" (cla: yes)
+
+[33883](https://github.com/flutter/flutter/pull/33883) Updated localizations (cla: yes)
+
+[33886](https://github.com/flutter/flutter/pull/33886) Add currentSystemFrameTimeStamp to SchedulerBinding (cla: yes, framework)
+
+[33892](https://github.com/flutter/flutter/pull/33892) add benchmarks to track web size (cla: yes, tool)
+
+[33901](https://github.com/flutter/flutter/pull/33901) Respond to AndroidView focus events. (cla: yes, framework)
+
+[33917](https://github.com/flutter/flutter/pull/33917) 'the the' doc fix (cla: yes, d: api docs, framework)
+
+[33923](https://github.com/flutter/flutter/pull/33923) [flutter_tool] Track APK sha calculation time (cla: yes, tool)
+
+[33924](https://github.com/flutter/flutter/pull/33924) Added --dart-flags option to flutter run (cla: yes, tool)
+
+[33928](https://github.com/flutter/flutter/pull/33928) Revert "Text inline widgets, TextSpan rework" (cla: yes)
+
+[33932](https://github.com/flutter/flutter/pull/33932) More removing of timeouts. (a: tests, cla: yes, team, team: flakes, waiting for tree to go green)
+
+[33936](https://github.com/flutter/flutter/pull/33936) New parameter for RawGestureDetector to customize semantics mapping (cla: yes, f: gestures, framework)
+
+[33946](https://github.com/flutter/flutter/pull/33946) Reland "Text inline widgets, TextSpan rework" (a: text input, a: typography, cla: yes, framework, severe: API break, severe: new feature)
+
+[33949](https://github.com/flutter/flutter/pull/33949) Fix a bug in Shortcuts with synonyms, and add tests. (cla: yes)
+
+[33951](https://github.com/flutter/flutter/pull/33951) Whitelist adb.exe heap corruption exit code. (cla: yes, tool)
+
+[33955](https://github.com/flutter/flutter/pull/33955) Add localFocalPoint to ScaleDetector (cla: yes, framework, waiting for tree to go green)
+
+[33956](https://github.com/flutter/flutter/pull/33956) Codegen an entrypoint for flutter web applications (cla: yes, tool, ☸ platform-web)
+
+[33980](https://github.com/flutter/flutter/pull/33980) Increase daemon protocol version for getSupportedPlatforms (cla: yes, tool)
+
+[33982](https://github.com/flutter/flutter/pull/33982) Revert engine back to afb9d510c3bb0f1b97980434b41200a2d3491697 (cla: yes)
+
+[33987](https://github.com/flutter/flutter/pull/33987) Add use_frameworks to macOS Podfile template (cla: yes)
+
+[33989](https://github.com/flutter/flutter/pull/33989) Manually roll the engine to land the timing API (cla: yes)
+
+[33990](https://github.com/flutter/flutter/pull/33990) Add device category for daemon (cla: yes, tool)
+
+[33996](https://github.com/flutter/flutter/pull/33996) Remove unused/dead code from WidgetInspector (cla: yes, framework)
+
+[33997](https://github.com/flutter/flutter/pull/33997) Make plugins Swift-first on macOS (cla: yes)
+
+[33999](https://github.com/flutter/flutter/pull/33999) Updating MediaQuery with viewPadding (cla: yes, framework)
+
+[34002](https://github.com/flutter/flutter/pull/34002) Revert "Text inline widgets, TextSpan rework (#33946)" (cla: yes)
+
+[34004](https://github.com/flutter/flutter/pull/34004) Remove print (cla: yes)
+
+[34006](https://github.com/flutter/flutter/pull/34006) Re-add deprecated method for plugin migration compatibility. (cla: yes)
+
+[34012](https://github.com/flutter/flutter/pull/34012) Extract DiagnosticsNode serializer from WidgetInspector (a: tests, cla: yes, customer: espresso, framework)
+
+[34017](https://github.com/flutter/flutter/pull/34017) Skip web test on crazy import (a: tests, cla: yes)
+
+[34018](https://github.com/flutter/flutter/pull/34018) Add flutter create for the web (cla: yes, tool, ☸ platform-web)
+
+[34022](https://github.com/flutter/flutter/pull/34022) Revert "Re-add deprecated method for plugin migration compatibility." (cla: yes)
+
+[34032](https://github.com/flutter/flutter/pull/34032) Enable web foundation tests (a: tests, cla: yes, team)
+
+[34049](https://github.com/flutter/flutter/pull/34049) [flutter_tool] Send build timing to analytics (cla: yes)
+
+[34050](https://github.com/flutter/flutter/pull/34050) limit open files on macOS when copying assets (cla: yes, tool)
+
+[34051](https://github.com/flutter/flutter/pull/34051) Reland "Text inline widgets, TextSpan rework (#30069)" with improved backwards compatibility (a: text input, a: typography, cla: yes, severe: API break, severe: new feature)
+
+[34054](https://github.com/flutter/flutter/pull/34054) Make it easier to pass local engine flags when running devicelab tests (a: tests, cla: yes, team)
+
+[34055](https://github.com/flutter/flutter/pull/34055) Toggle toolbar exception fix (a: text input, cla: yes, f: material design)
+
+[34056](https://github.com/flutter/flutter/pull/34056) fix devicelab test for chrome reload worklow (cla: yes)
+
+[34057](https://github.com/flutter/flutter/pull/34057) Add endIndent property to Divider and VerticalDivider (cla: yes, f: material design, framework)
+
+[34061](https://github.com/flutter/flutter/pull/34061) Revert "Prevent exception being thrown on hasScrolledBody" (cla: yes)
+
+[34062](https://github.com/flutter/flutter/pull/34062) Roll engine to 086b5a48d6acdb64dd7b2a4cbf9dd620c54812b9 (cla: yes)
+
+[34063](https://github.com/flutter/flutter/pull/34063) Fix web size test for new world (cla: yes)
+
+[34066](https://github.com/flutter/flutter/pull/34066) Adds the androidX flag to a modules pubspec.yaml template so it is se… (cla: yes, tool)
+
+[34068](https://github.com/flutter/flutter/pull/34068) fix empty selection arrow when double clicked on empty read only text… (a: text input, cla: yes, framework)
+
+[34073](https://github.com/flutter/flutter/pull/34073) Dartdoc Generation README Improvements (cla: yes, d: api docs, framework)
+
+[34074](https://github.com/flutter/flutter/pull/34074) add analytics fields for attached device os version & run mode (cla: yes, tool)
+
+[34079](https://github.com/flutter/flutter/pull/34079) don't warn on CHROME_EXECUTABLE missing if we've already located it. (cla: yes)
+
+[34081](https://github.com/flutter/flutter/pull/34081) Report async callback errors that currently go unreported. (cla: yes, tool)
+
+[34084](https://github.com/flutter/flutter/pull/34084) make running on web spooky (cla: yes, tool)
+
+[34085](https://github.com/flutter/flutter/pull/34085) Revert "Roll engine to 086b5a48d6acdb64dd7b2a4cbf9dd620c54812b9" (cla: yes)
+
+[34086](https://github.com/flutter/flutter/pull/34086) Add recognizer compatibility API (cla: yes)
+
+[34088](https://github.com/flutter/flutter/pull/34088) Revert "Roll engine 0602dbb27547..06dbe28e33e5 (13 commits)" (cla: yes)
+
+[34090](https://github.com/flutter/flutter/pull/34090) More verification on flutter build web, add tests and cleanup (cla: yes, tool)
+
+[34092](https://github.com/flutter/flutter/pull/34092) Revert "Added --dart-flags option to flutter run" (cla: yes)
+
+[34094](https://github.com/flutter/flutter/pull/34094) Roll engine 0602dbb27547..ddd36e8338ab (17 commits) (cla: yes)
+
+[34095](https://github.com/flutter/flutter/pull/34095) Cupertino text edit tooltip, reworked  (a: text input, cla: yes, f: cupertino, severe: API break)
+
+[34099](https://github.com/flutter/flutter/pull/34099) Roll engine to e8ee6acf8de3613fdd9f431fff5c4c37b65c3335 (cla: yes)
+
+[34112](https://github.com/flutter/flutter/pull/34112) Separate web and io implementations of network image (cla: yes, framework, team, tool, ☸ platform-web)
+
+[34114](https://github.com/flutter/flutter/pull/34114) roll engine to c5b55e9a6783ca811dd7b401332e9db8d4d54076 (cla: yes)
+
+[34121](https://github.com/flutter/flutter/pull/34121) Revert "Generate ELF shared libraries and allow multi-abi libs in APKs and App bundles" (cla: yes)
+
+[34123](https://github.com/flutter/flutter/pull/34123) Generate ELF shared libraries and allow multi-abi libs in APKs and App bundles (cla: yes, t: gradle, tool)
+
+[34137](https://github.com/flutter/flutter/pull/34137) Added tool sample for PageController (cla: yes, d: api docs, framework)
+
+[34159](https://github.com/flutter/flutter/pull/34159) Use product define for flutter web and remove extra asset server (cla: yes, tool, ☸ platform-web)
+
+[34162](https://github.com/flutter/flutter/pull/34162) Update the Fuchsia SDK (cla: yes, tool, ○ platform-fuchsia)
+
+[34163](https://github.com/flutter/flutter/pull/34163) update CupertinoDialogAction docs (cla: yes, d: api docs, f: cupertino)
+
+[34166](https://github.com/flutter/flutter/pull/34166) Revert "More verification on flutter build web, add tests and cleanup" (cla: yes)
+
+[34167](https://github.com/flutter/flutter/pull/34167) Disable CocoaPods input and output paths in Xcode build phase and adopt new Xcode build system (cla: yes)
+
+[34173](https://github.com/flutter/flutter/pull/34173) Reland: More verification on flutter build web, add tests and cleanup (cla: yes)
+
+[34175](https://github.com/flutter/flutter/pull/34175) Don't show scrollbar if there isn't enough content (cla: yes, f: scrolling, framework)
+
+[34178](https://github.com/flutter/flutter/pull/34178) [Material] Fix slider track shape to rounded (cla: yes)
+
+[34179](https://github.com/flutter/flutter/pull/34179) Consider all non-interactive terminals to be bots (cla: yes)
+
+[34181](https://github.com/flutter/flutter/pull/34181) Reland "Added --dart-flags option to flutter run (#33924)" (cla: yes, tool)
+
+[34189](https://github.com/flutter/flutter/pull/34189) Instrument usage of include_flutter.groovy and xcode_backend.sh (a: existing-apps, cla: yes, tool)
+
+[34199](https://github.com/flutter/flutter/pull/34199) make sure this test doesn't run for real (a: tests, cla: yes, team, team: flakes)
+
+[34202](https://github.com/flutter/flutter/pull/34202) Remove `_debugWillReattachChildren` assertions from `_TableElement` (cla: yes, customer: payouts, framework)
+
+[34243](https://github.com/flutter/flutter/pull/34243) update the Flutter.Frame event to use new engine APIs (cla: yes, framework)
+
+[34250](https://github.com/flutter/flutter/pull/34250) Strip debug symbols from ELF library snapshots (cla: yes)
+
+[34255](https://github.com/flutter/flutter/pull/34255) [flutter_tool] Don't truncate verbose logs from _flutter.listViews (cla: yes, tool)
+
+[34276](https://github.com/flutter/flutter/pull/34276) [flutter_tool,fuchsia] Prefetch tiles when starting an app (cla: yes, engine, tool, ○ platform-fuchsia)
+
+[34282](https://github.com/flutter/flutter/pull/34282) Split gradle_plugin_test.dart (cla: yes, tool)
+
+[34285](https://github.com/flutter/flutter/pull/34285) fix Applying decoration for a table row widget will cause render exce… (cla: yes, framework)
+
+[34288](https://github.com/flutter/flutter/pull/34288) Report commands that resulted in success or failure (cla: yes, tool)
+
+[34291](https://github.com/flutter/flutter/pull/34291) Check whether FLUTTER_ROOT and FLUTTER_ROOT/bin are writable. (cla: yes, tool)
+
+[34293](https://github.com/flutter/flutter/pull/34293) Change Xcode developmentRegion to 'en' and CFBundleDevelopmentRegion to DEVELOPMENT_LANGUAGE (cla: yes, t: xcode, tool)
+
+[34295](https://github.com/flutter/flutter/pull/34295) Prepare for Uint8List SDK breaking changes (cla: yes, dependency: dart, tool)
+
+[34298](https://github.com/flutter/flutter/pull/34298) Preserving SafeArea : Part 2 (cla: yes, customer: solaris, framework, severe: customer critical, waiting for tree to go green)
+
+[34301](https://github.com/flutter/flutter/pull/34301) Make it possible to override the FLUTTER_TEST env variable (a: tests, cla: yes, customer: mulligan (g3), team, tool)
+
+[34341](https://github.com/flutter/flutter/pull/34341) Re-apply compressionState changes. (cla: yes)
+
+[34352](https://github.com/flutter/flutter/pull/34352) Revert "update the Flutter.Frame event to use new engine APIs" (cla: yes)
+
+[34353](https://github.com/flutter/flutter/pull/34353) Refactor Gradle plugin (cla: yes, t: gradle, tool)
+
+[34355](https://github.com/flutter/flutter/pull/34355) Text field vertical align (cla: yes, f: material design, framework)
+
+[34356](https://github.com/flutter/flutter/pull/34356) Add widget of the week videos (cla: yes, d: api docs)
+
+[34365](https://github.com/flutter/flutter/pull/34365) redux of a change to use new engine APIs for Flutter.Frame events (cla: yes, framework)
+
+[34368](https://github.com/flutter/flutter/pull/34368) Fix semantics_tester (a: accessibility, a: tests, cla: yes, framework)
+
+[34369](https://github.com/flutter/flutter/pull/34369) Remove unused flag `--target-platform` from `flutter run` (cla: yes, tool)
+
+[34374](https://github.com/flutter/flutter/pull/34374) Update flakiness of tests (cla: yes)
+
+[34376](https://github.com/flutter/flutter/pull/34376) Add missing pieces for 'driver' support on macOS (cla: yes, tool)
+
+[34388](https://github.com/flutter/flutter/pull/34388) Change API doc link to api.dart.dev (cla: yes, d: api docs, framework)
+
+[34417](https://github.com/flutter/flutter/pull/34417) Include raw value in Diagnostics json for basic types (a: tests, cla: yes, framework)
+
+[34419](https://github.com/flutter/flutter/pull/34419) Disable flaky tests (cla: yes)
+
+[34424](https://github.com/flutter/flutter/pull/34424) SizedBox documentation minor update (cla: yes, d: api docs, framework)
+
+[34430](https://github.com/flutter/flutter/pull/34430) skip bottom_sheet (cla: yes)
+
+[34434](https://github.com/flutter/flutter/pull/34434) Semantics fixes (a: accessibility, cla: yes, framework)
+
+[34436](https://github.com/flutter/flutter/pull/34436) Allow web tests to fail (cla: yes)
+
+[34440](https://github.com/flutter/flutter/pull/34440) Add Driver command to get diagnostics tree (a: tests, cla: yes, customer: espresso, framework, waiting for tree to go green)
+
+[34447](https://github.com/flutter/flutter/pull/34447) [flutter_tool,fuchsia] Update the install flow for packaging migration. (cla: yes, tool)
+
+[34456](https://github.com/flutter/flutter/pull/34456) Allow flaky tests to pass or fail and mark web tests as flaky (cla: yes)
+
+[34457](https://github.com/flutter/flutter/pull/34457) Dont depend on web sdk unless running tests on chrome (cla: yes)
+
+[34460](https://github.com/flutter/flutter/pull/34460) Add back ability to override the local engine in Gradle (cla: yes, engine, severe: crash, t: gradle, tool)
+
+[34464](https://github.com/flutter/flutter/pull/34464) Skip flaky test on Windows (cla: yes)
+
+[34474](https://github.com/flutter/flutter/pull/34474) Release diagnostics (a: size, cla: yes, customer: google, framework, waiting for tree to go green)
+
+[34501](https://github.com/flutter/flutter/pull/34501) [Material] Fix TextDirection and selected thumb for RangeSliderThumbShape and RangeSliderValueIndicatorShape (cla: yes, f: material design, framework, severe: API break)
+
+[34508](https://github.com/flutter/flutter/pull/34508) add route information to Flutter.Navigation events (cla: yes, framework)
+
+[34512](https://github.com/flutter/flutter/pull/34512) Make sure fab semantics end up on top (cla: yes, framework)
+
+[34514](https://github.com/flutter/flutter/pull/34514) Revert "redux of a change to use new engine APIs for Flutter.Frame events" (cla: yes)
+
+[34515](https://github.com/flutter/flutter/pull/34515) OutlineInputBorder adjusts for borderRadius that is too large (a: text input, cla: yes, f: material design, framework)
+
+[34516](https://github.com/flutter/flutter/pull/34516) [flutter_tool] Fill in Fuchsia version string (cla: yes, tool)
+
+[34517](https://github.com/flutter/flutter/pull/34517) pass .packages path to snapshot invocation (cla: yes, tool)
+
+[34519](https://github.com/flutter/flutter/pull/34519) fix page scroll position rounding error (cla: yes, framework, severe: customer critical)
+
+[34521](https://github.com/flutter/flutter/pull/34521) redux of a change to use new engine APIs for Flutter.Frame events (cla: yes)
+
+[34526](https://github.com/flutter/flutter/pull/34526) retry on HttpException during cache download (cla: yes, tool)
+
+[34527](https://github.com/flutter/flutter/pull/34527) Don't crash on invalid .packages file (cla: yes, tool)
+
+[34529](https://github.com/flutter/flutter/pull/34529) Remove compilation trace and dynamic support code (cla: yes, tool)
+
+[34530](https://github.com/flutter/flutter/pull/34530) Reland "redux of a change to use new engine APIs for Flutter.Frame events" (cla: yes)
+
+[34535](https://github.com/flutter/flutter/pull/34535) Handles parsing APK manifests with additional namespaces or attributes (cla: yes)
+
+[34555](https://github.com/flutter/flutter/pull/34555) Added customizable padding for the segmented controll (cla: yes)
+
+[34573](https://github.com/flutter/flutter/pull/34573) Ensures flutter jar is added to all build types on plugin projects (cla: yes, t: gradle, tool, waiting for tree to go green)
+
+[34584](https://github.com/flutter/flutter/pull/34584) fix a typo (cla: yes, tool)
+
+[34587](https://github.com/flutter/flutter/pull/34587) Do not copy paths, rects, and rrects when layer offset is zero (cla: yes, framework)
+
+[34589](https://github.com/flutter/flutter/pull/34589) Remove most of the target logic for build web, cleanup rules (cla: yes, tool)
+
+[34592](https://github.com/flutter/flutter/pull/34592) Config lib dependencies for flavors (cla: yes, t: gradle, waiting for tree to go green)
+
+[34597](https://github.com/flutter/flutter/pull/34597) [Material] Update slider gallery demo, including range slider (cla: yes, f: material design, framework)
+
+[34600](https://github.com/flutter/flutter/pull/34600) Remove @protected annotation on ImageProvider.obtainKey (cla: yes)
+
+[34606](https://github.com/flutter/flutter/pull/34606) Remove portions of the Gradle script related to dynamic patching (cla: yes, tool, waiting for tree to go green)
+
+[34616](https://github.com/flutter/flutter/pull/34616) Kill compiler process when test does not exit cleanly (a: tests, cla: yes, tool)
+
+[34618](https://github.com/flutter/flutter/pull/34618) Temporarily allow failures on the docs shard (cla: yes)
+
+[34624](https://github.com/flutter/flutter/pull/34624) Break down flutter doctor validations and results (cla: yes, t: flutter doctor, tool)
+
+[34654](https://github.com/flutter/flutter/pull/34654) Disable the docs shard to get the build green (cla: yes)
+
+[34655](https://github.com/flutter/flutter/pull/34655) Revert "Config lib dependencies for flavors" (cla: yes, waiting for tree to go green)
+
+[34660](https://github.com/flutter/flutter/pull/34660) Add --target support for Windows and Linux (cla: yes, tool)
+
+[34664](https://github.com/flutter/flutter/pull/34664) Adjust defaults in docs to match new defaults in code. (cla: yes, framework)
+
+[34665](https://github.com/flutter/flutter/pull/34665) Selection handles position is off (a: text input, cla: yes, framework, severe: API break)
+
+[34668](https://github.com/flutter/flutter/pull/34668) Re-land config lib dependencies for flavors  (cla: yes, t: gradle)
+
+[34669](https://github.com/flutter/flutter/pull/34669) Bundle ios dependencies (cla: yes, tool)
+
+[34674](https://github.com/flutter/flutter/pull/34674) Revert "Roll engine 20d3861ac8e1..05c034e5bb0a (10 commits)" (cla: yes)
+
+[34679](https://github.com/flutter/flutter/pull/34679) Fix-up code sample for TweenSequence (cla: yes, d: api docs, framework)
+
+[34681](https://github.com/flutter/flutter/pull/34681) Re-enable docs with new container (cla: yes)
+
+[34683](https://github.com/flutter/flutter/pull/34683) add read only semantics flag (cla: yes, framework)
+
+[34684](https://github.com/flutter/flutter/pull/34684) Add more structure to errors. (cla: yes, framework)
+
+[34685](https://github.com/flutter/flutter/pull/34685) Close platform when tests are complete (dispose compiler and delete font files) (a: tests, cla: yes, tool, waiting for tree to go green)
+
+[34686](https://github.com/flutter/flutter/pull/34686) unpin build daemon and roll dependencies (cla: yes, tool)
+
+[34712](https://github.com/flutter/flutter/pull/34712) Fix FocusTraversalPolicy makes focus lost (a: desktop, cla: yes, framework)
+
+[34721](https://github.com/flutter/flutter/pull/34721) Add category/platformType to emulators (cla: yes)
+
+[34723](https://github.com/flutter/flutter/pull/34723) CupertinoTextField vertical alignment (cla: yes, f: cupertino, framework)
+
+[34725](https://github.com/flutter/flutter/pull/34725) Fix NPE in flutter tools (cla: yes, tool)
+
+[34736](https://github.com/flutter/flutter/pull/34736) Remove flags related to dynamic patching (cla: yes, tool)
+
+[34738](https://github.com/flutter/flutter/pull/34738) Update Xcode projects to recommended Xcode 10 project settings (cla: yes, t: xcode, team, waiting for tree to go green)
+
+[34739](https://github.com/flutter/flutter/pull/34739) Disable widgets and material web tests (cla: yes, team)
+
+[34750](https://github.com/flutter/flutter/pull/34750) Revert "Check whether FLUTTER_ROOT and FLUTTER_ROOT/bin are writable." (cla: yes)
+
+[34753](https://github.com/flutter/flutter/pull/34753) Revert "Add basic desktop linux checks" (cla: yes)
+
+[34754](https://github.com/flutter/flutter/pull/34754) Move hacky flag to common (cla: yes)
+
+[34755](https://github.com/flutter/flutter/pull/34755) Add linux doctor implementation (cla: yes, t: flutter doctor, tool)
+
+[34757](https://github.com/flutter/flutter/pull/34757) Backup docs to GCS (cla: yes)
+
+[34758](https://github.com/flutter/flutter/pull/34758) Added some Widgets of the Week Videos to documentation (cla: yes, d: api docs, framework)
+
+[34761](https://github.com/flutter/flutter/pull/34761) Revert "Backup docs to GCS" (cla: yes)
+
+[34785](https://github.com/flutter/flutter/pull/34785) Tweak the display name of emulators (cla: yes, tool)
+
+[34794](https://github.com/flutter/flutter/pull/34794) Add `emulatorID` field to devices in daemon (cla: yes, tool)
+
+[34802](https://github.com/flutter/flutter/pull/34802) Prefer ephemeral devices from command line run (cla: yes, tool)
+
+[34812](https://github.com/flutter/flutter/pull/34812) Shard framework tests (cla: yes, team)
+
+[34818](https://github.com/flutter/flutter/pull/34818) Make docs do less work/be less flaky (cla: yes, team)
+
+[34823](https://github.com/flutter/flutter/pull/34823) Introduce image loading performance test. (a: tests, cla: yes, framework)
+
+[34831](https://github.com/flutter/flutter/pull/34831) Fix source-links (cla: yes)
+
+[34856](https://github.com/flutter/flutter/pull/34856) set device name to Chrome (cla: yes, tool)
+
+[34857](https://github.com/flutter/flutter/pull/34857) More shards (cla: yes, team)
+
+[34859](https://github.com/flutter/flutter/pull/34859) Fix Vertical Alignment Regression (a: text input, cla: yes, f: material design, framework)
+
+[34863](https://github.com/flutter/flutter/pull/34863) Prepare for HttpClientResponse Uint8List SDK change (a: tests, cla: yes, framework)
+
+[34869](https://github.com/flutter/flutter/pull/34869) [Material] Properly call onChangeStart and onChangeEnd in Range Slider (cla: yes, f: material design, framework)
+
+[34870](https://github.com/flutter/flutter/pull/34870) Add test case for Flutter Issue #27677 as a benchmark. (cla: yes, engine, framework, severe: performance)
+
+[34872](https://github.com/flutter/flutter/pull/34872) [Material] Support for hovered, focused, and pressed border color on `OutlineButton`s (cla: yes, f: material design, framework)
+
+[34877](https://github.com/flutter/flutter/pull/34877) More shards (a: tests, cla: yes, team, waiting for tree to go green)
+
+[34884](https://github.com/flutter/flutter/pull/34884) Revert "set device name to Chrome" (cla: yes)
+
+[34885](https://github.com/flutter/flutter/pull/34885) Reland: rename web device (cla: yes, tool)
+
+[34895](https://github.com/flutter/flutter/pull/34895) Remove flutter_tools support for old AOT snapshotting (cla: yes)
+
+[34896](https://github.com/flutter/flutter/pull/34896) Allow multi-root web builds  (cla: yes, tool)
+
+[34906](https://github.com/flutter/flutter/pull/34906) Fix unused [applicationIcon] property on [showLicensePage] (cla: yes, f: material design, framework)
+
+[34907](https://github.com/flutter/flutter/pull/34907) Fixed LicensePage to close page before loaded the License causes an error (cla: yes, f: material design, framework, severe: crash)
+
+[34919](https://github.com/flutter/flutter/pull/34919) Remove duplicate error parts (cla: yes, framework, waiting for tree to go green)
+
+[34932](https://github.com/flutter/flutter/pull/34932) Added onChanged property to TextFormField (cla: yes, f: material design, framework)
+
+[34964](https://github.com/flutter/flutter/pull/34964) CupertinoTextField.onTap (cla: yes, f: cupertino)
+
+[35017](https://github.com/flutter/flutter/pull/35017) sync lint list (cla: yes)
+
+[35046](https://github.com/flutter/flutter/pull/35046) Add generated Icon diagram to api docs (cla: yes, d: api docs, d: examples, framework)
+
+[35055](https://github.com/flutter/flutter/pull/35055) enable lint avoid_bool_literals_in_conditional_expressions (cla: yes)
+
+[35056](https://github.com/flutter/flutter/pull/35056) enable lint use_full_hex_values_for_flutter_colors (cla: yes)
+
+[35059](https://github.com/flutter/flutter/pull/35059) prepare for lint update of prefer_final_fields (cla: yes)
+
+[35063](https://github.com/flutter/flutter/pull/35063) add documentation for conic path not supported (a: platform-views, cla: yes, d: api docs, framework, plugin)
+
+[35066](https://github.com/flutter/flutter/pull/35066) Manual engine roll, Update goldens, improved wavy text decoration 0f9e297ad..185087a65f (a: typography, cla: yes, engine)
+
+[35074](https://github.com/flutter/flutter/pull/35074) Attempt to enable tool coverage redux (a: tests, cla: yes, tool)
+
+[35075](https://github.com/flutter/flutter/pull/35075) Allow for customizing SnackBar's content TextStyle in its theme (cla: yes, f: material design, framework)
+
+[35084](https://github.com/flutter/flutter/pull/35084) Move findTargetDevices to DeviceManager (cla: yes, tool)
+
+[35092](https://github.com/flutter/flutter/pull/35092) Add FlutterProjectFactory so that it can be overridden internally. (cla: yes, tool)
+
+[35110](https://github.com/flutter/flutter/pull/35110) Always test semantics (a: accessibility, a: tests, cla: yes, framework, severe: API break)
+
+[35129](https://github.com/flutter/flutter/pull/35129) [Material] Wrap Flutter Gallery's Expansion Panel Slider in padded Container to make room for Value Indicator. (cla: yes, f: material design, framework, severe: regression)
+
+[35130](https://github.com/flutter/flutter/pull/35130) pass new users for release_smoke_tests (a: tests, cla: yes, team)
+
+[35132](https://github.com/flutter/flutter/pull/35132) Reduce allocations by reusing a matrix for transient transforms in _transformRect (cla: yes)
+
+[35136](https://github.com/flutter/flutter/pull/35136) Update Dark Theme disabledColor to White38 (cla: yes, f: material design, framework, severe: API break)
+
+[35143](https://github.com/flutter/flutter/pull/35143) More HttpClientResponse Uint8List fixes (cla: yes)
+
+[35149](https://github.com/flutter/flutter/pull/35149) More `HttpClientResponse implements Stream<Uint8List>` fixes (cla: yes)
+
+[35150](https://github.com/flutter/flutter/pull/35150) Change didUpdateConfig to didUpdateWidget (cla: yes, d: api docs, framework)
+
+[35157](https://github.com/flutter/flutter/pull/35157) Remove skip clause on tools coverage (cla: yes, team)
+
+[35160](https://github.com/flutter/flutter/pull/35160) Move usage flutter create tests into memory filesystem. (a: tests, cla: yes, tool)
+
+[35164](https://github.com/flutter/flutter/pull/35164) Update reassemble doc (cla: yes, customer: product, d: api docs, framework, severe: customer critical)
+
+[35186](https://github.com/flutter/flutter/pull/35186) Make tool coverage collection resilient to sentinel coverage data (cla: yes, tool)
+
+[35188](https://github.com/flutter/flutter/pull/35188) ensure test isolate is paused before collecting coverage (cla: yes, tool)
+
+[35189](https://github.com/flutter/flutter/pull/35189) enable lints prefer_spread_collections and prefer_inlined_adds (cla: yes)
+
+[35192](https://github.com/flutter/flutter/pull/35192) don't block any presubmit on coverage (cla: yes, tool)
+
+[35197](https://github.com/flutter/flutter/pull/35197) [flutter_tool] Update Fuchsia SDK (cla: yes, tool)
+
+[35206](https://github.com/flutter/flutter/pull/35206) Force-upgrade package deps (cla: yes)
+
+[35207](https://github.com/flutter/flutter/pull/35207) refactor out selection handlers (a: text input, cla: yes, customer: amplify, customer: fuchsia, framework)
+
+[35211](https://github.com/flutter/flutter/pull/35211) `child` param doc update in Ink and Ink.image (cla: yes, d: api docs, f: material design, framework)
+
+[35219](https://github.com/flutter/flutter/pull/35219) Text selection menu show/hide cases (a: text input, cla: yes, f: material design, framework)
+
+[35221](https://github.com/flutter/flutter/pull/35221) Twiggle bit to exclude dev and beta from desktop and web (cla: yes, tool)
+
+[35223](https://github.com/flutter/flutter/pull/35223) Navigator pushAndRemoveUntil Fix (a: animation, cla: yes, customer: mulligan (g3), f: routes, framework, severe: crash, waiting for tree to go green)
+
+[35225](https://github.com/flutter/flutter/pull/35225) add sample code for AnimatedContainer (a: animation, cla: yes, d: api docs, d: examples, framework)
+
+[35231](https://github.com/flutter/flutter/pull/35231) Fix coverage collection (cla: yes, tool)
+
+[35232](https://github.com/flutter/flutter/pull/35232) New benchmark: Gesture semantics (cla: yes, waiting for tree to go green)
+
+[35233](https://github.com/flutter/flutter/pull/35233) Attempt skipping coverage shard if tools did not change (cla: yes)
+
+[35237](https://github.com/flutter/flutter/pull/35237) Revert "Manual engine roll, Update goldens, improved wavy text decoration 0f9e297ad..185087a65f" (cla: yes)
+
+[35242](https://github.com/flutter/flutter/pull/35242) Reland "Manual engine roll, Update goldens, improved wavy text decoration 0f9e297ad..185087a65f"" (cla: yes)
+
+[35245](https://github.com/flutter/flutter/pull/35245) More preparation for HttpClientResponse implements Uint8List (cla: yes)
+
+[35246](https://github.com/flutter/flutter/pull/35246) attempt to not skip coverage on post commit (cla: yes)
+
+[35263](https://github.com/flutter/flutter/pull/35263) remove unnecessary ..toList() (cla: yes)
+
+[35276](https://github.com/flutter/flutter/pull/35276) Revert "[Material] Support for hovered, focused, and pressed border color on `OutlineButton`s" (cla: yes)
+
+[35278](https://github.com/flutter/flutter/pull/35278) Re-land "[Material] Support for hovered, focused, and pressed border color on `OutlineButton`s" (cla: yes)
+
+[35280](https://github.com/flutter/flutter/pull/35280) benchmarkWidgets.semanticsEnabled default false. (cla: yes)
+
+[35282](https://github.com/flutter/flutter/pull/35282) Add Container fallback to Ink build method (cla: yes, f: material design, framework)
+
+[35288](https://github.com/flutter/flutter/pull/35288) Apply coverage skip math correctly (cla: yes)
+
+[35290](https://github.com/flutter/flutter/pull/35290) tests for about page (cla: yes)
+
+[35303](https://github.com/flutter/flutter/pull/35303) fix default artifacts to exclude ios and android (cla: yes, tool)
+
+[35307](https://github.com/flutter/flutter/pull/35307) Clean up host_app_ephemeral Profile build settings (a: existing-apps, cla: yes, t: xcode, tool, ⌺‬ platform-ios)
+
+[35335](https://github.com/flutter/flutter/pull/35335) Using custom exception class for network loading error (a: images, cla: yes, framework)
+
+[35367](https://github.com/flutter/flutter/pull/35367) Add type to StreamChannel in generated test code. (cla: yes, tool)
+
+[35392](https://github.com/flutter/flutter/pull/35392) Add timer checking and Fake http client to testbed (cla: yes, tool)
+
+[35393](https://github.com/flutter/flutter/pull/35393) more ui-as-code (cla: yes, team)
+
+[35406](https://github.com/flutter/flutter/pull/35406) Refactor signal and command line handler from resident runner (cla: yes, team, tool)
+
+[35407](https://github.com/flutter/flutter/pull/35407) Manual engine roll (cla: yes, engine, team)
+
+[35408](https://github.com/flutter/flutter/pull/35408) Remove print (cla: yes)
+
+[35423](https://github.com/flutter/flutter/pull/35423) v1.7.8 hotfixes (cla: yes)
+
+[35424](https://github.com/flutter/flutter/pull/35424) Introduce image_list performance benchmark that runs on jit(debug) build. (a: images, a: tests, cla: yes, framework)
+
+[35464](https://github.com/flutter/flutter/pull/35464) Manual roll of engine 45b66b7...ffba2f6 (cla: yes, team)
+
+[35465](https://github.com/flutter/flutter/pull/35465) Mark update-packages as non-experimental (cla: yes, tool)
+
+[35467](https://github.com/flutter/flutter/pull/35467) Mark update-packages as non-experimental (cla: yes, tool)
+
+[35468](https://github.com/flutter/flutter/pull/35468) Add colorFilterLayer/Widget (a: accessibility, cla: yes, customer: octopod, framework, waiting for tree to go green)
+
+[35477](https://github.com/flutter/flutter/pull/35477) Update macrobenchmarks README and app name (a: tests, cla: yes, team)
+
+[35480](https://github.com/flutter/flutter/pull/35480) Update the help message on precache command for less confusion (cla: yes, tool)
+
+[35481](https://github.com/flutter/flutter/pull/35481) add APK build time benchmarks (cla: yes, tool)
+
+[35482](https://github.com/flutter/flutter/pull/35482) Use the new service protocol message names (cla: yes)
+
+[35487](https://github.com/flutter/flutter/pull/35487) Fix RenderFittedBox when child.size.isEmpty (a: accessibility, cla: yes, framework)
+
+[35491](https://github.com/flutter/flutter/pull/35491) Include tags in SemanticsNode debug properties (cla: yes, framework)
+
+[35492](https://github.com/flutter/flutter/pull/35492) Re-apply 'Add currentSystemFrameTimeStamp to SchedulerBinding' (cla: yes, framework)
+
+[35493](https://github.com/flutter/flutter/pull/35493) Do not use ideographic baseline for RenderPargraph baseline (a: typography, cla: yes, engine, framework)
+
+[35495](https://github.com/flutter/flutter/pull/35495) mark windows and macos chrome dev mode as flaky (cla: yes, team)
+
+[35496](https://github.com/flutter/flutter/pull/35496) [Material] Text scale and wide label fixes for Slider and Range Slider value indicator shape (cla: yes, f: material design)
+
+[35499](https://github.com/flutter/flutter/pull/35499) Added MaterialApp.themeMode to control which theme is used. (cla: yes, f: material design, framework)
+
+[35548](https://github.com/flutter/flutter/pull/35548) Various doc fixes (cla: yes, framework)
+
+[35556](https://github.com/flutter/flutter/pull/35556) ios (iPhone6) and iPhone XS tiles_scroll_perf tests (cla: yes, severe: performance, team, ⌺‬ platform-ios)
+
+[35560](https://github.com/flutter/flutter/pull/35560) Support for elevation based dark theme overlay color in the Material widget (cla: yes, f: material design, framework)
+
+[35573](https://github.com/flutter/flutter/pull/35573) update packages (cla: yes, team)
+
+[35574](https://github.com/flutter/flutter/pull/35574) Fix semantics for floating pinned sliver app bar (a: accessibility, cla: yes, f: scrolling, framework, waiting for tree to go green)
+
+[35646](https://github.com/flutter/flutter/pull/35646) Prepare for Socket implements Stream<Uint8List> (cla: yes)
+
+[35657](https://github.com/flutter/flutter/pull/35657) Remove paused check for tooling tests (cla: yes, tool)
+
+[35681](https://github.com/flutter/flutter/pull/35681) Disable incremental compiler in dartdevc (cla: yes, tool)
+
+[35684](https://github.com/flutter/flutter/pull/35684) Fix typo in main.dart templates (cla: yes, d: api docs, framework)
+
+[35708](https://github.com/flutter/flutter/pull/35708) disable a test case in xcode_backend.sh (cla: yes, tool)
+
+[35709](https://github.com/flutter/flutter/pull/35709) Remove web, fuchsia, and unsupported devices from all (cla: yes, tool)
+
+[35725](https://github.com/flutter/flutter/pull/35725) Update annotated region findAll implementation to use Iterables directly. (cla: yes, framework)
+
+[35731](https://github.com/flutter/flutter/pull/35731) Keep LLDB connection to iOS device alive while running from CLI. (cla: yes, tool)
+
+[35743](https://github.com/flutter/flutter/pull/35743) Simple Doc Fixes (cla: yes, d: api docs, framework)
+
+[35745](https://github.com/flutter/flutter/pull/35745) enable lint prefer_if_null_operators (cla: yes, team)
+
+[35749](https://github.com/flutter/flutter/pull/35749) add iOS build benchmarks (cla: yes, team, tool)
+
+[35756](https://github.com/flutter/flutter/pull/35756) Remove @objc inference build setting (cla: yes, t: xcode, tool)
+
+[35762](https://github.com/flutter/flutter/pull/35762) Refactor keymapping for resident_runner (cla: yes)
+
+[35763](https://github.com/flutter/flutter/pull/35763) UIApplicationLaunchOptionsKey -> UIApplication.LaunchOptionsKey (cla: yes, t: xcode, tool, ⌺‬ platform-ios)
+
+[35765](https://github.com/flutter/flutter/pull/35765) Use public _registerService RPC in flutter_tools (cla: yes, tool)
+
+[35767](https://github.com/flutter/flutter/pull/35767) set targets of zero percent for tools codecoverage (cla: yes, tool)
+
+[35775](https://github.com/flutter/flutter/pull/35775) Add platform_interaction_test_swift to devicelab (a: tests, cla: yes, framework, p: framework, plugin, ⌺‬ platform-ios)
+
+[35777](https://github.com/flutter/flutter/pull/35777) Fixed logLevel filter bug so that filter now works as expected (cla: yes, team)
+
+[35778](https://github.com/flutter/flutter/pull/35778) Build all example projects in CI build smoke test (a: tests, cla: yes, team)
+
+[35780](https://github.com/flutter/flutter/pull/35780) Remove CoocaPods support from layers example app (a: tests, cla: yes, d: examples, team)
+
+[35785](https://github.com/flutter/flutter/pull/35785) Remove reverseDuration from implicitly animated widgets, since it's ignored. (a: animation, cla: yes, framework, severe: API break)
+
+[35792](https://github.com/flutter/flutter/pull/35792) disable web tests (cla: yes)
+
+[35814](https://github.com/flutter/flutter/pull/35814) Roll engine e695a516f..75387dbc1 (8 commits) (cla: yes, team)
+
+[35825](https://github.com/flutter/flutter/pull/35825) Fixed build of example code to use new binary messenger API. (cla: yes, team)
+
+[35828](https://github.com/flutter/flutter/pull/35828) Cleanup widgets/sliver_persistent_header.dart with resolution of dart-lang/sdk#31543 (cla: yes, framework)
+
+[35833](https://github.com/flutter/flutter/pull/35833) Disable CocoaPods input and output paths in Xcode build phase for ephemeral add-to-app project (a: existing-apps, cla: yes, tool, ⌺‬ platform-ios)
+
+[35839](https://github.com/flutter/flutter/pull/35839) use pub run for create test and remove [INFO] logs (cla: yes, tool)
+
+[35846](https://github.com/flutter/flutter/pull/35846) move reload and restart handling into terminal (cla: yes, tool)
+
+[35878](https://github.com/flutter/flutter/pull/35878) Add flag to use root navigator for showModalBottomSheet (cla: yes, f: material design, framework)
+
+[35892](https://github.com/flutter/flutter/pull/35892) Doc fixes (cla: yes, d: api docs, d: examples, framework)
+
+[35906](https://github.com/flutter/flutter/pull/35906) Add anchors to samples (cla: yes, team)
+
+[35913](https://github.com/flutter/flutter/pull/35913) Change focus example to be more canonical (and correct) (cla: yes, framework)
+
+[35926](https://github.com/flutter/flutter/pull/35926) Add example showing how to move from one field to the next. (cla: yes, d: api docs, d: examples, framework)
+
+[35932](https://github.com/flutter/flutter/pull/35932) Upgraded framework packages with 'flutter update-packages --force-upgrade'. (cla: yes, framework)
+
+[35942](https://github.com/flutter/flutter/pull/35942) Use test instead of test_api package in platform_channel_swift example tests (a: tests, cla: yes, d: examples, team)
+
+[35971](https://github.com/flutter/flutter/pull/35971) [ImgBot] Optimize images (cla: yes, team)
+
+[35979](https://github.com/flutter/flutter/pull/35979) Optimizes gesture recognizer fixes #35658 (cla: yes, f: gestures, framework)
+
+[35991](https://github.com/flutter/flutter/pull/35991) Enable widget load assets in its own package in test (a: tests, cla: yes, tool)
+
+[35996](https://github.com/flutter/flutter/pull/35996) Revert "Keep LLDB connection to iOS device alive while running from CLI." (cla: yes)
+
+[35999](https://github.com/flutter/flutter/pull/35999) Deflake ImageProvider.evict test (a: images, a: tests, cla: yes, team: flakes)
+
+[36006](https://github.com/flutter/flutter/pull/36006) fix linesplitter (cla: yes, team)
+
+[36017](https://github.com/flutter/flutter/pull/36017) Move reporting files to reporting/ (cla: yes, tool)
+
+[36026](https://github.com/flutter/flutter/pull/36026) add the transformPoint and transformRect benchmarks (cla: yes, team)
+
+[36071](https://github.com/flutter/flutter/pull/36071) Revert "Bundle ios dependencies" (cla: yes, team, tool)
+
+[36082](https://github.com/flutter/flutter/pull/36082) Add better handling of JSON-RPC exception (cla: yes, tool)
+
+[36084](https://github.com/flutter/flutter/pull/36084) handle google3 version of pb (cla: yes, tool)
+
+[36089](https://github.com/flutter/flutter/pull/36089) Fix flaky peer connection (a: tests, cla: yes, framework)
+
+[36090](https://github.com/flutter/flutter/pull/36090) don't require diffs to have a percentage coverage greater (cla: yes, team)
+
+[36093](https://github.com/flutter/flutter/pull/36093) Reland bundle ios deps (cla: yes, team, tool)
+
+[36094](https://github.com/flutter/flutter/pull/36094) Revert "Part 1: Skia Gold Testing" (cla: yes, f: cupertino, f: material design, framework, team)
+
+[36096](https://github.com/flutter/flutter/pull/36096) Revert "Merge branches 'master' and 'master' of github.com:flutter/fl… (cla: yes, tool)
+
+[36097](https://github.com/flutter/flutter/pull/36097) Fix nested scroll view can rebuild without layout (cla: yes, f: scrolling, framework, severe: crash)
+
+[36098](https://github.com/flutter/flutter/pull/36098) Be clearer about errors in customer testing script (cla: yes, team)
+
+[36102](https://github.com/flutter/flutter/pull/36102) Move buildable module test to a module test (cla: yes, team)
+
+[36105](https://github.com/flutter/flutter/pull/36105) [flutter_tool] Catch a yaml parse failure during project creation (cla: yes, team, tool)
+
+[36108](https://github.com/flutter/flutter/pull/36108) Move tools tests into a general.shard directory in preparation to changing how we shard tools tests (cla: yes, tool)
+
+[36122](https://github.com/flutter/flutter/pull/36122) Make sure add-to-app build bundle from outer xcodebuild/gradlew sends analytics (cla: yes, team, tool)
+
+[36123](https://github.com/flutter/flutter/pull/36123) Attempt to re-enable integration_tests-macos (a: tests, cla: yes, team, team: flakes)
+
+[36135](https://github.com/flutter/flutter/pull/36135) add a kIsWeb constant to foundation (cla: yes, framework)
+
+[36138](https://github.com/flutter/flutter/pull/36138) Implement feature flag system for flutter tools (cla: yes, tool)
+
+[36174](https://github.com/flutter/flutter/pull/36174) [cupertino_icons] Add glyph refs for brightness #16102 (cla: yes, f: cupertino, framework)
+
+[36194](https://github.com/flutter/flutter/pull/36194) Keep LLDB connection to iOS device alive while running from CLI.  (cla: yes, tool)
+
+[36197](https://github.com/flutter/flutter/pull/36197) Fix windows, exclude widgets from others (cla: yes, team)
+
+[36199](https://github.com/flutter/flutter/pull/36199) Don't try to flutterExit if isolate is still paused (cla: yes, tool)
+
+[36200](https://github.com/flutter/flutter/pull/36200) Refactoring the Android_views tests app to prepare for adding the iOS platform view tests (a: platform-views, a: tests, cla: yes, team)
+
+[36202](https://github.com/flutter/flutter/pull/36202) Add clarifying docs on MaterialButton.colorBrightness (cla: yes, d: api docs, f: material design, framework)
+
+[36208](https://github.com/flutter/flutter/pull/36208) [flutter_tool] Allow analytics without a terminal attached (cla: yes, tool)
+
+[36213](https://github.com/flutter/flutter/pull/36213) Use DeviceManager instead of device to determine if device supports project. (cla: yes, tool)
+
+[36243](https://github.com/flutter/flutter/pull/36243) Allow semantics labels to be shorter or longer than raw text (a: accessibility, cla: yes, customer: money (g3), framework, waiting for tree to go green)
+
+[36289](https://github.com/flutter/flutter/pull/36289) FakeHttpClientResponse improvements (cla: yes, tool)
+
+[36293](https://github.com/flutter/flutter/pull/36293) Revert "Keep LLDB connection to iOS device alive while running from CLI. " (cla: yes, tool)
+
+[36302](https://github.com/flutter/flutter/pull/36302) Issues/30526 gc (cla: yes, framework)
+
+[36303](https://github.com/flutter/flutter/pull/36303) Add sync star benchmark cases (a: accessibility, cla: yes, team)
+
+[36317](https://github.com/flutter/flutter/pull/36317) Disable flaky tests on Windows (cla: yes, f: material design, framework)
+
+[36319](https://github.com/flutter/flutter/pull/36319) Revert "Fix semantics for floating pinned sliver app bar" (cla: yes, framework)
+
+[36327](https://github.com/flutter/flutter/pull/36327) Fix invocations of ideviceinstaller not passing DYLD_LIBRARY_PATH (cla: yes, tool)
+
+[36331](https://github.com/flutter/flutter/pull/36331) Minor fixes to precache help text (attempt #2) (cla: yes, tool)
+
+[36384](https://github.com/flutter/flutter/pull/36384) rename the test app android_views to platform_views  (cla: yes, team)
+
+[36394](https://github.com/flutter/flutter/pull/36394) Add missing protobuf dependency (cla: yes, tool)
+
+[36413](https://github.com/flutter/flutter/pull/36413) Revert "Roll engine f3482700474a..1af19ae67dd1 (4 commits)" (cla: yes, engine)
+
+
+## PRs closed in this release of flutter/engine
+
+From Wed May 1 16:56:00 2019 -0700 to Thu Jul 18 08:04:00 2019 -0700
+
+
+[7847](https://github.com/flutter/engine/pull/7847) Extracted PlatformViewsChannel from PlatformViewsController. (cla: yes)
+
+[8207](https://github.com/flutter/engine/pull/8207) Text inline widget LibTxt/dart:ui implementation (cla: yes)
+
+[8596](https://github.com/flutter/engine/pull/8596) Expose API to decode images to specified dimensions (cla: yes)
+
+[8685](https://github.com/flutter/engine/pull/8685) Platform_views gesture: let flutter view controller be the media to pass the touches. (cla: yes)
+
+[8731](https://github.com/flutter/engine/pull/8731) Fix the iOS accessibility tree structure of platform views. (cla: yes)
+
+[8794](https://github.com/flutter/engine/pull/8794) Download the Fuchsia SDK and toolchain in a gclient hook. (cla: yes)
+
+[8800](https://github.com/flutter/engine/pull/8800) Reformat dart dependencies in DEPS. (cla: yes)
+
+[8804](https://github.com/flutter/engine/pull/8804) Roll buildroot to pick up updated tools/dart/create_updated_flutter_deps.py (cla: yes)
+
+[8806](https://github.com/flutter/engine/pull/8806) Provide access to GLFW window in plugins (cla: yes)
+
+[8808](https://github.com/flutter/engine/pull/8808) Allow FlutterEngine to be used on back-to-back screens (#31264). (cla: yes)
+
+[8810](https://github.com/flutter/engine/pull/8810) Add flutter settings channel and window brightness to macOS shell (cla: yes)
+
+[8817](https://github.com/flutter/engine/pull/8817) Fix api conformance check (cla: yes)
+
+[8820](https://github.com/flutter/engine/pull/8820) remove legacy build deps (cla: yes)
+
+[8821](https://github.com/flutter/engine/pull/8821) Remove asserts and add BuildConfig (cla: yes)
+
+[8823](https://github.com/flutter/engine/pull/8823) Add font features (such as tabular numbers) as an option in text styles (cla: yes)
+
+[8824](https://github.com/flutter/engine/pull/8824) Guard Android logs (cla: yes)
+
+[8825](https://github.com/flutter/engine/pull/8825) Remove static leaks (cla: yes)
+
+[8826](https://github.com/flutter/engine/pull/8826) New Plugin API PR1: Introduces PluginRegistry and FlutterPlugin, adds support for plugin registration to FlutterEngine. (cla: yes)
+
+[8830](https://github.com/flutter/engine/pull/8830) Cause crash in FlutterJNI if invoked on non-main thread in debug mode (#31263). (cla: yes)
+
+[8833](https://github.com/flutter/engine/pull/8833) Default the animated frame cache to 0 when unset (cla: yes)
+
+[8837](https://github.com/flutter/engine/pull/8837) Only cache required frames (cla: yes)
+
+[8841](https://github.com/flutter/engine/pull/8841) Update buildroot, libjpeg-turbo and googletest to pull in Fuchsia SDK patches. (cla: yes)
+
+[8843](https://github.com/flutter/engine/pull/8843) Dynamically add certain AppDelegate methods. (cla: yes)
+
+[8844](https://github.com/flutter/engine/pull/8844) remove unnecessary usage of runtimeType in dart:ui (cla: yes)
+
+[8846](https://github.com/flutter/engine/pull/8846) Add asserts to semantics.dart (cla: yes)
+
+[8848](https://github.com/flutter/engine/pull/8848) Preserve safe area (cla: yes)
+
+[8849](https://github.com/flutter/engine/pull/8849) new lints (cla: yes)
+
+[8851](https://github.com/flutter/engine/pull/8851) fix assert (cla: yes)
+
+[8859](https://github.com/flutter/engine/pull/8859) Get prebuilt Dart via CIPD (cla: yes)
+
+[8864](https://github.com/flutter/engine/pull/8864) Add resize functions to GLFW shell (cla: yes)
+
+[8867](https://github.com/flutter/engine/pull/8867) Prevent redundant layouts when floor(width) is the same (cla: yes)
+
+[8869](https://github.com/flutter/engine/pull/8869) Wire up Fuchsia SDK related updated for shell dependencies. (cla: yes)
+
+[8870](https://github.com/flutter/engine/pull/8870) Roll buildroot to pull in Fuchsia SDK flag updates. (cla: yes)
+
+[8871](https://github.com/flutter/engine/pull/8871) Copy //runtime/dart/utils from Topaz into the engine. (cla: yes)
+
+[8873](https://github.com/flutter/engine/pull/8873) Synthesize buttons for embedders (cla: yes)
+
+[8881](https://github.com/flutter/engine/pull/8881) Log instead of throwing (cla: yes)
+
+[8884](https://github.com/flutter/engine/pull/8884) Copy //dart-pkg/zircon|fuchsia from Topaz into the engine. (cla: yes)
+
+[8886](https://github.com/flutter/engine/pull/8886) Copy the Flutter Runner from //topaz into the engine. (cla: yes)
+
+[8888](https://github.com/flutter/engine/pull/8888) Remove absolute path in new Fuchsia SDK based runner target dependency. (cla: yes)
+
+[8889](https://github.com/flutter/engine/pull/8889) Roll buildroot to bb316a9e. (cla: yes)
+
+[8891](https://github.com/flutter/engine/pull/8891) Add web sdk implementation. (cla: yes)
+
+[8894](https://github.com/flutter/engine/pull/8894) Prevent iOS from autofilling password into wrong text box (cla: yes)
+
+[8895](https://github.com/flutter/engine/pull/8895) Provide a resource context in the GLFW shell (cla: yes)
+
+[8896](https://github.com/flutter/engine/pull/8896) Remove more asserts and fix a11y check (cla: yes)
+
+[8910](https://github.com/flutter/engine/pull/8910) Fix TimePoint on Windows (cla: yes)
+
+[8912](https://github.com/flutter/engine/pull/8912) Make sure Window.dpr still has a setter (cla: yes)
+
+[8913](https://github.com/flutter/engine/pull/8913) Standardize TimePoint implementaion on std::chrono (cla: yes)
+
+[8920](https://github.com/flutter/engine/pull/8920) Replace Skia font macros with enums. (cla: yes)
+
+[8923](https://github.com/flutter/engine/pull/8923) [fuchsia] Guard out-of-tree Fuchsia targets to fix in-tree build (cla: yes)
+
+[8927](https://github.com/flutter/engine/pull/8927) libtxt: add a BoxHeightStyle option based on the height of the strut (cla: yes)
+
+[8928](https://github.com/flutter/engine/pull/8928) Update skew Docs (cla: yes)
+
+[8930](https://github.com/flutter/engine/pull/8930) Fix iOS crash when in background for 3 minutes (cla: yes)
+
+[8936](https://github.com/flutter/engine/pull/8936) Wire up the Skia Metal backend on iOS. (cla: yes)
+
+[8937](https://github.com/flutter/engine/pull/8937) Add a minimal set of symbols to the dynamic symbol table for Linux executables (cla: yes)
+
+[8939](https://github.com/flutter/engine/pull/8939) Move the Fuchsia Flutter Runner to //flutter/shell/platform/fuchsia/flutter (cla: yes)
+
+[8940](https://github.com/flutter/engine/pull/8940) Roll Tonic (cla: yes)
+
+[8943](https://github.com/flutter/engine/pull/8943) New Plugin API PR2: Introduces ActivityAware, ActivityControlSurface, and ActivityPluginBinding. (cla: yes)
+
+[8947](https://github.com/flutter/engine/pull/8947) Add @UiThread to MethodChannel and related classes/calls (#32642). (cla: yes)
+
+[8949](https://github.com/flutter/engine/pull/8949) Copy the Dart Runner from //topaz into the engine. (cla: yes)
+
+[8950](https://github.com/flutter/engine/pull/8950) Roll tonic and update #includes (cla: yes)
+
+[8952](https://github.com/flutter/engine/pull/8952) Rename frame_time and engine_time (cla: yes)
+
+[8954](https://github.com/flutter/engine/pull/8954) Avoid disabling sources assignment filters are these have been removed. (cla: yes)
+
+[8956](https://github.com/flutter/engine/pull/8956) Use Android text selection shifting API to delete (cla: yes)
+
+[8962](https://github.com/flutter/engine/pull/8962) New Plugin API PR3: Introduces Service, BroadcastReceiver, and ContentProvider awareness, control surfaces, and plugin bindings. (cla: yes)
+
+[8975](https://github.com/flutter/engine/pull/8975) Replace arraysize macro with fml::size function (cla: yes)
+
+[8977](https://github.com/flutter/engine/pull/8977) Add support for the Fontconfig-based Skia font manager (cla: yes)
+
+[8979](https://github.com/flutter/engine/pull/8979) Add mode to load AOT snapshots as a native lib (cla: yes)
+
+[8983](https://github.com/flutter/engine/pull/8983) Add onReportTimings and FrameRasterizedCallback API (cla: yes)
+
+[8985](https://github.com/flutter/engine/pull/8985) Add matrix4 param to Linear gradients (cla: yes)
+
+[8986](https://github.com/flutter/engine/pull/8986) remove `[new` from docs (cla: yes)
+
+[8987](https://github.com/flutter/engine/pull/8987) add observatoryUrl property to FlutterEngine (cla: yes)
+
+[8990](https://github.com/flutter/engine/pull/8990) Minor fixes/adjustments to the GLFW shell (cla: yes)
+
+[8991](https://github.com/flutter/engine/pull/8991) Enable hover by default for desktop shells (cla: yes)
+
+[8996](https://github.com/flutter/engine/pull/8996) Roll Buildroot (cla: yes)
+
+[8998](https://github.com/flutter/engine/pull/8998) [fuchsia] Update zx_clock_get callers (cla: yes)
+
+[8999](https://github.com/flutter/engine/pull/8999) Do nothing if the params didn't change when compositing platform views. (cla: yes)
+
+[9003](https://github.com/flutter/engine/pull/9003) Rename Fuchsia Dart and Flutter runners (cla: yes)
+
+[9019](https://github.com/flutter/engine/pull/9019) Macos systemnavigator pop (cla: yes)
+
+[9020](https://github.com/flutter/engine/pull/9020) Remove m prefix from fields in the Android PlatformViews code (cla: yes)
+
+[9022](https://github.com/flutter/engine/pull/9022) Fix horizontal scroll direction for macOS (cla: yes)
+
+[9023](https://github.com/flutter/engine/pull/9023) Forward custom IDE flags to GN. (cla: yes)
+
+[9025](https://github.com/flutter/engine/pull/9025) Correct the return type of addRetained (cla: yes)
+
+[9026](https://github.com/flutter/engine/pull/9026) Initialize next_pointer_flow_id_ to 0 (cla: yes)
+
+[9033](https://github.com/flutter/engine/pull/9033) Avoid unnecessary copying of vectors in AccessibilityBridge (cla: yes)
+
+[9034](https://github.com/flutter/engine/pull/9034) Expose pointer type and buttons in embedder.h (cla: yes)
+
+[9036](https://github.com/flutter/engine/pull/9036) Fix dartdevc build (cla: yes)
+
+[9039](https://github.com/flutter/engine/pull/9039) Update FlutterDevCompilerTarget for the new superclass constructor in the Dart SDK (cla: yes)
+
+[9041](https://github.com/flutter/engine/pull/9041) TextStyle.height property as a multiple of font size instead of multiple of ascent+descent+leading. (affects: text input, cla: yes, prod: API break)
+
+[9045](https://github.com/flutter/engine/pull/9045) remove over-optimistic assert (cla: yes)
+
+[9049](https://github.com/flutter/engine/pull/9049) New Plugin API PR4: Adds Lifecycle support to the new plugin system. (cla: yes)
+
+[9054](https://github.com/flutter/engine/pull/9054) Add mouse button support to the macOS shell (cla: yes)
+
+[9058](https://github.com/flutter/engine/pull/9058) libtxt: have GetRectsForRange(strut) fall back to tight bounds if layout isn't forcing use of the strut (cla: yes)
+
+[9060](https://github.com/flutter/engine/pull/9060) Add missing top level to stub_ui (cla: yes)
+
+[9061](https://github.com/flutter/engine/pull/9061) [scene_host] Cleanup scene_host closures (cla: yes)
+
+[9062](https://github.com/flutter/engine/pull/9062) Add a podspec for FlutterMacOS.framework (cla: yes)
+
+[9072](https://github.com/flutter/engine/pull/9072) Roll third_party/dart/tools/sdks to 2.3.0 (cla: yes)
+
+[9073](https://github.com/flutter/engine/pull/9073) Fix unchecked operation warnings in FlutterMain (cla: yes)
+
+[9074](https://github.com/flutter/engine/pull/9074) Rename macOS FLEPlugin* to FlutterPlugin* (cla: yes)
+
+[9075](https://github.com/flutter/engine/pull/9075) IOS Platform view transform/clipping (cla: yes)
+
+[9077](https://github.com/flutter/engine/pull/9077) Update macOS podspec version requirement (cla: yes)
+
+[9078](https://github.com/flutter/engine/pull/9078) Fix internal break since listing contents can return null (cla: yes)
+
+[9081](https://github.com/flutter/engine/pull/9081) Correct typos, adopt US spellings (cla: yes)
+
+[9083](https://github.com/flutter/engine/pull/9083) New Plugin API PR5: Integrates plugin lifecycle control with FlutterFragment. (cla: yes)
+
+[9085](https://github.com/flutter/engine/pull/9085) Jacobs - Use track-widget-creation transformer included in the sdk (cla: yes)
+
+[9086](https://github.com/flutter/engine/pull/9086) Delete BSDiff sources (cla: yes)
+
+[9087](https://github.com/flutter/engine/pull/9087) Removed outdated deprecation comments (cla: yes)
+
+[9088](https://github.com/flutter/engine/pull/9088) Apply minor cleanups to Android embedding (cla: yes)
+
+[9089](https://github.com/flutter/engine/pull/9089) Wire up custom event loop interop for the GLFW embedder. (cla: yes)
+
+[9097](https://github.com/flutter/engine/pull/9097) Better help message. (cla: yes)
+
+[9106](https://github.com/flutter/engine/pull/9106) Add checks to constructors and add missing constructor members (cla: yes)
+
+[9107](https://github.com/flutter/engine/pull/9107) Fix unopt variants of profile and release builds. (cla: yes)
+
+[9108](https://github.com/flutter/engine/pull/9108) Removing unused imports (cla: yes)
+
+[9110](https://github.com/flutter/engine/pull/9110) Change the virtual display size restriction to warning (cla: yes)
+
+[9112](https://github.com/flutter/engine/pull/9112) Fix type mismatches in C++ standard codec (cla: yes)
+
+[9113](https://github.com/flutter/engine/pull/9113) Allow specifying both Dart and non-Dart fixtures in engine unit-tests. (cla: yes)
+
+[9114](https://github.com/flutter/engine/pull/9114) Remove outdated TODOs (cla: yes)
+
+[9115](https://github.com/flutter/engine/pull/9115) Added support for transparent FlutterActivitys (#32740). (cla: yes)
+
+[9120](https://github.com/flutter/engine/pull/9120) Add plugin shim to facilitate old plugins in new embedding (#33478). (cla: yes)
+
+[9122](https://github.com/flutter/engine/pull/9122) Implemented Log proxy that only logs in BuildConfig.DEBUG (#25391). (cla: yes)
+
+[9129](https://github.com/flutter/engine/pull/9129) Roll buildroot to pick up fixed create_updated_flutter.deps.py (cla: yes)
+
+[9132](https://github.com/flutter/engine/pull/9132) Reduce pipeline depth when GPU and Platform are same thread (cla: yes)
+
+[9134](https://github.com/flutter/engine/pull/9134) Revert "Use track-widget-creation transformer included in the sdk. (#9085)" (cla: yes)
+
+[9143](https://github.com/flutter/engine/pull/9143) Add missing ifndef guard for count_down_latch.h (cla: yes)
+
+[9145](https://github.com/flutter/engine/pull/9145) Suppress an unchecked cast warning in ShimPluginRegistry (cla: yes)
+
+[9146](https://github.com/flutter/engine/pull/9146) Roll web sdk (cla: yes)
+
+[9148](https://github.com/flutter/engine/pull/9148) Allow for whitelisted flags to be passed to the Dart VM (cla: yes)
+
+[9149](https://github.com/flutter/engine/pull/9149) Always run the resource extractor in FlutterMain (cla: yes)
+
+[9156](https://github.com/flutter/engine/pull/9156) Eliminate deprecated super_goes_last lint (cla: yes)
+
+[9157](https://github.com/flutter/engine/pull/9157) Remove references to Fuchsia's ContextWriter (cla: yes)
+
+[9158](https://github.com/flutter/engine/pull/9158) Copy the macOS podspec during builds (cla: yes)
+
+[9172](https://github.com/flutter/engine/pull/9172) Use shared library when libapp.so is found (cla: yes, platform-android)
+
+[9176](https://github.com/flutter/engine/pull/9176) Make flow layers' attributes immutable (cla: yes)
+
+[9180](https://github.com/flutter/engine/pull/9180) Revert change by mistake: extract resources (cla: yes)
+
+[9185](https://github.com/flutter/engine/pull/9185) Fix platform views channel regression (cla: yes)
+
+[9186](https://github.com/flutter/engine/pull/9186) Add the key event source, vendorId, and productId from Android (cla: yes)
+
+[9187](https://github.com/flutter/engine/pull/9187) Compile the physical_shape_layer_unittests.cc TU. (cla: yes)
+
+[9189](https://github.com/flutter/engine/pull/9189) Allow the task queues to be swapped in MessageLoops (cla: yes)
+
+[9190](https://github.com/flutter/engine/pull/9190) [engine] Fix builds targeting Android from a Windows host gen_snapshot (cla: yes)
+
+[9192](https://github.com/flutter/engine/pull/9192) Fix rare crash on HuaWei device when use AndroidView. (cla: yes)
+
+[9193](https://github.com/flutter/engine/pull/9193) Switch PlatformViewsController from Activity ref to Application ref. (cla: yes)
+
+[9198](https://github.com/flutter/engine/pull/9198) Skip golden tests on non-Linux OSes (cla: yes)
+
+[9199](https://github.com/flutter/engine/pull/9199) Align fuchsia and non-fuchsia tracing (cla: yes)
+
+[9201](https://github.com/flutter/engine/pull/9201) Roll dart and update libraries files (cla: yes)
+
+[9203](https://github.com/flutter/engine/pull/9203) Keyboard support for embedded Android views. (cla: yes)
+
+[9204](https://github.com/flutter/engine/pull/9204) Add platform_fuchsia.cc for default font on fuchsia (cla: yes)
+
+[9206](https://github.com/flutter/engine/pull/9206) Android Embedding Refactor PR31: Integrate platform views with the new embedding and the plugin shim. (cla: yes)
+
+[9211](https://github.com/flutter/engine/pull/9211) Revert "Switch PlatformViewsController from Activity ref to Application ref." (cla: yes)
+
+[9215](https://github.com/flutter/engine/pull/9215) Update Engine::ReportTimings to use the new FML_TRACE macros (cla: yes)
+
+[9216](https://github.com/flutter/engine/pull/9216) Copy TimingsCallback declaration into the stub_ui package (cla: yes)
+
+[9218](https://github.com/flutter/engine/pull/9218) Add web integration test to build_and_test_host (cla: yes)
+
+[9222](https://github.com/flutter/engine/pull/9222) move webOnlyScheduleFrameCallback off of window (cla: yes)
+
+[9233](https://github.com/flutter/engine/pull/9233) Remove unnecessary whitelisted flags for --dart-flags (cla: yes)
+
+[9234](https://github.com/flutter/engine/pull/9234) Fix instantiateImageCodec api diff with web (stub) (cla: yes)
+
+[9237](https://github.com/flutter/engine/pull/9237) Document AccessibilityBridge.java (cla: yes)
+
+[9238](https://github.com/flutter/engine/pull/9238) Removed VIRTUAL_KEYBOARD check in TextInputPlugin (cla: yes)
+
+[9239](https://github.com/flutter/engine/pull/9239) Revert "Keyboard support for embedded Android views." (cla: yes)
+
+[9242](https://github.com/flutter/engine/pull/9242) Add stub implementation that doesn't throw (cla: yes)
+
+[9243](https://github.com/flutter/engine/pull/9243) Mark semantics functions const (cla: yes)
+
+[9244](https://github.com/flutter/engine/pull/9244) Correct typo (cla: yes)
+
+[9246](https://github.com/flutter/engine/pull/9246) Throw on unhandled license type (cla: yes)
+
+[9248](https://github.com/flutter/engine/pull/9248) Catch errors during production of kernel dill (cla: yes)
+
+[9255](https://github.com/flutter/engine/pull/9255) Reorganize darwin for shared ios/macOS (cla: yes)
+
+[9257](https://github.com/flutter/engine/pull/9257) Reland "Keyboard support for embedded Android views. (#9203) (cla: yes)
+
+[9260](https://github.com/flutter/engine/pull/9260) Load AOT compiled Dart assets only from ELF libraries (cla: yes)
+
+[9262](https://github.com/flutter/engine/pull/9262) Set identity instead of crash in opt build (cla: yes)
+
+[9264](https://github.com/flutter/engine/pull/9264) Wire up SwiftShader based OpenGL ES unit-tests on hosts. (cla: yes)
+
+[9266](https://github.com/flutter/engine/pull/9266) Whitelist to —enable_mirrors flag to fix regression in existing embedder. (cla: yes)
+
+[9270](https://github.com/flutter/engine/pull/9270) Unbreak internal rolls (cla: yes)
+
+[9278](https://github.com/flutter/engine/pull/9278) Fix crash on minimize with GLFW shell (cla: yes)
+
+[9280](https://github.com/flutter/engine/pull/9280) Add refresh callback to GLFW shell (cla: yes)
+
+[9281](https://github.com/flutter/engine/pull/9281) Introduce read only text field semantics (cla: yes)
+
+[9282](https://github.com/flutter/engine/pull/9282) [iOS] [a11y] Don't allow scroll views to grab a11y focus (cla: yes)
+
+[9283](https://github.com/flutter/engine/pull/9283) Fix TextInputPlugin NPE caused by PlatformViewsController ref in new embedding (#34283). (cla: yes)
+
+[9285](https://github.com/flutter/engine/pull/9285) Expose a hasRenderedFirstFrame() method in FlutterView (#34275). (cla: yes)
+
+[9287](https://github.com/flutter/engine/pull/9287) Report timings faster (100ms) in profile/debug (cla: yes)
+
+[9288](https://github.com/flutter/engine/pull/9288) Fixed memory leaks within FlutterFragment and FlutterView (#34268, #34269, #34270). (cla: yes)
+
+[9289](https://github.com/flutter/engine/pull/9289) [fuchsia] Fix alignment of Fuchsia/non-Fuchsia tracing (cla: yes)
+
+[9290](https://github.com/flutter/engine/pull/9290) Refactor Delayed Tasks to their own file (cla: yes)
+
+[9292](https://github.com/flutter/engine/pull/9292) Set Dart version to git hash 3166bbf24b0c929eef33fd5d0f69e0f36a9009f3 (Dart 2.3.3-dev) (cla: yes)
+
+[9296](https://github.com/flutter/engine/pull/9296) Revert tracing changes (cla: yes)
+
+[9297](https://github.com/flutter/engine/pull/9297) [scene_host] Expose Opacity and remove ExportNode (cla: yes)
+
+[9301](https://github.com/flutter/engine/pull/9301) Refactor: move Task Queue to its own class (cla: yes)
+
+[9302](https://github.com/flutter/engine/pull/9302) Handle Fuchsia SDK in license tool + roll SDK (cla: yes)
+
+[9303](https://github.com/flutter/engine/pull/9303) Added class docstrings for classes inside of shell/common. (cla: yes)
+
+[9304](https://github.com/flutter/engine/pull/9304) Decorate UIApplicationDelegate wrappers with matching UIKit deprecation (affects: dev experience, cla: yes, platform-ios)
+
+[9306](https://github.com/flutter/engine/pull/9306) When running in AOT modes create a flutter_assets directory that can be used as the bundle path (cla: yes)
+
+[9313](https://github.com/flutter/engine/pull/9313) [macos] Adds clipboard string read/write support to macOS (cla: yes)
+
+[9314](https://github.com/flutter/engine/pull/9314) Avoid using std::unary_function. (cla: yes)
+
+[9315](https://github.com/flutter/engine/pull/9315) Only build embedder unit tests for host builds (cla: yes)
+
+[9316](https://github.com/flutter/engine/pull/9316) MessageLoopTaskQueue schedules Wakes (cla: yes)
+
+[9318](https://github.com/flutter/engine/pull/9318) Update the Dart version to 1d8b81283c1dee38f1dd87b71b16aa1648b01155 (Dart 2.4.0 Stable version) (cla: yes)
+
+[9319](https://github.com/flutter/engine/pull/9319) Roll buildroot to 75660ad5 and complete the C++ 17 transition. (cla: yes)
+
+[9320](https://github.com/flutter/engine/pull/9320) Build the GLFW shell on Linux host builds but not target builds (cla: yes)
+
+[9321](https://github.com/flutter/engine/pull/9321) Fix a11y in embedded Android views post O (accessibility, cla: yes)
+
+[9322](https://github.com/flutter/engine/pull/9322) Check for invalid indexes when performing InputAdpator backspace. (affects: text input, cla: yes, crash)
+
+[9324](https://github.com/flutter/engine/pull/9324) Send the isolate service ID from the engine to the embedder (cla: yes)
+
+[9326](https://github.com/flutter/engine/pull/9326) Fix rawTypes errors in Android embedding classes (cla: yes)
+
+[9329](https://github.com/flutter/engine/pull/9329) Fixed memory leak by way of accidental retain on implicit self (cla: yes)
+
+[9330](https://github.com/flutter/engine/pull/9330) Build txt_benchmarks, make benches compile again (cla: yes)
+
+[9331](https://github.com/flutter/engine/pull/9331) Handle one-way platform messages in the embedder library (cla: yes)
+
+[9334](https://github.com/flutter/engine/pull/9334) Fix the name of the channel parameter in PlatformMessage constructors (cla: yes)
+
+[9335](https://github.com/flutter/engine/pull/9335) Message loop task heaps are shared (cla: yes)
+
+[9336](https://github.com/flutter/engine/pull/9336) Roll buildroot to d1bbc14 to pick up fixes for armv7 iOS targets. (cla: yes)
+
+[9337](https://github.com/flutter/engine/pull/9337) Use the DartServiceIsolate status callback to publish the observatory URI to the Android embedder (cla: yes)
+
+[9338](https://github.com/flutter/engine/pull/9338) Replace lock_guard with scoped_lock and use class template argument deduction. (cla: yes)
+
+[9343](https://github.com/flutter/engine/pull/9343) Avoid a full screen overlay within virtual displays (cla: yes)
+
+[9346](https://github.com/flutter/engine/pull/9346) Removed an unused class definition for iOS code. (cla: yes)
+
+[9347](https://github.com/flutter/engine/pull/9347) Surrogate binary messenger (cla: yes)
+
+[9350](https://github.com/flutter/engine/pull/9350) Update component manifests for ambient replace-as-executable (cla: yes)
+
+[9351](https://github.com/flutter/engine/pull/9351) Android Embedding Refactor PR32: Clean up logs in new embedding. (cla: yes)
+
+[9354](https://github.com/flutter/engine/pull/9354) Android Embedding Refactor PR33: Clean up FlutterJNI. (cla: yes)
+
+[9356](https://github.com/flutter/engine/pull/9356) Add APIs for querying FlutterView for a FlutterEngine and listening for attachment/detachment (#29114). (cla: yes)
+
+[9360](https://github.com/flutter/engine/pull/9360) Simplify loading of app bundles on Android (cla: yes)
+
+[9361](https://github.com/flutter/engine/pull/9361) [glfw]  Implement clipboard support from GLFW api (cla: yes)
+
+[9362](https://github.com/flutter/engine/pull/9362) Fix test name typo (cla: yes)
+
+[9365](https://github.com/flutter/engine/pull/9365) [glfw] Implement SystemNavigator.pop (cla: yes)
+
+[9366](https://github.com/flutter/engine/pull/9366) Request FlutterView focus when setting a platform view text client (cla: yes)
+
+[9368](https://github.com/flutter/engine/pull/9368) Do not remove the DartServiceIsolate status callback during FlutterMain destruction (cla: yes)
+
+[9374](https://github.com/flutter/engine/pull/9374) Roll Dart to version 7340a569caac6431d8698dc3788579b57ffcf0c6 (cla: yes)
+
+[9375](https://github.com/flutter/engine/pull/9375) Revert "Surrogate binary messenger (#9347)" (cla: yes)
+
+[9376](https://github.com/flutter/engine/pull/9376) libtxt: remove obsolete font_manager_available defines (cla: yes)
+
+[9377](https://github.com/flutter/engine/pull/9377) A fix for the platform view dismiss crash related to gl (cla: yes)
+
+[9378](https://github.com/flutter/engine/pull/9378) Wire intent args for observatory port (cla: yes)
+
+[9383](https://github.com/flutter/engine/pull/9383) Update Metal backend to account for Skia updates. (cla: yes)
+
+[9384](https://github.com/flutter/engine/pull/9384) Android Embedding Refactor PR34: Fill in missing nullability annotations (cla: yes)
+
+[9385](https://github.com/flutter/engine/pull/9385) Add Dart SDK > 2.3.0 constraint to license script (cla: yes)
+
+[9388](https://github.com/flutter/engine/pull/9388) Added unit tests for the ios code. (cla: yes)
+
+[9391](https://github.com/flutter/engine/pull/9391) Android Embedding Refactor PR35: Ensure all JNI methods are in FlutterJNI. (cla: yes)
+
+[9394](https://github.com/flutter/engine/pull/9394) Remove build flags for dynamic patching (cla: yes)
+
+[9398](https://github.com/flutter/engine/pull/9398) Made the license check ignore the .vscode directory. (cla: yes)
+
+[9402](https://github.com/flutter/engine/pull/9402) Clamp when overflowing z bounds (cla: yes)
+
+[9403](https://github.com/flutter/engine/pull/9403) Remove variants of ParagraphBuilder::AddText that are not used within the engine (cla: yes)
+
+[9406](https://github.com/flutter/engine/pull/9406) Update harfbuzz to 2.5.2 (affects: text input, cla: yes)
+
+[9419](https://github.com/flutter/engine/pull/9419) Has a binary messenger (cla: yes, prod: API break)
+
+[9423](https://github.com/flutter/engine/pull/9423) Don't hang to a platform view's input connection after it's disposed (cla: yes)
+
+[9424](https://github.com/flutter/engine/pull/9424) Send timings of the first frame without batching (cla: yes)
+
+[9425](https://github.com/flutter/engine/pull/9425) Resolves embedding log chattyness by disabling verbose, debug, and info logs by default (#34876). (cla: yes)
+
+[9426](https://github.com/flutter/engine/pull/9426) delegate checkInputConnectionProxy to the relevant platform view (cla: yes)
+
+[9428](https://github.com/flutter/engine/pull/9428) Update README.md for consistency with framework (cla: yes)
+
+[9429](https://github.com/flutter/engine/pull/9429) Revert "Update harfbuzz to 2.5.2" (cla: yes)
+
+[9430](https://github.com/flutter/engine/pull/9430) Use goma-aware Fuchsia clang toolchain (cla: yes)
+
+[9431](https://github.com/flutter/engine/pull/9431) Generate weak pointers only in the platform thread (cla: yes)
+
+[9432](https://github.com/flutter/engine/pull/9432) Ios unit tests choose engine (cla: yes)
+
+[9433](https://github.com/flutter/engine/pull/9433) Reland Update harfbuzz to 2.5.2 (#9406) (cla: yes)
+
+[9436](https://github.com/flutter/engine/pull/9436) Add the functionality to merge and unmerge MessageLoopTaskQueues (cla: yes)
+
+[9437](https://github.com/flutter/engine/pull/9437) Revert "Reland Update harfbuzz to 2.5.2 (#9406)" (cla: yes)
+
+[9439](https://github.com/flutter/engine/pull/9439) Eliminate unused import in FlutterView (cla: yes)
+
+[9446](https://github.com/flutter/engine/pull/9446) Revert "Roll fuchsia/sdk/core/mac-amd64 from Cx51F... to e8sS_..." (cla: yes)
+
+[9449](https://github.com/flutter/engine/pull/9449) Revert "Roll fuchsia/sdk/core/linux-amd64 from udf6w... to jQ8aw..." (cla: yes)
+
+[9450](https://github.com/flutter/engine/pull/9450) Revert "Roll fuchsia/sdk/core/mac-amd64 from Cx51F... to w-3t4..." (cla: yes)
+
+[9452](https://github.com/flutter/engine/pull/9452) Convert RRect.scaleRadii to public method (affects: framework, cla: yes)
+
+[9456](https://github.com/flutter/engine/pull/9456) Made sure that the run_tests script returns the right error code. (cla: yes)
+
+[9458](https://github.com/flutter/engine/pull/9458) Test cleanup geometry_test.dart  (affects: tests, cla: yes)
+
+[9459](https://github.com/flutter/engine/pull/9459) Remove unused/unimplemented shell constructor (cla: yes)
+
+[9460](https://github.com/flutter/engine/pull/9460) Fixed logLevel filter bug so that filter now works as expected. (cla: yes)
+
+[9461](https://github.com/flutter/engine/pull/9461) Adds API for retaining intermediate engine layers (cla: yes)
+
+[9462](https://github.com/flutter/engine/pull/9462) Reland Update harfbuzz to 2.5.2 (cla: yes)
+
+[9463](https://github.com/flutter/engine/pull/9463) Removed unused imports in new embedding. (cla: yes)
+
+[9464](https://github.com/flutter/engine/pull/9464) Added shebangs to ios unit test scripts. (cla: yes)
+
+[9466](https://github.com/flutter/engine/pull/9466) Re-enable the Wuffs GIF decoder (cla: yes)
+
+[9467](https://github.com/flutter/engine/pull/9467) ios-unit-tests: Forgot a usage of a variable in our script. (cla: yes)
+
+[9468](https://github.com/flutter/engine/pull/9468) Manually draw remainder curve for wavy decorations (cla: yes)
+
+[9469](https://github.com/flutter/engine/pull/9469) ios-unit-tests: Fixed ocmock system header search paths. (cla: yes)
+
+[9471](https://github.com/flutter/engine/pull/9471) ios-unit-tests: Started using rsync instead of cp -R to copy frameworks. (cla: yes)
+
+[9476](https://github.com/flutter/engine/pull/9476) fix NPE when a touch event is sent to an unknown Android platform view (cla: yes)
+
+[9478](https://github.com/flutter/engine/pull/9478) iOS PlatformView clip path (cla: yes)
+
+[9480](https://github.com/flutter/engine/pull/9480) Revert "IOS Platform view transform/clipping (#9075)" (cla: yes)
+
+[9482](https://github.com/flutter/engine/pull/9482) Re-enable embedder_unittests. (cla: yes)
+
+[9483](https://github.com/flutter/engine/pull/9483) Reland "IOS Platform view transform/clipping (#9075)" and fix the breakage. (cla: yes)
+
+[9485](https://github.com/flutter/engine/pull/9485) Add --observatory-host switch (cla: yes)
+
+[9486](https://github.com/flutter/engine/pull/9486) Rework image & texture management to use concurrent message queues. (cla: yes)
+
+[9489](https://github.com/flutter/engine/pull/9489) Handle ambiguous directionality of final trailing whitespace in mixed bidi text (cla: yes)
+
+[9490](https://github.com/flutter/engine/pull/9490) fix a bug where the platform view's transform is not reset before set frame (cla: yes)
+
+[9491](https://github.com/flutter/engine/pull/9491) Purge caches on low memory on iOS (cla: yes)
+
+[9493](https://github.com/flutter/engine/pull/9493) Run benchmarks on try jobs. (cla: yes)
+
+[9495](https://github.com/flutter/engine/pull/9495) fix build breakage on PlatformViews.mm (cla: yes)
+
+[9501](https://github.com/flutter/engine/pull/9501) [android] External textures must be rescaled to fill the canvas (cla: yes)
+
+[9503](https://github.com/flutter/engine/pull/9503) Improve caching limits for Skia (cla: yes)
+
+[9506](https://github.com/flutter/engine/pull/9506) Synchronize main thread and gpu thread for first render frame (cla: yes)
+
+[9507](https://github.com/flutter/engine/pull/9507) Revert Skia version to d8f79a27b06b5bce7a27f89ce2d43d39f8c058dc (cla: yes)
+
+[9508](https://github.com/flutter/engine/pull/9508) Support image filter on paint (cla: yes)
+
+[9509](https://github.com/flutter/engine/pull/9509) Roll Fuchsia SDK to latest (cla: yes)
+
+[9518](https://github.com/flutter/engine/pull/9518) Bump dart_resource_rev to f8e37558a1c4f54550aa463b88a6a831e3e33cd6 (cla: yes)
+
+[9532](https://github.com/flutter/engine/pull/9532) fix FlutterOverlayView doesn't remove from superview in some cases (cla: yes)
+
+[9546](https://github.com/flutter/engine/pull/9546) [all] add fuchsia.{net.NameLookup,posix.socket.Provider} (cla: yes)
+
+[9556](https://github.com/flutter/engine/pull/9556) Minimal integration with the Skia text shaper module (cla: yes)
+
+[9561](https://github.com/flutter/engine/pull/9561) libtxt: fix reference counting of SkFontStyleSets held by font asset providers (cla: yes)
+
+[9562](https://github.com/flutter/engine/pull/9562) Switched preprocessor logic for exporting symbols for testing. (cla: yes)
+
+[9581](https://github.com/flutter/engine/pull/9581) Revert "Avoid a full screen overlay within virtual displays" (cla: yes)
+
+[9585](https://github.com/flutter/engine/pull/9585) Fix a race in the embedder accessibility unit test (cla: yes)
+
+[9589](https://github.com/flutter/engine/pull/9589) Fixes a plugin overwrite bug in the plugin shim system. (cla: yes)
+
+[9590](https://github.com/flutter/engine/pull/9590) Apply patches that have landed in topaz since we ported the runners to the engine repo (cla: yes)
+
+[9591](https://github.com/flutter/engine/pull/9591) Document various classes in //flutter/shell/common. (cla: yes)
+
+[9593](https://github.com/flutter/engine/pull/9593) [trace clients] Remove fuchsia.tracelink.Registry (cla: yes)
+
+[9608](https://github.com/flutter/engine/pull/9608) Disable failing Mutators tests (cla: yes)
+
+[9613](https://github.com/flutter/engine/pull/9613) Fix uninitialized variables and put tests in flutter namespace. (cla: yes)
+
+[9632](https://github.com/flutter/engine/pull/9632) Added Doxyfile. (cla: yes)
+
+[9633](https://github.com/flutter/engine/pull/9633) Cherry-pick fix for flutter/flutter#35291 (cla: yes)
+
+[9634](https://github.com/flutter/engine/pull/9634) Roll Dart to 67ab3be10d35d994641da167cc806f20a7ffa679 (cla: yes)
+
+[9636](https://github.com/flutter/engine/pull/9636) Added shebangs to ios unit test scripts. (#9464) (cla: yes)
+
+[9637](https://github.com/flutter/engine/pull/9637) Revert "Roll Dart to 67ab3be10d35d994641da167cc806f20a7ffa679 (#9634)" (cla: yes)
+
+[9638](https://github.com/flutter/engine/pull/9638) Reland: Roll Dart to 67ab3be10d35d994641da167cc806f20a7ffa679 (cla: yes)
+
+[9640](https://github.com/flutter/engine/pull/9640) make EmbeddedViewParams a unique ptr (cla: yes)
+
+[9641](https://github.com/flutter/engine/pull/9641) Let pushColorFilter accept all types of ColorFilters (cla: yes)
+
+[9642](https://github.com/flutter/engine/pull/9642) Fix warning about settings unavailable GN arg build_glfw_shell (cla: yes)
+
+[9649](https://github.com/flutter/engine/pull/9649) Roll buildroot to c5a493b25. (cla: yes)
+
+[9651](https://github.com/flutter/engine/pull/9651) Move the mutators stack handling to preroll (cla: yes)
+
+[9652](https://github.com/flutter/engine/pull/9652) Pipeline allows continuations that can produce to front (cla: yes)
+
+[9653](https://github.com/flutter/engine/pull/9653) External view embedder can tell if embedded views have mutated (cla: yes)
+
+[9654](https://github.com/flutter/engine/pull/9654) Begin separating macOS engine from view controller (cla: yes)
+
+[9655](https://github.com/flutter/engine/pull/9655) Allow embedders to add callbacks for responses to platform messages from the framework. (cla: yes)
+
+[9660](https://github.com/flutter/engine/pull/9660) ExternalViewEmbedder can CancelFrame after pre-roll (cla: yes)
+
+[9661](https://github.com/flutter/engine/pull/9661) Raster now returns an enum rather than boolean (cla: yes)
+
+[9663](https://github.com/flutter/engine/pull/9663) Mutators Stack refactoring (cla: yes)
+
+[9667](https://github.com/flutter/engine/pull/9667) iOS platform view opacity (cla: yes)
+
+[9668](https://github.com/flutter/engine/pull/9668) Refactor ColorFilter to have a native wrapper (cla: yes)
+
+[9669](https://github.com/flutter/engine/pull/9669) Improve window documentation (cla: yes)
+
+[9672](https://github.com/flutter/engine/pull/9672) Add FLEDartProject for macOS embedding (cla: yes)
+
+[9685](https://github.com/flutter/engine/pull/9685) fix Picture.toImage return type check and api conform test. (cla: yes)
+
+[9698](https://github.com/flutter/engine/pull/9698) Ensure that platform messages without response handles can be dispatched. (cla: yes)
+
+[9707](https://github.com/flutter/engine/pull/9707) Revert "Revert "Use track-widget-creation transformer included in the… (cla: yes)
+
+[9713](https://github.com/flutter/engine/pull/9713) Explain why OpacityLayer has an offset field (cla: yes)
+
+[9717](https://github.com/flutter/engine/pull/9717) Fixed logLevel filter bug so that filter now works as expected. (#9460) (cla: yes)
+
+[9721](https://github.com/flutter/engine/pull/9721) Add comments to differentiate two cache paths (cla: yes)
+
+[9725](https://github.com/flutter/engine/pull/9725) Make the license script compatible with recently changed Dart I/O stream APIs (cla: yes)
+
+[9727](https://github.com/flutter/engine/pull/9727) Add hooks for InputConnection lock and unlocking (cla: yes)
+
+[9730](https://github.com/flutter/engine/pull/9730) Fix Fuchsia build. (cla: yes)
+
+[9734](https://github.com/flutter/engine/pull/9734) Fix backspace crash on Chinese devices (cla: yes)
+
+[9736](https://github.com/flutter/engine/pull/9736) Build Fuchsia as part of CI presumit (cla: yes)
+
+[9737](https://github.com/flutter/engine/pull/9737) Use libc++ variant of string view and remove the FML variant. (cla: yes)
+
+[9740](https://github.com/flutter/engine/pull/9740) Revert "Improve caching limits for Skia" (cla: yes)
+
+[9741](https://github.com/flutter/engine/pull/9741) Make FLEViewController's view an internal detail (cla: yes)
+
+[9745](https://github.com/flutter/engine/pull/9745) Fix windows test by not attempting to open a directory as a file. (cla: yes)
+
+[9746](https://github.com/flutter/engine/pull/9746) Make all shell unit tests use the OpenGL rasterizer. (cla: yes)
+
+[9750](https://github.com/flutter/engine/pull/9750) FLEViewController/Engine API changes (cla: yes)
+
+[9758](https://github.com/flutter/engine/pull/9758) Include SkParagraph headers only when the enable-skshaper flag is on (cla: yes)
+
+[9762](https://github.com/flutter/engine/pull/9762) Fall back to a fully qualified path to libapp.so if the library can not be loaded by name (cla: yes)
+
+[9767](https://github.com/flutter/engine/pull/9767) Un-deprecated FlutterViewController's binaryMessenger. (cla: yes)
+
+[9769](https://github.com/flutter/engine/pull/9769) Document //flutter/shell/common/engine. (cla: yes)
+
+[9772](https://github.com/flutter/engine/pull/9772) fix objcdoc generation (cla: yes)
+
+[9781](https://github.com/flutter/engine/pull/9781) SendPlatformMessage allow null message value (cla: yes)
+
+[9789](https://github.com/flutter/engine/pull/9789) fix ColorFilter.matrix constness (cla: yes)
+
+[9791](https://github.com/flutter/engine/pull/9791) Roll Wuffs and buildroot (cla: yes)
+
+[9792](https://github.com/flutter/engine/pull/9792) Update flutter_web to latest (cla: yes)
+
+[9793](https://github.com/flutter/engine/pull/9793) Fix typo in PlaceholderAlignment docs (cla: yes)
+
+[9797](https://github.com/flutter/engine/pull/9797) Remove breaking asserts (cla: yes)
+
+[9799](https://github.com/flutter/engine/pull/9799) Update buildroot to c4df4a7b to pull in MSVC 2017 Update 9 on Windows. (cla: yes)
+
+[9808](https://github.com/flutter/engine/pull/9808) Document FontFeature class (cla: yes)
+
+[9809](https://github.com/flutter/engine/pull/9809) Document //flutter/shell/common/rasterizer (cla: yes)
+
+[9813](https://github.com/flutter/engine/pull/9813) Made Picture::toImage happen on the IO thread with no need for an onscreen surface. (cla: yes)
+
+[9816](https://github.com/flutter/engine/pull/9816) Only release the image data in the unit-test once Skia has accepted ownership of it. (cla: yes)
+
+[9818](https://github.com/flutter/engine/pull/9818) Convert run_tests to python, allow running on Mac/Windows and allow filters for tests. (cla: yes)
+
+[9823](https://github.com/flutter/engine/pull/9823) Roll buildroot to support bitcode enabled builds for iOS (cla: yes)
+
+[9825](https://github.com/flutter/engine/pull/9825) In a single frame codec, release the encoded image buffer after giving it to the decoder (cla: yes)
+
+[9828](https://github.com/flutter/engine/pull/9828) Make the virtual display's window translucent (cla: yes)
+
+[9847](https://github.com/flutter/engine/pull/9847)  Started adding the engine hash to frameworks' Info.plist. (cla: yes)
+
+[9849](https://github.com/flutter/engine/pull/9849) Preserve the alpha for VD content by setting a transparent background. (cla: yes)
+
+[9850](https://github.com/flutter/engine/pull/9850) Add multi-line flag to semantics (cla: yes)
+
+[9852](https://github.com/flutter/engine/pull/9852) Selectively enable tests that work on Windows and file issues for ones that don't. (cla: yes)
+
+[9855](https://github.com/flutter/engine/pull/9855) Fix missing assignment to _allowHeadlessExecution (cla: yes)
+
+[9856](https://github.com/flutter/engine/pull/9856) Disable Fuchsia Debug & Release presubmits and only attempt the Profile unopt variant. (cla: yes)
+
+[9857](https://github.com/flutter/engine/pull/9857) Fix fuchsia license detection (cla: yes)
+
+[9859](https://github.com/flutter/engine/pull/9859) Fix justify for RTL paragraphs. (cla: yes, waiting for tree to go green)
+
+[9866](https://github.com/flutter/engine/pull/9866) Update buildroot to pick up Fuchsia artifact roller. (cla: yes)
+
+[9867](https://github.com/flutter/engine/pull/9867) Fixed error in generated xml Info.plist. (cla: yes)
+
+[9873](https://github.com/flutter/engine/pull/9873) Add clang version to Info.plist (cla: yes)
+
+[9875](https://github.com/flutter/engine/pull/9875) Simplify buildtools (cla: yes)
+
+[9890](https://github.com/flutter/engine/pull/9890) Log dlopen errors only in debug mode (cla: yes)
+
+[9898](https://github.com/flutter/engine/pull/9898) v1.7.8 hotfixes (cla: yes)
+
+[9903](https://github.com/flutter/engine/pull/9903) Revert to using fml::StringView instead of std::string_view (cla: yes)
+
+[9905](https://github.com/flutter/engine/pull/9905) Respect EXIF information while decompressing images. (cla: yes)
+
+
+## PRs closed in this release of flutter/plugins
+
+From Wed May 1 16:56:00 2019 -0700 to Thu Jul 18 08:04:00 2019 -0700
+
+
+[826](https://github.com/flutter/plugins/pull/826) [google_maps_flutter] enable/disable indoor view (cla: yes, feature, needs love)
+
+[837](https://github.com/flutter/plugins/pull/837) [camera] Add the ability to disable audio for video recording and image streaming (cla: yes, feature, marketplace)
+
+[844](https://github.com/flutter/plugins/pull/844) [google_sign_in] Added NonNull annotations, reduce Guava usage (bugfix, cla: yes, submit queue)
+
+[1067](https://github.com/flutter/plugins/pull/1067) [quick_actions]make QuickActions testable (cla: yes)
+
+[1075](https://github.com/flutter/plugins/pull/1075) [firebase_analytics]Refactor unit test to use `setMockMethodCallHandler` (cla: yes, flutterfire)
+
+[1078](https://github.com/flutter/plugins/pull/1078) [firebase_remote_config)Remove unused property "channel" (cla: yes, submit queue)
+
+[1119](https://github.com/flutter/plugins/pull/1119) [android_alarm_manager] add support for specifying startAt time for AlarmManager.periodic() (cla: yes)
+
+[1158](https://github.com/flutter/plugins/pull/1158) [firebase_auth] Add updatePhoneNumber function (WIP, cla: no, feature, flutterfire)
+
+[1198](https://github.com/flutter/plugins/pull/1198)  [shared_preferences] Added reload method  (cla: yes, feature)
+
+[1276](https://github.com/flutter/plugins/pull/1276) [shared_preferences] copying list for prevent mutate from outside (bugfix, cla: yes)
+
+[1308](https://github.com/flutter/plugins/pull/1308) [shared_preferences] release active instance for create new singleton with new mock values (cla: yes)
+
+[1313](https://github.com/flutter/plugins/pull/1313) [ci] Switch to macOS VM with Flutter pre-installed (WIP, bugfix, cla: yes)
+
+[1318](https://github.com/flutter/plugins/pull/1318) [Firebase messaging] iOS direct data messages (bugfix, cla: yes, flutterfire)
+
+[1355](https://github.com/flutter/plugins/pull/1355) [firebase_storage] Fix putFile method's Content-Type auto-detection for iOS (bugfix, cla: yes, flutterfire)
+
+[1401](https://github.com/flutter/plugins/pull/1401) [webview_flutter] add debuggingEnabled property (cla: yes, feature, webview)
+
+[1515](https://github.com/flutter/plugins/pull/1515) [firebase_admob] Fix firebase_admob crash when used with android alarm manager (bugfix, cla: yes, flutterfire, submit queue)
+
+[1550](https://github.com/flutter/plugins/pull/1550) [google_maps_flutter] Adds support for circle overlays to the Google Maps plugin (cla: yes)
+
+[1551](https://github.com/flutter/plugins/pull/1551) [google_maps_flutter] Adds support for polygon overlays to the Google Maps plugin (cla: yes)
+
+[1553](https://github.com/flutter/plugins/pull/1553) [google_maps_flutter] Avoid calling null callbacks (cla: yes)
+
+[1554](https://github.com/flutter/plugins/pull/1554) [video_player] Prevent Div/0 during network playback initialization. (cla: yes)
+
+[1555](https://github.com/flutter/plugins/pull/1555) [in_app_purchase] Minor doc updates (cla: yes)
+
+[1557](https://github.com/flutter/plugins/pull/1557) [firebase_performance] Testing of firebase performance rewrite PRs (cla: yes, flutterfire)
+
+[1558](https://github.com/flutter/plugins/pull/1558) [google_maps_flutter] Android: update myLocationButton preference on map load (cla: yes)
+
+[1559](https://github.com/flutter/plugins/pull/1559) add cyanglaz to codeowner of video_player (cla: yes)
+
+[1560](https://github.com/flutter/plugins/pull/1560) [in_app_purchase] Remove extraneous download logic (cla: yes)
+
+[1561](https://github.com/flutter/plugins/pull/1561) [in_app_purchase] Update README. Increment version. (cla: yes)
+
+[1564](https://github.com/flutter/plugins/pull/1564) [firebase_crashlytics] Migrate FlutterErrorDetails (cla: yes)
+
+[1565](https://github.com/flutter/plugins/pull/1565) [path_provider] Release as 1.0 and add integration tests (cla: yes)
+
+[1566](https://github.com/flutter/plugins/pull/1566) [path_provider] add getApplicationSupportDirectory (cla: yes)
+
+[1568](https://github.com/flutter/plugins/pull/1568) [firebase_auth] Removed automatic signing in behaviour when signing in with phone auth. (cla: yes)
+
+[1569](https://github.com/flutter/plugins/pull/1569) [firebase_dynamic_links] support clicking on link while app is running. (cla: yes, flutterfire)
+
+[1571](https://github.com/flutter/plugins/pull/1571) Updates to dynamic links plugin to remove deprecated API usage and update Android dependencies. (cla: yes)
+
+[1572](https://github.com/flutter/plugins/pull/1572) Update Flutterfire Android dependencies. (cla: yes)
+
+[1573](https://github.com/flutter/plugins/pull/1573) Remove flaky timeout test (cla: yes)
+
+[1575](https://github.com/flutter/plugins/pull/1575) [google_maps_flutter] Adds long press / long click support to GoogleMap (cla: yes)
+
+[1576](https://github.com/flutter/plugins/pull/1576) Update firebase_core dependency (cla: yes)
+
+[1577](https://github.com/flutter/plugins/pull/1577) [in_app_purchase] Add consumable demo (cla: yes)
+
+[1578](https://github.com/flutter/plugins/pull/1578) [firebase_auth] Update to latest CocoaPod (cla: yes)
+
+[1579](https://github.com/flutter/plugins/pull/1579) [firebase_messaging] more graceful handling of failed token read on startup (cla: yes)
+
+[1580](https://github.com/flutter/plugins/pull/1580) [cloud_firestore] Update CocoaPod versions dependency (cla: yes)
+
+[1581](https://github.com/flutter/plugins/pull/1581) Fix break in firebase_analytics CocoaPod (cla: yes)
+
+[1582](https://github.com/flutter/plugins/pull/1582) [firebase_core] set user agent (cla: yes, flutterfire)
+
+[1583](https://github.com/flutter/plugins/pull/1583) [image_picker] Add return statement into the image_picker example (cla: yes)
+
+[1584](https://github.com/flutter/plugins/pull/1584) Migrated linkWithCredential function to FirebaseUser object instead of FirebaseAuth (cla: yes)
+
+[1585](https://github.com/flutter/plugins/pull/1585) Return image picker method call results on the platform thread (cla: yes)
+
+[1586](https://github.com/flutter/plugins/pull/1586) [image_picker] iOS: save image to the correct type based on its original type and copy over exif data from the original image (cla: yes)
+
+[1587](https://github.com/flutter/plugins/pull/1587) [in_app_purchase] Updated error handling in `queryPastPurchases` and `queryProductDetails` (cla: yes)
+
+[1588](https://github.com/flutter/plugins/pull/1588) [in_app_purchase] Guard against dupe onBillingSetupFinished calls (cla: yes)
+
+[1589](https://github.com/flutter/plugins/pull/1589) [in_app_purchase] Fix issue with empty purchase updates (cla: yes)
+
+[1590](https://github.com/flutter/plugins/pull/1590) [in_app_purchase] Propagate launchBillingFlow failures (cla: yes)
+
+[1592](https://github.com/flutter/plugins/pull/1592) [android_intent] Add the component name to the intent. (cla: yes)
+
+[1593](https://github.com/flutter/plugins/pull/1593) remove iOS dependency on Firebase/Database and Firebase/Auth (cla: yes)
+
+[1597](https://github.com/flutter/plugins/pull/1597) [firebase_auth] Updated linking error code documentation (cla: yes, flutterfire)
+
+[1598](https://github.com/flutter/plugins/pull/1598) [camera] Enable camera plugin to compile with earlier android apis with custom AndroidManifest settings (cla: yes)
+
+[1600](https://github.com/flutter/plugins/pull/1600) [shared_preferences] Asynchronous commit() callback (cla: yes)
+
+[1601](https://github.com/flutter/plugins/pull/1601) Adjust user agent name (cla: yes)
+
+[1602](https://github.com/flutter/plugins/pull/1602) [webview_flutter] Fix wrong main thread checking condition. (cla: yes)
+
+[1603](https://github.com/flutter/plugins/pull/1603) Fix to check_hard_coded_version script (cla: yes)
+
+[1604](https://github.com/flutter/plugins/pull/1604) [firebase_performance] Update integration tests & version bump (cla: yes, flutterfire)
+
+[1605](https://github.com/flutter/plugins/pull/1605) [video_player] Fixed example and add texts (cla: yes)
+
+[1607](https://github.com/flutter/plugins/pull/1607) [cloud_functions] Update iOS dependencies to latest to match Android (cla: yes)
+
+[1609](https://github.com/flutter/plugins/pull/1609) [firebase_auth] Fix onMethodCall missing for updatePhoneNumberCredential (cla: yes, flutterfire)
+
+[1610](https://github.com/flutter/plugins/pull/1610) [camera] Fix bug preventing video recording with audio (cla: yes)
+
+[1612](https://github.com/flutter/plugins/pull/1612) [video_player] avoid deprecated seekToTime API (cla: yes)
+
+[1615](https://github.com/flutter/plugins/pull/1615) [firebase_ml_vision] release CVPixelBuffer to prevent memory leak (cla: yes)
+
+[1617](https://github.com/flutter/plugins/pull/1617) [image_picker] ios: copy all meta data from the original image. (bugfix, cla: yes)
+
+[1618](https://github.com/flutter/plugins/pull/1618) Allow changing the webview's platform specific implementation (cla: yes)
+
+[1619](https://github.com/flutter/plugins/pull/1619) [cloud_firestore] Group collection query on cloud firestore (cla: yes, flutterfire)
+
+[1620](https://github.com/flutter/plugins/pull/1620) [cloud_functions] Update README and dart docs, remove unused parameters. (cla: yes, flutterfire)
+
+[1621](https://github.com/flutter/plugins/pull/1621) Change LocalAuth to use Biometric API (cla: yes)
+
+[1622](https://github.com/flutter/plugins/pull/1622) Add missing import for UIKit (cla: yes)
+
+[1623](https://github.com/flutter/plugins/pull/1623) [cloud_firestore] add support for cacheSizeBytes (cla: yes, flutterfire)
+
+[1624](https://github.com/flutter/plugins/pull/1624) [webview_flutter] platform_interface: Use Dart objects for creationParams and webSettings. (cla: yes)
+
+[1625](https://github.com/flutter/plugins/pull/1625) [image_picker] Rename iOS class according to the official Objective-C naming convention. (cla: yes)
+
+[1630](https://github.com/flutter/plugins/pull/1630) [firebase_ml_vision] Add close method for detectors (cla: yes, flutterfire)
+
+[1633](https://github.com/flutter/plugins/pull/1633) [cloud_firestore] Fixed parent() methods (cla: yes)
+
+[1634](https://github.com/flutter/plugins/pull/1634) Add in_app_purchase for readme and replace pub.dartlang.org to pub.dev. (cla: yes)
+
+[1637](https://github.com/flutter/plugins/pull/1637) [in_app_purchase] Expanded description (cla: yes)
+
+[1638](https://github.com/flutter/plugins/pull/1638) [image_picker] ios:  support GIF animation and the scaling (cla: yes)
+
+[1639](https://github.com/flutter/plugins/pull/1639)  [cloud_functions]:Replace `call` with `getHttpsCallable` under Usage section in readme (cla: yes)
+
+[1640](https://github.com/flutter/plugins/pull/1640) [google_maps_flutter] Update and comment out the 'set marker icon' sample. (cla: yes)
+
+[1641](https://github.com/flutter/plugins/pull/1641) [android_alarm_manager] Move method channel usage to the platform main thread (cla: yes)
+
+[1642](https://github.com/flutter/plugins/pull/1642) [firebase_ml_vision] Update sample to use new ImageStreamListener API (cla: yes)
+
+[1643](https://github.com/flutter/plugins/pull/1643) suppress deprecation warning for BinaryMessages (cla: yes)
+
+[1644](https://github.com/flutter/plugins/pull/1644) [cloud_firestore] Add user agent submission to Firestore plugin (cla: yes)
+
+[1645](https://github.com/flutter/plugins/pull/1645) [webview_flutter] Move the method channel behind the platform interface (cla: yes)
+
+[1647](https://github.com/flutter/plugins/pull/1647) [cloud_firestore] Added source support (cla: yes, flutterfire)
+
+[1648](https://github.com/flutter/plugins/pull/1648) [connectivity]Adding missing type params. (cla: yes)
+
+[1649](https://github.com/flutter/plugins/pull/1649) [Device_info] Replace invokeMethod with invokeMapMethod and some refactoring around this change. (cla: yes)
+
+[1650](https://github.com/flutter/plugins/pull/1650) [cloud_firestore]bump up flutter version to 1.5 and use invokeMapMethod instead of invokeMethod (cla: yes, flutterfire)
+
+[1651](https://github.com/flutter/plugins/pull/1651) [firebase_admob]add missing type params for invokeMethod and bump min flutter version to 1.5.0… (cla: yes)
+
+[1652](https://github.com/flutter/plugins/pull/1652) [firebase_analytics]bump min flutter version to 1.5.0 and add type params to invokeMethod… (cla: yes, flutterfire)
+
+[1653](https://github.com/flutter/plugins/pull/1653) [shared_preferences] Updated Gradle tooling to match Android Studio 3.4. (cla: yes)
+
+[1654](https://github.com/flutter/plugins/pull/1654) [path_provider] Cast NSInteger to long (cla: yes)
+
+[1655](https://github.com/flutter/plugins/pull/1655) [firebase_auth] add type parameters for invokeMethod and bump min flutter version to 1.5.0 (cla: yes)
+
+[1656](https://github.com/flutter/plugins/pull/1656) Fixes merge conflict in shared_preferences release of 0.5.2+2 (cla: yes)
+
+[1657](https://github.com/flutter/plugins/pull/1657) [firebase_core] replace invokeMethod with invokeMapMethod, add type parameters to invokeMethod calls,  bump min Flutter version to 1.5.0 (cla: yes)
+
+[1658](https://github.com/flutter/plugins/pull/1658) [firebase_ml_vision] Fix crash when passing contact info from barcode (cla: yes)
+
+[1659](https://github.com/flutter/plugins/pull/1659) [local_auth] Fixed crash on API<28 while invoking authenticateWithBiometrics (cla: yes)
+
+[1662](https://github.com/flutter/plugins/pull/1662) [in_app_purchase]fix missing return statement analyzer warning (cla: yes)
+
+[1663](https://github.com/flutter/plugins/pull/1663) Move clearCookies behind the platform abstraction (cla: yes)
+
+[1664](https://github.com/flutter/plugins/pull/1664) Fix firebase_auth analyze issues (cla: yes)
+
+[1665](https://github.com/flutter/plugins/pull/1665) Fix firebase_crashlytics analyze errors (cla: yes)
+
+[1666](https://github.com/flutter/plugins/pull/1666) [firebase_auth] Fix iOS updatePhoneNumberCredential crash (cla: yes)
+
+[1667](https://github.com/flutter/plugins/pull/1667) [firebase_crashlytics]add missing type parameters and pump min flutter version to 1.5.0 (cla: yes)
+
+[1668](https://github.com/flutter/plugins/pull/1668) [firebase_database]Add missing template type parameter to  calls. Bump minimum Flutter v… (cla: yes)
+
+[1669](https://github.com/flutter/plugins/pull/1669) [firebase_dynamic_links]Add missing template type parameter to  calls. Bump minimum Flutter v… (cla: yes)
+
+[1670](https://github.com/flutter/plugins/pull/1670) [firebase_messaging]Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary. (cla: yes)
+
+[1671](https://github.com/flutter/plugins/pull/1671) [firebase_ml_vision] Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary. (cla: yes)
+
+[1672](https://github.com/flutter/plugins/pull/1672) [local_auth] The thread for executor needs to be UI thread. (cla: yes)
+
+[1674](https://github.com/flutter/plugins/pull/1674) [google_maps_flutter] Adds support for add padding to the map (cla: yes)
+
+[1676](https://github.com/flutter/plugins/pull/1676) [local_auth] Use post instead of postDelayed (cla: yes)
+
+[1677](https://github.com/flutter/plugins/pull/1677) [firebase_dynamic_links] Fix Android crashing when a headless plugin register this plugin. (bugfix, cla: yes, flutterfire)
+
+[1678](https://github.com/flutter/plugins/pull/1678) [firebase_remote_config] Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary. (cla: yes)
+
+[1679](https://github.com/flutter/plugins/pull/1679) [firebase_storage]Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary. (cla: yes)
+
+[1680](https://github.com/flutter/plugins/pull/1680) [google_map_flutter] Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary. (cla: yes)
+
+[1681](https://github.com/flutter/plugins/pull/1681) [google_sign_in] Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary. (cla: yes)
+
+[1682](https://github.com/flutter/plugins/pull/1682) [firebase_auth] Document support email requirement in README (cla: yes)
+
+[1683](https://github.com/flutter/plugins/pull/1683) [image_picker]Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary. (cla: yes)
+
+[1684](https://github.com/flutter/plugins/pull/1684) [in_app_purchase]Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary. (cla: yes)
+
+[1685](https://github.com/flutter/plugins/pull/1685) [connectivity] android: Respect case TYPE_MOBILE_HIPRI (cla: yes)
+
+[1688](https://github.com/flutter/plugins/pull/1688) [google_map_flutter] correct version (cla: yes)
+
+[1689](https://github.com/flutter/plugins/pull/1689) [local_auth]Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter versi (cla: yes)
+
+[1690](https://github.com/flutter/plugins/pull/1690) [location_background] Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary. (cla: yes)
+
+[1691](https://github.com/flutter/plugins/pull/1691) [In_app_purchase] Correct version. (cla: yes)
+
+[1692](https://github.com/flutter/plugins/pull/1692) [Package_info] Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary. (cla: yes)
+
+[1693](https://github.com/flutter/plugins/pull/1693) [quick_ actions] Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary. (cla: yes)
+
+[1694](https://github.com/flutter/plugins/pull/1694) [shared_preferences]Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary. (cla: yes)
+
+[1695](https://github.com/flutter/plugins/pull/1695) [url_launcher] Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary. (cla: yes)
+
+[1696](https://github.com/flutter/plugins/pull/1696) [video_player] Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary. (cla: yes)
+
+[1697](https://github.com/flutter/plugins/pull/1697) [google_maps_flutter] Add support for styling google maps (cla: yes)
+
+[1698](https://github.com/flutter/plugins/pull/1698) [webview_flutter]Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary. (cla: yes)
+
+[1699](https://github.com/flutter/plugins/pull/1699) [In_app_purchase] rename `PurchaseError` to `IAPError` and rename `PurchaseSource` to `IAPSource` (cla: yes)
+
+[1700](https://github.com/flutter/plugins/pull/1700) [android_alarm_manager] Wait in onHandleWork until the Dart callback returns a result (cla: yes)
+
+[1701](https://github.com/flutter/plugins/pull/1701) [cloud_firestore] Invoke on ui thread only (cla: yes, flutterfire)
+
+[1703](https://github.com/flutter/plugins/pull/1703) [package_info]Update README.md to reflect iOS issue. (cla: yes)
+
+[1705](https://github.com/flutter/plugins/pull/1705) Revert "1690" (cla: yes)
+
+[1707](https://github.com/flutter/plugins/pull/1707) Ensure that CocoaPods on Cirrus is always the latest version. (cla: yes)
+
+[1711](https://github.com/flutter/plugins/pull/1711) Initial plugins test app (cla: yes)
+
+[1712](https://github.com/flutter/plugins/pull/1712) [firebase_ml_vision] Separate integration tests (cla: yes)
+
+[1713](https://github.com/flutter/plugins/pull/1713) [firebase_ml_vision] Prepare example app to include Live Camera Preview demo and Material Barcode Scanner demo (cla: yes)
+
+[1714](https://github.com/flutter/plugins/pull/1714) [quick_actions] Update README.md (cla: yes)
+
+[1720](https://github.com/flutter/plugins/pull/1720) [cloud_firestore] Fix document pagination (cla: yes)
+
+[1722](https://github.com/flutter/plugins/pull/1722) [cloud_firestore] Added support for combining document pagination methods (cla: yes)
+
+[1724](https://github.com/flutter/plugins/pull/1724) Add a note about mockito to contribution guide (cla: yes)
+
+[1725](https://github.com/flutter/plugins/pull/1725) [all_plugins] Build all_plugins app on cirrus script (cla: yes)
+
+[1728](https://github.com/flutter/plugins/pull/1728) [firebase_messaging]: add additional documentation for the data in notifications (cla: no, flutterfire, submit queue)
+
+[1729](https://github.com/flutter/plugins/pull/1729) Fix build failures due to CocoaPods version (cla: yes)
+
+[1731](https://github.com/flutter/plugins/pull/1731) Update plugin Dart code to conform to current Dart formatter (cla: yes)
+
+[1733](https://github.com/flutter/plugins/pull/1733) [firebase_core] Automate version retrieval (cla: yes)
+
+[1734](https://github.com/flutter/plugins/pull/1734) [google_maps_flutter] ios build fix (cla: yes)
+
+[1735](https://github.com/flutter/plugins/pull/1735) Remove hard coded version check (cla: yes)
+
+[1737](https://github.com/flutter/plugins/pull/1737) [google_maps_flutter] Allow BitmapDescriptor scaling override (cla: yes)
+
+[1738](https://github.com/flutter/plugins/pull/1738) Update API link (cla: yes)
+
+[1739](https://github.com/flutter/plugins/pull/1739) [firebase_crashlytics] Fix parsing stacktrace (cla: yes)
+
+[1742](https://github.com/flutter/plugins/pull/1742) [firebase_core] roll back to 0.4.0+3 (cla: yes)
+
+[1744](https://github.com/flutter/plugins/pull/1744) [image_picker] return error in the event that permissions are not granted (cla: yes, submit queue)
+
+[1747](https://github.com/flutter/plugins/pull/1747) [cloud_functions] Remove unused header reference (cla: yes)
+
+[1748](https://github.com/flutter/plugins/pull/1748) Auto retrieve version to report user agent (cla: yes)
+
+[1749](https://github.com/flutter/plugins/pull/1749) re-add deleted files (cla: yes)
+
+[1750](https://github.com/flutter/plugins/pull/1750) [firebase_crashlytics][ios] setUserIdentifier incorrectly calls setUserEmail (cla: yes)
+
+[1751](https://github.com/flutter/plugins/pull/1751) [in_app_purchase] Fixed code example error & README links  (cla: yes, documentation, submit queue)
+
+[1753](https://github.com/flutter/plugins/pull/1753) [share] Add subject as optional parameter (cla: yes)
+
+[1756](https://github.com/flutter/plugins/pull/1756) [firebase_messaging] fix crash when func deleteInstanceID return result in incorrect thread (cla: no, flutterfire)
+
+[1758](https://github.com/flutter/plugins/pull/1758) [firebase_ml_vision] Move firebase_ml_vision examples to this repo (cla: yes, flutterfire)
+
+[1759](https://github.com/flutter/plugins/pull/1759) [firebase_crashlyitcs] On Android, use actual the Dart exception name instead of "Dart error." (cla: yes)
+
+[1760](https://github.com/flutter/plugins/pull/1760) Auto report ff (cla: yes, flutterfire)
+
+[1761](https://github.com/flutter/plugins/pull/1761) [Connectivity][Android] Updated check network info logic (cla: yes, submit queue)
+
+[1763](https://github.com/flutter/plugins/pull/1763) [firebase_performance] Fix bug that prevented plugin to work with hot restart (bugfix, cla: yes, flutterfire)
+
+[1764](https://github.com/flutter/plugins/pull/1764) [none] Update README.md (cla: yes)
+
+[1765](https://github.com/flutter/plugins/pull/1765) [firebase_auth] Leave UserInfo for phone provider in providerData (cla: yes, flutterfire)
+
+[1766](https://github.com/flutter/plugins/pull/1766) [firebase_messaging] Update README for build.gradle configuration (cla: yes)
+
+[1768](https://github.com/flutter/plugins/pull/1768) [script] Don't run incremental build when there are no changes in packages (cla: yes)
+
+[1769](https://github.com/flutter/plugins/pull/1769) Update README to reflect the requirement to use fragment activity (cla: yes)
+
+[1772](https://github.com/flutter/plugins/pull/1772) Set device density to polylines (cla: yes)
+
+[1775](https://github.com/flutter/plugins/pull/1775) [in_app_purchase]fix the type casting issue (cla: yes)
+
+[1776](https://github.com/flutter/plugins/pull/1776) [all_plugins] Compile all plugins together (cla: yes)
+
+[1778](https://github.com/flutter/plugins/pull/1778) Enable version checker to be run on cirrus (cla: yes)
+
+[1779](https://github.com/flutter/plugins/pull/1779) Add a PR triage policy to the contributing guide. (cla: yes)
+
+[1780](https://github.com/flutter/plugins/pull/1780) [cloud_firestore] Transactions improvements (cla: yes)
+
+[1781](https://github.com/flutter/plugins/pull/1781) [cloud_firestore] Support for map fields in document pagination (cla: yes)
+
+[1782](https://github.com/flutter/plugins/pull/1782) [url_launcher]: add option to enable DOM storage in android webview (cla: yes)
+
+[1785](https://github.com/flutter/plugins/pull/1785) [in_app_purchase]fix the regression introduced in 0.2.0+1 (cla: yes)
+
+[1786](https://github.com/flutter/plugins/pull/1786) Disable version-check until we fix the patch version (cla: yes)
+
+[1787](https://github.com/flutter/plugins/pull/1787) re-enable version check (cla: yes)
+
+[1795](https://github.com/flutter/plugins/pull/1795) [image_picker] Don't use modules (cla: yes)
+
+[1797](https://github.com/flutter/plugins/pull/1797) [android_intent] [battery] [shared_preferences] Fix Gradle version (cla: yes)
+
+[1798](https://github.com/flutter/plugins/pull/1798) [in_app_purchase] Readme updates (cla: yes, documentation, submit queue)
+
+[1799](https://github.com/flutter/plugins/pull/1799) [firebase_crashlytics] make sure the keys are actually added to the returned map (cla: yes)
+
+[1800](https://github.com/flutter/plugins/pull/1800) [quick_actions] Implementing sharedpreferences approach for killed apps (cla: yes)
+
+[1801](https://github.com/flutter/plugins/pull/1801) [google_maps_flutter] Fix incorrect polygon argument name in google maps controller (cla: yes)
+
+[1804](https://github.com/flutter/plugins/pull/1804) [image_picker] Removed cursor to prevent crash (cla: yes)
+
+[1805](https://github.com/flutter/plugins/pull/1805) [firebase_auth] Fix typo in some comments. (cla: yes, submit queue)
+
+[1806](https://github.com/flutter/plugins/pull/1806) [video_player] fixed markdown which causes pub.dev not show actu… (cla: no, submit queue)
+
+[1808](https://github.com/flutter/plugins/pull/1808) [google_maps_flutter] Add map toolbar support (cla: yes)
+
+[1811](https://github.com/flutter/plugins/pull/1811) [path_provider] Update to use getExternalFilesDir (cla: yes)
+
+[1812](https://github.com/flutter/plugins/pull/1812) [firebase_database] Move firebase_database transaction calls to UI thread on Android (cla: yes)
+
+[1815](https://github.com/flutter/plugins/pull/1815) [firebase_crashlytics] Update README with advice on testing installation (cla: yes)
+
+[1816](https://github.com/flutter/plugins/pull/1816) [firebase_messaging] add integration tests (cla: yes)
+
+[1817](https://github.com/flutter/plugins/pull/1817) [image_picker]use class instead of struct for GIFInfo on iOS (cla: yes)
+
+[1818](https://github.com/flutter/plugins/pull/1818) [firebase_messaging] Change signature of subscribe/unsubscribe (cla: yes)
+
+[1819](https://github.com/flutter/plugins/pull/1819) [in_app_purchase] iOS: Support unsupported UserInfo value types on NSError. (cla: yes, submit queue)
+
+[1822](https://github.com/flutter/plugins/pull/1822) [Connectivity] Fixes issue "connectivity using deprecated api" (cla: yes, submit queue)
+
+[1823](https://github.com/flutter/plugins/pull/1823) [image_picker] Update README example (cla: yes)
+
+[1826](https://github.com/flutter/plugins/pull/1826) [firebase_auth] Register for iOS notifications to support phone auth (cla: yes)
+
+[1827](https://github.com/flutter/plugins/pull/1827) [in_app_purchase] fix version (cla: yes)
+
+[1828](https://github.com/flutter/plugins/pull/1828) Revert "[google_sign_in] Added NonNull annotations, reduce Guava usage (#844) (cla: yes)
+
+[1830](https://github.com/flutter/plugins/pull/1830) [firebase_remote_config] fix config value source parsing (cla: yes)
+
+[1831](https://github.com/flutter/plugins/pull/1831) [firebase_crashlytics] Handle case where function isn't in class for stack (cla: yes)
+
+[1832](https://github.com/flutter/plugins/pull/1832) [camera] Dart Interface for camera refactor (cla: yes)
+
+[1833](https://github.com/flutter/plugins/pull/1833) [in_app_purchase] add missing `hashCode` implementation (cla: yes)
+
+[1834](https://github.com/flutter/plugins/pull/1834) [firebase_storage] Fix Content-Type auto-detection for Android (cla: yes)
+
+[1835](https://github.com/flutter/plugins/pull/1835) [firebase_dynamic_links] Allow FDL plugin to be registered without an activity (cla: yes)
+
+[1839](https://github.com/flutter/plugins/pull/1839) [firebase_auth] CHANGELOG entry and update pubspec.yaml for release (cla: yes)
+
+[1840](https://github.com/flutter/plugins/pull/1840) [local_auth] Fix usage syntax on README (cla: yes)
+
+[1844](https://github.com/flutter/plugins/pull/1844) [image_picker] Fix image_picker Hanging After Attempting to Open Unavailable Camera on iOS Simulator (bugfix, cla: yes)
+
+[1845](https://github.com/flutter/plugins/pull/1845) [webview_flutter] Basic fix for input pre N (cla: yes)
+
+[1846](https://github.com/flutter/plugins/pull/1846) [firebase_auth] [google_sign_in] Update consent screen docs (cla: yes)
+
+[1848](https://github.com/flutter/plugins/pull/1848) [url_launcher] add support for android headers (cla: yes)
+
+[1849](https://github.com/flutter/plugins/pull/1849) [android alarm manager] Fix crash below API 19 (cla: yes)
+
+[1850](https://github.com/flutter/plugins/pull/1850) [firebase_analytics] add missing named events tracking (cla: yes)
+
+[1852](https://github.com/flutter/plugins/pull/1852) [webview_flutter] Support Flutter `TextInput`s (cla: yes)
+
+[1853](https://github.com/flutter/plugins/pull/1853) [webview_flutter] Fix input bug on route changes (cla: yes)
+
+[1854](https://github.com/flutter/plugins/pull/1854) [webview_flutter] Fix typo (cla: yes)
+
+[1855](https://github.com/flutter/plugins/pull/1855) Update CODEWNERS for google_maps_flutter and webview_flutter (cla: yes)
+
+[1856](https://github.com/flutter/plugins/pull/1856) [quick_actions] Fixes Android action forwarding (cla: yes)
+
+[1857](https://github.com/flutter/plugins/pull/1857) [webview_flutter] Don't log unknown setting key for debuggingEnabled … (cla: yes)
+
+[1858](https://github.com/flutter/plugins/pull/1858) Update CHANGELOG and pubspec.yaml for release (cla: yes)
+
+[1862](https://github.com/flutter/plugins/pull/1862) [image_picker] Fix a crash when user takes a photo using devices under iOS 11. (cla: yes)
+
+[1863](https://github.com/flutter/plugins/pull/1863) [webview_flutter] fix typo in comment (cla: yes)
+
+[1865](https://github.com/flutter/plugins/pull/1865) [ci] Use the same upgrade script on Mac (cla: yes)
+
+[1869](https://github.com/flutter/plugins/pull/1869) [firebase_auth] Fix getIdToken refresh param on iOS (cla: yes)
+
+[1870](https://github.com/flutter/plugins/pull/1870) Cirrus should report errors on failures of incremental_build.sh (cla: yes)
+
+[1872](https://github.com/flutter/plugins/pull/1872) [connectivity] Fix the typo in the suppresswarnings qualifier (cla: yes)
+
+[1873](https://github.com/flutter/plugins/pull/1873) Add some more CODEOWNERS (cla: yes)
+
+[1874](https://github.com/flutter/plugins/pull/1874) [firebase_performance] Fix invokeMethod formatting that caused a bug with Dart code obfuscation (cla: yes)

--- a/src/docs/development/tools/sdk/release-notes/changelogs/changelog-1.9.1.md
+++ b/src/docs/development/tools/sdk/release-notes/changelogs/changelog-1.9.1.md
@@ -1,0 +1,1896 @@
+---
+title: Change log for Flutter 1.9.1 
+short-title: 1.9.1 change log
+description: Change log for Flutter 1.9.1 containing a list of all PRs merged for this release.
+---
+
+
+
+## PRs closed in this release of flutter/flutter
+
+From Fri Jun 21 22:31:55 2019 -0400 to Sun Aug 18 12:22:00 2019 -0700
+
+
+[28090](https://github.com/flutter/flutter/pull/28090) Ensure that cache dirs and files have appropriate permissions (cla: yes, tool)
+
+[29489](https://github.com/flutter/flutter/pull/29489) Made a few grammatical changes (cla: yes, team)
+
+[32511](https://github.com/flutter/flutter/pull/32511) Rendering errors with root causes in the widget layer should have a reference to the widget (cla: yes, customer: countless, customer: headline, framework)
+
+[32770](https://github.com/flutter/flutter/pull/32770) Dismiss modal with any button press (a: desktop, cla: yes, framework)
+
+[32816](https://github.com/flutter/flutter/pull/32816) Add initial implementation of flutter assemble (cla: yes, tool)
+
+[33140](https://github.com/flutter/flutter/pull/33140) flutter/tests support (cla: yes, team)
+
+[33281](https://github.com/flutter/flutter/pull/33281) Update TextStyle and StrutStyle height docs (a: typography, cla: yes, d: api docs, framework, severe: API break)
+
+[33688](https://github.com/flutter/flutter/pull/33688) Part 1: Skia Gold Testing (a: tests, cla: yes, framework)
+
+[33936](https://github.com/flutter/flutter/pull/33936) New parameter for RawGestureDetector to customize semantics mapping (cla: yes, f: gestures, framework)
+
+[34019](https://github.com/flutter/flutter/pull/34019) Selectable Text (a: text input, cla: yes, customer: amplify, customer: fuchsia, framework, severe: API break)
+
+[34202](https://github.com/flutter/flutter/pull/34202) Remove `_debugWillReattachChildren` assertions from `_TableElement` (cla: yes, customer: payouts, framework)
+
+[34252](https://github.com/flutter/flutter/pull/34252) Integrate dwds into flutter tool for web support (cla: yes, tool, ☸ platform-web)
+
+[34298](https://github.com/flutter/flutter/pull/34298) Preserving SafeArea : Part 2 (cla: yes, customer: solaris, framework, severe: customer critical, waiting for tree to go green)
+
+[34301](https://github.com/flutter/flutter/pull/34301) Make it possible to override the FLUTTER_TEST env variable (a: tests, cla: yes, customer: mulligan (g3), team, tool)
+
+[34515](https://github.com/flutter/flutter/pull/34515) OutlineInputBorder adjusts for borderRadius that is too large (a: text input, cla: yes, f: material design, framework)
+
+[34516](https://github.com/flutter/flutter/pull/34516) [flutter_tool] Fill in Fuchsia version string (cla: yes, tool)
+
+[34573](https://github.com/flutter/flutter/pull/34573) Ensures flutter jar is added to all build types on plugin projects (cla: yes, t: gradle, tool, waiting for tree to go green)
+
+[34597](https://github.com/flutter/flutter/pull/34597) [Material] Update slider gallery demo, including range slider (cla: yes, f: material design, framework)
+
+[34599](https://github.com/flutter/flutter/pull/34599) [Material] ToggleButtons (cla: yes, f: material design, framework, severe: new feature)
+
+[34624](https://github.com/flutter/flutter/pull/34624) Break down flutter doctor validations and results (cla: yes, t: flutter doctor, tool)
+
+[34626](https://github.com/flutter/flutter/pull/34626) AsyncSnapshot.data to throw if error or no data (cla: yes, framework)
+
+[34660](https://github.com/flutter/flutter/pull/34660) Add --target support for Windows and Linux (cla: yes, tool)
+
+[34665](https://github.com/flutter/flutter/pull/34665) Selection handles position is off (a: text input, cla: yes, framework, severe: API break)
+
+[34669](https://github.com/flutter/flutter/pull/34669) Bundle ios dependencies (cla: yes, tool)
+
+[34676](https://github.com/flutter/flutter/pull/34676) Enable selection by default for password text field and expose api to… (a: text input, cla: yes, f: cupertino, f: material design, framework)
+
+[34712](https://github.com/flutter/flutter/pull/34712) Fix FocusTraversalPolicy makes focus lost (a: desktop, cla: yes, framework)
+
+[34723](https://github.com/flutter/flutter/pull/34723) CupertinoTextField vertical alignment (cla: yes, f: cupertino, framework)
+
+[34752](https://github.com/flutter/flutter/pull/34752) [linux] Receives the unmodified characters obtained from GLFW (a: desktop, cla: yes, framework)
+
+[34785](https://github.com/flutter/flutter/pull/34785) Tweak the display name of emulators (cla: yes, tool)
+
+[34794](https://github.com/flutter/flutter/pull/34794) Add `emulatorID` field to devices in daemon (cla: yes, tool)
+
+[34823](https://github.com/flutter/flutter/pull/34823) Introduce image loading performance test. (a: tests, cla: yes, framework)
+
+[34869](https://github.com/flutter/flutter/pull/34869) [Material] Properly call onChangeStart and onChangeEnd in Range Slider (cla: yes, f: material design, framework)
+
+[34870](https://github.com/flutter/flutter/pull/34870) Add test case for Flutter Issue #27677 as a benchmark. (cla: yes, engine, framework, severe: performance)
+
+[34872](https://github.com/flutter/flutter/pull/34872) [Material] Support for hovered, focused, and pressed border color on `OutlineButton`s (cla: yes, f: material design, framework)
+
+[34877](https://github.com/flutter/flutter/pull/34877) More shards (a: tests, cla: yes, team, waiting for tree to go green)
+
+[34885](https://github.com/flutter/flutter/pull/34885) Reland: rename web device (cla: yes, tool)
+
+[34895](https://github.com/flutter/flutter/pull/34895) Remove flutter_tools support for old AOT snapshotting (cla: yes)
+
+[34896](https://github.com/flutter/flutter/pull/34896) Allow multi-root web builds  (cla: yes, tool)
+
+[34906](https://github.com/flutter/flutter/pull/34906) Fix unused [applicationIcon] property on [showLicensePage] (cla: yes, f: material design, framework)
+
+[34907](https://github.com/flutter/flutter/pull/34907) Fixed LicensePage to close page before loaded the License causes an error (cla: yes, f: material design, framework, severe: crash)
+
+[34919](https://github.com/flutter/flutter/pull/34919) Remove duplicate error parts (cla: yes, framework, waiting for tree to go green)
+
+[34932](https://github.com/flutter/flutter/pull/34932) Added onChanged property to TextFormField (cla: yes, f: material design, framework)
+
+[34964](https://github.com/flutter/flutter/pull/34964) CupertinoTextField.onTap (cla: yes, f: cupertino)
+
+[35017](https://github.com/flutter/flutter/pull/35017) sync lint list (cla: yes)
+
+[35046](https://github.com/flutter/flutter/pull/35046) Add generated Icon diagram to api docs (cla: yes, d: api docs, d: examples, framework)
+
+[35055](https://github.com/flutter/flutter/pull/35055) enable lint avoid_bool_literals_in_conditional_expressions (cla: yes)
+
+[35056](https://github.com/flutter/flutter/pull/35056) enable lint use_full_hex_values_for_flutter_colors (cla: yes)
+
+[35059](https://github.com/flutter/flutter/pull/35059) prepare for lint update of prefer_final_fields (cla: yes)
+
+[35063](https://github.com/flutter/flutter/pull/35063) add documentation for conic path not supported (a: platform-views, cla: yes, d: api docs, framework, plugin)
+
+[35066](https://github.com/flutter/flutter/pull/35066) Manual engine roll, Update goldens, improved wavy text decoration 0f9e297ad..185087a65f (a: typography, cla: yes, engine)
+
+[35074](https://github.com/flutter/flutter/pull/35074) Attempt to enable tool coverage redux (a: tests, cla: yes, tool)
+
+[35075](https://github.com/flutter/flutter/pull/35075) Allow for customizing SnackBar's content TextStyle in its theme (cla: yes, f: material design, framework)
+
+[35084](https://github.com/flutter/flutter/pull/35084) Move findTargetDevices to DeviceManager (cla: yes, tool)
+
+[35092](https://github.com/flutter/flutter/pull/35092) Add FlutterProjectFactory so that it can be overridden internally. (cla: yes, tool)
+
+[35110](https://github.com/flutter/flutter/pull/35110) Always test semantics (a: accessibility, a: tests, cla: yes, framework, severe: API break)
+
+[35129](https://github.com/flutter/flutter/pull/35129) [Material] Wrap Flutter Gallery's Expansion Panel Slider in padded Container to make room for Value Indicator. (cla: yes, f: material design, framework, severe: regression)
+
+[35130](https://github.com/flutter/flutter/pull/35130) pass new users for release_smoke_tests (a: tests, cla: yes, team)
+
+[35132](https://github.com/flutter/flutter/pull/35132) Reduce allocations by reusing a matrix for transient transforms in _transformRect (cla: yes)
+
+[35136](https://github.com/flutter/flutter/pull/35136) Update Dark Theme disabledColor to White38 (cla: yes, f: material design, framework, severe: API break)
+
+[35143](https://github.com/flutter/flutter/pull/35143) More HttpClientResponse Uint8List fixes (cla: yes)
+
+[35149](https://github.com/flutter/flutter/pull/35149) More `HttpClientResponse implements Stream<Uint8List>` fixes (cla: yes)
+
+[35150](https://github.com/flutter/flutter/pull/35150) Change didUpdateConfig to didUpdateWidget (cla: yes, d: api docs, framework)
+
+[35157](https://github.com/flutter/flutter/pull/35157) Remove skip clause on tools coverage (cla: yes, team)
+
+[35160](https://github.com/flutter/flutter/pull/35160) Move usage flutter create tests into memory filesystem. (a: tests, cla: yes, tool)
+
+[35164](https://github.com/flutter/flutter/pull/35164) Update reassemble doc (cla: yes, customer: product, d: api docs, framework, severe: customer critical)
+
+[35186](https://github.com/flutter/flutter/pull/35186) Make tool coverage collection resilient to sentinel coverage data (cla: yes, tool)
+
+[35188](https://github.com/flutter/flutter/pull/35188) ensure test isolate is paused before collecting coverage (cla: yes, tool)
+
+[35189](https://github.com/flutter/flutter/pull/35189) enable lints prefer_spread_collections and prefer_inlined_adds (cla: yes)
+
+[35192](https://github.com/flutter/flutter/pull/35192) don't block any presubmit on coverage (cla: yes, tool)
+
+[35197](https://github.com/flutter/flutter/pull/35197) [flutter_tool] Update Fuchsia SDK (cla: yes, tool)
+
+[35206](https://github.com/flutter/flutter/pull/35206) Force-upgrade package deps (cla: yes)
+
+[35207](https://github.com/flutter/flutter/pull/35207) refactor out selection handlers (a: text input, cla: yes, customer: amplify, customer: fuchsia, framework)
+
+[35211](https://github.com/flutter/flutter/pull/35211) `child` param doc update in Ink and Ink.image (cla: yes, d: api docs, f: material design, framework)
+
+[35217](https://github.com/flutter/flutter/pull/35217) Add flutter build aar (a: build, cla: yes, tool, waiting for tree to go green)
+
+[35219](https://github.com/flutter/flutter/pull/35219) Text selection menu show/hide cases (a: text input, cla: yes, f: material design, framework)
+
+[35221](https://github.com/flutter/flutter/pull/35221) Twiggle bit to exclude dev and beta from desktop and web (cla: yes, tool)
+
+[35223](https://github.com/flutter/flutter/pull/35223) Navigator pushAndRemoveUntil Fix (cla: yes, customer: mulligan (g3), f: routes, framework, severe: crash, waiting for tree to go green)
+
+[35225](https://github.com/flutter/flutter/pull/35225) add sample code for AnimatedContainer (a: animation, cla: yes, d: api docs, d: examples, framework)
+
+[35231](https://github.com/flutter/flutter/pull/35231) Fix coverage collection (cla: yes, tool)
+
+[35232](https://github.com/flutter/flutter/pull/35232) New benchmark: Gesture semantics (cla: yes, waiting for tree to go green)
+
+[35233](https://github.com/flutter/flutter/pull/35233) Attempt skipping coverage shard if tools did not change (cla: yes)
+
+[35237](https://github.com/flutter/flutter/pull/35237) Revert "Manual engine roll, Update goldens, improved wavy text decoration 0f9e297ad..185087a65f" (cla: yes)
+
+[35242](https://github.com/flutter/flutter/pull/35242) Reland "Manual engine roll, Update goldens, improved wavy text decoration 0f9e297ad..185087a65f"" (cla: yes)
+
+[35245](https://github.com/flutter/flutter/pull/35245) More preparation for HttpClientResponse implements Uint8List (cla: yes)
+
+[35246](https://github.com/flutter/flutter/pull/35246) attempt to not skip coverage on post commit (cla: yes)
+
+[35263](https://github.com/flutter/flutter/pull/35263) remove unnecessary ..toList() (cla: yes)
+
+[35276](https://github.com/flutter/flutter/pull/35276) Revert "[Material] Support for hovered, focused, and pressed border color on `OutlineButton`s" (cla: yes)
+
+[35278](https://github.com/flutter/flutter/pull/35278) Re-land "[Material] Support for hovered, focused, and pressed border color on `OutlineButton`s" (cla: yes)
+
+[35280](https://github.com/flutter/flutter/pull/35280) benchmarkWidgets.semanticsEnabled default false. (cla: yes)
+
+[35282](https://github.com/flutter/flutter/pull/35282) Add Container fallback to Ink build method (cla: yes, f: material design, framework)
+
+[35288](https://github.com/flutter/flutter/pull/35288) Apply coverage skip math correctly (cla: yes)
+
+[35290](https://github.com/flutter/flutter/pull/35290) tests for about page (cla: yes)
+
+[35297](https://github.com/flutter/flutter/pull/35297) Fix the first frame logic in tracing and driver (cla: yes, engine, framework, severe: performance, team)
+
+[35303](https://github.com/flutter/flutter/pull/35303) fix default artifacts to exclude ios and android (cla: yes, tool)
+
+[35307](https://github.com/flutter/flutter/pull/35307) Clean up host_app_ephemeral Profile build settings (a: existing-apps, cla: yes, t: xcode, tool, ⌺‬ platform-ios)
+
+[35335](https://github.com/flutter/flutter/pull/35335) Using custom exception class for network loading error (a: images, cla: yes, framework)
+
+[35367](https://github.com/flutter/flutter/pull/35367) Add type to StreamChannel in generated test code. (cla: yes, tool)
+
+[35392](https://github.com/flutter/flutter/pull/35392) Add timer checking and Fake http client to testbed (cla: yes, tool)
+
+[35393](https://github.com/flutter/flutter/pull/35393) more ui-as-code (cla: yes, team)
+
+[35406](https://github.com/flutter/flutter/pull/35406) Refactor signal and command line handler from resident runner (cla: yes, team, tool)
+
+[35407](https://github.com/flutter/flutter/pull/35407) Manual engine roll (cla: yes, engine, team)
+
+[35408](https://github.com/flutter/flutter/pull/35408) Remove print (cla: yes)
+
+[35423](https://github.com/flutter/flutter/pull/35423) v1.7.8 hotfixes (cla: yes)
+
+[35424](https://github.com/flutter/flutter/pull/35424) Introduce image_list performance benchmark that runs on jit(debug) build. (a: images, a: tests, cla: yes, framework)
+
+[35464](https://github.com/flutter/flutter/pull/35464) Manual roll of engine 45b66b7...ffba2f6 (cla: yes, team)
+
+[35465](https://github.com/flutter/flutter/pull/35465) Mark update-packages as non-experimental (cla: yes, tool)
+
+[35467](https://github.com/flutter/flutter/pull/35467) Mark update-packages as non-experimental (cla: yes, tool)
+
+[35468](https://github.com/flutter/flutter/pull/35468) Add colorFilterLayer/Widget (a: accessibility, cla: yes, customer: octopod, framework, waiting for tree to go green)
+
+[35477](https://github.com/flutter/flutter/pull/35477) Update macrobenchmarks README and app name (a: tests, cla: yes, team)
+
+[35480](https://github.com/flutter/flutter/pull/35480) Update the help message on precache command for less confusion (cla: yes, tool)
+
+[35481](https://github.com/flutter/flutter/pull/35481) add APK build time benchmarks (cla: yes, tool)
+
+[35482](https://github.com/flutter/flutter/pull/35482) Use the new service protocol message names (cla: yes)
+
+[35487](https://github.com/flutter/flutter/pull/35487) Fix RenderFittedBox when child.size.isEmpty (a: accessibility, cla: yes, framework)
+
+[35491](https://github.com/flutter/flutter/pull/35491) Include tags in SemanticsNode debug properties (cla: yes, framework)
+
+[35492](https://github.com/flutter/flutter/pull/35492) Re-apply 'Add currentSystemFrameTimeStamp to SchedulerBinding' (cla: yes, framework)
+
+[35493](https://github.com/flutter/flutter/pull/35493) Do not use ideographic baseline for RenderPargraph baseline (a: typography, cla: yes, engine, framework)
+
+[35495](https://github.com/flutter/flutter/pull/35495) mark windows and macos chrome dev mode as flaky (cla: yes, team)
+
+[35496](https://github.com/flutter/flutter/pull/35496) [Material] Text scale and wide label fixes for Slider and Range Slider value indicator shape (cla: yes, f: material design)
+
+[35499](https://github.com/flutter/flutter/pull/35499) Added MaterialApp.themeMode to control which theme is used. (cla: yes, f: material design, framework)
+
+[35548](https://github.com/flutter/flutter/pull/35548) Various doc fixes (cla: yes, framework)
+
+[35556](https://github.com/flutter/flutter/pull/35556) ios (iPhone6) and iPhone XS tiles_scroll_perf tests (cla: yes, severe: performance, team, ⌺‬ platform-ios)
+
+[35560](https://github.com/flutter/flutter/pull/35560) Support for elevation based dark theme overlay color in the Material widget (cla: yes, f: material design, framework)
+
+[35573](https://github.com/flutter/flutter/pull/35573) update packages (cla: yes, team)
+
+[35574](https://github.com/flutter/flutter/pull/35574) Fix semantics for floating pinned sliver app bar (a: accessibility, cla: yes, f: scrolling, framework, waiting for tree to go green)
+
+[35646](https://github.com/flutter/flutter/pull/35646) Prepare for Socket implements Stream<Uint8List> (cla: yes)
+
+[35657](https://github.com/flutter/flutter/pull/35657) Remove paused check for tooling tests (cla: yes, tool)
+
+[35681](https://github.com/flutter/flutter/pull/35681) Disable incremental compiler in dartdevc (cla: yes, tool)
+
+[35684](https://github.com/flutter/flutter/pull/35684) Fix typo in main.dart templates (cla: yes, d: api docs, framework)
+
+[35708](https://github.com/flutter/flutter/pull/35708) disable a test case in xcode_backend.sh (cla: yes, tool)
+
+[35709](https://github.com/flutter/flutter/pull/35709) Remove web, fuchsia, and unsupported devices from all (cla: yes, tool)
+
+[35725](https://github.com/flutter/flutter/pull/35725) Update annotated region findAll implementation to use Iterables directly. (cla: yes, framework)
+
+[35728](https://github.com/flutter/flutter/pull/35728) Added demo projects for splash screen support on Android. (a: existing-apps, cla: yes, team)
+
+[35731](https://github.com/flutter/flutter/pull/35731) Keep LLDB connection to iOS device alive while running from CLI. (cla: yes, tool)
+
+[35743](https://github.com/flutter/flutter/pull/35743) Simple Doc Fixes (cla: yes, d: api docs, framework)
+
+[35745](https://github.com/flutter/flutter/pull/35745) enable lint prefer_if_null_operators (cla: yes, team)
+
+[35749](https://github.com/flutter/flutter/pull/35749) add iOS build benchmarks (cla: yes, team, tool)
+
+[35750](https://github.com/flutter/flutter/pull/35750) use sentence case in error message titles (cla: yes, framework)
+
+[35756](https://github.com/flutter/flutter/pull/35756) Remove @objc inference build setting (cla: yes, t: xcode, tool)
+
+[35762](https://github.com/flutter/flutter/pull/35762) Refactor keymapping for resident_runner (cla: yes)
+
+[35763](https://github.com/flutter/flutter/pull/35763) UIApplicationLaunchOptionsKey -> UIApplication.LaunchOptionsKey (cla: yes, t: xcode, tool, ⌺‬ platform-ios)
+
+[35765](https://github.com/flutter/flutter/pull/35765) Use public _registerService RPC in flutter_tools (cla: yes, tool)
+
+[35767](https://github.com/flutter/flutter/pull/35767) set targets of zero percent for tools codecoverage (cla: yes, tool)
+
+[35775](https://github.com/flutter/flutter/pull/35775) Add platform_interaction_test_swift to devicelab (a: tests, cla: yes, framework, p: framework, plugin, ⌺‬ platform-ios)
+
+[35777](https://github.com/flutter/flutter/pull/35777) Fixed logLevel filter bug so that filter now works as expected (cla: yes, team)
+
+[35778](https://github.com/flutter/flutter/pull/35778) Build all example projects in CI build smoke test (a: tests, cla: yes, team)
+
+[35780](https://github.com/flutter/flutter/pull/35780) Remove CoocaPods support from layers example app (a: tests, cla: yes, d: examples, team)
+
+[35785](https://github.com/flutter/flutter/pull/35785) Remove reverseDuration from implicitly animated widgets, since it's ignored. (a: animation, cla: yes, framework, severe: API break)
+
+[35792](https://github.com/flutter/flutter/pull/35792) disable web tests (cla: yes)
+
+[35810](https://github.com/flutter/flutter/pull/35810) SliverFillRemaining accounts for child size when hasScrollBody is false (cla: yes, f: scrolling, framework, waiting for tree to go green)
+
+[35814](https://github.com/flutter/flutter/pull/35814) Roll engine e695a516f..75387dbc1 (8 commits) (cla: yes, team)
+
+[35825](https://github.com/flutter/flutter/pull/35825) Fixed build of example code to use new binary messenger API. (cla: yes, team)
+
+[35828](https://github.com/flutter/flutter/pull/35828) Cleanup widgets/sliver_persistent_header.dart with resolution of dart-lang/sdk#31543 (cla: yes, framework)
+
+[35829](https://github.com/flutter/flutter/pull/35829) iOS 13 scrollbar (cla: yes, f: cupertino, framework)
+
+[35833](https://github.com/flutter/flutter/pull/35833) Disable CocoaPods input and output paths in Xcode build phase for ephemeral add-to-app project (a: existing-apps, cla: yes, tool, ⌺‬ platform-ios)
+
+[35839](https://github.com/flutter/flutter/pull/35839) use pub run for create test and remove [INFO] logs (cla: yes, tool)
+
+[35846](https://github.com/flutter/flutter/pull/35846) move reload and restart handling into terminal (cla: yes, tool)
+
+[35878](https://github.com/flutter/flutter/pull/35878) Add flag to use root navigator for showModalBottomSheet (cla: yes, f: material design, framework)
+
+[35892](https://github.com/flutter/flutter/pull/35892) Doc fixes (cla: yes, d: api docs, d: examples, framework)
+
+[35906](https://github.com/flutter/flutter/pull/35906) Add anchors to samples (cla: yes, team)
+
+[35913](https://github.com/flutter/flutter/pull/35913) Change focus example to be more canonical (and correct) (cla: yes, framework)
+
+[35919](https://github.com/flutter/flutter/pull/35919) Animation API doc improvments (a: animation, cla: yes, framework, waiting for tree to go green)
+
+[35926](https://github.com/flutter/flutter/pull/35926) Add example showing how to move from one field to the next. (cla: yes, d: api docs, d: examples, framework)
+
+[35932](https://github.com/flutter/flutter/pull/35932) Upgraded framework packages with 'flutter update-packages --force-upgrade'. (cla: yes, framework)
+
+[35941](https://github.com/flutter/flutter/pull/35941) SliverLayoutBuilder (cla: yes, f: scrolling, framework)
+
+[35942](https://github.com/flutter/flutter/pull/35942) Use test instead of test_api package in platform_channel_swift example tests (a: tests, cla: yes, d: examples, team)
+
+[35971](https://github.com/flutter/flutter/pull/35971) [ImgBot] Optimize images (cla: yes, team)
+
+[35979](https://github.com/flutter/flutter/pull/35979) Optimizes gesture recognizer fixes #35658 (cla: yes, f: gestures, framework)
+
+[35991](https://github.com/flutter/flutter/pull/35991) Enable widget load assets in its own package in test (a: tests, cla: yes, tool)
+
+[35996](https://github.com/flutter/flutter/pull/35996) Revert "Keep LLDB connection to iOS device alive while running from CLI." (cla: yes)
+
+[35999](https://github.com/flutter/flutter/pull/35999) Deflake ImageProvider.evict test (a: images, a: tests, cla: yes, team: flakes)
+
+[36006](https://github.com/flutter/flutter/pull/36006) fix linesplitter (cla: yes, team)
+
+[36017](https://github.com/flutter/flutter/pull/36017) Move reporting files to reporting/ (cla: yes, tool)
+
+[36026](https://github.com/flutter/flutter/pull/36026) add the transformPoint and transformRect benchmarks (cla: yes, team)
+
+[36028](https://github.com/flutter/flutter/pull/36028) Fix slider preferred height (cla: yes, f: material design, framework)
+
+[36030](https://github.com/flutter/flutter/pull/36030) [Material] Implement TooltipTheme and Tooltip.textStyle, fix Tooltip debugLabel, update Tooltip defaults (cla: yes, f: material design, framework, severe: API break, severe: new feature)
+
+[36071](https://github.com/flutter/flutter/pull/36071) Revert "Bundle ios dependencies" (cla: yes, team, tool)
+
+[36082](https://github.com/flutter/flutter/pull/36082) Add better handling of JSON-RPC exception (cla: yes, tool)
+
+[36084](https://github.com/flutter/flutter/pull/36084) handle google3 version of pb (cla: yes, tool)
+
+[36087](https://github.com/flutter/flutter/pull/36087) Update visual style of CupertinoSwitch to match iOS 13 (cla: yes, f: cupertino, framework)
+
+[36088](https://github.com/flutter/flutter/pull/36088) Add PopupMenuTheme to enable theming color, shape, elevation, text style of Menu (cla: yes, f: material design, framework)
+
+[36089](https://github.com/flutter/flutter/pull/36089) Fix flaky peer connection (a: tests, cla: yes, framework)
+
+[36090](https://github.com/flutter/flutter/pull/36090) don't require diffs to have a percentage coverage greater (cla: yes, team)
+
+[36093](https://github.com/flutter/flutter/pull/36093) Reland bundle ios deps (cla: yes, team, tool)
+
+[36094](https://github.com/flutter/flutter/pull/36094) Revert "Part 1: Skia Gold Testing" (cla: yes, f: cupertino, f: material design, framework, team)
+
+[36096](https://github.com/flutter/flutter/pull/36096) Revert "Merge branches 'master' and 'master' of github.com:flutter/fl… (cla: yes, tool)
+
+[36097](https://github.com/flutter/flutter/pull/36097) Fix nested scroll view can rebuild without layout (cla: yes, f: scrolling, framework, severe: crash)
+
+[36098](https://github.com/flutter/flutter/pull/36098) Be clearer about errors in customer testing script (cla: yes, team)
+
+[36102](https://github.com/flutter/flutter/pull/36102) Move buildable module test to a module test (cla: yes, team)
+
+[36103](https://github.com/flutter/flutter/pull/36103) Re-land "Part 1: Skia Gold Testing" (a: tests, cla: yes, framework, waiting for tree to go green)
+
+[36105](https://github.com/flutter/flutter/pull/36105) [flutter_tool] Catch a yaml parse failure during project creation (cla: yes, team, tool)
+
+[36106](https://github.com/flutter/flutter/pull/36106) Updated ColorScheme.dark() colors to match the Material Dark theme specification (cla: yes, f: material design, framework, severe: API break)
+
+[36108](https://github.com/flutter/flutter/pull/36108) Move tools tests into a general.shard directory in preparation to changing how we shard tools tests (cla: yes, tool)
+
+[36109](https://github.com/flutter/flutter/pull/36109) Catch exceptions thrown by runChecked* when possible (cla: yes, tool, waiting for tree to go green)
+
+[36122](https://github.com/flutter/flutter/pull/36122) Make sure add-to-app build bundle from outer xcodebuild/gradlew sends analytics (cla: yes, team, tool)
+
+[36123](https://github.com/flutter/flutter/pull/36123) Attempt to re-enable integration_tests-macos (a: tests, cla: yes, team, team: flakes)
+
+[36135](https://github.com/flutter/flutter/pull/36135) add a kIsWeb constant to foundation (cla: yes, framework)
+
+[36138](https://github.com/flutter/flutter/pull/36138) Implement feature flag system for flutter tools (cla: yes, tool)
+
+[36174](https://github.com/flutter/flutter/pull/36174) [cupertino_icons] Add glyph refs for brightness #16102 (cla: yes, f: cupertino, framework)
+
+[36194](https://github.com/flutter/flutter/pull/36194) Keep LLDB connection to iOS device alive while running from CLI.  (cla: yes, tool)
+
+[36197](https://github.com/flutter/flutter/pull/36197) Fix windows, exclude widgets from others (cla: yes, team)
+
+[36199](https://github.com/flutter/flutter/pull/36199) Don't try to flutterExit if isolate is still paused (cla: yes, tool)
+
+[36200](https://github.com/flutter/flutter/pull/36200) Refactoring the Android_views tests app to prepare for adding the iOS platform view tests (a: platform-views, a: tests, cla: yes, team)
+
+[36202](https://github.com/flutter/flutter/pull/36202) Add clarifying docs on MaterialButton.colorBrightness (cla: yes, d: api docs, f: material design, framework)
+
+[36208](https://github.com/flutter/flutter/pull/36208) [flutter_tool] Allow analytics without a terminal attached (cla: yes, tool)
+
+[36213](https://github.com/flutter/flutter/pull/36213) Use DeviceManager instead of device to determine if device supports project. (cla: yes, tool)
+
+[36217](https://github.com/flutter/flutter/pull/36217) Split Mouse from Listener (a: desktop, cla: yes, framework, severe: API break, waiting for tree to go green)
+
+[36218](https://github.com/flutter/flutter/pull/36218) release lock in flutter pub context (cla: yes, tool)
+
+[36237](https://github.com/flutter/flutter/pull/36237) Recommend to use the final version of CDN support for the trunk specs repo. (cla: yes, tool)
+
+[36240](https://github.com/flutter/flutter/pull/36240) Rearrange flutter assemble implementation (cla: yes, tool)
+
+[36243](https://github.com/flutter/flutter/pull/36243) Allow semantics labels to be shorter or longer than raw text (a: accessibility, cla: yes, customer: money (g3), framework, waiting for tree to go green)
+
+[36262](https://github.com/flutter/flutter/pull/36262) Prevents infinite loop in Table._computeColumnWidths (cla: yes, framework)
+
+[36270](https://github.com/flutter/flutter/pull/36270) Change Future.done to Future.whenComplete (a: tests, cla: yes, framework, team, waiting for tree to go green)
+
+[36288](https://github.com/flutter/flutter/pull/36288) Throw exception if instantiating IOSDevice on non-mac os platform (cla: yes, tool)
+
+[36289](https://github.com/flutter/flutter/pull/36289) FakeHttpClientResponse improvements (cla: yes, tool)
+
+[36293](https://github.com/flutter/flutter/pull/36293) Revert "Keep LLDB connection to iOS device alive while running from CLI. " (cla: yes, tool)
+
+[36297](https://github.com/flutter/flutter/pull/36297) Add multi-line flag to semantics (a: accessibility, cla: yes, framework, ☸ platform-web)
+
+[36302](https://github.com/flutter/flutter/pull/36302) Issues/30526 gc (cla: yes, framework)
+
+[36303](https://github.com/flutter/flutter/pull/36303) Add sync star benchmark cases (a: accessibility, cla: yes, team)
+
+[36317](https://github.com/flutter/flutter/pull/36317) Disable flaky tests on Windows (cla: yes, f: material design, framework)
+
+[36318](https://github.com/flutter/flutter/pull/36318) Include flutter_runner in precache artifacts. (cla: yes, tool)
+
+[36319](https://github.com/flutter/flutter/pull/36319) Revert "Fix semantics for floating pinned sliver app bar" (cla: yes, framework)
+
+[36327](https://github.com/flutter/flutter/pull/36327) Fix invocations of ideviceinstaller not passing DYLD_LIBRARY_PATH (cla: yes, tool)
+
+[36331](https://github.com/flutter/flutter/pull/36331) Minor fixes to precache help text (attempt #2) (cla: yes, tool)
+
+[36333](https://github.com/flutter/flutter/pull/36333) fix sliver fixed pinned appbar (cla: yes, framework, waiting for tree to go green)
+
+[36334](https://github.com/flutter/flutter/pull/36334) Added a Driver API that waits until frame sync (a: tests, cla: yes, framework)
+
+[36379](https://github.com/flutter/flutter/pull/36379) Add missing test case for Usage (cla: yes, tool)
+
+[36384](https://github.com/flutter/flutter/pull/36384) rename the test app android_views to platform_views  (cla: yes, team)
+
+[36391](https://github.com/flutter/flutter/pull/36391) Adds doc example for Listview and pageview (cla: yes, d: api docs, framework)
+
+[36392](https://github.com/flutter/flutter/pull/36392) Increase pattern that matches operation duration in log_test (a: tests, cla: yes, tool, waiting for tree to go green)
+
+[36394](https://github.com/flutter/flutter/pull/36394) Add missing protobuf dependency (cla: yes, tool)
+
+[36396](https://github.com/flutter/flutter/pull/36396) Optimize the transformRect and transformPoint methods in matrix_utils. (cla: yes, framework)
+
+[36399](https://github.com/flutter/flutter/pull/36399) Added ThemeMode support to the Flutter Gallery (cla: yes, d: examples, team, team: gallery)
+
+[36402](https://github.com/flutter/flutter/pull/36402) Teach render objects to reuse engine layers (cla: yes, framework, severe: API break, severe: performance, ☸ platform-web)
+
+[36404](https://github.com/flutter/flutter/pull/36404) Make test back button label deterministic (cla: yes, team)
+
+[36409](https://github.com/flutter/flutter/pull/36409) Add searchFieldLabel to SearchDelegate in order to show a custom hint (cla: yes, f: material design, framework)
+
+[36410](https://github.com/flutter/flutter/pull/36410) Add plumbing for hello world startup test in devicelab (cla: yes, team)
+
+[36411](https://github.com/flutter/flutter/pull/36411) Implement InputDecorationTheme copyWith, ==, hashCode (cla: yes, f: material design, framework, severe: new feature)
+
+[36413](https://github.com/flutter/flutter/pull/36413) Revert "Roll engine f3482700474a..1af19ae67dd1 (4 commits)" (cla: yes, engine)
+
+[36418](https://github.com/flutter/flutter/pull/36418) Add testing to screenshot and printDetails method (cla: yes, tool)
+
+[36421](https://github.com/flutter/flutter/pull/36421) doc : ReorderableListView - added youtube video from WidgetOfTheWeek … (cla: yes, f: material design, framework)
+
+[36428](https://github.com/flutter/flutter/pull/36428) Bump engine version (cla: yes, engine, team)
+
+[36431](https://github.com/flutter/flutter/pull/36431) Re-enable `flutter test` expression evaluation tests (a: tests, cla: yes, tool)
+
+[36434](https://github.com/flutter/flutter/pull/36434) Clean up flutter driver device detection. (cla: yes, tool)
+
+[36460](https://github.com/flutter/flutter/pull/36460) Add images and update examples for top widgets: (cla: yes, d: api docs, d: examples, f: material design, framework)
+
+[36465](https://github.com/flutter/flutter/pull/36465) Use FlutterFeatures to configure web and desktop devices (cla: yes, tool)
+
+[36468](https://github.com/flutter/flutter/pull/36468) Fix test_widgets-windows not running tests (a: tests, cla: yes, framework, team, waiting for tree to go green)
+
+[36471](https://github.com/flutter/flutter/pull/36471) Enable bitcode compilation for AOT (cla: yes)
+
+[36481](https://github.com/flutter/flutter/pull/36481) Remove untested code (cla: yes, tool)
+
+[36482](https://github.com/flutter/flutter/pull/36482) Sped up shader warmup by only drawing on a 100x100 surface (cla: yes, framework)
+
+[36485](https://github.com/flutter/flutter/pull/36485) Add text border docs (a: typography, cla: yes, d: api docs, framework)
+
+[36490](https://github.com/flutter/flutter/pull/36490) [flutter_tool] Send analytics command before the command runs (cla: yes, tool)
+
+[36492](https://github.com/flutter/flutter/pull/36492) Add GitHub CODEOWNERS file to auto-add reviewers by path (cla: yes, team)
+
+[36493](https://github.com/flutter/flutter/pull/36493) Fixes sliver list does not layout firstchild when child reordered (cla: yes, framework)
+
+[36498](https://github.com/flutter/flutter/pull/36498) Clean up host_app_ephemeral_cocoapods Profile build settings (a: existing-apps, cla: yes, t: xcode, tool, ⌺‬ platform-ios)
+
+[36503](https://github.com/flutter/flutter/pull/36503) Disabling Firebase Test Lab smoke test to unblock autoroller (cla: yes)
+
+[36507](https://github.com/flutter/flutter/pull/36507) Bump engine version (cla: yes, engine, team, tool)
+
+[36510](https://github.com/flutter/flutter/pull/36510) flutter update-packages --force-upgrade (cla: yes, team)
+
+[36512](https://github.com/flutter/flutter/pull/36512) Renamed the Driver API waitUntilFrameSync to waitUntilNoPendingFrame (a: tests, cla: yes, framework)
+
+[36513](https://github.com/flutter/flutter/pull/36513) Fix `flutter pub -v` (cla: yes, tool)
+
+[36545](https://github.com/flutter/flutter/pull/36545) [flutter_tool] Send the local time to analytics with screens and events (cla: yes, tool, work in progress; do not review)
+
+[36546](https://github.com/flutter/flutter/pull/36546) Unskip date_picker_test on Windows as underlying issue 19696 was fixed. (cla: yes, f: material design, framework)
+
+[36548](https://github.com/flutter/flutter/pull/36548) Fix the web builds by reverting version bump of build_modules (cla: yes, tool)
+
+[36549](https://github.com/flutter/flutter/pull/36549) fix number encoding in message codecs for the Web (cla: yes, framework)
+
+[36553](https://github.com/flutter/flutter/pull/36553) Load assets during test from file system instead of manifest. (a: tests, cla: yes, framework)
+
+[36556](https://github.com/flutter/flutter/pull/36556) Fix usage test to use local usage (cla: yes, tool)
+
+[36560](https://github.com/flutter/flutter/pull/36560) [flutter_tools] Add some useful commands to the README.md (cla: yes, tool)
+
+[36564](https://github.com/flutter/flutter/pull/36564) Make sure fx flutter attach can find devices (cla: yes, tool)
+
+[36569](https://github.com/flutter/flutter/pull/36569) Some minor cleanup for flutter_tools (cla: yes, tool)
+
+[36570](https://github.com/flutter/flutter/pull/36570) Some minor fixes to the tool_coverage tool (cla: yes, tool)
+
+[36571](https://github.com/flutter/flutter/pull/36571) Some minor cleanup in devicelab (cla: yes, team)
+
+[36579](https://github.com/flutter/flutter/pull/36579) Add gradient text docs (a: typography, cla: yes, framework)
+
+[36585](https://github.com/flutter/flutter/pull/36585) Place build outputs under dart tool (cla: yes, tool)
+
+[36589](https://github.com/flutter/flutter/pull/36589) Update Localizations: added 24 new locales (reprise) (a: internationalization, cla: yes, f: cupertino, f: material design)
+
+[36595](https://github.com/flutter/flutter/pull/36595) More resident runner tests (cla: yes, tool)
+
+[36598](https://github.com/flutter/flutter/pull/36598) Expose functionality to compile dart to kernel for the VM (cla: yes, tool)
+
+[36618](https://github.com/flutter/flutter/pull/36618) Revert "AsyncSnapshot.data to throw if error or no data" (cla: yes, framework)
+
+[36654](https://github.com/flutter/flutter/pull/36654) Revert "Use FlutterFeatures to configure web and desktop devices" (cla: yes, team, tool)
+
+[36679](https://github.com/flutter/flutter/pull/36679) add line-length to `flutter format` command line (cla: yes, tool)
+
+[36690](https://github.com/flutter/flutter/pull/36690) Updating cirrus fingerprint script to include goldens version (a: tests, cla: yes, framework, waiting for tree to go green)
+
+[36695](https://github.com/flutter/flutter/pull/36695) Android visible password input type support (cla: yes, framework)
+
+[36698](https://github.com/flutter/flutter/pull/36698) fixes iphone force press keyboard select crashes (cla: yes, framework)
+
+[36699](https://github.com/flutter/flutter/pull/36699) Reland: use flutter features for web and desktop (cla: yes, team, tool)
+
+[36717](https://github.com/flutter/flutter/pull/36717) Fix devicelab tests that did not enable web config. (cla: yes, team)
+
+[36722](https://github.com/flutter/flutter/pull/36722) Skip flaky test windows (cla: yes, tool)
+
+[36727](https://github.com/flutter/flutter/pull/36727) Add missing config to create (cla: yes, team, tool)
+
+[36731](https://github.com/flutter/flutter/pull/36731) Revert "Add flutter build aar" (cla: yes, team, tool)
+
+[36732](https://github.com/flutter/flutter/pull/36732) Flutter build aar (a: build, cla: yes, team, tool, waiting for tree to go green)
+
+[36768](https://github.com/flutter/flutter/pull/36768) add an error count field to the Flutter.Error event (cla: yes, framework)
+
+[36773](https://github.com/flutter/flutter/pull/36773) Expose build-dir config option (cla: yes, tool)
+
+[36774](https://github.com/flutter/flutter/pull/36774) Parameterize CoverageCollector with a library name predicate (cla: yes, tool)
+
+[36784](https://github.com/flutter/flutter/pull/36784) [flutter_tool] Improve Windows flutter clean error message (cla: yes, tool)
+
+[36785](https://github.com/flutter/flutter/pull/36785) [flutter_tool] Clean up usage events and custom dimensions (cla: yes, tool)
+
+[36787](https://github.com/flutter/flutter/pull/36787) Check for directory instead of path separator (cla: yes, tool)
+
+[36793](https://github.com/flutter/flutter/pull/36793) Vend Flutter module App.framework as a local CocoaPod pod to be installed by a host app (a: existing-apps, cla: yes, t: xcode, team, tool, ⌺‬ platform-ios)
+
+[36805](https://github.com/flutter/flutter/pull/36805) Allow flavors and custom build types in host app (a: build, a: existing-apps, cla: yes, t: gradle, team, tool, waiting for tree to go green)
+
+[36832](https://github.com/flutter/flutter/pull/36832) Remove flaky check for analyzer message. (cla: yes, tool)
+
+[36845](https://github.com/flutter/flutter/pull/36845) Improve Windows build failure message (cla: yes, tool, waiting for tree to go green)
+
+[36851](https://github.com/flutter/flutter/pull/36851) Revert "[Material] Implement TooltipTheme and Tooltip.textStyle, fix Tooltip debugLabel, update Tooltip defaults" (cla: yes, f: material design, framework)
+
+[36856](https://github.com/flutter/flutter/pull/36856) [Material] Implement TooltipTheme and Tooltip.textStyle, update Tooltip defaults (cla: yes, f: material design, framework, severe: API break, severe: new feature)
+
+[36857](https://github.com/flutter/flutter/pull/36857) Ensure user-thrown errors have ErrorSummary nodes (cla: yes, framework)
+
+[36860](https://github.com/flutter/flutter/pull/36860) Remove Chain terse parsing (cla: yes, tool)
+
+[36866](https://github.com/flutter/flutter/pull/36866) Tests for `flutter test [some_directory]` (cla: yes, team, tool)
+
+[36867](https://github.com/flutter/flutter/pull/36867) Add reference to StrutStyle from TextStyle (cla: yes, framework)
+
+[36874](https://github.com/flutter/flutter/pull/36874) Adjust phrasing of features (cla: yes, tool)
+
+[36877](https://github.com/flutter/flutter/pull/36877) Revert "Dismiss modal with any button press" (cla: yes, framework)
+
+[36880](https://github.com/flutter/flutter/pull/36880) [Material] Create material Banner component (cla: yes, f: material design, framework)
+
+[36884](https://github.com/flutter/flutter/pull/36884) Unbreak build_runner (cla: yes, team, tool)
+
+[36885](https://github.com/flutter/flutter/pull/36885) Manual roll of flutter/engine@ef99738...72341ed (cla: yes, engine, tool)
+
+[36886](https://github.com/flutter/flutter/pull/36886) Add annotation dependency to plugins (cla: yes, team, tool, waiting for tree to go green)
+
+[36887](https://github.com/flutter/flutter/pull/36887) Fix thumb size calculation (cla: yes, f: cupertino, framework)
+
+[36893](https://github.com/flutter/flutter/pull/36893) Fix minor typos (cla: yes, framework)
+
+[36895](https://github.com/flutter/flutter/pull/36895) Mark splash test flaky until proved stable. (cla: yes, team)
+
+[36901](https://github.com/flutter/flutter/pull/36901) Run Gradle tests on Windows (a: build, cla: yes, team, tool)
+
+[36949](https://github.com/flutter/flutter/pull/36949) Remove stdout related to settings_aar.gradle (a: tests, cla: yes, t: flutter driver, team)
+
+[36955](https://github.com/flutter/flutter/pull/36955) Extract common PlatformView functionality: Painting and Semantics (a: platform-views, cla: yes, framework)
+
+[36956](https://github.com/flutter/flutter/pull/36956) Redo: Modal dismissed by any button (cla: yes, framework, waiting for tree to go green)
+
+[36963](https://github.com/flutter/flutter/pull/36963) Add margins to tooltips (cla: yes, f: material design, framework, severe: new feature)
+
+[36964](https://github.com/flutter/flutter/pull/36964) Interactive size const (cla: yes, f: cupertino, f: material design, framework, severe: API break)
+
+[36966](https://github.com/flutter/flutter/pull/36966) Roll back the AAR build experiment (cla: yes, tool)
+
+[36969](https://github.com/flutter/flutter/pull/36969) devicelab: replace the FLUTTER_ENGINE environment variable with the new local engine flags (cla: yes, team)
+
+[36970](https://github.com/flutter/flutter/pull/36970) Clarify showDuration and waitDuration API docs and test behavior (cla: yes, d: api docs, f: material design, framework)
+
+[36974](https://github.com/flutter/flutter/pull/36974) Multiline Selection Menu Position Bug (a: text input, cla: yes, f: material design, framework)
+
+[36987](https://github.com/flutter/flutter/pull/36987) Flutter assemble for macos take 2! (cla: yes, tool, ⌘‬ platform-mac)
+
+[36997](https://github.com/flutter/flutter/pull/36997) Added missing png's to demo splash screen project (was caused by global gitignore). (cla: yes, team)
+
+[37026](https://github.com/flutter/flutter/pull/37026) Add support for the Kannada (kn) locale (a: internationalization, cla: yes, f: cupertino, f: material design, team)
+
+[37027](https://github.com/flutter/flutter/pull/37027) Revert "Fix the first frame logic in tracing and driver" (a: tests, cla: yes, d: examples, framework, team, team: gallery, tool)
+
+[37030](https://github.com/flutter/flutter/pull/37030) Mark backdrop_filter_perf test nonflaky (cla: yes, team)
+
+[37033](https://github.com/flutter/flutter/pull/37033) fix debug paint crash when axis direction inverted (cla: yes, framework, severe: crash)
+
+[37036](https://github.com/flutter/flutter/pull/37036) Build number (part after +) is documented as optional, use entire app version if not present (cla: yes, tool)
+
+[37037](https://github.com/flutter/flutter/pull/37037) [flutter_tool] Update Fuchsia SDK (cla: yes, tool)
+
+[37038](https://github.com/flutter/flutter/pull/37038) Update SnackBar to the latest Material specs. (cla: yes, f: material design, framework)
+
+[37042](https://github.com/flutter/flutter/pull/37042) Fix selection menu not showing after clear (a: text input, cla: yes, framework)
+
+[37043](https://github.com/flutter/flutter/pull/37043) Tests for Engine ensuring debug-mode apps are attached on iOS. (cla: yes, team, tool)
+
+[37044](https://github.com/flutter/flutter/pull/37044) [flutter_tool] Make a couple file operations synchronous (cla: yes, tool)
+
+[37048](https://github.com/flutter/flutter/pull/37048) use SizedBox instead of Container for building collapsed selection (a: text input, cla: yes, f: cupertino, framework)
+
+[37049](https://github.com/flutter/flutter/pull/37049) Revert Optimize transformRect (cla: yes, framework, waiting for tree to go green)
+
+[37055](https://github.com/flutter/flutter/pull/37055) Revert "Enable selection by default for password text field and expos… (cla: yes, f: cupertino, f: material design, framework)
+
+[37158](https://github.com/flutter/flutter/pull/37158) Fix Textfields in Semantics Debugger (a: accessibility, cla: yes, framework, waiting for tree to go green)
+
+[37183](https://github.com/flutter/flutter/pull/37183) reland Enable selection by default for password text field and expose… (a: text input, cla: yes, customer: fun (g3), f: cupertino, f: material design)
+
+[37186](https://github.com/flutter/flutter/pull/37186) [flutter_tool] Usage refactor cleanup (cla: yes, tool)
+
+[37187](https://github.com/flutter/flutter/pull/37187) use FlutterError in MultiChildRenderObjectWidget (cla: yes, framework)
+
+[37192](https://github.com/flutter/flutter/pull/37192) Reland "Fix the first frame logic in tracing and driver (#35297)" (cla: yes, engine, framework)
+
+[37194](https://github.com/flutter/flutter/pull/37194) [flutter_tool] More gracefully handle Android sdkmanager failure (cla: yes, tool)
+
+[37196](https://github.com/flutter/flutter/pull/37196) [flutter_tool] Catch ProcessException from 'adb devices' (cla: yes, tool)
+
+[37198](https://github.com/flutter/flutter/pull/37198) [flutter_tool] Re-try sending the first crash report (cla: yes, tool)
+
+[37205](https://github.com/flutter/flutter/pull/37205) add cmx for complex_layout (cla: yes, team)
+
+[37206](https://github.com/flutter/flutter/pull/37206) Test that modules built as AAR contain the right assets and artifacts (a: build, cla: yes, team, waiting for tree to go green, ▣ platform-android)
+
+[37207](https://github.com/flutter/flutter/pull/37207) Update complex_layout.cmx (cla: yes, team)
+
+[37208](https://github.com/flutter/flutter/pull/37208) Roll flutter/engine@09f8bffb9...67319c00b (cla: yes)
+
+[37210](https://github.com/flutter/flutter/pull/37210) do not strip symbols when building profile (cla: yes, team, tool)
+
+[37211](https://github.com/flutter/flutter/pull/37211) Don't enable scroll wheel when scrolling is off (a: desktop, cla: yes, customer: octopod, framework)
+
+[37217](https://github.com/flutter/flutter/pull/37217) hide symbols from spotlight for App.framework (cla: yes, tool, waiting for tree to go green)
+
+[37250](https://github.com/flutter/flutter/pull/37250) Removing Leftover Golden Test Skips (a: tests, cla: yes, framework)
+
+[37254](https://github.com/flutter/flutter/pull/37254) Clamp Scaffold's max body height when extendBody is true (cla: yes, f: material design, framework, severe: crash)
+
+[37259](https://github.com/flutter/flutter/pull/37259) [Material] Add support for hovered, pressed, focused, and selected text color on Chips. (cla: yes, f: material design, framework)
+
+[37266](https://github.com/flutter/flutter/pull/37266) Change the value of kMaxUnsignedSMI for the Web (cla: yes, framework, severe: new feature, waiting for tree to go green, ☸ platform-web)
+
+[37269](https://github.com/flutter/flutter/pull/37269) [Material] FAB refactor - remove unnecessary IconTheme  (cla: yes, f: material design, framework)
+
+[37275](https://github.com/flutter/flutter/pull/37275) Optimize the transformRect and transformPoint methods in matrix_utils… (cla: yes, framework)
+
+[37276](https://github.com/flutter/flutter/pull/37276) Make podhelper.rb a template to avoid passing in the module name (a: existing-apps, cla: yes, t: xcode, team, tool, ⌺‬ platform-ios)
+
+[37295](https://github.com/flutter/flutter/pull/37295) Revert "reland Enable selection by default for password text field and expose…" (a: accessibility, cla: yes, f: cupertino, f: material design, framework, team)
+
+[37314](https://github.com/flutter/flutter/pull/37314) Update dartdoc to 28.4 (cla: yes, team)
+
+[37319](https://github.com/flutter/flutter/pull/37319) resizeToAvoidBottomInset Cupertino without NavBar (cla: yes, f: cupertino, framework)
+
+[37322](https://github.com/flutter/flutter/pull/37322) Add comments to an Android Platform view gesture test case (a: platform-views, cla: yes, framework, severe: crash, waiting for tree to go green)
+
+[37324](https://github.com/flutter/flutter/pull/37324) reland Enable selection by default for password text field and expose… (a: accessibility, cla: yes, f: cupertino, f: material design, framework, team)
+
+[37328](https://github.com/flutter/flutter/pull/37328) Fix some tests now that the isMultiline flag is added to values (a: accessibility, cla: yes, framework, waiting for tree to go green, ☸ platform-web)
+
+[37331](https://github.com/flutter/flutter/pull/37331) [flutter_tool] Add missing toString() (cla: yes, tool)
+
+[37338](https://github.com/flutter/flutter/pull/37338) Update constructor APIs TooltipTheme, ToggleButtonsTheme, PopupMenuTheme (cla: yes, f: material design, framework, severe: API break)
+
+[37341](https://github.com/flutter/flutter/pull/37341) hiding original hero after hero transition (a: animation, cla: yes, framework, severe: API break, severe: new feature)
+
+[37342](https://github.com/flutter/flutter/pull/37342) Fix mouse region crash when using closures (a: desktop, cla: yes, framework, waiting for tree to go green)
+
+[37344](https://github.com/flutter/flutter/pull/37344) Fix mouse region double render (a: desktop, cla: yes, framework, waiting for tree to go green)
+
+[37345](https://github.com/flutter/flutter/pull/37345) [flutter_tool] Include the local timezone in analytics timestamp (cla: yes, tool)
+
+[37351](https://github.com/flutter/flutter/pull/37351) fix errors caught by roll of macOS assemble (cla: yes, tool)
+
+[37355](https://github.com/flutter/flutter/pull/37355) Added ThemeData.from() method to construct a Theme from a ColorScheme (cla: yes, f: material design, framework)
+
+[37365](https://github.com/flutter/flutter/pull/37365) only build macOS kernel in debug mode (cla: yes, tool)
+
+[37378](https://github.com/flutter/flutter/pull/37378) Disable xcode indexing in CI via COMPILER_INDEX_STORE_ENABLE=NO argument (cla: yes, tool, waiting for customer response)
+
+[37403](https://github.com/flutter/flutter/pull/37403) add ontap to textformfield (cla: yes, f: material design, framework)
+
+[37405](https://github.com/flutter/flutter/pull/37405) Add .android/Flutter/flutter.iml to module template. (cla: yes, tool)
+
+[37407](https://github.com/flutter/flutter/pull/37407) Remove multi-arch check in iOS builds (cla: yes, tool)
+
+[37413](https://github.com/flutter/flutter/pull/37413) Revert "Remove multi-arch check in iOS builds" (cla: yes, engine, tool)
+
+[37417](https://github.com/flutter/flutter/pull/37417) Nosuchmethod window (a: tests, cla: yes, framework)
+
+[37422](https://github.com/flutter/flutter/pull/37422) [flutter_tool] Additional flutter manifest yaml validation (cla: yes, tool)
+
+[37425](https://github.com/flutter/flutter/pull/37425) Support for macOS release mode (1 of 3) (cla: yes, tool)
+
+[37436](https://github.com/flutter/flutter/pull/37436) Hide text selection handle after entering text (cla: yes, f: material design, framework)
+
+[37440](https://github.com/flutter/flutter/pull/37440) Print message when HttpException is thrown after running `flutter run` (cla: yes, tool, waiting for tree to go green)
+
+[37442](https://github.com/flutter/flutter/pull/37442) Disable flaky test (a: tests, cla: yes, team)
+
+[37445](https://github.com/flutter/flutter/pull/37445) Switch iOS gen_snapshot from multi-arch binary to multiple binaries (cla: yes, engine, tool)
+
+[37449](https://github.com/flutter/flutter/pull/37449) If xcode_backend.sh script fails or substitute variables are missing, fail the host Xcode build (a: existing-apps, cla: yes, t: xcode, team, tool)
+
+[37457](https://github.com/flutter/flutter/pull/37457) Find the app bundle when the flavor contains underscores (a: build, cla: yes, team, tool, waiting for tree to go green)
+
+[37479](https://github.com/flutter/flutter/pull/37479) Remove bogus code in ContainerParentDataMixin.detach (cla: yes, framework, waiting for tree to go green)
+
+[37489](https://github.com/flutter/flutter/pull/37489) Moved the default BinaryMessenger instance to ServicesBinding (a: tests, cla: yes, customer: espresso, d: examples, framework, severe: API break, t: flutter driver, team)
+
+[37492](https://github.com/flutter/flutter/pull/37492) Drawer edge drag width improvements (cla: yes, f: material design, framework, severe: new feature)
+
+[37497](https://github.com/flutter/flutter/pull/37497) Extract common PlatformView functionality: Gesture and PointerEvent (cla: yes, framework)
+
+[37500](https://github.com/flutter/flutter/pull/37500) Avoid killing Flutter tool process (#37471) (cla: yes, tool)
+
+[37503](https://github.com/flutter/flutter/pull/37503) Quickly fix start up tests (cla: yes, framework)
+
+[37509](https://github.com/flutter/flutter/pull/37509) Use macOS ephemeral directory for Pod env script (cla: yes, tool)
+
+[37512](https://github.com/flutter/flutter/pull/37512) Enable track widget creation on debug builds (cla: yes, tool)
+
+[37514](https://github.com/flutter/flutter/pull/37514) [flutter_tool] Remove unintended analytics screen send (cla: yes, tool)
+
+[37515](https://github.com/flutter/flutter/pull/37515) Upstream web support for IterableProperty<double> (cla: yes, framework, ☸ platform-web)
+
+[37516](https://github.com/flutter/flutter/pull/37516) Kill stale TODO (a: tests, cla: yes, framework, team)
+
+[37521](https://github.com/flutter/flutter/pull/37521) have xcodeSelectPath also catch ArgumentError (cla: yes, tool)
+
+[37524](https://github.com/flutter/flutter/pull/37524) Ensure that tests remove pointers by using addTearDown (a: tests, cla: yes, framework, waiting for tree to go green)
+
+[37556](https://github.com/flutter/flutter/pull/37556) [Material] Make RawChip.selected non-nullable.  (cla: yes, f: material design, framework)
+
+[37595](https://github.com/flutter/flutter/pull/37595) Closes #37593 Add flutter_export_environment.sh to gitignore (cla: yes, tool, waiting for tree to go green)
+
+[37624](https://github.com/flutter/flutter/pull/37624) Diagrams for API docs rank 10-20 in most views (cla: yes, d: api docs, d: examples, f: material design, framework, from: study, waiting for tree to go green)
+
+[37631](https://github.com/flutter/flutter/pull/37631) [Material] Create demo for material banner (cla: yes, d: examples, f: material design, team, team: gallery)
+
+[37634](https://github.com/flutter/flutter/pull/37634) [web][upstream] Update diagnostics to support web platform tests (cla: yes, f: material design, framework)
+
+[37636](https://github.com/flutter/flutter/pull/37636) Add CheckboxListTile checkColor (cla: yes, f: material design, framework)
+
+[37637](https://github.com/flutter/flutter/pull/37637) don't call Platform.operatingSystem in RenderView diagnostics (cla: yes, framework, ☸ platform-web)
+
+[37638](https://github.com/flutter/flutter/pull/37638) [web][upstream] Fix debugPrintStack for web platform (cla: yes, framework, ☸ platform-web)
+
+[37647](https://github.com/flutter/flutter/pull/37647) Change priority of gen_snapshot search paths (cla: yes, tool)
+
+[37649](https://github.com/flutter/flutter/pull/37649) Revert "Integrate dwds into flutter tool for web support" (a: accessibility, cla: yes, d: examples, team, team: gallery)
+
+[37650](https://github.com/flutter/flutter/pull/37650) Reland Integrate dwds into flutter tool for web support (a: accessibility, cla: yes, d: examples, team, team: gallery)
+
+[37652](https://github.com/flutter/flutter/pull/37652) Change RenderObject.getTransformTo to include ancestor. (cla: yes, framework, severe: API break)
+
+[37654](https://github.com/flutter/flutter/pull/37654) Add missing library to flutter tools BUILD.gn (cla: yes, tool)
+
+[37658](https://github.com/flutter/flutter/pull/37658) fix windows path for dwds/web builds (cla: yes, tool)
+
+[37661](https://github.com/flutter/flutter/pull/37661) flutter update-packages --force-upgrade  (a: accessibility, a: tests, cla: yes, d: examples, framework, team, team: gallery, tool)
+
+[37664](https://github.com/flutter/flutter/pull/37664) Partial macOS assemble revert (cla: yes, tool)
+
+[37703](https://github.com/flutter/flutter/pull/37703) PlatformViewLink, handling creation of the PlatformViewSurface and dispose PlatformViewController (a: platform-views, cla: yes, framework)
+
+[37712](https://github.com/flutter/flutter/pull/37712) [web][upstream] Optimize InactiveElements deactivation (cla: yes, framework, ☸ platform-web)
+
+[37714](https://github.com/flutter/flutter/pull/37714) remove unused script (cla: yes, team)
+
+[37715](https://github.com/flutter/flutter/pull/37715) Fix markdown link format (cla: yes, f: material design, framework)
+
+[37718](https://github.com/flutter/flutter/pull/37718) Adding physicalDepth to MediaQueryData & TestWindow (cla: yes, customer: fuchsia, framework, severe: customer critical, waiting for tree to go green)
+
+[37724](https://github.com/flutter/flutter/pull/37724) iOS 13 scrollbar vibration (cla: yes, f: cupertino, framework)
+
+[37730](https://github.com/flutter/flutter/pull/37730) Revert "remove unused script" (cla: yes, team)
+
+[37731](https://github.com/flutter/flutter/pull/37731) Add metadata to indicate if the host app contains a Flutter module (cla: yes, team, tool)
+
+[37733](https://github.com/flutter/flutter/pull/37733) Support macOS Catalina-style signing certificate names (cla: yes, tool)
+
+[37735](https://github.com/flutter/flutter/pull/37735) Remove unused no-build flag from the flutter run command (cla: yes, tool)
+
+[37738](https://github.com/flutter/flutter/pull/37738) Use relative paths when installing module pods (a: existing-apps, cla: yes, tool, ⌺‬ platform-ios)
+
+[37740](https://github.com/flutter/flutter/pull/37740) Disable gem documentation generation on Cirrus (cla: yes, team)
+
+[37743](https://github.com/flutter/flutter/pull/37743) Handle thrown maps and rejects from fe server (cla: yes, tool)
+
+[37752](https://github.com/flutter/flutter/pull/37752) Remove dead flag `gradle-dir` in flutter config (cla: yes, tool)
+
+[37760](https://github.com/flutter/flutter/pull/37760) Don't mark system_debug_ios as flaky. (cla: yes, team)
+
+[37790](https://github.com/flutter/flutter/pull/37790) Doc: Image.memory only accepts compressed format (cla: yes, framework, waiting for tree to go green)
+
+[37792](https://github.com/flutter/flutter/pull/37792) Disable the progress bar when downloading the Dart SDK via Invoke-WebRequest (cla: yes, tool)
+
+[37793](https://github.com/flutter/flutter/pull/37793) Add equals and hashCode to Tween (a: animation, cla: yes, framework, waiting for tree to go green)
+
+[37801](https://github.com/flutter/flutter/pull/37801) Fix TextField cursor color documentation (cla: yes, f: material design, framework)
+
+[37806](https://github.com/flutter/flutter/pull/37806) Add COMPILER_INDEX_STORE_ENABLE=NO to macOS build and tests (a: tests, cla: yes, t: xcode, team, tool)
+
+[37809](https://github.com/flutter/flutter/pull/37809) Add autofocus parameter to widgets which use Focus widget internally (cla: yes, f: cupertino, f: material design, framework)
+
+[37811](https://github.com/flutter/flutter/pull/37811) Add flutter_export_environment.sh to the framework tree gitignore (cla: yes, team)
+
+[37812](https://github.com/flutter/flutter/pull/37812) [web][upstream] Don't register exit/saveCompilationTrace for web platform since they are not available (cla: yes, framework, ☸ platform-web)
+
+[37815](https://github.com/flutter/flutter/pull/37815) Restructure resident web runner usage to avoid SDK users that don't support dwds (cla: yes, tool)
+
+[37816](https://github.com/flutter/flutter/pull/37816) update dependencies; add a Web smoke test (a: accessibility, a: tests, cla: yes, d: examples, framework, team, team: gallery)
+
+[37825](https://github.com/flutter/flutter/pull/37825) Automatic focus highlight mode for FocusManager (CQ+1, cla: yes, f: material design, framework)
+
+[37828](https://github.com/flutter/flutter/pull/37828) have android_semantics_testing use adb from ENV provided android sdk (a: accessibility, cla: yes, team)
+
+[37856](https://github.com/flutter/flutter/pull/37856) Remove references to solo flag in flutter test (a: tests, cla: yes, d: api docs, framework)
+
+[37863](https://github.com/flutter/flutter/pull/37863) Expose the timeline event names so they can be used in other systems that do tracing (cla: yes, tool)
+
+[37870](https://github.com/flutter/flutter/pull/37870) remove Header flag from BottomNavigationBar items (cla: yes, f: material design, framework, waiting for tree to go green)
+
+[37871](https://github.com/flutter/flutter/pull/37871) Catch failure to create directory in cache (cla: yes, tool)
+
+[37872](https://github.com/flutter/flutter/pull/37872) Unmark devicelab tests as flaky that are no longer flaky (cla: yes, team)
+
+[37877](https://github.com/flutter/flutter/pull/37877) Adds DefaultTextStyle ancestor to Tooltip Overlay (cla: yes, f: material design, framework)
+
+[37880](https://github.com/flutter/flutter/pull/37880) reduce mac workload (cla: yes)
+
+[37881](https://github.com/flutter/flutter/pull/37881) Remove no-longer-needed scripts (cla: yes, team, waiting for tree to go green)
+
+[37882](https://github.com/flutter/flutter/pull/37882) Add dense property to AboutListTile (cla: yes, f: material design, framework)
+
+[37891](https://github.com/flutter/flutter/pull/37891) Focus debug (a: desktop, cla: yes, framework)
+
+[37895](https://github.com/flutter/flutter/pull/37895) Revert "Add equals and hashCode to Tween" (cla: yes, framework)
+
+[37900](https://github.com/flutter/flutter/pull/37900) Listen to ExtensionEvent instead of TimelineEvent (cla: yes, framework, tool)
+
+[37904](https://github.com/flutter/flutter/pull/37904) test tool scheduling (cla: yes, team)
+
+[37906](https://github.com/flutter/flutter/pull/37906) Always install the ephemeral engine copy instead of fetching from CocoaPods specs (a: existing-apps, cla: yes, team, tool, ⌺‬ platform-ios)
+
+[37938](https://github.com/flutter/flutter/pull/37938) Revert "Adding physicalDepth to MediaQueryData & TestWindow" (a: tests, cla: yes, framework, waiting for tree to go green)
+
+[37940](https://github.com/flutter/flutter/pull/37940) skip docs shard for changes that don't include packages with docs (cla: yes, team, tool)
+
+[37941](https://github.com/flutter/flutter/pull/37941) Skip widget tests on non framework change (cla: yes, team)
+
+[37955](https://github.com/flutter/flutter/pull/37955) Update shader warm-up for recent Skia changes (cla: yes, framework, severe: performance, severe: regression)
+
+[37958](https://github.com/flutter/flutter/pull/37958) Catch FormatException caused by bad simctl output (cla: yes, tool)
+
+[37964](https://github.com/flutter/flutter/pull/37964) Update documentation for bottom sheets to accurately reflect usage (cla: yes, f: material design, framework)
+
+[37966](https://github.com/flutter/flutter/pull/37966) Remove ephemeral directories during flutter clean (a: existing-apps, cla: yes, tool)
+
+[37971](https://github.com/flutter/flutter/pull/37971) Update dependencies (a: accessibility, cla: yes, d: examples, team, team: gallery)
+
+[37981](https://github.com/flutter/flutter/pull/37981) Give `_runFlutterTest` the ability to validate command output (cla: yes, team)
+
+[37983](https://github.com/flutter/flutter/pull/37983) Revert "Moved the default BinaryMessenger instance to ServicesBinding… (a: accessibility, a: tests, cla: yes, f: cupertino, f: material design, framework, team)
+
+[37984](https://github.com/flutter/flutter/pull/37984) Fix some typos in flutter/dev/bots/README.md (cla: yes, team)
+
+[37994](https://github.com/flutter/flutter/pull/37994) Remove no-constant-update-2018, the underlying issue has been resolved. (cla: yes, tool)
+
+[38101](https://github.com/flutter/flutter/pull/38101) Catch filesystem exception from flutter create (cla: yes, tool)
+
+[38102](https://github.com/flutter/flutter/pull/38102) Fix type error hidden by implicit downcasts (cla: yes, tool)
+
+[38296](https://github.com/flutter/flutter/pull/38296) use common emulator/device list (cla: yes, t: flutter driver, tool, waiting for tree to go green)
+
+[38325](https://github.com/flutter/flutter/pull/38325) refactor `flutter upgrade` to be 2 part, with the second part re-entrant (cla: yes, tool)
+
+[38326](https://github.com/flutter/flutter/pull/38326) Re-enabling post-submit gold tests on mac (a: tests, cla: yes, framework)
+
+[38339](https://github.com/flutter/flutter/pull/38339) [flutter_tool] Flip create language defaults to swift and kotlin (cla: yes, tool)
+
+[38342](https://github.com/flutter/flutter/pull/38342) remove bsdiff from  BUILD.gn (cla: yes, tool)
+
+[38348](https://github.com/flutter/flutter/pull/38348) Analyzer fix that wasn't caught in the PR originally (cla: yes, d: examples, f: material design, team, team: gallery)
+
+[38353](https://github.com/flutter/flutter/pull/38353) [flutter_tool] Observatory connection error handling cleanup (cla: yes, tool)
+
+[38441](https://github.com/flutter/flutter/pull/38441) Fix getOffsetToReveal for growthDirection reversed and AxisDirection down or right (cla: yes, framework)
+
+[38462](https://github.com/flutter/flutter/pull/38462) Revert "Roll engine ff49ca1c6e5b..7dfdfc6faeb6 (52 commits)" (cla: yes, engine)
+
+[38463](https://github.com/flutter/flutter/pull/38463) Do not construct arguments to _focusDebug when running in non-debug modes (cla: yes, framework)
+
+[38467](https://github.com/flutter/flutter/pull/38467) [Material] Add splashColor to FAB and FAB ThemeData (cla: yes, f: material design, framework)
+
+[38472](https://github.com/flutter/flutter/pull/38472) [flutter_tool] Fix bug in manifest yaml validation (cla: yes, tool)
+
+[38486](https://github.com/flutter/flutter/pull/38486) Catch errors thrown into the Zone by json_rpc (cla: yes, tool)
+
+[38491](https://github.com/flutter/flutter/pull/38491) Update CONTRIBUTING.md (cla: yes, team)
+
+[38494](https://github.com/flutter/flutter/pull/38494) Navigator change backup (a: tests, cla: yes, framework, ☸ platform-web)
+
+[38495](https://github.com/flutter/flutter/pull/38495) Roll engine ff49ca1c6e5b..be4c8338a6ab (61 commits) (cla: yes, engine)
+
+[38497](https://github.com/flutter/flutter/pull/38497) handle unexpected exit from frontend server (cla: yes, tool)
+
+[38499](https://github.com/flutter/flutter/pull/38499) Update build web compilers and configure libraries (cla: yes, tool)
+
+[38546](https://github.com/flutter/flutter/pull/38546) Re-land 'Adding physicalDepth to MediaQueryData & TestWindow' (a: tests, cla: yes, customer: fuchsia, framework, severe: customer critical)
+
+[38558](https://github.com/flutter/flutter/pull/38558) Fix typos (and a few errors) in the API docs. (cla: yes, framework)
+
+[38564](https://github.com/flutter/flutter/pull/38564) Updating code owners for golden file changes (a: tests, cla: yes, framework, team, will affect goldens)
+
+[38567](https://github.com/flutter/flutter/pull/38567) Add smoke tests to test every commit on a Catalina host. (cla: yes, team)
+
+[38575](https://github.com/flutter/flutter/pull/38575) fix rpc exception for real (cla: yes, tool)
+
+[38579](https://github.com/flutter/flutter/pull/38579) Fix a smoke test. (cla: yes, team)
+
+[38586](https://github.com/flutter/flutter/pull/38586) Don't reload if compilation has errors (cla: yes, tool)
+
+[38587](https://github.com/flutter/flutter/pull/38587) Improve bitcode check (cla: yes, t: xcode, tool, ⌺‬ platform-ios)
+
+[38593](https://github.com/flutter/flutter/pull/38593) Fix text scale factor for non-content components of Cupertino scaffolds (a: fidelity, cla: yes, f: cupertino, f: material design, framework)
+
+[38603](https://github.com/flutter/flutter/pull/38603) Fix up iOS Add to App tests (a: existing-apps, a: tests, cla: yes, team, ⌺‬ platform-ios)
+
+[38621](https://github.com/flutter/flutter/pull/38621) [Material] Create theme for Dividers to enable customization of thickness (cla: yes, f: material design, framework)
+
+[38629](https://github.com/flutter/flutter/pull/38629) Handle case of a connected unpaired iOS device (cla: yes, tool)
+
+[38635](https://github.com/flutter/flutter/pull/38635) Toggle buttons docs (cla: yes, d: api docs, f: material design, framework)
+
+[38636](https://github.com/flutter/flutter/pull/38636) Adds the arrowColor option to UserAccountsDrawerHeader (#38608) (cla: yes, f: material design, framework)
+
+[38637](https://github.com/flutter/flutter/pull/38637) [flutter_tool] Throw tool exit on malformed storage url override (cla: yes, tool)
+
+[38639](https://github.com/flutter/flutter/pull/38639) PlatformViewLink. cached surface should be a Widget type (a: platform-views, cla: yes, framework)
+
+[38645](https://github.com/flutter/flutter/pull/38645) Rename iOS arch for macOS release mode (macOS release mode 2 of 3) (cla: yes, tool)
+
+[38651](https://github.com/flutter/flutter/pull/38651) Update the macOS Podfile template platform version (cla: yes, tool)
+
+[38652](https://github.com/flutter/flutter/pull/38652) Kill dead code (cla: yes, team, tool)
+
+[38658](https://github.com/flutter/flutter/pull/38658) Roll back engine to f8e7453f11067b5801a4484283592977d18be242 (cla: yes, engine)
+
+[38662](https://github.com/flutter/flutter/pull/38662) Change from using `defaults` to `plutil` for Plist parsing (cla: yes, tool)
+
+[38686](https://github.com/flutter/flutter/pull/38686) Rename patent file (cla: yes)
+
+[38704](https://github.com/flutter/flutter/pull/38704) Adds canRequestFocus toggle to FocusNode (cla: yes, framework)
+
+[38708](https://github.com/flutter/flutter/pull/38708) Fix Catalina hot reload test by specifying the platform is iOS. (cla: no, team)
+
+[38710](https://github.com/flutter/flutter/pull/38710) PlatformViewLink: Rename CreatePlatformViewController to CreatePlatformViewCallback (a: platform-views, cla: yes, framework)
+
+[38719](https://github.com/flutter/flutter/pull/38719) Fix stages of some iOS devicelab tests (cla: yes, team)
+
+
+
+## PRs closed in this release of `flutter/engine`
+
+From Fri Jun 21 22:31:55 2019 -0400 to Sun Aug 18 12:22:00 2019 -0700
+
+
+[9041](https://github.com/flutter/engine/pull/9041) TextStyle.height property as a multiple of font size instead of multiple of ascent+descent+leading. (affects: text input, cla: yes, prod: API break)
+
+[9075](https://github.com/flutter/engine/pull/9075) IOS Platform view transform/clipping (cla: yes)
+
+[9089](https://github.com/flutter/engine/pull/9089) Wire up custom event loop interop for the GLFW embedder. (cla: yes)
+
+[9206](https://github.com/flutter/engine/pull/9206) Android Embedding Refactor PR31: Integrate platform views with the new embedding and the plugin shim. (cla: yes)
+
+[9329](https://github.com/flutter/engine/pull/9329) Fixed memory leak by way of accidental retain on implicit self (cla: yes)
+
+[9341](https://github.com/flutter/engine/pull/9341) some drive-by docs while I was reading the embedding classes (cla: yes)
+
+[9360](https://github.com/flutter/engine/pull/9360) Simplify loading of app bundles on Android (cla: yes)
+
+[9403](https://github.com/flutter/engine/pull/9403) Remove variants of ParagraphBuilder::AddText that are not used within the engine (cla: yes)
+
+[9419](https://github.com/flutter/engine/pull/9419) Has a binary messenger (cla: yes, prod: API break)
+
+[9423](https://github.com/flutter/engine/pull/9423) Don't hang to a platform view's input connection after it's disposed (cla: yes)
+
+[9424](https://github.com/flutter/engine/pull/9424) Send timings of the first frame without batching (cla: yes)
+
+[9428](https://github.com/flutter/engine/pull/9428) Update README.md for consistency with framework (cla: yes)
+
+[9431](https://github.com/flutter/engine/pull/9431) Generate weak pointers only in the platform thread (cla: yes)
+
+[9436](https://github.com/flutter/engine/pull/9436) Add the functionality to merge and unmerge MessageLoopTaskQueues (cla: yes)
+
+[9439](https://github.com/flutter/engine/pull/9439) Eliminate unused import in FlutterView (cla: yes)
+
+[9446](https://github.com/flutter/engine/pull/9446) Revert "Roll fuchsia/sdk/core/mac-amd64 from Cx51F... to e8sS_..." (cla: yes)
+
+[9449](https://github.com/flutter/engine/pull/9449) Revert "Roll fuchsia/sdk/core/linux-amd64 from udf6w... to jQ8aw..." (cla: yes)
+
+[9450](https://github.com/flutter/engine/pull/9450) Revert "Roll fuchsia/sdk/core/mac-amd64 from Cx51F... to w-3t4..." (cla: yes)
+
+[9452](https://github.com/flutter/engine/pull/9452) Convert RRect.scaleRadii to public method (affects: framework, cla: yes)
+
+[9456](https://github.com/flutter/engine/pull/9456) Made sure that the run_tests script returns the right error code. (cla: yes)
+
+[9458](https://github.com/flutter/engine/pull/9458) Test cleanup geometry_test.dart  (affects: tests, cla: yes)
+
+[9459](https://github.com/flutter/engine/pull/9459) Remove unused/unimplemented shell constructor (cla: yes)
+
+[9460](https://github.com/flutter/engine/pull/9460) Fixed logLevel filter bug so that filter now works as expected. (cla: yes)
+
+[9461](https://github.com/flutter/engine/pull/9461) Adds API for retaining intermediate engine layers (cla: yes)
+
+[9462](https://github.com/flutter/engine/pull/9462) Reland Update harfbuzz to 2.5.2 (cla: yes)
+
+[9463](https://github.com/flutter/engine/pull/9463) Removed unused imports in new embedding. (cla: yes)
+
+[9464](https://github.com/flutter/engine/pull/9464) Added shebangs to ios unit test scripts. (cla: yes)
+
+[9466](https://github.com/flutter/engine/pull/9466) Re-enable the Wuffs GIF decoder (cla: yes)
+
+[9467](https://github.com/flutter/engine/pull/9467) ios-unit-tests: Forgot a usage of a variable in our script. (cla: yes)
+
+[9468](https://github.com/flutter/engine/pull/9468) Manually draw remainder curve for wavy decorations (cla: yes)
+
+[9469](https://github.com/flutter/engine/pull/9469) ios-unit-tests: Fixed ocmock system header search paths. (cla: yes)
+
+[9471](https://github.com/flutter/engine/pull/9471) ios-unit-tests: Started using rsync instead of cp -R to copy frameworks. (cla: yes)
+
+[9476](https://github.com/flutter/engine/pull/9476) fix NPE when a touch event is sent to an unknown Android platform view (cla: yes)
+
+[9478](https://github.com/flutter/engine/pull/9478) iOS PlatformView clip path (cla: yes)
+
+[9480](https://github.com/flutter/engine/pull/9480) Revert "IOS Platform view transform/clipping (#9075)" (cla: yes)
+
+[9482](https://github.com/flutter/engine/pull/9482) Re-enable embedder_unittests. (cla: yes)
+
+[9483](https://github.com/flutter/engine/pull/9483) Reland "IOS Platform view transform/clipping (#9075)" and fix the breakage. (cla: yes)
+
+[9485](https://github.com/flutter/engine/pull/9485) Add --observatory-host switch (cla: yes)
+
+[9486](https://github.com/flutter/engine/pull/9486) Rework image & texture management to use concurrent message queues. (cla: yes)
+
+[9489](https://github.com/flutter/engine/pull/9489) Handle ambiguous directionality of final trailing whitespace in mixed bidi text (cla: yes)
+
+[9490](https://github.com/flutter/engine/pull/9490) fix a bug where the platform view's transform is not reset before set frame (cla: yes)
+
+[9491](https://github.com/flutter/engine/pull/9491) Purge caches on low memory on iOS (cla: yes)
+
+[9493](https://github.com/flutter/engine/pull/9493) Run benchmarks on try jobs. (cla: yes)
+
+[9495](https://github.com/flutter/engine/pull/9495) fix build breakage on PlatformViews.mm (cla: yes)
+
+[9501](https://github.com/flutter/engine/pull/9501) [android] External textures must be rescaled to fill the canvas (cla: yes)
+
+[9503](https://github.com/flutter/engine/pull/9503) Improve caching limits for Skia (cla: yes)
+
+[9506](https://github.com/flutter/engine/pull/9506) Synchronize main thread and gpu thread for first render frame (cla: yes)
+
+[9507](https://github.com/flutter/engine/pull/9507) Revert Skia version to d8f79a27b06b5bce7a27f89ce2d43d39f8c058dc (cla: yes)
+
+[9508](https://github.com/flutter/engine/pull/9508) Support image filter on paint (cla: yes)
+
+[9509](https://github.com/flutter/engine/pull/9509) Roll Fuchsia SDK to latest (cla: yes)
+
+[9518](https://github.com/flutter/engine/pull/9518) Bump dart_resource_rev to f8e37558a1c4f54550aa463b88a6a831e3e33cd6 (cla: yes)
+
+[9525](https://github.com/flutter/engine/pull/9525) Android Embedding Refactor PR36: Add splash screen support. (cla: yes)
+
+[9532](https://github.com/flutter/engine/pull/9532) fix FlutterOverlayView doesn't remove from superview in some cases (cla: yes)
+
+[9546](https://github.com/flutter/engine/pull/9546) [all] add fuchsia.{net.NameLookup,posix.socket.Provider} (cla: yes)
+
+[9556](https://github.com/flutter/engine/pull/9556) Minimal integration with the Skia text shaper module (cla: yes)
+
+[9559](https://github.com/flutter/engine/pull/9559)  Roll src/third_party/dart b37aa3b036...1eb113ba27 (cla: yes)
+
+[9561](https://github.com/flutter/engine/pull/9561) libtxt: fix reference counting of SkFontStyleSets held by font asset providers (cla: yes)
+
+[9562](https://github.com/flutter/engine/pull/9562) Switched preprocessor logic for exporting symbols for testing. (cla: yes)
+
+[9581](https://github.com/flutter/engine/pull/9581) Revert "Avoid a full screen overlay within virtual displays" (cla: yes)
+
+[9584](https://github.com/flutter/engine/pull/9584) Revert " Roll src/third_party/dart b37aa3b036...1eb113ba27" (cla: yes)
+
+[9585](https://github.com/flutter/engine/pull/9585) Fix a race in the embedder accessibility unit test (cla: yes)
+
+[9588](https://github.com/flutter/engine/pull/9588) Roll src/third_party/dart b37aa3b036...0abff7b2bb (cla: yes)
+
+[9589](https://github.com/flutter/engine/pull/9589) Fixes a plugin overwrite bug in the plugin shim system. (cla: yes)
+
+[9590](https://github.com/flutter/engine/pull/9590) Apply patches that have landed in topaz since we ported the runners to the engine repo (cla: yes)
+
+[9591](https://github.com/flutter/engine/pull/9591) Document various classes in //flutter/shell/common. (cla: yes)
+
+[9593](https://github.com/flutter/engine/pull/9593) [trace clients] Remove fuchsia.tracelink.Registry (cla: yes)
+
+[9608](https://github.com/flutter/engine/pull/9608) Disable failing Mutators tests (cla: yes)
+
+[9613](https://github.com/flutter/engine/pull/9613) Fix uninitialized variables and put tests in flutter namespace. (cla: yes)
+
+[9632](https://github.com/flutter/engine/pull/9632) Added Doxyfile. (cla: yes)
+
+[9633](https://github.com/flutter/engine/pull/9633) Cherry-pick fix for flutter/flutter#35291 (cla: yes)
+
+[9634](https://github.com/flutter/engine/pull/9634) Roll Dart to 67ab3be10d35d994641da167cc806f20a7ffa679 (cla: yes)
+
+[9636](https://github.com/flutter/engine/pull/9636) Added shebangs to ios unit test scripts. (#9464) (cla: yes)
+
+[9637](https://github.com/flutter/engine/pull/9637) Revert "Roll Dart to 67ab3be10d35d994641da167cc806f20a7ffa679 (#9634)" (cla: yes)
+
+[9638](https://github.com/flutter/engine/pull/9638) Reland: Roll Dart to 67ab3be10d35d994641da167cc806f20a7ffa679 (cla: yes)
+
+[9640](https://github.com/flutter/engine/pull/9640) make EmbeddedViewParams a unique ptr (cla: yes)
+
+[9641](https://github.com/flutter/engine/pull/9641) Let pushColorFilter accept all types of ColorFilters (cla: yes)
+
+[9642](https://github.com/flutter/engine/pull/9642) Fix warning about settings unavailable GN arg build_glfw_shell (cla: yes)
+
+[9649](https://github.com/flutter/engine/pull/9649) Roll buildroot to c5a493b25. (cla: yes)
+
+[9651](https://github.com/flutter/engine/pull/9651) Move the mutators stack handling to preroll (cla: yes)
+
+[9652](https://github.com/flutter/engine/pull/9652) Pipeline allows continuations that can produce to front (cla: yes)
+
+[9653](https://github.com/flutter/engine/pull/9653) External view embedder can tell if embedded views have mutated (cla: yes)
+
+[9654](https://github.com/flutter/engine/pull/9654) Begin separating macOS engine from view controller (cla: yes)
+
+[9655](https://github.com/flutter/engine/pull/9655) Allow embedders to add callbacks for responses to platform messages from the framework. (cla: yes)
+
+[9660](https://github.com/flutter/engine/pull/9660) ExternalViewEmbedder can CancelFrame after pre-roll (cla: yes)
+
+[9661](https://github.com/flutter/engine/pull/9661) Raster now returns an enum rather than boolean (cla: yes)
+
+[9663](https://github.com/flutter/engine/pull/9663) Mutators Stack refactoring (cla: yes)
+
+[9667](https://github.com/flutter/engine/pull/9667) iOS platform view opacity (cla: yes)
+
+[9668](https://github.com/flutter/engine/pull/9668) Refactor ColorFilter to have a native wrapper (cla: yes)
+
+[9669](https://github.com/flutter/engine/pull/9669) Improve window documentation (cla: yes)
+
+[9670](https://github.com/flutter/engine/pull/9670)  Roll src/third_party/dart 67ab3be10d...43891316ca (cla: yes)
+
+[9672](https://github.com/flutter/engine/pull/9672) Add FLEDartProject for macOS embedding (cla: yes)
+
+[9673](https://github.com/flutter/engine/pull/9673) Revert " Roll src/third_party/dart 67ab3be10d...43891316ca" (cla: yes)
+
+[9675](https://github.com/flutter/engine/pull/9675)  Roll src/third_party/dart 67ab3be10d...b5aeaa6796 (cla: yes)
+
+[9685](https://github.com/flutter/engine/pull/9685) fix Picture.toImage return type check and api conform test. (cla: yes)
+
+[9698](https://github.com/flutter/engine/pull/9698) Ensure that platform messages without response handles can be dispatched. (cla: yes)
+
+[9707](https://github.com/flutter/engine/pull/9707) Revert "Revert "Use track-widget-creation transformer included in the… (cla: yes)
+
+[9708](https://github.com/flutter/engine/pull/9708) Roll src/third_party/dart b5aeaa6796...966038ef58 (cla: yes)
+
+[9711](https://github.com/flutter/engine/pull/9711) Revert "Roll src/third_party/dart b5aeaa6796...966038ef58" (cla: yes)
+
+[9713](https://github.com/flutter/engine/pull/9713) Explain why OpacityLayer has an offset field (cla: yes)
+
+[9716](https://github.com/flutter/engine/pull/9716) Roll src/third_party/dart b5aeaa6796..06c3d7ad3a (44 commits) (cla: yes)
+
+[9717](https://github.com/flutter/engine/pull/9717) Fixed logLevel filter bug so that filter now works as expected. (#9460) (cla: yes)
+
+[9721](https://github.com/flutter/engine/pull/9721) Add comments to differentiate two cache paths (cla: yes)
+
+[9722](https://github.com/flutter/engine/pull/9722) Forwards iOS dark mode trait to the Flutter framework (#34441). (cla: yes)
+
+[9723](https://github.com/flutter/engine/pull/9723) Roll src/third_party/dart 06c3d7ad3a..7acecda2cc (12 commits) (cla: yes)
+
+[9724](https://github.com/flutter/engine/pull/9724) Revert "Roll src/third_party/dart 06c3d7ad3a..7acecda2cc (12 commits)")
+
+[9725](https://github.com/flutter/engine/pull/9725) Make the license script compatible with recently changed Dart I/O stream APIs (cla: yes)
+
+[9727](https://github.com/flutter/engine/pull/9727) Add hooks for InputConnection lock and unlocking (cla: yes)
+
+[9728](https://github.com/flutter/engine/pull/9728) Roll src/third_party/dart 06c3d7ad3a...09fc76bc51 (cla: yes)
+
+[9730](https://github.com/flutter/engine/pull/9730) Fix Fuchsia build. (cla: yes)
+
+[9734](https://github.com/flutter/engine/pull/9734) Fix backspace crash on Chinese devices (cla: yes)
+
+[9736](https://github.com/flutter/engine/pull/9736) Build Fuchsia as part of CI presumit (cla: yes)
+
+[9737](https://github.com/flutter/engine/pull/9737) Use libc++ variant of string view and remove the FML variant. (cla: yes)
+
+[9740](https://github.com/flutter/engine/pull/9740) Revert "Improve caching limits for Skia" (cla: yes)
+
+[9741](https://github.com/flutter/engine/pull/9741) Make FLEViewController's view an internal detail (cla: yes)
+
+[9745](https://github.com/flutter/engine/pull/9745) Fix windows test by not attempting to open a directory as a file. (cla: yes)
+
+[9746](https://github.com/flutter/engine/pull/9746) Make all shell unit tests use the OpenGL rasterizer. (cla: yes)
+
+[9747](https://github.com/flutter/engine/pull/9747) Remove get engine (cla: yes)
+
+[9750](https://github.com/flutter/engine/pull/9750) FLEViewController/Engine API changes (cla: yes)
+
+[9758](https://github.com/flutter/engine/pull/9758) Include SkParagraph headers only when the enable-skshaper flag is on (cla: yes)
+
+[9762](https://github.com/flutter/engine/pull/9762) Fall back to a fully qualified path to libapp.so if the library can not be loaded by name (cla: yes)
+
+[9767](https://github.com/flutter/engine/pull/9767) Un-deprecated FlutterViewController's binaryMessenger. (cla: yes)
+
+[9769](https://github.com/flutter/engine/pull/9769) Document //flutter/shell/common/engine. (cla: yes)
+
+[9772](https://github.com/flutter/engine/pull/9772) fix objcdoc generation (cla: yes)
+
+[9781](https://github.com/flutter/engine/pull/9781) SendPlatformMessage allow null message value (cla: yes)
+
+[9787](https://github.com/flutter/engine/pull/9787) Roll src/third_party/dart 09fc76bc51..24725a8559 (43 commits) (cla: yes)
+
+[9789](https://github.com/flutter/engine/pull/9789) fix ColorFilter.matrix constness (cla: yes)
+
+[9791](https://github.com/flutter/engine/pull/9791) Roll Wuffs and buildroot (cla: yes)
+
+[9792](https://github.com/flutter/engine/pull/9792) Update flutter_web to latest (cla: yes)
+
+[9793](https://github.com/flutter/engine/pull/9793) Fix typo in PlaceholderAlignment docs (cla: yes)
+
+[9797](https://github.com/flutter/engine/pull/9797) Remove breaking asserts (cla: yes)
+
+[9799](https://github.com/flutter/engine/pull/9799) Update buildroot to c4df4a7b to pull in MSVC 2017 Update 9 on Windows. (cla: yes)
+
+[9808](https://github.com/flutter/engine/pull/9808) Document FontFeature class (cla: yes)
+
+[9809](https://github.com/flutter/engine/pull/9809) Document //flutter/shell/common/rasterizer (cla: yes)
+
+[9812](https://github.com/flutter/engine/pull/9812) Roll src/third_party/dart 24725a8559..28f95fcd24 (32 commits) (cla: yes)
+
+[9813](https://github.com/flutter/engine/pull/9813) Made Picture::toImage happen on the IO thread with no need for an onscreen surface. (cla: yes)
+
+[9815](https://github.com/flutter/engine/pull/9815) Made the persistent cache's directory a const pointer. (cla: yes)
+
+[9816](https://github.com/flutter/engine/pull/9816) Only release the image data in the unit-test once Skia has accepted ownership of it. (cla: yes)
+
+[9817](https://github.com/flutter/engine/pull/9817) Revert "Roll src/third_party/dart 24725a8559..28f95fcd24 (32 commits)" (cla: yes)
+
+[9818](https://github.com/flutter/engine/pull/9818) Convert run_tests to python, allow running on Mac/Windows and allow filters for tests. (cla: yes)
+
+[9819](https://github.com/flutter/engine/pull/9819) Allow for dynamic thread merging on IOS for embedded view mutations (cla: yes)
+
+[9823](https://github.com/flutter/engine/pull/9823) Roll buildroot to support bitcode enabled builds for iOS (cla: yes)
+
+[9825](https://github.com/flutter/engine/pull/9825) In a single frame codec, release the encoded image buffer after giving it to the decoder (cla: yes)
+
+[9826](https://github.com/flutter/engine/pull/9826) Roll src/third_party/dart 24725a8559..cbaf890f88 (33 commits) (cla: yes)
+
+[9828](https://github.com/flutter/engine/pull/9828) Make the virtual display's window translucent (cla: yes)
+
+[9829](https://github.com/flutter/engine/pull/9829) Revert "Roll src/third_party/dart 24725a8559..cbaf890f88 (33 commits)" (cla: yes)
+
+[9835](https://github.com/flutter/engine/pull/9835) [Windows] Alternative Windows shell platform implementation (affects: desktop, cla: yes, waiting for tree to go green)
+
+[9847](https://github.com/flutter/engine/pull/9847)  Started adding the engine hash to frameworks' Info.plist. (cla: yes)
+
+[9849](https://github.com/flutter/engine/pull/9849) Preserve the alpha for VD content by setting a transparent background. (cla: yes)
+
+[9850](https://github.com/flutter/engine/pull/9850) Add multi-line flag to semantics (cla: yes)
+
+[9851](https://github.com/flutter/engine/pull/9851) Add a macro for prefixing embedder.h symbols (cla: yes)
+
+[9852](https://github.com/flutter/engine/pull/9852) Selectively enable tests that work on Windows and file issues for ones that don't. (cla: yes)
+
+[9855](https://github.com/flutter/engine/pull/9855) Fix missing assignment to _allowHeadlessExecution (cla: yes)
+
+[9856](https://github.com/flutter/engine/pull/9856) Disable Fuchsia Debug & Release presubmits and only attempt the Profile unopt variant. (cla: yes)
+
+[9857](https://github.com/flutter/engine/pull/9857) Fix fuchsia license detection (cla: yes)
+
+[9859](https://github.com/flutter/engine/pull/9859) Fix justify for RTL paragraphs. (cla: yes, waiting for tree to go green)
+
+[9866](https://github.com/flutter/engine/pull/9866) Update buildroot to pick up Fuchsia artifact roller. (cla: yes)
+
+[9867](https://github.com/flutter/engine/pull/9867) Fixed error in generated xml Info.plist. (cla: yes)
+
+[9873](https://github.com/flutter/engine/pull/9873) Add clang version to Info.plist (cla: yes)
+
+[9875](https://github.com/flutter/engine/pull/9875) Simplify buildtools (cla: yes)
+
+[9883](https://github.com/flutter/engine/pull/9883) Roll src/third_party/dart 24725a8559..2b3336b51e (108 commits) (cla: yes)
+
+[9890](https://github.com/flutter/engine/pull/9890) Log dlopen errors only in debug mode (cla: yes)
+
+[9893](https://github.com/flutter/engine/pull/9893) Removed logic from FlutterAppDelegate into FlutterPluginAppLifeCycleDelegate (cla: yes)
+
+[9894](https://github.com/flutter/engine/pull/9894) Add the isMultiline semantics flag to values (cla: yes)
+
+[9895](https://github.com/flutter/engine/pull/9895) Android Embedding PR37: Separated FlutterActivity and FlutterFragment via FlutterActivityAndFragmentDelegate (cla: yes)
+
+[9896](https://github.com/flutter/engine/pull/9896) Capture stderr for ninja command (cla: yes)
+
+[9898](https://github.com/flutter/engine/pull/9898) v1.7.8 hotfixes (cla: yes)
+
+[9901](https://github.com/flutter/engine/pull/9901) Handle decompressed images in InstantiateImageCodec (cla: yes)
+
+[9903](https://github.com/flutter/engine/pull/9903) Revert to using fml::StringView instead of std::string_view (cla: yes)
+
+[9905](https://github.com/flutter/engine/pull/9905) Respect EXIF information while decompressing images. (cla: yes)
+
+[9906](https://github.com/flutter/engine/pull/9906) Update libcxx & libcxxabi to HEAD in prep for compiler upgrade. (cla: yes)
+
+[9909](https://github.com/flutter/engine/pull/9909) Roll src/third_party/dart 6bf1f8e280..63120303a7 (4 commits) (cla: yes)
+
+[9919](https://github.com/flutter/engine/pull/9919) Removed unused method. (cla: yes)
+
+[9920](https://github.com/flutter/engine/pull/9920) Fix caching of Locale.toString (cla: yes)
+
+[9922](https://github.com/flutter/engine/pull/9922) Split out lifecycle protocol (cla: yes)
+
+[9923](https://github.com/flutter/engine/pull/9923) Fix failure of the onReportTimings window hook test (cla: yes)
+
+[9924](https://github.com/flutter/engine/pull/9924) Don't try to use unset assets_dir setting (cla: yes)
+
+[9925](https://github.com/flutter/engine/pull/9925) Fix the geometry test to reflect that OffsetBase comparison operators are a partial ordering (cla: yes)
+
+[9927](https://github.com/flutter/engine/pull/9927) Update Buildroot Version (cla: yes)
+
+[9929](https://github.com/flutter/engine/pull/9929) Update the exception thrown for invalid data in the codec test (cla: yes)
+
+[9931](https://github.com/flutter/engine/pull/9931) Fix reentrancy handling in SingleFrameCodec (cla: yes)
+
+[9932](https://github.com/flutter/engine/pull/9932) Exit flutter_tester with an error code on an unhandled exception (cla: yes)
+
+[9933](https://github.com/flutter/engine/pull/9933) Build fuchsia artifacts from the engine (cla: yes)
+
+[9934](https://github.com/flutter/engine/pull/9934) Updates to the engine test runner script (cla: yes)
+
+[9935](https://github.com/flutter/engine/pull/9935) Fix backspace crash on Chinese devices (#9734) (cla: yes)
+
+[9936](https://github.com/flutter/engine/pull/9936) Move development.key from buildroot (cla: yes)
+
+[9937](https://github.com/flutter/engine/pull/9937) [platform view] do not make clipping view and interceptor view clipToBounds (cla: yes)
+
+[9938](https://github.com/flutter/engine/pull/9938) Removed PlatformViewsController if-statements from TextInputPlugin (#34286). (cla: yes)
+
+[9939](https://github.com/flutter/engine/pull/9939) Added hasRenderedFirstFrame() to old FlutterView for Espresso (#36211). (cla: yes)
+
+[9948](https://github.com/flutter/engine/pull/9948) [glfw] Enables replies on binary messenger in glfw embedder (cla: yes)
+
+[9951](https://github.com/flutter/engine/pull/9951) Roll src/third_party/dart 63120303a7...a089199b93 (cla: yes)
+
+[9952](https://github.com/flutter/engine/pull/9952) ios: Fixed the callback for the first frame so that it isn't predicated on having a splash screen. (cla: yes)
+
+[9953](https://github.com/flutter/engine/pull/9953) [macos] Add reply to binary messenger (cla: yes)
+
+[9954](https://github.com/flutter/engine/pull/9954) Add working Robolectric tests (cla: yes)
+
+[9958](https://github.com/flutter/engine/pull/9958) Clean up cirrus.yml file a little (cla: yes)
+
+[9959](https://github.com/flutter/engine/pull/9959) Update Dart engine tests to check for assertion failures only when running in debug mode (cla: yes)
+
+[9961](https://github.com/flutter/engine/pull/9961) Fix return type of assert function in gradient_test (cla: yes)
+
+[9977](https://github.com/flutter/engine/pull/9977) Fix flutter/flutter #34791 (cla: yes, platform-android)
+
+[9987](https://github.com/flutter/engine/pull/9987) Update GN to git_revision:152c5144ceed9592c20f0c8fd55769646077569b (cla: yes)
+
+[9998](https://github.com/flutter/engine/pull/9998) [luci] Reference the right fuchsia CIPD and upload only once (cla: yes)
+
+[9999](https://github.com/flutter/engine/pull/9999) Add support for Android's visible password input type (affects: text input, cla: yes)
+
+[10001](https://github.com/flutter/engine/pull/10001) Roll src/third_party/dart a089199b93..fedd74669a (8 commits) (cla: yes)
+
+[10003](https://github.com/flutter/engine/pull/10003) Declare a copy of the enable_bitcode flag within the Flutter build scripts for use in Fuchsia builds (cla: yes)
+
+[10004](https://github.com/flutter/engine/pull/10004) [fuchsia] Use GatherArtifacts to create the requisite dir structure (cla: yes)
+
+[10007](https://github.com/flutter/engine/pull/10007) Embedding testing app (cla: yes)
+
+[10009](https://github.com/flutter/engine/pull/10009) [macos] Revert check on FlutterCodecs and refactor message function] (cla: yes)
+
+[10010](https://github.com/flutter/engine/pull/10010) Use simarm_x64 when targeting arm (cla: yes)
+
+[10012](https://github.com/flutter/engine/pull/10012) Undelete used method (cla: yes)
+
+[10021](https://github.com/flutter/engine/pull/10021) Added a DartExecutor API for querying # of pending channel callbacks (cla: yes)
+
+[10056](https://github.com/flutter/engine/pull/10056) Update .cirrus.yml (cla: yes)
+
+[10063](https://github.com/flutter/engine/pull/10063) Track clusters and return cluster boundaries in getGlyphPositionForCoordinates (emoji fix) (affects: text input, cla: yes, crash)
+
+[10064](https://github.com/flutter/engine/pull/10064) Disable DartLifecycleTest::ShuttingDownTheVMShutsDownAllIsolates in runtime_unittests. (cla: yes)
+
+[10065](https://github.com/flutter/engine/pull/10065) test scenario_app on CI (cla: yes)
+
+[10066](https://github.com/flutter/engine/pull/10066) Roll src/third_party/dart fedd74669a..9c148623c5 (70 commits) (cla: yes)
+
+[10068](https://github.com/flutter/engine/pull/10068) Fixed memory leak with engine registrars. (cla: yes)
+
+[10069](https://github.com/flutter/engine/pull/10069) Enable consts from environment in DDK for flutter_web (cla: yes)
+
+[10073](https://github.com/flutter/engine/pull/10073) Basic structure for flutter_jit_runner far (cla: yes)
+
+[10074](https://github.com/flutter/engine/pull/10074) Change ParagraphBuilder to replace the parent style's font families with the child style's font families (cla: yes)
+
+[10075](https://github.com/flutter/engine/pull/10075) Change flutter runner target for LUCI (cla: yes)
+
+[10078](https://github.com/flutter/engine/pull/10078) One more luci fix (cla: yes)
+
+[10081](https://github.com/flutter/engine/pull/10081) [fuchsia] Add support for libs in packages (cla: yes)
+
+[10082](https://github.com/flutter/engine/pull/10082) [fuchsia] Add sysroot and clang libs to package (cla: yes)
+
+[10085](https://github.com/flutter/engine/pull/10085) [fuchsia] Use the new far package model (cla: yes)
+
+[10087](https://github.com/flutter/engine/pull/10087) [fuchsia] copy over the cmx file (cla: yes)
+
+[10096](https://github.com/flutter/engine/pull/10096) Roll src/third_party/skia 3ae30cc2e6e0..1cd1ed8976c4 (1 commits) (autoroller: dryrun, cla: yes)
+
+[10097](https://github.com/flutter/engine/pull/10097) Roll src/third_party/skia 1cd1ed8976c4..f564f1515bde (1 commits) (autoroller: dryrun, cla: yes)
+
+[10098](https://github.com/flutter/engine/pull/10098) Roll src/third_party/dart 9c148623c5..82f657d7cb (25 commits) (cla: yes)
+
+[10100](https://github.com/flutter/engine/pull/10100) Roll src/third_party/skia f564f1515bde..fdf4bfe6d389 (1 commits) (autoroller: dryrun, cla: yes)
+
+[10101](https://github.com/flutter/engine/pull/10101) Roll src/third_party/skia fdf4bfe6d389..b3956dc6ba6a (1 commits) (autoroller: dryrun, cla: yes)
+
+[10102](https://github.com/flutter/engine/pull/10102) [fuchsia] Use manifest file to better replicate the existing build (cla: yes)
+
+[10109](https://github.com/flutter/engine/pull/10109) Cache font family lookups that fail to obtain a font collection (cla: yes)
+
+[10114](https://github.com/flutter/engine/pull/10114) Roll src/third_party/dart 82f657d7cb..0c97c31b6e (7 commits) (cla: yes)
+
+[10122](https://github.com/flutter/engine/pull/10122) [fuchsia] Use the patched sdk to generate the flutter jit runner far (cla: yes)
+
+[10127](https://github.com/flutter/engine/pull/10127) Track detailed LibTxt metrics (cla: yes)
+
+[10128](https://github.com/flutter/engine/pull/10128) Started linking the test targets against Flutter. (cla: yes)
+
+[10139](https://github.com/flutter/engine/pull/10139) Roll src/third_party/dart 0c97c31b6e..a2aec5eb06 (22 commits) (cla: yes)
+
+[10140](https://github.com/flutter/engine/pull/10140) Revert "[fuchsia] Use the patched sdk to generate the flutter jit run… (cla: yes)
+
+[10141](https://github.com/flutter/engine/pull/10141) Revert "[macos] Revert check on FlutterCodecs and refactor message fu… (cla: yes)
+
+[10143](https://github.com/flutter/engine/pull/10143) Disable windows tests (cla: yes)
+
+[10144](https://github.com/flutter/engine/pull/10144) [fuchsia] Push CMX to fars and add product mode support (cla: yes)
+
+[10145](https://github.com/flutter/engine/pull/10145) Added integration test that tests that the first frame callback is called (cla: yes)
+
+[10146](https://github.com/flutter/engine/pull/10146) Revert "Disable windows tests" (cla: yes)
+
+[10150](https://github.com/flutter/engine/pull/10150) [fuchsia] Remove extraneous ShapeNodes (cla: yes)
+
+[10151](https://github.com/flutter/engine/pull/10151) [fucshia] fix name to reflect the cmx file (cla: yes)
+
+[10153](https://github.com/flutter/engine/pull/10153) Add gclient_gn_args_file to DEPS (cla: yes)
+
+[10155](https://github.com/flutter/engine/pull/10155) src/third_party/dart a2aec5eb06...86dba81dec (cla: yes)
+
+[10160](https://github.com/flutter/engine/pull/10160) Roll src/third_party/dart 86dba81dec..0ca1582afd (2 commits) (cla: yes)
+
+[10171](https://github.com/flutter/engine/pull/10171) [fuchsia] Add support for aot mode in flutter runner (cla: yes)
+
+[10172](https://github.com/flutter/engine/pull/10172) [dart_runner] Rename dart to dart runner (cla: yes)
+
+[10176](https://github.com/flutter/engine/pull/10176) Add suggested Java changes from flutter roll (cla: yes, platform-android)
+
+[10178](https://github.com/flutter/engine/pull/10178) Removed unnecessary call to find the App.framework. (cla: yes)
+
+[10179](https://github.com/flutter/engine/pull/10179) [dart_runner] dart jit runner and dart jit product runner (cla: yes)
+
+[10183](https://github.com/flutter/engine/pull/10183) [fuchsia] Uncomment publish to CIPD (cla: yes)
+
+[10185](https://github.com/flutter/engine/pull/10185) Add better CIPD docs. (cla: yes)
+
+[10186](https://github.com/flutter/engine/pull/10186) Ensure debug-mode apps are always attached on iOS. (cla: yes)
+
+[10188](https://github.com/flutter/engine/pull/10188) [fuchsia] Artifacts now contain gen_snapshot and gen_snapshot_product (cla: yes)
+
+[10189](https://github.com/flutter/engine/pull/10189)  [macos] Reland function refactor (cla: yes)
+
+[10195](https://github.com/flutter/engine/pull/10195) Allow embedder controlled composition of Flutter layers. (cla: yes)
+
+[10226](https://github.com/flutter/engine/pull/10226) Roll src/third_party/dart 0ca1582afd..1e43d65d4a (50 commits) (cla: yes)
+
+[10235](https://github.com/flutter/engine/pull/10235) Deprecate FlutterView#enableTransparentBackground (cla: yes)
+
+[10240](https://github.com/flutter/engine/pull/10240) [fuchsia] Update buildroot to support arm64 (cla: yes)
+
+[10242](https://github.com/flutter/engine/pull/10242) Remove Dead Scenic Clipping Code Path. (cla: yes)
+
+[10246](https://github.com/flutter/engine/pull/10246) [fuchsia] Start building dart_patched_sdk (cla: yes)
+
+[10250](https://github.com/flutter/engine/pull/10250) Android Embedding Refactor 38: Removed AssetManager from DartEntrypoint. (cla: yes)
+
+[10260](https://github.com/flutter/engine/pull/10260) [fuchsia] Add arm64 builds for flutter and dart runner (cla: yes)
+
+[10261](https://github.com/flutter/engine/pull/10261) [fuchsia] Bundle architecture specific gen_snapshots (cla: yes)
+
+[10265](https://github.com/flutter/engine/pull/10265) [dart-roll] Roll dart sdk to 80c4954d4d1d2a257005793d83b601f3ff2997a2 (cla: yes)
+
+[10268](https://github.com/flutter/engine/pull/10268) [fuchsia] Make cirrus build fuchsia artifacts (cla: yes)
+
+[10273](https://github.com/flutter/engine/pull/10273) Remove one last final call to AddPart() (cla: yes)
+
+[10282](https://github.com/flutter/engine/pull/10282) Export FFI from sky_engine. (cla: yes)
+
+[10293](https://github.com/flutter/engine/pull/10293) Add fuchsia.stamp for roller (cla: yes)
+
+[10294](https://github.com/flutter/engine/pull/10294) Roll src/third_party/dart 80c4954d4d..bd049f5b53 (37 commits) (cla: yes)
+
+[10295](https://github.com/flutter/engine/pull/10295) Fix memory overrun in minikin patch (cla: yes, crash)
+
+[10296](https://github.com/flutter/engine/pull/10296) fix CI (cla: yes)
+
+[10297](https://github.com/flutter/engine/pull/10297) Ensure that the SingleFrameCodec stays alive until the ImageDecoder invokes its callback (cla: yes)
+
+[10298](https://github.com/flutter/engine/pull/10298) Fix red build again (cla: yes)
+
+[10303](https://github.com/flutter/engine/pull/10303) Make tree green for real this time, I promise. (cla: yes)
+
+[10309](https://github.com/flutter/engine/pull/10309) [fuchsia] Kernel compiler is now ready (cla: yes)
+
+[10381](https://github.com/flutter/engine/pull/10381) Fix empty composing range on iOS (cla: yes)
+
+[10386](https://github.com/flutter/engine/pull/10386) Don't use DBC for hot-reload on iOS. (cla: yes)
+
+[10403](https://github.com/flutter/engine/pull/10403) [fuchsia] Add kernel compiler target (cla: yes)
+
+[10413](https://github.com/flutter/engine/pull/10413) Pass Android Q insets.systemGestureInsets to Window (cla: yes, platform-android)
+
+[10414](https://github.com/flutter/engine/pull/10414) expose max depth on Window (cla: yes)
+
+[10419](https://github.com/flutter/engine/pull/10419) Make kernel compiler use host toolchain (cla: yes)
+
+[10423](https://github.com/flutter/engine/pull/10423) Fix mac gen_snapshot uploader (cla: yes)
+
+[10424](https://github.com/flutter/engine/pull/10424) Fix deprecation warnings in the Android embedding (cla: yes)
+
+[10430](https://github.com/flutter/engine/pull/10430) Add copy_gen_snapshots.py tool (cla: yes)
+
+[10434](https://github.com/flutter/engine/pull/10434) Reland Skia Caching improvements (cla: yes)
+
+[10437](https://github.com/flutter/engine/pull/10437) Roll src/third_party/dart bd049f5b53...622ec5099f (cla: yes)
+
+[10440](https://github.com/flutter/engine/pull/10440) Revert "Remove one last final call to AddPart()" (cla: yes)
+
+[10475](https://github.com/flutter/engine/pull/10475) Roll src/third_party/dart 622ec5099f...9bb446aae1 (14 commits) (cla: yes)
+
+[10477](https://github.com/flutter/engine/pull/10477) Add #else, #endif condition comments (cla: yes)
+
+[10478](https://github.com/flutter/engine/pull/10478) Migrate Fuchsia runners to SDK tracing API (cla: yes)
+
+[10479](https://github.com/flutter/engine/pull/10479) Delete unused create_macos_gen_snapshot.py script (cla: yes)
+
+[10481](https://github.com/flutter/engine/pull/10481) Android embedding refactor pr40 add static engine cache (cla: yes)
+
+[10484](https://github.com/flutter/engine/pull/10484) Roll src/third_party/dart 9bb446aae1...4bebfebdbc (7 commits). (cla: yes)
+
+[10485](https://github.com/flutter/engine/pull/10485) Remove semi-redundant try-jobs. (cla: yes)
+
+[10629](https://github.com/flutter/engine/pull/10629) Fix engine platformviewscontroller leak (cla: yes)
+
+[10633](https://github.com/flutter/engine/pull/10633) skip flaky tests (cla: yes)
+
+[10634](https://github.com/flutter/engine/pull/10634) Use Fuchsia trace macros when targeting Fuchsia SDK (cla: yes)
+
+[10635](https://github.com/flutter/engine/pull/10635) [fuchsia] CloneChannelFromFD fix for system.cc (cla: yes)
+
+[10636](https://github.com/flutter/engine/pull/10636) Fix threading and re-enable resource cache shell unit-tests. (cla: yes)
+
+[10637](https://github.com/flutter/engine/pull/10637) Document the thread test fixture. (cla: yes)
+
+[10642](https://github.com/flutter/engine/pull/10642) Roll src/third_party/dart 4bebfebdbc..8cd01287b4 (30 commits) (cla: yes)
+
+[10644](https://github.com/flutter/engine/pull/10644) [flutter_runner] Port: Add connectToService, wrapping fdio_ns_connect. (cla: yes)
+
+[10645](https://github.com/flutter/engine/pull/10645) Don't use DBC for hot-reload on iOS.  (cla: yes)
+
+[10652](https://github.com/flutter/engine/pull/10652) Allow embedders to control Dart VM lifecycle on engine shutdown. (cla: yes)
+
+[10656](https://github.com/flutter/engine/pull/10656) fix iOS keyboard crash : -[__NSCFString substringWithRange:], range o… (cla: yes)
+
+[10662](https://github.com/flutter/engine/pull/10662) bump local podspec's ios deployment target version from 7.0 to 8.0 (cla: yes)
+
+[10663](https://github.com/flutter/engine/pull/10663) Roll src/third_party/dart 8cd01287b4..574c4a51c6 (35 commits) (cla: yes)
+
+[10667](https://github.com/flutter/engine/pull/10667) Roll buildroot for ANGLE support (cla: yes)
+
+[10671](https://github.com/flutter/engine/pull/10671) Roll src/third_party/dart 574c4a51c6..c262cbd414 (11 commits) (cla: yes)
+
+[10674](https://github.com/flutter/engine/pull/10674) When setting up AOT snapshots from symbol references, make buffer sizes optional. (cla: yes)
+
+[10675](https://github.com/flutter/engine/pull/10675) Improvements to the flutter GDB script (cla: yes)
+
+[10679](https://github.com/flutter/engine/pull/10679) Roll buildroot to pick up EGL library name fix (cla: yes)
+
+[10681](https://github.com/flutter/engine/pull/10681) Roll buildroot back to an earlier version (cla: yes)
+
+[10682](https://github.com/flutter/engine/pull/10682) Roll src/third_party/dart c262cbd414..8740bb5c68 (18 commits) (cla: yes)
+
+[10687](https://github.com/flutter/engine/pull/10687) Roll src/third_party/dart 8740bb5c68..f3139f57b4 (7 commits) (cla: yes)
+
+[10692](https://github.com/flutter/engine/pull/10692) Rolls engine to Android SDK 29 and its corresponding tools (cla: yes)
+
+[10693](https://github.com/flutter/engine/pull/10693) Roll src/third_party/dart f3139f57b4..f29f41f1a5 (3 commits) (cla: yes)
+
+[10694](https://github.com/flutter/engine/pull/10694) Roll buildroot (cla: yes)
+
+[10699](https://github.com/flutter/engine/pull/10699) Roll swiftshader (cla: yes)
+
+[10700](https://github.com/flutter/engine/pull/10700) [fuchsia] Migrate from custom FuchsiaFontManager to SkFontMgr_fuchsia (cla: yes)
+
+[10703](https://github.com/flutter/engine/pull/10703) Test perf overlay gold on Linux (cla: yes)
+
+[10705](https://github.com/flutter/engine/pull/10705) Revert "Remove semi-redundant try-jobs. (#10485)" (cla: yes)
+
+[10717](https://github.com/flutter/engine/pull/10717) Specify which android variant for tests (cla: yes, waiting for tree to go green)
+
+[10719](https://github.com/flutter/engine/pull/10719) Include Maven dependency in files.json (cla: yes)
+
+[10771](https://github.com/flutter/engine/pull/10771) Don't use gradle daemon for building (cla: yes, waiting for tree to go green)
+
+[10773](https://github.com/flutter/engine/pull/10773) Remove use of the deprecated AccessibilityNodeInfo boundsInParent API (cla: yes)
+
+[10774](https://github.com/flutter/engine/pull/10774) Manual roll of Fuchsia clang/linux-amd64 toolchain (cla: yes)
+
+[10776](https://github.com/flutter/engine/pull/10776) rename stub_ui to web_ui (cla: yes)
+
+[10777](https://github.com/flutter/engine/pull/10777) Manually roll Skia to pull in iOS armv7 build failure fix. (cla: yes)
+
+[10778](https://github.com/flutter/engine/pull/10778) Build JARs containing the Android embedding sources and the engine native library (cla: yes)
+
+[10780](https://github.com/flutter/engine/pull/10780) [flutter_runner] Improve frame scheduling (cla: yes)
+
+[10781](https://github.com/flutter/engine/pull/10781) [flutter] Create the compositor context on the GPU task runner. (cla: yes)
+
+[10782](https://github.com/flutter/engine/pull/10782) Update license script to handle ANGLE (cla: yes)
+
+[10783](https://github.com/flutter/engine/pull/10783) Make firebase test more LUCI friendly (cla: yes)
+
+[10784](https://github.com/flutter/engine/pull/10784) Roll buildroot for ANGLE support (cla: yes)
+
+[10786](https://github.com/flutter/engine/pull/10786) Remove 3 semi-redundant try-jobs (cla: yes)
+
+[10787](https://github.com/flutter/engine/pull/10787) Change call to |AddPart| to |AddChild| (cla: yes)
+
+[10788](https://github.com/flutter/engine/pull/10788) Wire up a concurrent message loop backed SkExecutor for Skia. (cla: yes)
+
+[10789](https://github.com/flutter/engine/pull/10789) Revert "Forwards iOS dark mode trait to the Flutter framework.". (cla: yes)
+
+[10791](https://github.com/flutter/engine/pull/10791) Re-lands platform brightness support on iOS (cla: yes)
+
+[10797](https://github.com/flutter/engine/pull/10797) Rename artifacts so they match the Maven convention (cla: yes)
+
+[10799](https://github.com/flutter/engine/pull/10799) Add a test for creating images from bytes. (cla: yes)
+
+[10802](https://github.com/flutter/engine/pull/10802) Roll src/third_party/dart f29f41f1a5..3d9a356f6e (65 commits) (cla: yes)
+
+[10805](https://github.com/flutter/engine/pull/10805) Roll src/third_party/dart 3d9a356f6e..78ce916d82 (7 commits) (cla: yes)
+
+[10808](https://github.com/flutter/engine/pull/10808) Remove flutter_kernel_sdk dart script (cla: yes)
+
+[10809](https://github.com/flutter/engine/pull/10809) [dart:zircon] Porting Cache re-usable handle wait objects (cla: yes)
+
+[10810](https://github.com/flutter/engine/pull/10810) Roll Dart SDK 78ce916d82..15a3bf82cb (cla: yes)
+
+[10811](https://github.com/flutter/engine/pull/10811) Revert "Remove flutter_kernel_sdk dart script" (cla: yes)
+
+[10815](https://github.com/flutter/engine/pull/10815) Return an empty mapping for an empty file asset (cla: yes)
+
+[10816](https://github.com/flutter/engine/pull/10816) Add firstFrameDidRender to FlutterViewController (cla: yes)
+
+[10817](https://github.com/flutter/engine/pull/10817) Roll src/third_party/dart 15a3bf82cb..ffefa124a7 (11 commits) (cla: yes)
+
+[10820](https://github.com/flutter/engine/pull/10820) iOS JIT support and enhancements for scenarios app (cla: yes)
+
+[10821](https://github.com/flutter/engine/pull/10821) Roll src/third_party/dart ffefa124a7..e29d6d0ecb (4 commits) (cla: yes)
+
+[10823](https://github.com/flutter/engine/pull/10823) Expose isolateId for engine (cla: yes)
+
+[10905](https://github.com/flutter/engine/pull/10905) Roll src/third_party/dart e29d6d0ecb..261fd6266b (2 commits) (cla: yes)
+
+[10925](https://github.com/flutter/engine/pull/10925) Roll src/third_party/dart 261fd6266b..9adf3c119e (2 commits) (cla: yes)
+
+[10934](https://github.com/flutter/engine/pull/10934) Roll src/third_party/dart 9adf3c119e..32b70ce2a5 (3 commits) (cla: yes)
+
+[10941](https://github.com/flutter/engine/pull/10941) Report test failures in run_tests.py (cla: yes)
+
+[10946](https://github.com/flutter/engine/pull/10946) Roll src/third_party/dart 32b70ce2a5..896c053803 (1 commits) (cla: yes)
+
+[10949](https://github.com/flutter/engine/pull/10949) Fix iOS references to PostPrerollResult (cla: yes)
+
+[10952](https://github.com/flutter/engine/pull/10952) Change SemanticsNode#children lists to be non-null (cla: yes)
+
+[10955](https://github.com/flutter/engine/pull/10955) Fix format (cla: yes)
+
+[10956](https://github.com/flutter/engine/pull/10956) Increase the license block scan from 5k to 6k (cla: yes)
+
+[10962](https://github.com/flutter/engine/pull/10962) Roll src/third_party/dart 896c053803..b31df28d72 (10 commits) (cla: yes)
+
+[10966](https://github.com/flutter/engine/pull/10966) Roll src/third_party/dart b31df28d72..baebba06af (5 commits) (cla: yes)
+
+[10968](https://github.com/flutter/engine/pull/10968) include zx::clock from new location to fix Fuchsia autoroll. (cla: yes)
+
+[10973](https://github.com/flutter/engine/pull/10973) Roll src/third_party/dart baebba06af..06509e333d (7 commits) (cla: yes)
+
+[10975](https://github.com/flutter/engine/pull/10975) Roll src/third_party/dart 06509e333d..9aea1f3489 (8 commits) (cla: yes)
+
+[10977](https://github.com/flutter/engine/pull/10977) Roll src/third_party/dart 9aea1f3489..b9217efc77 (7 commits) (cla: yes)
+
+[10981](https://github.com/flutter/engine/pull/10981) Roll src/third_party/dart b9217efc77..20407e28db (6 commits) (cla: yes)
+
+[10982](https://github.com/flutter/engine/pull/10982) Revert "Track detailed LibTxt metrics" (cla: yes)
+
+[10983](https://github.com/flutter/engine/pull/10983) Roll src/third_party/dart 20407e28db..45f892df68 (2 commits) (cla: yes)
+
+[10987](https://github.com/flutter/engine/pull/10987) Roll src/third_party/dart 45f892df68..88c43bbcc4 (7 commits) (cla: yes)
+
+[10990](https://github.com/flutter/engine/pull/10990) Roll src/third_party/dart 88c43bbcc4..b173229baa (14 commits) (cla: yes)
+
+[10993](https://github.com/flutter/engine/pull/10993) Roll src/third_party/dart b173229baa..76c99bcd01 (5 commits) (cla: yes)
+
+[10997](https://github.com/flutter/engine/pull/10997) Roll src/third_party/dart 76c99bcd01..c4727fddf4 (10 commits) (cla: yes)
+
+[10999](https://github.com/flutter/engine/pull/10999) Add script for running ios Tests on simulator (cla: yes)
+
+[11001](https://github.com/flutter/engine/pull/11001) Avoid dynamic lookups of the engine library's symbols on Android (cla: yes)
+
+[11002](https://github.com/flutter/engine/pull/11002) Remove a tracing macro with a dangling pointer (cla: yes)
+
+[11003](https://github.com/flutter/engine/pull/11003) Roll src/third_party/dart c4727fddf4..e35e8833ee (1 commits) (cla: yes)
+
+[11004](https://github.com/flutter/engine/pull/11004) Trace RasterCacheResult::Draw (cla: yes)
+
+[11005](https://github.com/flutter/engine/pull/11005) Drop firebase test from Cirrus (cla: yes)
+
+[11006](https://github.com/flutter/engine/pull/11006) On iOS report the preferred frames per second to tools via service protocol. (cla: yes)
+
+[11007](https://github.com/flutter/engine/pull/11007) Update README.md (cla: yes)
+
+[11009](https://github.com/flutter/engine/pull/11009) Revert "Update README.md" (cla: yes)
+
+[11010](https://github.com/flutter/engine/pull/11010) Rename macOS FLE* classes to Flutter* (affects: desktop, cla: yes, platform-macos, waiting for tree to go green)
+
+[11011](https://github.com/flutter/engine/pull/11011) Initialize the engine in the running state to match the animator's default state (cla: yes)
+
+[11012](https://github.com/flutter/engine/pull/11012) Remove the ParagraphImpl class from the text API (cla: yes)
+
+[11013](https://github.com/flutter/engine/pull/11013) Remove ability to override mac_sdk_path in flutter/tools/gn (cla: yes)
+
+[11015](https://github.com/flutter/engine/pull/11015) Remove the output directory prefix from the Android engine JAR filename (cla: yes)
+
+[11016](https://github.com/flutter/engine/pull/11016) Fix gn breakage on Fuchsia macOS host builds (cla: yes)
+
+[11017](https://github.com/flutter/engine/pull/11017) Roll src/third_party/dart e35e8833ee..e35e8833ee (0 commits) (cla: yes)
+
+[11019](https://github.com/flutter/engine/pull/11019) Fix gn breakage on non-Fuchsia macOS host builds (cla: yes)
+
+[11023](https://github.com/flutter/engine/pull/11023) Roll src/third_party/dart e35e8833ee..cae08c6813 (28 commits) (cla: yes)
+
+[11024](https://github.com/flutter/engine/pull/11024) Add _glfw versions of the GLFW desktop libraries (cla: yes)
+
+[11026](https://github.com/flutter/engine/pull/11026) Roll src/third_party/dart cae08c6813..9552646dc4 (3 commits) (cla: yes)
+
+[11027](https://github.com/flutter/engine/pull/11027) Fix first frame logic (cla: yes)
+
+[11029](https://github.com/flutter/engine/pull/11029) Disable a deprecation warning for use of a TaskDescription constructor for older platforms (cla: yes)
+
+[11030](https://github.com/flutter/engine/pull/11030) Roll src/third_party/dart 9552646dc4..cd16fba718 (5 commits) (cla: yes)
+
+[11033](https://github.com/flutter/engine/pull/11033) remove OS version (cla: yes)
+
+[11036](https://github.com/flutter/engine/pull/11036) [fuchsia] Add required trace so files for fuchsia fars (cla: yes)
+
+[11037](https://github.com/flutter/engine/pull/11037) Roll buildroot to pick up recent macOS changes (cla: yes)
+
+[11038](https://github.com/flutter/engine/pull/11038) Make JIT work on iPhone armv7 (cla: yes)
+
+[11039](https://github.com/flutter/engine/pull/11039) Roll src/third_party/dart cd16fba718..306f8e04bb (10 commits) (cla: yes)
+
+[11040](https://github.com/flutter/engine/pull/11040) Hide verbose dart snapshot during run_test.py (cla: yes)
+
+[11043](https://github.com/flutter/engine/pull/11043) Roll Dart back to e35e8833 (cla: yes)
+
+[11044](https://github.com/flutter/engine/pull/11044) Roll src/third_party/dart 306f8e04bb..fecc4c8f2d (4 commits) (cla: yes)
+
+[11046](https://github.com/flutter/engine/pull/11046) Add ccls config files to .gitignore (cla: yes)
+
+[11048](https://github.com/flutter/engine/pull/11048) Roll src/third_party/dart e35e8833ee..2023f09b56 (67 commits) (cla: yes)
+
+[11052](https://github.com/flutter/engine/pull/11052) Remove unused dstColorSpace argument to MakeCrossContextFromPixmap (cla: yes)
+
+[11055](https://github.com/flutter/engine/pull/11055) Roll src/third_party/dart 2023f09b56..a3b579d5c3 (8 commits) (cla: yes)
+
+[11056](https://github.com/flutter/engine/pull/11056) Sort the Skia typefaces in a font style set into a consistent order (cla: yes)
+
+[11060](https://github.com/flutter/engine/pull/11060) Roll src/third_party/dart a3b579d5c3..2a3b844b41 (5 commits) (cla: yes)
+
+[11061](https://github.com/flutter/engine/pull/11061) Roll buildroot to 5a33d6ab to pickup changes to toolchain version tracking. (cla: yes)
+
+[11066](https://github.com/flutter/engine/pull/11066) Roll src/third_party/dart 2a3b844b41..8ab978b6d4 (7 commits) (cla: yes)
+
+[11067](https://github.com/flutter/engine/pull/11067) Minor update to the Robolectric test harness (cla: yes)
+
+[11068](https://github.com/flutter/engine/pull/11068) More updates to the Robolectric test harness (cla: yes)
+
+[11071](https://github.com/flutter/engine/pull/11071) Roll src/third_party/dart 8ab978b6d4..beee442625 (17 commits) (cla: yes)
+
+[11072](https://github.com/flutter/engine/pull/11072) Roll src/third_party/dart beee442625..79e6c74337 (8 commits) (cla: yes)
+
+[11075](https://github.com/flutter/engine/pull/11075) [dynamic_thread_merging] Resubmit only on the frame where the merge (cla: yes)
+

--- a/src/docs/development/tools/sdk/release-notes/index.md
+++ b/src/docs/development/tools/sdk/release-notes/index.md
@@ -1,0 +1,11 @@
+---
+title: Flutter release notes
+short-title: release notes
+description: Release notes for Flutter for prior releases. 
+---
+
+Release notes for the following releases to the stable channel:
+* [1.9.1](release-notes/release-notes-1.9.1)
+* [1.7.8](release-notes/release-notes-1.7.8)
+* [1.5.4](release-notes/release-notes-1.5.4)
+* [1.2.1](release-notes/release-notes-1.2.1)

--- a/src/docs/development/tools/sdk/release-notes/release-notes-1.2.1.md
+++ b/src/docs/development/tools/sdk/release-notes/release-notes-1.2.1.md
@@ -1,0 +1,277 @@
+---
+title: Flutter 1.2.1 release notes
+short-title: 1.2.1 release notes
+description: Release notes for Flutter 1.2.1.
+---
+
+Our #1 priority since the Flutter v1.0 release has been to continue to address high priority issues reported both by Flutter developers and the Flutter team itself. This includes committing 672 Pull Requests in the Flutter engine and framework since December (we've been busy!). We've called out the new features and breaking changes that we think are noteworthy below. The biggest ones came from our Framework and Tool tags, but we also found and fixed a couple of Severe issues as well.
+
+## Framework
+
+To more fully round-out Flutter's animation support, this release adds several more of the standard easing functions:
+
+[#25788](https://github.com/flutter/flutter/pull/25788) Add Robert Penner's easing functions
+
+To integrate more fully with Android, this release adds support for [Android App Bundles](https://developer.android.com/guide/app-bundle/), a new packaging format that helps in reducing app size and enables new features like dynamic delivery for Android apps:
+
+[#24440](https://github.com/flutter/flutter/pull/24440) Adding support for android app bundle
+
+To integrate more fully with iOS, this release adds several new features and fixes for iOS, including a new CupertinoTheme:
+
+[#25183](https://github.com/flutter/flutter/pull/25183) Add navigatorKey to CupertinoTabView
+
+[#25593](https://github.com/flutter/flutter/pull/25593) Let CupertinoTabScaffold handle keyboard insets too
+
+[#24876](https://github.com/flutter/flutter/pull/24876) Adds a fade in and out, rounds corners, fixes offset and fixes height of cursor on iOS
+
+[#23759](https://github.com/flutter/flutter/pull/23759) Adds CupertinoTheme
+
+In addition to the iOS Cupertino theme support, this release continues to enhance the Material theme as well:
+
+[#24169](https://github.com/flutter/flutter/pull/24169) [Material] Theme-able elevation on dialogs
+
+[#25339](https://github.com/flutter/flutter/pull/25339) [Material] Theme-able TextStyles for AlertDialog
+
+To integrate more fully with desktop form-factors like Android tablets and ChromeOS as well as desktop web and desktop OS support, this release builds more support for keyboard and mouse as first class input devices: 
+
+[#7758](https://github.com/flutter/engine/pull/7758) Recommended implementation of combining characters implementation
+
+[#27853](https://github.com/flutter/flutter/pull/27853) Hook up character events and unmodified code points to Android raw key event handling
+
+[#27620](https://github.com/flutter/flutter/pull/27620) Add a keyboard key code generator
+
+[#27627](https://github.com/flutter/flutter/pull/27627) Adding support for logical and physical key events
+
+[#6961](https://github.com/flutter/engine/pull/6961) Add hover event support to the engine
+
+[#24830](https://github.com/flutter/flutter/pull/24830) Implement hover support for mouse pointers
+
+As widgets are the core way to interact with users in Flutter, this release continues to add features and fixes to the Flutter widget set with particular attention paid to the [SliverAppBar](https://docs.flutter.io/flutter/material/SliverAppBar-class.html):
+
+[#26021](https://github.com/flutter/flutter/pull/26021) Fix SliverAppBar title opacity and test all cases
+
+[#26101](https://github.com/flutter/flutter/pull/26101) Fix a floating snapping SliverAppBar crash
+
+[#25091](https://github.com/flutter/flutter/pull/25091) Add animations to SliverAppBar doc
+
+[#24736](https://github.com/flutter/flutter/pull/24736) Provide some more locations for the FAB
+
+[#25585](https://github.com/flutter/flutter/pull/25585) Expose font fallback API in TextStyle, Roll engine 54a3577c0139..215ca1560088
+
+[#24457](https://github.com/flutter/flutter/pull/24457) Revise Android and iOS gestures on Material TextField
+
+[#24554](https://github.com/flutter/flutter/pull/24554) Adds force press gesture detector and recognizer
+
+[#23919](https://github.com/flutter/flutter/pull/23919) Allow detection of taps on TabBar
+
+[#25384](https://github.com/flutter/flutter/pull/25384) Adds support for floating cursor
+
+[#24976](https://github.com/flutter/flutter/pull/24976) Support TextField multi-line hint text
+
+[#26332](https://github.com/flutter/flutter/pull/26332) Strut: fine tuned control over text minimum line heights, allows forcing the line height to be a specified height
+
+And finally, as Flutter usage continues to grow world-wide, we continue to enhance support for localizations across several languages, including Ukrainian, Polish, Swahili and Galician in this release.
+
+[#25394](https://github.com/flutter/flutter/pull/25394) Update localizations
+
+[#27506](https://github.com/flutter/flutter/pull/27506) Added support for Swahili (material_sw.arb)
+
+[#27352](https://github.com/flutter/flutter/pull/24876) Including Galician language
+
+
+## Plug-Ins
+
+As in the framework and engine itself, we're continuing to focus on plugin quality as well:
+
+[flutter/engine#7317](https://github.com/flutter/engine/pull/7317) Fix stale GrContext for iOS platform views
+
+[flutter/engine#7558](https://github.com/flutter/engine/pull/7558) Fix lost touch events for iOS platform views
+
+[flutter/plugins#1157](https://github.com/flutter/plugins/pull/1157) [google_maps_flutter] Fix camera positioning issue on iOS
+
+[flutter/plugins#1176](https://github.com/flutter/plugins/pull/1176) [firebase_auth] Fix Firebase phone auth on Android
+
+[flutter/plugins#1037](https://github.com/flutter/plugins/pull/1037) [camera] Save photo orientation on iOS
+
+[flutter/plugins#1129](https://github.com/flutter/plugins/pull/1129) [android_alarm_manager] Fix "background start not allowed" issues, queue events that are received too early
+
+[flutter/plugins#1051 ](https://github.com/flutter/plugins/pull/1051)[image_picker] Fix crash on iOS when the picker is tapped multiple times
+
+The webview_flutter plugin got a communication channel between Dart and JavaScript:
+
+[flutter/plugins#1116](https://github.com/flutter/plugins/pull/1116) Add WebView JavaScript channels (Dart side)
+
+[flutter/plugins#1130](https://github.com/flutter/plugins/pull/1130) WebView JavasScript channels Android implementation
+
+[flutter/plugins#1139](https://github.com/flutter/plugins/pull/1139) WebView JavaScript channels - iOS implementation
+
+[lutter/plugins1021](https://github.com/flutter/plugins/pull/1021) javascript evaluation ios/android
+
+We've made progress building the In App Purchase plugin (which is still pre-release):
+
+[#1057](https://github.com/flutter/plugins/pull/1057) [IAP] Check if the payment processor is available
+
+[#1084](https://github.com/flutter/plugins/pull/1084) [IAP] Fetch SkuDetails from Google Play
+
+[#1068](https://github.com/flutter/plugins/pull/1068) IAP productlist ios
+
+[#1172](https://github.com/flutter/plugins/pull/1172) [In_app_purchase] add payment objc translators
+
+
+## Dart
+
+The release contains a new Dart SDK which provides support for a new set literals syntax and increases AOT performance 10-20% by reducing the overhead of calling constructors or static methods:
+
+[#37](https://github.com/dart-lang/language/issues/37) Set Literal
+
+[#33274](https://github.com/dart-lang/sdk/issues/33274) Add support for "naked" instructions: global object pool, pc-relative static calls, faster indirect calls, potential code sharing
+
+
+## Tool
+
+We've added a number of new tools and new features to existing tools in this release.
+
+This release continues to improve error messages across a range of tools:
+
+[#26107](https://github.com/flutter/flutter/pull/26107) Better error messages for flutter tool --dynamic flag
+
+[#26084](https://github.com/flutter/flutter/pull/26084) Improve message when saving compilation training data
+
+[#25863](https://github.com/flutter/flutter/pull/25863) Friendlier messages when using dynamic patching
+
+This release also adds support for Java 1.8:
+
+[#25470](https://github.com/flutter/flutter/pull/25470) Support Java 1.8
+
+
+## Severe
+
+In this release, we've found and fixed a few severe issues from the previous release, including two crashes and one performance degradation.
+
+Crashes
+
+[#7314](https://github.com/flutter/flutter/issues/7314) Flutter crash on startup (metabug)
+
+Performance
+
+[#25381](https://github.com/flutter/flutter/pull/25381) Add cull opacity perf test to device lab
+
+
+## Breaking Changes
+
+In an effort to continue to improve Flutter since 1.0 to meet customer needs, we have had to make a few breaking changes:
+
+### [#8769](https://github.com/flutter/flutter/pull/8769) Rename ListItem to ListTile, document ListTile fixed height geometry
+
+Many developers were confused by the fact that ListItem was fixed height. We've renamed it to ListTile, to indicate that (like other tiles) its height is fixed, and the documentation has been updated to clearly say that about ListTile. You'll need to rename instances of the ListItem class to ListTile in your code.
+
+### [#7518](https://github.com/flutter/engine/pull/7518) Update default flutter_assets path for iOS embedding
+
+Flutter assets for iOS applications are now found in Frameworks/App.framework/flutter_assets instead of flutter_assets. The flutter command line tool should take care of this difference, but if you are writing an AddToApp application for iOS that shares assets with Flutter, you'll need to be aware of this change.
+
+
+### [#27697](https://github.com/flutter/flutter/pull/27697) Cupertino TextField Cursor Fix
+
+CupertinoTextField's cursorColor default now matches the app's theme. If this is undesirable, developers can use the cupertinoOverrideTheme property of ThemeData to provide a Cupertino-specific override using a CupertinoThemeData object, e.g: 
+ 
+```
+Widget build(BuildContext context) { 
+  // Set theme data for override in the CupertinoThemeData's constructor 
+  Theme.of(context).cupertinoOverrideTheme = CupertinoThemeData(  
+    brightness: Brightness.dark,  
+    primaryColor: Color(0xFF42A5F5) 
+  ); 
+  return Text( 
+    'Example', 
+    style: Theme.of(context).textTheme.title, 
+  ); 
+}
+```
+
+
+### [#23424](https://github.com/flutter/flutter/pull/23424) Teach drag start behaviors to DragGestureRecognizer
+
+By default, a drag gesture detector's onStart callback will be called with the location of where a drag gesture is detected (i.e. after dragging a certain number of pixels) instead of at the touch down location. To use the old functionality with a given drag gesture recognizer, the dragStartBehavior variable of the recognizer should be set DragStartBehavior.down, e.g., include the bolded line below when declaring your GestureDecorator:
+
+```
+GestureDectector( 
+  dragStartBehavior: DragStartBehavior.down,
+  onVerticalDragDown: myDragDown 
+  onVerticalDragEnd: myDragEnd, 
+  onVerticalDragStart: myDragStart, 
+  onVerticalDragUpdate: myDragUpdate, 
+  onVerticalDragCancel: myDragCancel, 
+  onHorizontalDragDown: myDragDown 
+  onHorizontalDragEnd: myDragEnd, 
+  onHorizontalDragStart: myDragStart, 
+  onHorizontalDragUpdate: myDragUpdate, 
+  onHorizontalDragCancel: myDragCancel, 
+// Other fields… 
+```
+
+
+### [#26238](https://github.com/flutter/flutter/pull/26238) Remove long-deprecated TwoLevelList
+
+Removed the long-deprecated TwoLevelList widget; use ListView with ExpansionTile instead. See [this example](https://github.com/flutter/flutter/blob/master/examples/catalog/lib/expansion_tile_sample.dart) for a sample that uses ExpansionTile.
+
+
+###[#7442](https://github.com/flutter/engine/pull/7442) Move Picture.toImage rasterization to the GPU thread
+
+Picture.toImage now returns a `Future<Image>` instead. This permits image rasterization to occur on the GPU thread, improving performance in many cases and ensuring correct results. At a minimum, you'll need to declare methods invoking on Picture instances as async, and use await, like this:
+
+```
+`void usePictureImage(Picture p) async { 
+  var image = await p.toImage(); 
+  // Do something with the pixels in image…. 
+}
+```
+
+However, your application may well be performing other asynchronous actions, and you should consider how you want to handle image processing in that light. For more on Dart's support for asynchronous programming and the Future class, see [https://www.dartlang.org/tutorials/language/futures.](https://www.dartlang.org/tutorials/language/futures.)
+
+
+### [#7567](https://github.com/flutter/engine/pull/7567) Rename FlutterResult in embedder.h
+
+In the Embedder API, the FlutterResult type has been renamed to FlutterEngineResult to better explain its purpose. You'll need to rename any instances of the former to the latter.
+
+
+### [#7414](https://github.com/flutter/engine/pull/7414) Strut implementation
+
+Rename dart:ui ParagraphStyle.lineHeight to ParagraphStyle.height. The ParagraphStyle.lineHeight property previously did not do anything and was renamed to stay consistent with TextStyle.height. You'll need to rename any instances of the former to the latter.
+
+
+## Regressions
+
+Soon after our 1.2 release, we found two regressions:
+
+
+* [#28640](https://github.com/flutter/flutter/issues/28640) NoSuchMethodError: android.view.MotionEvent.isFromSource
+
+[flutter/flutter#24830](https://github.com/flutter/flutter/pull/24830) ("Implement hover support for mouse pointers.") is using an Android API that doesn't exist on older devices. This can cause a crash on Android 4.1 (Jellybean) and 4.1 (Jellybean MR1).
+
+
+* [#28484](https://github.com/flutter/flutter/issues/28484) Widget rendering strange since Flutter update
+
+This can cause rendering issues when loading certain images on physical iOS devices.
+
+To get a fix for these regressions, once beta 1.3 lands in March,  you can switch to the beta channel and perform a "flutter upgrade" at the command line. At the time of this writing, that will update you to at least version 1.3.8, which includes [flutter/engine#8006](https://github.com/flutter/engine/pull/8006) ("Guard against using Android API not defined in API level 16 & 17") and the Skia commit that fixes the rendering issue. For the crashing issue, the two affected versions of Android are more than ten years old and represent at most 2.5% of Android users, few of which are likely to be installing new Android applications, whether they're Flutter or not. Even so, we hate to leave known regressions in a stable release, but after much internal debate, we decided it was the best way to proceed for Flutter developers and their app users.
+
+Our ideal fix for any serious issue is to create a "hotfix" release by taking an existing release and "cherry picking" the fixes that we'd like to apply. The ability to hotfix an existing stable release is something that we implemented for 1.2 but have not quite gotten to production quality. The consequence of this is that if we had created a new stable "1.2.1-a" release with the fix for the regressions, we'd have stranded all of our users at that branch; updating to future branches would've required users to remove and reinstall Flutter from scratch, which was clearly unacceptable. We are working hard to validate our ability to hotfix in 1.3+ so that we don't have this problem again.
+
+Another option would have been to bring 1.3 to a stable release. Our current policy is to only bring out a new stable release once per quarter to reduce churn for Flutter developers. As of this writing, the pre-stable 1.3 release contains 104 framework commits (and even more engine, Dart, and Skia commits), any of which is a risk to how your current apps are running. To reduce that risk, we leave releases in beta for a month, let developers test them, and only promote releases to the stable channel when we're confident in them. That's how we maintain stability in the quarterly releases.
+
+Our next stable release is currently planned for May, 2019, which is the first stable release that will include the fix for this regression. If you are affected by [#28640](https://github.com/flutter/flutter/issues/28640) and feel like the workaround to use the pre-release 1.3 is not an option for you, please let us know by on [flutter/flutter#29235](https://github.com/flutter/flutter/issues/29235) itself. Similarly, if you are affected by [#28484](https://github.com/flutter/flutter/issues/28484), et us know on [flutter/flutter/#29360](https://github.com/flutter/flutter/issues/29360). If we find that there's a lot of feedback from the Flutter community that we made the wrong decision here, we'll use your feedback to reevaluate. Flutter is, after all, a community effort, and your opinions matter.
+
+
+## Tooling Releases
+
+In addition to Flutter framework changes in the 1.2 release, we've made a number of tooling releases in the same timeframe, which you can read about here:
+
+
+
+*   Dart & Flutter support for Visual Studio Code: versions [2.21](https://dartcode.org/releases/v2-21/), [2.22](https://dartcode.org/releases/v2-22/), [2.23](https://dartcode.org/releases/v2-23/) and [2.24](https://dartcode.org/releases/v2-24/).
+*   Dart & Flutter support for IntelliJ & Android Studio: [January, 2019](https://groups.google.com/forum/#!searchin/flutter-dev/nilay%7Csort:date/flutter-dev/VCfGRhDsHgs/JcYKxkxHBAAJ) and [February, 2019](https://groups.google.com/forum/#!searchin/flutter-dev/nilay%7Csort:date/flutter-dev/VCfGRhDsHgs/JcYKxkxHBAAJ) releases.
+*   Dart DevTools [alpha release](https://flutter.github.io/devtools/).
+
+## Full Issue List
+
+You can see [the full list of PRs committed in this release](/docs/development/tools/sdk/release-notes/changelogs/changelog-1.2.1).

--- a/src/docs/development/tools/sdk/release-notes/release-notes-1.5.4.md
+++ b/src/docs/development/tools/sdk/release-notes/release-notes-1.5.4.md
@@ -1,0 +1,256 @@
+---
+title: Flutter 1.5.4 release notes
+short-title: 1.5.4 release notes
+description: Release notes for Flutter 1.5.4.
+---
+
+In addition to continuing to focus on quality and stability since the 1.2 release, the Flutter 1.5.4 stable release adds a set of new features as we approach the Google I/O conference. Further, [Apple has a deadline for building against the 12.1 version of their iOS SDK](https://developer.apple.com/news/?id=03202019a), which we now do in this update. You can meet Apple’s requirements simply by pulling down the 1.5.4 stable release, building and updating your Flutter app in the Apple Store.
+
+Also, this build sees fixes for the two regressions we saw in Flutter 1.2:
+
+* [#28640](https://github.com/flutter/flutter/issues/28640) NoSuchMethodError: **android.view.MotionEvent.isFromSource was closed and fixed in all versions after 1.3.7
+* [#28484](https://github.com/flutter/flutter/issues/28484) Widget rendering strange since Flutter update:** a change was made fixes this regression in 1.4.0
+
+Finally, for details about other fixes and new features, read on.
+
+
+## Breaking Changes
+
+Our recent survey showed that Flutter developers prefer a breaking change if it means that it improves the API and behavior of Flutter. Of course, we still make breaking changes sparingly. The following are the list of breaking changes in this release along with links to a full description of each change and how to handle it in your Flutter code.
+
+
+
+*   [flutter#26261](https://github.com/flutter/flutter/issues/26261): CupertinoTextField's cursorColor default now matches the app's theme ([Announcement & Mitigation](https://groups.google.com/forum/#!topic/flutter-announce/uJFi5sENr1g))
+*   [flutter#26026](https://github.com/flutter/flutter/issues/26261): Need to manually trigger selection toolbars when using raw EditableText ([Announcement & Mitigation](https://groups.google.com/forum/#!topic/flutter-announce/uJFi5sENr1g))
+*   [flutter#23148](https://github.com/flutter/flutter/issues/26261): Proposing a fix to unify Android and iOS response in the Firebase Messagng Plugin ([Announcement & Mitigation](https://groups.google.com/forum/#!topic/flutter-announce/v4dt7Zc-NGg))
+*   [flutter#28014](https://github.com/flutter/flutter/issues/26261): Converting PointerEvent to Diagnosticable ([Announcement & Mitigation](https://groups.google.com/forum/#!topic/flutter-announce/ZPPRKV642Uk))
+*   [flutter#20183](https://github.com/flutter/flutter/issues/26261): CupertinoTextField: Merge provided TextStyle with Theme's TextStyle ([Announcement & Mitigation](https://groups.google.com/forum/#!topic/flutter-announce/3OV8J3GhO6U))
+*   [flutter#20693](https://github.com/flutter/flutter/issues/26261): LongPressGestureRecognizer moving after long press no longer discards up event ([Announcement & Mitigation](https://groups.google.com/forum/#!topic/flutter-announce/kWT0J8Ii5Rw))
+*   [flutter#20693](https://github.com/flutter/flutter/issues/26261): The GestureRecognizerState enum has a new 'accepted' value ([Announcement & Mitigation](https://groups.google.com/forum/#!topic/flutter-announce/YXNZ4OFL8Uo))
+*   [flutter#18314](https://github.com/flutter/flutter/issues/26261), [flutter#22830](https://github.com/flutter/flutter/issues/26261), [flutter#23424](https://github.com/flutter/flutter/issues/26261): Drag moveBy calls are broken in two and the default DragStartBehavior in all widgets with drag recognizers is changed to DragStartBehavior.start ([Announcement & Mitigation](https://groups.google.com/forum/#!topic/flutter-announce/iTZt49dP_pU))
+*   [flutter#27891](https://github.com/flutter/flutter/issues/26261): Composite layers for physical shapes on all platforms ([Announcement & Mitigation](https://groups.google.com/forum/#!topic/flutter-announce/8bAn-BPQPE8))
+*   [flutter#19418](https://github.com/flutter/flutter/issues/26261): Adding onPlatformViewCreated to AndroidViewController ([Announcement & Mitigation](https://groups.google.com/forum/#!topic/flutter-announce/LoAfcK5IJ9A))
+*   [flutter#29070](https://github.com/flutter/flutter/issues/26261): BackdropFilter will fill its parent/ancestor clip ([Announcement & Mitigation](https://groups.google.com/forum/#!topic/flutter-announce/AC4NDVh1h5k))
+*   [flutter#29816](https://github.com/flutter/flutter/issues/26261): FontWeight.lerp to return null if args are null ([Announcement & Mitigation](https://groups.google.com/forum/#!topic/flutter-announce/0uS_Hzq894I))
+*   [flutter#29696](https://github.com/flutter/flutter/issues/26261): Proposal to rename PointerEnterEvent and PointerExitEvent fromHoverEvent to fromMouseEvent ([Announcement & Mitigation](https://groups.google.com/forum/#!topic/flutter-announce/ECoJc9LOs2M))
+*   [flutter#28602](https://github.com/flutter/flutter/pull/28602): Allow PointerEnterEvent and PointerExitEvents to be created from any PointerEvent
+*   [flutter#28953](https://github.com/flutter/flutter/pull/28953): Include platformViewId in semantics tree
+*   [flutter#27612](https://github.com/flutter/flutter/pull/27612): Force line height in TextFields with strut
+*   [flutter#30991](https://github.com/flutter/flutter/pull/30991): Use full height of the glyph for caret height on Android
+*   [flutter#30414](https://github.com/flutter/flutter/pull/30414): Remove pressure customization from some pointer events
+*   [engine#8274](https://github.com/flutter/engine/pull/8274): [ui] Add null check in FontWeight.lerp
+
+
+## Severe Performance and Crash Changes
+
+In this release, we fixed several severe performance and crash issues.
+
+
+
+*   [flutter#30990](https://github.com/flutter/flutter/pull/30990): Allow profile widget builds in profile mode
+*   [flutter#30985](https://github.com/flutter/flutter/pull/30985): Add rrect contains microbenchmark
+*   [flutter#28651](https://github.com/flutter/flutter/pull/28651): Cannot execute operation because FlutterJNI is not attached to native.
+
+
+## iOS Changes
+
+Supporting iOS is just as important to the Flutter team as support Android, which you can see in the huge volume of changes we’ve made in this release to make the iOS experience even better.  
+
+
+
+*   [flutter#29200](https://github.com/flutter/flutter/pull/29200): Cupertino localization step 1: add an English arb file
+*   [flutter#29821](https://github.com/flutter/flutter/pull/29821): Cupertino localization step 1.5: fix a resource mismatch in cupertino_en.arb
+*   [flutter#30160](https://github.com/flutter/flutter/pull/30160): Cupertino localization 1.9: add needed singular resource for cupertino_en.arb
+*   [flutter#29644](https://github.com/flutter/flutter/pull/29644): Cupertino localization step 3: in-place move some material tools around to make room for cupertino
+*   [flutter#29650](https://github.com/flutter/flutter/pull/29650): Cupertino localization step 4: let generated date localization combine material and cupertino locales
+*   [flutter#29708](https://github.com/flutter/flutter/pull/29708) Cupertino localization step 5: add french arb as translated example
+*   [flutter#29767](https://github.com/flutter/flutter/pull/29767): Cupertino localization step 6: add a GlobalCupertinoLocalizations base class with date time formatting
+*   [flutter#30527](https://github.com/flutter/flutter/pull/30527): Cupertino localization step 11: add more translation clarifications in the instructions
+*   [flutter#28629](https://github.com/flutter/flutter/pull/28629): Make sure everything in the Cupertino page transition can be linear when back swiping
+*   [flutter#28001](https://github.com/flutter/flutter/pull/28001): CupertinoTextField: added ability to change placeholder color
+*   [flutter#29304](https://github.com/flutter/flutter/pull/29304): Include platformViewId in semantics tree for iOS
+*   [flutter#29946](https://github.com/flutter/flutter/pull/29946): Let CupertinoPageScaffold have tap status bar to scroll to top
+*   [flutter#29474](https://github.com/flutter/flutter/pull/29474): Let CupertinoTextField's clear button also call onChanged
+*   [flutter#29008](https://github.com/flutter/flutter/pull/29008): Update CupertinoTextField
+*   [flutter#29630](https://github.com/flutter/flutter/pull/29630): Add heart shapes to CupertinoIcons
+*   [flutter#28597](https://github.com/flutter/flutter/pull/28597): Adjust remaining Cupertino route animations to match native
+*   [flutter#29407](https://github.com/flutter/flutter/pull/29407): [cupertino_icons] Add circle and circle_filled, for radio buttons.
+*   [flutter#29024](https://github.com/flutter/flutter/pull/29024): Fix CupertinoTabView tree re-shape on view inset change
+*   [flutter#28478](https://github.com/flutter/flutter/pull/28478): Support iOS devices reporting pressure data of 0
+*   [flutter#29987](https://github.com/flutter/flutter/pull/29987): update CupertinoSwitch documentation
+*   [flutter#29943](https://github.com/flutter/flutter/pull/29943): Remove unwanted gap between navigation bar and safe area's child
+*   [flutter#28855](https://github.com/flutter/flutter/pull/28855): Move material iOS back swipe test to material
+*   [flutter#28756](https://github.com/flutter/flutter/pull/28756): Handle Cupertino back gesture interrupted by Navigator push
+*   [flutter#31088](https://github.com/flutter/flutter/pull/31088): Text field scroll physics
+*   [flutter#30946](https://github.com/flutter/flutter/pull/30946): Add some more cupertino icons
+*   [flutter#30521](https://github.com/flutter/flutter/pull/30521): Provide a default IconTheme in CupertinoTheme
+*   [flutter#30475](https://github.com/flutter/flutter/pull/30475): Trackpad mode crash fix
+
+
+## Material Changes
+
+Of course, Material continues to be a priority for the Flutter team as well.
+
+
+
+*   [flutter#28290](https://github.com/flutter/flutter/pull/28290): [Material] Create a FloatingActionButton ThemeData and honor it within the FloatingActionButton ([#28735](https://github.com/flutter/flutter/pull/28735))
+*   [flutter#29980](https://github.com/flutter/flutter/pull/29980): Fix issue with account drawer header arrow rotating when setState is called
+*   [flutter#29563](https://github.com/flutter/flutter/pull/29563): Avoid flickering while dragging to select text
+*   [flutter#29138](https://github.com/flutter/flutter/pull/29138): Update DropdownButton underline to be customizable
+*   [flutter#29572](https://github.com/flutter/flutter/pull/29572): DropdownButton Icon customizability
+*   [flutter#29183](https://github.com/flutter/flutter/pull/29183): Implement labelPadding configuration in TabBarTheme
+*   [flutter#21834](https://github.com/flutter/flutter/pull/21834): Add shapeBorder option on App Bar
+*   [flutter#28163](https://github.com/flutter/flutter/pull/28163): [Material] Add ability to set shadow color and selected shadow color for chips and for chip themes
+*   [flutter#27711](https://github.com/flutter/flutter/pull/27711): Make extended FAB's icon optional
+*   [flutter#28159](https://github.com/flutter/flutter/pull/28159): [Material] Expand BottomNavigationBar API (reprise)
+*   [flutter#27973](https://github.com/flutter/flutter/pull/27973): Add extendBody parameter to Scaffold, body MediaQuery reflects BAB height
+*   [flutter#30390](https://github.com/flutter/flutter/pull/30390): [Material] Update slider and slider theme with new sizes, shapes, and color mappings
+*   [flutter#29390](https://github.com/flutter/flutter/pull/29390): Make expansion panel optionally toggle its state by tapping its header.
+*   [flutter#30754](https://github.com/flutter/flutter/pull/30754): [Material] Fix showDialog crasher caused by old contexts
+*   [flutter#30525](https://github.com/flutter/flutter/pull/30525): Fix cursor outside of input width
+*   [flutter#30805](https://github.com/flutter/flutter/pull/30805): Update ExpansionPanelList Samples with Scaffold Template
+*   [flutter#30537](https://github.com/flutter/flutter/pull/30537): Embedded images and added variations to ListTile sample code
+*   [flutter#30455](https://github.com/flutter/flutter/pull/30455): Prevent vertical scroll in shrine by ensuring card size fits the screen
+*   [flutter#29413](https://github.com/flutter/flutter/pull/29413): Fix MaterialApp's _navigatorObserver when only builder used
+
+
+## Desktop Changes
+
+Flutter has been making progress on expanding support for desktop-class input mechanisms with keyboard mappings, text selection, mouse wheels and hover along with the beginnings of desktop support in our tooling.
+
+
+
+*   [flutter#29993](https://github.com/flutter/flutter/pull/29993): Adds the keyboard mapping for Linux
+*   [flutter#29769](https://github.com/flutter/flutter/pull/29769): Add support for text selection via mouse to Cupertino text fields
+*   [flutter#22762](https://github.com/flutter/flutter/pull/22762): Add support for scrollwheels
+*   [flutter#28900](https://github.com/flutter/flutter/pull/28900): Add key support to cupertino button
+*   [flutter#28290](https://github.com/flutter/flutter/pull/28290): Text selection via mouse
+*   [flutter#28602](https://github.com/flutter/flutter/pull/28602): Allow PointerEnterEvent and PointerExitEvents to be created from any PointerEvent
+*   [flutter#30829](https://github.com/flutter/flutter/pull/30829): Keep hover annotation layers in sync with the mouse detector.
+*   [flutter#30648](https://github.com/flutter/flutter/pull/30648): Allow downloading of desktop embedding artifacts
+*   [flutter#31283](https://github.com/flutter/flutter/pull/31283): Add desktop workflows to doctor
+*   [flutter#31229](https://github.com/flutter/flutter/pull/31229): Add flutter run support for linux and windows
+*   [flutter#31277](https://github.com/flutter/flutter/pull/31277): pass track widget creation flag through to build script
+*   [flutter#31218](https://github.com/flutter/flutter/pull/31218): Add run capability for macOS target
+*   [flutter#31205](https://github.com/flutter/flutter/pull/31205): Add desktop projects and build commands (experimental)
+*   [flutter#30670](https://github.com/flutter/flutter/issues/30670): Implement StandardMethodCodec for C++ shells
+
+
+## Framework Changes
+
+In addition to platform specifics, we continue to push on the core of the Flutter framework.
+
+
+
+*   [engine#8402](https://github.com/flutter/engine/pull/8402): Enable shutting down all root isolates in a VM.
+*   [flutter#31210](https://github.com/flutter/flutter/pull/31210): Use full height of the glyph for caret height on Android v2
+*   [flutter#30422](https://github.com/flutter/flutter/pull/30422): Commit a navigator.pop as soon as the back swipe is lifted
+*   [flutter#30792](https://github.com/flutter/flutter/pull/30792): Rename Border.uniform() -> Border.fromSide()
+*   [flutter#31159](https://github.com/flutter/flutter/pull/31159): Revert "Use full height of the glyph for caret height on Android"
+*   [flutter#30932](https://github.com/flutter/flutter/pull/30932): 2d transforms UX improvements
+*   [flutter#30898](https://github.com/flutter/flutter/pull/30898): Check that ErrorWidget.builder is not modified after test
+*   [flutter#30809](https://github.com/flutter/flutter/pull/30809): Fix issue 23527: Exception: RenderViewport exceeded its maximum numb…
+*   [flutter#30880](https://github.com/flutter/flutter/pull/30880): Let sliver.dart _createErrorWidget work with other Widgets
+*   [flutter#30876](https://github.com/flutter/flutter/pull/30876): Simplify toImage future handling
+*   [flutter#30470](https://github.com/flutter/flutter/pull/30470): Fixed Table flex column layout error #30437
+*   [flutter#30215](https://github.com/flutter/flutter/pull/30215): Check for invalid elevations
+*   [flutter#30667](https://github.com/flutter/flutter/pull/30667): Fix additional @mustCallSuper indirect overrides and mixins
+*   [flutter#30814](https://github.com/flutter/flutter/pull/30814): Fix StatefulWidget and StatelessWidget Sample Documentation
+*   [flutter#30760](https://github.com/flutter/flutter/pull/30760): fix cast NPE in invokeListMethod and invokeMapMethod
+*   [flutter#30640](https://github.com/flutter/flutter/pull/30640): Add const Border.uniformSide()
+*   [flutter#30644](https://github.com/flutter/flutter/pull/30644): Make FormField._validate() return void
+*   [flutter#30645](https://github.com/flutter/flutter/pull/30645): Add docs to FormFieldValidator
+*   [flutter#30563](https://github.com/flutter/flutter/pull/30563): Fixed a typo in the Expanded API doc
+*   [flutter#30513](https://github.com/flutter/flutter/pull/30513): Fix issue 21640: Assertion Error : '_listenerAttached': is not true
+*   [flutter#30305](https://github.com/flutter/flutter/pull/30305): shorter nullable list duplications
+*   [flutter#30468](https://github.com/flutter/flutter/pull/30468): Embedding diagram for BottomNavigationBar.
+
+
+## Plugin Changes
+
+In this release, we also have a number of changes in the Flutter plugins, including camera, Google Maps, the Web View, the image picker, the Firebase plugins and, now for use in your apps, [the In-App Purchase plugin beta](https://pub.dartlang.org/packages/in_app_purchase).
+
+
+
+*   [plugins#1477](https://github.com/flutter/plugins/pull/1477): [camera] Remove activity lifecycle
+*   [plugins#1022](https://github.com/flutter/plugins/pull/1022): [camera] Add serial dispatch_queue for camera plugin to avoid blocking the UI
+*   [plugins#1331](https://github.com/flutter/plugins/pull/1331): [connectivity] Enable fetching current Wi-Fi network's BSSID
+*   [plugins#1455](https://github.com/flutter/plugins/pull/1455): [connectivity]Added integration test.
+*   [plugins#1377](https://github.com/flutter/plugins/pull/1377): [firebase_admob] Update documentation to add iOS Admob ID & add iOS Admob ID in example project
+*   [plugins#1492](https://github.com/flutter/plugins/pull/1492): [firebase_analytics] Initial integration test
+*   [plugins#896](https://github.com/flutter/plugins/pull/896): [firebase-analytics] Enable setAnalyticsCollectionEnabled support for iOS
+*   [plugins#1159](https://github.com/flutter/plugins/pull/1159): [firebase_auth] Enable passwordless sign in
+*   [plugins#1487](https://github.com/flutter/plugins/pull/1487): [firebase_auth] Migrate FlutterAuthPlugin from deprecated APIs
+*   [plugins#1443](https://github.com/flutter/plugins/pull/1443): [firebase_core] Use Gradle BoM with firebase_core
+*   [plugins#1427](https://github.com/flutter/plugins/pull/1427): [firebase_crashlytics] Do not break debug log formatting.
+*   [plugins#1437](https://github.com/flutter/plugins/pull/1437): [firebase_crashlytics] Fix to Initialize Fabric
+*   [plugins#1096](https://github.com/flutter/plugins/pull/1096) :[firebase_database]Return error message from DatabaseError#toString()
+*   [plugins#1532](https://github.com/flutter/plugins/pull/1532): [firebase_messaging] remove obsolete docs instruction
+*   [plugins#1405](https://github.com/flutter/plugins/pull/1405): [firebase_messaging] Additional step for iOS
+*   [plugins#1353](https://github.com/flutter/plugins/pull/1353): [firebase_messaging] Update example
+*   [plugins#1223](https://github.com/flutter/plugins/pull/1223): [firebase_ml_vision] Fix crash when scanning URL QR-code on iOS
+*   [plugins#1514](https://github.com/flutter/plugins/pull/1514): [firebase_remote_config] Initial integration tests
+*   [plugins#815](https://github.com/flutter/plugins/pull/815): [google_maps_flutter] adds support for custom icon from a byte array (PNG)
+*   [plugins#1229](https://github.com/flutter/plugins/pull/1229): [google_maps_flutter] Marker APIs are now widget based (Android)
+*   [plugins#1421](https://github.com/flutter/plugins/pull/1421): [in_app_purchase]make payment unified APIs
+*   [plugins#1380](https://github.com/flutter/plugins/pull/1380): [in_app_purchase]load purchase
+*   [flutter#26329](https://github.com/flutter/flutter/issues/26329): IAP: Purchase an auto-renewing subscription
+*   [flutter#26331](https://github.com/flutter/flutter/issues/26331): IAP: Purchase a non-renewing subscription
+*   [flutter#26326](https://github.com/flutter/flutter/issues/26326): IAP: Load previous purchases
+*   [plugins#1249](https://github.com/flutter/plugins/pull/1249): [in_app_purchase] payment queue dart ios
+*   [flutter#26327](https://github.com/flutter/flutter/pull/26327): IAP: Purchase an unlock
+*   [flutter#26328](https://github.com/flutter/flutter/pull/26328): IAP: Purchase a consumable
+*   [flutter#29837](https://github.com/flutter/flutter/issues/29837): Image_picker flickers when barcode_scan and image_picker are used together
+*   [flutter#17950](https://github.com/flutter/flutter/issues/17950): Image_picker plugin fails, if Flutter activity is killed while native one is shown
+*   [flutter#18700](https://github.com/flutter/flutter/issues/18700): [image_picker] Crash on Galaxy S5 and Note 4 when attempting to use the camera
+*   [plugins#1372](https://github.com/flutter/plugins/pull/1372): [image_picker] fix "Cancel button not visible in gallery, if camera was accessed first"
+*   [plugins#1471](https://github.com/flutter/plugins/pull/1471): [image_picker] Fix invalid path being returned from Google Photos
+*   [flutter#29422](https://github.com/flutter/flutter/issues/29422): image_picker error:Permission Denial
+*   [plugins#1237](https://github.com/flutter/plugins/pull/1237): [share] Changed compileSdkVersion of share plugin to 28
+*   [plugins#1373](https://github.com/flutter/plugins/pull/1373): [shared_preferences] Add contains method
+*   [plugins#1470](https://github.com/flutter/plugins/pull/1470): [video_player] Android: Added missing event.put("event", "completed");
+*   [flutter#25329](https://github.com/flutter/flutter/pull/25329): [WebView] Allow the webview to take control when a URL is about to be loaded
+
+
+## Tool Changes
+
+Last but certainly not least, we made a number of tooling changes in the core Flutter repos to improve the developer experience, particularly when it comes to improving hot reload performance (and you thought it was fast before!).
+
+
+
+*   [flutter#29693](https://github.com/flutter/flutter/pull/29693): Use source list from the compiler to track invalidated files for hot reload.
+*   [flutter#28152](https://github.com/flutter/flutter/pull/28152): Improve hot reload performance
+*   [flutter#29494](https://github.com/flutter/flutter/pull/29494): initial work on coverage generating script for tool
+*   [flutter#31171](https://github.com/flutter/flutter/pull/31171): Allow disabling all fingerprint caches via environment variable
+*   [flutter#31073](https://github.com/flutter/flutter/pull/31073): Fuchsia step 1: add SDK version file and artifact download
+*   [flutter#31064](https://github.com/flutter/flutter/pull/31064): Add sorting to flutter version command
+*   [flutter#31063](https://github.com/flutter/flutter/pull/31063): Download and handle product version of flutter patched sdk
+*   [flutter#31074](https://github.com/flutter/flutter/pull/31074): make flutterProject option of CoverageCollector optional
+*   [flutter#30818](https://github.com/flutter/flutter/pull/30818): New flag to flutter drive to skip installing fresh app on device
+*   [flutter#30867](https://github.com/flutter/flutter/pull/30867): Add toggle for debugProfileWidgetBuilds
+*   [flutter#27034](https://github.com/flutter/flutter/pull/27034): Updated package template .gitignore file
+*   [flutter#30115](https://github.com/flutter/flutter/pull/30115): Forward missing pub commands
+*   [flutter#30254](https://github.com/flutter/flutter/pull/30254): Reland: Ensure that flutter run/drive/test/update_packages only downloads required artifacts
+*   [flutter#30153](https://github.com/flutter/flutter/pull/30153): Allow disabling experimental commands, devices on stable branch
+*   [flutter#30428](https://github.com/flutter/flutter/pull/30428): Update repair command for Arch Linux
+
+Further, the IDE plugins for Flutter have had a number of updates since the last stable release of Flutter.
+
+
+
+*   Visual Studio Code: [February 21, 2019 (2.23.1)](https://dartcode.org/releases/v2-23/)
+*   Visual Studio Code: [February 27, 2019 (2.24.0)](https://dartcode.org/releases/v2-24/)
+*   IntelliJ/Android Studio: [March 29, 2019 (M34)](https://groups.google.com/forum/#!msg/flutter-dev/-g7MlcL7u9s/VwZtnh-XAgAJ)
+*   Visual Studio Code: [April 17, 2019 (2.25.1)](https://dartcode.org/releases/v2-25/)
+*   IntelliJ/Android Studio: [April 26, 2019 (M35)](https://groups.google.com/forum/#!topic/flutter-dev/qZNjCI_2BLE)
+*   Visual Studio Code: [May 1, 2019 (2.26.1)](https://dartcode.org/releases/v2-26/ )
+
+
+## Dynamic Update (aka Code Push)
+
+As a final note, we’re nearly at the midpoint of the year, when it’s time to reassess the areas where we can have the most important, we've decided to drop plans for dynamic updates (aka code push) from our 2019 roadmap. If you’re interested in the reasons why, you can read [the detailed explanation](https://github.com/flutter/flutter/issues/14330#issuecomment-485565194). Dropping this work allows us to increase our focus on quality as well as our experiments in Flutter for web and Flutter for desktop.
+
+
+## Full Issue List
+
+You can see [the full list of PRs committed in this release](/docs/development/tools/sdk/release-notes/changelogs/changelog-1.5.4).

--- a/src/docs/development/tools/sdk/release-notes/release-notes-1.7.8.md
+++ b/src/docs/development/tools/sdk/release-notes/release-notes-1.7.8.md
@@ -1,0 +1,353 @@
+---
+title: Flutter 1.7.8 release notes
+short-title: 1.7.8 release notes
+description: Release notes for Flutter 1.7.8.
+---
+
+The 1.7.8 release is a follow-on to the 1.5.4 stable release in May, providing 1289 merged PRs and closing 184 issues. The major themes of this release are:
+
+*   Support for 32-bit and 64-bit bundles on Android
+*   Large number of iOS features and fixes, including improved text editing and localization
+*   [AndroidX support](https://github.com/flutter/flutter/pull/31028) for new projects via the --androidx flag of ‘flutter create’
+*   A new widget: the [RangeSlider](https://api.flutter.dev/flutter/material/RangeSlider-class.html)
+
+As detailed in our [roadmap](https://github.com/flutter/flutter/wiki/Roadmap), we're also continuing the ongoing work in the Flutter engine and framework to support turning on web and desktop targets; however, this is not yet ready for general usage.
+
+
+## Support for 32-bit and 64-bit Android Bundles
+
+From August 1st, 2019, Android apps that use native code and target Android 9 Pie will[ be required to provide a 64-bit version](https://android-developers.googleblog.com/2019/01/get-your-apps-ready-for-64-bit.html) in addition to the 32-bit version when publishing to the Google Play Store. Since all Flutter apps include native code, this requirement will affect new Flutter apps submitted to the store, as well as updates to existing Flutter apps. This does not affect existing app versions published to the store.
+
+This release includes support for building app bundles and APKs that support both 32-bit and 64-bit binaries, completing our work on [https://github.com/flutter/flutter/issues/31922](https://github.com/flutter/flutter/issues/31922). By using this release when building an Android application, your App Bundle or APK now supports both 32-bit and 64-bit CPU architectures by default.
+
+
+## Breaking Changes
+
+The following are the list of breaking changes in this release along with descriptions of each change and how to handle it in your Flutter code.
+
+*   [#29188](https://github.com/flutter/flutter/pull/29188) Fix 25807: implement move in sliver multibox widget
+*   [#29683](https://github.com/flutter/flutter/pull/29683) [Show/hide toolbar and handles based on device kind](https://groups.google.com/d/msgid/flutter-announce/CAAzQ467mb_7ZC4-djDeWLiYEmAH815-R5eums2cWmo2ND%3Dz%3DOw%40mail.gmail.com.)
+*   [#30040](https://github.com/flutter/flutter/pull/30040) Implement focus traversal for desktop platforms, shoehorn edition.
+*   [#30579](https://github.com/flutter/flutter/pull/30579) [PointerDownEvent and PointerMoveEvent default buttons to 1](https://groups.google.com/d/msgid/flutter-announce/9ed026a5-f6e3-438d-b4fd-303ae444323d%40googlegroups.com.)
+*   [#30874](https://github.com/flutter/flutter/pull/30874) Redo “Remove pressure customization from some pointer events”
+*   [#31227](https://github.com/flutter/flutter/pull/31227) [Adding CupertinoTabController](https://groups.google.com/d/msgid/flutter-announce/a1e7e4df-0310-4083-93b6-12ffd150dad0%40googlegroups.com.)
+*   [#31574](https://github.com/flutter/flutter/pull/31574) Improve RadioListTile Callback Behavior Consistency
+*   [#32059](https://github.com/flutter/flutter/pull/32059) fix issue 14014 read only text field
+*   [#32842](https://github.com/flutter/flutter/pull/32842) Allow “from” hero state to survive hero animation in a push transition
+*   [#33148](https://github.com/flutter/flutter/pull/33148) ExpandIcon Custom Colors
+*   [#33164](https://github.com/flutter/flutter/pull/33164) [remove Layer.replaceWith due to no usage and no tests](https://groups.google.com/d/msgid/flutter-announce/f9823aec-676a-41e9-a9ff-b6598c63b7fe%40googlegroups.com)
+*   [#33370](https://github.com/flutter/flutter/pull/33370) [Update FadeInImage to use new Image APIs]( https://groups.google.com/d/msgid/flutter-announce/CAA8mi4cGh6BVXS5u0g_7Kep6LOL6gO5htViMTgS%2BkMJ08oAjAQ%40mail.gmail.com.)
+*   [#34051](https://github.com/flutter/flutter/pull/34051) [Text inline widgets, TextSpan rework (#30069)” with improved backwards compatibility](https://groups.google.com/d/msgid/flutter-announce/CAN87bmyu29-ikjeSouVFNcpR7OEL95NPLnb7DN-F8bVLsnzkzQ%40mail.gmail.com.)
+*   [#34095](https://github.com/flutter/flutter/pull/34095) [Cupertino text edit to oltip, reworked](https://groups.google.com/d/msgid/flutter-announce/f7cc747a-c812-4bab-a97c-4adb4ce04084%40googlegroups.com.)
+*   [#34501](https://github.com/flutter/flutter/pull/34501) [Material] Fix TextDirection and selected thumb for RangeSliderThumbShape and RangeSliderValueIndicatorShape
+*   [#33946](https://github.com/flutter/flutter/pull/33946) Reland “Text inline widgets, TextSpan rework”
+
+
+## Severe Crash Changes
+
+We’ve also fixed several crashing issues in this release.
+
+*   [#31228](https://github.com/flutter/flutter/pull/31228) Fix ExpansionPanelList Duplicate Global Keys Exception
+*   [#31581](https://github.com/flutter/flutter/pull/31581) Fix Exception on Nested TabBarView disposal
+*   [#34460](https://github.com/flutter/flutter/pull/34460) Add back ability to override the local engine in Gradle
+
+
+## iOS
+
+We continue to focus heavily on the iOS support in Flutter, including enhanced text editing and localization in this release.
+
+*   [#29809](https://github.com/flutter/flutter/pull/29809) Fix text selection toolbar appearing under obstructions
+*   [#29824](https://github.com/flutter/flutter/pull/29824) Cupertino localization step 8: create a gen_cupertino_localizations and generate one for cupertino english and french
+*   [#29954](https://github.com/flutter/flutter/pull/29954) Cupertino localization step 9: add tests
+*   [#30129](https://github.com/flutter/flutter/pull/30129) Fix refresh control in the gallery demo, update comments
+*   [#30224](https://github.com/flutter/flutter/pull/30224) Cupertino localization step 10: update the flutter_localizations README
+*   [#31039](https://github.com/flutter/flutter/pull/31039) Fix bundle id on iOS launch using flutter run
+*   [#31308](https://github.com/flutter/flutter/pull/31308) Added font bold when isDefaultAction is true in CupertinoDialogAction
+*   [#31326](https://github.com/flutter/flutter/pull/31326) Add more shuffle cupertino icons
+*   [#31332](https://github.com/flutter/flutter/pull/31332) iOS selection handles are invisible
+*   [#31464](https://github.com/flutter/flutter/pull/31464) CupertinoPicker fidelity revision
+*   [#31623](https://github.com/flutter/flutter/pull/31623) fix edge swiping and dropping back at starting point
+*   [#31644](https://github.com/flutter/flutter/pull/31644) Cupertino localization step 12: push translation for all supported languages
+*   [#31687](https://github.com/flutter/flutter/pull/31687) Center iOS caret, remove constant offsets that do not scale
+*   [#31763](https://github.com/flutter/flutter/pull/31763) Fix ScrollbarPainter thumbExtent calculation and add padding
+*   [#31852](https://github.com/flutter/flutter/pull/31852) Text selection handles are sometimes not interactive
+*   [#32013](https://github.com/flutter/flutter/pull/32013) Cupertino Turkish Translation
+*   [#32086](https://github.com/flutter/flutter/pull/32086) Fix CupertinoSliverRefreshControl onRefresh callback
+*   [#32469](https://github.com/flutter/flutter/pull/32469) Let CupertinoNavigationBarBackButton take a custom onPressed
+*   [#32513](https://github.com/flutter/flutter/pull/32513) Cupertino localization step 12 try 2: push translation for all supported languages
+*   [#32620](https://github.com/flutter/flutter/pull/32620) Added ScrollController to TextField
+*   [#32823](https://github.com/flutter/flutter/pull/32823) Add enableInteractiveSelection to CupertinoTextField
+*   [#32974](https://github.com/flutter/flutter/pull/32974) Fix disabled CupertinoTextField style
+*   [#33450](https://github.com/flutter/flutter/pull/33450) Do not return null from IosProject.isSwift
+*   [#33624](https://github.com/flutter/flutter/pull/33624) CupertinoTabScaffold crash fix
+*   [#33634](https://github.com/flutter/flutter/pull/33634) Let there be scroll bars
+*   [#33653](https://github.com/flutter/flutter/pull/33653) Include advice about dispose in TextEditingController api
+*   [#33684](https://github.com/flutter/flutter/pull/33684) Disable CocoaPods input and output paths in Xcode build phase and adopt new Xcode build system
+*   [#33739](https://github.com/flutter/flutter/pull/33739) fixed cupertinoTextField placeholder textAlign
+*   [#33852](https://github.com/flutter/flutter/pull/33852) Disable CocoaPods input and output paths in Xcode build phase and adopt new Xcode build system
+*   [#34293](https://github.com/flutter/flutter/pull/34293) Change Xcode developmentRegion to ‘en’ and CFBundleDevelopmentRegion to DEVELOPMENT_LANGUAGE
+*   [#34964](https://github.com/flutter/flutter/pull/34964) CupertinoTextField.onTap
+
+
+## Android
+
+In this release, we’ve improved support for Android with new support for AndroidX from an external contributor (Thanks, [Josh](https://github.com/athornz)!) and supporting 64-bit and 32-bit APK bundles in compliance with [the Google Play Store’s updated policy](https://developer.android.com/distribute/best-practices/develop/64-bit).
+
+
+
+*   [#31028](https://github.com/flutter/flutter/pull/31028) Adds support for generating projects that use AndroidX support libraries
+*   [#31359](https://github.com/flutter/flutter/pull/31359) Remove support for building dynamic patches on Android
+*   [#31491](https://github.com/flutter/flutter/pull/31491) Allow adb stdout to contain the port number without failing
+*   [#31835](https://github.com/flutter/flutter/pull/31835) Cherry-pick ADB CrOS fix to beta
+*   [#32787](https://github.com/flutter/flutter/pull/32787) Support 32 and 64 bit
+*   [#33191](https://github.com/flutter/flutter/pull/33191) Remove colon from Gradle task name since it’s deprecated
+*   [#33611](https://github.com/flutter/flutter/pull/33611) Use Dart’s new direct ELF generator to package AOT blobs as shared libraries in Android APKs
+*   [#33696](https://github.com/flutter/flutter/pull/33696) Generate ELF shared libraries and allow multi-abi libs in APKs and App bundles
+*   [#33901](https://github.com/flutter/flutter/pull/33901) Respond to AndroidView focus events.
+*   [#33923](https://github.com/flutter/flutter/pull/33923) [flutter_tool] Track APK sha calculation time
+*   [#33951](https://github.com/flutter/flutter/pull/33951) Whitelist adb.exe heap corruption exit code.
+*   [#34066](https://github.com/flutter/flutter/pull/34066) Adds the androidX flag to a modules pubspec.yaml template so it is se…
+*   [#34123](https://github.com/flutter/flutter/pull/34123) Generate ELF shared libraries and allow multi-abi libs in APKs and App bundles
+
+
+## Material
+
+This release includes a number of improvements to existing Material components, including the DatePicker, SnackBar and TimePicker, as well as a new component: the [RangeSlider](https://api.flutter.dev/flutter/material/RangeSlider-class.html).
+
+
+
+*   [#30572](https://github.com/flutter/flutter/pull/30572) [Material] Adaptive Slider constructor
+*   [#30884](https://github.com/flutter/flutter/pull/30884) [Material] Update TabController to support dynamic Tabs
+*   [#31018](https://github.com/flutter/flutter/pull/31018) [Material] selected/unselected label styles + icon themes on BottomNavigationBar
+*   [#31025](https://github.com/flutter/flutter/pull/31025) added scrimColor property in Scaffold widget
+*   [#31275](https://github.com/flutter/flutter/pull/31275) Update SnackBar to allow for support of the new style from Material spec
+*   [#31295](https://github.com/flutter/flutter/pull/31295) Improve ThemeData.accentColor connection to secondary color
+*   [#31318](https://github.com/flutter/flutter/pull/31318) Add BottomSheetTheme to enable theming color, elevation, shape of BottomSheet
+*   [#31438](https://github.com/flutter/flutter/pull/31438) Implements focus handling and hover for Material buttons.
+*   [#31514](https://github.com/flutter/flutter/pull/31514) Date picker layout exceptions
+*   [#31566](https://github.com/flutter/flutter/pull/31566) TimePicker moves to minute mode after hour selection
+*   [#31662](https://github.com/flutter/flutter/pull/31662) added shape property to SliverAppBar
+*   [#31681](https://github.com/flutter/flutter/pull/31681) [Material] Create a themable Range Slider (continuous and discrete)
+*   [#31693](https://github.com/flutter/flutter/pull/31693) Adds a note to Radio’s/RadioListTile’s onChange
+*   [#31902](https://github.com/flutter/flutter/pull/31902) Updated primaryColor docs to refer to colorScheme properties
+*   [#31938](https://github.com/flutter/flutter/pull/31938) Update scrimDrawerColor with proper const format
+*   [#32053](https://github.com/flutter/flutter/pull/32053) Increase TimePicker touch targets
+*   [#32070](https://github.com/flutter/flutter/pull/32070) rename foreground and background to light and dark [#32527](https://github.com/flutter/flutter/pull/32527) Added ‘enabled’ property to the PopupMenuButton
+*   [#32726](https://github.com/flutter/flutter/pull/32726) Material should not prevent ScrollNotifications from bubbling upwards
+*   [#32904](https://github.com/flutter/flutter/pull/32904) Use reverseDuration on Tooltip and InkWell
+*   [#32911](https://github.com/flutter/flutter/pull/32911) Material Long Press Text Handle Flash
+*   [#33073](https://github.com/flutter/flutter/pull/33073) SliverAppBar shape property
+*   [#34869](https://github.com/flutter/flutter/pull/34869) [Material] Properly call onChangeStart and onChangeEnd in Range Slider
+*   [#32950](https://github.com/flutter/flutter/pull/32950) Material allows “select all” when not collapsed
+
+
+## Web
+
+The work on web functionality continues with merging of the code from flutter_web repo into the main flutter repo, providing a simpler developer experience for this pre-release technology. We’ve already [compiled many of the existing Flutter samples for web](https://flutter.github.io/samples/). Enjoy!
+
+
+
+*   [#32360](https://github.com/flutter/flutter/pull/32360) Allow flutter web to be compiled with flutter
+*   [#33197](https://github.com/flutter/flutter/pull/33197) Wire up hot restart and incremental rebuilds for web
+*   [#33406](https://github.com/flutter/flutter/pull/33406) Add web safe indirection to Platform.isPlatform getters
+*   [#33525](https://github.com/flutter/flutter/pull/33525) Add capability to flutter test –platform=chrome
+*   [#33533](https://github.com/flutter/flutter/pull/33533) Reland - Wire up hot restart and incremental rebuilds for web
+*   [#33629](https://github.com/flutter/flutter/pull/33629) Add real-er restart for web using webkit inspection protocol
+*   [#33859](https://github.com/flutter/flutter/pull/33859) Reland support flutter test on platform chrome
+*   [#33892](https://github.com/flutter/flutter/pull/33892) add benchmarks to track web size
+*   [#33956](https://github.com/flutter/flutter/pull/33956) Codegen an entrypoint for flutter web applications
+*   [#34018](https://github.com/flutter/flutter/pull/34018) Add flutter create for the web
+*   [#34084](https://github.com/flutter/flutter/pull/34084) make running on web spooky
+*   [#34112](https://github.com/flutter/flutter/pull/34112) Separate web and io implementations of network image
+*   [#34159](https://github.com/flutter/flutter/pull/34159) Use product define for flutter web and remove extra asset server
+*   [#34589](https://github.com/flutter/flutter/pull/34589) Remove most of the target logic for build web, cleanup rules
+*   [#34856](https://github.com/flutter/flutter/pull/34856) set device name to Chrome
+*   [#34885](https://github.com/flutter/flutter/pull/34885) Reland: rename web device
+
+
+## Desktop
+
+The experimental support for desktop in Flutter continues as well, with many improvements to the basics needed on desktop like hover, focus traversal, shortcuts, actions and even game controllers! We’ve also continued to simplify the developer experience, which you can read about [here](http://github.com/google/flutter-desktop-embedding). This is very early, but if you are trying desktop support in Flutter, please [log issues](https://github.com/google/flutter-desktop-embedding/issues) when you find them!
+
+
+
+*   [#30076](https://github.com/flutter/flutter/pull/30076) Implements FocusTraversalPolicy and DefaultFocusTraversal features.
+*   [#30339](https://github.com/flutter/flutter/pull/30339) Add buttons to gestures
+*   [#31329](https://github.com/flutter/flutter/pull/31329) Add Xcode build script for macOS target
+*   [#31515](https://github.com/flutter/flutter/pull/31515) Support local engine and asset sync for macOS
+*   [#31567](https://github.com/flutter/flutter/pull/31567) Remove need for build/name scripts on Linux desktop
+*   [#31631](https://github.com/flutter/flutter/pull/31631) Teach Linux to use local engine
+*   [#31699](https://github.com/flutter/flutter/pull/31699) Re-land: Add support for Tooltip hover
+*   [#31802](https://github.com/flutter/flutter/pull/31802) Reland “Fix text field selection toolbar under Opacity (#31097)”
+*   [#31819](https://github.com/flutter/flutter/pull/31819) Redo: Add buttons to gestures
+*   [#31873](https://github.com/flutter/flutter/pull/31873) Add basic desktop linux checks
+*   [#31935](https://github.com/flutter/flutter/pull/31935) Redo#2: Add buttons to gestures
+*   [#32025](https://github.com/flutter/flutter/pull/32025) Make Hover Listener respect transforms
+*   [#32142](https://github.com/flutter/flutter/pull/32142) Fix RenderPointerListener so that callbacks aren’t called at the wrong time.
+*   [#32335](https://github.com/flutter/flutter/pull/32335) Teach flutter msbuild for Windows
+*   [#32776](https://github.com/flutter/flutter/pull/32776) Text field focus and hover support.
+*   [#32838](https://github.com/flutter/flutter/pull/32838) Handles hidden by keyboard
+*   [#32914](https://github.com/flutter/flutter/pull/32914) Make hover and focus not respond when buttons and fields are disabled.
+*   [#33090](https://github.com/flutter/flutter/pull/33090) [Material] Add support for hovered, pressed, and focused text color on Buttons.
+*   [#33277](https://github.com/flutter/flutter/pull/33277) Implement macOS support in flutter doctor
+*   [#33279](https://github.com/flutter/flutter/pull/33279) Fix a problem in first focus determination.
+*   [#33298](https://github.com/flutter/flutter/pull/33298) Add actions and keyboard shortcut map support
+*   [#33443](https://github.com/flutter/flutter/pull/33443) Wrap Windows build invocation in a batch script
+*   [#33454](https://github.com/flutter/flutter/pull/33454) ensure unpack declares required artifacts
+*   [#33477](https://github.com/flutter/flutter/pull/33477) Fix onExit calling when the mouse is removed.
+*   [#33540](https://github.com/flutter/flutter/pull/33540) Pass local engine variables to Windows build
+*   [#33608](https://github.com/flutter/flutter/pull/33608) Restructure macOS project files
+*   [#33632](https://github.com/flutter/flutter/pull/33632) Update the keycodes from source
+*   [#33636](https://github.com/flutter/flutter/pull/33636) Implement plugin tooling support for macOS
+*   [#33695](https://github.com/flutter/flutter/pull/33695) Add pseudo-key synonyms for keys like shift, meta, alt, and control.
+*   [#33868](https://github.com/flutter/flutter/pull/33868) Game controller button support
+*   [#33872](https://github.com/flutter/flutter/pull/33872) Add ‘doctor’ support for Windows
+*   [#33874](https://github.com/flutter/flutter/pull/33874) Prevent windows web doctor from launching chrome
+*   [#34050](https://github.com/flutter/flutter/pull/34050) limit open files on macOS when copying assets
+*   [#34376](https://github.com/flutter/flutter/pull/34376) Add missing pieces for ‘driver’ support on macOS
+*   [#34755](https://github.com/flutter/flutter/pull/34755) Add linux doctor implementation
+
+
+## Animation, Scrolling & Images
+
+In this release, we continue to polish animations, scrolling and image support.
+
+
+
+*   [#21896](https://github.com/flutter/flutter/pull/21896) Bottom sheet scrolling
+*   [#28834](https://github.com/flutter/flutter/pull/28834) Sliver animated list [#29677](https://github.com/flutter/flutter/pull/29677) Fix calculation of hero rectTween when Navigator isn’t fullscreen
+*   [#32730](https://github.com/flutter/flutter/pull/32730) Add reverseDuration to AnimationController
+*   [#32843](https://github.com/flutter/flutter/pull/32843) Added a missing dispose of an AnimationController that was leaking a ticker.
+*   [#31832](https://github.com/flutter/flutter/pull/31832) Allow DSS to be dragged when its children do not fill extent
+*   [#33627](https://github.com/flutter/flutter/pull/33627) SliverFillRemaining flag for different use cases
+*   [#32853](https://github.com/flutter/flutter/pull/32853) Add onBytesReceived callback to consolidateHttpClientResponseBytes()
+*   [#32857](https://github.com/flutter/flutter/pull/32857) Add debugNetworkImageHttpClientProvider
+*   [#32936](https://github.com/flutter/flutter/pull/32936) Add some sanity to the ImageStream listener API
+*   [#33729](https://github.com/flutter/flutter/pull/33729) Update consolidateHttpClientResponseBytes() to use compressionState
+*   [#33369](https://github.com/flutter/flutter/pull/33369) Add loading support to Image
+
+
+## Typography & Accessibility
+
+We’re also continuing to push towards excellent typography and accessibility, including support for accessing OpenType font-specific features, as demonstrated in [this sample](https://github.com/timsneath/typography).
+
+
+
+*   [#31987](https://github.com/flutter/flutter/pull/31987) Text wrap width
+*   [#33230](https://github.com/flutter/flutter/pull/33230) Framework support for font features in text styles
+*   [#33808](https://github.com/flutter/flutter/pull/33808) fix ExpansionPanelList merge the header semantics when it is not necessary
+*   [#34368](https://github.com/flutter/flutter/pull/34368) Fix semantics_tester
+*   [#34434](https://github.com/flutter/flutter/pull/34434) Semantics fixes
+
+
+## Fundamentals
+
+As always, we continue to polish the fundamentals.
+
+
+
+*   [#30388](https://github.com/flutter/flutter/pull/30388) Add hintStyle in SearchDelegate
+*   [#30406](https://github.com/flutter/flutter/pull/30406) Add binaryMessenger constructor argument to platform channels
+*   [#30612](https://github.com/flutter/flutter/pull/30612) Added required parameters to FlexibleSpaceBarSettings
+*   [#30796](https://github.com/flutter/flutter/pull/30796) Unbounded TextField width error
+*   [#30942](https://github.com/flutter/flutter/pull/30942) rectMoreOrLess equals, prep for 64bit rects
+*   [#31282](https://github.com/flutter/flutter/pull/31282) Stop precaching the artifacts for dynamic mode.
+*   [#31485](https://github.com/flutter/flutter/pull/31485) Prevent exception being thrown on hasScrolledBody
+*   [#31520](https://github.com/flutter/flutter/pull/31520) Don’t add empty OpacityLayer to the engine
+*   [#31526](https://github.com/flutter/flutter/pull/31526) replace no-op log reader with real implementation
+*   [#31757](https://github.com/flutter/flutter/pull/31757) Make FlutterProject factories synchronous
+*   [#31807](https://github.com/flutter/flutter/pull/31807) Make const available for classes that override AssetBundle
+*   [#31825](https://github.com/flutter/flutter/pull/31825) Fix missing return statements on function literals
+*   [#31861](https://github.com/flutter/flutter/pull/31861) Add Horizontal Padding to Constrained Chip Label Calculations
+*   [#31868](https://github.com/flutter/flutter/pull/31868) Handle notification errors
+*   [#31889](https://github.com/flutter/flutter/pull/31889) Start abstracting platform logic builds behind a shared interface
+*   [#32126](https://github.com/flutter/flutter/pull/32126) Bump multicast_dns version
+*   [#32192](https://github.com/flutter/flutter/pull/32192) Transform PointerEvents to the local coordinate system of the event receiver
+*   [#32328](https://github.com/flutter/flutter/pull/32328) Add breadcrumbs to TextOverflow
+*   [#32434](https://github.com/flutter/flutter/pull/32434) Support for replacing the TabController, after disposing the old one
+*   [#32528](https://github.com/flutter/flutter/pull/32528) Tapping a modal bottom sheet should not dismiss it by default
+*   [#33152](https://github.com/flutter/flutter/pull/33152) ModalRoute resumes previous focus on didPopNext
+*   [#33297](https://github.com/flutter/flutter/pull/33297) Instrument add to app flows
+*   [#33458](https://github.com/flutter/flutter/pull/33458) Add to app measurement
+*   [#33462](https://github.com/flutter/flutter/pull/33462) Fix text scaling of strut style
+*   [#33473](https://github.com/flutter/flutter/pull/33473) fix 23723 rounding error
+*   [#33474](https://github.com/flutter/flutter/pull/33474) Fixed for DropdownButton crashing when a style was used that didn’t include a fontSize
+*   [#33475](https://github.com/flutter/flutter/pull/33475) Move declaration of semantic handlers from detectors to recognizers
+*   [#33488](https://github.com/flutter/flutter/pull/33488) use toFixedAsString and DoubleProperty in diagnosticProperties
+*   [#33802](https://github.com/flutter/flutter/pull/33802) Double double tap toggles instead of error
+*   [#33876](https://github.com/flutter/flutter/pull/33876) Reland “Framework support for font features in text styles”
+*   [#33886](https://github.com/flutter/flutter/pull/33886) Add currentSystemFrameTimeStamp to SchedulerBinding
+*   [#33955](https://github.com/flutter/flutter/pull/33955) Add localFocalPoint to ScaleDetector
+*   [#33999](https://github.com/flutter/flutter/pull/33999) Updating MediaQuery with viewPadding
+*   [#34055](https://github.com/flutter/flutter/pull/34055) Toggle toolbar exception fix
+*   [#34057](https://github.com/flutter/flutter/pull/34057) Add endIndent property to Divider and VerticalDivider
+*   [#34068](https://github.com/flutter/flutter/pull/34068) fix empty selection arrow when double clicked on empty read only text…
+*   [#34081](https://github.com/flutter/flutter/pull/34081) Report async callback errors that currently go unreported.
+*   [#34175](https://github.com/flutter/flutter/pull/34175) Don’t show scrollbar if there isn’t enough content
+*   [#34243](https://github.com/flutter/flutter/pull/34243) update the Flutter.Frame event to use new engine APIs
+*   [#34295](https://github.com/flutter/flutter/pull/34295) Prepare for Uint8List SDK breaking changes
+*   [#34298](https://github.com/flutter/flutter/pull/34298) Preserving SafeArea : Part 2
+*   [#34355](https://github.com/flutter/flutter/pull/34355) Text field vertical align
+*   [#34365](https://github.com/flutter/flutter/pull/34365) redux of a change to use new engine APIs for Flutter.Frame events
+*   [#34508](https://github.com/flutter/flutter/pull/34508) add route information to Flutter.Navigation events
+*   [#34512](https://github.com/flutter/flutter/pull/34512) Make sure fab semantics end up on top
+*   [#34515](https://github.com/flutter/flutter/pull/34515) OutlineInputBorder adjusts for borderRadius that is too large
+*   [#34519](https://github.com/flutter/flutter/pull/34519) fix page scroll position rounding error
+*   [#34526](https://github.com/flutter/flutter/pull/34526) retry on HttpException during cache download
+*   [#34529](https://github.com/flutter/flutter/pull/34529) Remove compilation trace and dynamic support code
+*   [#34573](https://github.com/flutter/flutter/pull/34573) Ensures flutter jar is added to all build types on plugin projects
+*   [#34587](https://github.com/flutter/flutter/pull/34587) Do not copy paths, rects, and rrects when layer offset is zero
+*   [#34932](https://github.com/flutter/flutter/pull/34932) Added onChanged property to TextFormField
+*   [#35092](https://github.com/flutter/flutter/pull/35092) Add FlutterProjectFactory so that it can be overridden internally.
+*   [#33272](https://github.com/flutter/flutter/pull/33272) Add mustRunAfter on mergeAssets task to force task ordering
+*   [#33535](https://github.com/flutter/flutter/pull/33535) Custom height parameters for DataTable header and data rows
+*   [#33628](https://github.com/flutter/flutter/pull/33628) DataTable Custom Horizontal Padding
+
+
+## Tooling
+
+Last but not least, we continue to polish and simplify our tooling as well, including providing a much clearer error message when the flutter tooling finds itself in a read-only directory (a common problem for Flutter developers that we’re hoping this helps address).
+
+
+
+*   [#31342](https://github.com/flutter/flutter/pull/31342) check if project exists before regenerating platform specific tooling
+*   [#31399](https://github.com/flutter/flutter/pull/31399) add ignorable track-widget-creation flag to build aot
+*   [#31406](https://github.com/flutter/flutter/pull/31406) if there is no .ios or ios sub-project, don’t attempt building for iOS
+*   [#31446](https://github.com/flutter/flutter/pull/31446) Allow filtering devices to only those supported by current project
+*   [#31591](https://github.com/flutter/flutter/pull/31591) make sure we exit early if the Runner.xcodeproj file is missing
+*   [#31804](https://github.com/flutter/flutter/pull/31804) only build asset when there is asset declared in pubspec
+*   [#31812](https://github.com/flutter/flutter/pull/31812) Fix #31764: Show appropriate error message when fonts pubspec.yaml isn’t iterable
+*   [#32072](https://github.com/flutter/flutter/pull/32072) don’t NPE with empty pubspec
+*   [#33041](https://github.com/flutter/flutter/pull/33041) Rename flutter packages to flutter pub
+*   [#33448](https://github.com/flutter/flutter/pull/33448) Use vswhere to find Visual Studio
+*   [#33472](https://github.com/flutter/flutter/pull/33472) add daemon command to enumerate supported platforms
+*   [#33924](https://github.com/flutter/flutter/pull/33924) Added –dart-flags option to flutter run
+*   [#33980](https://github.com/flutter/flutter/pull/33980) Increase daemon protocol version for getSupportedPlatforms
+*   [#33990](https://github.com/flutter/flutter/pull/33990) Add device category for daemon
+*   [#34181](https://github.com/flutter/flutter/pull/34181) Reland “Added –dart-flags option to flutter run (#33924)”
+*   [#34291](https://github.com/flutter/flutter/pull/34291) Check whether FLUTTER_ROOT and FLUTTER_ROOT/bin are writable.
+*   [#34353](https://github.com/flutter/flutter/pull/34353) Refactor Gradle plugin
+*   [#34517](https://github.com/flutter/flutter/pull/34517) pass .packages path to snapshot invocation
+*   [#34527](https://github.com/flutter/flutter/pull/34527) Don’t crash on invalid .packages file
+*   [#34606](https://github.com/flutter/flutter/pull/34606) Remove portions of the Gradle script related to dynamic patching
+*   [#34616](https://github.com/flutter/flutter/pull/34616) Kill compiler process when test does not exit cleanly
+*   [#34624](https://github.com/flutter/flutter/pull/34624) Break down flutter doctor validations and results
+*   [#34683](https://github.com/flutter/flutter/pull/34683) add read only semantics flag
+*   [#34684](https://github.com/flutter/flutter/pull/34684) Add more structure to errors.
+*   [#34685](https://github.com/flutter/flutter/pull/34685) Close platform when tests are complete (dispose compiler and delete font files)
+*   [#34725](https://github.com/flutter/flutter/pull/34725) Fix NPE in flutter tools
+*   [#34736](https://github.com/flutter/flutter/pull/34736) Remove flags related to dynamic patching
+*   [#34785](https://github.com/flutter/flutter/pull/34785) Tweak the display name of emulators
+*   [#34794](https://github.com/flutter/flutter/pull/34794) Add emulatorID field to devices in daemon
+*   [#34802](https://github.com/flutter/flutter/pull/34802) Prefer ephemeral devices from command line run
+*   [#34859](https://github.com/flutter/flutter/pull/34859) Fix Vertical Alignment Regression
+*   [#35074](https://github.com/flutter/flutter/pull/35074) Attempt to enable tool coverage redux
+*   [#35084](https://github.com/flutter/flutter/pull/35084) Move findTargetDevices to DeviceManager
+*   [#33284](https://github.com/flutter/flutter/pull/33284) make sure we build test targets too
+*   [#33867](https://github.com/flutter/flutter/pull/33867) Remove environment variable guards for command line desktop and web
+*   [#33283](https://github.com/flutter/flutter/pull/33283) Fix relative paths and snapshot logic in tool
+
+
+## Full Issue List
+
+You can see the full list of issues addressed in this release [here](/docs/development/tools/sdk/release-notes/changelogs/changelog-1.7.8).

--- a/src/docs/development/tools/sdk/release-notes/release-notes-1.9.1.md
+++ b/src/docs/development/tools/sdk/release-notes/release-notes-1.9.1.md
@@ -1,0 +1,1242 @@
+---
+title: Flutter 1.9.1 release notes
+short-title: 1.9.1 release notes
+description: Release notes for Flutter 1.9.1.
+---
+
+Hello and welcome to another stable release of Flutter. So far this year, we’ve been right on target with one stable release each quarter, as per [our plan](https://github.com/flutter/flutter/wiki/Flutter-build-release-channels) (well, less of a plan and more of a goal, but still, it’s been working out pretty well so far…). This release is our biggest yet, with 620 Pull Requests merged from 116 contributors. As always, the interesting PRs are listed below. And there are lots of interesting things to discuss in this release, including:
+
+*   One regression fixed but also one added
+*   Some breaking API changes
+*   Some severe issues caught and fixed
+*   Support for macOS Catalina and iOS 13
+*   A number of new features
+*   And more!
+
+And to be clear, when I say “we,” I mean the Flutter community as a whole. The Flutter team couldn’t possibly continue to scale as we have without all of our contributors, no matter who your employer is. Thanks everyone for your contributions!
+
+
+## Regressions
+
+In this release, we fixed one regression ([37955](https://github.com/flutter/flutter/pull/37955) Update shader warm-up for recent Skia changes) and caused another ([38167](https://github.com/dart-lang/sdk/issues/38167) Incremental compiler re-issuing of errors from constant evaluator). The new regression is fixed after the 1.9.1 stable release ([00d14e7](https://github.com/dart-lang/sdk/commit/00d14e7) [CFE] Always start constant evaluation error where we are asked to evaluate), so if you’re seeing it, you can choose a more recent build to bring it into your Flutter apps.
+
+
+## Breaking API Changes
+
+We try hard not to make breaking changes, but we also don’t want to create unintuitive APIs as we move Flutter forward to new scenarios and new platforms. These are the breaking changes in this release. Please see the associated announcements so you can move your code forward.
+
+[33281](https://github.com/flutter/flutter/pull/33281) ([announcement](https://groups.google.com/forum/#!msg/flutter-announce/ZmnseDOW9Wc/5K7xD0V8BwAJ)) Update TextStyle and StrutStyle height docs
+
+[34019](https://github.com/flutter/flutter/pull/34019) ([announcement](https://groups.google.com/forum/#!searchin/flutter-announce/34019%7Csort:date/flutter-announce/GBFULLQxGp4/-3uujTAaCgAJ)) Selectable Text
+
+[34665](https://github.com/flutter/flutter/pull/34665) ([announcement](https://groups.google.com/forum/#!searchin/flutter-announce/34665%7Csort:date/flutter-announce/W9KQKpf0Ves/6bdDq_U8CQAJ)) Selection handles position is off
+
+[35110](https://github.com/flutter/flutter/pull/35110) ([announcement](https://groups.google.com/forum/#!searchin/flutter-announce/35110%7Csort:date/flutter-announce/FHicLlzr9gQ/OM9KgLxMBwAJ)) Always test semantics
+
+[35136](https://github.com/flutter/flutter/pull/35136) ([announcement](https://groups.google.com/forum/#!searchin/flutter-announce/35136%7Csort:date/flutter-announce/UrhJwkaKaSc/ONoMzKrtAwAJ)) Update Dark Theme disabledColor to White38
+
+[35785](https://github.com/flutter/flutter/pull/35785) ([announcement](https://groups.google.com/forum/#!searchin/flutter-announce/35785%7Csort:date/flutter-announce/AL5ure2NWNI/4gPoziQSBAAJ)) Remove reverseDuration from implicitly animated widgets, since it’s ignored.
+
+[36030](https://github.com/flutter/flutter/pull/36030) ([announcement](https://groups.google.com/forum/#!searchin/flutter-announce/36030%7Csort:date/flutter-announce/bN6vFnoVpmk/7UCOxj6LCwAJ)) [Material] Implement TooltipTheme and Tooltip.textStyle, fix Tooltip debugLabel, update Tooltip defaults
+
+[36106](https://github.com/flutter/flutter/pull/36106) ([announcement](https://groups.google.com/forum/#!searchin/flutter-announce/36106%7Csort:date/flutter-announce/Yo3WxDCria4/AgNUznoZBgAJ)) Updated ColorScheme.dark() colors to match the Material Dark theme specification
+
+[36217](https://github.com/flutter/flutter/pull/36217) ([announcement](https://groups.google.com/forum/#!searchin/flutter-announce/36217%7Csort:date/flutter-announce/3vyI_41YX44/yQy0MHAuBgAJ)) Split Mouse from Listener
+
+[36402](https://github.com/flutter/flutter/pull/36402) ([announcement](https://groups.google.com/forum/#!searchin/flutter-announce/36402%7Csort:date/flutter-announce/taTeI07sK0w/-fsJvpfCFQAJ)) Teach render objects to reuse engine layers
+
+[36856](https://github.com/flutter/flutter/pull/36856) (no announcement) [Material] Implement TooltipTheme and Tooltip.textStyle, update Tooltip defaults
+
+[36964](https://github.com/flutter/flutter/pull/36964) ([announcement](https://groups.google.com/forum/#!searchin/flutter-announce/36964%7Csort:date/flutter-announce/IALsYuwhzNk/OaP1ijOhCwAJ)) Interactive size const
+
+[37338](https://github.com/flutter/flutter/pull/37338) ([announcement](https://groups.google.com/forum/#!searchin/flutter-announce/37338%7Csort:date/flutter-announce/ZNX-Rd6IKSQ/3K4-1_skDAAJ)) Update constructor APIs TooltipTheme, ToggleButtonsTheme, PopupMenuTheme
+
+[37341](https://github.com/flutter/flutter/pull/37341) (no announcement) hiding original hero after hero transition
+
+[37544](https://github.com/flutter/flutter/pull/37544) ([announcement](https://groups.google.com/forum/#!searchin/flutter-announce/37544%7Csort:date/flutter-announce/Igg0DuIO6Zg/2QroNaSkDAAJ)) Replace ButtonBar.bar method with ButtonBarTheme
+
+[37652](https://github.com/flutter/flutter/pull/37652) ([announcement](https://groups.google.com/forum/#!searchin/flutter-announce/37652%7Csort:date/flutter-announce/bTliCEss-VA/CfqN9DCWEwAJ)) Change RenderObject.getTransformTo to include ancestor.
+
+[37736](https://github.com/flutter/flutter/pull/37736) ([announcement](https://groups.google.com/forum/#!searchin/flutter-announce/37736%7Csort:date/flutter-announce/-kotruZbBDQ/vny4JjFmFQAJ)) Added a composable waitForCondition Driver/extension API
+
+
+## Severe: Crash, Customer Critical and Performance Fixes
+
+In Flutter, we try to add a little bit of quality to every release. This time around, we fixed several severe issues, including crashes, customer critical issues and performance issues.
+
+[34907](https://github.com/flutter/flutter/pull/34907) Fixed LicensePage to close page before loaded the License causes an error
+
+[35223](https://github.com/flutter/flutter/pull/35223) Navigator pushAndRemoveUntil Fix
+
+[36097](https://github.com/flutter/flutter/pull/36097) Fix nested scroll view can rebuild without layout
+
+[37033](https://github.com/flutter/flutter/pull/37033) fix debug paint crash when axis direction inverted
+
+[37254](https://github.com/flutter/flutter/pull/37254) Clamp Scaffold's max body height when extendBody is true
+
+[34298](https://github.com/flutter/flutter/pull/34298) Preserving SafeArea : Part 2
+
+[37718](https://github.com/flutter/flutter/pull/37718) Adding physicalDepth to MediaQueryData & TestWindow
+
+[35297](https://github.com/flutter/flutter/pull/35297) Fix the first frame logic in tracing and driver
+
+
+## New Features
+
+This release also brings with it two new Material widgets: the ToggleButtons widget (called a [segmented control](https://developer.apple.com/design/human-interface-guidelines/ios/controls/segmented-controls/) on iOS) and a ColorFilter widget (described below in the Text & Accessibility section). To see these widgets in action, check out short [ToggleButtons ](https://github.com/csells/flutter_toggle_buttons)and [ColorFilter](https://github.com/csells/flutter_color_filter) samples. Also, the SelectableText widget allows the user to select read-only text.
+
+[34599](https://github.com/flutter/flutter/pull/34599) [Material] ToggleButtons
+
+[34019](https://github.com/flutter/flutter/pull/34019) Selectable Text
+
+[35207](https://github.com/flutter/flutter/pull/35207) refactor out selection handlers
+
+[36030](https://github.com/flutter/flutter/pull/36030) [Material] Implement TooltipTheme and Tooltip.textStyle, fix Tooltip debugLabel, update Tooltip defaults
+
+[36411](https://github.com/flutter/flutter/pull/36411) Implement InputDecorationTheme copyWith, ==, hashCode
+
+[36856](https://github.com/flutter/flutter/pull/36856) [Material] Implement TooltipTheme and Tooltip.textStyle, update Tooltip defaults
+
+[36963](https://github.com/flutter/flutter/pull/36963) Add margins to tooltips
+
+[37266](https://github.com/flutter/flutter/pull/37266) Change the value of kMaxUnsignedSMI for the Web
+
+[37341](https://github.com/flutter/flutter/pull/37341) hiding original hero after hero transition
+
+[37492](https://github.com/flutter/flutter/pull/37492) Drawer edge drag width improvements
+
+
+## macOS Catalina Support
+
+With the release of macOS Catalina just around the corner, we’ve made sure that our tooling continues to work smoothly as you migrate to Catalina, iOS 13 and Xcode 11. I should note that **you’ll want to upgrade to the Flutter 1.9.1 stable release before upgrading to Catalina**. The other order works, too, but you’ll see an error when you do it that way (the [error](https://github.com/flutter/flutter/issues/33890) is benign, but still…). 
+
+[38325](https://github.com/flutter/flutter/pull/38325) refactor flutter upgrade to be 2 part, with the second part re-entrant
+
+[cd70b](https://github.com/dart-lang/sdk/commit/ec2d06d4b9f4f0accad2b4aa841499e8e93cd70b) Use MAP_JIT when doing an mmap for executable pages (needed for macOS Catalina).
+
+[38662](https://github.com/flutter/flutter/pull/38662) Change from using defaults to plutil for Plist parsing
+
+[2856](https://github.com/flutter/website/issues/2856) Update "Getting Started" path setup to support zsh shell (macOS Catalina support)
+
+[2857](https://github.com/flutter/website/issues/2857) Update "iOS Setup" page to reflect Xcode 11 UI update
+
+[37733](https://github.com/flutter/flutter/pull/37733) Support macOS Catalina-style signing certificate names
+
+[10010](https://github.com/flutter/engine/pull/10010) Use simarm_x64 when targeting arm
+
+[37407](https://github.com/flutter/flutter/pull/37407) Remove multi-arch check in iOS builds
+
+[37445](https://github.com/flutter/flutter/pull/37445) Switch iOS gen_snapshot from multi-arch binary to multiple binaries
+
+[37647](https://github.com/flutter/flutter/pull/37647) Change priority of gen_snapshot search paths
+
+
+## iOS
+
+With over 50 PRs in this release, iOS support continues to be a big focus for Flutter, including an iOS 13 scrollbar implementation (that includes long-press, drag-from-right and vibration feedback support), an update to the CupertinoSwitch widget to match iOS 13 and continued experimentation with bitcode.
+
+[35829](https://github.com/flutter/flutter/pull/35829) iOS 13 scrollbar
+
+[37724](https://github.com/flutter/flutter/pull/37724) iOS 13 scrollbar vibration
+
+[36087](https://github.com/flutter/flutter/pull/36087) Update visual style of CupertinoSwitch to match iOS 13
+
+[38587](https://github.com/flutter/flutter/pull/38587) Improve bitcode check
+
+[36471](https://github.com/flutter/flutter/pull/36471) Enable bitcode compilation for AOT
+
+[36093](https://github.com/flutter/flutter/pull/36093) Reland bundle ios deps
+
+[34676](https://github.com/flutter/flutter/pull/34676) Enable selection by default for password text field and expose api to…
+
+[34723](https://github.com/flutter/flutter/pull/34723) CupertinoTextField vertical alignment
+
+[34964](https://github.com/flutter/flutter/pull/34964) CupertinoTextField.onTap
+
+[35303](https://github.com/flutter/flutter/pull/35303) fix default artifacts to exclude ios and android
+
+[35307](https://github.com/flutter/flutter/pull/35307) Clean up host_app_ephemeral Profile build settings
+
+[35731](https://github.com/flutter/flutter/pull/35731) Keep LLDB connection to iOS device alive while running from CLI.
+
+[35749](https://github.com/flutter/flutter/pull/35749) add iOS build benchmarks
+
+[35756](https://github.com/flutter/flutter/pull/35756) Remove @objc inference build setting
+
+[35763](https://github.com/flutter/flutter/pull/35763) UIApplicationLaunchOptionsKey -> UIApplication.LaunchOptionsKey
+
+[35833](https://github.com/flutter/flutter/pull/35833) Disable CocoaPods input and output paths in Xcode build phase for ephemeral add-to-app project
+
+[36174](https://github.com/flutter/flutter/pull/36174) [cupertino_icons] Add glyph refs for brightness #16102
+
+[36194](https://github.com/flutter/flutter/pull/36194) Keep LLDB connection to iOS device alive while running from CLI.
+
+[36498](https://github.com/flutter/flutter/pull/36498) Clean up host_app_ephemeral_cocoapods Profile build settings
+
+[36793](https://github.com/flutter/flutter/pull/36793) Vend Flutter module App.framework as a local CocoaPod pod to be installed by a host app
+
+[36887](https://github.com/flutter/flutter/pull/36887) Fix thumb size calculation
+
+[37026](https://github.com/flutter/flutter/pull/37026) Add support for the Kannada (kn) locale
+
+[37048](https://github.com/flutter/flutter/pull/37048) use SizedBox instead of Container for building collapsed selection
+
+[37276](https://github.com/flutter/flutter/pull/37276) Make podhelper.rb a template to avoid passing in the module name
+
+[37319](https://github.com/flutter/flutter/pull/37319) resizeToAvoidBottomInset Cupertino without NavBar
+
+[37449](https://github.com/flutter/flutter/pull/37449) If xcode_backend.sh script fails or substitute variables are missing, fail the host Xcode build
+
+[37738](https://github.com/flutter/flutter/pull/37738) Use relative paths when installing module pods
+
+[37809](https://github.com/flutter/flutter/pull/37809) Add autofocus parameter to widgets which use Focus widget internally
+
+[37906](https://github.com/flutter/flutter/pull/37906) Always install the ephemeral engine copy instead of fetching from CocoaPods specs
+
+[38593](https://github.com/flutter/flutter/pull/38593) Fix text scale factor for non-content components of Cupertino scaffolds
+
+[38629](https://github.com/flutter/flutter/pull/38629) Handle case of a connected unpaired iOS device
+
+[38645](https://github.com/flutter/flutter/pull/38645) Rename iOS arch for macOS release mode (macOS release mode 2 of 3)
+
+[9075](https://github.com/flutter/engine/pull/9075) IOS Platform view transform/clipping
+
+[9464](https://github.com/flutter/engine/pull/9464) Added shebangs to ios unit test scripts.
+
+[9478](https://github.com/flutter/engine/pull/9478) iOS PlatformView clip path
+
+[9491](https://github.com/flutter/engine/pull/9491) Purge caches on low memory on iOS
+
+[9636](https://github.com/flutter/engine/pull/9636) Added shebangs to ios unit test scripts. (#9464)
+
+[9667](https://github.com/flutter/engine/pull/9667) iOS platform view opacity
+
+[9722](https://github.com/flutter/engine/pull/9722) Forwards iOS dark mode trait to the Flutter framework (#34441).
+
+[9819](https://github.com/flutter/engine/pull/9819) Allow for dynamic thread merging on IOS for embedded view mutations
+
+[9952](https://github.com/flutter/engine/pull/9952) ios: Fixed the callback for the first frame so that it isn't predicated on having a splash screen.
+
+[10186](https://github.com/flutter/engine/pull/10186) Ensure debug-mode apps are always attached on iOS.
+
+[10381](https://github.com/flutter/engine/pull/10381) Fix empty composing range on iOS
+
+[10386](https://github.com/flutter/engine/pull/10386) Don't use DBC for hot-reload on iOS.
+
+[10645](https://github.com/flutter/engine/pull/10645) Don't use DBC for hot-reload on iOS.
+
+[10656](https://github.com/flutter/engine/pull/10656) fix iOS keyboard crash : -[__NSCFString substringWithRange:], range o…
+
+[10662](https://github.com/flutter/engine/pull/10662) bump local podspec's ios deployment target version from 7.0 to 8.0
+
+[10777](https://github.com/flutter/engine/pull/10777) Manually roll Skia to pull in iOS armv7 build failure fix.
+
+[10791](https://github.com/flutter/engine/pull/10791) Re-lands platform brightness support on iOS
+
+[10820](https://github.com/flutter/engine/pull/10820) iOS JIT support and enhancements for scenarios app
+
+[10949](https://github.com/flutter/engine/pull/10949) Fix iOS references to PostPrerollResult
+
+[11006](https://github.com/flutter/engine/pull/11006) On iOS report the preferred frames per second to tools via service protocol.
+
+
+## Android
+
+The biggest addition to Android this release is support for a new flutter command: ‘flutter build aar’. This new build command works just like ‘flutter build apk’ or ‘flutter build appbundle’, but for plugins and module projects. By building the plugins as [AARs](https://developer.android.com/studio/projects/android-library), the Android Gradle plugin can use Jetifier to translate support libraries into AndroidX libraries for all the plugin's native code, which reduces the error rate when using AndroidX in apps.
+
+[35217](https://github.com/flutter/flutter/pull/35217) Add flutter build aar
+
+[36732](https://github.com/flutter/flutter/pull/36732) Flutter build aar
+
+[10778](https://github.com/flutter/engine/pull/10778) Build JARs containing the Android embedding sources and the engine native library
+
+[34573](https://github.com/flutter/flutter/pull/34573) Ensures flutter jar is added to all build types on plugin projects
+
+[36695](https://github.com/flutter/flutter/pull/36695) Android visible password input type support
+
+[36805](https://github.com/flutter/flutter/pull/36805) Allow flavors and custom build types in host app
+
+[37194](https://github.com/flutter/flutter/pull/37194) [flutter_tool] More gracefully handle Android sdkmanager failure
+
+[37405](https://github.com/flutter/flutter/pull/37405) Add .android/Flutter/flutter.iml to module template.
+
+[37752](https://github.com/flutter/flutter/pull/37752) Remove dead flag gradle-dir in flutter config
+
+[9206](https://github.com/flutter/engine/pull/9206) Android Embedding Refactor PR31: Integrate platform views with the new embedding and the plugin shim.
+
+[9360](https://github.com/flutter/engine/pull/9360) Simplify loading of app bundles on Android
+
+[9476](https://github.com/flutter/engine/pull/9476) fix NPE when a touch event is sent to an unknown Android platform view
+
+[9501](https://github.com/flutter/engine/pull/9501) [android] External textures must be rescaled to fill the canvas
+
+[9525](https://github.com/flutter/engine/pull/9525) Android Embedding Refactor PR36: Add splash screen support.
+
+[9895](https://github.com/flutter/engine/pull/9895) Android Embedding PR37: Separated FlutterActivity and FlutterFragment via FlutterActivityAndFragmentDelegate
+
+[9999](https://github.com/flutter/engine/pull/9999) Add support for Android's visible password input type
+
+[10250](https://github.com/flutter/engine/pull/10250) Android Embedding Refactor 38: Removed AssetManager from DartEntrypoint.
+
+[10413](https://github.com/flutter/engine/pull/10413) Pass Android Q insets.systemGestureInsets to Window
+
+[10424](https://github.com/flutter/engine/pull/10424) Fix deprecation warnings in the Android embedding
+
+[10481](https://github.com/flutter/engine/pull/10481) Android embedding refactor pr40 add static engine cache
+
+[10771](https://github.com/flutter/engine/pull/10771) Don't use gradle daemon for building
+
+[11001](https://github.com/flutter/engine/pull/11001) Avoid dynamic lookups of the engine library's symbols on Android
+
+[11015](https://github.com/flutter/engine/pull/11015) Remove the output directory prefix from the Android engine JAR filename
+
+
+## Material
+
+Of course, the Material design language also continues to be a major focus for Flutter.
+
+[34869](https://github.com/flutter/flutter/pull/34869) [Material] Properly call onChangeStart and onChangeEnd in Range Slider
+
+[34872](https://github.com/flutter/flutter/pull/34872) [Material] Support for hovered, focused, and pressed border color on OutlineButtons
+
+[34906](https://github.com/flutter/flutter/pull/34906) Fix unused [applicationIcon] property on [showLicensePage]
+
+[34932](https://github.com/flutter/flutter/pull/34932) Added onChanged property to TextFormField
+
+[35075](https://github.com/flutter/flutter/pull/35075) Allow for customizing SnackBar's content TextStyle in its theme
+
+[35282](https://github.com/flutter/flutter/pull/35282) Add Container fallback to Ink build method
+
+[35496](https://github.com/flutter/flutter/pull/35496) [Material] Text scale and wide label fixes for Slider and Range Slider value indicator shape
+
+[35499](https://github.com/flutter/flutter/pull/35499) Added MaterialApp.themeMode to control which theme is used.
+
+[35560](https://github.com/flutter/flutter/pull/35560) Support for elevation based dark theme overlay color in the Material widget
+
+[35878](https://github.com/flutter/flutter/pull/35878) Add flag to use root navigator for showModalBottomSheet
+
+[36028](https://github.com/flutter/flutter/pull/36028) Fix slider preferred height
+
+[36088](https://github.com/flutter/flutter/pull/36088) Add PopupMenuTheme to enable theming color, shape, elevation, text style of Menu
+
+[36409](https://github.com/flutter/flutter/pull/36409) Add searchFieldLabel to SearchDelegate in order to show a custom hint
+
+[36880](https://github.com/flutter/flutter/pull/36880) [Material] Create material Banner component
+
+[37038](https://github.com/flutter/flutter/pull/37038) Update SnackBar to the latest Material specs.
+
+[37259](https://github.com/flutter/flutter/pull/37259) [Material] Add support for hovered, pressed, focused, and selected text color on Chips.
+
+[37269](https://github.com/flutter/flutter/pull/37269) [Material] FAB refactor - remove unnecessary IconTheme
+
+[37355](https://github.com/flutter/flutter/pull/37355) Added ThemeData.from() method to construct a Theme from a ColorScheme
+
+[37403](https://github.com/flutter/flutter/pull/37403) add ontap to textformfield
+
+[37436](https://github.com/flutter/flutter/pull/37436) Hide text selection handle after entering text
+
+[37556](https://github.com/flutter/flutter/pull/37556) [Material] Make RawChip.selected non-nullable.
+
+[37636](https://github.com/flutter/flutter/pull/37636) Add CheckboxListTile checkColor
+
+[37715](https://github.com/flutter/flutter/pull/37715) Fix markdown link format
+
+[37825](https://github.com/flutter/flutter/pull/37825) Automatic focus highlight mode for FocusManager
+
+[37870](https://github.com/flutter/flutter/pull/37870) remove Header flag from BottomNavigationBar items
+
+[37877](https://github.com/flutter/flutter/pull/37877) Adds DefaultTextStyle ancestor to Tooltip Overlay
+
+[37882](https://github.com/flutter/flutter/pull/37882) Add dense property to AboutListTile
+
+[38467](https://github.com/flutter/flutter/pull/38467) [Material] Add splashColor to FAB and FAB ThemeData
+
+[38621](https://github.com/flutter/flutter/pull/38621) [Material] Create theme for Dividers to enable customization of thickness
+
+[38636](https://github.com/flutter/flutter/pull/38636) Adds the arrowColor option to UserAccountsDrawerHeader (#38608)
+
+
+## Text & Accessibility
+
+The biggest change in text & accessibility for this release is the new ColorFilter support, which enables you to recolor an entire widget tree according, for example, to adjust your app for users with red/green color blindness. To see it in action, check out this [ColorFilter sample](https://github.com/csells/flutter_color_filter).
+
+[35468](https://github.com/flutter/flutter/pull/35468) Add colorFilterLayer/Widget
+
+[9641](https://github.com/flutter/engine/pull/9641) Let pushColorFilter accept all types of ColorFilters
+
+[9668](https://github.com/flutter/engine/pull/9668) Refactor ColorFilter to have a native wrapper
+
+[9789](https://github.com/flutter/engine/pull/9789) fix ColorFilter.matrix constness
+
+[34515](https://github.com/flutter/flutter/pull/34515) OutlineInputBorder adjusts for borderRadius that is too large
+
+[35100](https://github.com/flutter/flutter/pull/35100) Add handling of 'TextInput.clearClient' message from platform to framework (#35054).
+
+[35219](https://github.com/flutter/flutter/pull/35219) Text selection menu show/hide cases
+
+[35493](https://github.com/flutter/flutter/pull/35493) Do not use ideographic baseline for RenderPargraph baseline
+
+[36974](https://github.com/flutter/flutter/pull/36974) Multiline Selection Menu Position Bug
+
+[37042](https://github.com/flutter/flutter/pull/37042) Fix selection menu not showing after clear
+
+[38573](https://github.com/flutter/flutter/pull/38573) Clamp scrollOffset to prevent textfield bouncing
+
+[35487](https://github.com/flutter/flutter/pull/35487) Fix RenderFittedBox when child.size.isEmpty
+
+[36243](https://github.com/flutter/flutter/pull/36243) Allow semantics labels to be shorter or longer than raw text
+
+[36303](https://github.com/flutter/flutter/pull/36303) Add sync star benchmark cases
+
+[37158](https://github.com/flutter/flutter/pull/37158) Fix Textfields in Semantics Debugger
+
+[37828](https://github.com/flutter/flutter/pull/37828) have android_semantics_testing use adb from ENV provided android sdk
+
+
+## Web (tech preview)
+
+Work continues on adding to the technical preview of web platform support to Flutter in this release, including a flag to tell if an app is running on the web. To see it in action, check out [main.dart](https://github.com/csells/flutter_mazegen/blob/master/lib/main.dart) in the [flutter_mazegen sample](https://github.com/csells/flutter_mazegen/). To learn more, see [Flutter for web](https://flutter.dev/web).
+
+[36135](https://github.com/flutter/flutter/pull/36135) add a kIsWeb constant to foundation
+
+[34252](https://github.com/flutter/flutter/pull/34252) Integrate dwds into flutter tool for web support
+
+[34896](https://github.com/flutter/flutter/pull/34896) Allow multi-root web builds
+
+[35221](https://github.com/flutter/flutter/pull/35221) Twiggle bit to exclude dev and beta from desktop and web
+
+[36297](https://github.com/flutter/flutter/pull/36297) Add multi-line flag to semantics
+
+[36465](https://github.com/flutter/flutter/pull/36465) Use FlutterFeatures to configure web and desktop devices
+
+[36548](https://github.com/flutter/flutter/pull/36548) Fix the web builds by reverting version bump of build_modules
+
+[36549](https://github.com/flutter/flutter/pull/36549) fix number encoding in message codecs for the Web
+
+[37515](https://github.com/flutter/flutter/pull/37515) Upstream web support for IterableProperty
+
+[37637](https://github.com/flutter/flutter/pull/37637) don't call Platform.operatingSystem in RenderView diagnostics
+
+[37638](https://github.com/flutter/flutter/pull/37638) [web][upstream] Fix debugPrintStack for web platform
+
+[37658](https://github.com/flutter/flutter/pull/37658) fix windows path for dwds/web builds
+
+[37712](https://github.com/flutter/flutter/pull/37712) [web][upstream] Optimize InactiveElements deactivation
+
+[37812](https://github.com/flutter/flutter/pull/37812) [web][upstream] Don't register exit/saveCompilationTrace for web platform since they are not available
+
+[37815](https://github.com/flutter/flutter/pull/37815) Restructure resident web runner usage to avoid SDK users that don't support dwds
+
+[38499](https://github.com/flutter/flutter/pull/38499) Update build web compilers and configure libraries
+
+
+## Desktop (experimental)
+
+We continue to move forward with the experimental support for the desktop platform in Flutter. If you'd like to take part in the experiment, see [Flutter Desktop shells](https://flutter.dev/desktop).
+
+[32770](https://github.com/flutter/flutter/pull/32770) Dismiss modal with any button press
+
+[34660](https://github.com/flutter/flutter/pull/34660) Add --target support for Windows and Linux
+
+[34712](https://github.com/flutter/flutter/pull/34712) Fix FocusTraversalPolicy makes focus lost
+
+[34752](https://github.com/flutter/flutter/pull/34752) [linux] Receives the unmodified characters obtained from GLFW
+
+[35495](https://github.com/flutter/flutter/pull/35495) mark windows and macos chrome dev mode as flaky
+
+[36197](https://github.com/flutter/flutter/pull/36197) Fix windows, exclude widgets from others
+
+[36722](https://github.com/flutter/flutter/pull/36722) Skip flaky test windows
+
+[36784](https://github.com/flutter/flutter/pull/36784) [flutter_tool] Improve Windows flutter clean error message
+
+[36845](https://github.com/flutter/flutter/pull/36845) Improve Windows build failure message
+
+[36987](https://github.com/flutter/flutter/pull/36987) Flutter assemble for macos take 2!
+
+[37211](https://github.com/flutter/flutter/pull/37211) Don't enable scroll wheel when scrolling is off
+
+[37342](https://github.com/flutter/flutter/pull/37342) Fix mouse region crash when using closures
+
+[37344](https://github.com/flutter/flutter/pull/37344) Fix mouse region double render
+
+[37351](https://github.com/flutter/flutter/pull/37351) fix errors caught by roll of macOS assemble
+
+[37365](https://github.com/flutter/flutter/pull/37365) only build macOS kernel in debug mode
+
+[37425](https://github.com/flutter/flutter/pull/37425) Support for macOS release mode (1 of 3)
+
+[37509](https://github.com/flutter/flutter/pull/37509) Use macOS ephemeral directory for Pod env script
+
+[37664](https://github.com/flutter/flutter/pull/37664) Partial macOS assemble revert
+
+[37891](https://github.com/flutter/flutter/pull/37891) Focus debug
+
+[38651](https://github.com/flutter/flutter/pull/38651) Update the macOS Podfile template platform version
+
+[9654](https://github.com/flutter/engine/pull/9654) Begin separating macOS engine from view controller
+
+[9672](https://github.com/flutter/engine/pull/9672) Add FLEDartProject for macOS embedding
+
+[9745](https://github.com/flutter/engine/pull/9745) Fix windows test by not attempting to open a directory as a file.
+
+[9799](https://github.com/flutter/engine/pull/9799) Update buildroot to c4df4a7b to pull in MSVC 2017 Update 9 on Windows.
+
+[9835](https://github.com/flutter/engine/pull/9835) [Windows] Alternative Windows shell platform implementation
+
+[9953](https://github.com/flutter/engine/pull/9953) [macos] Add reply to binary messenger
+
+[10009](https://github.com/flutter/engine/pull/10009) [macos] Revert check on FlutterCodecs and refactor message function]
+
+[10189](https://github.com/flutter/engine/pull/10189) [macos] Reland function refactor
+
+[11010](https://github.com/flutter/engine/pull/11010) Rename macOS FLE* classes to Flutter*
+
+[36546](https://github.com/flutter/flutter/pull/36546) Unskip date_picker_test on Windows as underlying issue 19696 was fixed.
+
+
+## Framework
+
+The core framework for Flutter saw several important features in this release, including support for an additional 24 new locales (ranging [from Afrikaans to Zulu](https://github.com/flutter/flutter/pull/36589)).
+
+[36589](https://github.com/flutter/flutter/pull/36589) Update Localizations: added 24 new locales (reprise)
+
+[33936](https://github.com/flutter/flutter/pull/33936) New parameter for RawGestureDetector to customize semantics mapping
+
+[34202](https://github.com/flutter/flutter/pull/34202) Remove _debugWillReattachChildren assertions from _TableElement
+
+[34626](https://github.com/flutter/flutter/pull/34626) AsyncSnapshot.data to throw if error or no data
+
+[34895](https://github.com/flutter/flutter/pull/34895) Remove flutter_tools support for old AOT snapshotting
+
+[34919](https://github.com/flutter/flutter/pull/34919) Remove duplicate error parts
+
+[35132](https://github.com/flutter/flutter/pull/35132) Reduce allocations by reusing a matrix for transient transforms in _transformRect
+
+[35143](https://github.com/flutter/flutter/pull/35143) More HttpClientResponse Uint8List fixes
+
+[35149](https://github.com/flutter/flutter/pull/35149) More HttpClientResponse implements Stream<Uint8List> fixes
+
+[35232](https://github.com/flutter/flutter/pull/35232) New benchmark: Gesture semantics
+
+[35233](https://github.com/flutter/flutter/pull/35233) Attempt skipping coverage shard if tools did not change
+
+[35245](https://github.com/flutter/flutter/pull/35245) More preparation for HttpClientResponse implements Uint8List
+
+[35246](https://github.com/flutter/flutter/pull/35246) attempt to not skip coverage on post commit
+
+[35263](https://github.com/flutter/flutter/pull/35263) remove unnecessary ..toList()
+
+[35280](https://github.com/flutter/flutter/pull/35280) benchmarkWidgets.semanticsEnabled default false.
+
+[35288](https://github.com/flutter/flutter/pull/35288) Apply coverage skip math correctly
+
+[35408](https://github.com/flutter/flutter/pull/35408) Remove print
+
+[35482](https://github.com/flutter/flutter/pull/35482) Use the new service protocol message names
+
+[35491](https://github.com/flutter/flutter/pull/35491) Include tags in SemanticsNode debug properties
+
+[35646](https://github.com/flutter/flutter/pull/35646) Prepare for Socket implements Stream
+
+[35725](https://github.com/flutter/flutter/pull/35725) Update annotated region findAll implementation to use Iterables directly.
+
+[35750](https://github.com/flutter/flutter/pull/35750) use sentence case in error message titles
+
+[35762](https://github.com/flutter/flutter/pull/35762) Refactor keymapping for resident_runner
+
+[35828](https://github.com/flutter/flutter/pull/35828) Cleanup widgets/sliver_persistent_header.dart with resolution of dart-lang/sdk#31543
+
+[35913](https://github.com/flutter/flutter/pull/35913) Change focus example to be more canonical (and correct)
+
+[35932](https://github.com/flutter/flutter/pull/35932) Upgraded framework packages with 'flutter update-packages --force-upgrade'.
+
+[35979](https://github.com/flutter/flutter/pull/35979) Optimizes gesture recognizer fixes #35658
+
+[36262](https://github.com/flutter/flutter/pull/36262) Prevents infinite loop in Table._computeColumnWidths
+
+[36302](https://github.com/flutter/flutter/pull/36302) Issues/30526 gc
+
+[36333](https://github.com/flutter/flutter/pull/36333) fix sliver fixed pinned appbar
+
+[36396](https://github.com/flutter/flutter/pull/36396) Optimize the transformRect and transformPoint methods in matrix_utils.
+
+[36482](https://github.com/flutter/flutter/pull/36482) Sped up shader warmup by only drawing on a 100x100 surface
+
+[36493](https://github.com/flutter/flutter/pull/36493) Fixes sliver list does not layout firstchild when child reordered
+
+[36503](https://github.com/flutter/flutter/pull/36503) Disabling Firebase Test Lab smoke test to unblock autoroller
+
+[36698](https://github.com/flutter/flutter/pull/36698) fixes iphone force press keyboard select crashes
+
+[36768](https://github.com/flutter/flutter/pull/36768) add an error count field to the Flutter.Error event
+
+[36857](https://github.com/flutter/flutter/pull/36857) Ensure user-thrown errors have ErrorSummary nodes
+
+[36867](https://github.com/flutter/flutter/pull/36867) Add reference to StrutStyle from TextStyle
+
+[36955](https://github.com/flutter/flutter/pull/36955) Extract common PlatformView functionality: Painting and Semantics
+
+[37187](https://github.com/flutter/flutter/pull/37187) use FlutterError in MultiChildRenderObjectWidget
+
+[37275](https://github.com/flutter/flutter/pull/37275) Optimize the transformRect and transformPoint methods in matrix_utils…
+
+[37479](https://github.com/flutter/flutter/pull/37479) Remove bogus code in ContainerParentDataMixin.detach
+
+[37497](https://github.com/flutter/flutter/pull/37497) Extract common PlatformView functionality: Gesture and PointerEvent
+
+[37703](https://github.com/flutter/flutter/pull/37703) PlatformViewLink, handling creation of the PlatformViewSurface and dispose PlatformViewController
+
+[37790](https://github.com/flutter/flutter/pull/37790) Doc: Image.memory only accepts compressed format
+
+[37880](https://github.com/flutter/flutter/pull/37880) reduce mac workload
+
+[38441](https://github.com/flutter/flutter/pull/38441) Fix getOffsetToReveal for growthDirection reversed and AxisDirection down or right
+
+[38463](https://github.com/flutter/flutter/pull/38463) Do not construct arguments to _focusDebug when running in non-debug modes
+
+[38639](https://github.com/flutter/flutter/pull/38639) PlatformViewLink. cached surface should be a Widget type
+
+[38686](https://github.com/flutter/flutter/pull/38686) Rename patent file
+
+[38704](https://github.com/flutter/flutter/pull/38704) Adds canRequestFocus toggle to FocusNode
+
+[38710](https://github.com/flutter/flutter/pull/38710) PlatformViewLink: Rename CreatePlatformViewController to CreatePlatformViewCallback
+
+[35335](https://github.com/flutter/flutter/pull/35335) Using custom exception class for network loading error
+
+[35574](https://github.com/flutter/flutter/pull/35574) Fix semantics for floating pinned sliver app bar
+
+[35810](https://github.com/flutter/flutter/pull/35810) SliverFillRemaining accounts for child size when hasScrollBody is false
+
+[35941](https://github.com/flutter/flutter/pull/35941) SliverLayoutBuilder
+
+
+## Engine
+
+The core engine continues to see many improvements across the board in this release.
+
+[9041](https://github.com/flutter/engine/pull/9041) TextStyle.height property as a multiple of font size instead of multiple of ascent+descent+leading.
+
+[9089](https://github.com/flutter/engine/pull/9089) Wire up custom event loop interop for the GLFW embedder.
+
+[9329](https://github.com/flutter/engine/pull/9329) Fixed memory leak by way of accidental retain on implicit self
+
+[9403](https://github.com/flutter/engine/pull/9403) Remove variants of ParagraphBuilder::AddText that are not used within the engine
+
+[9419](https://github.com/flutter/engine/pull/9419) Has a binary messenger
+
+[9423](https://github.com/flutter/engine/pull/9423) Don't hang to a platform view's input connection after it's disposed
+
+[9424](https://github.com/flutter/engine/pull/9424) Send timings of the first frame without batching
+
+[9431](https://github.com/flutter/engine/pull/9431) Generate weak pointers only in the platform thread
+
+[9436](https://github.com/flutter/engine/pull/9436) Add the functionality to merge and unmerge MessageLoopTaskQueues
+
+[9439](https://github.com/flutter/engine/pull/9439) Eliminate unused import in FlutterView
+
+[9452](https://github.com/flutter/engine/pull/9452) Convert RRect.scaleRadii to public method
+
+[9456](https://github.com/flutter/engine/pull/9456) Made sure that the run_tests script returns the right error code.
+
+[9459](https://github.com/flutter/engine/pull/9459) Remove unused/unimplemented shell constructor
+
+[9460](https://github.com/flutter/engine/pull/9460) Fixed logLevel filter bug so that filter now works as expected.
+
+[9461](https://github.com/flutter/engine/pull/9461) Adds API for retaining intermediate engine layers
+
+[9463](https://github.com/flutter/engine/pull/9463) Removed unused imports in new embedding.
+
+[9466](https://github.com/flutter/engine/pull/9466) Re-enable the Wuffs GIF decoder
+
+[9468](https://github.com/flutter/engine/pull/9468) Manually draw remainder curve for wavy decorations
+
+[9485](https://github.com/flutter/engine/pull/9485) Add --observatory-host switch
+
+[9486](https://github.com/flutter/engine/pull/9486) Rework image & texture management to use concurrent message queues.
+
+[9489](https://github.com/flutter/engine/pull/9489) Handle ambiguous directionality of final trailing whitespace in mixed bidi text
+
+[9490](https://github.com/flutter/engine/pull/9490) fix a bug where the platform view's transform is not reset before set frame
+
+[9493](https://github.com/flutter/engine/pull/9493) Run benchmarks on try jobs.
+
+[9495](https://github.com/flutter/engine/pull/9495) fix build breakage on [PlatformViews.mm](http://platformviews.mm/)
+
+[9498](https://github.com/flutter/engine/pull/9498) Notify framework to clear input connection when app is backgrounded (#35054).
+
+[9503](https://github.com/flutter/engine/pull/9503) Improve caching limits for Skia
+
+[9506](https://github.com/flutter/engine/pull/9506) Synchronize main thread and gpu thread for first render frame
+
+[9508](https://github.com/flutter/engine/pull/9508) Support image filter on paint
+
+[9532](https://github.com/flutter/engine/pull/9532) fix FlutterOverlayView doesn't remove from superview in some cases
+
+[9556](https://github.com/flutter/engine/pull/9556) Minimal integration with the Skia text shaper module
+
+[9561](https://github.com/flutter/engine/pull/9561) libtxt: fix reference counting of SkFontStyleSets held by font asset providers
+
+[9585](https://github.com/flutter/engine/pull/9585) Fix a race in the embedder accessibility unit test
+
+[9589](https://github.com/flutter/engine/pull/9589) Fixes a plugin overwrite bug in the plugin shim system.
+
+[9590](https://github.com/flutter/engine/pull/9590) Apply patches that have landed in topaz since we ported the runners to the engine repo
+
+[9591](https://github.com/flutter/engine/pull/9591) Document various classes in //flutter/shell/common.
+
+[9632](https://github.com/flutter/engine/pull/9632) Added Doxyfile.
+
+[9633](https://github.com/flutter/engine/pull/9633) Cherry-pick fix for flutter/flutter#35291
+
+[9640](https://github.com/flutter/engine/pull/9640) make EmbeddedViewParams a unique ptr
+
+[9642](https://github.com/flutter/engine/pull/9642) Fix warning about settings unavailable GN arg build_glfw_shell
+
+[9651](https://github.com/flutter/engine/pull/9651) Move the mutators stack handling to preroll
+
+[9652](https://github.com/flutter/engine/pull/9652) Pipeline allows continuations that can produce to front
+
+[9653](https://github.com/flutter/engine/pull/9653) External view embedder can tell if embedded views have mutated
+
+[9655](https://github.com/flutter/engine/pull/9655) Allow embedders to add callbacks for responses to platform messages from the framework.
+
+[9660](https://github.com/flutter/engine/pull/9660) ExternalViewEmbedder can CancelFrame after pre-roll
+
+[9661](https://github.com/flutter/engine/pull/9661) Raster now returns an enum rather than boolean
+
+[9663](https://github.com/flutter/engine/pull/9663) Mutators Stack refactoring
+
+[9685](https://github.com/flutter/engine/pull/9685) fix Picture.toImage return type check and api conform test.
+
+[9698](https://github.com/flutter/engine/pull/9698) Ensure that platform messages without response handles can be dispatched.
+
+[9713](https://github.com/flutter/engine/pull/9713) Explain why OpacityLayer has an offset field
+
+[9717](https://github.com/flutter/engine/pull/9717) Fixed logLevel filter bug so that filter now works as expected. (#9460)
+
+[9721](https://github.com/flutter/engine/pull/9721) Add comments to differentiate two cache paths
+
+[9725](https://github.com/flutter/engine/pull/9725) Make the license script compatible with recently changed Dart I/O stream APIs
+
+[9727](https://github.com/flutter/engine/pull/9727) Add hooks for InputConnection lock and unlocking
+
+[9734](https://github.com/flutter/engine/pull/9734) Fix backspace crash on Chinese devices
+
+[9737](https://github.com/flutter/engine/pull/9737) Use libc++ variant of string view and remove the FML variant.
+
+[9741](https://github.com/flutter/engine/pull/9741) Make FLEViewController's view an internal detail
+
+[9747](https://github.com/flutter/engine/pull/9747) Remove get engine
+
+[9750](https://github.com/flutter/engine/pull/9750) FLEViewController/Engine API changes
+
+[9758](https://github.com/flutter/engine/pull/9758) Include SkParagraph headers only when the enable-skshaper flag is on
+
+[9762](https://github.com/flutter/engine/pull/9762) Fall back to a fully qualified path to [libapp.so](http://libapp.so/) if the library can not be loaded by name
+
+[9767](https://github.com/flutter/engine/pull/9767) Un-deprecated FlutterViewController's binaryMessenger.
+
+[9769](https://github.com/flutter/engine/pull/9769) Document //flutter/shell/common/engine.
+
+[9772](https://github.com/flutter/engine/pull/9772) fix objcdoc generation
+
+[9781](https://github.com/flutter/engine/pull/9781) SendPlatformMessage allow null message value
+
+[9797](https://github.com/flutter/engine/pull/9797) Remove breaking asserts
+
+[9808](https://github.com/flutter/engine/pull/9808) Document FontFeature class
+
+[9809](https://github.com/flutter/engine/pull/9809) Document //flutter/shell/common/rasterizer
+
+[9813](https://github.com/flutter/engine/pull/9813) Made Picture::toImage happen on the IO thread with no need for an onscreen surface.
+
+[9815](https://github.com/flutter/engine/pull/9815) Made the persistent cache's directory a const pointer.
+
+[9816](https://github.com/flutter/engine/pull/9816) Only release the image data in the unit-test once Skia has accepted ownership of it.
+
+[9825](https://github.com/flutter/engine/pull/9825) In a single frame codec, release the encoded image buffer after giving it to the decoder
+
+[9828](https://github.com/flutter/engine/pull/9828) Make the virtual display's window translucent
+
+[9847](https://github.com/flutter/engine/pull/9847) Started adding the engine hash to frameworks' Info.plist.
+
+[9849](https://github.com/flutter/engine/pull/9849) Preserve the alpha for VD content by setting a transparent background.
+
+[9850](https://github.com/flutter/engine/pull/9850) Add multi-line flag to semantics
+
+[9851](https://github.com/flutter/engine/pull/9851) Add a macro for prefixing embedder.h symbols
+
+[9855](https://github.com/flutter/engine/pull/9855) Fix missing assignment to _allowHeadlessExecution
+
+[9859](https://github.com/flutter/engine/pull/9859) Fix justify for RTL paragraphs.
+
+[9867](https://github.com/flutter/engine/pull/9867) Fixed error in generated xml Info.plist.
+
+[9873](https://github.com/flutter/engine/pull/9873) Add clang version to Info.plist
+
+[9875](https://github.com/flutter/engine/pull/9875) Simplify buildtools
+
+[9890](https://github.com/flutter/engine/pull/9890) Log dlopen errors only in debug mode
+
+[9893](https://github.com/flutter/engine/pull/9893) Removed logic from FlutterAppDelegate into FlutterPluginAppLifeCycleDelegate
+
+[9894](https://github.com/flutter/engine/pull/9894) Add the isMultiline semantics flag to values
+
+[9896](https://github.com/flutter/engine/pull/9896) Capture stderr for ninja command
+
+[9901](https://github.com/flutter/engine/pull/9901) Handle decompressed images in InstantiateImageCodec
+
+[9905](https://github.com/flutter/engine/pull/9905) Respect EXIF information while decompressing images.
+
+[9906](https://github.com/flutter/engine/pull/9906) Update libcxx & libcxxabi to HEAD in prep for compiler upgrade.
+
+[9919](https://github.com/flutter/engine/pull/9919) Removed unused method.
+
+[9920](https://github.com/flutter/engine/pull/9920) Fix caching of Locale.toString
+
+[9922](https://github.com/flutter/engine/pull/9922) Split out lifecycle protocol
+
+[9923](https://github.com/flutter/engine/pull/9923) Fix failure of the onReportTimings window hook test
+
+[9924](https://github.com/flutter/engine/pull/9924) Don't try to use unset assets_dir setting
+
+[9925](https://github.com/flutter/engine/pull/9925) Fix the geometry test to reflect that OffsetBase comparison operators are a partial ordering
+
+[9927](https://github.com/flutter/engine/pull/9927) Update Buildroot Version
+
+[9929](https://github.com/flutter/engine/pull/9929) Update the exception thrown for invalid data in the codec test
+
+[9931](https://github.com/flutter/engine/pull/9931) Fix reentrancy handling in SingleFrameCodec
+
+[9932](https://github.com/flutter/engine/pull/9932) Exit flutter_tester with an error code on an unhandled exception
+
+[9934](https://github.com/flutter/engine/pull/9934) Updates to the engine test runner script
+
+[9935](https://github.com/flutter/engine/pull/9935) Fix backspace crash on Chinese devices (#9734)
+
+[9936](https://github.com/flutter/engine/pull/9936) Move development.key from buildroot
+
+[9937](https://github.com/flutter/engine/pull/9937) [platform view] do not make clipping view and interceptor view clipToBounds
+
+[9938](https://github.com/flutter/engine/pull/9938) Removed PlatformViewsController if-statements from TextInputPlugin (#34286).
+
+[9939](https://github.com/flutter/engine/pull/9939) Added hasRenderedFirstFrame() to old FlutterView for Espresso (#36211).
+
+[9948](https://github.com/flutter/engine/pull/9948) [glfw] Enables replies on binary messenger in glfw embedder
+
+[9958](https://github.com/flutter/engine/pull/9958) Clean up cirrus.yml file a little
+
+[9961](https://github.com/flutter/engine/pull/9961) Fix return type of assert function in gradient_test
+
+[9977](https://github.com/flutter/engine/pull/9977) Fix flutter/flutter #34791
+
+[9987](https://github.com/flutter/engine/pull/9987) Update GN to git_revision:152c5144ceed9592c20f0c8fd55769646077569b
+
+[10012](https://github.com/flutter/engine/pull/10012) Undelete used method
+
+[10021](https://github.com/flutter/engine/pull/10021) Added a DartExecutor API for querying ## of pending channel callbacks
+
+[10056](https://github.com/flutter/engine/pull/10056) Update .cirrus.yml
+
+[10063](https://github.com/flutter/engine/pull/10063) Track clusters and return cluster boundaries in getGlyphPositionForCoordinates (emoji fix)
+
+[10064](https://github.com/flutter/engine/pull/10064) Disable DartLifecycleTest::ShuttingDownTheVMShutsDownAllIsolates in runtime_unittests.
+
+[10068](https://github.com/flutter/engine/pull/10068) Fixed memory leak with engine registrars.
+
+[10069](https://github.com/flutter/engine/pull/10069) Enable consts from environment in DDK for flutter_web
+
+[10073](https://github.com/flutter/engine/pull/10073) Basic structure for flutter_jit_runner far
+
+[10074](https://github.com/flutter/engine/pull/10074) Change ParagraphBuilder to replace the parent style's font families with the child style's font families
+
+[10075](https://github.com/flutter/engine/pull/10075) Change flutter runner target for LUCI
+
+[10078](https://github.com/flutter/engine/pull/10078) One more luci fix
+
+[10109](https://github.com/flutter/engine/pull/10109) Cache font family lookups that fail to obtain a font collection
+
+[10127](https://github.com/flutter/engine/pull/10127) Track detailed LibTxt metrics
+
+[10128](https://github.com/flutter/engine/pull/10128) Started linking the test targets against Flutter.
+
+[10151](https://github.com/flutter/engine/pull/10151) [fucshia] fix name to reflect the cmx file
+
+[10155](https://github.com/flutter/engine/pull/10155) src/third_party/dart a2aec5eb06...86dba81dec
+
+[10172](https://github.com/flutter/engine/pull/10172) [dart_runner] Rename dart to dart runner
+
+[10176](https://github.com/flutter/engine/pull/10176) Add suggested Java changes from flutter roll
+
+[10178](https://github.com/flutter/engine/pull/10178) Removed unnecessary call to find the App.framework.
+
+[10179](https://github.com/flutter/engine/pull/10179) [dart_runner] dart jit runner and dart jit product runner
+
+[10195](https://github.com/flutter/engine/pull/10195) Allow embedder controlled composition of Flutter layers.
+
+[10235](https://github.com/flutter/engine/pull/10235) Deprecate FlutterView#enableTransparentBackground
+
+[10242](https://github.com/flutter/engine/pull/10242) Remove Dead Scenic Clipping Code Path.
+
+[10265](https://github.com/flutter/engine/pull/10265) [dart-roll] Roll dart sdk to 80c4954d4d1d2a257005793d83b601f3ff2997a2
+
+[10273](https://github.com/flutter/engine/pull/10273) Remove one last final call to AddPart()
+
+[10282](https://github.com/flutter/engine/pull/10282) Export FFI from sky_engine.
+
+[10295](https://github.com/flutter/engine/pull/10295) Fix memory overrun in minikin patch
+
+[10296](https://github.com/flutter/engine/pull/10296) fix CI
+
+[10297](https://github.com/flutter/engine/pull/10297) Ensure that the SingleFrameCodec stays alive until the ImageDecoder invokes its callback
+
+[10298](https://github.com/flutter/engine/pull/10298) Fix red build again
+
+[10303](https://github.com/flutter/engine/pull/10303) Make tree green for real this time, I promise.
+
+[10414](https://github.com/flutter/engine/pull/10414) expose max depth on Window
+
+[10419](https://github.com/flutter/engine/pull/10419) Make kernel compiler use host toolchain
+
+[10423](https://github.com/flutter/engine/pull/10423) Fix mac gen_snapshot uploader
+
+[10430](https://github.com/flutter/engine/pull/10430) Add copy_gen_snapshots.py tool
+
+[10477](https://github.com/flutter/engine/pull/10477) Add #else, #endif condition comments
+
+[10479](https://github.com/flutter/engine/pull/10479) Delete unused create_macos_gen_snapshot.py script
+
+[10485](https://github.com/flutter/engine/pull/10485) Remove semi-redundant try-jobs.
+
+[10629](https://github.com/flutter/engine/pull/10629) Fix engine platformviewscontroller leak
+
+[10637](https://github.com/flutter/engine/pull/10637) Document the thread test fixture.
+
+[10644](https://github.com/flutter/engine/pull/10644) [flutter_runner] Port: Add connectToService, wrapping fdio_ns_connect.
+
+[10652](https://github.com/flutter/engine/pull/10652) Allow embedders to control Dart VM lifecycle on engine shutdown.
+
+[10674](https://github.com/flutter/engine/pull/10674) When setting up AOT snapshots from symbol references, make buffer sizes optional.
+
+[10675](https://github.com/flutter/engine/pull/10675) Improvements to the flutter GDB script
+
+[10773](https://github.com/flutter/engine/pull/10773) Remove use of the deprecated AccessibilityNodeInfo boundsInParent API
+
+[10776](https://github.com/flutter/engine/pull/10776) rename stub_ui to web_ui
+
+[10780](https://github.com/flutter/engine/pull/10780) [flutter_runner] Improve frame scheduling
+
+[10781](https://github.com/flutter/engine/pull/10781) [flutter] Create the compositor context on the GPU task runner.
+
+[10782](https://github.com/flutter/engine/pull/10782) Update license script to handle ANGLE
+
+[10783](https://github.com/flutter/engine/pull/10783) Make firebase test more LUCI friendly
+
+[10786](https://github.com/flutter/engine/pull/10786) Remove 3 semi-redundant try-jobs
+
+[10787](https://github.com/flutter/engine/pull/10787) Change call to |AddPart| to |AddChild|
+
+[10788](https://github.com/flutter/engine/pull/10788) Wire up a concurrent message loop backed SkExecutor for Skia.
+
+[10797](https://github.com/flutter/engine/pull/10797) Rename artifacts so they match the Maven convention
+
+[10799](https://github.com/flutter/engine/pull/10799) Add a test for creating images from bytes.
+
+[10808](https://github.com/flutter/engine/pull/10808) Remove flutter_kernel_sdk dart script
+
+[10809](https://github.com/flutter/engine/pull/10809) [dart:zircon] Porting Cache re-usable handle wait objects
+
+[10815](https://github.com/flutter/engine/pull/10815) Return an empty mapping for an empty file asset
+
+[10816](https://github.com/flutter/engine/pull/10816) Add firstFrameDidRender to FlutterViewController
+
+[10823](https://github.com/flutter/engine/pull/10823) Expose isolateId for engine
+
+[10941](https://github.com/flutter/engine/pull/10941) Report test failures in run_tests.py
+
+[10952](https://github.com/flutter/engine/pull/10952) Change SemanticsNode#children lists to be non-null
+
+[10955](https://github.com/flutter/engine/pull/10955) Fix format
+
+[10956](https://github.com/flutter/engine/pull/10956) Increase the license block scan from 5k to 6k
+
+[11002](https://github.com/flutter/engine/pull/11002) Remove a tracing macro with a dangling pointer
+
+[11004](https://github.com/flutter/engine/pull/11004) Trace RasterCacheResult::Draw
+
+[11005](https://github.com/flutter/engine/pull/11005) Drop firebase test from Cirrus
+
+[11007](https://github.com/flutter/engine/pull/11007) Update [README.md](http://readme.md/)
+
+[11011](https://github.com/flutter/engine/pull/11011) Initialize the engine in the running state to match the animator's default state
+
+[11012](https://github.com/flutter/engine/pull/11012) Remove the ParagraphImpl class from the text API
+
+[11013](https://github.com/flutter/engine/pull/11013) Remove ability to override mac_sdk_path in flutter/tools/gn
+
+[11024](https://github.com/flutter/engine/pull/11024) Add _glfw versions of the GLFW desktop libraries
+
+[11027](https://github.com/flutter/engine/pull/11027) Fix first frame logic
+
+[11029](https://github.com/flutter/engine/pull/11029) Disable a deprecation warning for use of a TaskDescription constructor for older platforms
+
+[11033](https://github.com/flutter/engine/pull/11033) remove OS version
+
+[11034](https://github.com/flutter/engine/pull/11034) Show all license diffs
+
+[11038](https://github.com/flutter/engine/pull/11038) Make JIT work on iPhone armv7
+
+[11040](https://github.com/flutter/engine/pull/11040) Hide verbose dart snapshot during run_test.py
+
+[11041](https://github.com/flutter/engine/pull/11041) Add a BroadcastStream to FrameTiming
+
+[11046](https://github.com/flutter/engine/pull/11046) Add ccls config files to .gitignore
+
+[11052](https://github.com/flutter/engine/pull/11052) Remove unused dstColorSpace argument to MakeCrossContextFromPixmap
+
+[11056](https://github.com/flutter/engine/pull/11056) Sort the Skia typefaces in a font style set into a consistent order
+
+[11062](https://github.com/flutter/engine/pull/11062) Provide a placeholder queue ID for the custom embedder task runner.
+
+[11067](https://github.com/flutter/engine/pull/11067) Minor update to the Robolectric test harness
+
+[11068](https://github.com/flutter/engine/pull/11068) More updates to the Robolectric test harness
+
+[11075](https://github.com/flutter/engine/pull/11075) [dynamic_thread_merging] Resubmit only on the frame where the merge
+
+
+## Tools
+
+As always, the end-to-end experience for Flutter relies heavily on its tools. With that in mind, in addition to the PRs listed below, which focus on the flutter CLI tool, you should also check out the following releases for the IntelliJ/Android Studio Flutter plugin, the VSCode Flutter plugin and Dart DevTools:
+
+
+
+*   [DevTools 0.1.6 Release Notes](https://groups.google.com/forum/#!topic/flutter-announce/x9eiBq-OZUk) - Sept 5, 2019
+*   [IntelliJ Plugin M39 Release Notes](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/flutter-announce/HH2-z-wYMH4/Yb1mzIPWBgAJ) - Sept 3, 2019
+*   [VSCode Plugin v3.4](https://dartcode.org/releases/v3-4/) - Sept 3, 2019
+*   [DevTools 0.1.5 Release Notes](https://groups.google.com/forum/#!searchin/flutter-announce/release$20notes|sort:date/flutter-announce/_tBeov94GEk/8IMoZnV0DQAJ) - Aug 5, 2019
+*   [VSCode Plugin v3.3](https://dartcode.org/releases/v3-3/) - Aug 2, 2019
+*   [IntelliJ Plugin M38 Release Notes](https://groups.google.com/forum/#!searchin/flutter-announce/intellij|sort:date/flutter-announce/-LQPz3C3JAM/ZR2WnOklEQAJ) - Aug 2, 2019
+*   [DevTools 0.1.4 Release Notes](https://groups.google.com/forum/#!searchin/flutter-announce/release$20notes|sort:date/flutter-announce/ZUcqjzEDTKc/ABZtXXOpCgAJ) - Jul 19, 2019
+*   [VSCode Plugin v3.2](https://dartcode.org/releases/v3-2/) - Jun 28, 2019
+
+In addition, this release also has a lot going on under the hood to provide you with better, more actionable error messages. You can read about those details in [this blog post](https://medium.com/@taodong/e098513cecf9) from the Flutter User Experience team.
+
+[32511](https://github.com/flutter/flutter/pull/32511) Rendering errors with root causes in the widget layer should have a reference to the widget
+
+[28090](https://github.com/flutter/flutter/pull/28090) Ensure that cache dirs and files have appropriate permissions
+
+[32816](https://github.com/flutter/flutter/pull/32816) Add initial implementation of flutter assemble
+
+[34624](https://github.com/flutter/flutter/pull/34624) Break down flutter doctor validations and results
+
+[34785](https://github.com/flutter/flutter/pull/34785) Tweak the display name of emulators
+
+[34794](https://github.com/flutter/flutter/pull/34794) Add emulatorID field to devices in daemon
+
+[35084](https://github.com/flutter/flutter/pull/35084) Move findTargetDevices to DeviceManager
+
+[35092](https://github.com/flutter/flutter/pull/35092) Add FlutterProjectFactory so that it can be overridden internally.
+
+[35186](https://github.com/flutter/flutter/pull/35186) Make tool coverage collection resilient to sentinel coverage data
+
+[35188](https://github.com/flutter/flutter/pull/35188) ensure test isolate is paused before collecting coverage
+
+[35192](https://github.com/flutter/flutter/pull/35192) don't block any presubmit on coverage
+
+[35231](https://github.com/flutter/flutter/pull/35231) Fix coverage collection
+
+[35367](https://github.com/flutter/flutter/pull/35367) Add type to StreamChannel in generated test code.
+
+[35392](https://github.com/flutter/flutter/pull/35392) Add timer checking and Fake http client to testbed
+
+[35406](https://github.com/flutter/flutter/pull/35406) Refactor signal and command line handler from resident runner
+
+[35465](https://github.com/flutter/flutter/pull/35465) Mark update-packages as non-experimental
+
+[35467](https://github.com/flutter/flutter/pull/35467) Mark update-packages as non-experimental
+
+[35480](https://github.com/flutter/flutter/pull/35480) Update the help message on precache command for less confusion
+
+[35681](https://github.com/flutter/flutter/pull/35681) Disable incremental compiler in dartdevc
+
+[35765](https://github.com/flutter/flutter/pull/35765) Use public _registerService RPC in flutter_tools
+
+[35767](https://github.com/flutter/flutter/pull/35767) set targets of zero percent for tools codecoverage
+
+[35839](https://github.com/flutter/flutter/pull/35839) use pub run for create test and remove [INFO] logs
+
+[35846](https://github.com/flutter/flutter/pull/35846) move reload and restart handling into terminal
+
+[36017](https://github.com/flutter/flutter/pull/36017) Move reporting files to reporting/
+
+[36082](https://github.com/flutter/flutter/pull/36082) Add better handling of JSON-RPC exception
+
+[36084](https://github.com/flutter/flutter/pull/36084) handle google3 version of pb
+
+[36105](https://github.com/flutter/flutter/pull/36105) [flutter_tool] Catch a yaml parse failure during project creation
+
+[36109](https://github.com/flutter/flutter/pull/36109) Catch exceptions thrown by runChecked* when possible
+
+[36122](https://github.com/flutter/flutter/pull/36122) Make sure add-to-app build bundle from outer xcodebuild/gradlew sends analytics
+
+[36138](https://github.com/flutter/flutter/pull/36138) Implement feature flag system for flutter tools
+
+[36199](https://github.com/flutter/flutter/pull/36199) Don't try to flutterExit if isolate is still paused
+
+[36208](https://github.com/flutter/flutter/pull/36208) [flutter_tool] Allow analytics without a terminal attached
+
+[36213](https://github.com/flutter/flutter/pull/36213) Use DeviceManager instead of device to determine if device supports project.
+
+[36218](https://github.com/flutter/flutter/pull/36218) release lock in flutter pub context
+
+[36237](https://github.com/flutter/flutter/pull/36237) Recommend to use the final version of CDN support for the trunk specs repo.
+
+[36240](https://github.com/flutter/flutter/pull/36240) Rearrange flutter assemble implementation
+
+[36288](https://github.com/flutter/flutter/pull/36288) Throw exception if instantiating IOSDevice on non-mac os platform
+
+[36289](https://github.com/flutter/flutter/pull/36289) FakeHttpClientResponse improvements
+
+[36318](https://github.com/flutter/flutter/pull/36318) Include flutter_runner in precache artifacts.
+
+[36327](https://github.com/flutter/flutter/pull/36327) Fix invocations of ideviceinstaller not passing DYLD_LIBRARY_PATH
+
+[36331](https://github.com/flutter/flutter/pull/36331) Minor fixes to precache help text (attempt #2)
+
+[36434](https://github.com/flutter/flutter/pull/36434) Clean up flutter driver device detection.
+
+[36481](https://github.com/flutter/flutter/pull/36481) Remove untested code
+
+[36490](https://github.com/flutter/flutter/pull/36490) [flutter_tool] Send analytics command before the command runs
+
+[36507](https://github.com/flutter/flutter/pull/36507) Bump engine version
+
+[36513](https://github.com/flutter/flutter/pull/36513) Fix flutter pub -v
+
+[36556](https://github.com/flutter/flutter/pull/36556) Fix usage test to use local usage
+
+[36560](https://github.com/flutter/flutter/pull/36560) [flutter_tools] Add some useful commands to the [README.md](http://readme.md/)
+
+[36564](https://github.com/flutter/flutter/pull/36564) Make sure fx flutter attach can find devices
+
+[36569](https://github.com/flutter/flutter/pull/36569) Some minor cleanup for flutter_tools
+
+[36570](https://github.com/flutter/flutter/pull/36570) Some minor fixes to the tool_coverage tool
+
+[36585](https://github.com/flutter/flutter/pull/36585) Place build outputs under dart tool
+
+[36598](https://github.com/flutter/flutter/pull/36598) Expose functionality to compile dart to kernel for the VM
+
+[36679](https://github.com/flutter/flutter/pull/36679) add line-length to flutter format command line
+
+[36727](https://github.com/flutter/flutter/pull/36727) Add missing config to create
+
+[36773](https://github.com/flutter/flutter/pull/36773) Expose build-dir config option
+
+[36774](https://github.com/flutter/flutter/pull/36774) Parameterize CoverageCollector with a library name predicate
+
+[36785](https://github.com/flutter/flutter/pull/36785) [flutter_tool] Clean up usage events and custom dimensions
+
+[36787](https://github.com/flutter/flutter/pull/36787) Check for directory instead of path separator
+
+[36832](https://github.com/flutter/flutter/pull/36832) Remove flaky check for analyzer message.
+
+[37036](https://github.com/flutter/flutter/pull/37036) Build number (part after +) is documented as optional, use entire app version if not present
+
+[37044](https://github.com/flutter/flutter/pull/37044) [flutter_tool] Make a couple file operations synchronous
+
+[37186](https://github.com/flutter/flutter/pull/37186) [flutter_tool] Usage refactor cleanup
+
+[37196](https://github.com/flutter/flutter/pull/37196) [flutter_tool] Catch ProcessException from 'adb devices'
+
+[37198](https://github.com/flutter/flutter/pull/37198) [flutter_tool] Re-try sending the first crash report
+
+[37210](https://github.com/flutter/flutter/pull/37210) do not strip symbols when building profile
+
+[37217](https://github.com/flutter/flutter/pull/37217) hide symbols from spotlight for App.framework
+
+[37331](https://github.com/flutter/flutter/pull/37331) [flutter_tool] Add missing toString()
+
+[37345](https://github.com/flutter/flutter/pull/37345) [flutter_tool] Include the local timezone in analytics timestamp
+
+[37378](https://github.com/flutter/flutter/pull/37378) Disable xcode indexing in CI via COMPILER_INDEX_STORE_ENABLE=NO argument
+
+[37422](https://github.com/flutter/flutter/pull/37422) [flutter_tool] Additional flutter manifest yaml validation
+
+[37440](https://github.com/flutter/flutter/pull/37440) Print message when HttpException is thrown after running flutter run
+
+[37457](https://github.com/flutter/flutter/pull/37457) Find the app bundle when the flavor contains underscores
+
+[37500](https://github.com/flutter/flutter/pull/37500) Avoid killing Flutter tool process (#37471)
+
+[37512](https://github.com/flutter/flutter/pull/37512) Enable track widget creation on debug builds
+
+[37514](https://github.com/flutter/flutter/pull/37514) [flutter_tool] Remove unintended analytics screen send
+
+[37521](https://github.com/flutter/flutter/pull/37521) have xcodeSelectPath also catch ArgumentError
+
+[37595](https://github.com/flutter/flutter/pull/37595) Closes #37593 Add flutter_export_environment.sh to gitignore
+
+[37654](https://github.com/flutter/flutter/pull/37654) Add missing library to flutter tools [BUILD.gn](http://build.gn/)
+
+[37731](https://github.com/flutter/flutter/pull/37731) Add metadata to indicate if the host app contains a Flutter module
+
+[37735](https://github.com/flutter/flutter/pull/37735) Remove unused no-build flag from the flutter run command
+
+[37743](https://github.com/flutter/flutter/pull/37743) Handle thrown maps and rejects from fe server
+
+[37792](https://github.com/flutter/flutter/pull/37792) Disable the progress bar when downloading the Dart SDK via Invoke-WebRequest
+
+[37863](https://github.com/flutter/flutter/pull/37863) Expose the timeline event names so they can be used in other systems that do tracing
+
+[37871](https://github.com/flutter/flutter/pull/37871) Catch failure to create directory in cache
+
+[37900](https://github.com/flutter/flutter/pull/37900) Listen to ExtensionEvent instead of TimelineEvent
+
+[37958](https://github.com/flutter/flutter/pull/37958) Catch FormatException caused by bad simctl output
+
+[37966](https://github.com/flutter/flutter/pull/37966) Remove ephemeral directories during flutter clean
+
+[37994](https://github.com/flutter/flutter/pull/37994) Remove no-constant-update-2018, the underlying issue has been resolved.
+
+[38101](https://github.com/flutter/flutter/pull/38101) Catch filesystem exception from flutter create
+
+[38102](https://github.com/flutter/flutter/pull/38102) Fix type error hidden by implicit downcasts
+
+[38296](https://github.com/flutter/flutter/pull/38296) use common emulator/device list
+
+[38339](https://github.com/flutter/flutter/pull/38339) [flutter_tool] Flip create language defaults to swift and kotlin
+
+[38342](https://github.com/flutter/flutter/pull/38342) remove bsdiff from [BUILD.gn](http://build.gn/)
+
+[38353](https://github.com/flutter/flutter/pull/38353) [flutter_tool] Observatory connection error handling cleanup
+
+[38472](https://github.com/flutter/flutter/pull/38472) [flutter_tool] Fix bug in manifest yaml validation
+
+[38486](https://github.com/flutter/flutter/pull/38486) Catch errors thrown into the Zone by json_rpc
+
+[38490](https://github.com/flutter/flutter/pull/38490) Fix publish cmd
+
+[38497](https://github.com/flutter/flutter/pull/38497) handle unexpected exit from frontend server
+
+[38575](https://github.com/flutter/flutter/pull/38575) fix rpc exception for real
+
+[38586](https://github.com/flutter/flutter/pull/38586) Don't reload if compilation has errors
+
+[38637](https://github.com/flutter/flutter/pull/38637) [flutter_tool] Throw tool exit on malformed storage url override
+
+[38652](https://github.com/flutter/flutter/pull/38652) Kill dead code
+
+[36860](https://github.com/flutter/flutter/pull/36860) Remove Chain terse parsing
+
+[36874](https://github.com/flutter/flutter/pull/36874) Adjust phrasing of features
+
+[36884](https://github.com/flutter/flutter/pull/36884) Unbreak build_runner
+
+
+## Full PR List
+
+You can see the full list of merged PRs in this release [here](/docs/development/tools/sdk/release-notes/changelogs/changelog-1.9.1).


### PR DESCRIPTION
We'd like to move the release notes for stable releases from the wiki to the web site. This PR:
* Adds a "Release notes" item to the Flutter SDK item in the sidenav.
* Adds an index page with a list of the release notes for the stable releases
* Copies the Markdown (with light editing) from the wiki release notes pages.
* Adds changelogs generated by running the latest version of the changelog tool.

You can see it staged [here](https://kf6gpe-flutter-staging.firebaseapp.com). [Here](https://kf6gpe-flutter-staging.firebaseapp.com/docs/development/tools/sdk/release-notes) is the release notes index page with links to each of the release notes.