### PR TITLE
throw if invalid comment

### DIFF
--- a/tool/extract.dart
+++ b/tool/extract.dart
@@ -58,7 +58,14 @@ int _processFile(File file) {
     } else if (lines[index].trim().startsWith('<!--')) {
       // Look for <!-- comment sections.
       int startIndex = index;
-      while (!lines[index].trim().endsWith('-->')) index++;
+      while (!lines[index].trim().endsWith('-->')) {
+        index++;
+        if (index >= lines.length) {
+          throw StateError(
+              'Line ${startIndex + 1} in $file has an unterminated '
+              'comment - failed to find "-->" before EOF.');
+        }
+      }
 
       lastComment = lines.sublist(startIndex, index + 1).join('\n').trim();
       lastComment = lastComment.substring(4);


### PR DESCRIPTION
Throws a better error if a comment does not terminate properly - fixes #3873

For example, adding an unterminated comment to `basic-list.md` on line 26 results in:

```
src/docs/cookbook/lists/basic-list.md
Unhandled exception:
Bad state: Line 26 in File: 'src/docs/cookbook/lists/basic-list.md' has an unterminated comment - failed to find "-->" before EOF.
#0      _processFile (file:///Users/dnfield/src/flutter/website/tool/extract.dart:64:11)
#1      main.<anonymous closure> (file:///Users/dnfield/src/flutter/website/tool/extract.dart:28:60)
#2      Iterable.forEach (dart:core/iterable.dart:279:30)
#3      main (file:///Users/dnfield/src/flutter/website/tool/extract.dart:28:9)
#4      _startIsolate.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:299:32)
#5      _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:168:12)
```