### PR TITLE
Update Basic Widgets example to avoid deprecated field.

### DIFF
--- a/src/docs/development/ui/widgets-intro.md
+++ b/src/docs/development/ui/widgets-intro.md
@@ -143,7 +143,7 @@ class MyScaffold extends StatelessWidget {
           MyAppBar(
             title: Text(
               'Example title',
-              style: Theme.of(context).primaryTextTheme.title,
+              style: Theme.of(context).primaryTextTheme.headline6,
             ),
           ),
           Expanded(


### PR DESCRIPTION
Update Theme.of(context).primaryTextTheme.title to Theme.of(context).primaryTextTheme.headline6 as the previous one was deprecated after version v1.13.8