### PR TITLE
Update platform-channels.md

### DIFF
--- a/src/docs/development/platform-integration/platform-channels.md
+++ b/src/docs/development/platform-integration/platform-channels.md
@@ -241,7 +241,7 @@ public class MainActivity extends FlutterActivity {
 
   @Override
   public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
-    GeneratedPluginRegistrant.registerWith(flutterEngine);
+    GeneratedPluginRegistrant.registerWith(new ShimPluginRegistry(flutterEngine));
     new MethodChannel(flutterEngine.getDartExecutor().getBinaryMessenger(), CHANNEL)
         .setMethodCallHandler(
           (call, result) -> {
@@ -358,7 +358,7 @@ class MainActivity: FlutterActivity() {
   private val CHANNEL = "samples.flutter.dev/battery"
 
   override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
-    GeneratedPluginRegistrant.registerWith(flutterEngine)
+    GeneratedPluginRegistrant.registerWith(new ShimPluginRegistry(flutterEngine))
     MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
       call, result ->
       // Note: this method is invoked on the main thread.


### PR DESCRIPTION
Fix issues with wrong argument in 'MainActivity.java'

> error: incompatible types: FlutterEngine cannot be converted to PluginRegistry

Some conflict when using import `io.flutter.embedding.android.FlutterActivity;`  apparently doing this change the use of `GeneratedPluginRegistrant.registerWith(flutterEngine)` to `GeneratedPluginRegistrant.registerWith(new ShimPluginRegistry(flutterEngine));` for some reason.