### PR TITLE
Code fixes of "FlutterFragment"

### DIFF
--- a/src/docs/development/add-to-app/android/add-flutter-fragment.md
+++ b/src/docs/development/add-to-app/android/add-flutter-fragment.md
@@ -286,7 +286,7 @@ FlutterEngineCache
 
 <!--code-excerpt "MyActivity.java" title-->
 ```java
-flutterFragment.withCachedEngine("my_engine_id").build();
+FlutterFragment.withCachedEngine("my_engine_id").build();
 ```
 {% sample Kotlin %}
 <!--code-excerpt "MyApplication.kt" title-->
@@ -309,7 +309,7 @@ FlutterEngineCache
 
 <!--code-excerpt "MyActivity.kt" title-->
 ```kotlin
-flutterFragment.withCachedEngine("my_engine_id").build()
+FlutterFragment.withCachedEngine("my_engine_id").build()
 ```
 {% endsamplecode %}
 


### PR DESCRIPTION
Hi team:

There's a feedback from the CN community here https://github.com/cfug/flutter.cn/issues/657, the `flutterFragment` here at `flutterFragment.withCachedEngine("my_engine_id").build(); ` should be upper case to `FlutterFragment`.

cc/ @xster, could you please valid this?

Thanks to @SevenWalnut for having this feedback.