### PR TITLE
Fix navi highlighting, consistent releases links

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -230,7 +230,7 @@
             - title: Upgrading
               permalink: /docs/development/tools/sdk/upgrading
             - title: Releases
-              permalink: /docs/development/tools/sdk/archive
+              permalink: /docs/development/tools/sdk/releases
             - title: Breaking changes
               permalink: /docs/release/breaking-changes
             - title: Release notes

--- a/src/community/china.md
+++ b/src/community/china.md
@@ -11,7 +11,7 @@ Flutter website available at
 [https://flutter.cn](https://flutter.cn).
 
 If you’d like to install Flutter using an [installation
-bundle](/docs/development/tools/sdk/archive),
+bundle](/docs/development/tools/sdk/releases),
 you can replace the domain of the original URL with a trusted mirror
 to speed it up. For example:
 

--- a/src/docs/development/tools/sdk/upgrading.md
+++ b/src/docs/development/tools/sdk/upgrading.md
@@ -49,7 +49,7 @@ $ flutter upgrade
 
 {{site.alert.note}}
   If you need a specific version of the Flutter SDK,
-  you can download it from the [Flutter SDK archive][].
+  you can download it from the [Flutter SDK releases][].
 {{site.alert.end}}
 
 
@@ -95,7 +95,7 @@ $ flutter version v1.9.1+hotfix.3
 ```
 
 
-[Flutter SDK archive]: /docs/development/tools/sdk/archive
+[Flutter SDK releases]: /docs/development/tools/sdk/releases
 [release channels]: {{site.github}}/flutter/flutter/wiki/Flutter-build-release-channels
 [flutter-announce]: {{site.groups}}/forum/#!forum/flutter-announce
 [flutter-dev]: {{site.groups}}/forum/#!forum/flutter-dev

--- a/src/docs/get-started/install/_get-sdk-chromeos.md
+++ b/src/docs/get-started/install/_get-sdk-chromeos.md
@@ -14,7 +14,7 @@
     [(loading...)](#){:.download-latest-link-{{os}}.btn.btn-primary}
 
     For other release channels, and older builds,
-    see the [SDK archive][] page.
+    see the [SDK releases][] page.
 
  1. In the Files app, drag-and-drop the downloaded file from "Downloads"
     to "Linux Files" to access Flutter from your Linux container.
@@ -118,7 +118,7 @@ command again to verify that you’ve set everything up correctly.
 
 [Flutter repo]: {{site.github}}/flutter/flutter
 [Installing snapd]: https://snapcraft.io/docs/installing-snapd
-[SDK archive]: /docs/development/tools/sdk/archive
+[SDK releases]: /docs/development/tools/sdk/releases
 [Snap Store]: https://snapcraft.io/store
 [snapd]: https://snapcraft.io/flutter
 [Update your path]: #update-your-path

--- a/src/docs/get-started/install/_get-sdk-linux.md
+++ b/src/docs/get-started/install/_get-sdk-linux.md
@@ -35,7 +35,7 @@ install Flutter using the following steps.
     [(loading...)](#){:.download-latest-link-{{os}}.btn.btn-primary}
 
     For other release channels, and older builds,
-    see the [SDK archive][] page.
+    see the [SDK releases][] page.
 
  1. Extract the file in the desired location, for example:
 
@@ -137,6 +137,6 @@ command again to verify that you’ve set everything up correctly.
 [Flutter repo]: {{site.github}}/flutter/flutter
 [install Flutter using the Snap Store]: https://snapcraft.io/flutter
 [Installing snapd]: https://snapcraft.io/docs/installing-snapd
-[SDK archive]: /docs/development/tools/sdk/archive
+[SDK releases]: /docs/development/tools/sdk/releases
 [Update your path]: #update-your-path
 [Upgrading Flutter]: /docs/development/tools/sdk/upgrading

--- a/src/docs/get-started/install/_get-sdk-win.md
+++ b/src/docs/get-started/install/_get-sdk-win.md
@@ -6,7 +6,7 @@
     [(loading...)](#){:.download-latest-link-{{os}}.btn.btn-primary}
 
     For other release channels, and older builds, see the
-    [SDK archive][] page.
+    [SDK releases][] page.
  1. Extract the zip file and place the contained `flutter`
     in the desired installation location for the Flutter SDK
     (for example, `C:\src\flutter`).
@@ -86,5 +86,5 @@ verify that you’ve set everything up correctly.
 
 
 [Flutter repo]: {{site.github}}/flutter/flutter
-[SDK archive]: /docs/development/tools/sdk/archive
+[SDK releases]: /docs/development/tools/sdk/releases
 [Set up an editor]: /docs/get-started/editor?tab=androidstudio

--- a/src/docs/get-started/install/_get-sdk.md
+++ b/src/docs/get-started/install/_get-sdk.md
@@ -14,7 +14,7 @@
     [(loading...)](#){:.download-latest-link-{{os}}.btn.btn-primary}
 
     For other release channels, and older builds,
-    see the [SDK archive][] page.
+    see the [SDK releases][] page.
 
  1. Extract the file in the desired location, for example:
 
@@ -115,7 +115,7 @@ command again to verify that you’ve set everything up correctly.
 
 [Flutter repo]: {{site.github}}/flutter/flutter
 [Installing snapd]: https://snapcraft.io/docs/installing-snapd
-[SDK archive]: /docs/development/tools/sdk/archive
+[SDK releases]: /docs/development/tools/sdk/releases
 [Snap Store]: https://snapcraft.io/store
 [snapd]: https://snapcraft.io/flutter
 [Update your path]: #update-your-path

--- a/src/docs/whats-new.md
+++ b/src/docs/whats-new.md
@@ -474,7 +474,7 @@ We are updating DartPad to work with Flutter. Try our new
 [Basic Flutter layout codelab][] and tell us what you think!
 
 [Basic Flutter layout codelab]: /docs/codelabs/layout-basics
-[download the release]: /docs/development/tools/sdk/archive
+[download the release]: /docs/development/tools/sdk/releases
 [Flutter 1.5]: https://developers.googleblog.com/2019/05/Flutter-io19.html
 [1.5.4 release notes]: /docs/development/tools/sdk/release-notes/release-notes-1.5.4
 
@@ -512,7 +512,7 @@ If you have questions or comments about any of these docs,
 
 [Android Studio/IntelliJ]: /docs/development/tools/android-studio
 [different state management options]: /docs/development/data-and-backend/state-mgmt/options
-[download the release]: /docs/development/tools/sdk/archive
+[download the release]: /docs/development/tools/sdk/releases
 [ephemeral vs app state]: /docs/development/data-and-backend/state-mgmt/ephemeral-vs-app
 [file an issue]: {{site.repo.this}}/issues
 [introduction]: /docs/development/data-and-backend/state-mgmt/intro


### PR DESCRIPTION
Changes proposed in this pull request:

* Fix navi highlighting (see images)
* Make SDK releases links consistent by linking to `sdk/releases` instead of `sdk/archive` (`sdk/archive` is permanently redirected to `sdk/releases`, see https://github.com/flutter/website/blob/master/firebase.json#L92)

This menu entry should be highlighted:

![image](https://user-images.githubusercontent.com/326935/95254746-a67b3480-0820-11eb-9b3a-c67855d9adad.png)

This is how all other links are highlighted (I checked them all :))

![image](https://user-images.githubusercontent.com/326935/95254543-54d2aa00-0820-11eb-9ccc-ec3ac22ff2cb.png)
