### PR TITLE
Clarify Step 3 of Widget Testing

### DIFF
--- a/src/docs/cookbook/testing/widget/introduction.md
+++ b/src/docs/cookbook/testing/widget/introduction.md
@@ -97,6 +97,7 @@ The `testWidgets` function allows you to define a
 widget test and creates a `WidgetTester` to work with.
 
 This test verifies that `MyWidget` displays a given title and message.
+It is titled accordingly, and it will be populated in the next section.
 
 <!-- skip -->
 ```dart


### PR DESCRIPTION
Fixes #3596
Makes the text in Step 3 match the code a little more. 
I think this was already something of a non-issue but hopefully it's a little more clear than it was before.