### PR TITLE
Fix MissingPluginException for 3rd party plugins

### DIFF
--- a/src/docs/development/platform-integration/platform-channels.md
+++ b/src/docs/development/platform-integration/platform-channels.md
@@ -243,6 +243,7 @@ class MainActivity: FlutterActivity() {
   private val CHANNEL = "samples.flutter.dev/battery"
 
   override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
+    super.configureFlutterEngine(flutterEngine)
     MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
       call, result ->
       // Note: this method is invoked on the main thread.


### PR DESCRIPTION
If you add some platform-specific code and you have also added some flutter plugins e.g sqflite. Then sqflite plugin won't be able to register with the flutter engine.
The Java version of the above code is fine but the Kotlin version missed the super call.