### PR TITLE
Some rearranging and cleanup.

### DIFF
--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -1,8 +1,3 @@
-{% if page.show_banner -%}
-  <!--{% assign fl_url = '/jobs/infrastructure' -%}-->
-  {% assign fl_url = '/create' -%}
-  <div class="site-banner site-banner--default" role="alert">
-    {% comment %} For headings use <h3> elements. {% endcomment -%}
-    <a href="/clock">See the winners of the Flutter Clock challenge!</a>
-  </div>
-{% endif -%}
+{% comment %}
+To get the banner back, mv oldbanner.html to banner.html
+{% endcomment %}

--- a/src/_includes/oldbanner.html
+++ b/src/_includes/oldbanner.html
@@ -1,0 +1,8 @@
+{% if page.show_banner -%}
+  <!--{% assign fl_url = '/jobs/infrastructure' -%}-->
+  {% assign fl_url = '/create' -%}
+  <div class="site-banner site-banner--default" role="alert">
+    {% comment %} For headings use <h3> elements. {% endcomment -%}
+    <a href="/clock">See the winners of the Flutter Clock challenge!</a>
+  </div>
+{% endif -%}

--- a/src/_plugins/code_tabs.rb
+++ b/src/_plugins/code_tabs.rb
@@ -5,21 +5,28 @@
 # Example Android usage:
 #
 #   {% samplecode sample-title %}
-#   {% sample Java %}
-#   <?code-excerpt "MyActivity.java" title?>
-#   ```java
-#   // Java code here
-#   ```
 #   {% sample Kotlin %}
 #   <?code-excerpt "MyActivity.kt" title?>
 #   ```kotlin
 #   // Kotlin code here
+#   ```
+
+#   {% sample Java %}
+#   <?code-excerpt "MyActivity.java" title?>
+#   ```java
+#   // Java code here
 #   ```
 #   {% endsamplecode %}
 #
 # Example iOS usage:
 #
 #   {% samplecode sample-title %}
+#   {% sample Swift %}
+#   <?code-excerpt "MyVC.swift" title?>
+#   ```swift
+#   // Swift code here
+#   ```
+
 #   {% sample Objective-C %}
 #   <?code-excerpt "MyVC.h" title?>
 #   ```objectivec
@@ -29,20 +36,17 @@
 #   ```objectivec
 #   // Implementation file code
 #   ```
-#   {% sample Swift %}
-#   <?code-excerpt "MyVC.swift" title?>
-#   ```swift
-#   // Swift code here
-#   ```
 #   {% endsamplecode %}
 #
-# The "samplecode" tag accepts a single parameter that represents the title of this sample. The
-# title is not displayed on the page, but it is injected into a number of HTML attributes to
-# differentiate itself from other code samples. The "samplecode" tag is a block tag and therefore
+# The "samplecode" tag accepts a single parameter that
+# represents the title of this sample. The title is not
+# displayed on the page, but it is injected into a number of
+# HTML attributes to differentiate itself from other code samples.
+# The "samplecode" tag is a block tag and therefore
 # must be closed with a "endsamplecode" tag.
 #
-# The "sample" tag accepts one parameter: the name of the language as it should appear to
-# the reader.
+# The "sample" tag accepts one parameter: the name of the
+# language as it should appear to the reader.
 #
 # Code samples are placed directly beneath their associated "sample" tag.
 #
@@ -56,34 +60,50 @@
 #
 # Understanding custom tags and this class:
 #
-# There does not seem to be much documentation available for creating custom Liquid tags. The root
-# class "Tag" establishes a number of methods that are called at specific times by the templating
-# engine. The "Block" class subclasses "Tag" and adds some behavior on top of that protocol.
+# There does not seem to be much documentation available
+# for creating custom Liquid tags. The root class "Tag"
+# establishes a number of methods that are called at
+# specific times by the templating engine.
+# The "Block" class subclasses "Tag" and adds some
+# behavior on top of that protocol.
 #
 # The fundamental process is:
