### PR TITLE
:memo: New release version mismatch

### DIFF
--- a/src/docs/release/breaking-changes/cupertino-icons-1.0.0.md
+++ b/src/docs/release/breaking-changes/cupertino-icons-1.0.0.md
@@ -110,8 +110,8 @@ the automatically mapped new icons are suitable for your desired aesthetics.
 
 ## Timeline
 
-Landed in: 1.22.0-10.0.pre.65<br>
-In stable release: not yet
+Landed in: 1.22.0<br>
+In stable release: yes
 
 ## References
 


### PR DESCRIPTION
Fixes Issue #4791 
as suggested by @deandreamatias

Page URL: https://flutter.dev/docs/release/breaking-changes/cupertino-icons-1.0.0.html
Page source: https://github.com/flutter/website/tree/master/src/docs/release/breaking-changes/cupertino-icons-1.0.0.md

Description of issue:
In the Timeline section say:
Landed in: 1.22.0-10.0.pre.65
In stable release: not yet

But with a new release, will be said
Landed in: 1.22.0
In stable release: yes (?)
