### PR TITLE
Added missing descriptions to front matter.

### DIFF
--- a/src/docs/cookbook/testing/integration/introduction.md
+++ b/src/docs/cookbook/testing/integration/introduction.md
@@ -1,5 +1,6 @@
 ---
 title: An introduction to integration testing
+description: Learn about integration testing in Flutter.
 short-title: Introduction
 prev:
   title: Take a picture using the camera

--- a/src/docs/cookbook/testing/integration/profiling.md
+++ b/src/docs/cookbook/testing/integration/profiling.md
@@ -1,5 +1,6 @@
 ---
 title: Performance profiling
+description: How to profile performance for a Flutter app.
 prev:
   title: An introduction to integration testing
   path: /docs/cookbook/testing/integration/introduction

--- a/src/docs/cookbook/testing/unit/mocking.md
+++ b/src/docs/cookbook/testing/unit/mocking.md
@@ -1,6 +1,6 @@
 ---
 title: Mock dependencies using Mockito
-description: Use the mockito package to mimic the behavior of services for testing.
+description: Use the Mockito package to mimic the behavior of services for testing.
 short-title: Mocking
 prev:
   title: An introduction to unit testing

--- a/src/docs/cookbook/testing/unit/mocking.md
+++ b/src/docs/cookbook/testing/unit/mocking.md
@@ -1,5 +1,6 @@
 ---
 title: Mock dependencies using Mockito
+description: Use the mockito package to mimic the behavior of services for testing.
 short-title: Mocking
 prev:
   title: An introduction to unit testing

--- a/src/docs/cookbook/testing/widget/finders.md
+++ b/src/docs/cookbook/testing/widget/finders.md
@@ -1,5 +1,6 @@
 ---
 title: Find widgets
+description: How to use the Finder classes for testing widgets.
 prev:
   title: An introduction to widget testing
   path: /docs/cookbook/testing/widget/introduction

--- a/src/docs/cookbook/testing/widget/introduction.md
+++ b/src/docs/cookbook/testing/widget/introduction.md
@@ -1,5 +1,6 @@
 ---
 title: An introduction to widget testing
+description: Learn more about widget testing in Flutter.
 short-title: Introduction
 prev:
   title: Mock dependencies using Mockito

--- a/src/docs/cookbook/testing/widget/tap-drag.md
+++ b/src/docs/cookbook/testing/widget/tap-drag.md
@@ -1,5 +1,6 @@
 ---
 title: Tap, drag, and enter text
+description: How to test widgets for user interaction.
 prev:
   title: Find widgets
   path: /docs/cookbook/testing/widget/finders

--- a/src/docs/development/tools/sdk/release-notes/release-notes-1.12.13.md
+++ b/src/docs/development/tools/sdk/release-notes/release-notes-1.12.13.md
@@ -12,8 +12,8 @@ for the number of PRs in each release. Over the past year,
 the number of PRs has been growing in each release
 (except for Flutter 1.9, which was an out-of-band
 release to support Catalina). In the recent
