### PR TITLE
Fix navigation order for integration test (#4074)

### DIFF
--- a/src/docs/cookbook/testing/integration/introduction.md
+++ b/src/docs/cookbook/testing/integration/introduction.md
@@ -6,8 +6,8 @@ prev:
   title: Take a picture using the camera
   path: /docs/cookbook/plugins/picture-using-camera
 next:
-  title: Performance profiling
-  path: /docs/cookbook/testing/integration/profiling
+  title: Handle scrolling
+  path: /docs/cookbook/testing/integration/scrolling
 ---
 
 Unit tests and widget tests are handy for testing individual classes,

--- a/src/docs/cookbook/testing/integration/profiling.md
+++ b/src/docs/cookbook/testing/integration/profiling.md
@@ -2,11 +2,11 @@
 title: Performance profiling
 description: How to profile performance for a Flutter app.
 prev:
-  title: An introduction to integration testing
-  path: /docs/cookbook/testing/integration/introduction
-next:
   title: Handle scrolling
   path: /docs/cookbook/testing/integration/scrolling
+next:
+  title: An introduction to unit testing
+  path: /docs/cookbook/testing/unit/introduction
 ---
 
 When it comes to mobile apps, performance is critical to user experience.

--- a/src/docs/cookbook/testing/integration/scrolling.md
+++ b/src/docs/cookbook/testing/integration/scrolling.md
@@ -2,11 +2,11 @@
 title: Handle scrolling
 description: How to handle scrolling in an integration test.
 prev:
+  title: An introduction to integration testing
+  path: /docs/cookbook/testing/integration/introduction
+next:
   title: Performance profiling
   path: /docs/cookbook/testing/integration/profiling
-next:
-  title: An introduction to unit testing
-  path: /docs/cookbook/testing/unit/introduction
 ---
 
 Many apps feature lists of content,


### PR DESCRIPTION
Change the order of `scrolling.md` and `profiling.md` for both consistency with the index and logical order. Issue #4074 