### PR TITLE
Add another entry in iOS 14 changes to point out font rendering issues

### DIFF
--- a/src/docs/development/ios-14.md
+++ b/src/docs/development/ios-14.md
@@ -32,11 +32,11 @@ shown when building text fields.
 ## System font rendering
 
 If your iOS 14 app uses system fonts such as San Francisco (used by default
-by Cupertino widgets), text will not render correctly and will incorrectly
-be shown in a condensed letter spacing due to changes in iOS's font loading
-mechanism. This affects production apps on iOS 14.
+by Cupertino widgets), text will be incorrectly rendered in a condensed letter
+spacing due to changes in iOS's font loading mechanism. This affects debug and
+production apps on iOS 14.
 
-To ensure correct font renderer, you should build your production apps with
+To ensure correct font rendering, you should build your production apps with
 Flutter 1.22 beta.
 
 ## Debugging Flutter

--- a/src/docs/development/ios-14.md
+++ b/src/docs/development/ios-14.md
@@ -15,7 +15,7 @@ won't be able to launch apps (by using `flutter run`
 or a Flutter-enabled IDE) on physical iOS devices
 running iOS 14. This affects **debug**, **profile**, and
 **release** builds. Simulator builds, add-to-app modules,
-and running directly from Xcode are unaffected. 
+and running directly from Xcode are unaffected.
 
 Upgrading to Flutter 1.22 beta allows you to build,
 test, and deploy to iOS without issue. Upgrading to
@@ -26,15 +26,25 @@ but not debug.
 
 If your iOS 14 app uses text fields, you should build your
 production apps with Flutter 1.20 or the 1.22 beta to
-ensure that clipboard access notifications are not spuriously 
+ensure that clipboard access notifications are not spuriously
 shown when building text fields.
- 
+
+## System font rendering
+
+If your iOS 14 app uses system fonts such as San Francisco (used by default
+by Cupertino widgets), text will not render correctly and will incorrectly
+be shown in a condensed letter spacing due to changes in iOS's font loading
+mechanism. This affects production apps on iOS 14.
+
+To ensure correct font renderer, you should build your production apps with
+Flutter 1.22 beta.
+
 ## Debugging Flutter
 
 Due to added security around local network permissions in
 iOS 14, a permission dialog box must now be accepted for
 each application in order to enable Flutter debugging
-functionalities such as hot-reload and DevTools. 
+functionalities such as hot-reload and DevTools.
 
 ![Screenshot of "allow network connections" dialog]({% asset development/device-connect.png @path %})
 
@@ -45,7 +55,7 @@ by enabling **Settings > Privacy > Local Network > Your App**.
 For add-to-app users, one additional step has been added
 to the [add-to-app project setup guide][],
 to re-enable flutter attach for debug builds on physical
-devices on iOS 14. 
+devices on iOS 14.
 
 [add-to-app project setup guide]: /docs/development/add-to-app/ios/project-setup
 
@@ -56,10 +66,10 @@ debug application is installed on the device
 (either by using `flutter run` a Flutter-enabled IDE,
 or from Xcode), the application can no
 longer be re-launched by tapping the application’s icon
-in the home screen in iOS 14 on physical devices. 
+in the home screen in iOS 14 on physical devices.
 
 Other launch paths without a host computer, such as deep links
-or notifications, won't work on iOS 14 physical devices in debug mode. 
+or notifications, won't work on iOS 14 physical devices in debug mode.
 
 Add-to-app debug mode modules will crash on iOS 14
 physical devices when running the [`FlutterEngine`][]
@@ -67,10 +77,10 @@ if the host application is launched from the home screen.
 
 To launch the application in debug mode on a physical
 device again, re-run the app from the host computer
-(by using `flutter run`, a Flutter-enabled IDE, or Xcode). 
+(by using `flutter run`, a Flutter-enabled IDE, or Xcode).
 
 You can also build the application or add-to-app module in profile
-or release mode, or on a simulator, which are not affected. 
+or release mode, or on a simulator, which are not affected.
 
 See [Issue 60657][] for more details.
 


### PR DESCRIPTION
Just remembered that we had this issue https://github.com/flutter/flutter/issues/60013 and users should rebuild with Flutter 1.22 for correct font rendering.