### PR TITLE
Adding info about the tester.pump* methods

### DIFF
--- a/src/docs/cookbook/testing/unit/introduction.md
+++ b/src/docs/cookbook/testing/unit/introduction.md
@@ -10,8 +10,9 @@ next:
   path: /docs/cookbook/testing/unit/mocking
 ---
 
-How can you ensure that your app continues to work as you add more features or
-change existing functionality? By writing tests.
+How can you ensure that your app continues to work as you
+add more features or change existing functionality?
+By writing tests.
 
 Unit tests are handy for verifying the behavior of a single function,
 method, or class. The [`test`][] package provides the
@@ -51,8 +52,10 @@ The `counter.dart` file contains a class that you want to test and
 resides in the `lib` folder. The `counter_test.dart` file contains
 the tests themselves and lives inside the `test` folder.
 
-In general, test files should reside inside a `test` folder located at the root
-of your Flutter application or package. Test files should always end with `_test.dart`, this is the convention used by the test runner when searching for tests.
+In general, test files should reside inside a `test` folder
+located at the root of your Flutter application or package.
+Test files should always end with `_test.dart`,
+this is the convention used by the test runner when searching for tests.
 
 When you're finished, the folder structure should look like this:
 
@@ -147,7 +150,8 @@ void main() {
 
 ### 6. Run the tests
 
-Now that you have a `Counter` class with tests in place, you can run the tests.
+Now that you have a `Counter` class with tests in place,
+you can run the tests.
 
 #### Run tests using IntelliJ or VSCode
 
@@ -159,12 +163,14 @@ fastest feedback loop as well as the ability to set breakpoints.
     1. Open the `counter_test.dart` file
     2. Select the `Run` menu
     3. Click the `Run 'tests in counter_test.dart'` option
-    4. *Alternatively, use the appropriate keyboard shortcut for your platform.*
+    4. *Alternatively, use the appropriate keyboard shortcut
+       for your platform.*
   * **VSCode**
     1. Open the `counter_test.dart` file
     2. Select the `Debug` menu
     3. Click the `Start Debugging` option
-    4. *Alternatively, use the appropriate keyboard shortcut for your platform.*
+    4. *Alternatively, use the appropriate keyboard shortcut
+       for your platform.*
 
 #### Run tests in a terminal
 

--- a/src/docs/cookbook/testing/widget/introduction.md
+++ b/src/docs/cookbook/testing/widget/introduction.md
@@ -142,8 +142,9 @@ Use one of the following methods to ask Flutter to rebuild the widget.
 [`tester.pump(Duration duration)`][]
 : Schedules a frame and triggers a rebuild of the widget.
   If a `Duration` is specified, it advances the clock by
-  that amount and schedules a frame. It does _not_
-  schedule `N` frames where `N = duration * frame_rate`.
+  that amount and schedules a frame. It does not schedule
+  multiple frames even if the duration is longer than a
+  single frame.
 
 {{site.alert.note}}
   To kick off the animation, you need to call `pump()`

--- a/src/docs/cookbook/testing/widget/introduction.md
+++ b/src/docs/cookbook/testing/widget/introduction.md
@@ -129,7 +129,7 @@ void main() {
 }
 ```
 
-#### Note
+#### Notes about the pump() methods
 
 After the initial call to `pumpWidget()`, the `WidgetTester` provides
 additional ways to rebuild the same widget. This is useful if you're
@@ -139,13 +139,22 @@ For example, tapping a button calls `setState()`, but Flutter won't
 automatically rebuild your widget in the test environment.
 Use one of the following methods to ask Flutter to rebuild the widget.
 
-[`tester.pump()`][]
-: Triggers a rebuild of the widget after a given duration.
+[`tester.pump(Duration duration)`][]
+: Schedules a frame and triggers a rebuild of the widget.
+  If a `Duration` is specified, it advances the clock by
+  that amount and schedules a frame. It does _not_
+  schedule `N` frames where `N = duration * frame_rate`.
+
+{{site.alert.note}}
+  To kick off the animation, you need to call `pump()`
+  once (with no duration specified) to start the ticker.
+  Without it, the animation does not start.
+{{site.alert.end}}
 
 [`tester.pumpAndSettle()`][]
-: Repeatedly calls pump with the given duration until
+: Repeatedly calls `pump()` with the given duration until
   there are no longer any frames scheduled.
-  This essentially waits for all animations to complete.
+  This, essentially, waits for all animations to complete.
 
 These methods provide fine-grained control over the build lifecycle,
 which is particularly useful while testing.
@@ -284,7 +293,7 @@ class MyWidget extends StatelessWidget {
 [introduction to unit testing]: /docs/cookbook/testing/unit/introduction
 [`Matcher`]: {{api}}/package-matcher_matcher/Matcher-class.html
 [`pumpWidget()`]: {{api}}/flutter_test/WidgetTester/pumpWidget.html
-[`tester.pump()`]: {{api}}/flutter_test/TestWidgetsFlutterBinding/pump.html
+[`tester.pump(Duration duration)`]: {{api}}/flutter_test/TestWidgetsFlutterBinding/pump.html
 [`tester.pumpAndSettle()`]: {{api}}/flutter_test/WidgetTester/pumpAndSettle.html
 [`testWidgets()`]: {{api}}/flutter_test/testWidgets.html
 [`WidgetTester`]: {{api}}/flutter_test/WidgetTester-class.html

--- a/src/docs/testing/index.md
+++ b/src/docs/testing/index.md
@@ -1,5 +1,6 @@
 ---
 title: Testing Flutter apps
+description: Learn more about the different types of testing and how to write them.
 ---
 
 The more features your app has, the harder it is to test manually.
@@ -14,11 +15,11 @@ Automated testing falls into a few categories:
 * An [_integration test_](#integration-tests)
   tests a complete app or a large part of an app.
 
-Generally speaking, a well-tested app has many unit and widget tests, tracked by
-[code coverage](https://en.wikipedia.org/wiki/Code_coverage), plus enough
-integration tests to cover all the important use cases. This advice is based on
-the fact that there are trade-offs between different kinds of testing, seen
-below.
+Generally speaking, a well-tested app has many unit and widget tests,
+tracked by [code coverage][], plus enough integration tests
+to cover all the important use cases. This advice is based on
+the fact that there are trade-offs between different kinds of testing,
+seen below.
 
 |                      | Unit   | Widget | Integration |
 |----------------------|--------|--------|-------------|
@@ -31,12 +32,14 @@ below.
 
 ## Unit tests
 
-A _unit test_ tests a single function, method, or class. The goal of a unit test
-is to verify the correctness of a unit of logic under a variety of conditions.
-External dependencies of the unit under test are generally [mocked
-out](/cookbook/testing/mocking). Unit tests generally don't read from or write
-to disk, render to screen, or receive user actions from outside the process
-running the test.
+A _unit test_ tests a single function, method, or class.
+The goal of a unit test is to verify the correctness of a
+unit of logic under a variety of conditions.
+External dependencies of the unit under test are generally
+[mocked out](/cookbook/testing/mocking).
+Unit tests generally don't read from or write
+to disk, render to screen, or receive user actions from
+outside the process running the test.
 
 ### Recipes
 
@@ -62,13 +65,15 @@ an implementation much simpler than a full-blown UI system.
 
 ## Integration tests
 
-An _integration test_ tests a complete app or a large part of an app. The goal
-of an integration test is to verify that all the widgets and services being
-tested work together as expected. Furthermore, you can use integration
+An _integration test_ tests a complete app or a large part of an app.
+The goal of an integration test is to verify that all the widgets
+and services being tested work together as expected.
+Furthermore, you can use integration
 tests to verify your app's performance.
 
-Generally, an _integration test_ runs on a real device or an OS emulator, such
-as iOS Simulator or Android Emulator. The app under test is typically isolated
+Generally, an _integration test_ runs on a real device or an OS emulator,
+such as iOS Simulator or Android Emulator.
+The app under test is typically isolated
 from the test driver code to avoid skewing the results.
 
 ### Recipes
@@ -77,17 +82,25 @@ from the test driver code to avoid skewing the results.
 
 ## Continuous integration services
 
-Continuous integration (CI) services allow you to run your tests automatically
-when pushing new code changes. This provides timely feedback on whether the code
+Continuous integration (CI) services allow you to run your
+tests automatically when pushing new code changes.
+This provides timely feedback on whether the code
 changes work as expected and do not introduce bugs.
 
-For information on running tests on various continuous integration services,
-see the following:
+For information on running tests on various continuous
+integration services, see the following:
 
-* [Continuous delivery using fastlane with
-  Flutter](/docs/deployment/cd#fastlane)
-* [Test Flutter apps on
-  Travis]({{site.flutter-medium}}/test-flutter-apps-on-travis-3fd5142ecd8c)
-* [Test Flutter apps on Cirrus](https://cirrus-ci.org/examples/#flutter)
-* [Codemagic CI/CD for Flutter](https://blog.codemagic.io/getting-started-with-codemagic/)
-* [Flutter CI/CD with Bitrise](https://devcenter.bitrise.io/getting-started/getting-started-with-flutter-apps/)
+* [Continuous delivery using fastlane with Flutter][]
+* [Test Flutter apps on Travis][]
+* [Test Flutter apps on Cirrus][]
+* [Codemagic CI/CD for Flutter][]
+* [Flutter CI/CD with Bitrise][]
+
+
+[code coverage]: https://en.wikipedia.org/wiki/Code_coverage
+[Codemagic CI/CD for Flutter]: https://blog.codemagic.io/getting-started-with-codemagic/
+[Continuous delivery using fastlane with Flutter]: /docs/deployment/cd#fastlane
+[Flutter CI/CD with Bitrise]: https://devcenter.bitrise.io/getting-started/getting-started-with-flutter-apps/
+[mocked out]: /cookbook/testing/mocking
+[Test Flutter apps on Cirrus]: https://cirrus-ci.org/examples/#flutter
+[Test Flutter apps on Travis]: {{site.flutter-medium}}/test-flutter-apps-on-travis-3fd5142ecd8c

--- a/src/docs/testing/oem-debuggers.md
+++ b/src/docs/testing/oem-debuggers.md
@@ -7,13 +7,14 @@ description: How to connect an OEM debugger to your running Flutter app.
 If you are exclusively writing Flutter apps with Dart code and not using
 platform-specific libraries, or otherwise accessing platform-specific
 features, you can debug your code using your IDE's debugger.
-Only the first section of this guide, Debugging Dart code, is relevant for you.
+Only the first section of this guide, Debugging Dart code,
+is relevant for you.
 
 If you're writing a platform-specific plugin or using platform-specific
 libraries written in Swift, ObjectiveC, Java, or Kotlin, you can debug
-that portion of your code using Xcode (for iOS) or Android Gradle (for Android).
-This guide shows you how you can connect _two_ debuggers to your Dart app,
-one for Dart, and one for the OEM code.
+that portion of your code using Xcode (for iOS) or Android Gradle
+(for Android).  This guide shows you how you can connect _two_
+debuggers to your Dart app, one for Dart, and one for the OEM code.
 
 ## Debugging Dart code
 
@@ -42,7 +43,8 @@ plugins installed and configured.
 
   {% asset 'testing/debugging/oem/debug-pane.png' alt='Debug pane' %}{:width="100%"}
 
-  You can configure where the debug pane appears, or even tear it off to its own
+  You can configure where the debug pane appears,
+  or even tear it off to its own
   window using the gear to the right in the Debug pane bar.
   This is true for any inspector in Android Studio.
 
@@ -54,8 +56,8 @@ Not needed for breakpoints to work.
   {% asset 'get-started/hot-reload-button.png' alt='looks like a lightning bolt' %}
 {% endcomment -%}
 
-* In the app, click the **+** button (FloatingActionButton, or FAB, for short)
-  to increment the counter. The app pauses.
+* In the app, click the **+** button (FloatingActionButton,
+  or FAB, for short) to increment the counter. The app pauses.
 
 * The following screenshot shows:
   * Breakpoint in the edit pane.
@@ -136,8 +138,8 @@ Considere moving the info below to a new page.
 
     {% asset 'testing/debugging/oem/presentation-assistant-search-results.png' alt='Find panel' %}
 
-  * After an update, you might enter _Flutter_ or _Dart_ to see if new actions
-    are available.
+  * After an update, you might enter _Flutter_ or _Dart_ to see if
+    new actions are available.
 
   Hide the Presentation Assistant's Find panel by using **Escape**.
 {{site.alert.end}}
@@ -145,9 +147,10 @@ Considere moving the info below to a new page.
 
 ## Debugging with Android Gradle (Android)
 
-In order to debug OEM Android code, you need an app that contains OEM Android code.
-In this section, you'll learn how to connect two debuggers to your app: 1) the
-Dart debugger and, 2) the Android Gradle debugger.
+In order to debug OEM Android code, you need an app that contains
+OEM Android code. In this section, you'll learn how to connect
+two debuggers to your app: 1) the Dart debugger and,
+2) the Android Gradle debugger.
 
 * Create a basic Flutter app.
 
@@ -258,7 +261,7 @@ class _MyHomePageState extends State<MyHomePage> {
 * Add the `url_launcher` dependency to the pubspec file,
   and run flutter pub get:
 
-{% prettify yaml %}
+```yaml
 name: flutter_app
 description: A new Flutter application.
 version: 1.0.0+1
@@ -267,13 +270,13 @@ dependencies:
   flutter:
     sdk: flutter
 
-  [[highlight]]url_launcher: ^3.0.3[[/highlight]]
+  url_launcher: ^3.0.3
   cupertino_icons: ^0.1.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-{% endprettify %}
+```
 
 * Click the debug icon
   ({% asset 'testing/debugging/oem/debug-run.png' alt='Debug-run icon' %})
@@ -306,11 +309,13 @@ dev_dependencies:
 
   {% asset 'testing/debugging/oem/choose-process-dialog.png' alt='screenshot containing two buttons for opening flutter.dev' %}{:width="100%"}
 
-*  In the debug pane, you should now see a tab for **Android Debugger**.
+* In the debug pane, you should now see a tab for **Android Debugger**.
 
 * In the project pane, expand
-  <strong><em>app_name</em> > android > app > src > main > java > io.flutter plugins</strong>.
-  Double click **GeneratedProjectRegistrant** to open the Java code in the edit pane.
+  <nobr><strong><em>app_name</em> > android > app > src > main >
+  java > io.flutter plugins</strong></nobr>.
+  Double click **GeneratedProjectRegistrant** to open the
+  Java code in the edit pane.
 
 Both the Dart and OEM debuggers are interacting with the same process.
 User either, or both, to set breakpoints, examine stack, resume execution...
@@ -328,8 +333,8 @@ In other words, debug!
 ## Debugging with Xcode (iOS)
 
 In order to debug OEM iOS code, you need an app that contains OEM iOS code.
-In this section, you'll learn how to connect two debuggers to your app: 1) the
-Dart debugger and, 2) the Xcode debugger.
+In this section, you'll learn how to connect two debuggers to your app:
+1) the Dart debugger and, 2) the Xcode debugger.
 
 [PENDING]
 
@@ -362,12 +367,12 @@ You can find the following debugging resources on
 * [Instruments Help][]
 
 
-[Flutter's modes]: /docs/testing/build-modes
-[developer.android.com]: {{site.android-dev}}
-[Debug your app]: {{site.android-dev}}/studio/debug
 [Android Debug Bridge (adb)]: {{site.android-dev}}/studio/command-line/adb
-[developer.apple.com]: https://developer.apple.com
+[Debug your app]: {{site.android-dev}}/studio/debug
 [Debugging]: https://developer.apple.com/support/debugging/
-[Instruments Help]: https://help.apple.com/instruments/mac/current/
-[Flutter inspector]: /docs/development/tools/devtools/inspector
+[developer.android.com]: {{site.android-dev}}
+[developer.apple.com]: https://developer.apple.com
 [DevTools]: /docs/development/tools/devtools
+[Flutter inspector]: /docs/development/tools/devtools/inspector
+[Flutter's modes]: /docs/testing/build-modes
+[Instruments Help]: https://help.apple.com/instruments/mac/current/


### PR DESCRIPTION
Staged:  https://sz-flutter.firebaseapp.com/docs/cookbook/testing/widget/introduction#notes-about-the-pump-methods

Fixes issue https://github.com/flutter/website/issues/3956

Please only review the relevant changes in the /docs/cookbook/testing/widget/introduction.md file. That other stuff was some cleanup I did while wondering if I should add links from those pages to this page.