### PR TITLE
Clarify debugDumpApp meant for debug builds

### DIFF
--- a/src/docs/testing/code-debugging.md
+++ b/src/docs/testing/code-debugging.md
@@ -121,7 +121,7 @@ current state or events to the console (using `debugPrint`).
 To dump the state of the Widgets library, call [`debugDumpApp()`][].
 You can call this more or less any time that the application is not in
 the middle of running a build phase (in other words, not anywhere inside a
-`build()` method), so long as the application has built at least once in debug mode.
+`build()` method), if the app has built at least once and is in debug mode
 (in other words, any time after calling `runApp()`).
 
 For example, the following application:

--- a/src/docs/testing/code-debugging.md
+++ b/src/docs/testing/code-debugging.md
@@ -121,7 +121,7 @@ current state or events to the console (using `debugPrint`).
 To dump the state of the Widgets library, call [`debugDumpApp()`][].
 You can call this more or less any time that the application is not in
 the middle of running a build phase (in other words, not anywhere inside a
-`build()` method), so long as the application has built at least once
+`build()` method), so long as the application has built at least once in debug mode.
 (in other words, any time after calling `runApp()`).
 
 For example, the following application:


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/56199

Easy doc fix to clarify that debugDumpApp should be used in debug mode. :) 