### PR TITLE
Outdated ChangeNotifierProvider construction

### DIFF
--- a/src/docs/development/data-and-backend/state-mgmt/simple.md
+++ b/src/docs/development/data-and-backend/state-mgmt/simple.md
@@ -270,7 +270,7 @@ the only widget that is on top of both `MyCart` and `MyCatalog` is `MyApp`.
 void main() {
   runApp(
     [!ChangeNotifierProvider!](
-      builder: (context) => CartModel(),
+      create: (context) => CartModel(),
       child: MyApp(),
     ),
   );


### PR DESCRIPTION
The `ChangeNotifierProvider` construction was referring to an old version of the library.

Closes #3534