### PR TITLE
Update chromeos install

### DIFF
--- a/src/docs/get-started/install/_android-setup-chromeos.md
+++ b/src/docs/get-started/install/_android-setup-chromeos.md
@@ -42,8 +42,11 @@ you need an Android device running Android 4.1 (API level 16) or higher.
 
 With the latest version of Chrome OS, you no longer need to put your
 device into developer mode to push apps to your Chrome OS device.
-You can [enable ADB][] in Settings and start deploying directly to
-your Chromebook. Note that this will require you to reboot your
-device once.
 
-[enable ADB]: https://support.google.com/chromebook/answer/977069
+ 1. [Enable ADB][] in Settings. Note that this will require you to reboot your
+    device once. 
+ 1. In the Terminal, run `flutter devices`. If prompted, authorize access to
+    the Android container. Verify that `flutter devices` lists your Chrome
+    OS device as a recognized device.
+    
+[Enable ADB]: https://support.google.com/chromebook/answer/9770692

--- a/src/docs/get-started/install/_android-setup-chromeos.md
+++ b/src/docs/get-started/install/_android-setup-chromeos.md
@@ -1,0 +1,49 @@
+## Android setup
+
+{{site.alert.note}}
+  Flutter relies on a full installation of Android Studio to supply
+  its Android platform dependencies. However, you can write your
+  Flutter apps in a number of editors; a later step discusses that.
+{{site.alert.end}}
+
+### Install Android Studio
+
+ 1. Download and install [Android Studio]({{site.android-dev}}/studio).
+ 1. Start Android Studio, and go through the 'Android Studio Setup Wizard'.
+    This installs the latest Android SDK, Android SDK Command-line Tools,
+    and Android SDK Build-Tools, which are required by Flutter
+    when developing for Android.
+ 1. Accept Android licenses.
+
+ ```terminal
+$ flutter doctor --android-licenses
+```
+
+### Set up your Android device
+
+To prepare to run and test your Flutter app on an Android device,
+you need an Android device running Android 4.1 (API level 16) or higher.
+
+ 1. Enable **Developer options** and **USB debugging** on your device.
+    Detailed instructions are available in the
+    [Android documentation]({{site.android-dev}}/studio/debug/dev-options).
+ 1. Using a USB cable, plug your phone into your computer. On your Chromebook,
+    you may see a notification for "USB device detected". Click on "Connect
+    to Linux" If prompted on your Android device, authorize your computer
+    to access your device. 
+ 1. In the terminal, run the `flutter devices` command to verify that
+    Flutter recognizes your connected Android device.  By default,
+    Flutter uses the version of the Android SDK where your `adb`
+    tool is based. If you want Flutter to use a different installation
+    of the Android SDK, you must set the `ANDROID_SDK_ROOT` environment
+    variable to that installation directory.
+
+### Deploy to your Chromebook
+
+With the latest version of Chrome OS, you no longer need to put your
+device into developer mode to push apps to your Chrome OS device.
+You can [enable ADB][] in Settings and start deploying directly to
+your Chromebook. Note that this will require you to reboot your
+device once.
+
+[enable ADB]: https://support.google.com/chromebook/answer/977069

