### PR TITLE
Update web.md

### DIFF
--- a/src/docs/get-started/web.md
+++ b/src/docs/get-started/web.md
@@ -17,7 +17,8 @@ This page covers the following steps for getting started with web support:
 For more information, see the [web FAQ][].
 
 {{ site.alert.note }}
-  As of 1.12, Flutter has early support for running web applications.
+  As of 1.12, Flutter has early support for running web applications, but
+  you need to be running the `beta` channel of Flutter at present.
   If you experience a problem that hasn’t yet been reported,
   please [file an issue][] and make sure that “web” appears in the title.
 {{ site.alert.end }}


### PR DESCRIPTION
Clarify that Flutter requires `beta` channel for web support at present.