### PR TITLE
Revert "Update codelab-web.md (#4649)"

### DIFF
--- a/src/docs/get-started/codelab-web.md
+++ b/src/docs/get-started/codelab-web.md
@@ -450,7 +450,7 @@ Add the code below marked as NEW:
 ```dart
 ...
 return Form(
-  onChanged: () => _updateFormProgress, // NEW
+  onChanged: _updateFormProgress, // NEW
   child: Column(
 ...
 ```


### PR DESCRIPTION
This reverts commit 97835468621bd182657c8b961f6b109af28a1b72.

As noted https://github.com/flutter/website/pull/4649#issuecomment-698659558, the original code is correct.

```dart
// Correct(Original)
onChanged: _updateFormProgress,
// Also correct 
onChanged: () => _updateFormProgress(),
// Wrong(#4649)
onChanged: () => _updateFormProgress,
```