### PR TITLE
Missing dependency in docs: Add 'file' to required tools list for Linux

### DIFF
--- a/src/docs/get-started/install/linux.md
+++ b/src/docs/get-started/install/linux.md
@@ -20,6 +20,7 @@ your development environment must meet these minimum requirements:
   in your environment.
   - `bash`
   - `curl`
+  - `file`
   - `git` 2.x
   - `mkdir`
   - `rm`


### PR DESCRIPTION
Linux builds are failing if `file` command is not present as `CMke` is using it under the hood. However, as of now [documentation](https://flutter.dev/docs/get-started/install/linux#system-requirements) does not suggest that it is needed.

The issue becomes aparent if one is using an Ubuntu container, which by default is lacking `file` command.

Example of failing build logs:

```
$ flutter build linux --release --verbose
...
[  +22 ms] [14/15] Linking CXX static library flutter/libflutter_wrapper_plugin.a
[        ] [14/15] Install the project...
[  +17 ms] -- Install configuration: "Release"
[        ] -- Installing: /tmp/wallio/build/linux/release/bundle/wallio
[   +1 ms] -- Set runtime path of "/tmp/wallio/build/linux/release/bundle/wallio" to "$ORIGIN"
[  +16 ms] -- fixup_bundle
[        ] --   app='/tmp/wallio/build/linux/release/bundle/wallio'
[        ] --   libs=''
[        ] --   dirs=';/tmp/wallio/linux/flutter/ephemeral'
[        ] --   ignoreItems=''
[        ] -- warning: No 'file' command, skipping execute_process...
[        ] -- warning: *NOT* handled - not .app dir, not executable file...
[        ] -- fixup_bundle: done
[        ] -- Installing: /tmp/wallio/build/linux/release/bundle/data/icudtl.dat
[   +2 ms] CMake Error at /usr/share/cmake-3.16/Modules/BundleUtilities.cmake:988 (message):
[   +3 ms]   error: fixup_bundle: not a valid bundle
[        ] Call Stack (most recent call first):
[        ]   cmake_install.cmake:77 (fixup_bundle)
``` 