### PR TITLE
Using Packages: Explicitly state how relative paths are evaluated

### DIFF
--- a/src/docs/development/packages-and-plugins/using-packages.md
+++ b/src/docs/development/packages-and-plugins/using-packages.md
@@ -212,6 +212,7 @@ additional dependency options are available:
 **Path dependency**
 : A Flutter app can depend on a plugin via a file system
   `path:` dependency. The path can be either relative or absolute.
+  Relative paths are evaluated relative to the directory containing `pubspec.yaml`.
   For example, to depend on a plugin `plugin1` located in a directory
   next to the app, use the following syntax:
 


### PR DESCRIPTION
Before, the current directory used
when evaluating relative paths in the pubspec
was implicit in the example.

Now, it is explicitly stated.