### PR TITLE
Mentions 'flutter upgrade' and 'flutter update-packages' to minimize confusion

### DIFF
--- a/src/docs/development/packages-and-plugins/using-packages.md
+++ b/src/docs/development/packages-and-plugins/using-packages.md
@@ -201,7 +201,10 @@ run `flutter pub upgrade`
 (**Upgrade dependencies** in IntelliJ or Android Studio)
 to retrieve the highest available version of the package
 that is allowed by the version constraint specified in
-`pubspec.yaml`.
+`pubspec.yaml`. 
+Note that this is a different command from 
+`flutter upgrade` or `flutter update-packages', 
+which both update Flutter itself.
 
 ### Dependencies on unpublished packages
 


### PR DESCRIPTION
Fixes #1143
Notes in the "Updating package dependencies" section of https://flutter.dev/docs/development/packages-and-plugins/using-packages#updating-package-dependencies, as #1143 recommends, that `flutter upgrade` and `flutter update-packages` are not related to upgrading packages within apps, and are instead used to upgrade Flutter itself.