### PR TITLE
Get started > Install: give prominence to the OS icon

### DIFF
--- a/src/docs/get-started/install/index.md
+++ b/src/docs/get-started/install/index.md
@@ -14,8 +14,10 @@ Select the operating system on which you are installing Flutter:
   <a class="card" href="/docs/get-started/install/{{os | remove: ' ' | downcase}}">
     <div class="card-body">
       <header class="card-title text-center m-0">
-        <span class="d-block text-nowrap">{{os}}</span>
-        <i class="fab fa-{{os | downcase}}"></i>
+        <span class="d-block h1">
+          <i class="fab fa-{{os | downcase}}"></i>
+        </span>
+        <span class="text-muted text-nowrap">{{os}}</span>
       </header>
     </div>
   </a>


### PR DESCRIPTION
Followup to https://github.com/flutter/website/pull/4364#issuecomment-660647922. This PR places the OS icon on top, and makes it bigger.

### Screenshots

> <img width="465" alt="Screen Shot 2020-07-19 at 09 57 33" src="https://user-images.githubusercontent.com/4140793/87876506-7b621100-c9a6-11ea-901c-55bc69868f0b.png">

> <img width="415" alt="Screen Shot 2020-07-19 at 09 57 23" src="https://user-images.githubusercontent.com/4140793/87876556-d431a980-c9a6-11ea-8179-841ab727b420.png">

