### PR TITLE
Clean Up the "Persist data with SQLite" Page

### DIFF
--- a/src/docs/cookbook/persistence/sqlite.md
+++ b/src/docs/cookbook/persistence/sqlite.md
@@ -179,6 +179,7 @@ class Dog {
 }
 ```
 
+<!-- skip -->
 ```dart
 // Define a function that inserts dogs into the database
 Future<void> insertDog(Dog dog) async {
@@ -197,6 +198,7 @@ Future<void> insertDog(Dog dog) async {
 }
 ```
 
+<!-- skip -->
 ```dart
 // Create a Dog and add it to the dogs table.
 final fido = Dog(
@@ -237,6 +239,7 @@ Future<List<Dog>> dogs() async {
 }
 ```
 
+<!-- skip -->
 ```dart
 // Now, use the method above to retrieve all the dogs.
 print(await dogs()); // Prints a list that include Fido.
@@ -272,6 +275,7 @@ Future<void> updateDog(Dog dog) async {
 }
 ```
 
+<!-- skip -->
 ```dart
 // Update Fido's age.
 await updateDog(Dog(

--- a/src/docs/cookbook/persistence/sqlite.md
+++ b/src/docs/cookbook/persistence/sqlite.md
@@ -9,13 +9,13 @@ next:
   path: /docs/cookbook/persistence/reading-writing-files
 ---
 
-If writing an app that needs to persist and query larger amounts of data on
+If you are writing an app that needs to persist and query large amounts of data on
 the local device, consider using a database instead of a local file or
 key-value store. In general, databases provide faster inserts, updates,
-and queries, compared to other local persistence solutions.
+and queries compared to other local persistence solutions.
 
 Flutter apps can make use of the SQLite databases via the
-[`sqflite`][] plugin available on pub.
+[`sqflite`][] plugin available on pub.dev.
 This recipe demonstrates the basics of using `sqflite`
 to insert, read, update, and remove data about various Dogs.
 
@@ -88,11 +88,17 @@ to the database. This involves two steps:
   `sqflite` package, combined with the `join` function from the `path` package.
   2. Open the database with the `openDatabase()` function from `sqflite`.
 
-Note: In order to use the keyword `await`, the code must be placed
-inside an `async` function.
+{{site.alert.note}}
+  In order to use the keyword `await`, the code must be placed
+  inside an `async` function. You should place all the following
+  table functions inside `void main() async {}`. 
+{{site.alert.end}}
 
 <!-- skip -->
 ```dart
+// Avoid errors caused by flutter upgrade.
+// Importing 'package:flutter/widgets.dart' is required.
+WidgetsFlutterBinding.ensureInitialized();
 // Open the database and store the reference.
 final Future<Database> database = openDatabase(
   // Set the path to the database. Note: Using the `join` function from the
@@ -123,7 +129,9 @@ SQLite database, see the [official SQLite Datatypes documentation][].
 <!-- skip -->
 ```dart
 final Future<Database> database = openDatabase(
-  // Set the path to the database.
+  // Set the path to the database. Note: Using the `join` function from the
+  // `path` package is best practice to ensure the path is correctly
+  // constructed for each platform.
   join(await getDatabasesPath(), 'doggie_database.db'),
   // When the database is first created, create a table to store dogs.
   onCreate: (db, version) {
@@ -169,7 +177,9 @@ class Dog {
     };
   }
 }
+```
 
+```dart
 // Define a function that inserts dogs into the database
 Future<void> insertDog(Dog dog) async {
   // Get a reference to the database.
@@ -185,7 +195,9 @@ Future<void> insertDog(Dog dog) async {
     conflictAlgorithm: ConflictAlgorithm.replace,
   );
 }
+```
 
+```dart
 // Create a Dog and add it to the dogs table.
 final fido = Dog(
   id: 0,
@@ -223,7 +235,9 @@ Future<List<Dog>> dogs() async {
     );
   });
 }
+```
 
+```dart
 // Now, use the method above to retrieve all the dogs.
 print(await dogs()); // Prints a list that include Fido.
 ```
@@ -256,7 +270,9 @@ Future<void> updateDog(Dog dog) async {
     whereArgs: [dog.id],
   );
 }
+```
 
+```dart
 // Update Fido's age.
 await updateDog(Dog(
   id: 0,
@@ -324,6 +340,7 @@ void main() async {
   // Avoid errors caused by flutter upgrade.
   // Importing 'package:flutter/widgets.dart' is required.
   WidgetsFlutterBinding.ensureInitialized();
+  // Open the database and store the reference.
   final Future<Database> database = openDatabase(
     // Set the path to the database. Note: Using the `join` function from the
     // `path` package is best practice to ensure the path is correctly


### PR DESCRIPTION
Makes a bunch of fixes to the page:
* Removes typos and grammar mistakes in the first paragraph. 
* Breaks up Dart sections that misleadingly look like they are next to each other when they aren't. (From Issue #3758)
* Also adds a note to make the final example easier to arrive at by following the tutorial.
* Basically makes the final example consistent with the rest of the cookbook.