### PR TITLE
Add TestWidgetsFlutterBinding.clock migration guide

### DIFF
--- a/src/docs/release/breaking-changes/index.md
+++ b/src/docs/release/breaking-changes/index.md
@@ -17,6 +17,7 @@ The following guides (in alphabetical order) are available:
 * [Rebuild optimization for OverlayEntries and Routes][]
 * [Scrollable AlertDialog][]
 * [TestTextInput state reset][]
+* [TestWidgetsFlutterBinding clock][]
 * [TextInputClient currentTextEditingValue][]
 * [The Route and Navigator Refactoring][]
 * [The `forgetChild` method must call super][]
@@ -37,6 +38,7 @@ The following guides (in alphabetical order) are available:
 [Rebuild optimization for OverlayEntries and Routes]: /docs/release/breaking-changes/overlay-entry-rebuilds
 [Scrollable AlertDialog]: /docs/release/breaking-changes/scrollable-alert-dialog
 [TestTextInput state reset]: /docs/release/breaking-changes/test-text-input
+[TestWidgetsFlutterBinding.clock]: /docs/release/breaking-changes/test-widgets-flutter-binding-clock
 [TextInputClient currentTextEditingValue]: /docs/release/breaking-changes/text-input-client-current-value
 [The `forgetChild` method must call super]: /docs/release/breaking-changes/forgetchild-call-super
 [The Route and Navigator Refactoring]: /docs/release/breaking-changes/route-navigator-refactoring

--- a/src/docs/release/breaking-changes/test-widgets-flutter-binding-clock.md
+++ b/src/docs/release/breaking-changes/test-widgets-flutter-binding-clock.md
@@ -5,7 +5,7 @@ description: The `Clock` implementation will now come from package:clock.
 
 ## Summary
 
-The `TestWidgetsFlutterBinding.clock` will now come from `package:clock` and
+The `TestWidgetsFlutterBinding.clock` now comes from `package:clock` and
 not `package:quiver`.
 
 ## Context
@@ -26,6 +26,14 @@ testWidgets('some test', (WidgetTester tester) {
 ```
 
 ## Migration guide
+
+The error you might see after this change will look something like this:
+
+```
+Error: The argument type 'Clock/*1*/' can't be assigned to the parameter type 'Clock/*2*/'.
+ - 'Clock/*1*/' is from 'package:clock/src/clock.dart' ('<pub-cache>/clock/lib/src/clock.dart').
+ - 'Clock/*2*/' is from 'package:quiver/time.dart' ('<pub-cache>/quiver/lib/time.dart').
+```
 
 ### Option #1: Create a packge:quiver Clock from a package:clock Clock
 

--- a/src/docs/release/breaking-changes/test-widgets-flutter-binding-clock.md
+++ b/src/docs/release/breaking-changes/test-widgets-flutter-binding-clock.md
@@ -100,5 +100,5 @@ API documentation:
 Relevant PRs:
 * [PR 54125][]
 
-[`TestWidgetsFlutterBinding`]: https://api.flutter.dev/flutter/flutter_test/TestWidgetsFlutterBinding-class.html
+[`TestWidgetsFlutterBinding`]: {{site.api}}/flutter/flutter_test/TestWidgetsFlutterBinding-class.html
 [PR 54125]: {{site.github}}/flutter/flutter/pull/54125

--- a/src/docs/release/breaking-changes/test-widgets-flutter-binding-clock.md
+++ b/src/docs/release/breaking-changes/test-widgets-flutter-binding-clock.md
@@ -96,7 +96,7 @@ testWidgets('some test', (WidgetTester tester) {
 
 ## Timeline
 
-This change is not yet landed, see [PR 54125][]
+This change was released in version 1.18.0.
 
 ## References
 

--- a/src/docs/release/breaking-changes/test-widgets-flutter-binding-clock.md
+++ b/src/docs/release/breaking-changes/test-widgets-flutter-binding-clock.md
@@ -1,0 +1,104 @@
+---
+title: `TestWidgetsFlutterBinding.clock` change
+description: The `Clock` implementation will now come from package:clock.
+---
+
+## Summary
+
+The `TestWidgetsFlutterBinding.clock` will now come from `package:clock` and
+not `package:quiver`.
+
+## Context
+
+The `flutter_test` package is removing its dependency on the heavier weight
+`quiver` package in favor of a dependency on two more targeted and lighter
+weight packages, `clock` and `fake_async`.
+
+This can affect user code which grabs the clock from a
+`TestWidgetsFlutterBinding` and passes that to an api that expects a `Clock`
+from `package:quiver`, for example some code like this:
+
+<!-- skip -->
+```dart
+testWidgets('some test', (WidgetTester tester) {
+  someApiThatWantsAQuiverClock(tester.binding.clock);
+});
+```
+
+## Migration guide
+
+### Option #1: Create a packge:quiver Clock from a package:clock Clock
+
+The easiest migration is to create a `package:quiver` clock from the
+`package:clock` clock, which can be done by passing the `.now` function
+tearoff to the `Clock` constructor:
+
+Code before migration:
+
+<!-- skip -->
+```dart
+testWidgets('some test', (WidgetTester tester) {
+  someApiThatWantsAQuiverClock(tester.binding.clock);
+});
+```
+
+Code after migration:
+
+<!-- skip -->
+```dart
+testWidgets('some test', (WidgetTester tester) {
+  someApiThatWantsAQuiverClock(Clock(tester.binding.clock.now));
+});
+```
+
+### Option #2: Change the api to accept a package:clock Clock
+
+If you own the api you are calling, you may want to change it to accept a Clock
+from `package:clock`. This is a judgement call based on how many places are
+calling this api with something other than a clock retreived from a
+`TestWidgetsFlutterBinding`.
+
+If you go this route your call sites that are passing `tester.binding.clock`
+will not need to be modified, but other call sites will.
+
+### Option #3: Change the api to accept a `DateTime function()`
+
+If all you use the `Clock` for is the `now` function, and you control the api,
+then you can also change it to accept that function directly instead of a
+`Clock`. This makes it easily callable with either type of `Clock`, by passing
+a tearoff of the `now` method from either type of clock:
+
+Calling code before migration:
+
+<!-- skip -->
+```dart
+testWidgets('some test', (WidgetTester tester) {
+  someApiThatWantsAQuiverClock(tester.binding.clock);
+});
+```
+
+Calling code after migration:
+
+<!-- skip -->
+```dart
+testWidgets('some test', (WidgetTester tester) {
+  modifiedApiThatTakesANowFunction(tester.binding.clock.now);
+});
+```
+
+## Timeline
+
+This change is not yet landed, see [PR 54125][]
+
+## References
+
+{% include master-api.md %}
+
+API documentation:
+* [`TestWidgetsFlutterBinding`][]
+
+Relevant PRs:
+* [PR 54125][]
+
+[`TestWidgetsFlutterBinding`]: https://api.flutter.dev/flutter/flutter_test/TestWidgetsFlutterBinding-class.html
+[PR 54125]: {{site.github}}/flutter/flutter/pull/54125


### PR DESCRIPTION
This change has not yet actually landed - I am not sure the protocol exactly on that (should I wait to merge this until I know the release number it will land in etc, or leave that as unspecified here?).