### PR TITLE
FlutterPluginRegistrant is for plugins

### DIFF
--- a/src/docs/development/add-to-app/ios/project-setup.md
+++ b/src/docs/development/add-to-app/ios/project-setup.md
@@ -201,8 +201,8 @@ some/path/MyApp/
     ├── Debug/
     │   ├── Flutter.framework
     │   ├── App.framework
-    │   ├── FlutterPluginRegistrant.framework
-    │   └── example_plugin.framework (each plugin with iOS platform code is a separate framework)
+    │   ├── FlutterPluginRegistrant.framework (only if you have plugins with iOS platform code)
+    │   └── example_plugin.framework (each plugin is a separate framework)
     ├── Profile/
     │   ├── Flutter.framework
     │   ├── App.framework


### PR DESCRIPTION
FlutterPluginRegistrant.framework is only generated when the module has plugins with iOS platform code.
See confusion in https://github.com/flutter/flutter/issues/50364#issuecomment-593250166