### PR TITLE
Include more details about uses-material-design

### DIFF
--- a/src/docs/development/ui/widgets-intro.md
+++ b/src/docs/development/ui/widgets-intro.md
@@ -167,7 +167,8 @@ void main() {
 
 Be sure to have a `uses-material-design: true` entry in the `flutter`
 section of your `pubspec.yaml` file. It allows you to use the predefined
-set of [Material icons][].
+set of [Material icons][]. It's generally a good idea to include this line 
+if you are using the Materials library.
 
 ```yaml
 name: my_app

--- a/src/docs/get-started/codelab-web.md
+++ b/src/docs/get-started/codelab-web.md
@@ -272,7 +272,7 @@ From your IDE, editor, or at the command line,
   Flutter also offers the Cupertino widget library,
   which implements the current iOS design language.
   Or you can create your own custom widget library.
-* In Flutter, most everything is a [Widget][].
+* In Flutter, almost everything is a [Widget][].
   Even the app itself is a widget.
   The app’s UI can be described as a widget tree.
 

--- a/src/docs/get-started/codelab.md
+++ b/src/docs/get-started/codelab.md
@@ -190,6 +190,11 @@ where the Dart code lives.
   [Material][] is a visual design language
   that is standard on mobile and the web.
   Flutter offers a rich set of Material widgets.
+  It's a good idea to have a `uses-material-design: true` entry
+  in the `flutter` section of your `pubspec.yaml` file. 
+  This will allow you to use more features of Material,
+  such as their set of predefined [Icons][].
+
 * The `main()` method uses arrow (`=>`) notation.
   Use arrow notation for one-line functions or methods.
 * The app extends `StatelessWidget`, which makes the app itself a
@@ -650,6 +655,7 @@ where you add the following functionality:
 [Google Developers Codelabs]: {{site.codelabs}}
 [hot reload]: /docs/get-started/test-drive
 [in the way your IDE describes]: /docs/get-started/test-drive
+[Icons]: https://design.google.com/icons/
 [iOS]: install/macos#deploy-to-ios-devices
 [iOS simulator]: install/macos#set-up-the-ios-simulator
 [Material]: {{site.material}}/guidelines

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -1084,6 +1084,8 @@ make sure to set `uses-material-design: true` in
 the project's `pubspec.yaml` file.
 This ensures that the `MaterialIcons` font,
 which displays the icons, is included in your app.
+In general, if you intend to use the Material library, 
+you should include this line.
 
 ```yaml
 name: my_awesome_application


### PR DESCRIPTION
Fixes #1984 
Adds details about `uses-material-design` to the "Write your first app" page of the Getting Started section. Also expanded its description in the two other pages it was mentioned in to make it more clear how to use it, so #1984 isn't a problem for anyone else. Lastly, fixed a typo in codelab-web.