### PR TITLE
Add breaking change "Material Chip button semantics"

### DIFF
--- a/src/docs/release/breaking-changes/index.md
+++ b/src/docs/release/breaking-changes/index.md
@@ -43,6 +43,7 @@ release, and listed in alphabetical order:
 * [The RenderEditable needs to be laid out before hit testing][]
 * [The Route Transition record and Transition delegate updates][]
 * [TestWidgetsFlutterBinding.clock][]
+* [Material Chip button semantics][]
 
 [Actions API revision]: /docs/release/breaking-changes/actions-api-revision
 [Adding 'linux' and 'windows' to TargetPlatform enum]: /docs/release/breaking-changes/target-platform-linux-windows
@@ -72,3 +73,4 @@ release, and listed in alphabetical order:
 [The Route and Navigator refactoring]: /docs/release/breaking-changes/route-navigator-refactoring
 [The Route Transition record and Transition delegate updates]: /docs/release/breaking-changes/route-transition-record-and-transition-delegate
 [ThemeData's accent properties]: /docs/release/breaking-changes/theme-data-accent-properties
+[Material Chip button semantics]: /docs/release/breaking-changes/material-chip-button-semantics

--- a/src/docs/release/breaking-changes/material-chip-button-semantics.md
+++ b/src/docs/release/breaking-changes/material-chip-button-semantics.md
@@ -1,0 +1,177 @@
+---
+title: Material Chip Button Semantics
+description: Brief description similar to the "context" section below.
+---
+
+## Summary
+
+Flutter now applies the semantic label of `button` to all interactive [Material Chips](https://material.io/components/chips) for accessibility purposes.
+
+## Context
+
+Interactive Material Chips (namely [ActionChip](https://api.flutter.dev/flutter/material/ActionChip-class.html), [ChoiceChip](https://api.flutter.dev/flutter/material/ChoiceChip-class.html), [FilterChip](https://api.flutter.dev/flutter/material/FilterChip-class.html), and [InputChip](https://api.flutter.dev/flutter/material/InputChip-class.html)) are now semantically marked as being buttons. Please note that the non-interactive information [Chip](https://api.flutter.dev/flutter/material/Chip-class.html) is not.
+
+This will allow accessibility tools, search engines, and other semantic analysis software to determine the meaning of the application. For example, it will allow screen readers (such as TalkBack on Android and VoiceOver on iOS) to announce a tappable Chip as a "button", which can assist users in navigating the application. Prior to this change, users of accessibility tools may have had a subpar experience, unless application developers implemented a workaround by manually adding the missing semantics to the Chips in their applications.
+
+## Description of change
+
+In `package:flutter/material.dart`, the `build(...)` method of the `_RawChipState` class (used by all chips) returns the resulting built chip widget wrapped in a [Semantics](https://api.flutter.dev/flutter/widgets/Semantics-class.html) widget.
+
+This method looked akin to the following:
+
+<!-- skip -->
+```dart
+@override
+Widget build(BuildContext context) {
+  Widget result = ... // Actually build the widget here.
+  return Semantics(
+    container: true,
+    selected: widget.selected,
+    enabled: canTap ? widget.isEnabled : null,
+    child: result,
+  );
+}
+```
+
+The properties set on the `Semantics` widget have now been altered to:
+
+1. Mark the chip as a `button` if it _could_ be interacted with, regardless of whether it is currently `enabled` or not.
+    1. This means any chip class which passes `tapEnabled: true` to the `RawButton` class it extends will be marked as a button. This includes [ActionChip](https://api.flutter.dev/flutter/material/ActionChip-class.html), [ChoiceChip](https://api.flutter.dev/flutter/material/ChoiceChip-class.html), [FilterChip](https://api.flutter.dev/flutter/material/FilterChip-class.html), and [InputChip](https://api.flutter.dev/flutter/material/InputChip-class.html), but not the non-interactive information [Chip](https://api.flutter.dev/flutter/material/Chip-class.html).
+2. Make the chip's `enabled` semantic flag reflect whether the chip is currently tappable or not, if and only if the chip _could_ be interacted with at some point (see point 1), otherwise `enabled` is set to `null` (meaning this widget is _never_ tappable, as with the non-interactive information [Chip](https://api.flutter.dev/flutter/material/Chip-class.html)).
+    1. This change brings chips' `enabled` behavior in-line with that of other buttons.
+
+The code above now looks akin to the following:
+
+<!-- skip -->
+```dart
+@override
+Widget build(BuildContext context) {
+  Widget result = ... // Actually build the widget here.
+  return Semantics(
+  	button: widget.tapEnabled, // Added this line.
+    container: true,
+    selected: widget.selected,
+    enabled: widget.tapEnabled ? canTap : null, // Changed this line.
+    child: result,
+  );
+}
+```
+
+The `canTap` property has remained unchanged, and is defined as the following logical expression:
+
+<!-- skip -->
+```dart
+bool get canTap {
+  return widget.isEnabled
+      && widget.tapEnabled
+      && (widget.onPressed != null || widget.onSelected != null);
+}
+```
+
+## Migration guide
+
+**Most developers likely won't need to perform any migration.** This change will only affect developers who worked around the issue of Material Chips missing `button` semantics by wrapping the widget given to the `label` field of a `Chip` with a `Semantics` widget marked as `button: true`. **In this case, the inner and outer `button` semantics will conflict, resulting in the tappable area of the button shrinking down to the size of the label after this change is introduced.** This can be fixed by deleting that `Semantics` widget and replacing it with its child, or simply removing the `button: true` property if other semantic properties still need to be applied to the label widget of the Chip.
+
+The following snippets use [InputChip](https://api.flutter.dev/flutter/material/InputChip-class.html) as an example, but the same process applies to [ActionChip](https://api.flutter.dev/flutter/material/ActionChip-class.html), [ChoiceChip](https://api.flutter.dev/flutter/material/ChoiceChip-class.html), and [FilterChip](https://api.flutter.dev/flutter/material/FilterChip-class.html) as well.
+
+**Case 1: remove the `Semantics` widget.**
+
+Code before migration:
+
+<!-- skip -->
+```dart
+Widget myInputChip = InputChip(
+  onPressed: () {},
+  label: Semantics(
+    button: true,
+    child: Text('My Input Chip'),
+  ),
+);
+```
+
+Code after migration:
+
+<!-- skip -->
+```dart
+Widget myInputChip = InputChip(
+  onPressed: () {},
+  label: Text('My Input Chip'),
+);
+```
+
+**Case 2: remove `button:true` from the `Semantics` widget.**
+
+Code before migration:
+
+<!-- skip -->
+```dart
+Widget myInputChip = InputChip(
+  onPressed: () {},
+  label: Semantics(
+    button: true,
+    hint: 'Example Hint',
+    child: Text('My Input Chip'),
+  ),
+);
+```
+
+Code after migration:
+
+<!-- skip -->
+```dart
+Widget myInputChip = InputChip(
+  onPressed: () {},
+  label: Semantics(
+  	hint: 'Example Hint',
+    child: Text('My Input Chip'),
+  ),
+);
+```
+
+## Timeline
+
+Landed in version: xxx<br>
+In stable release: not yet
+
+{% comment %}
+The version # of the SDK where this change was
+introduced.  If there is a deprecation window,
+the version # to which we guarantee to maintain the old API.
+{% endcomment %}
+
+## References
+
+{% include master-api.md %}
+
+API documentation:
+* [`Semantics`][]
+* [`SemanticsProperties.button`][]
+* [`SemanticsProperties.enabled`][]
+* [`Chip`][]
+* [`ActionChip`][]
+* [`ChoiceChip`][]
+* [`FilterChip`][]
+* [`InputChip`][]
+
+Relevant issues:
+* [flutter/flutter#58010][]
+
+Relevant PRs:
+* [Tweaking Material Chip a11y semantics to match buttons][]
+* [Revert "Tweaking Material Chip a11y semantics to match buttons (#60141)"][]
+* [Re-land "Tweaking Material Chip a11y semantics to match buttons (#60141)"][]
+
+[`Semantics`]: {{site.api}}/flutter/widgets/Semantics-class.html
+[`SemanticsProperties.button`]: {{site.api}}/flutter/semantics/SemanticsProperties/button.html
+[`SemanticsProperties.enabled`]: {{site.api}}/flutter/semantics/SemanticsProperties/enabled.html
+[`Chip`]: {{site.api}}/flutter/material/Chip-class.html
+[`ActionChip`]: {{site.api}}/flutter/material/ActionChip-class.html
+[`ChoiceChip`]: {{site.api}}/flutter/material/ChoiceChip-class.html
+[`FilterChip`]: {{site.api}}/flutter/material/FilterChip-class.html
+[`InputChip`]: {{site.api}}/flutter/material/InputChip-class.html
+
+[flutter/flutter#58010]: {{site.github}}/flutter/flutter/issues/58010
+
+[Tweaking Material Chip a11y semantics to match buttons]: {{site.github}}/flutter/flutter/pull/60141
+[Revert "Tweaking Material Chip a11y semantics to match buttons (#60141)"]: {{site.github}}/flutter/flutter/pull/60645
+[Re-land "Tweaking Material Chip a11y semantics to match buttons (#60141)"]: {{site.github}}/flutter/flutter/pull/61048

--- a/src/docs/release/breaking-changes/material-chip-button-semantics.md
+++ b/src/docs/release/breaking-changes/material-chip-button-semantics.md
@@ -1,126 +1,60 @@
 ---
-title: Material Chip Button Semantics description: Brief description similar to
-the "context" section below.
+title: Material Chip button semantics
+description: Interactive Material Chips are now semantically marked as buttons.
 ---
 
 ## Summary
 
 Flutter now applies the semantic label of `button` to all interactive [Material
-Chips](https://material.io/components/chips) for accessibility purposes.
+Chips][] for accessibility purposes.
 
 ## Context
 
-Interactive Material Chips (namely
-[ActionChip](https://api.flutter.dev/flutter/material/ActionChip-class.html),
-[ChoiceChip](https://api.flutter.dev/flutter/material/ChoiceChip-class.html),
-[FilterChip](https://api.flutter.dev/flutter/material/FilterChip-class.html),
-and [InputChip](https://api.flutter.dev/flutter/material/InputChip-class.html))
-are now semantically marked as being buttons. Please note that the
-non-interactive information
-[Chip](https://api.flutter.dev/flutter/material/Chip-class.html) is not.
+Interactive Material Chips (namely [`ActionChip`][], [`ChoiceChip`][],
+[`FilterChip`][], and [`InputChip`][]) are now semantically marked as being
+buttons. However, the non-interactive information [`Chip`][] is not.
 
-This will allow accessibility tools, search engines, and other semantic analysis
-software to determine the meaning of the application. For example, it will allow
-screen readers (such as TalkBack on Android and VoiceOver on iOS) to announce a
-tappable Chip as a "button", which can assist users in navigating the
-application. Prior to this change, users of accessibility tools may have had a
-subpar experience, unless application developers implemented a workaround by
-manually adding the missing semantics to the Chips in their applications.
+Marking Chips as buttons helps accessibility tools, search engines, and other
+semantic analysis software understand the meaning of an app. For example, it
+allows screen readers (such as TalkBack on Android and VoiceOver on iOS) to
+announce a tappable Chip as a "button", which can assist users in navigating
+your app. Prior to this change, users of accessibility tools may have had a
+subpar experience, unless you implemented a workaround by manually adding the
+missing semantics to the Chip widgets in your app.
 
 ## Description of change
 
-In `package:flutter/material.dart`, the `build(...)` method of the
-`_RawChipState` class (used by all chips) returns the resulting built chip
-widget wrapped in a
-[Semantics](https://api.flutter.dev/flutter/widgets/Semantics-class.html)
-widget.
+The outermost [`Semantics`][] widget which wraps all Chip classes to describe
+their semantic properties has been modified.
 
-This method looked akin to the following:
+For [`ActionChip`][], [`ChoiceChip`][], [`FilterChip`][], and [`InputChip`][]:
 
-<!-- skip -->
-```dart
-@override
-Widget build(BuildContext context) {
-  Widget result = ... // Actually build the widget here.
-  return Semantics(
-    container: true,
-    selected: widget.selected,
-    enabled: canTap ? widget.isEnabled : null,
-    child: result,
-  );
-}
-```
+- The [`button`][`SemanticsProperties.button`] property is set to `true`.
+- The [`enabled`][`SemanticsProperties.enabled`] property reflects whether the
+  Chip is _currently_ tappable (by having a callback set).
 
-The properties set on the `Semantics` widget have now been altered to:
+These property changes bring interactive Chips' semantic behavior in-line with
+that of other [Material Buttons][].
 
-1. Mark the chip as a `button` if it _could_ be interacted with, regardless of
-   whether it is currently `enabled` or not.
-    1. This means any chip class which passes `tapEnabled: true` to the
-       `RawButton` class it extends will be marked as a button. This includes
-       [ActionChip](https://api.flutter.dev/flutter/material/ActionChip-class.html),
-       [ChoiceChip](https://api.flutter.dev/flutter/material/ChoiceChip-class.html),
-       [FilterChip](https://api.flutter.dev/flutter/material/FilterChip-class.html),
-       and
-       [InputChip](https://api.flutter.dev/flutter/material/InputChip-class.html),
-       but not the non-interactive information
-       [Chip](https://api.flutter.dev/flutter/material/Chip-class.html).
-2. Make the chip's `enabled` semantic flag reflect whether the chip is currently
-   tappable or not, if and only if the chip _could_ be interacted with at some
-   point (see point 1), otherwise `enabled` is set to `null` (meaning this
-   widget is _never_ tappable, as with the non-interactive information
-   [Chip](https://api.flutter.dev/flutter/material/Chip-class.html)).
-    1. This change brings chips' `enabled` behavior in-line with that of other
-       buttons.
+For the non-interactive information [`Chip`][]:
 
-The code above now looks akin to the following:
-
-<!-- skip -->
-```dart
-@override
-Widget build(BuildContext context) {
-  Widget result = ... // Actually build the widget here.
-  return Semantics(
-    button: widget.tapEnabled, // Added this line.
-    container: true,
-    selected: widget.selected,
-    enabled: widget.tapEnabled ? canTap : null, // Changed this line.
-    child: result,
-  );
-}
-```
-
-The `canTap` property has remained unchanged, and is defined as the following
-logical expression:
-
-<!-- skip -->
-```dart
-bool get canTap {
-  return widget.isEnabled
-      && widget.tapEnabled
-      && (widget.onPressed != null || widget.onSelected != null);
-}
-```
+- The [`button`][`SemanticsProperties.button`] property is set to `false`.
+- The [`enabled`][`SemanticsProperties.enabled`] property is set to `null`.
 
 ## Migration guide
 
-**Most developers likely won't need to perform any migration.** This change will
-only affect developers who worked around the issue of Material Chips missing
-`button` semantics by wrapping the widget given to the `label` field of a `Chip`
-with a `Semantics` widget marked as `button: true`. **In this case, the inner
-and outer `button` semantics will conflict, resulting in the tappable area of
-the button shrinking down to the size of the label after this change is
-introduced.** This can be fixed by deleting that `Semantics` widget and
-replacing it with its child, or simply removing the `button: true` property if
-other semantic properties still need to be applied to the label widget of the
-Chip.
+**You might not need to perform any migration.** This change only affects you if
+you worked around the issue of Material Chips missing `button` semantics by
+wrapping the widget given to the `label` field of a `Chip` with a `Semantics`
+widget marked as `button: true`. **In this case, the inner and outer `button`
+semantics will conflict, resulting in the tappable area of the button shrinking
+down to the size of the label after this change is introduced.** This issue can
+be fixed by deleting that `Semantics` widget and replacing it with its child, or
+simply removing the `button: true` property if other semantic properties still
+need to be applied to the `label` widget of the Chip.
 
-The following snippets use
-[InputChip](https://api.flutter.dev/flutter/material/InputChip-class.html) as an
-example, but the same process applies to
-[ActionChip](https://api.flutter.dev/flutter/material/ActionChip-class.html),
-[ChoiceChip](https://api.flutter.dev/flutter/material/ChoiceChip-class.html),
-and [FilterChip](https://api.flutter.dev/flutter/material/FilterChip-class.html)
-as well.
+The following snippets use [`InputChip`][] as an example, but the same process
+applies to [`ActionChip`][], [`ChoiceChip`][], and [`FilterChip`][] as well.
 
 **Case 1: remove the `Semantics` widget.**
 
@@ -185,14 +119,16 @@ Landed in version: TBD<br> In stable release: not yet
 {% include master-api.md %}
 
 API documentation:
-* [`Semantics`][]
-* [`SemanticsProperties.button`][]
-* [`SemanticsProperties.enabled`][]
-* [`Chip`][]
 * [`ActionChip`][]
+* [`Chip`][]
 * [`ChoiceChip`][]
 * [`FilterChip`][]
 * [`InputChip`][]
+* [Material Buttons][]
+* [Material Chips][]
+* [`Semantics`][]
+* [`SemanticsProperties.button`][]
+* [`SemanticsProperties.enabled`][]
 
 Relevant issues:
 * [flutter/flutter#58010][]
@@ -202,14 +138,16 @@ Relevant PRs:
 * [Revert "Tweaking Material Chip a11y semantics to match buttons (#60141)"][]
 * [Re-land "Tweaking Material Chip a11y semantics to match buttons (#60141)"][]
 
-[`Semantics`]: {{site.api}}/flutter/widgets/Semantics-class.html
-[`SemanticsProperties.button`]: {{site.api}}/flutter/semantics/SemanticsProperties/button.html
-[`SemanticsProperties.enabled`]: {{site.api}}/flutter/semantics/SemanticsProperties/enabled.html
-[`Chip`]: {{site.api}}/flutter/material/Chip-class.html
 [`ActionChip`]: {{site.api}}/flutter/material/ActionChip-class.html
+[`Chip`]: {{site.api}}/flutter/material/Chip-class.html
 [`ChoiceChip`]: {{site.api}}/flutter/material/ChoiceChip-class.html
 [`FilterChip`]: {{site.api}}/flutter/material/FilterChip-class.html
 [`InputChip`]: {{site.api}}/flutter/material/InputChip-class.html
+[Material Buttons]: {{site.url}}/docs/development/ui/widgets/material#Buttons
+[Material Chips]: {{site.material}}/components/chips
+[`Semantics`]: {{site.api}}/flutter/widgets/Semantics-class.html
+[`SemanticsProperties.button`]: {{site.api}}/flutter/semantics/SemanticsProperties/button.html
+[`SemanticsProperties.enabled`]: {{site.api}}/flutter/semantics/SemanticsProperties/enabled.html
 
 [flutter/flutter#58010]: {{site.github}}/flutter/flutter/issues/58010
 

--- a/src/docs/release/breaking-changes/material-chip-button-semantics.md
+++ b/src/docs/release/breaking-changes/material-chip-button-semantics.md
@@ -143,7 +143,7 @@ Relevant PRs:
 [`ChoiceChip`]: {{site.api}}/flutter/material/ChoiceChip-class.html
 [`FilterChip`]: {{site.api}}/flutter/material/FilterChip-class.html
 [`InputChip`]: {{site.api}}/flutter/material/InputChip-class.html
-[Material Buttons]: {{site.url}}/docs/development/ui/widgets/material#Buttons
+[Material Buttons]: {{site.material}}/components/buttons
 [Material Chips]: {{site.material}}/components/chips
 [`Semantics`]: {{site.api}}/flutter/widgets/Semantics-class.html
 [`SemanticsProperties.button`]: {{site.api}}/flutter/semantics/SemanticsProperties/button.html

--- a/src/docs/release/breaking-changes/material-chip-button-semantics.md
+++ b/src/docs/release/breaking-changes/material-chip-button-semantics.md
@@ -24,7 +24,7 @@ missing semantics to the Chip widgets in your app.
 
 ## Description of change
 
-The outermost [`Semantics`][] widget which wraps all Chip classes to describe
+The outermost [`Semantics`][] widget that wraps all Chip classes to describe
 their semantic properties has been modified.
 
 For [`ActionChip`][], [`ChoiceChip`][], [`FilterChip`][], and [`InputChip`][]:
@@ -47,10 +47,10 @@ For the non-interactive information [`Chip`][]:
 you worked around the issue of Material Chips missing `button` semantics by
 wrapping the widget given to the `label` field of a `Chip` with a `Semantics`
 widget marked as `button: true`. **In this case, the inner and outer `button`
-semantics will conflict, resulting in the tappable area of the button shrinking
-down to the size of the label after this change is introduced.** This issue can
-be fixed by deleting that `Semantics` widget and replacing it with its child, or
-simply removing the `button: true` property if other semantic properties still
+semantics conflict, resulting in the tappable area of the button shrinking
+down to the size of the label after this change is introduced.** Fix this issue
+either by deleting that `Semantics` widget and replacing it with its child,
+or by removing the `button: true` property if other semantic properties still
 need to be applied to the `label` widget of the Chip.
 
 The following snippets use [`InputChip`][] as an example, but the same process

--- a/src/docs/release/breaking-changes/material-chip-button-semantics.md
+++ b/src/docs/release/breaking-changes/material-chip-button-semantics.md
@@ -1,21 +1,39 @@
 ---
-title: Material Chip Button Semantics
-description: Brief description similar to the "context" section below.
+title: Material Chip Button Semantics description: Brief description similar to
+the "context" section below.
 ---
 
 ## Summary
 
-Flutter now applies the semantic label of `button` to all interactive [Material Chips](https://material.io/components/chips) for accessibility purposes.
+Flutter now applies the semantic label of `button` to all interactive [Material
+Chips](https://material.io/components/chips) for accessibility purposes.
 
 ## Context
 
-Interactive Material Chips (namely [ActionChip](https://api.flutter.dev/flutter/material/ActionChip-class.html), [ChoiceChip](https://api.flutter.dev/flutter/material/ChoiceChip-class.html), [FilterChip](https://api.flutter.dev/flutter/material/FilterChip-class.html), and [InputChip](https://api.flutter.dev/flutter/material/InputChip-class.html)) are now semantically marked as being buttons. Please note that the non-interactive information [Chip](https://api.flutter.dev/flutter/material/Chip-class.html) is not.
+Interactive Material Chips (namely
+[ActionChip](https://api.flutter.dev/flutter/material/ActionChip-class.html),
+[ChoiceChip](https://api.flutter.dev/flutter/material/ChoiceChip-class.html),
+[FilterChip](https://api.flutter.dev/flutter/material/FilterChip-class.html),
+and [InputChip](https://api.flutter.dev/flutter/material/InputChip-class.html))
+are now semantically marked as being buttons. Please note that the
+non-interactive information
+[Chip](https://api.flutter.dev/flutter/material/Chip-class.html) is not.
 
-This will allow accessibility tools, search engines, and other semantic analysis software to determine the meaning of the application. For example, it will allow screen readers (such as TalkBack on Android and VoiceOver on iOS) to announce a tappable Chip as a "button", which can assist users in navigating the application. Prior to this change, users of accessibility tools may have had a subpar experience, unless application developers implemented a workaround by manually adding the missing semantics to the Chips in their applications.
+This will allow accessibility tools, search engines, and other semantic analysis
+software to determine the meaning of the application. For example, it will allow
+screen readers (such as TalkBack on Android and VoiceOver on iOS) to announce a
+tappable Chip as a "button", which can assist users in navigating the
+application. Prior to this change, users of accessibility tools may have had a
+subpar experience, unless application developers implemented a workaround by
+manually adding the missing semantics to the Chips in their applications.
 
 ## Description of change
 
-In `package:flutter/material.dart`, the `build(...)` method of the `_RawChipState` class (used by all chips) returns the resulting built chip widget wrapped in a [Semantics](https://api.flutter.dev/flutter/widgets/Semantics-class.html) widget.
+In `package:flutter/material.dart`, the `build(...)` method of the
+`_RawChipState` class (used by all chips) returns the resulting built chip
+widget wrapped in a
+[Semantics](https://api.flutter.dev/flutter/widgets/Semantics-class.html)
+widget.
 
 This method looked akin to the following:
 
@@ -35,10 +53,24 @@ Widget build(BuildContext context) {
 
 The properties set on the `Semantics` widget have now been altered to:
 
-1. Mark the chip as a `button` if it _could_ be interacted with, regardless of whether it is currently `enabled` or not.
-    1. This means any chip class which passes `tapEnabled: true` to the `RawButton` class it extends will be marked as a button. This includes [ActionChip](https://api.flutter.dev/flutter/material/ActionChip-class.html), [ChoiceChip](https://api.flutter.dev/flutter/material/ChoiceChip-class.html), [FilterChip](https://api.flutter.dev/flutter/material/FilterChip-class.html), and [InputChip](https://api.flutter.dev/flutter/material/InputChip-class.html), but not the non-interactive information [Chip](https://api.flutter.dev/flutter/material/Chip-class.html).
-2. Make the chip's `enabled` semantic flag reflect whether the chip is currently tappable or not, if and only if the chip _could_ be interacted with at some point (see point 1), otherwise `enabled` is set to `null` (meaning this widget is _never_ tappable, as with the non-interactive information [Chip](https://api.flutter.dev/flutter/material/Chip-class.html)).
-    1. This change brings chips' `enabled` behavior in-line with that of other buttons.
+1. Mark the chip as a `button` if it _could_ be interacted with, regardless of
+   whether it is currently `enabled` or not.
+    1. This means any chip class which passes `tapEnabled: true` to the
+       `RawButton` class it extends will be marked as a button. This includes
+       [ActionChip](https://api.flutter.dev/flutter/material/ActionChip-class.html),
+       [ChoiceChip](https://api.flutter.dev/flutter/material/ChoiceChip-class.html),
+       [FilterChip](https://api.flutter.dev/flutter/material/FilterChip-class.html),
+       and
+       [InputChip](https://api.flutter.dev/flutter/material/InputChip-class.html),
+       but not the non-interactive information
+       [Chip](https://api.flutter.dev/flutter/material/Chip-class.html).
+2. Make the chip's `enabled` semantic flag reflect whether the chip is currently
+   tappable or not, if and only if the chip _could_ be interacted with at some
+   point (see point 1), otherwise `enabled` is set to `null` (meaning this
+   widget is _never_ tappable, as with the non-interactive information
+   [Chip](https://api.flutter.dev/flutter/material/Chip-class.html)).
+    1. This change brings chips' `enabled` behavior in-line with that of other
+       buttons.
 
 The code above now looks akin to the following:
 
@@ -48,7 +80,7 @@ The code above now looks akin to the following:
 Widget build(BuildContext context) {
   Widget result = ... // Actually build the widget here.
   return Semantics(
-  	button: widget.tapEnabled, // Added this line.
+    button: widget.tapEnabled, // Added this line.
     container: true,
     selected: widget.selected,
     enabled: widget.tapEnabled ? canTap : null, // Changed this line.
@@ -57,7 +89,8 @@ Widget build(BuildContext context) {
 }
 ```
 
-The `canTap` property has remained unchanged, and is defined as the following logical expression:
+The `canTap` property has remained unchanged, and is defined as the following
+logical expression:
 
 <!-- skip -->
 ```dart
@@ -70,9 +103,24 @@ bool get canTap {
 
 ## Migration guide
 
-**Most developers likely won't need to perform any migration.** This change will only affect developers who worked around the issue of Material Chips missing `button` semantics by wrapping the widget given to the `label` field of a `Chip` with a `Semantics` widget marked as `button: true`. **In this case, the inner and outer `button` semantics will conflict, resulting in the tappable area of the button shrinking down to the size of the label after this change is introduced.** This can be fixed by deleting that `Semantics` widget and replacing it with its child, or simply removing the `button: true` property if other semantic properties still need to be applied to the label widget of the Chip.
+**Most developers likely won't need to perform any migration.** This change will
+only affect developers who worked around the issue of Material Chips missing
+`button` semantics by wrapping the widget given to the `label` field of a `Chip`
+with a `Semantics` widget marked as `button: true`. **In this case, the inner
+and outer `button` semantics will conflict, resulting in the tappable area of
+the button shrinking down to the size of the label after this change is
+introduced.** This can be fixed by deleting that `Semantics` widget and
+replacing it with its child, or simply removing the `button: true` property if
+other semantic properties still need to be applied to the label widget of the
+Chip.
 
-The following snippets use [InputChip](https://api.flutter.dev/flutter/material/InputChip-class.html) as an example, but the same process applies to [ActionChip](https://api.flutter.dev/flutter/material/ActionChip-class.html), [ChoiceChip](https://api.flutter.dev/flutter/material/ChoiceChip-class.html), and [FilterChip](https://api.flutter.dev/flutter/material/FilterChip-class.html) as well.
+The following snippets use
+[InputChip](https://api.flutter.dev/flutter/material/InputChip-class.html) as an
+example, but the same process applies to
+[ActionChip](https://api.flutter.dev/flutter/material/ActionChip-class.html),
+[ChoiceChip](https://api.flutter.dev/flutter/material/ChoiceChip-class.html),
+and [FilterChip](https://api.flutter.dev/flutter/material/FilterChip-class.html)
+as well.
 
 **Case 1: remove the `Semantics` widget.**
 
@@ -122,7 +170,7 @@ Code after migration:
 Widget myInputChip = InputChip(
   onPressed: () {},
   label: Semantics(
-  	hint: 'Example Hint',
+    hint: 'Example Hint',
     child: Text('My Input Chip'),
   ),
 );
@@ -130,14 +178,7 @@ Widget myInputChip = InputChip(
 
 ## Timeline
 
-Landed in version: xxx<br>
-In stable release: not yet
-
-{% comment %}
-The version # of the SDK where this change was
-introduced.  If there is a deprecation window,
-the version # to which we guarantee to maintain the old API.
-{% endcomment %}
+Landed in version: TBD<br> In stable release: not yet
 
 ## References
 


### PR DESCRIPTION
This is a pretty minor breaking change which shouldn't affect many people, but it's my first time writing a breaking change doc so please let me know what I could improve.

**Note: currently unsure about timeline, will update that soon.**

**Relevant PRs:**
Original: flutter/flutter#60141
Revert: flutter/flutter#60645
Re-land: flutter/flutter#61048