### PR TITLE
Fixing examples that specify supported locales

### DIFF
--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -74,8 +74,8 @@ MaterialApp(
    GlobalCupertinoLocalizations.delegate,
  ],
  supportedLocales: [
-    const Locale('en'), // English
-    const Locale('he'), // Hebrew
+    const Locale('en', ''), // English, no country code
+    const Locale('he', ''), // Hebrew, no country code
     const Locale.fromSubtags(languageCode: 'zh'), // Chinese *See Advanced Locales below*
     // ... other locales the app supports
   ],
@@ -258,9 +258,9 @@ MaterialApp(
    GlobalWidgetsLocalizations.delegate,
  ],
  supportedLocales: [
-    const Locale('en'), // English
-    const Locale('he'), // Hebrew
-    const Locale('zh'), // Chinese
+    const Locale('en', ''), // English, no country code
+    const Locale('he', ''), // Hebrew, no country code
+    const Locale('zh', ''), // Chinese, no country code
     // ... other locales the app supports
   ],
   // ...


### PR DESCRIPTION
The code quoted later (and in the example app) depends on country code not being null (and instead being empty string):
```dart
final String name = locale.countryCode.isEmpty ? locale.languageCode : locale.toString();
```
This should resolve https://github.com/flutter/flutter/issues/16667 by documenting the expected setup consistently. The demo app already handles this correctly: https://github.com/flutter/website/blob/333b5f95c16233e41c9cfb9dc7667b41db0af3e9/examples/internationalization/minimal/lib/main.dart#L94