### PR TITLE
Introduce runZonedGuarded

### DIFF
--- a/src/docs/cookbook/maintenance/error-reporting.md
+++ b/src/docs/cookbook/maintenance/error-reporting.md
@@ -124,7 +124,8 @@ This provides a convenient way to capture all errors
 that occur within that context by providing an `onError()`
 function.
 
-In this case, run the app in a new `Zone` and capture all errors by
+In this case, run the app in a new `Zone` and capture all errors.
+With Flutter 1.16 or older, you can do that by
 providing an `onError()` callback.
 
 <!-- skip -->
@@ -132,6 +133,19 @@ providing an `onError()` callback.
 runZoned<Future<void>>(() async {
   runApp(CrashyApp());
 }, onError: (error, stackTrace) {
+  // Whenever an error occurs, call the `_reportError` function. This sends
+  // Dart errors to the dev console or Sentry depending on the environment.
+  _reportError(error, stackTrace);
+});
+```
+
+With Flutter 1.17 which includes Dart 2.8, use `runZonedGuarded` instead:
+
+<!-- skip -->
+```dart
+runZonedGuarded<Future<void>>(() async {
+  runApp(CrashyApp());
+}, (Object error, StackTrace stackTrace) {
   // Whenever an error occurs, call the `_reportError` function. This sends
   // Dart errors to the dev console or Sentry depending on the environment.
   _reportError(error, stackTrace);

--- a/src/docs/cookbook/maintenance/error-reporting.md
+++ b/src/docs/cookbook/maintenance/error-reporting.md
@@ -125,7 +125,7 @@ that occur within that context by providing an `onError()`
 function.
 
 In this case, run the app in a new `Zone` and capture all errors.
-With Flutter 1.16 or older, you can do that by
+With Flutter older than 1.17, you can do that by
 providing an `onError()` callback.
 
 <!-- skip -->


### PR DESCRIPTION
[Flutter is in the process of migrating to `runZonedGuarded`.](https://github.com/flutter/flutter/issues/53185).
Would it make sense to suggest both for a while or simply drop `runZoned` in favor of `runZonedGuarded` is the way to go?

/cc @yjbanov 
