### PR TITLE
Replace Post with Album

### DIFF
--- a/src/docs/cookbook/networking/authenticated-requests.md
+++ b/src/docs/cookbook/networking/authenticated-requests.md
@@ -21,9 +21,9 @@ class from the `dart:io` library.
 
 <!-- skip -->
 ```dart
-Future<http.Response> fetchPost() {
+Future<http.Response> fetchAlbum() {
   return http.get(
-    'https://jsonplaceholder.typicode.com/posts/1',
+    'https://jsonplaceholder.typicode.com/albums/1',
     // Send authorization headers to the backend.
     headers: {HttpHeaders.authorizationHeader: "Basic your_api_token_here"},
   );
@@ -42,30 +42,28 @@ import 'dart:io';
 
 import 'package:http/http.dart' as http;
 
-Future<Post> fetchPost() async {
+Future<Album> fetchAlbum() async {
   final response = await http.get(
-    'https://jsonplaceholder.typicode.com/posts/1',
+    'https://jsonplaceholder.typicode.com/albums/1',
     headers: {HttpHeaders.authorizationHeader: "Basic your_api_token_here"},
   );
   final responseJson = json.decode(response.body);
 
-  return Post.fromJson(responseJson);
+  return Album.fromJson(responseJson);
 }
 
-class Post {
+class Album {
   final int userId;
   final int id;
   final String title;
-  final String body;
 
-  Post({this.userId, this.id, this.title, this.body});
+  Album({this.userId, this.id, this.title});
 
-  factory Post.fromJson(Map<String, dynamic> json) {
-    return Post(
+  factory Album.fromJson(Map<String, dynamic> json) {
+    return Album(
       userId: json['userId'],
       id: json['id'],
       title: json['title'],
-      body: json['body'],
     );
   }
 }

--- a/src/docs/cookbook/networking/fetch-data.md
+++ b/src/docs/cookbook/networking/fetch-data.md
@@ -42,13 +42,13 @@ import 'package:http/http.dart' as http;
 
 ## 2. Make a network request
 
-In this example, fetch a sample post from the
+In this example, fetch a sample album from the
 [JSONPlaceholder][] using the [http.get()][] method.
 
 <!-- skip -->
 ```dart
