### PR TITLE
Updated title, headline and body1

### DIFF
--- a/src/docs/cookbook/design/themes.md
+++ b/src/docs/cookbook/design/themes.md
@@ -156,9 +156,9 @@ class MyApp extends StatelessWidget {
         // Define the default TextTheme. Use this to specify the default
         // text styling for headlines, titles, bodies of text, and more.
         textTheme: TextTheme(
-          headline: TextStyle(fontSize: 72.0, fontWeight: FontWeight.bold),
-          title: TextStyle(fontSize: 36.0, fontStyle: FontStyle.italic),
-          body1: TextStyle(fontSize: 14.0, fontFamily: 'Hind'),
+          headline5: TextStyle(fontSize: 72.0, fontWeight: FontWeight.bold),
+          headline6: TextStyle(fontSize: 36.0, fontStyle: FontStyle.italic),
+          bodyText2: TextStyle(fontSize: 14.0, fontFamily: 'Hind'),
         ),
       ),
       home: MyHomePage(
@@ -184,7 +184,7 @@ class MyHomePage extends StatelessWidget {
           color: Theme.of(context).accentColor,
           child: Text(
             'Text with a background color',
-            style: Theme.of(context).textTheme.title,
+            style: Theme.of(context).textTheme.headline6,
           ),
         ),
       ),


### PR DESCRIPTION
Updated the `title`, `headline` and `body1` properties to headline5, headline6 and bodyText2 to remove deprecation messages in the interactive example