### PR TITLE
Migration guide for reversing dependency of scheduler/services

### DIFF
--- a/src/docs/release/breaking-changes/index.md
+++ b/src/docs/release/breaking-changes/index.md
@@ -15,6 +15,7 @@ The following guides (in alphabetical order) are available:
 * [MouseTracker no longer attaches annotations][]
 * [Nullable `CupertinoTheme.brightness`][]
 * [Rebuild optimization for OverlayEntries and Routes][]
+* [Reversing the dependency between the scheduler and services layer][]
 * [Scrollable AlertDialog][]
 * [TestTextInput state reset][]
 * [TextInputClient currentTextEditingValue][]
@@ -35,6 +36,7 @@ The following guides (in alphabetical order) are available:
 [MouseTracker no longer attaches annotations]: /docs/release/breaking-changes/mouse-tracker-no-longer-attaches-annotations
 [Nullable `CupertinoTheme.brightness`]: /docs/release/breaking-changes/nullable-cupertinothemedata-brightness
 [Rebuild optimization for OverlayEntries and Routes]: /docs/release/breaking-changes/overlay-entry-rebuilds
+[Reversing the dependency between the scheduler and services layer]: /docs/release/breaking-changes/services-scheduler-dependency-reversed
 [Scrollable AlertDialog]: /docs/release/breaking-changes/scrollable-alert-dialog
 [TestTextInput state reset]: /docs/release/breaking-changes/test-text-input
 [TextInputClient currentTextEditingValue]: /docs/release/breaking-changes/text-input-client-current-value

--- a/src/docs/release/breaking-changes/services-scheduler-dependency-reversed.md
+++ b/src/docs/release/breaking-changes/services-scheduler-dependency-reversed.md
@@ -5,10 +5,9 @@ description: The services layer now depends on the scheduler layer.
 
 ## Summary
 
-The dependency chain between the services layer and the scheduler layer has been
-reversed: The services layer now depends on the scheduler layer. This change may
-affect you if you have defined your own custom binding based on Flutter's
-`SchedulerBinding` and `ServicesBinding`.
+The services layer now depends on the scheduler layer. Previously, the opposite
+was true. This may affect you if you have defined custom bindings overriding
+Flutter's `SchedulerBinding` or `ServicesBinding`.
 
 ## Context
 
@@ -16,7 +15,6 @@ Prior to this change, the scheduler layer was dependent on the services layer.
 This change reverses the dependency chain and allows the services layer to make
 use of the scheduling primitives in the scheduler layer. For example, services
 in the services layer can now schedule tasks via `SchedulerBinding.scheduleTask`.
-
 
 ## Description of change
 

--- a/src/docs/release/breaking-changes/services-scheduler-dependency-reversed.md
+++ b/src/docs/release/breaking-changes/services-scheduler-dependency-reversed.md
@@ -1,21 +1,21 @@
 ---
 title: Reversing the dependency between the scheduler and services layer
-description: The service layer now depends on the scheduler layer.
+description: The services layer now depends on the scheduler layer.
 ---
 
 ## Summary
 
-The dependency chain between the service layer and the scheduler layer has been
-reversed: The service layer now depends on the scheduler layer. This change may
+The dependency chain between the services layer and the scheduler layer has been
+reversed: The services layer now depends on the scheduler layer. This change may
 affect you if you have defined your own custom binding based on Flutter's
 `SchedulerBinding` and `ServicesBinding`.
 
 ## Context
 
-Prior to this change, the scheduler layer was dependent on the service layer.
-This change reverses the dependency chain and allows the service layer to make
+Prior to this change, the scheduler layer was dependent on the services layer.
+This change reverses the dependency chain and allows the services layer to make
 use of the scheduling primitives in the scheduler layer. For example, services
-in the service layer can now schedule tasks via `SchedulerBinding.scheduleTask`.
+in the services layer can now schedule tasks via `SchedulerBinding.scheduleTask`.
 
 
 ## Description of change

