### PR TITLE
Add info on Plugin Installation

### DIFF
--- a/src/docs/get-started/install/_get-sdk-win.md
+++ b/src/docs/get-started/install/_get-sdk-win.md
@@ -76,8 +76,15 @@ finish the setup process. Once you have installed any missing
 dependencies, you can run the `flutter doctor` command again to
 verify that you’ve set everything up correctly.
 
+{{site.alert.note}}
+  If `flutter doctor` returns that either the Flutter plugin
+  or  Dart plugin of Android Studio are not installed, move
+  on to [Set up an editor][] to resolve this issue.
+{{site.alert.end}}
+
 {% include_relative _analytics.md %}
 
 
 [Flutter repo]: {{site.github}}/flutter/flutter
 [SDK archive]: /docs/development/tools/sdk/archive
+[Set up an editor]: /docs/get-started/editor?tab=androidstudio


### PR DESCRIPTION
Fixes #3831
Tells readers to go to the next section to resolve any issues with plugins not being installed. 
While it directly addresses the issue, I also feel like it's a temporary fix to a larger issue of re-arranging the order of the tutorials. 