### PR TITLE
remove zip as a system requirement

### DIFF
--- a/src/docs/get-started/install/macos.md
+++ b/src/docs/get-started/install/macos.md
@@ -25,7 +25,6 @@ your development environment must meet these minimum requirements:
   - `rm`
   - `unzip`
   - `which`
-  - `zip`
 
 {% include_relative _get-sdk.md %}
 


### PR DESCRIPTION
We haven't actually required the `zip` binary in a long time, and yet the website still lists it as a macos dependency. This change removes it. This will likely not affect users, as `zip` comes installed on Mac OS X (this is why we use zip archives, rather than tarballs).