### PR TITLE
:memo: Fixed a typo

### DIFF
--- a/src/docs/perf/rendering/ui-performance.md
+++ b/src/docs/perf/rendering/ui-performance.md
@@ -274,9 +274,6 @@ If the performance overlay shows red in the UI graph,
 start by profiling the Dart VM, even if the GPU graph
 also shows red.
 
-PENDING: Other than saying "debug with DevTools", what
-can be said here?
-
 ## Identifying problems in the GPU graph
 
 Sometimes a scene results in a layer tree that is easy to construct,


### PR DESCRIPTION
Page URL: https://flutter.dev/docs/perf/rendering/ui-performance.html
Page source: https://github.com/flutter/website/tree/master/src/docs/perf/rendering/ui-performance.md

Description of issue:
There's a "Pending" note in the section at https://flutter.dev/docs/perf/rendering/ui-performance#identifying-problems-in-the-ui-graph which doesn't seem to belong in production content.
<img width="1440" alt="Screenshot 2020-09-27 at 8 22 46 PM" src="https://user-images.githubusercontent.com/53955200/94367961-57861e80-00ff-11eb-9d6f-d2b88f4b850b.png">