### PR TITLE
fix command line code copy has extra space after prompt.

### DIFF
--- a/src/_assets/js/main.js
+++ b/src/_assets/js/main.js
@@ -150,7 +150,15 @@ function initSnackbar() {
 }
 
 function setupClipboardJS() {
-  var clipboard = new ClipboardJS('.code-excerpt__copy-btn'); // [data-clipboard-target]
+  var clipboard = new ClipboardJS('.code-excerpt__copy-btn', {
+    text: function (trigger) {
+      var targetId = trigger.getAttribute('data-clipboard-target');
+      var target = document.querySelector(targetId);
+      var terminalRegExp = /^\$\s*/gm;
+      var copy = target.textContent.replace(terminalRegExp, '');
+      return copy;
+    }
+  });
   clipboard.on('success', _copiedFeedback);
 }
 


### PR DESCRIPTION
I find command line code copy has extra space after prompt($), like [macOS install - Flutter](https://flutter.dev/docs/get-started/install/macos).

In addition, I hope the flutter/website project can support building on zsh as soon as possible, Setting up the environment to run the website locally and testing tortured me.

P.S. macOS Catalina uses the Z shell by default