### PR TITLE
HTTP change landed to Dart SDK. Expected to roll to Flutter with 1.23.

### DIFF
--- a/src/docs/release/breaking-changes/index.md
+++ b/src/docs/release/breaking-changes/index.md
@@ -14,16 +14,15 @@ release, and listed in alphabetical order:
 
 * [Android v1 embedding app and plugin creation deprecation][]
 * [Material Chip button semantics][]
-* [Network Policy on iOS and Android][]
 * [The new Form, FormField auto-validation API][]
 * [Cupertino icons 1.0.0][]
+* [Network Policy on iOS and Android][]
 
 [Cupertino icons 1.0.0]: /docs/release/breaking-changes/cupertino-icons-1.0.0
 [Android v1 embedding app and plugin creation deprecation]: /docs/release/breaking-changes/android-v1-embedding-create-deprecation
 [Material Chip button semantics]: /docs/release/breaking-changes/material-chip-button-semantics
 [The new Form, FormField auto-validation API]: /docs/release/breaking-changes/form-field-autovalidation-api
-<!-- Re-enable once HTTP ban lands to flutter/flutter -->
-<!-- [Network Policy on iOS and Android]: /docs/release/breaking-changes/network-policy-ios-android -->
+[Network Policy on iOS and Android]: /docs/release/breaking-changes/network-policy-ios-android
 
 ### Released in Flutter 1.20
 


### PR DESCRIPTION
https://dart.googlesource.com/sdk/+/ae0fbde71c23c9353b1095d1f480c5e239927abd landed. 