### PR TITLE
Fix Twitter username

### DIFF
--- a/src/_data/community.yml
+++ b/src/_data/community.yml
@@ -40,7 +40,7 @@
   logo_src: community/logo-meetup.svg
   learn_more_link: https://www.meetup.com/find/?allMeetups=false&keywords=flutter&radius=Infinity&userFreeform=Santa+Clara%2C+CA&mcId=z95054&mcName=Santa+Clara%2C+CA&sort=recommended&eventFilter=mysugg
 
-- name: "@flutter.dev"
+- name: "@FlutterDev"
   description: >
     Follow the Flutter team in real-time with information on new features, upcoming events, and more.
   logo_src: community/logo-twitter.png


### PR DESCRIPTION
Fixed Flutter's Twitter username @ Community from `@flutter.dev` to `@FlutterDev`