### PR TITLE
Renamed packages get to pub get 

### DIFF
--- a/src/docs/get-started/codelab.md
+++ b/src/docs/get-started/codelab.md
@@ -215,7 +215,7 @@ as well as many other open source packages, on [pub.dev][].
     Process finished with exit code 0
     ```
 
-    Performing `Packages get` also auto-generates the `pubspec.lock`
+    Performing `Pub get` also auto-generates the `pubspec.lock`
     file with a list of all packages pulled into the project and
     their version numbers.
 

--- a/src/docs/get-started/codelab.md
+++ b/src/docs/get-started/codelab.md
@@ -206,7 +206,7 @@ as well as many other open source packages, on [pub.dev][].
     ```
 
  2. While viewing the `pubspec.yaml` file in Android Studio's editor view,
-    click **Packages get**. This pulls the package into
+    click **Pub get**. This pulls the package into
     your project. You should see the following in the console:
 
     ```terminal


### PR DESCRIPTION
install new dependencies was renamed to **Pub get** from ```Packages get```
quick fix ref issue https://github.com/flutter/flutter/issues/58143 towards issue
