### PR TITLE
fixed the wrong keyboard shortcuts for vscode

### DIFF
--- a/src/docs/development/tools/vs-code.md
+++ b/src/docs/development/tools/vs-code.md
@@ -238,15 +238,15 @@ You can also define custom snippets by executing
 
 ### Keyboard shortcuts
 
-**Hot reload**
-: During a debug session, clicking the **Restart** button on the
-  **Debug Toolbar**, or pressing `Ctrl`+`Shift`+`F5`
-  (`Cmd`+`Shift`+`F5` on macOS) performs a hot reload.
+**Hot Reload**
+: During a debug session, clicking the **Hot Reload** button on the
+  **Debug Toolbar**, or pressing `Ctrl`+`F5`
+  (`Cmd`+`F5` on macOS) performs a hot reload.
 
   Keyboard mappings can be changed by executing the
   **Open Keyboard Shortcuts** command from the [Command Palette][].
 
-### Hot reload vs. hot restart
+### Hot Reload vs. Hot Restart
 
 Hot reload works by injecting updated source code files into the
 running Dart VM (Virtual Machine). This includes not only
@@ -261,7 +261,7 @@ A few types of code changes cannot be hot reloaded though:
 For these changes, fully restart your application without
 having to end your debugging session. To perform a hot restart,
 run the **Flutter: Hot Restart** command from the
-[Command Palette][], or press `Ctrl`+`F5`.
+[Command Palette][], or press `Ctrl`+`Shift`+`F5`(`Cmd`+`Shift`+`F5` on macOS).
 
 ## Troubleshooting
 

--- a/src/docs/development/tools/vs-code.md
+++ b/src/docs/development/tools/vs-code.md
@@ -238,7 +238,7 @@ You can also define custom snippets by executing
 
 ### Keyboard shortcuts
 
-**Hot Reload**
+**Hot reload**
 : During a debug session, clicking the **Hot Reload** button on the
   **Debug Toolbar**, or pressing `Ctrl`+`F5`
   (`Cmd`+`F5` on macOS) performs a hot reload.
@@ -246,7 +246,7 @@ You can also define custom snippets by executing
   Keyboard mappings can be changed by executing the
   **Open Keyboard Shortcuts** command from the [Command Palette][].
 
-### Hot Reload vs. Hot Restart
+### Hot reload vs. hot restart
 
 Hot reload works by injecting updated source code files into the
 running Dart VM (Virtual Machine). This includes not only


### PR DESCRIPTION
Fixed the wrong keyboard shortcuts for **Hot Reload** and **Hot Restart** on [Visual Studio Code](https://flutter.dev/docs/development/tools/vs-code) page.