### PR TITLE
Fix typo in code

### DIFF
--- a/src/docs/release/breaking-changes/text-input-client-current-value.md
+++ b/src/docs/release/breaking-changes/text-input-client-current-value.md
@@ -112,7 +112,7 @@ class _MyCustomTextWidgetState extends State<MyCustomWidget> implements TextEdit
   ...
 
   @override
-  TextEditingValue get currentTextEditingState => widget.textEditingController.value;
+  TextEditingValue get currentTextEditingValue => widget.textEditingController.value;
 
   @override
   void updateEditingValue(TextEditingValue value) {


### PR DESCRIPTION
The `currentTextEditingState` variable should be `currentTextEditingValue`. The former wasn't defined anywhere.