### PR TITLE
Add to App: Render link rather than Markdown syntax

### DIFF
--- a/src/docs/development/add-to-app/index.md
+++ b/src/docs/development/add-to-app/index.md
@@ -26,7 +26,7 @@ It currently has the _**following limitations**_:
 * Packing multiple Flutter libraries into an
   application isn't supported.
 * Plugins used in add-to-app on Android should migrate
-  to the [new Android plugin APIs][], based on [`FlutterPlugin`].
+  to the [new Android plugin APIs][Android plugin APIs], based on [`FlutterPlugin`].
   Plugins that don't support `FlutterPlugin` may have unexpected
   behaviors if they make assumptions that are untenable in add-to-app
   (such as assuming that a Flutter `Activity` is always present).


### PR DESCRIPTION
Before, the literal text `[new Android plugin APIs][]`
was rendered on the page.

Now, the text `new Android plugin APIs` renders as a hyperlink
to the URL tagged as "Android plugin APIs".