### PR TITLE
Fix sentence fragment in _get-sdk.md

### DIFF
--- a/src/docs/get-started/install/_get-sdk.md
+++ b/src/docs/get-started/install/_get-sdk.md
@@ -31,9 +31,10 @@
     $ {{unzip}} ~/Downloads/flutter_{{os}}_vX.X.X-{{site.sdk.channel}}{{file_ext}}
     ```
     
-    Steps 1 and 2 can be replaced. If you don't want to install a fixed version of the installation bundle.
-    The Flutter SDK is free and open source, so you can get the source code from the [Flutter repo](https://github.com/flutter/flutter) on GitHub,
-    and change branches or tags as needed.
+     If you don't want to install a fixed version of the installation bundle, 
+     you can skip steps 1 and 2. 
+     Instead, get the source code from the [Flutter repo](https://github.com/flutter/flutter) on GitHub,
+     and change branches or tags as needed.
     
     ```terminal
     $ git clone https://github.com/flutter/flutter.git


### PR DESCRIPTION
Just noticed this while going to install Flutter locally. 

I believe this rearrangement preserves the intent of the statement(s) and attaches the dangling "If" clause to something.