### PR TITLE
Change the CN community resource portal URL

### DIFF
--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -12,7 +12,7 @@
               <li><a href="/security">security</a></li>
               <li><a href="https://www.google.com/intl/en/policies/privacy">privacy</a></li>
               <li><a href="https://flutter-es.io/">español</a></li>
-              <li><a href="https://flutter-io.cn" class="text-nowrap">社区中文资源</a></li>
+              <li><a href="https://flutter.cn" class="text-nowrap">社区中文资源</a></li>
           </ul>
 
           <p class="licenses">

--- a/src/community/china.md
+++ b/src/community/china.md
@@ -8,7 +8,7 @@ toc: true
 
 The Flutter community has made a Simplified Chinese version of the
 Flutter website available at
-[https://flutter-io.cn](https://flutter-io.cn).
+[https://flutter.cn](https://flutter.cn).
 
 If you’d like to install Flutter using an [installation
 bundle](/docs/development/tools/sdk/archive),


### PR DESCRIPTION
Hi team:

Since we have launched the flutter.cn last GDD China, it's time to change the URL flutter-io.cn to flutter.cn ;-)

Thanks!