### PR TITLE
:memo: Issue #4586

### DIFF
--- a/src/_includes/dart-tool.md
+++ b/src/_includes/dart-tool.md
@@ -14,7 +14,7 @@
   support a similar `where` command.)
 
   ```terminal
-  $ which flutter dart
+  $ where flutter dart
   /path-to-flutter-sdk/bin/flutter
   /usr/local/bin/dart
   ```
@@ -29,7 +29,7 @@
   now come from the same directory.
 
   ```terminal
-  $ which flutter dart
+  $ where flutter dart
   /path-to-flutter-sdk/bin/flutter
   /path-to-flutter-sdk/bin/dart
   ```


### PR DESCRIPTION
Page URL: https://flutter.dev/docs/get-started/install/windows.html
Page source: https://github.com/flutter/website/tree/master/src/docs/get-started/install/windows.md

Description of issue:
Under the "Update your path" header, there is a note which tells us to run this command which flutter dart which is not available on Windows. I request you to change that to use the where command built into Windows. This will avoid confusion among Windows users.