### PR TITLE
Adds 'zip' to linux prereqs

### DIFF
--- a/src/docs/get-started/install/linux.md
+++ b/src/docs/get-started/install/linux.md
@@ -25,6 +25,8 @@ your development environment must meet these minimum requirements:
   - `unzip`
   - `which`
   - `xz-utils`
+  - `zip`
+
 - **Shared libraries**: Flutter `test` command depends on this library
   being available in your environment.
   - `libGLU.so.1` - provided by mesa packages such as `libglu1-mesa` on


### PR DESCRIPTION
unzip does not necessarily imply zip, so it needs to be listed separately.