### PR TITLE
Reference "flutter test --help" in Testing Docs

### DIFF
--- a/src/docs/cookbook/testing/unit/introduction.md
+++ b/src/docs/cookbook/testing/unit/introduction.md
@@ -181,6 +181,11 @@ command from the root of the project:
 flutter test test/counter_test.dart
 ```
 
+For more options regarding unit tests, you can execute this command:
+
+```
+flutter test --help
+```
 
 [`flutter_test`]: {{site.api}}/flutter/flutter_test/flutter_test-library.html
 [`test`]: {{site.pub-pkg}}/test

--- a/src/docs/testing/index.md
+++ b/src/docs/testing/index.md
@@ -40,6 +40,9 @@ External dependencies of the unit under test are generally
 Unit tests generally don't read from or write
 to disk, render to screen, or receive user actions from
 outside the process running the test.
+For more information regarding unit tests, 
+you can view the following recipes 
+or run `flutter test --help` in your terminal.
 
 ### Recipes
 


### PR DESCRIPTION
Resolves issue #1131 
Adds references to `flutter test --help` on the "Testing" and the "An Introduction to Unit Testing" pages as a way to get more information. Arguably redundant, so perhaps only one of these two additions should be kept. 