### PR TITLE
fix : Rearrange Video Links on Main Documentation Page

### DIFF
--- a/src/docs/index.md
+++ b/src/docs/index.md
@@ -60,25 +60,18 @@ Coming from another platform? Check out:
 
 ### Videos
 
-We also have some helpful videos on our
-[Flutter YouTube channel][]! In particular, check
-out the Flutter in Focus series,
-and learn about other series on our [videos][] page.
+We also have some helpful videos on our [Flutter YouTube channel][]! In particular, check out the [Flutter in Focus series][], and learn about other series on our [videos][] page.
 
-First up, why use Flutter? What makes it different than other
-app frameworks?
+First up, why use Flutter? What makes it different than otherapp frameworks?
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/l-YO9CmaSUM" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe><br>
-How is Flutter different for app development?
+
+Flutter in Focus: Learn Flutter features in 10 minutes or less.
 
 <iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube.com/embed/wgTBLj7rMPM" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-Flutter in Focus: Learn Flutter features in 10 minutes or less.<br>
-[Flutter in Focus playlist][]
 
-In Flutter, "everything is a widget"! If you want to better
-understand the two kinds of widgets, Stateless and Stateful,
-see the following videos,
-part of the [Flutter in Focus][] series.
+In Flutter, "everything is a widget"! If you want to better understand
+the two kinds of widgets, Stateless and Stateful, see the following videos,
 
 <iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube.com/embed/wE7khGHVkYY" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe> <iframe width="560" height="315" src="https://www.youtube.com/embed/AqCMFXEmf3w" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
@@ -111,7 +104,7 @@ You might also find these docs useful:
 [FAQ]: /docs/resources/faq
 [flutter-announce]: https://groups.google.com/forum/#!forum/flutter-announce
 [Flutter in Focus]: https://www.youtube.com/playlist?list=PLjxrf2q8roU2HdJQDjJzOeO6J3FoFLWr2
-[Flutter in Focus playlist]: https://www.youtube.com/playlist?list=PLjxrf2q8roU2HdJQDjJzOeO6J3FoFLWr2
+[Flutter in Focus series]: https://www.youtube.com/playlist?list=PLjxrf2q8roU2HdJQDjJzOeO6J3FoFLWr2
 [Flutter YouTube channel]: {{site.social.youtube}}
 [Get started]: /docs/get-started/install
 [iOS]: /docs/get-started/flutter-for/ios-devs
@@ -125,4 +118,3 @@ You might also find these docs useful:
 [What's new archive]: /docs/whats-new-archive
 [Write your first Flutter app]: /docs/get-started/codelab
 [Xamarin.Forms]: /docs/get-started/flutter-for/xamarin-forms-devs
-

--- a/src/docs/index.md
+++ b/src/docs/index.md
@@ -62,7 +62,7 @@ Coming from another platform? Check out:
 
 We also have some helpful videos on our [Flutter YouTube channel][]! In particular, check out the [Flutter in Focus series][], and learn about other series on our [videos][] page.
 
-First up, why use Flutter? What makes it different than otherapp frameworks?
+First up, why use Flutter? What makes it different than other app frameworks?
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/l-YO9CmaSUM" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe><br>
 


### PR DESCRIPTION
## Description
This PR is to fix the [Flutter main Documentation page](https://flutter.dev/docs),  #4438 , It has some inconsistency in Links and Text.

1. In the first line in the video section ` Flutter in Focus` is not a link.
2. Later on, in the middle of a series of videos, Flutter in Focus playlist is a link, but it interrupts the flow of the videos and looks inconsistent.
## Related Issues

Fixes [*#4438*](https://github.com/flutter/website/issues/4438)

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking 
## Results

![Result)](https://user-images.githubusercontent.com/59207688/91105721-728fe980-e68e-11ea-8138-13595a27a42c.png)

 