### PR TITLE
Updated broken links to pub.dev closes #4538

### DIFF
--- a/src/docs/cookbook/networking/delete-data.md
+++ b/src/docs/cookbook/networking/delete-data.md
@@ -278,7 +278,7 @@ class _MyAppState extends State<MyApp> {
 [JSONPlaceholder]: https://jsonplaceholder.typicode.com/
 [`http`]: {{site.pub-pkg}}/http
 [`http.delete()`]: {{site.pub-api}}/http/latest/http/delete.html
-[`http` package]: {{site.pub-pkg}}/http#-installing-tab-
+[`http` package]: {{site.pub-pkg}}/http/install
 [`InheritedWidget`]: {{site.api}}/flutter/widgets/InheritedWidget-class.html
 [Introduction to unit testing]: /docs/cookbook/testing/unit/introduction
 [`initState()`]: {{site.api}}/flutter/widgets/State/initState.html

--- a/src/docs/cookbook/networking/fetch-data.md
+++ b/src/docs/cookbook/networking/fetch-data.md
@@ -317,7 +317,7 @@ class _MyAppState extends State<MyApp> {
 [JSONPlaceholder]: https://jsonplaceholder.typicode.com/
 [`http`]: {{site.pub-pkg}}/http
 [`http.get()`]: {{site.pub-api}}/http/latest/http/get.html
-[`http` package]: {{site.pub-pkg}}/http#-installing-tab-
+[`http` package]: {{site.pub-pkg}}/http/install
 [`InheritedWidget`]: {{site.api}}/flutter/widgets/InheritedWidget-class.html
 [Introduction to unit testing]: /docs/cookbook/testing/unit/introduction
 [`initState()`]: {{site.api}}/flutter/widgets/State/initState.html

--- a/src/docs/cookbook/networking/send-data.md
+++ b/src/docs/cookbook/networking/send-data.md
@@ -341,7 +341,7 @@ class _MyAppState extends State<MyApp> {
 [`FutureBuilder`]: {{site.api}}/flutter/widgets/FutureBuilder-class.html
 [`http`]: {{site.pub-pkg}}/http
 [`http.post()`]: {{site.pub-api}}/http/latest/http/post.html
-[`http` package]: {{site.pub-pkg}}/http#-installing-tab-
+[`http` package]: {{site.pub-pkg}}/http/install
 [`InheritedWidget`]: {{site.api}}/flutter/widgets/InheritedWidget-class.html
 [Introduction to unit testing]: /docs/cookbook/testing/unit/introduction
 [`initState()`]: {{site.api}}/flutter/widgets/State/initState.html

--- a/src/docs/cookbook/networking/update-data.md
+++ b/src/docs/cookbook/networking/update-data.md
@@ -394,7 +394,7 @@ class _MyAppState extends State<MyApp> {
 [JSONPlaceholder]: https://jsonplaceholder.typicode.com/
 [`http`]: {{site.pub-pkg}}/http
 [`http.put()`]: {{site.pub-api}}/http/latest/http/put.html
-[`http` package]: {{site.pub}}/packages/http#-installing-tab-
+[`http` package]: {{site.pub}}/packages/http/install
 [`InheritedWidget`]: {{site.api}}/flutter/widgets/InheritedWidget-class.html
 [Introduction to unit testing]: /docs/cookbook/testing/unit/introduction
 [`initState()`]: {{site.api}}/flutter/widgets/State/initState.html

--- a/src/docs/development/packages-and-plugins/using-packages.md
+++ b/src/docs/development/packages-and-plugins/using-packages.md
@@ -399,13 +399,13 @@ To use this plugin:
 [FlutterFire]: {{site.github}}/flutter/plugins/blob/master/FlutterFire.md
 [Gradle modules]: https://docs.gradle.org/current/userguide/declaring_dependencies.html
 [`http`]: /docs/cookbook/networking/fetch-data
-[Installing tab]: {{site.pub-pkg}}/css_colors#-installing-tab-
+[Installing tab]: {{site.pub-pkg}}/css_colors/install
 [iOS plugins]: {{site.pub}}/flutter/packages?platform=ios
 [lockfile]: {{site.dart-site}}/tools/pub/glossary#lockfile
 [Package dependencies]: {{site.dart-site}}/tools/pub/dependencies
 [package versioning guide]: {{site.dart-site}}/tools/pub/versioning
 [pub.dev]: {{site.pub}}
 [`url_launcher`]: {{site.pub-pkg}}/url_launcher
-[`url_launcher` versions]: {{site.pub-pkg}}/url_launcher#-versions-tab-
+[`url_launcher` versions]: {{site.pub-pkg}}/url_launcher/versions
 [version ranges]: {{site.dart-site}}/tools/pub/dependencies#version-constraints
 [web plugins]: {{site.pub}}/flutter/packages?platform=web

--- a/tool/config/linkcheck-skip-list.txt
+++ b/tool/config/linkcheck-skip-list.txt
@@ -25,7 +25,6 @@ https://groups.google.com/forum/\#!forum/flutter-dev
 https://groups.google.com/forum/\#!forum/flutter-announce
 https://guides.cocoapods.org/syntax/podspec.html\#dependency
 https://help.apple.com/.*?/\#/dev
-https://pub.dev/packages/.*?\#-.*?-tab-$
 
 # Links that get redirected, and the target page doesn't have the specified anchor:
 https://developer.android.com/guide/practices/ui_guidelines/icon_design_launcher\#size


### PR DESCRIPTION
I updated all the links, (searched for `site.pub-pkg` in the whole site to find all links to pub.dart. Also because anchors are not used, I Removed pub.dev's condition from the `tool/config/linkcheck-skip-list.txt`.

full issue description is at #4538