### PR TITLE
Add TargetPlatform linux/windows breaking change migration guide.

### DIFF
--- a/src/docs/release/breaking-changes/index.md
+++ b/src/docs/release/breaking-changes/index.md
@@ -3,11 +3,10 @@ title: Breaking changes
 description: A list of migration guides for breaking changes in Flutter.
 ---
 
-As described in the [breaking change policy][],
-on occasion we publish guides for migrating code
-across a breaking change.
-The following guides (in alphabetical order) are
-available:
+As described in the [breaking change policy][], on occasion we publish guides
+for migrating code across a breaking change.
+
+The following guides (in alphabetical order) are available:
 
 * [Annotations return local position relative to object][]
 * [Generic type of ParentDataWidget changed to ParentData][]
@@ -21,18 +20,20 @@ available:
 * [The Route and Navigator Refactoring][]
 * [The `forgetChild` method must call super][]
 * [ThemeData's accent properties][]
+* [Adding `linux` and `windows` to `TargetPlatform` enum][]
 
-[breaking change policy]: /docs/resources/compatibility
+[Adding `linux` and `windows` to `TargetPlatform` enum]: /docs/release/breaking-changes/target-platform-linux-windows
 [Annotations return local position relative to object]: /docs/release/breaking-changes/annotations-return-local-position-relative-to-object
+[breaking change policy]: /docs/resources/compatibility
 [Generic type of ParentDataWidget changed to ParentData]: /docs/release/breaking-changes/parent-data-widget-generic-type
-[ImageCache large images]: /docs/release/breaking-changes/imagecache-large-images
 [ImageCache and ImageProvider changes]: /docs/release/breaking-changes/image-cache-and-provider
+[ImageCache large images]: /docs/release/breaking-changes/imagecache-large-images
 [MouseTracker no longer attaches annotations]: /docs/release/breaking-changes/mouse-tracker-no-longer-attaches-annotations
 [Nullable `CupertinoTheme.brightness`]: /docs/release/breaking-changes/nullable-cupertinothemedata-brightness
 [Rebuild optimization for OverlayEntries and Routes]: /docs/release/breaking-changes/overlay-entry-rebuilds
 [Scrollable AlertDialog]: /docs/release/breaking-changes/scrollable-alert-dialog
 [TestTextInput state reset]: /docs/release/breaking-changes/test-text-input
 [TextInputClient currentTextEditingValue]: /docs/release/breaking-changes/text-input-client-current-value
-[The Route and Navigator Refactoring]: /docs/release/breaking-changes/route-navigator-refactoring
 [The `forgetChild` method must call super]: /docs/release/breaking-changes/forgetchild-call-super
+[The Route and Navigator Refactoring]: /docs/release/breaking-changes/route-navigator-refactoring
 [ThemeData's accent properties]: /docs/release/breaking-changes/theme-data-accent-properties

--- a/src/docs/release/breaking-changes/target-platform-linux-windows.md
+++ b/src/docs/release/breaking-changes/target-platform-linux-windows.md
@@ -1,15 +1,18 @@
 ---
-title: Adding `linux` and `windows` to [`TargetPlatform`][] enum
-description: Two new values were added to the [`TargetPlatform`][] enum that could require additional cases in switch statements that switch on a [`TargetPlatform`][].
+title: Adding `linux` and `windows` to `TargetPlatform` enum
+description: Two new values were added to the `TargetPlatform` enum that could require additional cases in switch statements that switch on a `TargetPlatform`.
 ---
 
 ## Summary
 
-Two new values were added to the [`TargetPlatform`][] enum that could require additional cases in switch statements that switch on a [`TargetPlatform`][] and don't include a `default:` case.
+Two new values were added to the [`TargetPlatform`][] enum that could require
+additional cases in switch statements that switch on a `TargetPlatform` and
+don't include a `default:` case.
 
 ## Context
 
-Prior to this change, the [`TargetPlatform`][] enum only contained four values, and was defined like this:
+Prior to this change, the `TargetPlatform` enum only contained four values,
+and was defined like this:
 ```dart
 enum TargetPlatform {
   android,
@@ -19,7 +22,9 @@ enum TargetPlatform {
 }
 ```
 
-A `switch` statement only needed to handle these cases, and desktop applications which wanted to run on Linux or Windows usually had a shim something like this in their main:
+A `switch` statement only needed to handle these cases, and desktop applications
+which wanted to run on Linux or Windows usually had a test something like this
+in their `main()` method:
 
 ```dart
 // Sets a platform override for desktop to avoid exceptions. See
@@ -38,7 +43,7 @@ void main() {
 
 ## Description of change
 
-The [`TargetPlatform`][] enum is now defined as:
+The `TargetPlatform` enum is now defined as:
 
 ```dart
 enum TargetPlatform {
@@ -51,16 +56,19 @@ enum TargetPlatform {
 }
 ```
 
-And the shim in `main()` is no longer required.
+And the platform test setting [`debugDefaultTargetPlatformOverride`][] in `main()`
+is no longer required on Linux and Windows.
 
-This can cause the Dart analyzer to give the [`missing_enum_constant_in_switch`][]
-warning for switch statements which don't include a `default` case. Writing a
-switch without a `default:` case is the recommended way to handle enums, since
-the analyzer can then help you find any cases which aren't handled.
+This can cause the Dart analyzer to give the
+[`missing_enum_constant_in_switch`][] warning for switch statements that don't
+include a `default` case. Writing a switch without a `default:` case is the
+recommended way to handle enums, since the analyzer can then help you find any
+cases that aren't handled.
 
 ## Migration guide
 
-In order to migrate to the new enum, and avoid the analyzer's [`missing_enum_constant_in_switch`][] error, which looks like:
+In order to migrate to the new enum, and avoid the analyzer's
+`missing_enum_constant_in_switch` error, which looks like:
 
 ```
 warning: Missing case clause for 'linux'. (missing_enum_constant_in_switch at [package] path/to/file.dart:111)
@@ -127,8 +135,8 @@ void dance(TargetPlatform platform) {
 Having `default:` cases in such switch statements isn't recommended, because
 then the analyzer can't help you find all the cases which need to be handled.
 
-Also, any shims like the one above that set the
-[`debugDefaultTargetPlatformOverride`][] are no longer needed for Linux and Windows
+Also, any tests like the one referenced above that set the
+`debugDefaultTargetPlatformOverride` are no longer needed for Linux and Windows
 applications.
 
 ## Timeline
@@ -146,8 +154,8 @@ Relevant issues:
 Relevant PRs:
 * [Add Windows, and Linux as TargetPlatforms][]
 
+[Add Windows, and Linux as TargetPlatforms]: {{site.github}}/flutter/flutter/pull/51519
 [`debugDefaultTargetPlatformOverride`]: {{site.api}}/flutter/foundation/debugDefaultTargetPlatformOverride.html
+[Issue #31366]: {{site.github}}/flutter/flutter/issues/31366
 [`missing_enum_constant_in_switch`]: {{site.dart-site}}/tools/diagnostic-messages#missing_enum_constant_in_switch
 [`TargetPlatform`]: {{site.api}}/flutter/foundation/TargetPlatform-class.html
-[Add Windows, and Linux as TargetPlatforms]: {{site.github}}/flutter/flutter/pull/51519
-[Issue #31366]: {{site.github}}/flutter/flutter/issues/31366

--- a/src/docs/release/breaking-changes/target-platform-linux-windows.md
+++ b/src/docs/release/breaking-changes/target-platform-linux-windows.md
@@ -141,7 +141,7 @@ applications.
 
 ## Timeline
 
-This change was made in March 2020.
+This change was made in March 2020, in v1.15.4.
 
 ## References
 

--- a/src/docs/release/breaking-changes/target-platform-linux-windows.md
+++ b/src/docs/release/breaking-changes/target-platform-linux-windows.md
@@ -1,0 +1,153 @@
+---
+title: Adding `linux` and `windows` to [`TargetPlatform`][] enum
+description: Two new values were added to the [`TargetPlatform`][] enum that could require additional cases in switch statements that switch on a [`TargetPlatform`][].
+---
+
+## Summary
+
+Two new values were added to the [`TargetPlatform`][] enum that could require additional cases in switch statements that switch on a [`TargetPlatform`][] and don't include a `default:` case.
+
+## Context
+
+Prior to this change, the [`TargetPlatform`][] enum only contained four values, and was defined like this:
+```dart
+enum TargetPlatform {
+  android,
+  fuchsia,
+  iOS,
+  macOS,
+}
+```
+
+A `switch` statement only needed to handle these cases, and desktop applications which wanted to run on Linux or Windows usually had a shim something like this in their main:
+
+```dart
+// Sets a platform override for desktop to avoid exceptions. See
+// https://flutter.dev/desktop#target-platform-override for more info.
+void _enablePlatformOverrideForDesktop() {
+  if (!kIsWeb && (Platform.isWindows || Platform.isLinux)) {
+    debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
+  }
+}
+
+void main() {
+  _enablePlatformOverrideForDesktop();
+  runApp(MyApp());
+}
+```
+
+## Description of change
+
+The [`TargetPlatform`][] enum is now defined as:
+
+```dart
+enum TargetPlatform {
+  android,
+  fuchsia,
+  iOS,
+  linux, // new value
+  macOS,
+  windows, // new value
+}
+```
+
+And the shim in `main()` is no longer required.
+
+This can cause the Dart analyzer to give the [`missing_enum_constant_in_switch`][]
+warning for switch statements which don't include a `default` case. Writing a
+switch without a `default:` case is the recommended way to handle enums, since
+the analyzer can then help you find any cases which aren't handled.
+
+## Migration guide
+
+In order to migrate to the new enum, and avoid the analyzer's [`missing_enum_constant_in_switch`][] error, which looks like:
+
+```
+warning: Missing case clause for 'linux'. (missing_enum_constant_in_switch at [package] path/to/file.dart:111)
+```
+
+or 
+
+```
+warning: Missing case clause for 'windows'. (missing_enum_constant_in_switch at [package] path/to/file.dart:111)
+```
+
+Modify your code as follows: 
+
+Code before migration:
+
+<!-- skip -->
+```dart
+void dance(TargetPlatform platform) {
+  switch (platform) {
+    case TargetPlatform.android:
+      // Do Android dance.
+      break;
+    case TargetPlatform.fuchsia:
+      // Do Fuchsia dance.
+      break;
+    case TargetPlatform.iOS:
+      // Do iOS dance.
+      break;
+    case TargetPlatform.macOS:
+      // Do macOS dance.
+      break;
+  }
+}
+```
+
+Code after migration:
+
+<!-- skip -->
+```dart
+void dance(TargetPlatform platform) {
+  switch (platform) {
+    case TargetPlatform.android:
+      // Do Android dance.
+      break;
+    case TargetPlatform.fuchsia:
+      // Do Fuchsia dance.
+      break;
+    case TargetPlatform.iOS:
+      // Do iOS dance.
+      break;
+    case TargetPlatform.linux: // new case
+      // Do Linux dance.
+      break;
+    case TargetPlatform.macOS:
+      // Do macOS dance.
+      break;
+    case TargetPlatform.windows: // new case
+      // Do Windows dance.
+      break;
+  }
+}
+```
+
+Having `default:` cases in such switch statements isn't recommended, because
+then the analyzer can't help you find all the cases which need to be handled.
+
+Also, any shims like the one above that set the
+[`debugDefaultTargetPlatformOverride`][] are no longer needed for Linux and Windows
+applications.
+
+## Timeline
+
+This change was made in March 2020.
+
+## References
+
+API documentation:
+* [`TargetPlatform`][]
+
+Relevant issues:
+* [Issue #31366][]
+
+Relevant PRs:
+* [Add Windows, and Linux as TargetPlatforms][]
+
+[`debugDefaultTargetPlatformOverride`]: {{site.api}}/flutter/foundation/debugDefaultTargetPlatformOverride.html
+[`missing_enum_constant_in_switch`]: {{site.dart-site}}/tools/diagnostic-messages#missing_enum_constant_in_switch
+[`TargetPlatform`]: {{site.api}}/flutter/foundation/TargetPlatform-class.html
+[Add Windows, and Linux as TargetPlatforms]: {{site.github}}/flutter/flutter/pull/51519
+[Issue #31366]: {{site.github}}/flutter/flutter/issues/31366


### PR DESCRIPTION
This adds a migration guide to go with the flutter/flutter#51519 PR.