### PR TITLE
Add a common errors page

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -267,6 +267,8 @@
       permalink: /docs/testing/oem-debuggers
     - title: Flutter's build modes
       permalink: /docs/testing/build-modes
+    - title: Common Flutter errors
+      permalink: /docs/testing/common-errors
     - title: Handling errors
       permalink: /docs/testing/errors
     - title: Testing

--- a/src/docs/testing/common-errors.md
+++ b/src/docs/testing/common-errors.md
@@ -21,10 +21,12 @@ This page explains several frequently-encountered Flutter Framework errors and g
 
 ## ‘A RenderFlex overflowed…’
 
+RenderFlex overflow is one of the most frequently encountered Flutter Framework 
+errors, and you probably have run into it already.
 
 ### What does the error look like?
 
-RenderFlex overflow is one of the most frequently encountered Flutter Framework errors, and you probably have run into it already. When it happens, you’ll see yellow & black stripes indicating the area of overflow in the app UI in addition to the error message in the debug console: 
+When it happens, you’ll see yellow & black stripes indicating the area of overflow in the app UI in addition to the error message in the debug console: 
 
 
 ```
@@ -115,6 +117,8 @@ The resources linked below provide further information about this error.
 
 ## ‘RenderBox was not laid out’
 
+While this error is pretty common, it’s often a side effect of a primary error 
+occurring earlier in the rendering pipeline.
 
 ### What does the error look like?
 
@@ -133,17 +137,19 @@ The relevant error-causing widget was
 
 ### How might you run into this error?
 
-While this error is pretty common, it’s often a side effect of a primary error occurring earlier in the rendering pipeline. Usually, the issue is related to violation of box constraints, and it needs to be solved by providing more information to Flutter about how you’d like to constrain the widgets in question. You can learn more about how constraints work in Flutter on the page [Understanding constraints][]. 
+Usually, the issue is related to violation of box constraints, and it needs to be solved by providing more information to Flutter about how you’d like to constrain the widgets in question. You can learn more about how constraints work in Flutter on the page [Understanding constraints][]. 
 
 [Understanding constraints]: /docs/development/ui/layout/constraints
 
-The `RenderBox was not laid out` error is often caused by one of two reasons:
+The `RenderBox was not laid out` error is often caused by one of two other errors:
 
 * [‘Vertical viewport was given unbounded height’](#vertical-viewport-was-given-unbounded-height)
 * [‘An InputDecorator...cannot have an unbounded width’](#an-inputdecoratorcannot-have-an-unbounded-width)
 
 ## ‘Vertical viewport was given unbounded height’
 
+This is another common layout error you could run into 
+while creating a UI in your Flutter app.
 
 ### What does the error look like?
 
@@ -238,6 +244,9 @@ The resources linked below provide further information about this error.
 
 ## ‘An InputDecorator...cannot have an unbounded width’
 
+The error message suggests that it's also related to box constraints, 
+which are important to understand to avoid many of the most common 
+Flutter Framework errors. 
 
 ### What does the error look like?
 
@@ -304,6 +313,7 @@ As suggested by the error message, fix this error by constraining the text field
 
 ## ‘Incorrect use of ParentData widget’
 
+This error is about missing an expected parent widget.
 
 ### What does the error look like?
 
@@ -347,6 +357,8 @@ The fix should be obvious once you know which parent widget is missing.
 
 ## ‘setState called during build’
 
+The `build` method in your Flutter code is not a good place to call `setState` 
+either directly or indirectly. 
 
 ### What does the error look like?
 
@@ -429,6 +441,9 @@ class FirstScreen extends StatelessWidget {
 ```
 
 ## References
+
+To learn more about how to debug errors, especially layout errors in Flutter, 
+check out the following resources: 
 
 *   [How to debug layout issues with the Flutter Inspector]({{site.medium}}/flutter/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db)
 *   [Understanding constraints](/docs/development/ui/layout/constraints)

