### PR TITLE
Apply #4099 with formatting fix

### DIFF
--- a/src/docs/cookbook/persistence/sqlite.md
+++ b/src/docs/cookbook/persistence/sqlite.md
@@ -312,10 +312,15 @@ To run the example:
 ```dart
 import 'dart:async';
 
+import 'package:flutter/widgets.dart';
+
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
 
 void main() async {
+  // Avoid errors coused by flutter upgrade. 
+  // Importing 'package:flutter/widgets.dart' is required.
+  WidgetsFlutterBinding.ensureInitialized();
   final database = openDatabase(
     // Set the path to the database. Note: Using the `join` function from the
     // `path` package is best practice to ensure the path is correctly

--- a/src/docs/cookbook/persistence/sqlite.md
+++ b/src/docs/cookbook/persistence/sqlite.md
@@ -318,7 +318,7 @@ import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
 
 void main() async {
-  // Avoid errors coused by flutter upgrade. 
+  // Avoid errors coused by flutter upgrade.
   // Importing 'package:flutter/widgets.dart' is required.
   WidgetsFlutterBinding.ensureInitialized();
   final database = openDatabase(

--- a/src/docs/cookbook/persistence/sqlite.md
+++ b/src/docs/cookbook/persistence/sqlite.md
@@ -318,7 +318,7 @@ import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
 
 void main() async {
-  // Avoid errors coused by flutter upgrade.
+  // Avoid errors caused by flutter upgrade.
   // Importing 'package:flutter/widgets.dart' is required.
   WidgetsFlutterBinding.ensureInitialized();
   final database = openDatabase(


### PR DESCRIPTION
Applies #4099 after running `dartfmt` on the snippet