### PR TITLE
Update disk space needed for Windows install

### DIFF
--- a/src/docs/get-started/install/windows.md
+++ b/src/docs/get-started/install/windows.md
@@ -15,7 +15,7 @@ To install and run Flutter,
 your development environment must meet these minimum requirements:
 
 - **Operating Systems**: Windows 7 SP1 or later (64-bit)
-- **Disk Space**: 400 MB (does not include disk space for IDE/tools).
+- **Disk Space**: 1.32 GB (does not include disk space for IDE/tools).
 - **Tools**: Flutter depends on these tools being available in your environment.
   - [Windows PowerShell 5.0][] or newer (this is pre-installed with Windows 10)
   - [Git for Windows][] 2.x, with the


### PR DESCRIPTION
Fixes https://github.com/flutter/website/issues/4298
The `.zip` file is `595MB` and the unzipped package is also `1.32GB` on my local machine as the issue mentioned. (flutter_windows_1.17.5-stable)