-# 1. The templating engine instructs the Block/Tag to "parse()" a given tag with parameters and content
+# 1. The templating engine instructs the Block/Tag to "parse()"
+#    a given tag with parameters and content
 #    - the 1st parameter, tag_name, is the literal name of the tag
-#    - the 2nd parameter, params, is a string that includes all content that appears after the tag name in a tag.
-#      The Liquid template engine does not parse multiple parameters for you. You have to do that, yourself.
-#    - the 3rd parameter, tokens, is an object that understands all types of content that follows this tag, e.g.,
-#      other tags and regular text content. The tokens object is used by the Block class to find and report each
-#      inner tag that it finds, so it should probably not be directly manipulated in this class.
+#    - the 2nd parameter, params, is a string that includes all
+#      content that appears after the tag name in a tag.
+#      The Liquid template engine does not parse multiple parameters
+#      for you. You have to do that, yourself.
+#    - the 3rd parameter, tokens, is an object that understands all
+#      types of content that follows this tag, e.g.,
+#      other tags and regular text content. The token's object
+#      is used by the Block class to find and report each
+#      inner tag that it finds, so it should probably not be
+#      directly manipulated in this class.
 #
 # 2. The Block superclass looks for other tags within itself while parsing
-#    a. If inner tags are found, but not recognized, then the "unknown_tag()" method is invoked.
+#    a. If inner tags are found, but not recognized,
+#       then the "unknown_tag()" method is invoked.
 #    b. This class overrides "unknown_tag()" to find inner "sample" tags.
-#    c. For each "sample" tag, fields are set that will be processed when rendering.
+#    c. For each "sample" tag, fields are set that will be processed
+#       when rendering.
 #
-# 3. The Block/Tag is instructed to "render()". The render step occurs after all parsing is complete. Therefore,
-#    it appears that the standard workflow is to collect all needed information during parsing and then apply it
+# 3. The Block/Tag is instructed to "render()".
+#    The render step occurs after all parsing is complete. Therefore,
+#    it appears that the standard workflow is to collect all
+#    needed information during parsing and then apply it
 #    during rendering.
-#    a. HTML for language tabs are generated for all languages that were found.
-#    b. HTML for each code sample is generated, inserting the literal code that was written beneath the given
+#    a. HTML for language tabs are generated for all languages
+#       that were found.
+#    b. HTML for each code sample is generated, inserting the
+#       literal code that was written beneath the given
 #       "sample" tag.
 #    c. The generated code is returned form the "render()" function.
 #
-# Reading the source code for Tag, Block, and BlockBody will be helpful in understanding this code. In the
-# Liquid project, those classes can be found at:
+# Reading the source code for Tag, Block, and BlockBody will be
+# helpful in understanding this code. In the Liquid project,
+# those classes can be found at:
 #
 # - lib/liquid/tag.rb
 # - lib/liquid/block.rb
@@ -94,10 +114,12 @@ module Jekyll
 
         def initialize(tag_name, params, tokens)
             super
-            # Title that differentiates this code sample from others on the page.
+            # Title that differentiates this code sample
+            # from others on the page.
             @title = params.strip
 
-            # Info needed to render the HTML for the language tabs above the sample.
+            # Info needed to render the HTML for the language
+            # tabs above the sample.
             @tabs = CodeTabsBlock.new(@title)
 
             # Info needed to render each per-language code sample.
@@ -108,13 +130,15 @@ module Jekyll
             @blocks << @tabs
         end
 
-        # Invoked by the superclass throughout the parsing process. The nodelist
-        # represents the mutating data structure that is being filled during parsing.
+        # Invoked by the superclass throughout the parsing process.
+        # The nodelist represents the mutating data structure that
+        # is being filled during parsing.
         #
-        # By default the super class has a single BodyBlock and that BodyBlock's internal
-        # nodelist is used here. We override that behavior, offering our own list, which
-        # allows us to construct a list of various kinds of BodyBlocks, e.g., CodeTabBlock
-        # and CodeBlocks.
+        # By default, the super class has a single BodyBlock
+        # and that BodyBlock's internal nodelist is used here.
+        # We override that behavior, offering our own list, which
+        # allows us to construct a list of various kinds of BodyBlocks,
+        # e.g., CodeTabBlock # and CodeBlocks.
         def nodelist
             @blocks
         end
