### PR TITLE
Add flavor help articles back to flavor page

### DIFF
--- a/src/docs/deployment/flavors.md
+++ b/src/docs/deployment/flavors.md
@@ -6,8 +6,13 @@ description: How to create build flavors specific to different release types or 
 
 Do you need to set up product flavors for different development
 environments or release types?
-The community has created some packages that you might find useful.
+The community has written some articles and packages you might find useful.
+These articles address flavors for both iOS and Android.
 
+* [Creating flavors of a Flutter app][]
+* [Flavoring Flutter][]
+* [Flutter Ready to Go][]
+* [Build flavors in Flutter (Android and iOS) with different Firebase projects per flavor][]
 
 The following packages are listed alphabetically:
 
@@ -15,8 +20,9 @@ The following packages are listed alphabetically:
 * [`flutter_flavorizr`][]
 
 
-
-
-
+[Creating flavors of a Flutter app]: https://cogitas.net/creating-flavors-of-a-flutter-app/
+[Flavoring Flutter]: {{site.medium}}/@salvatoregiordanoo/flavoring-flutter-392aaa875f36
+[Flutter Ready to Go]: {{site.medium}}/flutter-community/flutter-ready-to-go-e59873f9d7de
+[Build flavors in Flutter (Android and iOS) with different Firebase projects per flavor]: {{site.medium}}/@animeshjain/build-flavors-in-flutter-android-and-ios-with-different-firebase-projects-per-flavor-27c5c5dac10b
 [`flutter_flavor`]: {{site.pub}}/packages/flutter_flavor
 [`flutter_flavorizr`]: {{site.pub}}/packages/flutter_flavorizr

--- a/src/docs/deployment/flavors.md
+++ b/src/docs/deployment/flavors.md
@@ -20,6 +20,9 @@ The following packages are listed alphabetically:
 * [`flutter_flavorizr`][]
 
 
+
+
+
 [Creating flavors of a Flutter app]: https://cogitas.net/creating-flavors-of-a-flutter-app/
 [Flavoring Flutter]: {{site.medium}}/@salvatoregiordanoo/flavoring-flutter-392aaa875f36
 [Flutter Ready to Go]: {{site.medium}}/flutter-community/flutter-ready-to-go-e59873f9d7de


### PR DESCRIPTION
Re-add some helpful flavor articles that were removed in https://github.com/flutter/website/pull/4111.

Also add https://medium.com/@animeshjain/build-flavors-in-flutter-android-and-ios-with-different-firebase-projects-per-flavor-27c5c5dac10b which is a good Firebase flavor reference.