-Future<http.Response> fetchPost() {
-  return http.get('https://jsonplaceholder.typicode.com/posts/1');
+Future<http.Response> fetchAlbum() {
+  return http.get('https://jsonplaceholder.typicode.com/albums/1');
 }
 ```
 
@@ -66,11 +66,11 @@ While it's easy to make a network request, working with a raw
 `Future<http.Response>` isn't very convenient. To make your life easier,
 convert the `http.Response` into a Dart object.
 
-### Create a `Post` class
+### Create a `Album` class
 
-First, create a `Post` class that contains the data from the
+First, create a `Album` class that contains the data from the
 network request. It includes a factory constructor that
-creates a `Post` from JSON.
+creates a `Album` from JSON.
 
 Converting JSON by hand is only one option.
 For more information, see the full article on
@@ -78,34 +78,32 @@ For more information, see the full article on
 
 <!-- skip -->
 ```dart
-class Post {
+class Album {
   final int userId;
   final int id;
   final String title;
-  final String body;
 
-  Post({this.userId, this.id, this.title, this.body});
+  Album({this.userId, this.id, this.title});
 
-  factory Post.fromJson(Map<String, dynamic> json) {
-    return Post(
+  factory Album.fromJson(Map<String, dynamic> json) {
+    return Album(
       userId: json['userId'],
       id: json['id'],
       title: json['title'],
-      body: json['body'],
     );
   }
 }
 ```
 
-### Convert the `http.Response` to a `Post`
+### Convert the `http.Response` to a `Album`
 
-Now, use the following steps to update the `fetchPost()`
-function to return a `Future<Post>`:
+Now, use the following steps to update the `fetchAlbum()`
+function to return a `Future<Album>`:
 
   1. Convert the response body into a JSON `Map` with the `dart:convert`
      package.
   2. If the server does return an OK response with a status code of 200, then convert
-     the JSON `Map` into a `Post` using the `fromJson()` factory method.
+     the JSON `Map` into a `Album` using the `fromJson()` factory method.
   3. If the server does not return an OK response with a status code of 200,
      then throw an exception. (Even in the case of a 404 Not Found server response,
      throw an exception. Do not return `null`. This is important when examining
@@ -113,20 +111,20 @@ function to return a `Future<Post>`:
 
 <!-- skip -->
 ```dart
-Future<Post> fetchPost() async {
-  final response = await http.get('https://jsonplaceholder.typicode.com/posts/1');
+Future<Album> fetchAlbum() async {
+  final response = await http.get('https://jsonplaceholder.typicode.com/albums/1');
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response, then parse the JSON.
-    return Post.fromJson(json.decode(response.body));
+    return Album.fromJson(json.decode(response.body));
   } else {
     // If the server did not return a 200 OK response, then throw an exception.
-    throw Exception('Failed to load post');
+    throw Exception('Failed to load album');
   }
 }
 ```
 
-Hooray! Now you've got a function that fetches a post from the
+Hooray! Now you've got a function that fetches an album from the
 internet.
 
 ## 4. Fetch the data
@@ -142,12 +140,12 @@ If you want to have the option of reloading the API in response to an
 <!-- skip -->
 ```dart
 class _MyAppState extends State<MyApp> {
-  Future<Post> post;
+  Future<Album> futureAlbum;
 
   @override
   void initState() {
     super.initState();
-    post = fetchPost();
+    futureAlbum = fetchAlbum();
   }
 ```
 
@@ -162,19 +160,19 @@ makes it easy to work with async data sources.
 You must provide two parameters:
 
   1. The `Future` you want to work with. In this case, the future returned from
-  the `fetchPost()` function.
+  the `fetchAlbum()` function.
   2. A `builder` function that tells Flutter what to render, depending on the
   state of the `Future`: loading, success, or error.
 
 Note that `snapshot.hasData` will only return `true` when the snapshot contains
-a non-null data value. This is why the `fetchPost` function should throw an exception
-even in the case of a 404 Not Found server response. If `fetchPost` returns `null`
+a non-null data value. This is why the `fetchAlbum` function should throw an exception
+even in the case of a 404 Not Found server response. If `fetchAlbum` returns `null`
 then the spinner will show indefinitely.
 
 <!-- skip -->
 ```dart
-FutureBuilder<Post>(
-  future: post,
+FutureBuilder<Album>(
+  future: futureAlbum,
   builder: (context, snapshot) {
     if (snapshot.hasData) {
       return Text(snapshot.data.title);
@@ -188,7 +186,7 @@ FutureBuilder<Post>(
 );
 ```
 
-## Why is fetchPost() called in initState()?
+## Why is fetchAlbum() called in initState()?
 
 Although it's convenient, it's not recommended to put an API call in a
 `build()` method.
@@ -215,33 +213,31 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 
-Future<Post> fetchPost() async {
+Future<Album> fetchAlbum() async {
   final response =
-      await http.get('https://jsonplaceholder.typicode.com/posts/1');
+      await http.get('https://jsonplaceholder.typicode.com/albums/1');
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response, then parse the JSON.
-    return Post.fromJson(json.decode(response.body));
+    return Album.fromJson(json.decode(response.body));
   } else {
     // If the server did not return a 200 OK response, then throw an exception.
-    throw Exception('Failed to load post');
+    throw Exception('Failed to load album');
   }
 }
 
-class Post {
+class Album {
   final int userId;
   final int id;
   final String title;
-  final String body;
 
-  Post({this.userId, this.id, this.title, this.body});
+  Album({this.userId, this.id, this.title});
 
-  factory Post.fromJson(Map<String, dynamic> json) {
-    return Post(
+  factory Album.fromJson(Map<String, dynamic> json) {
+    return Album(
       userId: json['userId'],
       id: json['id'],
       title: json['title'],
-      body: json['body'],
     );
   }
 }
@@ -256,12 +252,12 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-Future<Post> post;
+Future<Album> futureAlbum;
 
   @override
   void initState() {
     super.initState();
-    post = fetchPost();
+    futureAlbum = fetchAlbum();
   }
 
   @override
@@ -276,8 +272,8 @@ Future<Post> post;
           title: Text('Fetch Data Example'),
         ),
         body: Center(
-          child: FutureBuilder<Post>(
-            future: post,
+          child: FutureBuilder<Album>(
+            future: futureAlbum,
             builder: (context, snapshot) {
               if (snapshot.hasData) {
                 return Text(snapshot.data.title);


### PR DESCRIPTION
Changing the cookbook `fetch-data` & `authenticated-requests` examples to use `albums` instead if `posts` as someone new to the example would misinterpret the model `Post` with the http request type `POST`.

Closes: #2836 