### PR TITLE
Update Test Package Contradictory Info

### DIFF
--- a/src/docs/cookbook/testing/unit/introduction.md
+++ b/src/docs/cookbook/testing/unit/introduction.md
@@ -34,9 +34,8 @@ see the [test package documentation][].
 
 ## 1. Add the test dependency
 
-If you're working on a Dart package that does not depend on Flutter,
-you can import the `test` package. The test package provides the core
-functionality for writing tests in Dart. This is the best approach when
+The `test` package provides the core functionality for 
+writing tests in Dart. This is the best approach when
 writing packages consumed by web, server, and Flutter apps.
 
 ```yaml


### PR DESCRIPTION
Fixes #3145
Removed a confusing sentence in the section on the 'test' package. 
The pub.dev link that the issue asks for is already present on the page.