### PR TITLE
Update iOS Emulator Scaling Information

### DIFF
--- a/src/docs/get-started/install/_ios-setup.md
+++ b/src/docs/get-started/install/_ios-setup.md
@@ -49,8 +49,13 @@ follow these steps:
     the simulator's **Hardware > Device** menu.
  3. Depending on your development machine's screen size,
     simulated high-screen-density iOS devices
-    might overflow your screen. Set the device scale under the
-    **Window > Scale** menu in the simulator.
+    might overflow your screen. Grab the corner of the 
+    simulator and drag it to change the scale. You can also 
+    use the **Window > Physical Size** or **Window > Pixel Accurate**
+    options if your computer's resolution is high enough.
+    * If you are using a version of XCode older 
+    than 9.1, you should instead set the device scale
+    in the **Window > Scale** menu.
 
 ### Create and run a simple Flutter app
 


### PR DESCRIPTION
Fixes #3575
Updates info in the iOS Setup section to mention a change in XCode 9.1, where users can drag their emulator's edge to change its size. 