### PR TITLE
Fixing api reference to AnimatedPhysicalModel on the FAQ page

### DIFF
--- a/src/docs/resources/faq.md
+++ b/src/docs/resources/faq.md
@@ -582,7 +582,7 @@ Check out an [example of using isolates with Flutter][].
 
 Yes, you can run Dart code in a background process on both
 iOS and Android  For more information, see the Medium article
-[Executing Dart in the Background with Flutter Plugins and Geofencing][].  
+[Executing Dart in the Background with Flutter Plugins and Geofencing][].
 
 ### Can I use JSON/XML/<wbr>protobuffers, etc. with Flutter?
 
@@ -931,7 +931,7 @@ that Flutter apps can be deployed to Apple's App Store.
 [Android Studio instructions]: {{site.android-dev}}/studio/build/apk-analyzer
 [Android Studio/IntelliJ]: /docs/development/tools/android-studio
 [`AnimatedDefaultTextStyle`]: {{site.api}}/flutter/widgets/AnimatedDefaultTextStyle-class.html
-[`AnimatedPhysicalModel`]: {{site.api}}/flutter/widgets/NotificationListener-class.html
+[`AnimatedPhysicalModel`]: {{site.api}}/flutter/widgets/AnimatedPhysicalModel-class.html
 [apkanalyzer]: {{site.android-dev}}/studio/command-line/apkanalyzer
 [architecture diagram]: https://docs.google.com/presentation/d/1cw7A4HbvM_Abv320rVgPVGiUP2msVs7tfGbkgdrTy0I/edit#slide=id.gbb3c3233b_0_162
 [`BasicMessageChannel`]: {{site.api}}/flutter/services/BasicMessageChannel-class.html


### PR DESCRIPTION
Right now, AnimatedPhysicalModel links to the NotificationListener api page. This pull request fixes that.