### PR TITLE
add missing  alignment: _dragAlignment to Animate a widget using a physics simulation  example.

### DIFF
--- a/src/docs/cookbook/animation/physics-simulation.md
+++ b/src/docs/cookbook/animation/physics-simulation.md
@@ -140,6 +140,7 @@ Widget build(BuildContext context) {
     },
     onPanEnd: (details) {},
     child: Align(
+      alignment: _dragAlignment,
       child: Card(
         child: widget.child,
       ),


### PR DESCRIPTION
as explained in step 2 

> Then, set the Align widget’s alignment to _dragAlignment

the `alignment` argument is missing.