### PR TITLE
fix </ol> showing up in article

### DIFF
--- a/src/docs/get-started/codelab-web.md
+++ b/src/docs/get-started/codelab-web.md
@@ -749,6 +749,7 @@ Then, replace the `LinearProgressIndicator` in the Form with this new
 
 This widget uses an `AnimatedBuilder` to animate the progress indicator to the
 latest value. 
+</li>
 
 <li markdown="1">Run the app.<br>
 Type anything into the three fields to verify that the animation works,


### PR DESCRIPTION
This is something I missed in https://github.com/flutter/website/pull/3848