### PR TITLE
First time users should git clone from the stable branch

### DIFF
--- a/src/docs/get-started/install/_get-sdk-win.md
+++ b/src/docs/get-started/install/_get-sdk-win.md
@@ -18,7 +18,7 @@ bundle, you can skip steps 1 and 2. Instead, get the source code
 from the Flutter repo on GitHub, and change branches or tags as
 needed. For example:
 
-```cmd
+```console
 C:\src>git clone https://github.com/flutter/flutter.git -b stable
 ```
 
@@ -47,7 +47,7 @@ From a console window that has the Flutter directory in the
 path (see above), run the following command to see if there
 are any platform dependencies you need to complete the setup:
 
-```cmd
+```console
 C:\src\flutter>flutter doctor
 ```
 

--- a/src/docs/get-started/install/_get-sdk-win.md
+++ b/src/docs/get-started/install/_get-sdk-win.md
@@ -14,9 +14,9 @@
     `C:\Program Files\` that requires elevated privileges).
 
 If you don't want to install a fixed version of the installation 
-bundle, you can skip steps 1 and 2. Instead, get the source code
-from the Flutter repo on GitHub, and change branches or tags as
-needed. For example:
+bundle, you can skip steps 1 and 2. Instead, get the source code 
+from the [Flutter repo](https://github.com/flutter/flutter) on 
+GitHub, and change branches or tags as needed. For example:
 
 ```batchfile
 C:\src>git clone https://github.com/flutter/flutter.git -b stable

--- a/src/docs/get-started/install/_get-sdk-win.md
+++ b/src/docs/get-started/install/_get-sdk-win.md
@@ -13,12 +13,13 @@
     do not install Flutter in a directory like
     `C:\Program Files\` that requires elevated privileges).
 
-Steps 1 and 2 can be replaced. If you don't want to install a fixed version of the installation bundle.
-The Flutter SDK is free and open source, so you can get the source code from the [Flutter repo](https://github.com/flutter/flutter) on GitHub,
-and change branches or tags as needed.
+If you don't want to install a fixed version of the installation 
+bundle, you can skip steps 1 and 2. Instead, get the source code
+from the Flutter repo on GitHub, and change branches or tags as
+needed. For example:
 
 ```terminal
-$ git clone https://github.com/flutter/flutter.git
+$ git clone https://github.com/flutter/flutter.git -b stable
 ```
 
 You are now ready to run Flutter commands in the Flutter Console!

--- a/src/docs/get-started/install/_get-sdk-win.md
+++ b/src/docs/get-started/install/_get-sdk-win.md
@@ -19,7 +19,7 @@ from the Flutter repo on GitHub, and change branches or tags as
 needed. For example:
 
 ```terminal
-$ git clone https://github.com/flutter/flutter.git -b stable
+C:\src> git clone https://github.com/flutter/flutter.git -b stable
 ```
 
 You are now ready to run Flutter commands in the Flutter Console!

--- a/src/docs/get-started/install/_get-sdk-win.md
+++ b/src/docs/get-started/install/_get-sdk-win.md
@@ -18,8 +18,8 @@ bundle, you can skip steps 1 and 2. Instead, get the source code
 from the Flutter repo on GitHub, and change branches or tags as
 needed. For example:
 
-```terminal
-C:\src> git clone https://github.com/flutter/flutter.git -b stable
+```cmd
+C:\src>git clone https://github.com/flutter/flutter.git -b stable
 ```
 
 You are now ready to run Flutter commands in the Flutter Console!
@@ -47,7 +47,7 @@ From a console window that has the Flutter directory in the
 path (see above), run the following command to see if there
 are any platform dependencies you need to complete the setup:
 
-```console
+```cmd
 C:\src\flutter>flutter doctor
 ```
 

--- a/src/docs/get-started/install/_get-sdk-win.md
+++ b/src/docs/get-started/install/_get-sdk-win.md
@@ -18,7 +18,7 @@ bundle, you can skip steps 1 and 2. Instead, get the source code
 from the Flutter repo on GitHub, and change branches or tags as
 needed. For example:
 
-```console
+```batchfile
 C:\src>git clone https://github.com/flutter/flutter.git -b stable
 ```
 
@@ -47,7 +47,7 @@ From a console window that has the Flutter directory in the
 path (see above), run the following command to see if there
 are any platform dependencies you need to complete the setup:
 
-```console
+```batchfile
 C:\src\flutter>flutter doctor
 ```
 

--- a/src/docs/get-started/install/_get-sdk.md
+++ b/src/docs/get-started/install/_get-sdk.md
@@ -34,10 +34,10 @@
      If you don't want to install a fixed version of the installation bundle, 
      you can skip steps 1 and 2. 
      Instead, get the source code from the [Flutter repo](https://github.com/flutter/flutter) on GitHub,
-     and change branches or tags as needed.
+     and change branches or tags as needed. For example:
     
     ```terminal
-    $ git clone https://github.com/flutter/flutter.git
+    $ git clone https://github.com/flutter/flutter.git -b stable
     ```
     
  1. Add the `flutter` tool to your path:


### PR DESCRIPTION
The getting started directions lead a novice user to `git clone` from the `master` branch, as a result of a recent edit. Instead, we should be encouraging users to start with the `stable` branch. Other branches are advanced scenarios that shouldn't be more than touched upon in the opening flow.