### PR TITLE
Specify Command-line tools instead of Platform tools

### DIFF
--- a/src/docs/get-started/install/_android-setup.md
+++ b/src/docs/get-started/install/_android-setup.md
@@ -13,7 +13,9 @@
     This installs the latest Android SDK, Android SDK Command-line Tools,
     and Android SDK Build-Tools, which are required by Flutter
     when developing for Android.
-
+{{site.alert.note}}
+We're updating the flutter tool to use either the Platform-Tools (now obsolete), or the new Command-Line tool if it is available. 
+{{site.alert.end}}
 ### Set up your Android device
 
 To prepare to run and test your Flutter app on an Android device,

--- a/src/docs/get-started/install/_android-setup.md
+++ b/src/docs/get-started/install/_android-setup.md
@@ -10,7 +10,7 @@
 
  1. Download and install [Android Studio]({{site.android-dev}}/studio).
  1. Start Android Studio, and go through the 'Android Studio Setup Wizard'.
-    This installs the latest Android SDK, Android SDK Platform-Tools,
+    This installs the latest Android SDK, Android SDK Command-line Tools,
     and Android SDK Build-Tools, which are required by Flutter
     when developing for Android.
 


### PR DESCRIPTION
As of 3.6, The android SDK has marked Platform-Tools as obsolete and hidden them in the default view. We're updating the flutter tool to use either the obsolete tool, or the new Command-Line tool if it is available. This also updates the documentation to suggest the Command-Line tools

See also: https://github.com/flutter/flutter/pull/51980
https://github.com/flutter/flutter/issues/51712

Unclear if we should mention that this doesn't work on older flutter versions, or if we need to hotfix