### PR TITLE
Fixed the issue about the 'Integrate a Flutter module into your Android project' page

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -119,6 +119,7 @@
       { "source": "/go/remove-include-flutter-groovy", "destination": "https://docs.google.com/document/d/1OulURfRSWgJnnFA_cSup4ev7wrJwnZ7Siao_FGbLN9I", "type": 301 },
       { "source": "/go/build-flows", "destination": "https://docs.google.com/document/d/1imsVxbeAsttTi90EFpbnbVzov9z0xXd7tLCAr_QAJ38", "type": 301 },
       { "source": "/go/add-to-app-samples", "destination": "https://docs.google.com/document/d/1M_GsAL8C1NxbsmzI35w2Th1wvX1KMoPHY5yeeNbzjY0", "type": 301 },
+      { "source": "/go/build-aar", "destination": "/docs/development/add-to-app/android/project-setup", "type": 301 },
       { "source": "/go/golden-workflow", "destination": "https://docs.google.com/document/d/1MuIUz9pyE_bBZPbtMCj3pYgkdgG4s4Egh6FMknTngKw", "type": 301 },
       { "source": "/go/androidx-transition", "destination": "https://docs.google.com/document/d/1JnMxQinUeouuV5kcenoq03TsvLyn_xaHXIT_6c5b7nQ", "type": 301 },
       { "source": "/go/plugin-binding-review", "destination": "https://docs.google.com/document/d/1-9Si_ocFYh-Wa1qKV4PV2ocywKDYdiR_1yO3twPvrfM", "type": 301 },

--- a/src/docs/development/add-to-app/android/project-setup.md
+++ b/src/docs/development/add-to-app/android/project-setup.md
@@ -193,9 +193,9 @@ repositories {
 
 dependencies {
   // ...
-  debugImplementation 'com.example.flutter_module:flutter_debug:1.0
-  profileImplementation 'com.example.flutter_module:flutter_profile:1.0
-  releaseImplementation 'com.example.flutter_module:flutter_release:1.0
+  debugImplementation 'com.example.flutter_module:flutter_debug:1.0'
+  profileImplementation 'com.example.flutter_module:flutter_profile:1.0'
+  releaseImplementation 'com.example.flutter_module:flutter_release:1.0'
 }
 ```
 

--- a/src/docs/development/add-to-app/android/project-setup.md
+++ b/src/docs/development/add-to-app/android/project-setup.md
@@ -145,7 +145,7 @@ Then, follow the on-screen instructions to integrate.
 {% include app-figure.md image="development/add-to-app/android/project-setup/build-aar-instructions.png" %}
 
 More specifically, this command creates (by default all debug/profile/release
-modes) a [local repository](https://docs.gradle.org/current/userguide/repository_types.html#sub:maven_local), with the following files:
+modes) a [local repository](https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:maven_local), with the following files:
 
 ```text
 build/host/outputs/repo


### PR DESCRIPTION
Got the feedback from the China community that we just missed the flutter.dev/go/build-aar link which is shown from the Flutter SDK. I've already fixed this URI on the .cn site, FYI.

![image](https://user-images.githubusercontent.com/2258420/70962924-c7bc3a00-20c1-11ea-9b77-523be866126d.png)

cc/ @xster, @sfshaza2 

Thanks to @zmtzawqlp and @Vadaski!