### PR TITLE
Remove Flutter 1.13.6 note

### DIFF
--- a/src/docs/development/add-to-app/ios/project-setup.md
+++ b/src/docs/development/add-to-app/ios/project-setup.md
@@ -308,10 +308,6 @@ instead of an engine Flutter.framework.
 The App.framework and plugin frameworks are generated
 as described in Option B.
 
-{{site.alert.important}}
-  The `--cocoapods` flag is available in Flutter v1.13.6.
-{{site.alert.end}}
-
 ```sh
 flutter build ios-framework --cocoapods --output=some/path/MyApp/Flutter/
 ```


### PR DESCRIPTION
Flutter 1.17.0 has been in stable since May, remove note about 1.13.6.