### PR TITLE
Update count of widgets in the diagram

### DIFF
--- a/src/docs/development/data-and-backend/state-mgmt/simple.md
+++ b/src/docs/development/data-and-backend/state-mgmt/simple.md
@@ -44,7 +44,7 @@ Here's the app visualized as a widget tree.
   Source drawing for the png above: https://docs.google.com/drawings/d/1KXxAl_Ctxc-avhR4uE58BXBM6Tyhy0pQMCsSMFHVL_0/edit?zx=y4m1lzbhsrvx
 {% endcomment %}
 
-So we have at least 6 subclasses of `Widget`. Many of them need
+So we have at least 5 subclasses of `Widget`. Many of them need
 access to state that "belongs" elsewhere. For example, each
 `MyListItem` needs to be able to add itself to the cart.
 It might also want to see whether the currently displayed item


### PR DESCRIPTION
Back to basics: Filip learns to count.

![diagram](https://flutter.dev/assets/development/data-and-backend/state-mgmt/simple-widget-tree-0731408a48dff242cc0ea9b8203bd9a6e0d6f1be0bb158e095ea99212fe8e727.png)

The diagram shows 5 different widget classes, but somehow I failed to count correctly back when I wrote this.