### PR TITLE
Add old design docs to list

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -167,7 +167,9 @@
       { "source": "/go/globalkey-duplication-refactoring", "destination": "https://docs.google.com/document/d/15U1XDLrP-SXfgeu5DBBsA7MQuFpDUW005Y2ObwmYWIc/", "type": 301 },
       { "source": "/go/platform-based-key-events", "destination": "https://docs.google.com/document/d/1FDuxxEh810XpY561SgeiyUR0gU2eVz5kRpCFI55ibec/edit?usp=sharing", "type": 301 },
       { "source": "/go/dartle", "destination": "https://docs.google.com/document/d/1Ei0ZIqdqNjxTHoGB3Ay6SWQg3DMSsKKWl70XoBUCFTA", "type": 301 },
-      { "source": "/go/widget-tree-image-cache", "destination": "https://docs.google.com/document/d/1deEtxZk1VYRmzvkL4gTb3sEnjBrHejQkWObQ4yrP5jE/edit?pli=1#", "type": 301 }
+      { "source": "/go/widget-tree-image-cache", "destination": "https://docs.google.com/document/d/1deEtxZk1VYRmzvkL4gTb3sEnjBrHejQkWObQ4yrP5jE/edit?pli=1#", "type": 301 },
+      { "source": "/go/unobstructed-platform-views", "destination": "https://docs.google.com/document/d/1_P3wa_nMqnhKsy-lDlNxT9GThZX2WhfVym4O4M7Q9qs/edit#", "type": 301 },
+      { "source": "/go/dart-flutterbuffers", "destination": "https://docs.google.com/document/d/1rqKq6DwqaeBfTLTixxurrdT9HwZ02DyRjFigO9SiB1Q/edit#", "type": 301 }
     ]
   }
 }


### PR DESCRIPTION
Previously I hadn't added these since I didn't require short links for them, but with the new https://flutter.dev/docs/resources/design-docs it would be good to add these to the list of all the docs.