### PR TITLE
Update obfuscate.md

### DIFF
--- a/src/docs/deployment/obfuscate.md
+++ b/src/docs/deployment/obfuscate.md
@@ -51,8 +51,9 @@ channels.)
 For example:
 
 ```terminal
-flutter build apk --obfuscate --split-debug-info=../<project-name>/<directory>
+flutter build apk --obfuscate --split-debug-info=<directory>
 ```
+<directory> would be created inside your project folder
 
 Once you've obfuscated your binary, save
 the symbols file. You need this if you later

--- a/src/docs/deployment/obfuscate.md
+++ b/src/docs/deployment/obfuscate.md
@@ -88,8 +88,9 @@ use the following steps to make it human readable:
    For example:
 
 ```terminal
-flutter symbolize -i <stack trace file> -d /out/android/app.android-arm64.symbols
+flutter symbolize -i <stack trace file> -d <directory>/app.android-arm64.symbols
 ```
+   NOTE that this <directory> is same as the one you used earlier. 
 
    For more information on the `symbolize` command,
    run `flutter symbolize -h`.

--- a/src/docs/deployment/obfuscate.md
+++ b/src/docs/deployment/obfuscate.md
@@ -51,7 +51,7 @@ channels.)
 For example:
 
 ```terminal
-flutter build apk --obfuscate --split-debug-info=/<project-name>/<directory>
+flutter build apk --obfuscate --split-debug-info=../<project-name>/<directory>
 ```
 
 Once you've obfuscated your binary, save


### PR DESCRIPTION
```terminal
flutter build apk --obfuscate --split-debug-info=../<project-name>/<directory>
```
otherwise it would cause error

Adding `..` no error shows up , wihout that it shows https://pastebin.com/ga9D6uZB


A little example why this happens

```
aman@amanverma:~/Desktop$ mkdir /am
mkdir: cannot create directory ‘/am’: Permission denied
``` 

while this :
```
aman@amanverma:~/Desktop$ mkdir am
```
 works so in the case mentioned above i guess the same problem is there
other way around

```
flutter build apk --obfuscate --split-debug-info=<directory>
``` 
would mean same and would rather be more convenient