### PR TITLE
Remove androidx flag from flutter create

### DIFF
--- a/src/docs/development/androidx-migration.md
+++ b/src/docs/development/androidx-migration.md
@@ -59,7 +59,7 @@ assets to the new project.
 To create a new project run:
 
 ```bash
-flutter create --androidx -t <project-type> <new-project-path>
+flutter create -t <project-type> <new-project-path>
 ```
 
 ### Add to App


### PR DESCRIPTION
This can be removed from the docs, since --androidx is currently the default, and once https://github.com/flutter/flutter/pull/52340 is merged, this flag will be gone.