### PR TITLE
Update references to "Debug" menu in VS Code

### DIFF
--- a/src/docs/cookbook/testing/unit/introduction.md
+++ b/src/docs/cookbook/testing/unit/introduction.md
@@ -167,7 +167,7 @@ fastest feedback loop as well as the ability to set breakpoints.
        for your platform.*
   * **VSCode**
     1. Open the `counter_test.dart` file
-    2. Select the `Debug` menu
+    2. Select the `Run` menu
     3. Click the `Start Debugging` option
     4. *Alternatively, use the appropriate keyboard shortcut
        for your platform.*

--- a/src/docs/development/tools/devtools/vscode.md
+++ b/src/docs/development/tools/devtools/vscode.md
@@ -13,7 +13,7 @@ the [Flutter extension][].
 
 Start a debug session for your application by opening the root
 folder of your project (the one containing `pubspec.yaml`)
-in VS Code and clicking **Debug > Start Debugging** (`F5`).
+in VS Code and clicking **Run > Start Debugging** (`F5`).
 
 ## Launch DevTools
 

--- a/src/docs/development/tools/vs-code.md
+++ b/src/docs/development/tools/vs-code.md
@@ -91,7 +91,7 @@ enables the following:
   [Running DevTools from VS Code][] in the [DevTools][] docs.
 {{site.alert.end}}
 
-Start debugging by clicking **Debug > Start Debugging**
+Start debugging by clicking **Run > Start Debugging**
 from the main IDE window, or press `F5`.
 
 ### Selecting a target device
@@ -129,7 +129,7 @@ running or debugging.
 
 ### Run app without breakpoints
 
- 1. Click **Debug > Start Without Debugging** in the
+ 1. Click **Run > Start Without Debugging** in the
     main IDE window, or press `Ctrl`+`F5`.
     The status bar turns orange to show you are in a debug session.<br>
     ![Debug console]({% asset tools/vs-code/debug_console.png @path %}){:width="490px"}
@@ -137,7 +137,7 @@ running or debugging.
 ### Run app with breakpoints
 
  1. If desired, set breakpoints in your source code.
- 1. Click **Debug > Start Debugging** in the main IDE window,
+ 1. Click **Run > Start Debugging** in the main IDE window,
     or press `F5`.
 
     * The left **Debug Sidebar** shows stack frames and variables.

--- a/src/docs/get-started/test-drive/_vscode.md
+++ b/src/docs/get-started/test-drive/_vscode.md
@@ -34,7 +34,7 @@ contains a simple demo app that uses [Material Components][].
     Select flutter. And choose the debug configuration:
     To create your emulator if it is closed or to run the
     emulator or device that is now connected.
- 1. Invoke **Debug > Start Debugging** or press <kbd>F5</kbd>.
+ 1. Invoke **Run > Start Debugging** or press <kbd>F5</kbd>.
  1. Wait for the app to launch &mdash; progress is printed
     in the **Debug Console** view.
 


### PR DESCRIPTION
VS Code renamed this menu to "Run" in an earlier update.

<img width="286" alt="Screenshot 2020-06-29 at 16 38 53" src="https://user-images.githubusercontent.com/1078012/86026220-0d6d9e00-ba27-11ea-9e1c-c21a6bf8c942.png">

Fixes https://github.com/Dart-Code/Dart-Code/issues/2591.