### PR TITLE
Fix initial route documentation for iOS

### DIFF
--- a/src/docs/development/add-to-app/ios/add-flutter-screen.md
+++ b/src/docs/development/add-to-app/ios/add-flutter-screen.md
@@ -422,45 +422,52 @@ flutterEngine.run(withEntrypoint: "myOtherEntrypoint", libraryURI: "other_file.d
 
 ### Route
 
-An initial route can be set for your Flutter [`WidgetsApp`][]
-when constructing the engine.
+Starting in Flutter version 1.22, an initial route can be set for your Flutter
+[`WidgetsApp`][] when constructing the FlutterEngine or the
+FlutterViewController.
 
 {% samplecode initial-route %}
 {% sample Objective-C %}
 <!--code-excerpt "Creating engine" title-->
 ```objectivec
-FlutterEngine *flutterEngine =
-    [[FlutterEngine alloc] initWithName:@"my flutter engine"];
-[[flutterEngine navigationChannel] invokeMethod:@"setInitialRoute"
-                                      arguments:@"/onboarding"];
-[flutterEngine run];
+FlutterEngine *flutterEngine = [[FlutterEngine alloc] init];
+// FlutterDefaultDartEntrypoint is the same as nil, which will run main().
+[flutterEngine runWithEntrypoint:FlutterDefaultDartEntrypoint
+                    initialRoute:@"/onboarding"];
 ```
 {% sample Swift %}
 <!--code-excerpt "Creating engine" title-->
 ```swift
-let flutterEngine = FlutterEngine(name: "my flutter engine")
-flutterEngine.navigationChannel.invokeMethod("setInitialRoute", arguments:"/onboarding")
-flutterEngine.run()
+let flutterEngine = FlutterEngine()
+// FlutterDefaultDartEntrypoint is the same as nil, which will run main().
+engine.run(
+  withEntrypoint: FlutterDefaultDartEntrypoint, initialRoute: "/onboarding")
 ```
 {% endsamplecode %}
 
 This code sets your `dart:ui`'s [`window.defaultRouteName`][]
 to `"/onboarding"` instead of `"/"`.
 
-{{site.alert.warning}}
-  `"setInitialRoute"` on the `navigationChannel` must be called
-  before running your `FlutterEngine` in order for Flutter's
-  first frame to use the desired route.
+Alternatively, to construct a FlutterViewController directly without pre-warming
+a FlutterEngine:
 
-  Specifically, this must be called before running the Dart entrypoint.
-  The entrypoint may lead to a series of events where
-  [`runApp`][] builds a Material/Cupertino/WidgetsApp
-  that implicitly creates a [Navigator][] that might
-  `window.defaultRouteName` when the [`NavigatorState`][] is
-  first initialized.
-
-  Setting the initial route after running the engine doesn't have an effect.
-{{site.alert.end}}
+{% samplecode initial-route %}
+{% sample Objective-C %}
+<!--code-excerpt "Creating view controller" title-->
+```objectivec
+FlutterViewController* flutterViewController =
+      [[FlutterViewController alloc] initWithProject:nil
+                                        initialRoute:@"/onboarding"
+                                             nibName:nil
+                                              bundle:nil];
+```
+{% sample Swift %}
+<!--code-excerpt "Creating view controller" title-->
+```swift
+let flutterViewController = FlutterViewController(
+      project: nil, initialRoute: "/onboarding", nibName: nil, bundle: nil)
+```
+{% endsamplecode %}
 
 {{site.alert.tip}}
   In order to imperatively change your current Flutter


### PR DESCRIPTION
The previous documentation was incorrect https://github.com/flutter/flutter/issues/59895. 

Update to reflect the new fix https://github.com/flutter/engine/pull/20468. 