--- a/src/docs/release/breaking-changes/services-scheduler-dependency-reversed.md
+++ b/src/docs/release/breaking-changes/services-scheduler-dependency-reversed.md
@@ -1,0 +1,74 @@
+---
+title: Reversing the dependency between the scheduler and services layer
+description: The service layer now depends on the scheduler layer.
+---
+
+## Summary
+
+The dependency chain between the service layer and the scheduler layer has been
+reversed: The service layer now depends on the scheduler layer. This change may
+affect you if you have defined your own custom binding based on Flutter's
+`SchedulerBinding` and `ServicesBinding`.
+
+## Context
+
+Prior to this change, the scheduler layer was dependent on the service layer.
+This change reverses the dependency chain and allows the service layer to make
+use of the scheduling primitives in the scheduler layer. For example, services
+in the service layer can now schedule tasks via `SchedulerBinding.scheduleTask`.
+
+
+## Description of change
+
+The change only affects users who are defining their own custom bindings based
+on Flutter's `SchedulerBinding` and `ServicesBinding`.
+
+## Migration guide
+
+Prior to this change, the `ServiceBinding` had to be defined before the
+`SchedulerBinding`. With this change, it is the other way around:
+
+Code before migration:
+
+<!-- skip -->
+```dart
+class FooBinding extends BindingBase with ServicesBinding, SchedulerBinding {
+ // ...
+}
+```
+
+Code after migration:
+
+<!-- skip -->
+```dart
+class FooBinding extends BindingBase with SchedulerBinding, ServicesBinding {
+ // ...
+}
+```
+
+## Timeline
+
+This change was made in April 2020 after the v1.18.0-dev.4.0 release.
+
+## References
+
+API documentation:
+* [`ServicesBinding`][]
+* [`SchedulerBinding`][]
+
+Relevant PRs:
+* [Reverse dependency between services and scheduler][]
+* [Remove compatibility fallback for lifecycle API][]
+
+{% include master-api.md %}
+
+Stable channel link:
+[`SchedulerBinding`]: {{site.api}}/flutter/scheduler/SchedulerBinding-mixin.html
+[`ServicesBinding`]: {{site.api}}/flutter/scheduler/ServicesBinding-mixin.html
+
+Master channel link:
+[`SchedulerBinding`]: https://master-api.flutter.dev/flutter/scheduler/SchedulerBinding-mixin.html
+[`ServicesBinding`]: https://master-api.flutter.dev/flutter/scheduler/ServicesBinding-mixin.html
+
+[Reverse dependency between services and scheduler]: {{site.github}}/flutter/flutter/pull/54212
+[Remove compatibility fallback for lifecycle API]: {{site.github}}/flutter/flutter/pull/TODO

--- a/src/docs/release/breaking-changes/services-scheduler-dependency-reversed.md
+++ b/src/docs/release/breaking-changes/services-scheduler-dependency-reversed.md
@@ -56,7 +56,7 @@ API documentation:
 
 Relevant PRs:
 * [Reverse dependency between services and scheduler][]
-* [Remove compatibility fallback for lifecycle API][]
+* [Revert bindings dependency workaround][]
 
 {% include master-api.md %}
 
@@ -69,4 +69,4 @@ Master channel link:
 [`ServicesBinding`]: https://master-api.flutter.dev/flutter/scheduler/ServicesBinding-mixin.html
 
 [Reverse dependency between services and scheduler]: {{site.github}}/flutter/flutter/pull/54212
-[Remove compatibility fallback for lifecycle API]: {{site.github}}/flutter/flutter/pull/TODO
+[Revert bindings dependency workaround]: {{site.github}}/flutter/flutter/pull/54286


### PR DESCRIPTION
This guide is for https://github.com/flutter/flutter/pull/54212, https://github.com/flutter/flutter/pull/54286.