### PR TITLE
Fixes deprecated instruction for dependency configuration in Android

### DIFF
--- a/src/docs/development/packages-and-plugins/developing-packages.md
+++ b/src/docs/development/packages-and-plugins/developing-packages.md
@@ -546,7 +546,7 @@ The following example sets a dependency for
 android {
     // lines skipped
     dependencies {
-        provided rootProject.findProject(":url_launcher")
+        compileOnly rootProject.findProject(":url_launcher")
     }
 }
 ```


### PR DESCRIPTION
As explained in [the documentation](https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations), `provided` is deprecated and should be replaced by `compileOnly`