### PR TITLE
Mention Gradle and CocoaPods in Package Development

### DIFF
--- a/src/docs/development/packages-and-plugins/developing-packages.md
+++ b/src/docs/development/packages-and-plugins/developing-packages.md
@@ -570,6 +570,9 @@ You can now `import io.flutter.plugins.urllauncher.UrlLauncherPlugin`
 and access the `UrlLauncherPlugin`
 class in the source code at `hello/android/src`.
 
+For more information on `build.gradle` files, see the
+[Gradle Documentation][] on build scripts.
+
 ### iOS
 
 The following example sets a dependency for
@@ -584,6 +587,9 @@ You can now `#import "UrlLauncherPlugin.h"` and
 access the `UrlLauncherPlugin` class in the source code
 at `hello/ios/Classes`.
 
+For additional details on `.podspec` files, see the
+[CocoaPods Documentation][] on them.
+
 ### Web
 
 All web dependencies are handled by the `pubspec.yaml`
@@ -596,6 +602,7 @@ file like any other Dart package.
 PENDING
 {% endcomment %}
 
+[CocoaPods Documentation]: https://guides.cocoapods.org/syntax/podspec.html
 [Dart library package]: {{site.dart-site}}/guides/libraries/create-library-packages
 [`device_info`]: {{site.pub-api}}/device_info/latest
 [Effective Dart Documentation]: {{site.dart-site}}/guides/language/effective-dart/documentation
@@ -604,6 +611,7 @@ PENDING
 [Flutter editor]: /docs/get-started/editor
 [Flutter Favorites]: {{site.pub}}/flutter/favorites
 [Flutter Favorites program]: /docs/development/packages-and-plugins/favorites
+[Gradle Documentation]: https://docs.gradle.org/current/userguide/tutorial_using_tasks.html
 [How to Write a Flutter Web Plugin, Part 1]: {{site.medium}}/flutter/how-to-write-a-flutter-web-plugin-5e26c689ea1
 [How To Write a Flutter Web Plugin, Part 2]: {{site.medium}}/flutter/how-to-write-a-flutter-web-plugin-part-2-afdddb69ece6
 [issue #33302]: https://github.com/flutter/flutter/issues/33302


### PR DESCRIPTION
Resolves issue #3991 
Solves this issue and prevents a future issue by mentioning Gradle, build.gradle files, CocoaPods, and .podspec files in developing-packages.md.