### PR TITLE
Tweak note about dart command as of Flutter 1.19.0

### DIFF
--- a/src/_includes/dart-tool.md
+++ b/src/_includes/dart-tool.md
@@ -13,30 +13,29 @@
   compatible. (Some versions of Windows
   support a similar `where` command.)
 
-  ```sh
-  $ which flutter; which dart
-  <path-to-flutter-sdk>/flutter-sdk/bin/flutter
+  ```terminal
+  $ which flutter dart
+  /path-to-flutter-sdk/bin/flutter
   /usr/local/bin/dart
   ```
 
   As shown above, the two commands don't come from
   the same `bin` directory. Update your path to use
-  commands from `<path-to-flutter-sdk>/bin` before 
+  commands from `/path-to-flutter-sdk/bin` before
   commands from `/usr/local/bin` (in this case).
   After updating your shell for the change to take effect,
   running the `which` or `where` command again
   should show that the `flutter` and `dart` commands
   now come from the same directory.
 
-  ```sh
-  $ which flutter; which dart
-  <path-to-flutter-sdk>/flutter-sdk/bin/flutter
-  <path-to-flutter-sdk>/flutter-sdk/bin/dart
+  ```terminal
+  $ which flutter dart
+  /path-to-flutter-sdk/bin/flutter
+  /path-to-flutter-sdk/bin/dart
   ```
 
   To learn more about the `dart` command, run `dart -h`
-  from the command line, or see the [`dart` tool][] page
-  on dart.dev.
+  from the command line, or see the [dart tool][] page.
 {{site.alert.end}}
 
-[`dart` tool]: {{site.dart-site}}/tools/dart-vm
+[dart tool]: {{site.dart-site}}/tools/dart-vm


### PR DESCRIPTION
- Fixes the code block styling
- Use a single `which` command
- Followup to #4187

### Screenshots

Before:

> <img src="https://user-images.githubusercontent.com/4140793/87227749-0e79c600-c36b-11ea-90ae-cf06b37d3fc9.png" width=600>

After:

> <img src="https://user-images.githubusercontent.com/4140793/87227820-4c76ea00-c36b-11ea-846d-c048aca35e24.png" width=600>

cc @sfshaza2 @kwalrath 