### PR TITLE
Remove Redundant Next Steps from Get Started

### DIFF
--- a/src/docs/get-started/editor.md
+++ b/src/docs/get-started/editor.md
@@ -108,11 +108,6 @@ For information on how to install and use the package, see the [lsp-dart documen
 </div>
 </div>{% comment %} End: Tab panes. {% endcomment -%}
 
-## Next step
-
-Take Flutter for a test drive: create a first project, run it, and experience
-"hot reload".
-
 
 
 [Android Studio]: {{site.android-dev}}/studio

--- a/src/docs/get-started/test-drive/index.md
+++ b/src/docs/get-started/test-drive/index.md
@@ -36,9 +36,7 @@ Flutter apps.
   {% include_relative _terminal.md %}
 </div>
 
-## Next step
 
-You'll next learn some core Flutter concepts by creating a small app.
 
 [Install]: /docs/get-started/install
 [Main IntelliJ toolbar]: {% asset tools/android-studio/main-toolbar.png @path %}


### PR DESCRIPTION
Resolves issue #2015
Removes the redundant "Next Steps" sections on the "Set up and editor" and "Test drive" pages, which add little to the page. The "Next Steps" section on the "Install" page was removed at some other point. The issues brought up within the comments of the issue have also been fixed already. 