### PR TITLE
Removing word duplication

### DIFF
--- a/src/docs/cookbook/testing/integration/profiling.md
+++ b/src/docs/cookbook/testing/integration/profiling.md
@@ -119,7 +119,7 @@ After the test completes successfully, the `build` directory at the root of
 the project contains two files:
 
   1. `scrolling_summary.timeline_summary.json` contains the summary. Open
-     Open the file with any text editor to review the information contained
+     the file with any text editor to review the information contained
      within.  With a more advanced setup, you could save a summary every
      time the test runs and create a graph of the results.
   2. `scrolling_timeline.timeline.json` contains the complete timeline data.


### PR DESCRIPTION
The word 'Open' is appearing duplicated in the cookbook/testing/integration/profiling page. I just removed it.