@@ -149,9 +173,9 @@ module Jekyll
             # Start rendering code blocks with an appropriate div.
             output += "<div class=\"tab-content\">" + "\n"
 
-            # We want to display the first code block when the page loads. To do that
-            # we tell the first code block that it is active, which will generate the
-            # appropriate HTML to display itself.
+            # We want to display the first code block when the page loads.
+            # To do that we tell the first code block that it is active,
+            # which will generate the appropriate HTML to display itself.
             @codeBlocks[0].is_active = true
 
             # Render all language code blocks.

--- a/src/docs/development/platform-integration/platform-channels.md
+++ b/src/docs/development/platform-integration/platform-channels.md
@@ -32,9 +32,9 @@ but rather on a flexible message passing style:
 
 {{site.alert.note}}
   This guide addresses using the platform channel mechanism if you need
-  to use the platform's APIs or libraries in Java, Kotlin, Objective-C, or Swift.
-  But you can also write platform-specific Dart code in your Flutter app
-  by inspecting the [defaultTargetPlatform][] property.
+  to use the platform's APIs or libraries in Java, Kotlin, Objective-C,
+  or Swift.  But you can also write platform-specific Dart code
+  in your Flutter app by inspecting the [defaultTargetPlatform][] property.
   [Platform adaptations][] lists some platform-specific adaptations
   that Flutter automatically does for you in the framework.
 {{site.alert.end}}
@@ -62,8 +62,8 @@ messages that correspond to method calls. On the platform side,
 `MethodChannel` on Android ([`MethodChannelAndroid`][]) and
 `FlutterMethodChannel` on iOS ([`MethodChanneliOS`][])
 enable receiving method calls and sending back a
-result. These classes allow you to develop a platform plugin with very little
-'boilerplate' code.
+result. These classes allow you to develop a platform plugin
+with very little 'boilerplate' code.
 
 *Note*: If desired, method calls can also be sent in the reverse direction,
 with the platform acting as client to methods implemented in Dart.
@@ -81,7 +81,7 @@ messages happens automatically when you send and receive values.
 The following table shows how Dart values are received on the
 platform side and vice versa:
 
-| Dart                       | Java                | Kotlin      | OC                                             | Swift                                   |
+| Dart                       | Java                | Kotlin      | Obj-C                                             | Swift                                   |
 | -------------------------- | ------------------- | ----------- | ---------------------------------------------- | --------------------------------------- |
 | null                       | null                | null        | nil (NSNull when nested)                       | nil                                     |
 | bool                       | java.lang.Boolean   | Boolean     | NSNumber numberWithBool:                       | NSNumber(value: Bool)                   |
@@ -122,7 +122,7 @@ Start by creating a new app:
 
 * In a terminal run: `flutter create batterylevel`
 
-By default our template supports writing Android code using Kotlin,
+By default, our template supports writing Android code using Kotlin,
 or iOS code using Swift. To use Java or Objective-C,
 use the `-i` and/or `-a` flags:
 
@@ -136,8 +136,9 @@ Extend that to hold the current battery state.
 First, construct the channel. Use a `MethodChannel` with a single
 platform method that returns the battery level.
 
-The client and host sides of a channel are connected through a channel name
-passed in the channel constructor. All channel names used in a single app must
+The client and host sides of a channel are connected through
+a channel name passed in the channel constructor.
+All channel names used in a single app must
 be unique; prefix the channel name with a unique 'domain
 prefix', for example: `samples.flutter.dev/battery`.
 
