### PR TITLE
Add <code> tag

### DIFF
--- a/src/create/index.html
+++ b/src/create/index.html
@@ -201,7 +201,7 @@ body_class: landing-page create
                the command <code>flutter run --release</code> to execute it
                on an attached Android or iOS device.</p>
             <p>The ZIP file may contain other files and directories that are
-               created using the flutter create command, such as
+               created using the <code> flutter create </code> command, such as
                <code>pubspec.yaml</code>; it may also include asset files
                (e.g. images, fonts) or data. We recommend running
                <code>flutter clean</code> before creating the ZIP file to


### PR DESCRIPTION
I think there is a code tag for 'flutter create' command in this paragraph:
             <p>The ZIP file may contain other files and directories that are
               created using the **\<code\> flutter create \</code\>** command, such as
               <code>pubspec.yaml</code>; it may also include asset files
               (e.g. images, fonts) or data. We recommend running
               <code>flutter clean</code> before creating the ZIP file to
               strip out unnecessary binaries.</p>
I just added it.