### PR TITLE
Update navigation information for xamarin.forms.

### DIFF
--- a/src/docs/get-started/flutter-for/xamarin-forms-devs.md
+++ b/src/docs/get-started/flutter-for/xamarin-forms-devs.md
@@ -657,9 +657,9 @@ Widget build(BuildContext context) {
 
 ### How do I navigate between pages?
 
-In Xamarin.Forms, you navigate between pages normally through a
-CarouselPage. In Flutter, you can use a `NavigationPage`
-that manages the stack of pages to display.
+In Xamarin.Forms, the `NavigationPage` class provides a hierarchical 
+navigation experience where the user is able to navigate through pages, 
+forwards and backwards.
 
 Flutter has a similar implementation, using a `Navigator` and
 `Routes`. A `Route` is an abstraction for a `Page` of an app, and


### PR DESCRIPTION
Update the information in "How do I navigate between pages?" section for Xamarin.Forms.
Comparison between "CarouselPage" of Xamarin.Forms and Navigator of Flutter is not quite accurate.
Comparison with NavigationPage is makes sense.
Please check the docs about 
CarouselPage https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/navigation/carousel-page
and
NavigationPage https://docs.microsoft.com/en-us/dotnet/api/xamarin.forms.navigationpage?view=xamarin-forms