### PR TITLE
Add deprecation page for ActivityControlSurface API

### DIFF
--- a/src/docs/release/breaking-changes/android-activity-control-surface-attach.md
+++ b/src/docs/release/breaking-changes/android-activity-control-surface-attach.md
@@ -1,0 +1,123 @@
+---
+title: Android ActivityControlSurface attachToActivity signature change
+description: attachToActivity activity parameter changed to ExclusiveAppComponent instead of Activity
+---
+
+## Summary
+
+*If you use standard Android embedding Java classes like [`FlutterActivity`][],
+[`FlutterFragment`][], and don't manually embed a [`FlutterView`][] inside your
+own custom Activity (this should be uncommon), you can stop reading.*
+
+A new [`ActivityControlSurface`][] method
+
+```java
+void attachToActivity(
+    @NonNull ExclusiveAppComponent<Activity> exclusiveActivity,
+    @NonNull Lifecycle lifecycle);
+```
+
+is replacing the now deprecated method
+
+```java
+void attachToActivity(@NonNull Activity activity, @NonNull Lifecycle lifecycle);
+```
+
+The existing deprecated method with the `Activity` parameter will be removed
+after 2021-03-01
+
+## Context
+
+In order for custom Activities to also supply the Activity lifecycle events
+Flutter plugins expect via the [`ActivityAware`][] interface, the
+[`FlutterEngine`][] exposes a [`getActivityControlSurface()`][] API.
+
+This lets custom Activities signal to the engine (with which it has a `(0|1):1`
+relationship) that it's being attached or detached from the engine.
+
+{{site.alert.note}}
+  This lifecycle signaling is done automatically when you use the engine's
+  bundled [`FlutterActivity`][] or [`FlutterFragment`][] (which should be
+  the most common case).
+{{site.alert.end}}
+
+However, the existing API had the flaw that it didn't enforce exclusion between
+activities connecting to the engine, thus enabling `n:1` relationships between
+the activity and the engine, causing lifecycle cross-talk issues.
+
+## Description of change
+
+After [#21272][], instead of attaching your activity to the [`FlutterEngine`][] via the
+
+```java
+void attachToActivity(@NonNull Activity activity, @NonNull Lifecycle lifecycle);
+```
+
+API, which is now deprecated, use
+
+```java
+void attachToActivity(
+    @NonNull ExclusiveAppComponent<Activity> exclusiveActivity,
+    @NonNull Lifecycle lifecycle);
+```
+
+instead. A `ExclusiveAppComponent<Activity>` interface is now expected instead
+of an `Activity`. The `ExclusiveAppComponent<Activity>` provides a callback
+in case your exclusive activity is being replaced by another activity attaching
+itself to the FlutterEngine.
+
+The
+
+```java
+void detachFromActivity();
+```
+
+API remains unchanged and you're still expect to call it when your custom
+activity is being destroyed naturally.
+
+## Migration guide
+
+If you have your own activity holding a [`FlutterView`][], replace calls to
+
+```java
+void attachToActivity(@NonNull Activity activity, @NonNull Lifecycle lifecycle);
+```
+
+with calls to
+
+```java
+void attachToActivity(
+    @NonNull ExclusiveAppComponent<Activity> exclusiveActivity,
+    @NonNull Lifecycle lifecycle);
+```
+
+on the [`ActivityControlSurface`][] that you obtained by calling
+[`getActivityControlSurface()`][] on the [`FlutterEngine`][].
+
+Wrap your activity with an `ExclusiveAppComponent<Activity>` and implement
+the callback method
+
+```java
+void detachFromFlutterEngine();
+```
+
+to handle your activity being replaced by another activity being attached to the
+[`FlutterEngine`][]. Generally you want to perform the same detaching operations
+you perform when the activity is being naturally destroyed.
+
+## Timeline
+
+Landed in version: https://github.com/flutter/engine/pull/21272<br>
+In stable release: not yet
+
+## References
+
+Motivating bug: https://github.com/flutter/flutter/issues/66192.
+
+[`ActivityControlSurface`]: {{site.api}}/javadoc/io/flutter/embedding/engine/plugins/activity/ActivityControlSurface.html
+[`FlutterActivity`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterActivity.html
+[`FlutterFragment`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterFragment.html
+[`ActivityAware`]: {{site.api}}/javadoc/io/flutter/embedding/engine/plugins/activity/ActivityAware.html
+[`FlutterEngine`]: {{site.api}}/javadoc/io/flutter/embedding/engine/FlutterEngine.html
+[`getActivityControlSurface()`]: {{site.api}}/javadoc/io/flutter/embedding/engine/FlutterEngine.html#getActivityControlSurface--
+[#21272]: https://github.com/flutter/engine/pull/21272

--- a/src/docs/release/breaking-changes/index.md
+++ b/src/docs/release/breaking-changes/index.md
@@ -13,6 +13,7 @@ release, and listed in alphabetical order:
 ### Not yet released to stable
 
 * [Android v1 embedding app and plugin creation deprecation][]
+* [Android ActivityControlSurface attachToActivity signature change][]
 * [Material Chip button semantics][]
 * [The new Form, FormField auto-validation API][]
 * [Cupertino icons 1.0.0][]
@@ -20,6 +21,7 @@ release, and listed in alphabetical order:
 
 [Cupertino icons 1.0.0]: /docs/release/breaking-changes/cupertino-icons-1.0.0
 [Android v1 embedding app and plugin creation deprecation]: /docs/release/breaking-changes/android-v1-embedding-create-deprecation
+[Android ActivityControlSurface attachToActivity signature change]: /docs/release/breaking-changes/android-activity-control-surface-attach
 [Material Chip button semantics]: /docs/release/breaking-changes/material-chip-button-semantics
 [The new Form, FormField auto-validation API]: /docs/release/breaking-changes/form-field-autovalidation-api
 [Network Policy on iOS and Android]: /docs/release/breaking-changes/network-policy-ios-android


### PR DESCRIPTION
Deprecation warning doc for https://github.com/flutter/engine/pull/21272