### PR TITLE
Fix Classes path on iOS in Xcode

### DIFF
--- a/src/docs/development/packages-and-plugins/developing-packages.md
+++ b/src/docs/development/packages-and-plugins/developing-packages.md
@@ -157,8 +157,7 @@ Next,
 1. Launch Xcode
 1. Select 'File > Open', and select the `hello/example/ios/Runner.xcworkspace` file.
 
-The iOS platform code of your plugin is located in `Pods/Development
-Pods/hello/Classes/` in the Project Navigator.
+The iOS platform code of your plugin is located in `Pods/Development Pods/hello/../../example/ios/.symlinks/plugins/hello/ios/Classes` in the Project Navigator.
 
 You can run the example app by pressing the &#9654; button.
 


### PR DESCRIPTION
Documentation appears to not reflect the actual path shown in Xcode. This PR corrects this.

<img width="292" alt="Screen Shot 2020-02-07 at 9 37 57 PM" src="https://user-images.githubusercontent.com/666539/74077986-f0421f80-49f2-11ea-9753-8802f194a109.png">
