### PR TITLE
Encourage Flutter desktop developers to use dev

### DIFF
--- a/src/desktop.md
+++ b/src/desktop.md
@@ -54,7 +54,7 @@ then make sure that you have installed the
 [Flutter SDK][] and that it’s in your path.
 
 ```terminal
-$ flutter channel master  # or dev
+$ flutter channel dev
 $ flutter upgrade
 $ flutter config --enable-macos-desktop
 ```


### PR DESCRIPTION
We probably shouldn't encourage developers to use `master` channel.