### PR TITLE
Add specific Xcode error text to promote search discoverability

### DIFF
--- a/src/docs/development/ios-project-migration.md
+++ b/src/docs/development/ios-project-migration.md
@@ -47,4 +47,4 @@ add `$(inherited) -framework Flutter`.
 </li>
 </ol>
 
-[experience issues switching between iOS devices and simulators]: https://github.com/flutter/flutter/issues/50568
+[see the following errors when switching between iOS devices and simulators:]: https://github.com/flutter/flutter/issues/50568

--- a/src/docs/development/ios-project-migration.md
+++ b/src/docs/development/ios-project-migration.md
@@ -10,7 +10,15 @@ description: How to migrate existing Flutter iOS projects to Xcode 11.4.
 
 To develop Flutter apps for iOS, you need a Mac with Xcode installed.
 Xcode 11.4 changed the way frameworks are linked and embedded, and
-you may [experience issues switching between iOS devices and simulators][].
+you may [see the following errors when switching between iOS devices and simulators:][]
+```
+Building for iOS, but the linked and embedded framework 'App.framework' was built for iOS Simulator.
+```
+or
+```
+Building for iOS Simulator, but the linked and embedded framework 'App.framework' was built for iOS.
+```
+
 Flutter v1.15.3 and later will automatically migrate your Xcode project.
 
 If you need to manually upgrade your project, use the following steps:

--- a/src/docs/development/ios-project-migration.md
+++ b/src/docs/development/ios-project-migration.md
@@ -10,7 +10,7 @@ description: How to migrate existing Flutter iOS projects to Xcode 11.4.
 
 To develop Flutter apps for iOS, you need a Mac with Xcode installed.
 Xcode 11.4 changed the way frameworks are linked and embedded, and
-you may [see the following errors when switching between iOS devices and simulators:][]
+you may [see the following errors when switching between iOS devices and simulators:][errors]
 ```
 Building for iOS, but the linked and embedded framework 'App.framework' was built for iOS Simulator.
 ```
@@ -47,4 +47,4 @@ add `$(inherited) -framework Flutter`.
 </li>
 </ol>
 
-[see the following errors when switching between iOS devices and simulators:]: https://github.com/flutter/flutter/issues/50568
+[errors]: https://github.com/flutter/flutter/issues/50568


### PR DESCRIPTION
@kf6gpe hit this error, but couldn't find the migration guide by Googling around.
Add the Xcode error text to increase discoverability