### PR TITLE
Clarify Tickers

### DIFF
--- a/src/docs/development/ui/animations/overview.md
+++ b/src/docs/development/ui/animations/overview.md
@@ -139,13 +139,14 @@ A `Ticker` can be started and stopped. When started,
 it returns a `Future` that will resolve when it is stopped.
 
 Each tick, the `Ticker` provides the callback with the
-duration since the first tick after it was started.
+duration since the first tick after it was started. 
 
 Because tickers always give their elapsed time relative to the first
 tick after they were started, tickers are all synchronised. If you
-start three ticks at different times between two frames, they will all
+start three tickers at different times between two ticks, they will all
 nonetheless be synchronised with the same starting time, and will
-subsequently tick in lockstep.
+subsequently tick in lockstep. Like people at a bus-stop, all the tickers 
+will wait for a regularly occuring event (the tick) to begin moving (counting time).
 
 ### Simulations
 


### PR DESCRIPTION
Fixes #4199
Adds a metaphor to explain how tickers can tick simultaneously despite starting at different times. Also fixes some typos and misused terms. 
Please let me know if this isn't clear enough and how it can be made clearer. 