### PR TITLE
Add a note about creating launch.config for add2app

### DIFF
--- a/src/docs/development/add-to-app/debugging.md
+++ b/src/docs/development/add-to-app/debugging.md
@@ -27,19 +27,38 @@ These functionalities are provided by the `flutter attach` mechanism.
 such as through the SDK's CLI tools,
 through VS Code or IntelliJ/Android Studio.
 
-{% include app-figure.md image="development/add-to-app/debugging/cli-attach.png" caption="flutter attach via terminal" %}
-
-{% include app-figure.md image="development/add-to-app/debugging/vscode-attach.png" caption="flutter attach via VS Code" %}
-
-{% include app-figure.md image="development/add-to-app/debugging/intellij-attach.png" caption="flutter attach via IntelliJ" %}
-
 `flutter attach` can connect as soon as you run your `FlutterEngine`, and
 remains attached until your `FlutterEngine` is disposed. But you can invoke
 `flutter attach` before starting your engine. `flutter attach` waits for
 the next available Dart VM that is hosted by your engine.
 
-In IntelliJ or VS Code, you should select the device on which the Flutter
-module runs so `flutter attach` filters for the right start signals.
+#### Terminal
+
+Run `flutter attach` or `flutter attach -d deviceId` to attach from the terminal.
+
+{% include app-figure.md image="development/add-to-app/debugging/cli-attach.png" caption="flutter attach via terminal" %}
+
+#### VS Code
+
+Select the correct device using the status bar in VS Code, then run the **Flutter: Attach to Flutter on Device** command from the command palette.
+
+{% include app-figure.md image="development/add-to-app/debugging/vscode-attach.png" caption="flutter attach via VS Code" %}
+
+Alternatively, create a `.vscode/launch.json` file to enable attaching using the **Run > Start Debugging** command or `F5`:
+
+```js
+{
+  name: "Flutter: Attach",
+  request: "attach",
+  type: "dart",
+}
+```
+
+#### IntelliJ / Android Studio
+
+Select the device on which the Flutter module runs so `flutter attach` filters for the right start signals.
+
+{% include app-figure.md image="development/add-to-app/debugging/intellij-attach.png" caption="flutter attach via IntelliJ" %}
 
 ### Debugging specific instances of Flutter
 

--- a/src/docs/development/add-to-app/debugging.md
+++ b/src/docs/development/add-to-app/debugging.md
@@ -44,7 +44,7 @@ Select the correct device using the status bar in VS Code, then run the **Flutte
 
 {% include app-figure.md image="development/add-to-app/debugging/vscode-attach.png" caption="flutter attach via VS Code" %}
 
-Alternatively, create a `.vscode/launch.json` file to enable attaching using the **Run > Start Debugging** command or `F5`:
+Alternatively, create a `.vscode/launch.json` file in your Flutter module project to enable attaching using the **Run > Start Debugging** command or `F5`:
 
 ```js
 {


### PR DESCRIPTION
This adds a note about how to create a launch configuration for attaching with add2app. This does the same as running **Flutter: Attach to Flutter on Device** but allows you to use `F5` to launch, use in compound configs, have dependant tasks etc.

Before/After:

![Screenshot 2020-08-24 at 14 46 07](https://user-images.githubusercontent.com/1078012/91052154-f9a27a80-e618-11ea-997c-5349cd8f02fa.png)

(fyi @xster as suggested in https://github.com/Dart-Code/Dart-Code/issues/2115)
