### PR TITLE
Move the link to avoid interrupt markdown ordered Lists

### DIFF
--- a/src/docs/perf/rendering/shader.md
+++ b/src/docs/perf/rendering/shader.md
@@ -153,9 +153,6 @@ The worst frame rasterization time is a nice metric from such integration tests 
    rasterization time in release mode; the worst frame rasterization time is
    a good indicator on how severe the shader compilation jank is.)
 
-[`FrameTiming`]: {{site.api}}/flutter/dart-ui/FrameTiming-class.html
-[SkSL-based warmup issue]: {{site.github}}/flutter/flutter/issues/53607#issuecomment-608587484
-
 3. **SkSL warm-up doesn't help newer iPhones using Metal.**<br>
    Flutter recently migrated from OpenGL to Metal for all newer iOS
    devices. However, Skia currently only implements the SkSL warm-up for
@@ -167,6 +164,9 @@ The worst frame rasterization time is a nice metric from such integration tests 
    shader compilation jank on newer iPhones, please leave feedback on
    [Issue 61045][], and we can help you turn on OpenGL for your app.
 
+
+[`FrameTiming`]: {{site.api}}/flutter/dart-ui/FrameTiming-class.html
+[SkSL-based warmup issue]: {{site.github}}/flutter/flutter/issues/53607#issuecomment-608587484
 [GitHub issue]: {{site.github}}/flutter/flutter/issues
 [Issue 61045]: {{site.github}}/flutter/flutter/issues/61045
 


### PR DESCRIPTION
The current version is causing https://flutter.dev/docs/perf/rendering/shader#limitations-and-considerations showing 1, 2, 1 as the enumeration label:

![image](https://user-images.githubusercontent.com/11715538/89669470-845f4780-d8ad-11ea-9abe-d0d7a4da66d7.png)
