### PR TITLE
update platform-specific java code page

### DIFF
--- a/src/docs/development/platform-integration/platform-channels.md
+++ b/src/docs/development/platform-integration/platform-channels.md
@@ -359,6 +359,7 @@ public class MainActivity extends FlutterActivity {
 
   @Override
   public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+  super.configureFlutterEngine(flutterEngine);
     new MethodChannel(flutterEngine.getDartExecutor().getBinaryMessenger(), CHANNEL)
         .setMethodCallHandler(
           (call, result) -> {


### PR DESCRIPTION
With the new Flutter update (17), you have to call ```super.configureFlutterEngine(flutterEngine);``` in java when writing platform-specific java code in order to keep other platform channels work like official camera plugin. The current page does not include this step and it can mislead newcomers.