### PR TITLE
update app/build.gradle code snippet

### DIFF
--- a/src/docs/deployment/android.md
+++ b/src/docs/deployment/android.md
@@ -157,7 +157,7 @@ Configure signing for your app by editing the
        release {
            keyAlias keystoreProperties['keyAlias']
            keyPassword keystoreProperties['keyPassword']
-           storeFile file(keystoreProperties['storeFile'])
+           storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
            storePassword keystoreProperties['storePassword']
        }
    }


### PR DESCRIPTION
Check for null before passing to file(), because it seems like this gets evaluated even when building with a different signingConfig.  
If this gets evaluated and you have not set up key.properties, file() throws an obscure error:
```
* What went wrong:
A problem occurred evaluating project ':app'.
> path may not be null or empty string. path='null'
```

Flutter should not fail, if I do not build with `--release`  
Concrete example: Clone an app to try out. `flutter run` would fail.

With this change when building with `--release` the following error would be thrown if signing has not been set up properly:
```
* What went wrong:                                                      
Execution failed for task ':app:validateSigningRelease'.                
> Keystore file not set for signing config release
```