### PR TITLE
Add tip to remove disable_input_output_paths from Podfile

### DIFF
--- a/src/docs/development/ios-project-migration.md
+++ b/src/docs/development/ios-project-migration.md
@@ -47,4 +47,11 @@ add `$(inherited) -framework Flutter`.
 </li>
 </ol>
 
+{{site.alert.tip}}
+  If you are using Flutter plugins, you can now delete the line
+  `install! 'cocoapods', :disable_input_output_paths => true` from `ios/Podfile`
+  to improve compilation time. Flutter projects created after v1.15.4 will not
+  contain this line.
+{{site.alert.end}}
+
 [errors]: https://github.com/flutter/flutter/issues/50568


### PR DESCRIPTION
This migration means users can remove workaround introduced in https://github.com/flutter/flutter/issues/20685#issuecomment-542322890, which will improve compilation time.