### PR TITLE
Avoid error caused by flutter upgrade.

### DIFF
--- a/src/docs/cookbook/persistence/sqlite.md
+++ b/src/docs/cookbook/persistence/sqlite.md
@@ -312,10 +312,15 @@ To run the example:
 ```dart
 import 'dart:async';
 
+import 'package:flutter/widgets.dart';
+
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
 
 void main() async {
+  // Avoid errors coused by flutter upgrade. 
+  // Importing 'package:flutter/widgets.dart' is required.
+  WidgetsFlutterBinding.ensureInitialized();
   final database = openDatabase(
     // Set the path to the database. Note: Using the `join` function from the
     // `path` package is best practice to ensure the path is correctly


### PR DESCRIPTION
Error occurs like this when I run example code. 
```
FlutterError (ServicesBinding.defaultBinaryMessenger was accessed before the binding was initialized.
If you're running an application and need to access the binary messenger before `runApp()` has been called (for example, during plugin initialization), then you need to explicitly call the `WidgetsFlutterBinding.ensureInitialized()` first.
If you're running a test, you can call the `TestWidgetsFlutterBinding.ensureInitialized()` as the first line in your test's `main()` method to initialize the binding.)
```
I dealt with this problem by reference to 
https://stackoverflow.com/questions/57689492/flutter-unhandled-exception-servicesbinding-defaultbinarymessenger-was-accesse