### PR TITLE
Keep React Packages Installation docs consistent.

### DIFF
--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -749,7 +749,7 @@ dependencies:
 
 <!-- skip -->
 ```dart
-import 'package:flutter/cupertino.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 ```
 
 For more information, see [Using Packages][] and


### PR DESCRIPTION
Resolves issue #1469 by keeping all parts of the "How do I install packages and plugins?" section consistent. 
This is accomplished by replacing a reference to `cupertino.dart` (which was not mentioned previously in this section) with a reference to `google_sign_in.dart` (which was mentioned).