--- a/src/docs/get-started/install/_get-sdk-chromeos.md
+++ b/src/docs/get-started/install/_get-sdk-chromeos.md
@@ -1,0 +1,125 @@
+{% if os == 'linux' -%}
+  {% assign unzip = 'tar xf' -%}
+  {% assign file_ext = '.tar.xz' -%}
+{% else -%}
+  {% assign unzip = 'unzip' -%}
+  {% assign file_ext = '.zip' -%}
+{% endif -%}
+
+## Get the Flutter SDK {#get-sdk}
+
+ 1. Download the following installation bundle to get the latest
+    {{site.sdk.channel}} release of the Flutter SDK:
+
+    [(loading...)](#){:.download-latest-link-{{os}}.btn.btn-primary}
+
+    For other release channels, and older builds,
+    see the [SDK archive][] page.
+
+ 1. In the Files app, drag-and-drop the downloaded file from "Downloads"
+    to "Linux Files" to access Flutter from your Linux container.
+
+ 1. Extract the file in the desired location, for example:
+
+    {% comment %}
+      Our JS also updates the filename in this template, but it doesn't include the terminal formatting:
+
+      {% prettify shell %}
+      $ cd ~/development
+      $ {{unzip}} ~/Downloads/[[download-latest-link-filename]]flutter_{{os}}_vX.X.X-{{site.sdk.channel}}{{file_ext}}[[/end]]
+      {% endprettify %}
+    {% endcomment -%}
+
+    ```terminal
+    $ cd ~/development
+    $ {{unzip}} ~/Downloads/flutter_{{os}}_vX.X.X-{{site.sdk.channel}}{{file_ext}}
+    ```
+    
+    If you don't want to install a fixed version of the installation bundle, 
+    you can skip steps 1 and 2. 
+    Instead, get the source code from the [Flutter repo][]
+    on GitHub with the following command:
+    
+    ```terminal
+    $ git clone https://github.com/flutter/flutter.git
+    ```
+    
+    You can also change branches or tags as needed.
+    For example, to get just the stable version:
+    
+    ```terminal
+    $ git clone https://github.com/flutter/flutter.git -b stable --depth 1
+    ```
+    
+ 1. Add the `flutter` tool to your path:
+
+    ```terminal
+    $ export PATH="$PATH:`pwd`/flutter/bin"
+    ```
+
+    This command sets your `PATH` variable for the
+    _current_ terminal window only.
+    To permanently add Flutter to your path, see
+    [Update your path][].
+
+ 1. Optionally, pre-download development binaries:
+
+    The `flutter` tool downloads platform-specific development binaries as
+    needed. For scenarios where pre-downloading these artifacts is preferable
+    (for example, in hermetic build environments,
+    or with intermittent network availability), iOS
+    and Android binaries can be downloaded ahead of time by running:
+
+    ```terminal
+    $ flutter precache
+    ```
+
+    For additional download options, see `flutter help precache`.
+
+You are now ready to run Flutter commands!
+
+{{site.alert.note}}
+  To update an existing version of Flutter, see
+  [Upgrading Flutter][].
+{{site.alert.end}}
+
+
+### Run flutter doctor
+
+Run the following command to see if there are any dependencies you need to
+install to complete the setup (for verbose output, add the `-v` flag):
+
+```terminal
+$ flutter doctor
+```
+
+This command checks your environment and displays a report to the terminal
+window. The Dart SDK is bundled with Flutter; it is not necessary to install
+Dart separately. Check the output carefully for other software you might
+need to install or further tasks to perform (shown in **bold** text).
+
+For example:
+
+<pre>
+[-] Android toolchain - develop for Android devices
+    • Android SDK at /Users/obiwan/Library/Android/sdk
+    <strong>✗ Android SDK is missing command line tools; download from https://goo.gl/XxQghQ</strong>
+    • Try re-installing or updating your Android SDK,
+      visit {{site.url}}/setup/#android-setup for detailed instructions.
+</pre>
+
+The following sections describe how to perform these tasks and finish the setup
+process.
+
+Once you have installed any missing dependencies, run the `flutter doctor`
+command again to verify that you’ve set everything up correctly.
+
+{% include_relative _analytics.md %}
+
+[Flutter repo]: {{site.github}}/flutter/flutter
+[Installing snapd]: https://snapcraft.io/docs/installing-snapd
+[SDK archive]: /docs/development/tools/sdk/archive
+[Snap Store]: https://snapcraft.io/store
+[snapd]: https://snapcraft.io/flutter
+[Update your path]: #update-your-path
+[Upgrading Flutter]: /docs/development/tools/sdk/upgrading

--- a/src/docs/get-started/install/chromeos.md
+++ b/src/docs/get-started/install/chromeos.md
@@ -50,7 +50,7 @@ Flutter DevTools for an Android app with ports
 that will work:
 
 ```terminal
-$ flutter packages pub global run devtools -p 8000
+$ flutter pub global run devtools -p 8000
 $ cd path/to/your/app
 $ flutter run --observatory-port=8080
 ```

--- a/src/docs/get-started/install/chromeos.md
+++ b/src/docs/get-started/install/chromeos.md
@@ -14,7 +14,7 @@ next:
 To install and run Flutter, your development environment
 must meet these minimum requirements:
 
-* **Operating Systems**: Linux (64-bit)
+* **Operating Systems**: Chrome OS (64-bit) with [Linux (Beta)][] turned on
 * **Disk Space**: 600 MB (does not include disk space for IDE/tools).
 * **Tools**: Flutter depends on these command-line
   tools being available in your environment.
@@ -31,47 +31,17 @@ must meet these minimum requirements:
   * `libGLU.so.1` - provided by mesa packages such as `libglu1-mesa` on
      Ubuntu/Debian
 
-For the best experience right now, you should put your
-Chrome OS Device into developer mode (this is necessary
-to push apps on the Chrome OS Device).  For more information,
-see [how to enable developer mode on your Chromebook][].
-
-{% include_relative _get-sdk.md %}
+{% include_relative _get-sdk-chromeos.md %}
 
 {% include_relative _path-linux-chromeos.md %}
 
-{% include_relative _chromeos-android-sdk-setup.md %}
+{% include_relative _android-setup-chromeos.md %}
 
 ## Next step
 
 Set up your preferred editor.
 
 ## Flutter & Chrome OS tips & tricks
-
-Wondering how to run your app? On Chrome OS,
-you can either connect your phone
-or push directly to the Android container on device.
-To do that you must enable Developer mode on your machine,
-and then connect to the local container with ADB:
-
-```terminal
-$ adb connect 100.115.92.2:5555
-```
-
-Want to build your first app optimized for Chrome OS?
-Clone the flutter-samples repo and build our specific Chrome
-OS Best Practices example:
-
-```terminal
-$ git clone https://github.com/flutter/samples
-$ cd samples/chrome-os-best-practices
-$ flutter run
-```
-
-Wondering how to access your favorite F-Key shortcuts
-on the Chrome OS keyboard?
-
-* Press the search key along with 1 through = to access F1–F12.
 
 For the current versions of Chrome OS, only certain ports from
 Crostini are exposed to the rest of the environments.
@@ -80,13 +50,18 @@ Flutter DevTools for an Android app with ports
 that will work:
 
 ```terminal
-$ flutter pub global run devtools -p 8000
+$ flutter packages pub global run devtools -p 8000
 $ cd path/to/your/app
 $ flutter run --observatory-port=8080
 ```
 
-Then, navigate to http://localhost:8000/?port=8080
-in your Chrome browser.
+Then, navigate to http://127.0.0.1:8000/#
+in your Chrome browser and enter the URL to your
+application. The last `flutter run` command you
+just ran should output a URL similar to the format
+of `http://127.0.0.1:8080/auth_code=/`. Use this URL
+and select "Connect" to start the Flutter DevTools
+for your Android app.
 
 #### Flutter Chrome OS lint analysis
 
@@ -133,5 +108,4 @@ this functionality work with your Chrome OS
 targeted Flutter app.
 
 
-[how to enable developer mode on your Chromebook]: https://chromium.googlesource.com/chromiumos/docs/+/master/developer_mode.md
-
+[Linux (Beta)]: https://support.google.com/chromebook/answer/9145439


### PR DESCRIPTION
- Some minor updates to install instructions for Chrome OS like being able to enable ADB without entering Developer Mode anymore.
- Removed Install without Android Studio instructions because it doesn't work very well. The current Android command line tools requires a certain version of Java/JDK to run.
- Added Android Setup instructions instead which is a modification of the Android setup instructions for other platforms.