### PR TITLE
Fix reference link in 'Test Drive' page 

### DIFF
--- a/src/docs/get-started/test-drive/_androidstudio.md
+++ b/src/docs/get-started/test-drive/_androidstudio.md
@@ -50,8 +50,8 @@ contains a simple demo app that uses [Material Components][].
 {% include_relative _try-hot-reload.md save_changes=save_changes %}
 {% include run-profile.md ide_profile=ide_profile %}
 
+[trusted your computer]: /docs/get-started/install/macos#trust
 </div>
 
-[trusted your computer]: /docs/get-started/install/macos#trust
 
 

--- a/src/docs/get-started/test-drive/_terminal.md
+++ b/src/docs/get-started/test-drive/_terminal.md
@@ -44,7 +44,8 @@ contains a simple demo app that uses [Material Components][].
 {% include_relative _try-hot-reload.md save_changes=save_changes %}
 {% include run-profile.md %}
 
+[trusted your computer]: /docs/get-started/install/macos#trust
+
 </div>
 
-[trusted your computer]: /docs/get-started/install/macos#trust
 

--- a/src/docs/get-started/test-drive/_vscode.md
+++ b/src/docs/get-started/test-drive/_vscode.md
@@ -55,11 +55,10 @@ contains a simple demo app that uses [Material Components][].
 {% include_relative _try-hot-reload.md save_changes=save_changes %}
 {% include run-profile.md %}
 
-</div>
-
 [Install]: /docs/get-started/install
 [Material Components]: {{site.material}}/guidelines
 [Quickly switching between Flutter devices]: https://dartcode.org/docs/quickly-switching-between-flutter-devices
 [status bar]: {% asset tools/vs-code/device_status_bar.png @path %}
 [trusted your computer]: /docs/get-started/install/macos#trust
 
+</div>


### PR DESCRIPTION
fix #3832

After:

![image](https://user-images.githubusercontent.com/8542907/77227053-8eafcc00-6bc0-11ea-8979-48b8bf6fc968.png)
![image](https://user-images.githubusercontent.com/8542907/77227058-9a02f780-6bc0-11ea-825e-e5c55d579f19.png)

Links can be parsed correctly.