### PR TITLE
Make Rotating Components help section a bit more comprehensive

### DIFF
--- a/src/docs/get-started/flutter-for/web-devs.md
+++ b/src/docs/get-started/flutter-for/web-devs.md
@@ -297,8 +297,8 @@ Use the `Transform` widget’s `alignment` and `origin` properties to
 specify the transform origin (fulcrum) in relative and absolute terms,
 respectively.
 
-For a simple 2D rotation, the widget is rotated on the Z axis using radians.
-(degrees × π / 180)
+For a simple 2D rotation, in which the widget is rotated on the Z axis, create a new [`Matrix4`][] identity object and use
+its `rotateZ()` method to specify the rotation factor using radians (degrees × π / 180).
 
 <div class="lefthighlight">
 {% prettify css %}


### PR DESCRIPTION
Mention the Matrix4 identity object in Rotating components section, as it's used in the proceeding example.