### PR TITLE
Main git clone command retrieves all branches

### DIFF
--- a/src/docs/get-started/install/_get-sdk.md
+++ b/src/docs/get-started/install/_get-sdk.md
@@ -31,10 +31,15 @@
     $ {{unzip}} ~/Downloads/flutter_{{os}}_vX.X.X-{{site.sdk.channel}}{{file_ext}}
     ```
     
-     If you don't want to install a fixed version of the installation bundle, 
-     you can skip steps 1 and 2. 
-     Instead, get the source code from the [Flutter repo][] on GitHub,
-     and change branches or tags as needed. For example:
+    If you don't want to install a fixed version of the installation bundle, 
+    you can skip steps 1 and 2. 
+    Instead, get the source code from the [Flutter repo][] on GitHub with the following command:
+    
+    ```terminal
+    $ git clone https://github.com/flutter/flutter.git
+    ```
+    
+    You can also change branches or tags as needed. For example, to get just the stable version:
     
     ```terminal
     $ git clone https://github.com/flutter/flutter.git -b stable --depth 1


### PR DESCRIPTION
I started using Flutter a few days ago and was following the Get Started documentation.

Without too much thought, I used the git clone command, then forgot about it.

Today, as I was tinkering, I realized I needed to be on the beta channel, not stable. But ```flutter channel``` was only giving me the stable channel and trying to switch caused an error.

It took me a while before I realized that it was because of this earlier command.

In my opinion, to reduce confusion for new users, the main command should be to simply clone the entire repository. Open to feedback though, so I figure I make this PR and have maintainers decide.