### PR TITLE
add redirects for devtools pages

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -77,6 +77,7 @@
       { "source": "/images/intellij/hot-reload.gif", "destination": "https://raw.githubusercontent.com/flutter/website/master/src/_assets/image/tools/android-studio/hot-reload.gif", "type": 301 },
       { "source": "/inspector", "destination": "/docs/development/tools/devtools/inspector", "type": 301 },
       { "source": "/docs/development/tools/inspector", "destination": "/docs/development/tools/devtools/inspector", "type": 301 },
+      { "source": "/devtools/:rest*", "destination": "/docs/development/tools/devtools/:rest*", "type": 301 },
       { "source": "/intellij-ide", "destination": "/docs/development/tools/android-studio", "type": 301 },
       { "source": "/intellij-setup", "destination": "/docs/get-started/editor", "type": 301 },
       { "source": "/ios-release", "destination": "/docs/deployment/ios", "type": 301 },


### PR DESCRIPTION
- this PR adds 301 redirects for devtools - it allows us to use short urls - `https://flutter.dev/devtools/memory` - and re-direct to the devtools content
- fix https://github.com/flutter/website/issues/3811

cc @sfshaza2 