### PR TITLE
Adds 'zip' to macos prereqs

### DIFF
--- a/src/docs/get-started/install/macos.md
+++ b/src/docs/get-started/install/macos.md
@@ -24,6 +24,7 @@ your development environment must meet these minimum requirements:
   - `rm`
   - `unzip`
   - `which`
+  - `zip`
 
 {% include_relative _get-sdk.md %}
 


### PR DESCRIPTION
`unzip` does not necessarily imply `zip`, so it needs to be listed separately.