### PR TITLE
Fix: Update unused method name in docs

### DIFF
--- a/src/docs/development/platform-integration/platform-channels.md
+++ b/src/docs/development/platform-integration/platform-channels.md
@@ -225,7 +225,7 @@ Start by opening the Android host portion of your Flutter app in Android Studio:
    Project view.
 
 Next, create a `MethodChannel` and set a `MethodCallHandler` inside the
-`onCreate()` method. Make sure to use the same channel name as was used on the
+`configureFlutterEngine()` method. Make sure to use the same channel name as was used on the
 Flutter client side.
 
 <?code-excerpt "MainActivity.java" title?>


### PR DESCRIPTION
Changed 'onCreate()' to 'configureFlutterEngine()' in [this article](https://flutter.dev/docs/development/platform-integration/platform-channels?tab=android-channel-java-tab#step-3-add-an-android-platform-specific-implementation).
- There is no 'onCreate()' function in the example code.