### PR TITLE
README: add diffutils 3.6+ as prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ Install the following tools if you don't have them already.
 - **[rvm][]**, the Ruby Version Manager.
 - **[Flutter][Flutter install]**
 - **[Dart SDK][Dart install]**
+- **[GNU diffutils][]** version 3.6 or later.
+  > NOTE: `diff` v3.6+ is required to ensure that in-page code diffs are
+  > consistently refreshed across macOS and Linux. [Issue #3076][] was due to
+  > the default macOS `diff` being at v2.x -- to up upgrade `diffutils` run:<br>
+  > `brew install diffutils`.
+  >
+  > [issue #3076]: https://github.com/flutter/website/issues/3076
 
 > IMPORTANT: Follow the installation instructions for each of the tools
 carefully. In particular, configure your shell/environment so
@@ -231,6 +238,7 @@ Also check out the site-shared
 [Firebase]: https://firebase.google.com/
 [first-timers SVG]: https://img.shields.io/badge/first--timers--only-friendly-blue.svg?style=flat-square
 [first-timers]: https://www.firsttimersonly.com/
+[GNU diffutils]: https://www.gnu.org/software/diffutils
 [DartPad embedding guide]: https://github.com/dart-lang/dart-pad/wiki/Embedding-Guide
 [Jekyll]: https://jekyllrb.com/
 [nvm]: https://github.com/creationix/nvm#installation


### PR DESCRIPTION
- Contributes to #3076.
  After you upgrad `diff` under macOS, you'll be able to run [tool/refresh-code-excerpts.sh](https://github.com/flutter/website/blob/master/tool/refresh-code-excerpts.sh) locally under macOS once again, and get results consistent with Travis (ubuntu).
- For some context, also see comment https://github.com/flutter/website/pull/3809/commits/7bdd4bed563cd99d4435bee6bdd89677c668bc73#r399332979 from #3809.

cc @dnfield @legalcodes 
cc @kwalrath, FYI in case this arises on the site-www side