### PR TITLE
Updating install web warning

### DIFF
--- a/src/docs/get-started/install/_web-setup.md
+++ b/src/docs/get-started/install/_web-setup.md
@@ -1,10 +1,9 @@
 ## Web setup
 
 {{site.alert.warning}}
-  Flutter on the web is currently available as a technical preview.
-  When trying Flutter apps on the web, you can expect to experience
-  crashes and missing features.
-  If this happens, please [file an issue][].
+Note: As of 1.12, Flutter has early support for running web applications, but you need to be running the beta channel of
+Flutter at present. If you experience a problem that hasn’t yet been reported, please [file an issue][] and make sure that
+“web” appears in the title.
 {{site.alert.end}}
 
 To prepare to run and test your Flutter app on the web,


### PR DESCRIPTION
the current warning on install web is out of date. Changing it to the current one on the building a web application page.