### PR TITLE
Fix add-to-app iOS setup code snippet whitespace

### DIFF
--- a/src/docs/development/add-to-app/ios/project-setup.md
+++ b/src/docs/development/add-to-app/ios/project-setup.md
@@ -114,8 +114,8 @@ If your existing application (`MyApp`) doesn't already have a Podfile, follow th
 
     <?code-excerpt "MyApp/Podfile" title?>
     ```ruby
-      flutter_application_path = '../my_flutter'
-      load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
+    flutter_application_path = '../my_flutter'
+    load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
     ```
 
 2. For each [Podfile target][] that needs to
@@ -123,9 +123,9 @@ embed Flutter, call `install_all_flutter_pods(flutter_application_path)`.
 
     <?code-excerpt "MyApp/Podfile" title?>
     ```ruby
-      target 'MyApp' do
-        install_all_flutter_pods(flutter_application_path)
-      end
+    target 'MyApp' do
+      install_all_flutter_pods(flutter_application_path)
+    end
     ```
 
 3. Run `pod install`.


### PR DESCRIPTION
See weird spacing in https://flutter.dev/docs/development/add-to-app/ios/project-setup#option-a---embed-with-cocoapods-and-the-flutter-sdk.