### PR TITLE
Adding import statements to code examples

### DIFF
--- a/src/docs/cookbook/testing/unit/mocking.md
+++ b/src/docs/cookbook/testing/unit/mocking.md
@@ -52,7 +52,8 @@ so define that dependency in the `dependencies` section.
 dependencies:
   http: <newest_version>
 dev_dependencies:
-  test: <newest_version>
+  flutter_test:
+    sdk: flutter
   mockito: <newest_version>
 ```
 
@@ -105,6 +106,10 @@ and return different http responses in each test.
 
 <!-- skip -->
 ```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:http/http.dart' as http;
+
 // Create a MockClient using the Mock class provided by the Mockito package.
 // Create new instances of this class in each test.
 class MockClient extends Mock implements http.Client {}
@@ -129,6 +134,10 @@ Mockito:
 
 <!-- skip -->
 ```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:http/http.dart' as http;
+
 // Create a MockClient using the Mock class provided by the Mockito package.
 // Create new instances of this class in each test.
 class MockClient extends Mock implements http.Client {}


### PR DESCRIPTION
Import statements resolve ambiguity. As user of this documentation, I could have saved valuable time if I did not have to guess which test libs to import.

Also changing `dev_dependencies` to use `flutter_test` instead of `test` as this is what actually works when running these tests.