### PR TITLE
Added a migration guide for TextSelectionTheme.

### DIFF
--- a/src/docs/release/breaking-changes/index.md
+++ b/src/docs/release/breaking-changes/index.md
@@ -18,6 +18,7 @@ release, and listed in alphabetical order:
 * [The new Form, FormField auto-validation API][]
 * [Cupertino icons 1.0.0][]
 * [Network Policy on iOS and Android][]
+* [TextSelectionTheme migration][]
 
 [Cupertino icons 1.0.0]: /docs/release/breaking-changes/cupertino-icons-1.0.0
 [Android v1 embedding app and plugin creation deprecation]: /docs/release/breaking-changes/android-v1-embedding-create-deprecation
@@ -26,6 +27,7 @@ release, and listed in alphabetical order:
 [The new Form, FormField auto-validation API]: /docs/release/breaking-changes/form-field-autovalidation-api
 [Network Policy on iOS and Android]: /docs/release/breaking-changes/network-policy-ios-android
 [Bottom Navigation Item Title]: /docs/release/breaking-changes/bottom-navigation-title-to-label
+[TextSelectionTheme migration]: /docs/release/breaking-changes/text-selection-theme
 
 ### Released in Flutter 1.20
 

--- a/src/docs/release/breaking-changes/text-selection-theme.md
+++ b/src/docs/release/breaking-changes/text-selection-theme.md
@@ -1,0 +1,115 @@
+---
+title: TextSelectionTheme migration
+description: The default properties for text selection are migrating to TextSelectionTheme.
+---
+
+## Summary
+
+The `ThemeData` properties that controlled the look of selected text in
+Material widgets have been moved into their own `TextSelectionTheme`. These
+properties include `cursorColor`, `textSelectionColor`, and
+`textSelectionHandleColor`. The defaults for these properties have also
+been changed to match the Material Design specification.
+
+## Context
+
+As part of the larger [Material Theme Updates][], we have introduced a new
+[Text Selection Theme][] used to specify the properties of selected text in
+`TextField` and `SelectableText` widgets. These replace several top-level
+properties of `ThemeData` and update their default values to match the Material
+Design specification. This document describes what applications will need to
+do to migrate to this new API.
+
+## Migration guide
+
+If you are currently using the following properties of `ThemeData`, you will
+need to update them to use the new equivalent properties on
+`ThemeData.textSelectionTheme`:
+
+| Before                               | After                                         |
+|--------------------------------------|-----------------------------------------------|
+| `ThemeData.cursorColor`              | `TextSelectionThemeData.cursorColor`          |
+| `ThemeData.textSelectionColor`       | `TextSelectionThemeData.selectionColor`       |
+| `ThemeData.textSelectionHandleColor` | `TextSelectionThemeData.selectionHandleColor` |
+
+<br/>
+**Code before migration:**
+
+<!-- skip -->
+```dart
+ThemeData(
+  cursorColor: Colors.red,
+  textSelectionColor: Colors.green,
+  textSelectionHandleColor: Colors.blue,
+)
+```
+
+**Code after migration:**
+
+<!-- skip -->
+```dart
+ThemeData(
+  textSelectionTheme: TextSelectionThemeData(
+    cursorColor: Colors.red,
+    selectionColor: Colors.green,
+    selectionHandleColor: Colors.blue,
+  )
+)
+```
+
+**Default changes**
+
+If you weren't using these properties explicitly, but depended on the previous
+default colors used for text selection you can add a new field to your
+`ThemeData` for your app to return to the old defaults:
+
+<!-- skip -->
+```dart
+// Old defaults for a light theme
+ThemeData(
+  textSelectionTheme: TextSelectionThemeData(
+    cursorColor: const Color.fromRGBO(66, 133, 244, 1.0),
+    selectionColor: const Color(0xff90caf9),
+    selectionHandleColor: const Color(0xff64b5f6),
+  )
+)
+```
+
+<!-- skip -->
+```dart
+// Old defaults for a dark theme
+ThemeData(
+  textSelectionTheme: TextSelectionThemeData(
+    cursorColor: const Color.fromRGBO(66, 133, 244, 1.0),
+    selectionColor: const Color(0xff64ffda),
+    selectionHandleColor: const Color(0xff1de9b6),
+  )
+)
+```
+
+If you are fine with the new defaults, but have failing golden file tests, you
+can update your master golden files using this command:
+
+```bash
+flutter test --update-goldens
+```
+
+## Timeline
+
+Landed in version: 1.23.0-4.0.pre<br>
+In stable release: 1.23
+
+## References
+
+API documentation:
+* [`TextSelectionThemeData`][]
+* [`ThemeData`][]
+
+Relevant PRs:
+* [PR 62014: TextSelectionTheme support][]
+
+[Material Theme Updates]: /go/material-theme-system-updates
+[PR 62014: TextSelectionTheme support]: {{site.github}}/flutter/flutter/pull/62014
+[Text Selection Theme]: /go/text-selection-theme
+[`TextSelectionThemeData`]: https://master-api.flutter.dev/flutter/material/TextSelectionThemeData-class.html
+[`ThemeData`]: {{site.api}}/flutter/material/ThemeData-class.html


### PR DESCRIPTION
Added a migration guide for the `TextSelectionTheme` breaking change described in: https://flutter.dev/go/text-selection-theme.

