### PR TITLE
Include alternate method in "Custom Fonts" recipe

### DIFF
--- a/src/docs/cookbook/design/fonts.md
+++ b/src/docs/cookbook/design/fonts.md
@@ -19,6 +19,12 @@ or perhaps you downloaded a font from [Google Fonts][].
   to almost 1000 open-sourced font families.
 {{site.alert.end}}
 
+{{site.alert.note}}
+  For another method to use a font, 
+  especially if you want to re-use one font over multiple projects, 
+  see https://flutter.dev/docs/cookbook/design/package-fonts.
+{{site.alert.end}}
+
 Flutter works with custom fonts and you can apply a custom
 font across an entire app or to individual widgets.
 This recipe creates an app that uses custom fonts with

--- a/src/docs/cookbook/design/fonts.md
+++ b/src/docs/cookbook/design/fonts.md
@@ -20,9 +20,9 @@ or perhaps you downloaded a font from [Google Fonts][].
 {{site.alert.end}}
 
 {{site.alert.note}}
-  For another method to use a font, 
+  For another approach to using custom fonts, 
   especially if you want to re-use one font over multiple projects, 
-  see https://flutter.dev/docs/cookbook/design/package-fonts.
+  see [Export fonts from a package][].
 {{site.alert.end}}
 
 Flutter works with custom fonts and you can apply a custom
@@ -217,8 +217,7 @@ class MyHomePage extends StatelessWidget {
 ```
 
 ![Custom Fonts Demo](/images/cookbook/fonts.png){:.site-mobile-screenshot}
-
-
+[Export fonts from a package]:  /docs/cookbook/design/package-fonts
 [`fontFamily`]: {{site.api}}/flutter/painting/TextStyle/fontFamily.html
 [`fontStyle`]: {{site.api}}/flutter/painting/TextStyle/fontStyle.html
 [`FontStyle`]: {{site.api}}/flutter/dart-ui/FontStyle-class.html

--- a/src/docs/cookbook/design/package-fonts.md
+++ b/src/docs/cookbook/design/package-fonts.md
@@ -2,7 +2,7 @@
 title: Export fonts from a package
 description: How to export fonts from a package.
 prev:
-  title: Display a snackbars
+  title: Display a snackbar
   path: /docs/cookbook/design/snackbars
 next:
   title: Update the UI based on orientation


### PR DESCRIPTION
Fixes #1822
The issue presented in #1822, which is the lack of clarity on how to use fonts from Google Fonts, has been cleared up already. It seems like all font related pages already mention that you should download directly from Google Fonts. This commit adds the recommendation in @sfshaza2 's comment to add a link to an alternate method of importing fonts. 
On an unrelated note, it also fixes a small typo on said alternate method's page.