### PR TITLE
Add explicit reference to dart's convert pkg

### DIFF
--- a/src/docs/cookbook/networking/fetch-data.md
+++ b/src/docs/cookbook/networking/fetch-data.md
@@ -117,6 +117,8 @@ function to return a `Future<Album>`:
 
 <!-- skip -->
 ```dart
+import 'dart:convert';
+
 Future<Album> fetchAlbum() async {
   final response = await http.get('https://jsonplaceholder.typicode.com/albums/1');
 


### PR DESCRIPTION
I think it would be helpful to see the import reference on the snippet the same way we have reference to import the http package over the initial code snippet.