### PR TITLE
Include flag `hostAppProjectName` in add-to-app Android setup

### DIFF
--- a/src/docs/development/add-to-app/android/project-setup.md
+++ b/src/docs/development/add-to-app/android/project-setup.md
@@ -231,14 +231,17 @@ This option is convenient when you work on both parts simultaneously and rapidly
 iterate, but your team must install the Flutter SDK to build the host app.
 
 {{site.alert.tip}}
-By default the host app is the `:app` Gradle project. To change the name of this project, 
-set `flutter.hostAppProjectName` in the Flutter module's `gradle.properties`.
+  By default, the host app provides the `:app` Gradle project.
+  To change the name of this project, set `flutter.hostAppProjectName` in the
+  Flutter module's `gradle.properties` file. Finally, include this project in the
+  host app `settings.gradle` file mentioned below.
 {{site.alert.end}}
 
 Include the Flutter module as a subproject in the host app's `settings.gradle`:
 
 <!--code-excerpt "MyApp/settings.gradle" title-->
 ```groovy
+// Include the host app project.
 include ':app'                                     // assumed existing content
 setBinding(new Binding([gradle: this]))                                 // new
 evaluate(new File(                                                      // new

--- a/src/docs/development/add-to-app/android/project-setup.md
+++ b/src/docs/development/add-to-app/android/project-setup.md
@@ -230,6 +230,11 @@ This option enables a one-step build for both your Android project and Flutter p
 This option is convenient when you work on both parts simultaneously and rapidly
 iterate, but your team must install the Flutter SDK to build the host app.
 
+{{site.alert.tip}}
+By default the host app is the `:app` Gradle project. To change the name of this project, 
+set `flutter.hostAppProjectName` in the Flutter module's `gradle.properties`.
+{{site.alert.end}}
+
 Include the Flutter module as a subproject in the host app's `settings.gradle`:
 
 <!--code-excerpt "MyApp/settings.gradle" title-->

--- a/src/docs/development/add-to-app/android/project-setup.md
+++ b/src/docs/development/add-to-app/android/project-setup.md
@@ -234,7 +234,7 @@ iterate, but your team must install the Flutter SDK to build the host app.
   By default, the host app provides the `:app` Gradle project.
   To change the name of this project, set `flutter.hostAppProjectName` in the
   Flutter module's `gradle.properties` file. Finally, include this project in the
-  host app `settings.gradle` file mentioned below.
+  host app's `settings.gradle` file mentioned below.
 {{site.alert.end}}
 
 Include the Flutter module as a subproject in the host app's `settings.gradle`:


### PR DESCRIPTION
This was implemented in https://github.com/flutter/flutter/pull/52791.