@@ -158,7 +159,7 @@ class _MyHomePageState extends State<MyHomePage> {
 Next, invoke a method on the method channel, specifying the concrete method
 to call using the String identifier `getBatteryLevel`.
 The call might fail&mdash;for example if the platform does not support the
-platform API (such as when running in a simulator), so wrap the
+platform API (such as when running in a simulator)&mdash;so wrap the
 `invokeMethod` call in a try-catch statement.
 
 Use the returned result to update the user interface state in `_batteryLevel`
@@ -179,14 +180,14 @@ inside `setState`.
     }
 
     setState(() {
-      _batteryLevel = batteryLevel;
+
     });
   }
 ```
 
-Finally, replace the `build` method from the template to contain a small user
-interface that displays the battery state in a string,
-and a button for refreshing the value.
+Finally, replace the `build` method from the template to
+contain a small user interface that displays the battery
+state in a string, and a button for refreshing the value.
 
 <!-- skip -->
 ```dart
@@ -212,8 +213,124 @@ and a button for refreshing the value.
 ### Step 3: Add an Android platform-specific implementation
 
 {% samplecode android-channel %}
+{% sample Kotlin %}
+Start by opening the Android host portion of your Flutter app
+in Android Studio:
+
+1. Start Android Studio
+
+1. Select the menu item **File > Open...**
+
+1. Navigate to the directory holding your Flutter app,
+   and select the **android** folder inside it. Click **OK**.
+
+1. Open the file `MainActivity.kt` located in the **kotlin** folder in the
+   Project view. (Note: If editing with Android Studio 2.3,
+   note that the **kotlin** folder is shown as if named **java**.)
+
+Inside the `configureFlutterEngine()` method, create a `MethodChannel` and call
+`setMethodCallHandler()`. Make sure to use the same channel name as
+was used on the Flutter client side.
+
+<!--code-excerpt "MyActivity.kt" title-->
+```kotlin
+import androidx.annotation.NonNull
+import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+
+class MainActivity: FlutterActivity() {
+  private val CHANNEL = "samples.flutter.dev/battery"
+
+  override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
+    MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
+      call, result ->
+      // Note: this method is invoked on the main thread.
+      // TODO
+    }
+  }
+}
+```
+
+Add the Android Kotlin code that uses the Android battery APIs to
+retrieve the battery level. This code is exactly the same as you
+would write in a native Android app.
+
+First, add the needed imports at the top of the file:
+
+<!--code-excerpt "MyActivity.kt" title-->
+```kotlin
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
+```
+
+Next, add the following method in the `MainActivity` class,
+below the `configureFlutterEngine()` method:
+
+<!--code-excerpt "MyActivity.kt" title-->
+```kotlin
+  private fun getBatteryLevel(): Int {
+    val batteryLevel: Int
+    if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
+      val batteryManager = getSystemService(Context.BATTERY_SERVICE) as BatteryManager
+      batteryLevel = batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
+    } else {
+      val intent = ContextWrapper(applicationContext).registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+      batteryLevel = intent!!.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) * 100 / intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+    }
+
+    return batteryLevel
+  }
+```
+
+Finally, complete the `setMethodCallHandler()` method added earlier.
+You need to handle a single platform method, `getBatteryLevel()`,
+so test for that in the `call` argument.
+The implementation of this platform method calls the
+Android code written in the previous step, and returns a response for both
+the success and error cases using the `result` argument.
+If an unknown method is called, report that instead.
+
+Remove the following code:
+
+<!--code-excerpt "MyActivity.kt" title-->
+```kotlin
+    MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
+      call, result ->
+      // Note: this method is invoked on the main thread.
+      // TODO
+    }
+```
+
+And replace with the following:
+
+<!--code-excerpt "MyActivity.kt" title-->
+```kotlin
+    MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
+      // Note: this method is invoked on the main thread.
+      call, result ->
+      if (call.method == "getBatteryLevel") {
+        val batteryLevel = getBatteryLevel()
+
+        if (batteryLevel != -1) {
+          result.success(batteryLevel)
+        } else {
+          result.error("UNAVAILABLE", "Battery level not available.", null)
+        }
+      } else {
+        result.notImplemented()
+      }
+    }
+```
+
 {% sample Java %}
-Start by opening the Android host portion of your Flutter app in Android Studio:
+Start by opening the Android host portion of your Flutter app
+in Android Studio:
 
 1. Start Android Studio
 
