### PR TITLE
Fix Kotlin sample issue on 'Adding a Flutter screen to an Android app' page

### DIFF
--- a/src/docs/development/add-to-app/android/add-flutter-screen.md
+++ b/src/docs/development/add-to-app/android/add-flutter-screen.md
@@ -209,7 +209,7 @@ myButton.addOnClickListener(new OnClickListener() {
   }
 });
 ```
-{% sample Kotlin,ExistingActivity.kt %}
+{% sample Kotlin %}
 <?code-excerpt "ExistingActivity.kt" title?>
 ```kotlin
 myButton.setOnClickListener {


### PR DESCRIPTION


This fixes the documentation to correctly show the kotlin sample on the 'Adding a Flutter screen to an Android app' page.