### PR TITLE
Fixing issue #3952

### DIFF
--- a/src/docs/cookbook/testing/unit/mocking.md
+++ b/src/docs/cookbook/testing/unit/mocking.md
@@ -143,7 +143,7 @@ main() {
       when(client.get('https://jsonplaceholder.typicode.com/posts/1'))
           .thenAnswer((_) async => http.Response('{"title": "Test"}', 200));
 
-      expect(await fetchPost(client), const TypeMatcher<Post>());
+      expect(await fetchPost(client), isA<Post>());
     });
 
     test('throws an exception if the http call completes with an error', () {


### PR DESCRIPTION
`const TypeMatcher` can no longer be passed into `expect` as it is deprecated and causes unit test to fail. API docs indicate `isA` should be used instead. Therefore this PR updates the code example to reflect this change.