@@ -328,119 +445,6 @@ And replace with the following:
             }
           }
 ```
-
-{% sample Kotlin %}
-Start by opening the Android host portion of your Flutter app in Android Studio:
-
-1. Start Android Studio
-
-1. Select the menu item **File > Open...**
-
-1. Navigate to the directory holding your Flutter app,
-   and select the **android** folder inside it. Click **OK**.
-
-1. Open the file `MainActivity.kt` located in the **kotlin** folder in the
-   Project view. (Note: If editing with Android Studio 2.3,
-   note that the **kotlin** folder is shown as if named **java**.)
-
-Inside the `configureFlutterEngine()` method, create a `MethodChannel` and call
-`setMethodCallHandler()`. Make sure to use the same channel name as
-was used on the Flutter client side.
-
-<!--code-excerpt "MyActivity.kt" title-->
-```kotlin
-import androidx.annotation.NonNull
-import io.flutter.embedding.android.FlutterActivity
-import io.flutter.embedding.engine.FlutterEngine
-import io.flutter.plugin.common.MethodChannel
-
-class MainActivity: FlutterActivity() {
-  private val CHANNEL = "samples.flutter.dev/battery"
-
-  override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
-    MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
-      call, result ->
-      // Note: this method is invoked on the main thread.
-      // TODO
-    }
-  }
-}
-```
-
-Add the Android Kotlin code that uses the Android battery APIs to
-retrieve the battery level. This code is exactly the same as you
-would write in a native Android app.
-
-First, add the needed imports at the top of the file:
-
-<!--code-excerpt "MyActivity.kt" title-->
-```kotlin
-import android.content.Context
-import android.content.ContextWrapper
-import android.content.Intent
-import android.content.IntentFilter
-import android.os.BatteryManager
-import android.os.Build.VERSION
-import android.os.Build.VERSION_CODES
-```
-
-Next, add the following method in the `MainActivity` class,
-below the `configureFlutterEngine()` method:
-
-<!--code-excerpt "MyActivity.kt" title-->
-```kotlin
-  private fun getBatteryLevel(): Int {
-    val batteryLevel: Int
-    if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
-      val batteryManager = getSystemService(Context.BATTERY_SERVICE) as BatteryManager
-      batteryLevel = batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
-    } else {
-      val intent = ContextWrapper(applicationContext).registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
-      batteryLevel = intent!!.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) * 100 / intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
-    }
-
-    return batteryLevel
-  }
-```
-
-Finally, complete the `setMethodCallHandler()` method added earlier. You need to
-handle a single platform method, `getBatteryLevel()`, so test for that in the
-`call` argument. The implementation of this platform method calls the
-Android code written in the previous step, and returns a response for both
-the success and error cases using the `result` argument.
-If an unknown method is called, report that instead.
-
-Remove the following code:
-
-<!--code-excerpt "MyActivity.kt" title-->
-```kotlin
-    MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
-      call, result ->
-      // Note: this method is invoked on the main thread.
-      // TODO
-    }
-```
-
-And replace with the following:
-
-<!--code-excerpt "MyActivity.kt" title-->
-```kotlin
-    MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
-      // Note: this method is invoked on the main thread.
-      call, result ->
-      if (call.method == "getBatteryLevel") {
-        val batteryLevel = getBatteryLevel()
-
-        if (batteryLevel != -1) {
-          result.success(batteryLevel)
-        } else {
-          result.error("UNAVAILABLE", "Battery level not available.", null)
-        }
-      } else {
-        result.notImplemented()
-      }
-    }
-```
 {% endsamplecode %}
 
 You should now be able to run the app on Android. If using the Android
@@ -450,8 +454,8 @@ accessible from the **...** button in the toolbar.
 ### Step 4: Add an iOS platform-specific implementation
 
 {% samplecode ios-channel %}
-{% sample Objective-C %}
-Start by opening the iOS host portion of the Flutter app in Xcode:
+{% sample Swift %}
+Start by opening the iOS host portion of your Flutter app in Xcode:
 
 1. Start Xcode.
 
@@ -460,13 +464,99 @@ Start by opening the iOS host portion of the Flutter app in Xcode:
 1. Navigate to the directory holding your Flutter app, and select the **ios**
 folder inside it. Click **OK**.
 
+Add support for Swift in the standard template setup that uses Objective-C:
+
+1. **Expand Runner > Runner** in the Project navigator.
+
+1. Open the file `AppDelegate.swift` located under **Runner > Runner**
+   in the Project navigator.
+
+Override the `application:didFinishLaunchingWithOptions:` function and create
+a `FlutterMethodChannel` tied to the channel name
+`samples.flutter.dev/battery`:
+
+<!--code-excerpt "AppDelegate.swift" title-->
+```swift
+@UIApplicationMain
+@objc class AppDelegate: FlutterAppDelegate {
+  override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+    let controller : FlutterViewController = window?.rootViewController as! FlutterViewController
+    let batteryChannel = FlutterMethodChannel(name: "samples.flutter.dev/battery",
+                                              binaryMessenger: controller.binaryMessenger)
+    batteryChannel.setMethodCallHandler({
+      (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
+      // Note: this method is invoked on the UI thread.
+      // Handle battery messages.
+    })
+
+    GeneratedPluginRegistrant.register(with: self)
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+}
+```
+
+Next, add the iOS Swift code that uses the iOS battery APIs to retrieve
+the battery level. This code is exactly the same as you
+would write in a native iOS app.
+
+Add the following as a new method at the bottom of `AppDelegate.swift`:
+
+<!--code-excerpt "AppDelegate.swift" title-->
+```swift
+private func receiveBatteryLevel(result: FlutterResult) {
+  let device = UIDevice.current
+  device.isBatteryMonitoringEnabled = true
+  if device.batteryState == UIDevice.BatteryState.unknown {
+    result(FlutterError(code: "UNAVAILABLE",
+                        message: "Battery info unavailable",
+                        details: nil))
+  } else {
+    result(Int(device.batteryLevel * 100))
+  }
+}
+```
+
+Finally, complete the `setMethodCallHandler()` method added earlier.
+You need to handle a single platform method, `getBatteryLevel()`,
+so test for that in the `call` argument.
+The implementation of this platform method calls
+the iOS code written in the previous step. If an unknown method
+is called, report that instead.
+
+<!--code-excerpt "AppDelegate.swift" title-->
+```swift
+batteryChannel.setMethodCallHandler({
+  [weak self] (call: FlutterMethodCall, result: FlutterResult) -> Void in
+  // Note: this method is invoked on the UI thread.
+  guard call.method == "getBatteryLevel" else {
+    result(FlutterMethodNotImplemented)
+    return
+  }
+  self?.receiveBatteryLevel(result: result)
+})
+```
+
+{% sample Objective-C %}
+Start by opening the iOS host portion of the Flutter app in Xcode:
+
+1. Start Xcode.
+
+1. Select the menu item **File > Open...**.
+
+1. Navigate to the directory holding your Flutter app,
+   and select the **ios** folder inside it. Click **OK**.
+
 1. Make sure the Xcode projects builds without errors.
 
 1. Open the file `AppDelegate.m`, located under **Runner > Runner**
    in the Project navigator.
 
 Create a `FlutterMethodChannel` and add a handler inside the `application
-didFinishLaunchingWithOptions:` method. Make sure to use the same channel name
+didFinishLaunchingWithOptions:` method.
+Make sure to use the same channel name
 as was used on the Flutter client side.
 
 <!--code-excerpt "AppDelegate.m" title-->
@@ -538,92 +628,10 @@ __weak typeof(self) weakSelf = self;
   }
 }];
 ```
-{% sample Swift %}
-Start by opening the iOS host portion of your Flutter app in Xcode:
-
-1. Start Xcode.
-
-1. Select the menu item **File > Open...**.
-
-1. Navigate to the directory holding your Flutter app, and select the **ios**
-folder inside it. Click **OK**.
-
-Add support for Swift in the standard template setup that uses Objective-C:
-
-1. **Expand Runner > Runner** in the Project navigator.
-
-1. Open the file `AppDelegate.swift` located under **Runner > Runner**
-   in the Project navigator.
-
-Override the `application:didFinishLaunchingWithOptions:` function and create
-a `FlutterMethodChannel` tied to the channel name
-`samples.flutter.dev/battery`:
-
-<!--code-excerpt "AppDelegate.swift" title-->
-```swift
-@UIApplicationMain
-@objc class AppDelegate: FlutterAppDelegate {
-  override func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-
-    let controller : FlutterViewController = window?.rootViewController as! FlutterViewController
-    let batteryChannel = FlutterMethodChannel(name: "samples.flutter.dev/battery",
-                                              binaryMessenger: controller.binaryMessenger)
-    batteryChannel.setMethodCallHandler({
-      (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
-      // Note: this method is invoked on the UI thread.
-      // Handle battery messages.
-    })
-
-    GeneratedPluginRegistrant.register(with: self)
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }
-}
-```
-
-Next, add the iOS Swift code that uses the iOS battery APIs to retrieve
-the battery level. This code is exactly the same as you
-would write in a native iOS app.
-
-Add the following as a new method at the bottom of `AppDelegate.swift`:
-
-<!--code-excerpt "AppDelegate.swift" title-->
-```swift
-private func receiveBatteryLevel(result: FlutterResult) {
-  let device = UIDevice.current
-  device.isBatteryMonitoringEnabled = true
-  if device.batteryState == UIDevice.BatteryState.unknown {
-    result(FlutterError(code: "UNAVAILABLE",
-                        message: "Battery info unavailable",
-                        details: nil))
-  } else {
-    result(Int(device.batteryLevel * 100))
-  }
-}
-```
-
-Finally, complete the `setMethodCallHandler()` method added earlier. You need
-to handle a single platform method, `getBatteryLevel()`, so test for that in
-the `call` argument. The implementation of this platform method calls
-the iOS code written in the previous step. If an unknown method
-is called, report that instead.
-
-<!--code-excerpt "AppDelegate.swift" title-->
-```swift
-batteryChannel.setMethodCallHandler({
-  [weak self] (call: FlutterMethodCall, result: FlutterResult) -> Void in
-  // Note: this method is invoked on the UI thread.
-  guard call.method == "getBatteryLevel" else {
-    result(FlutterMethodNotImplemented)
-    return
-  }
-  self?.receiveBatteryLevel(result: result)
-})
-```
 {% endsamplecode %}
 
-You should now be able to run the app on iOS. If using the iOS Simulator,
+You should now be able to run the app on iOS.
+If using the iOS Simulator,
 note that it does not support battery APIs,
 and the app displays 'battery info unavailable'.
 
@@ -654,10 +662,11 @@ in the [`cloud_firestore`][] plugin,
 which is able to serialize and deserialize many more
 types than the default types.
 
-## Channels and Platform Threading
+## Channels and platform threading
 
-Invoke all channel methods on the platform's main thread when writing code on
-the platform side. On Android, this thread is sometimes called the "main
+Invoke all channel methods on the platform's main thread when
+writing code on the platform side. On Android,
+this thread is sometimes called the "main
 thread", but it is technically defined as [the UI thread][].
 Annotate methods that need to be run on the UI thread with `@UiThread`.
 On iOS, this thread is officially referred to as [the main thread][].

--- a/src/docs/development/platform-integration/platform-channels.md
+++ b/src/docs/development/platform-integration/platform-channels.md
@@ -180,7 +180,7 @@ inside `setState`.
     }
 
     setState(() {
-
+      _batteryLevel = batteryLevel;
     });
   }
 ```


### PR DESCRIPTION
Staged:  https://sz-flutter.firebaseapp.com/docs/development/platform-integration/platform-channels?tab=android-channel-kotlin-tab

Fixes issue https://github.com/flutter/website/issues/3610

The typo reported in this bug has already been fixed. However, the engineer suggested that we swap the order of the Java/Kotlin code, and the Objective-C/Swift code.