### PR TITLE
mdashh->mdash

### DIFF
--- a/src/docs/development/add-to-app/ios/project-setup.md
+++ b/src/docs/development/add-to-app/ios/project-setup.md
@@ -223,7 +223,7 @@ some/path/MyApp/
 
 Embed and link the generated frameworks into your existing
 application in Xcode.  There are multiple ways to do
-this&mdashh;use the method that is best for your project.
+this&mdash;use the method that is best for your project.
 
 ### Link on the frameworks
 


### PR DESCRIPTION
Fix typo, mdashh->mdash

Currently looks like:
![Screen Shot 2020-02-03 at 2 57 28 PM](https://user-images.githubusercontent.com/682784/73698278-84c81d00-4695-11ea-81af-989d0d329843.png)
