### PR TITLE
Fixes #3770 broken reference links

### DIFF
--- a/src/docs/get-started/test-drive/_androidstudio.md
+++ b/src/docs/get-started/test-drive/_androidstudio.md
@@ -44,7 +44,4 @@ contains a simple demo app that uses [Material Components][].
 {% include_relative _try-hot-reload.md save_changes=save_changes %}
 {% include run-profile.md ide_profile=ide_profile %}
 
-[Main IntelliJ toolbar]: {% asset tools/android-studio/main-toolbar.png @path %}
-[Managing AVDs]: {{site.android-dev}}/studio/run/managing-avds
-[Material Components]: {{site.material}}/guidelines
 </div>

--- a/src/docs/get-started/test-drive/_terminal.md
+++ b/src/docs/get-started/test-drive/_terminal.md
@@ -40,6 +40,3 @@ contains a simple demo app that uses [Material Components][].
 {% include run-profile.md %}
 
 </div>
-
-[Install]: /docs/get-started/install
-[Material Components]: {{site.material}}/guidelines/

--- a/src/docs/get-started/test-drive/index.md
+++ b/src/docs/get-started/test-drive/index.md
@@ -39,3 +39,8 @@ Flutter apps.
 ## Next step
 
 You'll next learn some core Flutter concepts by creating a small app.
+
+[Install]: /docs/get-started/install
+[Main IntelliJ toolbar]: {% asset tools/android-studio/main-toolbar.png @path %}
+[Managing AVDs]: {{site.android-dev}}/studio/run/managing-avds
+[Material Components]: {{site.material}}/guidelines


### PR DESCRIPTION
Before (scroll to bottom):
https://flutter.dev/docs/get-started/test-drive?tab=vscode
https://flutter.dev/docs/get-started/test-drive?tab=androidstudio
https://flutter.dev/docs/get-started/test-drive?tab=terminal

After:
https://jt-flutter-website-4.firebaseapp.com/docs/get-started/test-drive?tab=vscode
https://jt-flutter-website-4.firebaseapp.com/docs/get-started/test-drive?tab=androidstudio
https://jt-flutter-website-4.firebaseapp.com/docs/get-started/test-drive?tab=terminal