### PR TITLE
Fix paragraph spacing in `deployment/ios.md`

### DIFF
--- a/src/docs/deployment/ios.md
+++ b/src/docs/deployment/ios.md
@@ -86,6 +86,7 @@ In the **Identity** section:
 `Display Name`
 : The name of the app to be displayed on the home screen and
   elsewhere.
+  
 `Bundle Identifier`
 : The App ID you registered on App Store Connect.
 


### PR DESCRIPTION
On **Review Xcode project settings**, `Bundle Identifier` was missing a line break before it to ensure it is on a separate paragraph.