--- a/src/docs/testing/common-errors.md
+++ b/src/docs/testing/common-errors.md
@@ -65,8 +65,7 @@ Widget build(BuildContext context) {
 
 In the above example, the `Column` tries to be wider than the space the `Row` (its parent) can allocate to it, causing an overflow error.  Why does the `Column` try to do that? To understand this layout behavior, you need to know how Flutter framework performs layout:
 
-<!-- TODO: Fix the blockquote style -->
->"_To perform layout, Flutter walks the render tree in a depth-first traversal and **passes down size constraints** from parent to child… Children respond by **passing up a size** to their parent object within the constraints the parent established._"  – [Flutter architectural overview](/docs/resources/architectural-overview#layout-and-rendering)
+"_To perform layout, Flutter walks the render tree in a depth-first traversal and **passes down size constraints** from parent to child… Children respond by **passing up a size** to their parent object within the constraints the parent established._"  – [Flutter architectural overview](/docs/resources/architectural-overview#layout-and-rendering)
 
 In this case, the `Row` widget doesn’t constrain the size of its children, nor does the `Column` widget. Lacking constraints from its parent widget, the second Text widget tries to be as wide as all the characters it needs to display. The self-determined width of the Text widget then gets adopted by the `Column` which clashes with the maximum amount of horizontal space its parent the `Row` widget can provide.  
 

--- a/src/docs/testing/common-errors.md
+++ b/src/docs/testing/common-errors.md
@@ -5,7 +5,7 @@ description: How to recognize and resolve common Flutter Framework errors.
 
 ## Introduction
 
-This page explains several frequently-encountered Flutter Framework errors and gives suggestions on how to resolve them. This is a living document with more errors we’d like to add in future revisions, and we welcome contributions from all Flutter users. Feel free to open an issue or submit a pull request to make this page more useful to you and the Flutter community. 
+This page explains several frequently-encountered Flutter Framework errors and gives suggestions on how to resolve them. This is a living document with more errors to be added in future revisions, and your contributions are welcomed. Feel free to open an issue or submit a pull request to make this page more useful to you and the Flutter community. 
 
 
 ### List of errors
@@ -24,9 +24,7 @@ This page explains several frequently-encountered Flutter Framework errors and g
 
 ### What does the error look like?
 
-RenderFlex overflow is one of the most frequent Flutter Framework errors we’ve seen, and you probably have run into it already. When it happens, you’ll see yellow & black stripes indicating the area of overflow in the app UI in addition to the error message in the debug console: 
-
-<!-- ![alt_text](images/image1.png "image_tooltip") -->
+RenderFlex overflow is one of the most frequently encountered Flutter Framework errors, and you probably have run into it already. When it happens, you’ll see yellow & black stripes indicating the area of overflow in the app UI in addition to the error message in the debug console: 
 
 
 ```
@@ -48,7 +46,7 @@ The specific RenderFlex in question is: RenderFlex#c3a70 relayoutBoundary=up1 OV
 
 ### How might you run into this error?
 
-The error often occurs when a `Column` or `Row` has a child widget that is not constrained in its size. Let’s take a look at a common scenario in the code below:
+The error often occurs when a `Column` or `Row` has a child widget that is not constrained in its size. For example, the code snippet below demonstrates a common scenario:
 
 <!-- skip -->
 ```dart
@@ -77,17 +75,17 @@ Widget build(BuildContext context) {
 ```
 
 
-In the above example, the `Column` will try to be wider than the space the `Row` (its parent) can allocate to it, causing an overflow error.  Why does the `Column` try to do that? To understand this layout behavior, we need to remember how Flutter Framework does layout:
+In the above example, the `Column` tries to be wider than the space the `Row` (its parent) can allocate to it, causing an overflow error.  Why does the `Column` try to do that? To understand this layout behavior, you need to know how Flutter Framework performs layout:
 
 <!-- TODO: Fix the blockquote style -->
->"To perform layout, Flutter walks the render tree in a depth-first traversal and **passes down size constraints** from parent to child… Children respond by **passing up a size** to their parent object within the constraints the parent established."  – [Flutter architectural overview](/docs/resources/architectural-overview#layout-and-rendering)
+>"_To perform layout, Flutter walks the render tree in a depth-first traversal and **passes down size constraints** from parent to child… Children respond by **passing up a size** to their parent object within the constraints the parent established._"  – [Flutter architectural overview](/docs/resources/architectural-overview#layout-and-rendering)
 
 In this case, the `Row` widget doesn’t constrain the size of its children, nor does the `Column` widget. Lacking constraints from its parent widget, the second Text widget tries to be as wide as all the characters it needs to display. The self-determined width of the Text widget then gets adopted by the `Column` which clashes with the maximum amount of horizontal space its parent the `Row` widget can provide.  
 
 
 ### How to fix it?
 
-Well, we need to make sure the `Column` won’t attempt to be wider than it can be. To achieve this, we need to constrain its width. One way to do it is to wrap the `Column` in an `Expanded` widget:
+Well, you need to make sure the `Column` won’t attempt to be wider than it can be. To achieve this, you need to constrain its width. One way to do it is to wrap the `Column` in an `Expanded` widget:
 
 <!-- skip -->
 ```dart
@@ -104,14 +102,14 @@ child: Row(
 ```
 
 
-Another way is to wrap the `Column` in a `Flexible` widget and specify a `flex` factor. In fact, the `Expanded` widget is equivalent to the `Flexible` widget with a `flex` factor of 1.0, as [its source code](https://github.com/flutter/flutter/blob/127e67902e8bbb0dcbfb3351b8fd00f7cbdf0178/packages/flutter/lib/src/widgets/basic.dart#L4677-L4686) shows. To further understand how to use the `Flex` widget in Flutter layouts, please check out [this Widget of the Week video](https://youtu.be/CI7x0mAZiY0) on the Flexible widget.
+Another way is to wrap the `Column` in a `Flexible` widget and specify a `flex` factor. In fact, the `Expanded` widget is equivalent to the `Flexible` widget with a `flex` factor of 1.0, as [its source code]({{site.github}}/flutter/flutter/blob/127e67902e8bbb0dcbfb3351b8fd00f7cbdf0178/packages/flutter/lib/src/widgets/basic.dart#L4677-L4686) shows. To further understand how to use the `Flex` widget in Flutter layouts, please check out [this Widget of the Week video](https://youtu.be/CI7x0mAZiY0) on the Flexible widget.
 
-### Further readings:
+### Further information:
 
-
+The resources linked below provide further information about this error. 
 
 *   [Flexible (Flutter Widget of the Week)](https://youtu.be/CI7x0mAZiY0)
-*   [How to debug layout issues with the Flutter Inspector](https://medium.com/flutter/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db#738b)
+*   [How to debug layout issues with the Flutter Inspector]({{site.medium}}/flutter/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db#738b)
 *   [Understanding constraints](/docs/development/ui/layout/constraints)
 
 
@@ -121,8 +119,6 @@ Another way is to wrap the `Column` in a `Flexible` widget and specify a `flex` 
 ### What does the error look like?
 
 The message shown by the error looks like this: 
-
-<!-- ![alt_text](images/image2.png "image_tooltip") -->
 
 
 ```
@@ -137,15 +133,14 @@ The relevant error-causing widget was
 
 ### How might you run into this error?
 
-While this error is pretty common, it’s often a side effect of a primary error occurring earlier in the rendering pipeline. Usually, the issue is related to violation of box constraints, and it needs to be solved by providing more information to Flutter about how you’d like to constrain the widgets in question. You can learn more about how constraints work in Flutter on [this page](/docs/development/ui/layout/constraints). 
+While this error is pretty common, it’s often a side effect of a primary error occurring earlier in the rendering pipeline. Usually, the issue is related to violation of box constraints, and it needs to be solved by providing more information to Flutter about how you’d like to constrain the widgets in question. You can learn more about how constraints work in Flutter on the page [Understanding constraints][]. 
 
-In this doc, we describe two primary errors that can lead to the ‘RenderBox was not laid out’ error:
+[Understanding constraints]: /docs/development/ui/layout/constraints
 
+The `RenderBox was not laid out` error is often caused by one of two reasons:
 
-
-*   [‘Vertical viewport was given unbounded height’](#vertical-viewport-was-given-unbounded-height)
+* [‘Vertical viewport was given unbounded height’](#vertical-viewport-was-given-unbounded-height)
 * [‘An InputDecorator...cannot have an unbounded width’](#an-inputdecoratorcannot-have-an-unbounded-width)
-
 
 ## ‘Vertical viewport was given unbounded height’
 
@@ -153,9 +148,6 @@ In this doc, we describe two primary errors that can lead to the ‘RenderBox wa
 ### What does the error look like?
 
 The message shown by the error looks like this: 
-
-<!-- ![alt_text](images/image3.png "image_tooltip") -->
-
 
 
 ```
@@ -174,7 +166,7 @@ The relevant error-causing widget was
 
 ### How might you run into this error?
 
-The error is often caused when a `ListView` (or other kinds of scrollable widgets such as `GridView`) is placed inside a `Column`. A `ListView` takes all the vertical space available to it, unless it’s constrained by its parent widget. However, a `Column` doesn’t impose any constraint on it’s children’s height by default. The combination of the two behaviors lead to the failure of determining the size of the `ListView`. 
+The error is often caused when a `ListView` (or other kinds of scrollable widgets such as `GridView`) is placed inside a `Column`. A `ListView` takes all the vertical space available to it, unless it’s constrained by its parent widget. However, a `Column` doesn’t impose any constraint on its children’s height by default. The combination of the two behaviors leads to the failure of determining the size of the `ListView`. 
 
 <!-- skip -->
 ```dart
@@ -205,7 +197,7 @@ Widget build(BuildContext context) {
 
 ### How to fix it?
 
-To fix this error, you need to specify how tall you’d like the `ListView` to be. If you’d like to have the `ListView` be as tall as the remaining space in the `Column`, you can wrap it using an `Expanded` widget (see the example below). Otherwise, you can specify an absolute height using a `SizedBox` widget or a relative height using a `Flexible` widget.
+To fix this error, specify how tall the `ListView` should be. To make it as tall as the remaining space in the `Column`, wrap it using an `Expanded` widget (see the example below). Otherwise, specify an absolute height using a `SizedBox` widget or a relative height using a `Flexible` widget.
 
 <!-- skip -->
 ```dart
@@ -236,11 +228,11 @@ Widget build(BuildContext context) {
 
 
 
-### Further readings:
+### Further information:
 
+The resources linked below provide further information about this error.
 
-
-*   [How to debug layout issues with the Flutter Inspector](https://medium.com/flutter/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db#1de2)
+*   [How to debug layout issues with the Flutter Inspector]({{site.medium}}/flutter/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db#1de2)
 *   [Understanding constraints](/docs/development/ui/layout/constraints)
 
 
@@ -250,8 +242,6 @@ Widget build(BuildContext context) {
 ### What does the error look like?
 
 The message shown by the error looks like this: 
-
-<!-- ![alt_text](images/image4.png "image_tooltip") -->
 
 ```
 The following assertion was thrown during performLayout():
@@ -263,7 +253,7 @@ This happens when the parent widget does not provide a finite width constraint. 
 
 ### How might you run into the error?
 
-This error would occur, when you put a `TextFormField` or a `TextField` in a `Row` without constraining the width of the `TextField`.
+This error occurs, for example, when a `Row` contains a `TextFormField` or a `TextField` but the latter has no width constraint.
 
 <!-- skip -->
 ```dart
@@ -288,7 +278,7 @@ Widget build(BuildContext context) {
 
 ### How to fix it?
 
-As suggested by the error message, you can fix this error by constrain the `TextField` using an `Expanded` widget (see the example below) or a `SizedBox` widget. 
+As suggested by the error message, fix this error by constraining the text field using either an `Expanded` or `SizedBox` widget. The following example demonstrates using an `Expanded` widget:
 
 <!-- skip -->
 ```dart
@@ -319,9 +309,6 @@ As suggested by the error message, you can fix this error by constrain the `Text
 
 The message shown by the error looks like this: 
 
-<!-- ![alt_text](images/image5.png "image_tooltip") -->
-
-
 
 ```
 The following assertion was thrown while looking for parent data.:
@@ -339,9 +326,9 @@ Usually, this indicates that at least one of the offending ParentDataWidgets lis
 
 ### How might you run into the error?
 
-While Flutter’s widgets are generally flexible in how they get composed together in a UI, a small subset of those widgets expect specific parent widgets. When this expectation can’t be satisfied in your widget tree, you’re likely to see this error. 
+While Flutter’s widgets are generally flexible in how they can be composed together in a UI, a small subset of those widgets expect specific parent widgets. When this expectation can’t be satisfied in your widget tree, you’re likely to see this error. 
 
-Here is an _incomplete_ list of widgets that expect specific parent widgets within the Flutter Framework. Feel free to submit a PR to add more of such widgets. 
+Here is an _incomplete_ list of widgets that expect specific parent widgets within the Flutter Framework. Feel free to submit a PR (using the doc icon in the top right corner of the page) to expand this list.
 
 | Widget                            | Expected parent widget(s) |
 | :-------------------------------- | ------------------------: |
@@ -355,15 +342,13 @@ Here is an _incomplete_ list of widgets that expect specific parent widgets with
 
 ### How to fix it?
 
-The fix should be obvious once you know what parent widget is missing. 
+The fix should be obvious once you know which parent widget is missing. 
 
 
 ## ‘setState called during build’
 
 
 ### What does the error look like?
-
-<!-- ![alt_text](images/image6.png "image_tooltip") -->
 
 ```
 The following assertion was thrown building DialogPage(dirty, dependencies: [_InheritedTheme, _LocalizationsScope-[GlobalKey#59a8e]], state: _DialogPageState#f121e):
@@ -377,7 +362,7 @@ The widget on which setState() or markNeedsBuild() was called was: Overlay-[Labe
 
 In general, this error occurs when the `setState` method is called within the `build` method. 
 
-A common scenario where this error would occur is when attempting to trigger a dialog from within the `build` method. This scenario is often motivated by the requirement of showing some information to the user immediately upon their entry to a new page.  
+A common scenario where this error occurs is when attempting to trigger a Dialog from within the `build` method. This is often motivated by the need to immediately show information to the user, but setState should never be called from a `build` method.
 
 Below is a snippet that seems to be a common culprit of this error:
 
@@ -405,11 +390,11 @@ Widget build(BuildContext context) {
 ```
 
 
-You can’t see the call to `setState` here, but it’s being used as part of `showDialog`, which is why this error is coming up. The build method is never the right place to call `showDialog`. The `build` method could be called by the framework for every frame, for example, during an animation. 
+You don't see the explicit call to `setState`, but it's called by `showDialog`. The `build` method is not the right place to call `showDialog` because `build` can be called by the framework for every frame, for example, during an animation.
 
 ### How to fix it?
 
-One way to avoid this error is to use the `Navigator` API to trigger the dialog as a route. In the example below, there are two pages. The second page has a dialog to be displayed upon entry. When the user requests the second page from clicking on a button on the first page, the `Navigator` would push two routes in a row – one for the second page and another for the dialog.  
+One way to avoid this error is to use the `Navigator` API to trigger the dialog as a route. In the example below, there are two pages. The second page has a dialog to be displayed upon entry. When the user requests the second page from clicking on a button on the first page, the `Navigator` pushes two routes in a row – one for the second page and another for the dialog.  
 
 <!-- skip -->
 ```dart
@@ -445,7 +430,7 @@ class FirstScreen extends StatelessWidget {
 
 ## References
 
-*   [How to debug layout issues with the Flutter Inspector](https://medium.com/flutter/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db)
+*   [How to debug layout issues with the Flutter Inspector]({{site.medium}}/flutter/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db)
 *   [Understanding constraints](/docs/development/ui/layout/constraints)
 *   [Dealing with box constraints](/docs/development/ui/layout/box-constraints)
 *   [Flutter architectural overview](/docs/resources/architectural-overview#layout-and-rendering)

--- a/src/docs/testing/common-errors.md
+++ b/src/docs/testing/common-errors.md
@@ -1,0 +1,451 @@
+---
+title: Common Flutter Errors
+description: How to recognize and resolve common Flutter Framework errors.
+---
+
+## Introduction
+
+This page explains several frequently-encountered Flutter Framework errors and gives suggestions on how to resolve them. This is a living document with more errors we’d like to add in future revisions, and we welcome contributions from all Flutter users. Feel free to open an issue or submit a pull request to make this page more useful to you and the Flutter community. 
+
+
+### List of Errors
+
+* [A RenderFlex overflowed…](#a-renderflex-overflowed)
+* [RenderBox was not laid out](#renderbox-was-not-laid-out)
+* [Vertical viewport was given unbounded height](#vertical-viewport-was-given-unbounded-height)
+* [Incorrect use of ParentData widget](#incorrect-use-of-parentdata-widget)
+* [‘An InputDecorator...cannot have an unbounded width’](#an-inputdecoratorcannot-have-an-unbounded-width)
+* [setState called during build](#setstate-called-during-build)
+
+
+
+## ‘A RenderFlex overflowed…’
+
+
+### What does the error look like?
+
+RenderFlex overflow is one of the most frequent Flutter Framework errors we’ve seen, and you probably have run into it already. When it happens, you’ll see yellow & black stripes indicating the area of overflow in the app UI in addition to the error message in the debug console: 
+
+<!-- ![alt_text](images/image1.png "image_tooltip") -->
+
+
+```
+The following assertion was thrown during layout:
+A RenderFlex overflowed by 1146 pixels on the right.
+
+The relevant error-causing widget was
+    Row 							lib/errors/renderflex_overflow_column.dart:23
+The overflowing RenderFlex has an orientation of Axis.horizontal.
+The edge of the RenderFlex that is overflowing has been marked in the rendering with a yellow and black striped pattern. This is usually caused by the contents being too big for the RenderFlex.
+
+Consider applying a flex factor (e.g. using an Expanded widget) to force the children of the RenderFlex to fit within the available space instead of being sized to their natural size.
+This is considered an error condition because it indicates that there is content that cannot be seen. If the content is legitimately bigger than the available space, consider clipping it with a ClipRect widget before putting it in the flex, or using a scrollable container rather than a Flex, like a ListView.
+
+The specific RenderFlex in question is: RenderFlex#c3a70 relayoutBoundary=up1 OVERFLOWING
+```
+
+
+
+### How might you run into this error?
+
+The error often occurs when a Column or Row has a child widget that is not constrained in its size. Let’s take a look at a common scenario in the code below:
+
+
+```dart
+Widget build(BuildContext context) {
+  return Container(
+    child: Row(
+      children: [
+        Icon(Icons.message),
+        Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text("Title", style: Theme.of(context).textTheme.headline4),
+            Text(
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed"
+                " do eiusmod tempor incididunt ut labore et dolore magna "
+                "aliqua. Ut enim ad minim veniam, quis nostrud "
+                "exercitation ullamco laboris nisi ut aliquip ex ea "
+                "commodo consequat."),
+          ],
+        ),
+      ],
+    ),
+  );
+}
+```
+
+
+In the above example, the Column will try to be wider than the space the Row (its parent) can allocate to it, causing an overflow error.  Why does the Column try to do that? To understand this layout behavior, we need to remember how Flutter Framework does layout:
+
+<!-- TODO: Fix the blockquote style -->
+>"To perform layout, Flutter walks the render tree in a depth-first traversal and **passes down size constraints** from parent to child… Children respond by **passing up a size** to their parent object within the constraints the parent established."  – [Flutter architectural overview](/docs/resources/architectural-overview#layout-and-rendering)
+
+In this case, the Row widget doesn’t constrain the size of its children, nor does the Column widget. Lacking constraints from its parent widget, the second Text widget tries to be as wide as all the characters it needs to display. The self-determined width of the Text widget then gets adopted by the Column which clashes with the maximum amount of horizontal space its parent the Row widget can provide.  
+
+
+### How to fix it?
+
+Well, we need to make sure the Column won’t attempt to be wider than it can be. To achieve this, we need to constrain its width. One way to do it is to wrap the Column in an Expanded widget:
+
+
+```dart
+child: Row(
+  children: [
+    Icon(Icons.message),
+    Expanded(
+      child: Column(
+        // code omitted
+      ),
+    ),
+  ]
+)
+```
+
+
+Another way is to wrap the Column in a Flexible widget and specify a flex factor. In fact, the Expanded widget is equivalent to the Flexible widget with a flex factor of 1.0, as [its source code](https://github.com/flutter/flutter/blob/127e67902e8bbb0dcbfb3351b8fd00f7cbdf0178/packages/flutter/lib/src/widgets/basic.dart#L4677-L4686) shows. To further understand how to use the Flex widget in Flutter layouts, please check out [this Widget of the Week video](https://youtu.be/CI7x0mAZiY0) on the Flexible widget.
+
+### Further readings:
+
+
+
+*   [Flexible (Flutter Widget of the Week)](https://youtu.be/CI7x0mAZiY0)
+*   [How to debug layout issues with the Flutter Inspector](https://medium.com/flutter/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db#738b)
+*   [Understanding constraints](/docs/development/ui/layout/constraints)
+
+
+## ‘RenderBox was not laid out’
+
+
+### What does the error look like?
+
+The message shown by the error looks like this: 
+
+<!-- ![alt_text](images/image2.png "image_tooltip") -->
+
+
+```
+RenderBox was not laid out: RenderViewport#5a477 NEEDS-LAYOUT NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
+'package:flutter/src/rendering/box.dart':
+Failed assertion: line 1785 pos 12: 'hasSize'
+The relevant error-causing widget was
+    ListView 					lib/errors/unbounde...
+```
+
+
+
+### How might you run into this error?
+
+While this error is pretty common, it’s often a side effect of a primary error occurring earlier in the rendering pipeline. Usually, the issue is related to violation of box constraints and needs to be solved by providing more information to Flutter about how you’d like to constrain the widgets in question. You can learn more about how constraints work in Flutter on [this page](/docs/development/ui/layout/constraints). 
+
+In this doc, we describe two primary errors that can lead to the ‘RenderBox was not laid out’ error:
+
+
+
+*   [‘Vertical viewport was given unbounded height’](#vertical-viewport-was-given-unbounded-height)
+* [‘An InputDecorator...cannot have an unbounded width’](#an-inputdecoratorcannot-have-an-unbounded-width)
+
+
+## ‘Vertical viewport was given unbounded height’
+
+
+### What does the error look like?
+
+The message shown by the error looks like this: 
+
+<!-- ![alt_text](images/image3.png "image_tooltip") -->
+
+
+
+```
+The following assertion was thrown during performResize():
+Vertical viewport was given unbounded height.
+
+Viewports expand in the scrolling direction to fill their container. In this case, a vertical viewport was given an unlimited amount of vertical space in which to expand. This situation typically happens when a scrollable widget is nested inside another scrollable widget.
+
+If this widget is always nested in a scrollable widget there is no need to use a viewport because there will always be enough vertical space for the children. In this case, consider using a Column instead. Otherwise, consider using the "shrinkWrap" property (or a ShrinkWrappingViewport) to size the height of the viewport to the sum of the heights of its children.
+
+The relevant error-causing widget was
+    ListView 						lib/errors/unbounded...
+```
+
+
+
+### How might you run into this error?
+
+The error is often caused when a ListView (or other kinds of scrollable widgets such as GridView) is placed inside a Column. A ListView takes all the vertical space available to it, unless it’s constrained by its parent widget. However, a Column doesn’t impose any constraint on it’s children’s height by default. The combination of the two behaviors lead to the failure of determining the size of the ListView. 
+
+
+```dart
+Widget build(BuildContext context) {
+  return Center(
+    child: Column(
+      children: <Widget>[
+        Text('Header'),
+        ListView(
+          children: <Widget>[
+            ListTile(
+              leading: Icon(Icons.map),
+              title: Text('Map'),
+            ),
+            ListTile(
+              leading: Icon(Icons.subway),
+              title: Text('Subway'),
+            ),
+          ],
+        ),
+      ],
+    ),
+  );
+}
+```
+
+
+
+### How to fix it?
+
+To fix this error, you need to specify how tall you’d like the ListView to be. If you’d like to have the ListView be as tall as the remaining space in the Column, you can wrap it using an Expanded widget (see the example below). Otherwise, you can specify an absolute height using SizedBox or a relative height using a Flexible widget.
+
+
+```dart
+Widget build(BuildContext context) {
+  return Center(
+    child: Column(
+      children: <Widget>[
+        Text('Header'),
+        Expanded(
+          child: ListView(
+            children: <Widget>[
+              ListTile(
+                leading: Icon(Icons.map),
+                title: Text('Map'),
+              ),
+              ListTile(
+                leading: Icon(Icons.subway),
+                title: Text('Subway'),
+              ),
+            ],
+          ),
+        ),
+      ],
+    ),
+  );
+}
+```
+
+
+
+### Further readings:
+
+
+
+*   [How to debug layout issues with the Flutter Inspector](https://medium.com/flutter/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db#1de2)
+*   [Understanding constraints](/docs/development/ui/layout/constraints)
+
+
+## ‘An InputDecorator...cannot have an unbounded width’
+
+
+### What does the error look like?
+
+The message shown by the error looks like this: 
+
+<!-- ![alt_text](images/image4.png "image_tooltip") -->
+
+```
+The following assertion was thrown during performLayout():
+An InputDecorator, which is typically created by a TextField, cannot have an unbounded width.
+This happens when the parent widget does not provide a finite width constraint. For example, if the InputDecorator is contained by a Row, then its width must be constrained. An Expanded widget or a SizedBox can be used to constrain the width of the InputDecorator or the TextField that contains it.
+```
+
+
+
+### How might you run into the error?
+
+This error would occur, when you put a TextFormField or a TextField in a Row without constraining the width of the TextField.
+
+
+```dart
+Widget build(BuildContext context) {
+  return MaterialApp(
+    home: Scaffold(
+      appBar: AppBar(
+        title:
+            Text('Unbounded Width of the TextField'),
+      ),
+      body: Row(
+        children: [
+          TextField(),
+        ],
+      ),
+    ),
+  );
+}
+```
+
+
+
+### How to fix it?
+
+As suggested by the error message, you can fix this error by constrain the TextField using an Expanded widget (see the example below) or a SizedBox widget. 
+
+
+```dart
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: Text('Unbounded Width of the TextField'),
+        ),
+        body: Row(
+          children: [
+            Expanded(
+                child: TextFormField()
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+```
+
+
+
+## ‘Incorrect use of ParentData widget’
+
+
+### What does the error look like?
+
+The message shown by the error looks like this: 
+
+<!-- ![alt_text](images/image5.png "image_tooltip") -->
+
+
+
+```
+The following assertion was thrown while looking for parent data.:
+Incorrect use of ParentDataWidget.
+
+The following ParentDataWidgets are providing parent data to the same RenderObject:
+- Expanded(flex: 1) (typically placed directly inside a Flex widget)
+- LayoutId-[<_ScaffoldSlot.body>](id: _ScaffoldSlot.body) (typically placed directly inside a CustomMultiChildLayout widget)
+However, a RenderObject can only receive parent data from at most one ParentDataWidget.
+
+Usually, this indicates that at least one of the offending ParentDataWidgets listed above is not placed directly inside a compatible ancestor widget.
+```
+
+
+
+### How might you run into the error?
+
+While Flutter’s widgets are generally flexible in how they get composed together in a UI, a small subset of those widgets expect specific parent widgets. When this expectation can’t be satisfied in your widget tree, you’re likely to see this error. 
+
+Here is an _incomplete_ list of widgets that expect specific parent widgets within the Flutter Framework. Feel free to submit a PR to add more of such widgets. 
+
+| Widget                            | Expected parent widget(s) |
+| :-------------------------------- | ------------------------: |
+| Flexible                          |      Row, Column, or Flex |
+| Expanded (a specialized Flexible) |      Row, Column, or Flex |
+| Positioned                        |                     Stack |
+| Flexible                          |      Row, Column, or Flex |
+| TableCell                         |                     Table |
+
+
+
+### How to fix it?
+
+The fix should be obvious once you know what parent widget is missing. 
+
+
+## ‘setState called during build’
+
+
+### What does the error look like?
+
+<!-- ![alt_text](images/image6.png "image_tooltip") -->
+
+```
+The following assertion was thrown building DialogPage(dirty, dependencies: [_InheritedTheme, _LocalizationsScope-[GlobalKey#59a8e]], state: _DialogPageState#f121e):
+setState() or markNeedsBuild() called during build.
+
+This Overlay widget cannot be marked as needing to build because the framework is already in the process of building widgets.  A widget can be marked as needing to be built during the build phase only if one of its ancestors is currently building. This exception is allowed because the framework builds parent widgets before children, which means a dirty descendant will always be built. Otherwise, the framework might not visit this widget during this build phase.
+The widget on which setState() or markNeedsBuild() was called was: Overlay-[LabeledGlobalKey<OverlayState>#783d6]
+```
+
+### How might you run into the error?
+
+In general, this error occurs when the `setState` method is called within the build method. 
+
+A common scenario where this error would occur is when attempting to trigger a Dialog from within the build method. This scenario is often motivated by the requirement of showing some information to the user immediately upon their entry to a new page.  
+
+Below is a snippet that seems to be a common culprit of this error:
+
+
+```dart
+Widget build(BuildContext context) {
+
+  // Don't do this. 
+  showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text("Alert Dialog"),
+        );
+      });
+
+  return Center(
+    child: Column(
+      children: <Widget>[
+        Text('Show Material Dialog'),
+      ],
+    ),
+  );
+}
+```
+
+
+You can’t see the call to `setState` here, but it’s being used as part of `showDialog`, which is why this error is coming up. The build method is never the right place to call `showDialog`. The `build` method could be called by the framework for every frame, e.g., during an animation. 
+
+### How to fix it?
+
+One way to avoid this error is to use the Navigator API to trigger the dialog as a route. In the example below, there are two pages. The second page has a dialog to be displayed upon entry. When the user requests the second page from clicking on a button on the first page, the Navigator would push two routes in a row – one for the second page and another for the dialog.  
+
+
+```dart
+class FirstScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('First Screen'),
+      ),
+      body: Center(
+        child: RaisedButton(
+          child: Text('Launch screen'),
+          onPressed: () {
+            // Navigate to the second screen using a named route.
+            Navigator.pushNamed(context, '/second');
+            // Immediately show a dialog upon loading the second screen.
+            Navigator.push(
+              context,
+              PageRouteBuilder(
+                barrierDismissible: true,
+                opaque: false,
+                pageBuilder: (_, anim1, anim2) => MyDialog(),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+```
+
+## References
+
+*   [How to debug layout issues with the Flutter Inspector](https://medium.com/flutter/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db)
+*   [Understanding constraints](/docs/development/ui/layout/constraints)
+*   [Dealing with box constraints](/docs/development/ui/layout/box-constraints)
+*   [Flutter architectural overview](/docs/resources/architectural-overview#layout-and-rendering)

--- a/src/docs/testing/common-errors.md
+++ b/src/docs/testing/common-errors.md
@@ -1,5 +1,5 @@
 ---
-title: Common Flutter Errors
+title: Common Flutter errors
 description: How to recognize and resolve common Flutter Framework errors.
 ---
 
@@ -8,7 +8,7 @@ description: How to recognize and resolve common Flutter Framework errors.
 This page explains several frequently-encountered Flutter Framework errors and gives suggestions on how to resolve them. This is a living document with more errors we’d like to add in future revisions, and we welcome contributions from all Flutter users. Feel free to open an issue or submit a pull request to make this page more useful to you and the Flutter community. 
 
 
-### List of Errors
+### List of errors
 
 * [A RenderFlex overflowed…](#a-renderflex-overflowed)
 * [RenderBox was not laid out](#renderbox-was-not-laid-out)
@@ -48,9 +48,9 @@ The specific RenderFlex in question is: RenderFlex#c3a70 relayoutBoundary=up1 OV
 
 ### How might you run into this error?
 
-The error often occurs when a Column or Row has a child widget that is not constrained in its size. Let’s take a look at a common scenario in the code below:
+The error often occurs when a `Column` or `Row` has a child widget that is not constrained in its size. Let’s take a look at a common scenario in the code below:
 
-
+<!-- skip -->
 ```dart
 Widget build(BuildContext context) {
   return Container(
@@ -77,19 +77,19 @@ Widget build(BuildContext context) {
 ```
 
 
-In the above example, the Column will try to be wider than the space the Row (its parent) can allocate to it, causing an overflow error.  Why does the Column try to do that? To understand this layout behavior, we need to remember how Flutter Framework does layout:
+In the above example, the `Column` will try to be wider than the space the `Row` (its parent) can allocate to it, causing an overflow error.  Why does the `Column` try to do that? To understand this layout behavior, we need to remember how Flutter Framework does layout:
 
 <!-- TODO: Fix the blockquote style -->
 >"To perform layout, Flutter walks the render tree in a depth-first traversal and **passes down size constraints** from parent to child… Children respond by **passing up a size** to their parent object within the constraints the parent established."  – [Flutter architectural overview](/docs/resources/architectural-overview#layout-and-rendering)
 
-In this case, the Row widget doesn’t constrain the size of its children, nor does the Column widget. Lacking constraints from its parent widget, the second Text widget tries to be as wide as all the characters it needs to display. The self-determined width of the Text widget then gets adopted by the Column which clashes with the maximum amount of horizontal space its parent the Row widget can provide.  
+In this case, the `Row` widget doesn’t constrain the size of its children, nor does the `Column` widget. Lacking constraints from its parent widget, the second Text widget tries to be as wide as all the characters it needs to display. The self-determined width of the Text widget then gets adopted by the `Column` which clashes with the maximum amount of horizontal space its parent the `Row` widget can provide.  
 
 
 ### How to fix it?
 
-Well, we need to make sure the Column won’t attempt to be wider than it can be. To achieve this, we need to constrain its width. One way to do it is to wrap the Column in an Expanded widget:
+Well, we need to make sure the `Column` won’t attempt to be wider than it can be. To achieve this, we need to constrain its width. One way to do it is to wrap the `Column` in an `Expanded` widget:
 
-
+<!-- skip -->
 ```dart
 child: Row(
   children: [
@@ -104,7 +104,7 @@ child: Row(
 ```
 
 
-Another way is to wrap the Column in a Flexible widget and specify a flex factor. In fact, the Expanded widget is equivalent to the Flexible widget with a flex factor of 1.0, as [its source code](https://github.com/flutter/flutter/blob/127e67902e8bbb0dcbfb3351b8fd00f7cbdf0178/packages/flutter/lib/src/widgets/basic.dart#L4677-L4686) shows. To further understand how to use the Flex widget in Flutter layouts, please check out [this Widget of the Week video](https://youtu.be/CI7x0mAZiY0) on the Flexible widget.
+Another way is to wrap the `Column` in a `Flexible` widget and specify a `flex` factor. In fact, the `Expanded` widget is equivalent to the `Flexible` widget with a `flex` factor of 1.0, as [its source code](https://github.com/flutter/flutter/blob/127e67902e8bbb0dcbfb3351b8fd00f7cbdf0178/packages/flutter/lib/src/widgets/basic.dart#L4677-L4686) shows. To further understand how to use the `Flex` widget in Flutter layouts, please check out [this Widget of the Week video](https://youtu.be/CI7x0mAZiY0) on the Flexible widget.
 
 ### Further readings:
 
@@ -137,7 +137,7 @@ The relevant error-causing widget was
 
 ### How might you run into this error?
 
-While this error is pretty common, it’s often a side effect of a primary error occurring earlier in the rendering pipeline. Usually, the issue is related to violation of box constraints and needs to be solved by providing more information to Flutter about how you’d like to constrain the widgets in question. You can learn more about how constraints work in Flutter on [this page](/docs/development/ui/layout/constraints). 
+While this error is pretty common, it’s often a side effect of a primary error occurring earlier in the rendering pipeline. Usually, the issue is related to violation of box constraints, and it needs to be solved by providing more information to Flutter about how you’d like to constrain the widgets in question. You can learn more about how constraints work in Flutter on [this page](/docs/development/ui/layout/constraints). 
 
 In this doc, we describe two primary errors that can lead to the ‘RenderBox was not laid out’ error:
 
@@ -164,7 +164,7 @@ Vertical viewport was given unbounded height.
 
 Viewports expand in the scrolling direction to fill their container. In this case, a vertical viewport was given an unlimited amount of vertical space in which to expand. This situation typically happens when a scrollable widget is nested inside another scrollable widget.
 
-If this widget is always nested in a scrollable widget there is no need to use a viewport because there will always be enough vertical space for the children. In this case, consider using a Column instead. Otherwise, consider using the "shrinkWrap" property (or a ShrinkWrappingViewport) to size the height of the viewport to the sum of the heights of its children.
+If this widget is always nested in a scrollable widget there is no need to use a viewport because there will always be enough vertical space for the children. In this case, consider using a `Column` instead. Otherwise, consider using the "shrinkWrap" property (or a ShrinkWrappingViewport) to size the height of the viewport to the sum of the heights of its children.
 
 The relevant error-causing widget was
     ListView 						lib/errors/unbounded...
@@ -174,9 +174,9 @@ The relevant error-causing widget was
 
 ### How might you run into this error?
 
-The error is often caused when a ListView (or other kinds of scrollable widgets such as GridView) is placed inside a Column. A ListView takes all the vertical space available to it, unless it’s constrained by its parent widget. However, a Column doesn’t impose any constraint on it’s children’s height by default. The combination of the two behaviors lead to the failure of determining the size of the ListView. 
+The error is often caused when a `ListView` (or other kinds of scrollable widgets such as `GridView`) is placed inside a `Column`. A `ListView` takes all the vertical space available to it, unless it’s constrained by its parent widget. However, a `Column` doesn’t impose any constraint on it’s children’s height by default. The combination of the two behaviors lead to the failure of determining the size of the `ListView`. 
 
-
+<!-- skip -->
 ```dart
 Widget build(BuildContext context) {
   return Center(
@@ -205,9 +205,9 @@ Widget build(BuildContext context) {
 
 ### How to fix it?
 
-To fix this error, you need to specify how tall you’d like the ListView to be. If you’d like to have the ListView be as tall as the remaining space in the Column, you can wrap it using an Expanded widget (see the example below). Otherwise, you can specify an absolute height using SizedBox or a relative height using a Flexible widget.
+To fix this error, you need to specify how tall you’d like the `ListView` to be. If you’d like to have the `ListView` be as tall as the remaining space in the `Column`, you can wrap it using an `Expanded` widget (see the example below). Otherwise, you can specify an absolute height using a `SizedBox` widget or a relative height using a `Flexible` widget.
 
-
+<!-- skip -->
 ```dart
 Widget build(BuildContext context) {
   return Center(
@@ -256,16 +256,16 @@ The message shown by the error looks like this:
 ```
 The following assertion was thrown during performLayout():
 An InputDecorator, which is typically created by a TextField, cannot have an unbounded width.
-This happens when the parent widget does not provide a finite width constraint. For example, if the InputDecorator is contained by a Row, then its width must be constrained. An Expanded widget or a SizedBox can be used to constrain the width of the InputDecorator or the TextField that contains it.
+This happens when the parent widget does not provide a finite width constraint. For example, if the InputDecorator is contained by a `Row`, then its width must be constrained. An `Expanded` widget or a SizedBox can be used to constrain the width of the InputDecorator or the TextField that contains it.
 ```
 
 
 
 ### How might you run into the error?
 
-This error would occur, when you put a TextFormField or a TextField in a Row without constraining the width of the TextField.
+This error would occur, when you put a `TextFormField` or a `TextField` in a `Row` without constraining the width of the `TextField`.
 
-
+<!-- skip -->
 ```dart
 Widget build(BuildContext context) {
   return MaterialApp(
@@ -288,9 +288,9 @@ Widget build(BuildContext context) {
 
 ### How to fix it?
 
-As suggested by the error message, you can fix this error by constrain the TextField using an Expanded widget (see the example below) or a SizedBox widget. 
+As suggested by the error message, you can fix this error by constrain the `TextField` using an `Expanded` widget (see the example below) or a `SizedBox` widget. 
 
-
+<!-- skip -->
 ```dart
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -345,11 +345,11 @@ Here is an _incomplete_ list of widgets that expect specific parent widgets with
 
 | Widget                            | Expected parent widget(s) |
 | :-------------------------------- | ------------------------: |
-| Flexible                          |      Row, Column, or Flex |
-| Expanded (a specialized Flexible) |      Row, Column, or Flex |
-| Positioned                        |                     Stack |
-| Flexible                          |      Row, Column, or Flex |
-| TableCell                         |                     Table |
+| `Flexible`                          |      `Row`, `Column`, or `Flex` |
+| `Expanded` (a specialized `Flexible`) |      `Row`, `Column`, or `Flex` |
+| `Positioned`                        |                     `Stack` |
+| `Flexible`                          |      `Row`, `Column`, or `Flex` |
+| `TableCell`                         |                     `Table` |
 
 
 
@@ -375,13 +375,13 @@ The widget on which setState() or markNeedsBuild() was called was: Overlay-[Labe
 
 ### How might you run into the error?
 
-In general, this error occurs when the `setState` method is called within the build method. 
+In general, this error occurs when the `setState` method is called within the `build` method. 
 
-A common scenario where this error would occur is when attempting to trigger a Dialog from within the build method. This scenario is often motivated by the requirement of showing some information to the user immediately upon their entry to a new page.  
+A common scenario where this error would occur is when attempting to trigger a dialog from within the `build` method. This scenario is often motivated by the requirement of showing some information to the user immediately upon their entry to a new page.  
 
 Below is a snippet that seems to be a common culprit of this error:
 
-
+<!-- skip -->
 ```dart
 Widget build(BuildContext context) {
 
@@ -405,13 +405,13 @@ Widget build(BuildContext context) {
 ```
 
 
-You can’t see the call to `setState` here, but it’s being used as part of `showDialog`, which is why this error is coming up. The build method is never the right place to call `showDialog`. The `build` method could be called by the framework for every frame, e.g., during an animation. 
+You can’t see the call to `setState` here, but it’s being used as part of `showDialog`, which is why this error is coming up. The build method is never the right place to call `showDialog`. The `build` method could be called by the framework for every frame, for example, during an animation. 
 
 ### How to fix it?
 
-One way to avoid this error is to use the Navigator API to trigger the dialog as a route. In the example below, there are two pages. The second page has a dialog to be displayed upon entry. When the user requests the second page from clicking on a button on the first page, the Navigator would push two routes in a row – one for the second page and another for the dialog.  
+One way to avoid this error is to use the `Navigator` API to trigger the dialog as a route. In the example below, there are two pages. The second page has a dialog to be displayed upon entry. When the user requests the second page from clicking on a button on the first page, the `Navigator` would push two routes in a row – one for the second page and another for the dialog.  
 
-
+<!-- skip -->
 ```dart
 class FirstScreen extends StatelessWidget {
   @override

--- a/src/docs/testing/common-errors.md
+++ b/src/docs/testing/common-errors.md
@@ -34,14 +34,12 @@ The following assertion was thrown during layout:
 A RenderFlex overflowed by 1146 pixels on the right.
 
 The relevant error-causing widget was
-    Row 							lib/errors/renderflex_overflow_column.dart:23
+    Row 	    lib/errors/renderflex_overflow_column.dart:23
 The overflowing RenderFlex has an orientation of Axis.horizontal.
-The edge of the RenderFlex that is overflowing has been marked in the rendering with a yellow and black striped pattern. This is usually caused by the contents being too big for the RenderFlex.
-
-Consider applying a flex factor (e.g. using an Expanded widget) to force the children of the RenderFlex to fit within the available space instead of being sized to their natural size.
-This is considered an error condition because it indicates that there is content that cannot be seen. If the content is legitimately bigger than the available space, consider clipping it with a ClipRect widget before putting it in the flex, or using a scrollable container rather than a Flex, like a ListView.
-
-The specific RenderFlex in question is: RenderFlex#c3a70 relayoutBoundary=up1 OVERFLOWING
+The edge of the RenderFlex that is overflowing has been marked in the rendering 
+with a yellow and black striped pattern. This is usually caused by the contents 
+being too big for the RenderFlex.
+(Additional lines of this message omitted)
 ```
 
 
@@ -126,11 +124,8 @@ The message shown by the error looks like this:
 
 
 ```
-RenderBox was not laid out: RenderViewport#5a477 NEEDS-LAYOUT NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
-'package:flutter/src/rendering/box.dart':
-Failed assertion: line 1785 pos 12: 'hasSize'
-The relevant error-causing widget was
-    ListView 					lib/errors/unbounde...
+RenderBox was not laid out: 
+RenderViewport#5a477 NEEDS-LAYOUT NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
 ```
 
 
@@ -160,12 +155,11 @@ The message shown by the error looks like this:
 The following assertion was thrown during performResize():
 Vertical viewport was given unbounded height.
 
-Viewports expand in the scrolling direction to fill their container. In this case, a vertical viewport was given an unlimited amount of vertical space in which to expand. This situation typically happens when a scrollable widget is nested inside another scrollable widget.
-
-If this widget is always nested in a scrollable widget there is no need to use a viewport because there will always be enough vertical space for the children. In this case, consider using a `Column` instead. Otherwise, consider using the "shrinkWrap" property (or a ShrinkWrappingViewport) to size the height of the viewport to the sum of the heights of its children.
-
-The relevant error-causing widget was
-    ListView 						lib/errors/unbounded...
+Viewports expand in the scrolling direction to fill their container. 
+In this case, a vertical viewport was given an unlimited amount of 
+vertical space in which to expand. This situation typically happens when a 
+scrollable widget is nested inside another scrollable widget.
+(Additional lines of this message omitted)
 ```
 
 
@@ -254,8 +248,13 @@ The message shown by the error looks like this:
 
 ```
 The following assertion was thrown during performLayout():
-An InputDecorator, which is typically created by a TextField, cannot have an unbounded width.
-This happens when the parent widget does not provide a finite width constraint. For example, if the InputDecorator is contained by a `Row`, then its width must be constrained. An `Expanded` widget or a SizedBox can be used to constrain the width of the InputDecorator or the TextField that contains it.
+An InputDecorator, which is typically created by a TextField, cannot have an 
+unbounded width.
+This happens when the parent widget does not provide a finite width constraint. 
+For example, if the InputDecorator is contained by a `Row`, then its width must 
+be constrained. An `Expanded` widget or a SizedBox can be used to constrain the 
+width of the InputDecorator or the TextField that contains it.
+(Additional lines of this message omitted)
 ```
 
 
@@ -321,15 +320,11 @@ The message shown by the error looks like this:
 
 
 ```
-The following assertion was thrown while looking for parent data.:
+The following assertion was thrown while looking for parent data:
 Incorrect use of ParentDataWidget.
-
-The following ParentDataWidgets are providing parent data to the same RenderObject:
-- Expanded(flex: 1) (typically placed directly inside a Flex widget)
-- LayoutId-[<_ScaffoldSlot.body>](id: _ScaffoldSlot.body) (typically placed directly inside a CustomMultiChildLayout widget)
-However, a RenderObject can only receive parent data from at most one ParentDataWidget.
-
-Usually, this indicates that at least one of the offending ParentDataWidgets listed above is not placed directly inside a compatible ancestor widget.
+(Some lines of this message omitted)
+Usually, this indicates that at least one of the offending ParentDataWidgets 
+listed above is not placed directly inside a compatible ancestor widget.
 ```
 
 
@@ -365,11 +360,14 @@ either directly or indirectly.
 When the error occurs, the following message gets displayed in the console:
 
 ```
-The following assertion was thrown building DialogPage(dirty, dependencies: [_InheritedTheme, _LocalizationsScope-[GlobalKey#59a8e]], state: _DialogPageState#f121e):
+The following assertion was thrown building DialogPage(dirty, dependencies: 
+[_InheritedTheme, _LocalizationsScope-[GlobalKey#59a8e]], 
+state: _DialogPageState#f121e):
 setState() or markNeedsBuild() called during build.
 
-This Overlay widget cannot be marked as needing to build because the framework is already in the process of building widgets.  A widget can be marked as needing to be built during the build phase only if one of its ancestors is currently building. This exception is allowed because the framework builds parent widgets before children, which means a dirty descendant will always be built. Otherwise, the framework might not visit this widget during this build phase.
-The widget on which setState() or markNeedsBuild() was called was: Overlay-[LabeledGlobalKey<OverlayState>#783d6]
+This Overlay widget cannot be marked as needing to build because the framework 
+is already in the process of building widgets.
+(Additional lines of this message omitted)
 ```
 
 ### How might you run into the error?

--- a/src/docs/testing/common-errors.md
+++ b/src/docs/testing/common-errors.md
@@ -5,16 +5,21 @@ description: How to recognize and resolve common Flutter framework errors.
 
 ## Introduction
 
-This page explains several frequently-encountered Flutter framework errors and gives suggestions on how to resolve them. This is a living document with more errors to be added in future revisions, and your contributions are welcomed. Feel free to open an issue or submit a pull request to make this page more useful to you and the Flutter community. 
+This page explains several frequently-encountered Flutter framework errors and
+gives suggestions on how to resolve them. This is a living document with more
+errors to be added in future revisions, and your contributions are welcomed.
+Feel free to open an issue or submit a pull request to make this page more
+useful to you and the Flutter community. 
 
 ## ‘A RenderFlex overflowed…’
 
-RenderFlex overflow is one of the most frequently encountered Flutter framework 
+RenderFlex overflow is one of the most frequently encountered Flutter framework
 errors, and you probably have run into it already.
 
 **What does the error look like?**
 
-When it happens, you’ll see yellow & black stripes indicating the area of overflow in the app UI in addition to the error message in the debug console: 
+When it happens, you’ll see yellow & black stripes indicating the area of
+overflow in the app UI in addition to the error message in the debug console: 
 
 
 ```
@@ -34,7 +39,9 @@ being too big for the RenderFlex.
 
 **How might you run into this error?**
 
-The error often occurs when a `Column` or `Row` has a child widget that is not constrained in its size. For example, the code snippet below demonstrates a common scenario:
+The error often occurs when a `Column` or `Row` has a child widget that is not
+constrained in its size. For example, the code snippet below demonstrates a
+common scenario:
 
 <!-- skip -->
 ```dart
@@ -63,16 +70,30 @@ Widget build(BuildContext context) {
 ```
 
 
-In the above example, the `Column` tries to be wider than the space the `Row` (its parent) can allocate to it, causing an overflow error.  Why does the `Column` try to do that? To understand this layout behavior, you need to know how Flutter framework performs layout:
+In the above example, the `Column` tries to be wider than the space the `Row`
+(its parent) can allocate to it, causing an overflow error.  Why does the
+`Column` try to do that? To understand this layout behavior, you need to know
+how Flutter framework performs layout:
 
-"_To perform layout, Flutter walks the render tree in a depth-first traversal and **passes down size constraints** from parent to child… Children respond by **passing up a size** to their parent object within the constraints the parent established._"  – [Flutter architectural overview](/docs/resources/architectural-overview#layout-and-rendering)
+"_To perform layout, Flutter walks the render tree in a depth-first traversal
+and **passes down size constraints** from parent to child… Children respond by
+**passing up a size** to their parent object within the constraints the parent
+established._"  – [Flutter architectural
+overview](/docs/resources/architectural-overview#layout-and-rendering)
 
-In this case, the `Row` widget doesn’t constrain the size of its children, nor does the `Column` widget. Lacking constraints from its parent widget, the second Text widget tries to be as wide as all the characters it needs to display. The self-determined width of the Text widget then gets adopted by the `Column` which clashes with the maximum amount of horizontal space its parent the `Row` widget can provide.  
+In this case, the `Row` widget doesn’t constrain the size of its children, nor
+does the `Column` widget. Lacking constraints from its parent widget, the second
+Text widget tries to be as wide as all the characters it needs to display. The
+self-determined width of the Text widget then gets adopted by the `Column` which
+clashes with the maximum amount of horizontal space its parent the `Row` widget
+can provide.  
 
 
 **How to fix it?**
 
-Well, you need to make sure the `Column` won’t attempt to be wider than it can be. To achieve this, you need to constrain its width. One way to do it is to wrap the `Column` in an `Expanded` widget:
+Well, you need to make sure the `Column` won’t attempt to be wider than it can
+be. To achieve this, you need to constrain its width. One way to do it is to
+wrap the `Column` in an `Expanded` widget:
 
 <!-- skip -->
 ```dart
@@ -89,7 +110,13 @@ child: Row(
 ```
 
 
-Another way is to wrap the `Column` in a `Flexible` widget and specify a `flex` factor. In fact, the `Expanded` widget is equivalent to the `Flexible` widget with a `flex` factor of 1.0, as [its source code]({{site.github}}/flutter/flutter/blob/127e67902e8bbb0dcbfb3351b8fd00f7cbdf0178/packages/flutter/lib/src/widgets/basic.dart#L4677-L4686) shows. To further understand how to use the `Flex` widget in Flutter layouts, please check out [this Widget of the Week video](https://youtu.be/CI7x0mAZiY0) on the Flexible widget.
+Another way is to wrap the `Column` in a `Flexible` widget and specify a `flex`
+factor. In fact, the `Expanded` widget is equivalent to the `Flexible` widget
+with a `flex` factor of 1.0, as [its source
+code]({{site.github}}/flutter/flutter/blob/127e67902e8bbb0dcbfb3351b8fd00f7cbdf0178/packages/flutter/lib/src/widgets/basic.dart#L4677-L4686)
+shows. To further understand how to use the `Flex` widget in Flutter layouts,
+please check out [this Widget of the Week video](https://youtu.be/CI7x0mAZiY0)
+on the Flexible widget.
 
 **Further information:**
 
@@ -119,7 +146,10 @@ RenderViewport#5a477 NEEDS-LAYOUT NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
 
 **How might you run into this error?**
 
-Usually, the issue is related to violation of box constraints, and it needs to be solved by providing more information to Flutter about how you’d like to constrain the widgets in question. You can learn more about how constraints work in Flutter on the page [Understanding constraints][]. 
+Usually, the issue is related to violation of box constraints, and it needs to
+be solved by providing more information to Flutter about how you’d like to
+constrain the widgets in question. You can learn more about how constraints work
+in Flutter on the page [Understanding constraints][]. 
 
 [Understanding constraints]: /docs/development/ui/layout/constraints
 
@@ -153,7 +183,12 @@ scrollable widget is nested inside another scrollable widget.
 
 **How might you run into this error?**
 
-The error is often caused when a `ListView` (or other kinds of scrollable widgets such as `GridView`) is placed inside a `Column`. A `ListView` takes all the vertical space available to it, unless it’s constrained by its parent widget. However, a `Column` doesn’t impose any constraint on its children’s height by default. The combination of the two behaviors leads to the failure of determining the size of the `ListView`. 
+The error is often caused when a `ListView` (or other kinds of scrollable
+widgets such as `GridView`) is placed inside a `Column`. A `ListView` takes all
+the vertical space available to it, unless it’s constrained by its parent
+widget. However, a `Column` doesn’t impose any constraint on its children’s
+height by default. The combination of the two behaviors leads to the failure of
+determining the size of the `ListView`. 
 
 <!-- skip -->
 ```dart
@@ -184,7 +219,10 @@ Widget build(BuildContext context) {
 
 **How to fix it?**
 
-To fix this error, specify how tall the `ListView` should be. To make it as tall as the remaining space in the `Column`, wrap it using an `Expanded` widget (see the example below). Otherwise, specify an absolute height using a `SizedBox` widget or a relative height using a `Flexible` widget.
+To fix this error, specify how tall the `ListView` should be. To make it as tall
+as the remaining space in the `Column`, wrap it using an `Expanded` widget (see
+the example below). Otherwise, specify an absolute height using a `SizedBox`
+widget or a relative height using a `Flexible` widget.
 
 <!-- skip -->
 ```dart
@@ -248,7 +286,8 @@ width of the InputDecorator or the TextField that contains it.
 
 **How might you run into the error?**
 
-This error occurs, for example, when a `Row` contains a `TextFormField` or a `TextField` but the latter has no width constraint.
+This error occurs, for example, when a `Row` contains a `TextFormField` or a
+`TextField` but the latter has no width constraint.
 
 <!-- skip -->
 ```dart
@@ -273,7 +312,9 @@ Widget build(BuildContext context) {
 
 **How to fix it?**
 
-As suggested by the error message, fix this error by constraining the text field using either an `Expanded` or `SizedBox` widget. The following example demonstrates using an `Expanded` widget:
+As suggested by the error message, fix this error by constraining the text field
+using either an `Expanded` or `SizedBox` widget. The following example
+demonstrates using an `Expanded` widget:
 
 <!-- skip -->
 ```dart
@@ -318,9 +359,14 @@ listed above is not placed directly inside a compatible ancestor widget.
 
 **How might you run into the error?**
 
-While Flutter’s widgets are generally flexible in how they can be composed together in a UI, a small subset of those widgets expect specific parent widgets. When this expectation can’t be satisfied in your widget tree, you’re likely to see this error. 
+While Flutter’s widgets are generally flexible in how they can be composed
+together in a UI, a small subset of those widgets expect specific parent
+widgets. When this expectation can’t be satisfied in your widget tree, you’re
+likely to see this error. 
 
-Here is an _incomplete_ list of widgets that expect specific parent widgets within the Flutter framework. Feel free to submit a PR (using the doc icon in the top right corner of the page) to expand this list.
+Here is an _incomplete_ list of widgets that expect specific parent widgets
+within the Flutter framework. Feel free to submit a PR (using the doc icon in
+the top right corner of the page) to expand this list.
 
 | Widget                            | Expected parent widget(s) |
 | :-------------------------------- | ------------------------: |
@@ -359,9 +405,13 @@ is already in the process of building widgets.
 
 **How might you run into the error?**
 
-In general, this error occurs when the `setState` method is called within the `build` method. 
+In general, this error occurs when the `setState` method is called within the
+`build` method. 
 
-A common scenario where this error occurs is when attempting to trigger a Dialog from within the `build` method. This is often motivated by the need to immediately show information to the user, but setState should never be called from a `build` method.
+A common scenario where this error occurs is when attempting to trigger a Dialog
+from within the `build` method. This is often motivated by the need to
+immediately show information to the user, but setState should never be called
+from a `build` method.
 
 Below is a snippet that seems to be a common culprit of this error:
 
@@ -389,11 +439,18 @@ Widget build(BuildContext context) {
 ```
 
 
-You don't see the explicit call to `setState`, but it's called by `showDialog`. The `build` method is not the right place to call `showDialog` because `build` can be called by the framework for every frame, for example, during an animation.
+You don't see the explicit call to `setState`, but it's called by `showDialog`.
+The `build` method is not the right place to call `showDialog` because `build`
+can be called by the framework for every frame, for example, during an
+animation.
 
 **How to fix it?**
 
-One way to avoid this error is to use the `Navigator` API to trigger the dialog as a route. In the example below, there are two pages. The second page has a dialog to be displayed upon entry. When the user requests the second page from clicking on a button on the first page, the `Navigator` pushes two routes in a row – one for the second page and another for the dialog.  
+One way to avoid this error is to use the `Navigator` API to trigger the dialog
+as a route. In the example below, there are two pages. The second page has a
+dialog to be displayed upon entry. When the user requests the second page from
+clicking on a button on the first page, the `Navigator` pushes two routes in a
+row – one for the second page and another for the dialog.  
 
 <!-- skip -->
 ```dart
@@ -435,4 +492,5 @@ check out the following resources:
 *   [How to debug layout issues with the Flutter Inspector]({{site.medium}}/flutter/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db)
 *   [Understanding constraints](/docs/development/ui/layout/constraints)
 *   [Dealing with box constraints](/docs/development/ui/layout/box-constraints)
-*   [Flutter architectural overview](/docs/resources/architectural-overview#layout-and-rendering)
+*   [Flutter architectural
+    overview](/docs/resources/architectural-overview#layout-and-rendering)

--- a/src/docs/testing/common-errors.md
+++ b/src/docs/testing/common-errors.md
@@ -125,14 +125,8 @@ Usually, the issue is related to violation of box constraints, and it needs to b
 
 The `RenderBox was not laid out` error is often caused by one of two other errors:
 
-- [Introduction](#introduction)
-- [‘A RenderFlex overflowed…’](#a-renderflex-overflowed)
-- [‘RenderBox was not laid out’](#renderbox-was-not-laid-out)
-- [‘Vertical viewport was given unbounded height’](#vertical-viewport-was-given-unbounded-height)
-- [‘An InputDecorator...cannot have an unbounded width’](#an-inputdecoratorcannot-have-an-unbounded-width)
-- [‘Incorrect use of ParentData widget’](#incorrect-use-of-parentdata-widget)
-- [‘setState called during build’](#setstate-called-during-build)
-- [References](#references)
+* ‘Vertical viewport was given unbounded height’
+* ‘An InputDecorator...cannot have an unbounded width’
 
 ## ‘Vertical viewport was given unbounded height’
 

--- a/src/docs/testing/common-errors.md
+++ b/src/docs/testing/common-errors.md
@@ -7,24 +7,12 @@ description: How to recognize and resolve common Flutter framework errors.
 
 This page explains several frequently-encountered Flutter framework errors and gives suggestions on how to resolve them. This is a living document with more errors to be added in future revisions, and your contributions are welcomed. Feel free to open an issue or submit a pull request to make this page more useful to you and the Flutter community. 
 
-
-### List of errors
-
-* [A RenderFlex overflowed…](#a-renderflex-overflowed)
-* [RenderBox was not laid out](#renderbox-was-not-laid-out)
-* [Vertical viewport was given unbounded height](#vertical-viewport-was-given-unbounded-height)
-* [Incorrect use of ParentData widget](#incorrect-use-of-parentdata-widget)
-* [‘An InputDecorator...cannot have an unbounded width’](#an-inputdecoratorcannot-have-an-unbounded-width)
-* [setState called during build](#setstate-called-during-build)
-
-
-
 ## ‘A RenderFlex overflowed…’
 
 RenderFlex overflow is one of the most frequently encountered Flutter framework 
 errors, and you probably have run into it already.
 
-### What does the error look like?
+**What does the error look like?**
 
 When it happens, you’ll see yellow & black stripes indicating the area of overflow in the app UI in addition to the error message in the debug console: 
 
@@ -44,7 +32,7 @@ being too big for the RenderFlex.
 
 
 
-### How might you run into this error?
+**How might you run into this error?**
 
 The error often occurs when a `Column` or `Row` has a child widget that is not constrained in its size. For example, the code snippet below demonstrates a common scenario:
 
@@ -83,7 +71,7 @@ In the above example, the `Column` tries to be wider than the space the `Row` (i
 In this case, the `Row` widget doesn’t constrain the size of its children, nor does the `Column` widget. Lacking constraints from its parent widget, the second Text widget tries to be as wide as all the characters it needs to display. The self-determined width of the Text widget then gets adopted by the `Column` which clashes with the maximum amount of horizontal space its parent the `Row` widget can provide.  
 
 
-### How to fix it?
+**How to fix it?**
 
 Well, you need to make sure the `Column` won’t attempt to be wider than it can be. To achieve this, you need to constrain its width. One way to do it is to wrap the `Column` in an `Expanded` widget:
 
@@ -104,7 +92,7 @@ child: Row(
 
 Another way is to wrap the `Column` in a `Flexible` widget and specify a `flex` factor. In fact, the `Expanded` widget is equivalent to the `Flexible` widget with a `flex` factor of 1.0, as [its source code]({{site.github}}/flutter/flutter/blob/127e67902e8bbb0dcbfb3351b8fd00f7cbdf0178/packages/flutter/lib/src/widgets/basic.dart#L4677-L4686) shows. To further understand how to use the `Flex` widget in Flutter layouts, please check out [this Widget of the Week video](https://youtu.be/CI7x0mAZiY0) on the Flexible widget.
 
-### Further information:
+**Further information:**
 
 The resources linked below provide further information about this error. 
 
@@ -118,7 +106,7 @@ The resources linked below provide further information about this error.
 While this error is pretty common, it’s often a side effect of a primary error 
 occurring earlier in the rendering pipeline.
 
-### What does the error look like?
+**What does the error look like?**
 
 The message shown by the error looks like this: 
 
@@ -130,7 +118,7 @@ RenderViewport#5a477 NEEDS-LAYOUT NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE
 
 
 
-### How might you run into this error?
+**How might you run into this error?**
 
 Usually, the issue is related to violation of box constraints, and it needs to be solved by providing more information to Flutter about how you’d like to constrain the widgets in question. You can learn more about how constraints work in Flutter on the page [Understanding constraints][]. 
 
@@ -138,15 +126,21 @@ Usually, the issue is related to violation of box constraints, and it needs to b
 
 The `RenderBox was not laid out` error is often caused by one of two other errors:
 
-* [‘Vertical viewport was given unbounded height’](#vertical-viewport-was-given-unbounded-height)
-* [‘An InputDecorator...cannot have an unbounded width’](#an-inputdecoratorcannot-have-an-unbounded-width)
+- [Introduction](#introduction)
+- [‘A RenderFlex overflowed…’](#a-renderflex-overflowed)
+- [‘RenderBox was not laid out’](#renderbox-was-not-laid-out)
+- [‘Vertical viewport was given unbounded height’](#vertical-viewport-was-given-unbounded-height)
+- [‘An InputDecorator...cannot have an unbounded width’](#an-inputdecoratorcannot-have-an-unbounded-width)
+- [‘Incorrect use of ParentData widget’](#incorrect-use-of-parentdata-widget)
+- [‘setState called during build’](#setstate-called-during-build)
+- [References](#references)
 
 ## ‘Vertical viewport was given unbounded height’
 
 This is another common layout error you could run into 
 while creating a UI in your Flutter app.
 
-### What does the error look like?
+**What does the error look like?**
 
 The message shown by the error looks like this: 
 
@@ -164,7 +158,7 @@ scrollable widget is nested inside another scrollable widget.
 
 
 
-### How might you run into this error?
+**How might you run into this error?**
 
 The error is often caused when a `ListView` (or other kinds of scrollable widgets such as `GridView`) is placed inside a `Column`. A `ListView` takes all the vertical space available to it, unless it’s constrained by its parent widget. However, a `Column` doesn’t impose any constraint on its children’s height by default. The combination of the two behaviors leads to the failure of determining the size of the `ListView`. 
 
@@ -195,7 +189,7 @@ Widget build(BuildContext context) {
 
 
 
-### How to fix it?
+**How to fix it?**
 
 To fix this error, specify how tall the `ListView` should be. To make it as tall as the remaining space in the `Column`, wrap it using an `Expanded` widget (see the example below). Otherwise, specify an absolute height using a `SizedBox` widget or a relative height using a `Flexible` widget.
 
@@ -228,7 +222,7 @@ Widget build(BuildContext context) {
 
 
 
-### Further information:
+**Further information:**
 
 The resources linked below provide further information about this error.
 
@@ -242,7 +236,7 @@ The error message suggests that it's also related to box constraints,
 which are important to understand to avoid many of the most common 
 Flutter framework errors. 
 
-### What does the error look like?
+**What does the error look like?**
 
 The message shown by the error looks like this: 
 
@@ -259,7 +253,7 @@ width of the InputDecorator or the TextField that contains it.
 
 
 
-### How might you run into the error?
+**How might you run into the error?**
 
 This error occurs, for example, when a `Row` contains a `TextFormField` or a `TextField` but the latter has no width constraint.
 
@@ -284,7 +278,7 @@ Widget build(BuildContext context) {
 
 
 
-### How to fix it?
+**How to fix it?**
 
 As suggested by the error message, fix this error by constraining the text field using either an `Expanded` or `SizedBox` widget. The following example demonstrates using an `Expanded` widget:
 
@@ -314,7 +308,7 @@ As suggested by the error message, fix this error by constraining the text field
 
 This error is about missing an expected parent widget.
 
-### What does the error look like?
+**What does the error look like?**
 
 The message shown by the error looks like this: 
 
@@ -329,7 +323,7 @@ listed above is not placed directly inside a compatible ancestor widget.
 
 
 
-### How might you run into the error?
+**How might you run into the error?**
 
 While Flutter’s widgets are generally flexible in how they can be composed together in a UI, a small subset of those widgets expect specific parent widgets. When this expectation can’t be satisfied in your widget tree, you’re likely to see this error. 
 
@@ -345,7 +339,7 @@ Here is an _incomplete_ list of widgets that expect specific parent widgets with
 
 
 
-### How to fix it?
+**How to fix it?**
 
 The fix should be obvious once you know which parent widget is missing. 
 
@@ -355,7 +349,7 @@ The fix should be obvious once you know which parent widget is missing.
 The `build` method in your Flutter code is not a good place to call `setState` 
 either directly or indirectly. 
 
-### What does the error look like?
+**What does the error look like?**
 
 When the error occurs, the following message gets displayed in the console:
 
@@ -370,7 +364,7 @@ is already in the process of building widgets.
 (Additional lines of this message omitted)
 ```
 
-### How might you run into the error?
+**How might you run into the error?**
 
 In general, this error occurs when the `setState` method is called within the `build` method. 
 
@@ -404,7 +398,7 @@ Widget build(BuildContext context) {
 
 You don't see the explicit call to `setState`, but it's called by `showDialog`. The `build` method is not the right place to call `showDialog` because `build` can be called by the framework for every frame, for example, during an animation.
 
-### How to fix it?
+**How to fix it?**
 
 One way to avoid this error is to use the `Navigator` API to trigger the dialog as a route. In the example below, there are two pages. The second page has a dialog to be displayed upon entry. When the user requests the second page from clicking on a button on the first page, the `Navigator` pushes two routes in a row – one for the second page and another for the dialog.  
 

--- a/src/docs/testing/common-errors.md
+++ b/src/docs/testing/common-errors.md
@@ -1,11 +1,11 @@
 ---
 title: Common Flutter errors
-description: How to recognize and resolve common Flutter Framework errors.
+description: How to recognize and resolve common Flutter framework errors.
 ---
 
 ## Introduction
 
-This page explains several frequently-encountered Flutter Framework errors and gives suggestions on how to resolve them. This is a living document with more errors to be added in future revisions, and your contributions are welcomed. Feel free to open an issue or submit a pull request to make this page more useful to you and the Flutter community. 
+This page explains several frequently-encountered Flutter framework errors and gives suggestions on how to resolve them. This is a living document with more errors to be added in future revisions, and your contributions are welcomed. Feel free to open an issue or submit a pull request to make this page more useful to you and the Flutter community. 
 
 
 ### List of errors
@@ -21,7 +21,7 @@ This page explains several frequently-encountered Flutter Framework errors and g
 
 ## ‘A RenderFlex overflowed…’
 
-RenderFlex overflow is one of the most frequently encountered Flutter Framework 
+RenderFlex overflow is one of the most frequently encountered Flutter framework 
 errors, and you probably have run into it already.
 
 ### What does the error look like?
@@ -77,7 +77,7 @@ Widget build(BuildContext context) {
 ```
 
 
-In the above example, the `Column` tries to be wider than the space the `Row` (its parent) can allocate to it, causing an overflow error.  Why does the `Column` try to do that? To understand this layout behavior, you need to know how Flutter Framework performs layout:
+In the above example, the `Column` tries to be wider than the space the `Row` (its parent) can allocate to it, causing an overflow error.  Why does the `Column` try to do that? To understand this layout behavior, you need to know how Flutter framework performs layout:
 
 <!-- TODO: Fix the blockquote style -->
 >"_To perform layout, Flutter walks the render tree in a depth-first traversal and **passes down size constraints** from parent to child… Children respond by **passing up a size** to their parent object within the constraints the parent established._"  – [Flutter architectural overview](/docs/resources/architectural-overview#layout-and-rendering)
@@ -246,7 +246,7 @@ The resources linked below provide further information about this error.
 
 The error message suggests that it's also related to box constraints, 
 which are important to understand to avoid many of the most common 
-Flutter Framework errors. 
+Flutter framework errors. 
 
 ### What does the error look like?
 
@@ -338,7 +338,7 @@ Usually, this indicates that at least one of the offending ParentDataWidgets lis
 
 While Flutter’s widgets are generally flexible in how they can be composed together in a UI, a small subset of those widgets expect specific parent widgets. When this expectation can’t be satisfied in your widget tree, you’re likely to see this error. 
 
-Here is an _incomplete_ list of widgets that expect specific parent widgets within the Flutter Framework. Feel free to submit a PR (using the doc icon in the top right corner of the page) to expand this list.
+Here is an _incomplete_ list of widgets that expect specific parent widgets within the Flutter framework. Feel free to submit a PR (using the doc icon in the top right corner of the page) to expand this list.
 
 | Widget                            | Expected parent widget(s) |
 | :-------------------------------- | ------------------------: |
@@ -361,6 +361,8 @@ The `build` method in your Flutter code is not a good place to call `setState`
 either directly or indirectly. 
 
 ### What does the error look like?
+
+When the error occurs, the following message gets displayed in the console:
 
 ```
 The following assertion was thrown building DialogPage(dirty, dependencies: [_InheritedTheme, _LocalizationsScope-[GlobalKey#59a8e]], state: _DialogPageState#f121e):


### PR DESCRIPTION
Adding a page about common Flutter framework errors. There are a few things to be done:

- [X] Use sentence case for headers and titles
- [X] Add "skip" tags before incomplete Dart code snippets
- [X] All class names should be codefonted
- [X] Don't use "e.g."
- [x] Avoid using first person (we, let's). Either use second person or avoid pronouns altogether
- [x] Avoid future tense or past participle (will, would)
- [x] Use macros for Medium, GitHub, API docs, dart.dev, and pub links
- [x] Link on descriptive text, not "this" or "here" or anything nonspecific like that
- [x] There needs to be text after every header, before sub headers, lists, or images, for example.
- [x] Text lines should be 80 chars or less. We generally break on phrases
- [x] Add the page to the navigation under Testing & debugging

Tasks decided not to do in this PR:
- Figure out how to style a blockquote
- Style the error messages to match the styling in the IDE