### PR TITLE
Fixed missing link notation in codelab.md

### DIFF
--- a/src/docs/get-started/codelab.md
+++ b/src/docs/get-started/codelab.md
@@ -34,8 +34,8 @@ you can complete this tutorial. You don’t need
 previous experience with Dart, mobile, or web programming.
 
 This guide is part 1 of a two-part codelab.
-You can find [part 2][] on the [Google Developers][] site.
-[Part 1][] can also be found on [Google Developers][].
+You can find [part 2][] on the [Google Developers Codelabs][],
+as well as [part 1][].
 
 ## What you'll build in part 1
 {:.no_toc}


### PR DESCRIPTION
The link notations were broken. Fixing it.

<img width="779" alt="Screen Shot 2020-02-04 at 10 30 15 PM" src="https://user-images.githubusercontent.com/28604/73808854-50408800-479f-11ea-931a-e9a94599bd00.png">
