### PR TITLE
Simplify main in implicit animations codelab

### DIFF
--- a/src/_includes/implicit-animations/fade-in-complete.md
+++ b/src/_includes/implicit-animations/fade-in-complete.md
@@ -53,7 +53,7 @@ class MyApp extends StatelessWidget {
   }
 }
 
-Future<void> main() async {
+void main() {
   runApp(
     MyApp(),
   );

--- a/src/_includes/implicit-animations/fade-in-starter-code.md
+++ b/src/_includes/implicit-animations/fade-in-starter-code.md
@@ -46,7 +46,7 @@ class MyApp extends StatelessWidget {
   }
 }
 
-Future<void> main() async {
+void main() {
   runApp(
     MyApp(),
   );

--- a/src/_includes/implicit-animations/shape-shifting-complete.md
+++ b/src/_includes/implicit-animations/shape-shifting-complete.md
@@ -86,7 +86,7 @@ class MyApp extends StatelessWidget {
   }
 }
 
-Future<void> main() async {
+void main() {
   runApp(
     MyApp(),
   );

--- a/src/_includes/implicit-animations/shape-shifting-starter-code.md
+++ b/src/_includes/implicit-animations/shape-shifting-starter-code.md
@@ -74,7 +74,7 @@ class MyApp extends StatelessWidget {
   }
 }
 
-Future<void> main() async {
+void main() {
   runApp(
     MyApp(),
   );


### PR DESCRIPTION
The `async` and `Future<void>` is not really necessary. This simplifies the codelab code a little and may help to avoid confusion. 

Fixes https://github.com/flutter/website/issues/4128

/cc @legalcodes @sfshaza2 