-[Github Octoverse report,](https://octoverse.github.com/)
-Flutter is listed as one of the top 3 active repos on Github!
+[GitHub Octoverse report][],
+Flutter is listed as one of the top 3 active repos on GitHub!
 
 As the holiday season is upon us, we would like to express
 our sincerest appreciation to our amazing developer community
@@ -42,10 +42,10 @@ In general, we want to avoid introducing breaking changes to Flutter,
 our plugins, or our packages. However, sometimes it is inevitable
 when we need to make our APIs more intuitive.
 We have implemented a new process that invites you to submit
-tests to help us detect breaking changes;
-see [this post](https://groups.google.com/g/flutter-announce/c/Z09a317E21o)
-to flutter-announce and our
-[breaking change policy on our wiki](https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes).
+tests to help us detect breaking changes.
+For more information, see [this post from Ian Hickson][]
+on [flutter-announce][] and the
+[breaking change policy on the Flutter wiki][].
 
 The following list includes breaking changes in this release.
 Please see the related announcements so that you can move
@@ -2959,3 +2959,8 @@ In addition to the PRs listed below, please also check out the following release
 
  See the [full list](/docs/development/tools/sdk/release-notes/changelogs/changelog-1.12.13) of merged PRs for the 1.12 release.
 
+
+[breaking change policy on the Flutter wiki]: {{site.github}}/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
+[flutter announce]: https://groups.google.com/g/flutter-announce
+[GitHub Octoverse report]: https://octoverse.github.com/
+[this post from Ian Hickson]: https://groups.google.com/g/flutter-announce/c/Z09a317E21o

--- a/src/docs/development/tools/sdk/release-notes/release-notes-1.2.1.md
+++ b/src/docs/development/tools/sdk/release-notes/release-notes-1.2.1.md
@@ -7,7 +7,7 @@ description: Release notes for Flutter 1.2.1.
 Our #1 priority since the Flutter v1.0 release has been to
 continue to address high priority issues reported both by
 Flutter developers and the Flutter team itself.
-This includes committing 672 Pull Requests in the Flutter
+This includes committing 672 pull requests in the Flutter
 engine and framework since December (we've been busy!).
 We've called out the new features and breaking changes
 that we think are noteworthy below. The biggest ones came

--- a/src/docs/development/tools/sdk/release-notes/release-notes-1.2.1.md
+++ b/src/docs/development/tools/sdk/release-notes/release-notes-1.2.1.md
@@ -4,15 +4,27 @@ short-title: 1.2.1 release notes
 description: Release notes for Flutter 1.2.1.
 ---
 
-Our #1 priority since the Flutter v1.0 release has been to continue to address high priority issues reported both by Flutter developers and the Flutter team itself. This includes committing 672 Pull Requests in the Flutter engine and framework since December (we've been busy!). We've called out the new features and breaking changes that we think are noteworthy below. The biggest ones came from our Framework and Tool tags, but we also found and fixed a couple of Severe issues as well.
+Our #1 priority since the Flutter v1.0 release has been to
+continue to address high priority issues reported both by
+Flutter developers and the Flutter team itself.
+This includes committing 672 Pull Requests in the Flutter
+engine and framework since December (we've been busy!).
+We've called out the new features and breaking changes
+that we think are noteworthy below. The biggest ones came
+from our Framework and Tool tags, but we also found and
+fixed a couple of Severe issues as well.
 
 ## Framework
 
-To more fully round-out Flutter's animation support, this release adds several more of the standard easing functions:
+To more fully round-out Flutter's animation support,
+this release adds several more of the standard easing functions:
 
 [#25788](https://github.com/flutter/flutter/pull/25788) Add Robert Penner's easing functions
 
-To integrate more fully with Android, this release adds support for [Android App Bundles](https://developer.android.com/guide/app-bundle/), a new packaging format that helps in reducing app size and enables new features like dynamic delivery for Android apps:
+To integrate more fully with Android,
+this release adds support for [Android App Bundles][],
+a new packaging format that helps in reducing app size
+and enables new features like dynamic delivery for Android apps:
 
 [#24440](https://github.com/flutter/flutter/pull/24440) Adding support for android app bundle
 
@@ -275,3 +287,5 @@ In addition to Flutter framework changes in the 1.2 release, we've made a number
 ## Full Issue List
 
 You can see [the full list of PRs committed in this release](/docs/development/tools/sdk/release-notes/changelogs/changelog-1.2.1).
+
+[Android App Bundles]: https://developer.android.com/guide/app-bundle/

--- a/src/docs/development/tools/sdk/release-notes/release-notes-1.7.8.md
+++ b/src/docs/development/tools/sdk/release-notes/release-notes-1.7.8.md
@@ -4,14 +4,23 @@ short-title: 1.7.8 release notes
 description: Release notes for Flutter 1.7.8.
 ---
 
-The 1.7.8 release is a follow-on to the 1.5.4 stable release in May, providing 1289 merged PRs and closing 184 issues. The major themes of this release are:
+The 1.7.8 release is a follow-on to the 1.5.4 stable release in May,
+providing 1289 merged PRs and closing 184 issues.
+The major themes of this release are:
 
 *   Support for 32-bit and 64-bit bundles on Android
-*   Large number of iOS features and fixes, including improved text editing and localization
-*   [AndroidX support](https://github.com/flutter/flutter/pull/31028) for new projects via the --androidx flag of ‘flutter create’
-*   A new widget: the [RangeSlider](https://api.flutter.dev/flutter/material/RangeSlider-class.html)
+*   Large number of iOS features and fixes,
+    including improved text editing and localization
+*   [AndroidX support](https://github.com/flutter/flutter/pull/31028)
+    for new projects via the --androidx flag of ‘flutter create’
+*   A new widget: the
+    [RangeSlider](https://api.flutter.dev/flutter/material/RangeSlider-class.html)
 
-As detailed in our [roadmap](https://github.com/flutter/flutter/wiki/Roadmap), we're also continuing the ongoing work in the Flutter engine and framework to support turning on web and desktop targets; however, this is not yet ready for general usage.
+As detailed in our
+[roadmap](https://github.com/flutter/flutter/wiki/Roadmap),
+we're also continuing the ongoing work in the Flutter engine
+and framework to support turning on web and desktop targets;
+however, this is not yet ready for general usage.
 
 
 ## Support for 32-bit and 64-bit Android Bundles

--- a/src/docs/development/tools/sdk/releases.md
+++ b/src/docs/development/tools/sdk/releases.md
@@ -1,7 +1,7 @@
 ---
 title: Flutter SDK releases
 short-title: Releases
-description: All current Flutter SDK releases, both stable and developer.
+description: All current Flutter SDK releases, both stable and dev.
 toc: false
 ---
 

--- a/src/docs/development/tools/sdk/upgrading.md
+++ b/src/docs/development/tools/sdk/upgrading.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Flutter
 short-title: Upgrading
-description: Upgrading Flutter
+description: How to upgrade Flutter.
 ---
 
 No matter which one of the Flutter [release channels][]

--- a/src/docs/development/ui/advanced/gestures.md
+++ b/src/docs/development/ui/advanced/gestures.md
@@ -1,5 +1,6 @@
 ---
 title: Taps, drags, and other gestures
+description: How gestures, such as taps and drags, work in Flutter.
 ---
 
 This document explains how to listen for, and respond to,

--- a/src/docs/development/ui/advanced/slivers.md
+++ b/src/docs/development/ui/advanced/slivers.md
@@ -1,5 +1,6 @@
 ---
 title: Slivers
+description: What are slivers in Flutter and how to use them.
 ---
 
 A sliver is a portion of a scrollable area. You can use slivers to

--- a/src/docs/development/ui/animations/overview.md
+++ b/src/docs/development/ui/animations/overview.md
@@ -1,7 +1,7 @@
 ---
 title: Animations overview
 short-title: Overview
-description: An overview of animation concepts
+description: An overview of animation concepts.
 ---
 
 The animation system in Flutter is based on typed

--- a/src/docs/development/ui/animations/staggered-animations.md
+++ b/src/docs/development/ui/animations/staggered-animations.md
@@ -1,5 +1,6 @@
 ---
 title: Staggered Animations
+description: How to write a staggered animation in Flutter.
 short-title: Staggered
 ---
 

--- a/src/docs/development/ui/interactive.md
+++ b/src/docs/development/ui/interactive.md
@@ -1,5 +1,6 @@
 ---
 title: Adding interactivity to your Flutter app
+description: How to implement a stateful widget that responds to taps.
 short-title: Adding interactivity
 diff2html: true
 ---

--- a/src/docs/development/ui/navigation.md
+++ b/src/docs/development/ui/navigation.md
@@ -1,6 +1,6 @@
 ---
 title: Navigation and routing
-Description: Articles and cookbook recipes that address screen navigation.
+description: Articles and cookbook recipes that address screen navigation.
 ---
 
 {% comment %}

--- a/src/docs/get-started/install/chromeos.md
+++ b/src/docs/get-started/install/chromeos.md
@@ -1,5 +1,6 @@
 ---
 title: Chrome OS install
+description: How to install on Chrome OS.
 short-title: Chrome OS
 next:
   title: Set up an editor

--- a/src/docs/get-started/install/linux.md
+++ b/src/docs/get-started/install/linux.md
@@ -1,5 +1,6 @@
 ---
 title: Linux install
+description: How to install on Linux.
 short-title: Linux
 next:
   title: Set up an editor

--- a/src/docs/get-started/install/macos.md
+++ b/src/docs/get-started/install/macos.md
@@ -1,5 +1,6 @@
 ---
 title: macOS install
+description: How to install on macOS.
 short-title: macOS
 next:
   title: Set up an editor

--- a/src/docs/get-started/install/windows.md
+++ b/src/docs/get-started/install/windows.md
@@ -1,5 +1,6 @@
 ---
 title: Windows install
+description: How to install on Windows.
 short-title: Windows
 next:
   title: Set up an editor

--- a/src/docs/perf/index.md
+++ b/src/docs/perf/index.md
@@ -1,6 +1,6 @@
 ---
 title: Performance
-description: Evaluating the performance of your app from several angles..
+description: Evaluating the performance of your app from several angles.
 ---
 
 There are different ways to evaluate performance.

--- a/src/docs/reference/crash-reporting.md
+++ b/src/docs/reference/crash-reporting.md
@@ -1,11 +1,12 @@
 ---
 title: Flutter crash reporting
+description: How Google uses crash reporting, what is collected, and how to opt out.
 ---
 
-If you have not opted-out of Flutter's analytics and crash reporting, when a
-`flutter` command crashes it attempts to send a crash report to Google in order
-to help Google contribute improvements to Flutter over time. A crash report
-may contain the following information:
+If you have not opted-out of Flutter's analytics and crash reporting,
+when a `flutter` command crashes it attempts to send a crash report
+to Google in order to help Google contribute improvements to Flutter
+over time. A crash report may contain the following information:
 
 * The name and version of your local operating system.
 * The version of Flutter.
@@ -24,8 +25,8 @@ Google handles all data reported by this tool in accordance with the
 
 ## Disabling analytics reporting
 
-You can opt out of anonymous crash reporting and feature usage statistics from
-Flutter by running the following command:
+You can opt out of anonymous crash reporting and feature
+usage statistics from Flutter by running the following command:
 
 ```terminal
 $ flutter config --no-analytics

--- a/src/docs/reference/tutorials.md
+++ b/src/docs/reference/tutorials.md
@@ -1,5 +1,6 @@
 ---
 title: Tutorials
+description: A list of Flutter tutorials.
 ---
 
 The **Flutter tutorials** teach you how to use the Flutter framework to
@@ -12,9 +13,9 @@ Choose from the following:
   basic principles, you'll build the layout for a sample screenshot.
 
 * [Adding interactivity to your Flutter app](/docs/development/ui/interactive)
-: You'll extend the simple layout app created in "Building Layouts in Flutter"
-  to make an icon tappable.  Different ways of managing a widget's
-  state are also discussed.
+: You'll extend the simple layout app created in
+  "Building Layouts in Flutter" to make an icon tappable.
+  Different ways of managing a widget's state are also discussed.
 
 * [Animations in Flutter](/docs/development/ui/animations/tutorial)
 : Explains the fundamental classes in the Flutter animation package

--- a/src/docs/reference/widgets.md
+++ b/src/docs/reference/widgets.md
@@ -1,5 +1,6 @@
 ---
 title: Flutter widget index
+description: An alphabetical list of Flutter widgets.
 short-title: Widgets
 show_breadcrumbs: false
 ---

--- a/src/docs/resources/design-docs.md
+++ b/src/docs/resources/design-docs.md
@@ -1,5 +1,6 @@
 ---
 title: Flutter Design Documents
+description: Design documents for Flutter.
 js:
   - defer: true
     url: /assets/js/go_link_index.js

--- a/src/docs/resources/inside-flutter.md
+++ b/src/docs/resources/inside-flutter.md
@@ -1,5 +1,6 @@
 ---
 title: Inside Flutter
+description: Learn about Flutter's inner workings from one of the founding engineers.
 ---
 
 This document describes the inner workings of the Flutter toolkit that make

--- a/src/docs/resources/platform-adaptations.md
+++ b/src/docs/resources/platform-adaptations.md
@@ -1,5 +1,6 @@
 ---
 title: Platform specific behaviors and adaptations
+description: Learn more about Flutter's platform adaptiveness.
 ---
 
 

--- a/src/docs/resources/technical-overview.md
+++ b/src/docs/resources/technical-overview.md
@@ -1,12 +1,15 @@
 ---
 title: Technical overview
+description: A technical overview of Flutter.
 ---
 
 ## What is Flutter?
 
 Flutter is an app SDK for building high-performance,
 high-fidelity apps for iOS, Android, web
-([beta](https://flutter.dev/web)), and desktop ([technical preview](https://flutter.dev/desktop)) from a single codebase.
+([beta](https://flutter.dev/web)),
+and desktop ([technical preview](https://flutter.dev/desktop))
+from a single codebase.
 
 The goal is to enable developers to deliver high-performance
 apps that feel natural on different platforms.


### PR DESCRIPTION
Addresses issue https://github.com/flutter/website/issues/3727

I did a sweep through the site and added descriptions to all markdown pages except:

* included pages (which have an underbar prefix)
* generated index pages 