### PR TITLE
Fixing more malformed links in meta text

### DIFF
--- a/src/docs/cookbook/testing/integration/scrolling.md
+++ b/src/docs/cookbook/testing/integration/scrolling.md
@@ -1,5 +1,6 @@
 ---
 title: Handle scrolling
+description: How to handle scrolling in an integration test.
 prev:
   title: Performance profiling
   path: /docs/cookbook/testing/integration/profiling
@@ -8,13 +9,14 @@ next:
   path: /docs/cookbook/testing/unit/introduction
 ---
 
-Many apps feature lists of content, from email clients to music apps
-and beyond.
-To verify that lists contain the expected content using integration
-tests, you need a way to scroll through lists to search for particular items.
+Many apps feature lists of content,
+from email clients to music apps and beyond.
+To verify that lists contain the expected content
+using integration tests,
+you need a way to scroll through lists to search for particular items.
 
-To scroll through lists via integration tests, use the methods
-provided by the [`FlutterDriver`][] class,
+To scroll through lists via integration tests,
+use the methods provided by the [`FlutterDriver`][] class,
 which is included in the [`flutter_driver`][] package:
 
 In this recipe, learn how to scroll through a list of items to

--- a/src/docs/cookbook/testing/unit/introduction.md
+++ b/src/docs/cookbook/testing/unit/introduction.md
@@ -1,5 +1,6 @@
 ---
 title: An introduction to unit testing
+description: How to write unit tests.
 short-title: Introduction
 prev:
   title: Perform scrolling

--- a/src/docs/get-started/codelab-web.md
+++ b/src/docs/get-started/codelab-web.md
@@ -1,5 +1,6 @@
 ---
 title: Write your first Flutter app on the web
+description: How to create a Flutter web app.
 short-title: Write your first web app
 ---
 

--- a/src/docs/get-started/install/index.md
+++ b/src/docs/get-started/install/index.md
@@ -1,5 +1,6 @@
 ---
 title: Install
+description: How to set up your code editor.
 next:
   title: Set up an editor
   path: /docs/get-started/editor

--- a/src/docs/release/breaking-changes/template.md
+++ b/src/docs/release/breaking-changes/template.md
@@ -96,7 +96,7 @@ Relevant PRs:
 {% comment %}
 Add the links to the end of the file in alphabetical order.
 I've had to comment out these faux links because they cause
-the Travia build to believe they are broken linksconfuse,
+the Travis build to believe they are broken links,
 but please remove the comment lines before you commit!
 
 [`ClassName`]: {{site.api}}/flutter/[link_to_relevant_page].html

--- a/src/docs/release/breaking-changes/template.md
+++ b/src/docs/release/breaking-changes/template.md
@@ -76,6 +76,11 @@ the version # to which we guarantee to maintain the old API.
 
 ## References
 
+{% comment %}
+I've had to comment out these non-functional links because
+they are messing up our Travis build. Remove the comment
+tags once you fill this in with real links.
+
 API documentation:
 * [`ClassName`][]
 
@@ -86,10 +91,13 @@ Relevant issues:
 Relevant PRs:
 * [PR title #1][]
 * [PR title #2][]
+{% endcomment %}
 
 {% comment %}
 Add the links to the end of the file in alphabetical order.
-I've had to comment out these faux links because they break the build.
+I've had to comment out these faux links because they cause
+the Travia build to believe they are broken linksconfuse,
+but please remove the comment lines before you commit!
 
 [`ClassName`]: {{site.api}}/flutter/[link_to_relevant_page].html
 [Issue xxxx]: {{site.github}}/flutter/flutter/issues/[link_to_actual_issue]


### PR DESCRIPTION
Fixes https://github.com/flutter/website/issues/3717

I think I got them all!

website [fixes2] $ cd /Users/shaza/GoogleDrive/site/flutter/website
website [fixes2] $ fgrep -Rl "][]" _site/docs
website [fixes2] $ 

Please review @kwalrath 