### PR TITLE
Fix: update unused argument name in docs

### DIFF
--- a/src/docs/development/platform-integration/platform-channels.md
+++ b/src/docs/development/platform-integration/platform-channels.md
@@ -296,7 +296,7 @@ You need to handle a single platform method, `getBatteryLevel()`,
 so test for that in the `call` argument. The implementation of
 this platform method calls the Android code written
 in the previous step, and returns a response for both
-the success and error cases using the `response` argument.
+the success and error cases using the `result` argument.
 If an unknown method is called, report that instead.
 
 Remove the following code:

--- a/src/docs/development/platform-integration/platform-channels.md
+++ b/src/docs/development/platform-integration/platform-channels.md
@@ -225,7 +225,7 @@ Start by opening the Android host portion of your Flutter app in Android Studio:
    Project view.
 
 Next, create a `MethodChannel` and set a `MethodCallHandler` inside the
-`onCreate()` method. Make sure to use the same channel name as was used on the
+`configureFlutterEngine()` method. Make sure to use the same channel name as was used on the
 Flutter client side.
 
 <?code-excerpt "MainActivity.java" title?>


### PR DESCRIPTION
Hello, I found another document issue in [this article](https://flutter.dev/docs/development/platform-integration/platform-channels?tab=android-channel-java-tab#step-3-add-an-android-platform-specific-implementation).
I changed `response` to `result`, because `setMethodCallHandler()` only provides `call` and `result` arguments.