### PR TITLE
Make the video width fill available space.

### DIFF
--- a/src/docs/development/ui/advanced/slivers.md
+++ b/src/docs/development/ui/advanced/slivers.md
@@ -16,4 +16,4 @@ an article on Medium's [Flutter Publication]({{site.flutter-medium}}), or
 watch the [Slivers episode](https://www.youtube.com/watch?v=Mz3kHQxBjGg) of the
 [Boring Show](https://www.youtube.com/results?search_query=%23BoringShow):
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/Mz3kHQxBjGg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="-webkit-fill-available" height="315" src="https://www.youtube.com/embed/Mz3kHQxBjGg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/src/docs/development/ui/advanced/slivers.md
+++ b/src/docs/development/ui/advanced/slivers.md
@@ -16,4 +16,4 @@ an article on Medium's [Flutter Publication]({{site.flutter-medium}}), or
 watch the [Slivers episode](https://www.youtube.com/watch?v=Mz3kHQxBjGg) of the
 [Boring Show](https://www.youtube.com/results?search_query=%23BoringShow):
 
-<iframe width="-webkit-fill-available" height="315" src="https://www.youtube.com/embed/Mz3kHQxBjGg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="inherit" height="315" src="https://www.youtube.com/embed/Mz3kHQxBjGg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
Previously this took up 560px always making it not very mobile friendly. 
![Screen Shot 2020-09-22 at 10 04 45 pm](https://user-images.githubusercontent.com/11433468/93880083-39e04000-fd20-11ea-899a-fe055b26b7b1.png)
![Screen Shot 2020-09-22 at 10 04 38 pm](https://user-images.githubusercontent.com/11433468/93880093-3d73c700-fd20-11ea-8012-f5c5b7416386.png)

This PR fixes it by making the video take up the remaning width of the page.

![Screen Shot 2020-09-22 at 10 04 54 pm](https://user-images.githubusercontent.com/11433468/93880088-3c429a00-fd20-11ea-84f0-a8f8649ebffd.png)
![Screen Shot 2020-09-22 at 10 10 18 pm](https://user-images.githubusercontent.com/11433468/93880256-875cad00-fd20-11ea-8d1b-6c3498b83a4d.png)
