### PR TITLE
Update codelab-web.md

### DIFF
--- a/src/docs/get-started/codelab-web.md
+++ b/src/docs/get-started/codelab-web.md
@@ -450,7 +450,7 @@ Add the code below marked as NEW:
 ```dart
 ...
 return Form(
-  onChanged: _updateFormProgress, // NEW
+  onChanged: () => _updateFormProgress, // NEW
   child: Column(
 ...
 ```


### PR DESCRIPTION
When assigning the function _updateFormProgress() to the onChanged: property of the form, the current instructions in the example illegally assign the value of the returned function as opposed to the function itself so this line:

onChanged: _updateFormProgress(),

Needs to be changed to:

onChanged: () => _updateFormProgress(),

In order to make this code compile and run correctly.