### PR TITLE
Back slash for windows keytool command

### DIFF
--- a/src/docs/deployment/android.md
+++ b/src/docs/deployment/android.md
@@ -71,7 +71,7 @@ keytool -genkey -v -keystore ~/key.jks -keyalg RSA -keysize 2048 -validity 10000
 On Windows, use the following command:
 
 ```terminal
-keytool -genkey -v -keystore c:/Users/USER_NAME/key.jks -storetype JKS -keyalg RSA -keysize 2048 -validity 10000 -alias key
+keytool -genkey -v -keystore c:\Users\USER_NAME\key.jks -storetype JKS -keyalg RSA -keysize 2048 -validity 10000 -alias key
 ```
 
 This command stores the `key.jks` file in your home


### PR DESCRIPTION
Change path in keytool command for windows from forward slash to back slash.