### PR TITLE
What's new archive -> What's new

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -110,6 +110,7 @@
       { "source": "/using-packages", "destination": "/docs/development/packages-and-plugins/using-packages", "type": 301 },
       { "source": "/web-analogs", "destination": "/docs/get-started/flutter-for/web-devs", "type": 301 },
       { "source": "/webflutter.dev/web", "destination": "/web", "type": 301 },
+      { "source": "/docs/whats-new-archive", "destination": "/docs/whats-new", "type": 301 },
       { "source": "/widgets", "destination": "/docs/development/ui/widgets/catalog", "type": 301 },
       { "source": "/widgets/:rest*", "destination": "/docs/development/ui/widgets/:rest*", "type": 301 },
       { "source": "/widgets-intro", "destination": "/docs/development/ui/widgets-intro", "type": 301 },

--- a/src/docs/index.md
+++ b/src/docs/index.md
@@ -25,7 +25,7 @@ description: Get started with Flutter. Widgets, examples, updates, and API docs 
 ## What's new on this site
 
 To see changes to the site since our last release,
-see the [What's new archive][].
+see [What's new][].
 
 ## New to Flutter?
 
@@ -115,6 +115,6 @@ You might also find these docs useful:
 [Using packages]: /docs/development/packages-and-plugins/using-packages
 [videos]: /docs/resources/videos
 [Web]: /docs/get-started/flutter-for/web-devs
-[What's new archive]: /docs/whats-new-archive
+[What's new]: /docs/whats-new
 [Write your first Flutter app]: /docs/get-started/codelab
 [Xamarin.Forms]: /docs/get-started/flutter-for/xamarin-forms-devs

--- a/src/docs/whats-new.md
+++ b/src/docs/whats-new.md
@@ -1,10 +1,10 @@
 ---
-title: What's new archive
-description: An archive of what's new on the site.
+title: What’s new
+description: A list of what’s new on flutter.dev and related sites.
 ---
 
-This archive contains current and previous announcements of
-what's new on the site.
+This page contains current and previous announcements of
+what's new on the Flutter website and blog.
 
 To stay on top of Flutter announcements, including breaking changes,
 join the [flutter-announce][] Google group.


### PR DESCRIPTION
Since this page is no longer just an archive, and since I'm creating a What's new page for dart.dev, I thought I'd make them more parallel. Also, I used a curly quote in the title, since that seems to work and looks nicer.

Staged:

https://kw-flutter-1.firebaseapp.com/docs/whats-new-archive
https://kw-flutter-1.firebaseapp.com/docs/whats-new