### PR TITLE
Update scrollable-alert-dialog.md

### DIFF
--- a/src/docs/release/breaking-changes/scrollable-alert-dialog.md
+++ b/src/docs/release/breaking-changes/scrollable-alert-dialog.md
@@ -22,7 +22,7 @@ This resulted in the following issues:
 ## Description of change
 
 The previous approach listed the title and content
-widgets consecutively in a `Row` widget.
+widgets consecutively in a `Column` widget.
 
 <!-- skip -->
 ```dart


### PR DESCRIPTION
`Row` in the description seems wrong where `Column` is used in the code below it.