### PR TITLE
Add note about potential Dex merging issues

### DIFF
--- a/src/docs/development/add-to-app/android/project-setup.md
+++ b/src/docs/development/add-to-app/android/project-setup.md
@@ -132,6 +132,10 @@ module an embeddable Android library.
   Android project using the Flutter module.
 {{site.alert.end}}
 
+{{site.alert.note}}
+  To avoid Dex merging issues, `flutter.androidPackage` should not be identical to your host app's package name
+{{site.alert.end}}
+
 ### Java 8 requirement
 
 The Flutter Android engine uses Java 8 features.


### PR DESCRIPTION
After encountering [issues](https://github.com/flutter/flutter/issues/62388) related to the module package name after manually adding a Flutter module to an existing Android project, I thought it'd be worth mentioning in the docs that identical package names in the host app and module can (and most likely will) lead to Dex merging issues.