### PR TITLE
Update ios add-to-app instructions

### DIFF
--- a/src/docs/development/add-to-app/ios/add-flutter-screen.md
+++ b/src/docs/development/add-to-app/ios/add-flutter-screen.md
@@ -60,7 +60,8 @@ the app delegate.
 
 <!--code-excerpt "AppDelegate.m" title-->
 ```objectivec
-#import <FlutterPluginRegistrant/GeneratedPluginRegistrant.h> // Used to connect plugins.
+// Used to connect plugins (only if you have plugins with iOS platform code).
+#import <FlutterPluginRegistrant/GeneratedPluginRegistrant.h>
 
 #import "AppDelegate.h"
 
@@ -71,6 +72,7 @@ the app delegate.
   self.flutterEngine = [[FlutterEngine alloc] initWithName:@"my flutter engine"];
   // Runs the default Dart entrypoint with a default Flutter route.
   [self.flutterEngine run];
+  // Used to connect plugins (only if you have plugins with iOS platform code).
   [GeneratedPluginRegistrant registerWithRegistry:self.flutterEngine];
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
@@ -84,7 +86,8 @@ the app delegate.
 ```swift
 import UIKit
 import Flutter
-import FlutterPluginRegistrant // Used to connect plugins.
+// Used to connect plugins (only if you have plugins with iOS platform code).
+import FlutterPluginRegistrant
 
 @UIApplicationMain
 class AppDelegate: FlutterAppDelegate { // More on the FlutterAppDelegate.
@@ -93,6 +96,7 @@ class AppDelegate: FlutterAppDelegate { // More on the FlutterAppDelegate.
   override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // Runs the default Dart entrypoint with a default Flutter route.
     flutterEngine.run();
+    // Used to connect plugins (only if you have plugins with iOS platform code).
     GeneratedPluginRegistrant.register(with: self.flutterEngine);
     return super.application(application, didFinishLaunchingWithOptions: launchOptions);
   }

--- a/src/docs/development/add-to-app/ios/project-setup.md
+++ b/src/docs/development/add-to-app/ios/project-setup.md
@@ -89,6 +89,9 @@ There are two ways to embed Flutter in your existing application.
   not yet support output x86 ahead-of-time (AOT) binaries for your Dart code.
   You can run in Debug mode on a simulator or a real device,
   and Release on a real device.
+
+  To run your app on a simulator follow the instructions in the bottom of section
+  [embed the frameworks][].
 {{site.alert.end}}
 
 Using Flutter [increases your app size][].
@@ -349,3 +352,4 @@ You can now [add a Flutter screen][] to your existing application.
 [XCFrameworks]: https://developer.apple.com/documentation/xcode_release_notes/xcode_11_release_notes
 [static or dynamic frameworks]: https://stackoverflow.com/questions/32591878/ios-is-it-a-static-or-a-dynamic-framework
 [add a Flutter screen]: /docs/development/add-to-app/ios/add-flutter-screen
+[embed the frameworks]: /docs/development/add-to-app/ios/project-setup#embed-the-frameworks


### PR DESCRIPTION
Make more clear tip about embedding Debug version of Flutter frameworks that allows building for iOS SImulator.