### PR TITLE
clone flutter sdk without git history

### DIFF
--- a/src/docs/get-started/install/_get-sdk.md
+++ b/src/docs/get-started/install/_get-sdk.md
@@ -37,7 +37,7 @@
      and change branches or tags as needed. For example:
     
     ```terminal
-    $ git clone https://github.com/flutter/flutter.git -b stable
+    $ git clone https://github.com/flutter/flutter.git -b stable --depth 1
     ```
     
  1. Add the `flutter` tool to your path:


### PR DESCRIPTION
Instead of fetching full git history we can download only last commit. This will reduce "time to open first flutter app".

speed test:
```
curl -s https://raw.githubusercontent.com/sivel/speedtest-cli/master/speedtest.py | python3 -
Retrieving speedtest.net configuration...
Testing from Bilink LLC (176.104.246.14)...
Retrieving speedtest.net server list...
Selecting best server based on ping...
Hosted by lifecell (Kiev) [0.49 km]: 5.691 ms
Testing download speed................................................................................
Download: 88.62 Mbit/s
Testing upload speed......................................................................................................
Upload: 92.51 Mbit/s

```
with full git history:
```
time git clone https://github.com/flutter/flutter.git -b stable
Cloning into 'flutter'...
remote: Enumerating objects: 237750, done.
remote: Total 237750 (delta 0), reused 0 (delta 0), pack-reused 237750
Receiving objects: 100% (237750/237750), 98.83 MiB | 3.00 MiB/s, done.
Resolving deltas: 100% (182260/182260), done.

________________________________________________________
Executed in   37.39 secs   fish           external
   usr time   17.37 secs  898.00 micros   17.37 secs
   sys time    3.66 secs  350.00 micros    3.66 secs
```
without:

```
time git clone https://github.com/flutter/flutter.git -b stable --depth 1
Cloning into 'flutter'...
remote: Enumerating objects: 4599, done.
remote: Counting objects: 100% (4599/4599), done.
remote: Compressing objects: 100% (3803/3803), done.
remote: Total 4599 (delta 900), reused 1837 (delta 396), pack-reused 0
Receiving objects: 100% (4599/4599), 7.07 MiB | 1.90 MiB/s, done.
Resolving deltas: 100% (900/900), done.

________________________________________________________
Executed in    8.40 secs   fish           external
   usr time    1.69 secs  550.00 micros    1.69 secs
   sys time    0.54 secs  205.00 micros    0.54 secs

```