### PR TITLE
Mention debugging.md in faq.md

### DIFF
--- a/src/docs/resources/faq.md
+++ b/src/docs/resources/faq.md
@@ -172,6 +172,13 @@ integration tests. Learn more about
 We use our own testing capabilities to test our SDK.
 We measure our [test coverage][] on every commit.
 
+### Does Flutter come with debugging tools?
+
+While Flutter doesn't ship with debugging tools, 
+there are many tools available that 
+can help you debug your Flutter application. 
+Learn more about [debugging with Flutter][].
+
 ### Does Flutter come with a dependency injection framework or solution?
 
 Not at this time. Share your ideas at
@@ -945,6 +952,7 @@ that Flutter apps can be deployed to Apple's App Store.
 [Contributing Guide]: {{site.github}}/flutter/flutter/blob/master/CONTRIBUTING.md
 [CodePen]: https://codepen.io/flutter
 [Dart DevTools]: /docs/development/tools/devtools
+[debugging with Flutter]: /docs/testing/debugging
 [desktop]: /desktop
 [detailed discussion on the API docs for `State.build`]: {{site.api}}/flutter/widgets/State/build.html
 [Discord]: https://discord.gg/N7Yshp4

--- a/src/docs/testing/debugging.md
+++ b/src/docs/testing/debugging.md
@@ -3,7 +3,7 @@ title: Debugging Flutter apps
 description: How to debug your app using the DevTools suite.
 ---
 
-There are a wide variety of tools and features to help debug
+There's a wide variety of tools and features to help debug
 Flutter applications. Here are some of the available tools:
 
 * [DevTools][], a suite of performance and profiling


### PR DESCRIPTION
Fixes #2002
Adds a section for debugging in the FAQ and a link to it.
Also fixes a typo/awkward phrasing in debugging.md