### PR TITLE
Fix: FlutterEngine cannot be converted to PluginRegistry

### DIFF
--- a/src/docs/development/platform-integration/platform-channels.md
+++ b/src/docs/development/platform-integration/platform-channels.md
@@ -230,9 +230,9 @@ Flutter client side.
 
 <?code-excerpt "MainActivity.java" title?>
 ```java
-import androidx.annotation.NonNull;
-import io.flutter.embedding.android.FlutterActivity;
-import io.flutter.embedding.engine.FlutterEngine;
+import android.os.Bundle;
+
+import io.flutter.app.FlutterActivity;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
@@ -240,16 +240,16 @@ public class MainActivity extends FlutterActivity {
   private static final String CHANNEL = "samples.flutter.dev/battery";
 
   @Override
-  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
-    GeneratedPluginRegistrant.registerWith(flutterEngine);
-    new MethodChannel(flutterEngine.getDartExecutor().getBinaryMessenger(), CHANNEL)
-        .setMethodCallHandler(
-          (call, result) -> {
-            // Note: this method is invoked on the main thread.
-            // TODO
-          }
-        );
-  }
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    GeneratedPluginRegistrant.registerWith(this);
+    new MethodChannel(getFlutterView(), CHANNEL)
+      .setMethodCallHandler(
+         (call, result) -> {
+           // Note: this method is invoked on the main thread.
+           // TODO
+         });
+    }
 }
 ```
 


### PR DESCRIPTION
Fix issues with wrong argument in 'MainActivity.java'

> error: incompatible types: FlutterEngine cannot be converted to PluginRegistry