### PR TITLE
changed grey background color to grey[50]

### DIFF
--- a/src/docs/development/ui/layout/constraints.md
+++ b/src/docs/development/ui/layout/constraints.md
@@ -260,7 +260,7 @@ class _FlutterLayoutArticleState extends State<FlutterLayoutArticle> {
                               )),
                         ),
                         height: 273,
-                        color: Colors.grey),
+                        color: Colors.grey[50]),
                   ],
                 ),
               ),


### PR DESCRIPTION
Fixes https://github.com/flutter/website/issues/4267

Changed grey background color of explanation part of each example to grey[50] to improve readability.