### PR TITLE
Replace deprecated ANDROID_HOME references

### DIFF
--- a/src/docs/deployment/cd.md
+++ b/src/docs/deployment/cd.md
@@ -155,7 +155,7 @@ secrets in pull requests that you accept and merge.
     * See [fastlane CI documentation][] for CI specific setup.
     * During the setup phase, depending on the platform, make sure that:
          * Bundler is available using `gem install bundler`.
-         * For Android, make sure the Android SDK is available and the `ANDROID_HOME`
+         * For Android, make sure the Android SDK is available and the `ANDROID_SDK_ROOT`
            path is set.
          * Run `bundle install` in `[project]/android` or `[project]/ios`.
          * Make sure the Flutter SDK is available and set in `PATH`.

--- a/src/docs/get-started/install/_android-setup.md
+++ b/src/docs/get-started/install/_android-setup.md
@@ -30,7 +30,7 @@ you need an Android device running Android 4.1 (API level 16) or higher.
     Flutter recognizes your connected Android device.  By default,
     Flutter uses the version of the Android SDK where your `adb`
     tool is based. If you want Flutter to use a different installation
-    of the Android SDK, you must set the `ANDROID_HOME` environment
+    of the Android SDK, you must set the `ANDROID_SDK_ROOT` environment
     variable to that installation directory.
 
 ### Set up the Android emulator

--- a/src/docs/get-started/install/_chromeos-android-sdk-setup.md
+++ b/src/docs/get-started/install/_chromeos-android-sdk-setup.md
@@ -40,11 +40,11 @@ ran the sdkmanager command: $PLATFORM_PATH):
 $ export PATH="$PATH:$PLATFORM_PATH/platform-tools"
 ```
 
-Set the ANDROID_HOME variable to where you unzipped sdk-tools before (aka
+Set the `ANDROID_SDK_ROOT` variable to where you unzipped sdk-tools before (aka
 your $TOOLS_PATH):
 
 ```terminal
-$ export ANDROID_HOME="$TOOLS_PATH"
+$ export ANDROID_SDK_ROOT="$TOOLS_PATH"
 ```
 
 Now, run flutter doctor to accept the android-licenses:


### PR DESCRIPTION
[ANDROID_HOME is deprecated](https://developer.android.com/studio/command-line/variables.html#envar) and has been replaced with ANDROID_SDK_ROOT.

The Flutter tool supports both variables so nothing will break for users if they use either one, but we should remove the deprecated reference from the docs.