### PR TITLE
Typo in Localizaitons

### DIFF
--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -589,7 +589,7 @@ project's `Runner` folder.
 
 Next, select the **Information Property List** item,
 select **Add Item** from the **Editor** menu,
-then select **eLocalizations** from the pop-up menu.
+then select **Localizations** from the pop-up menu.
 
 Select and expand the newly-created `Localizations` item then,
 for each locale your application supports,


### PR DESCRIPTION
eLocalizations was not found. It's "Localizations"

<img width="675" alt="Screen Shot 2020-04-11 at 5 01 29 PM" src="https://user-images.githubusercontent.com/28604/79055257-912ea000-7c19-11ea-9c9d-5d0fe48f24b4.png">
