### PR TITLE
Add another splash-screen redirect

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -33,6 +33,7 @@
       { "source": "/docs/development/tools/ide/android-studio", "destination": "/docs/development/tools/android-studio", "type": 301 },
       { "source": "/docs/development/tools/ide/vs-code", "destination": "/docs/development/tools/vs-code", "type": 301 },
       { "source": "/docs/development/tools/sdk", "destination": "/docs/development/tools/sdk/upgrading", "type": 301 },
+      { "source": "/docs/development/ui/splash-screen", "destination": "/docs/development/ui/advanced/splash-screen", "type": 301 },
       { "source": "/docs/development/ui/splash-screen/android-splash-screen", "destination": "/docs/development/ui/advanced/splash-screen", "type": 301 },
       { "source": "/docs/development/ui/widgets/catalog", "destination": "/docs/development/ui/widgets", "type": 301 },
       { "source": "/docs/development/ui/widgets/widgetindex", "destination": "/docs/reference/widgets", "type": 301 },


### PR DESCRIPTION
This fixes the new top of the 404 list: /docs/development/ui/splash-screen.

Staged: https://kw-flutter-2.firebaseapp.com/docs/development/ui/splash-screen
