### PR TITLE
Integration test advice for animated screens

### DIFF
--- a/src/docs/cookbook/testing/integration/introduction.md
+++ b/src/docs/cookbook/testing/integration/introduction.md
@@ -246,6 +246,23 @@ void main() {
 }
 ```
 
+By default, `flutter_driver` will wait until there are no pending frames,
+and thus tests similar to the example above will fail with a timeout if,
+for example, you have a continuous animation running.  In that case, wrap
+the driver actions in `runUnsynchronized` as follows:
+
+```dart
+test('increments the counter during animation', () async {
+  await driver.runUnsynchronized(() async {
+    // First, tap the button.
+    await driver.tap(buttonFinder);
+
+    // Then, verify the counter text is incremented by 1.
+    expect(await driver.getText(counterTextFinder), "1");
+  });
+});
+```
+
 ### 6. Run the tests
 
 Now that you have an instrumented app _and_ a test suite,

--- a/src/docs/cookbook/testing/integration/introduction.md
+++ b/src/docs/cookbook/testing/integration/introduction.md
@@ -246,11 +246,12 @@ void main() {
 }
 ```
 
-By default, `flutter_driver` will wait until there are no pending frames,
-and thus tests similar to the example above will fail with a timeout if,
+By default, `flutter_driver` waits until there are no pending frames,
+and tests similar to the example above fail with a timeout if,
 for example, you have a continuous animation running.  In that case, wrap
 the driver actions in `runUnsynchronized` as follows:
 
+<!-- skip -->
 ```dart
 test('increments the counter during animation', () async {
   await driver.runUnsynchronized(() async {


### PR DESCRIPTION
Changes proposed in this pull request:

*  Documents the need for runUnsychronized when using flutter_driver to test continuously animated screens.

Knowing this would've saved me quite a bit of time - and probably others too: https://github.com/flutter/flutter/issues/34503 , https://stackoverflow.com/questions/56492561/flutterdriver-problem-not-able-to-find-widget-by-key
