### PR TITLE
Update iOS App Clip integration doc

### DIFF
--- a/src/docs/development/platform-integration/ios-app-clip.md
+++ b/src/docs/development/platform-integration/ios-app-clip.md
@@ -213,7 +213,7 @@ image="development/platform-integration/ios-app-clip/app-clip-framework-search.p
 
 **7.2**
 
-For Swift target, Set the `Objective-C Bridging Header` build setting to
+For Swift target, set the `Objective-C Bridging Header` build setting to
 `Runner/Runner-Bridging-Header.h`
 
 In other words, the same as the main app target's build settings.

--- a/src/docs/development/platform-integration/ios-app-clip.md
+++ b/src/docs/development/platform-integration/ios-app-clip.md
@@ -60,7 +60,8 @@ Select `UIKit App Delegate` for Life Cycle.
 
 Select the same language as your original target for Language.
 
-(Note: Don't create a Swift target for an Objective-C's project, and vice versa.)
+(In other words, don't create a Swift App Clip target for an Objective-C
+main target, and vice versa to simplify the setup.)
 
 {% include app-figure.md
 image="development/platform-integration/ios-app-clip/app-clip-details.png" %}
@@ -138,7 +139,7 @@ the App Clip, share the same code and assets.
 
 For each of the following: `Main.storyboard`, `Assets.xcassets`,
 `LaunchScreen.storyboard`, `GeneratedPluginRegistrant.m`, and
-`AppDelegate.swift` (and `Supporting Files/main.m` for Objective-C's target),
+`AppDelegate.swift` (and `Supporting Files/main.m` if using Objective-C),
 select the file, then in the first tab of the inspector,
 also include the App Clip target in the `Target Membership` checkbox group.
 

--- a/src/docs/development/platform-integration/ios-app-clip.md
+++ b/src/docs/development/platform-integration/ios-app-clip.md
@@ -58,6 +58,10 @@ Select `Storyboard` for Interface.
 
 Select `UIKit App Delegate` for Life Cycle.
 
+Select the same language as your original target for Language.
+
+(Note: Don't create a Swift target for an Objective-C's project, and vice versa.)
+
 {% include app-figure.md
 image="development/platform-integration/ios-app-clip/app-clip-details.png" %}
 
@@ -134,7 +138,8 @@ the App Clip, share the same code and assets.
 
 For each of the following: `Main.storyboard`, `Assets.xcassets`,
 `LaunchScreen.storyboard`, `GeneratedPluginRegistrant.m`, and
-`AppDelegate.swift`, select the file, then in the first tab of the inspector,
+`AppDelegate.swift` (and `Supporting Files/main.m` for Objective-C's target),
+select the file, then in the first tab of the inspector,
 also include the App Clip target in the `Target Membership` checkbox group.
 
 {% include app-figure.md
@@ -200,22 +205,22 @@ For setting `Framework Search Paths`, add 2 entries:
 - `$(inherited)`
 - `$(PROJECT_DIR)/Flutter`
 
+In other words, the same as the main app target's build settings.
+
 {% include app-figure.md
 image="development/platform-integration/ios-app-clip/app-clip-framework-search.png"
 %}
 
-In other words, the same as the main app target's build settings.
-
 **7.2**
 
-Set the `Objective-C Bridging Header` build setting to
+For Swift target, Set the `Objective-C Bridging Header` build setting to
 `Runner/Runner-Bridging-Header.h`
+
+In other words, the same as the main app target's build settings.
 
 {% include app-figure.md
 image="development/platform-integration/ios-app-clip/bridge-header.png"
 %}
-
-In other words, the same as the main app target's build settings.
 
 **7.3**
 
@@ -234,11 +239,11 @@ Expand the new phase and add this line to the script content:
 /bin/sh "$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh" build
 ```
 
+In other words, the same as the main app target's build phases.
+
 {% include app-figure.md
 image="development/platform-integration/ios-app-clip/xcode-backend-build.png"
 %}
-
-In other words, the same as the main app target's build phases.
 
 This ensures that your Flutter Dart code is compiled when running the App Clip
 target.
@@ -254,11 +259,11 @@ This time, add:
 /bin/sh "$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh" embed_and_thin
 ```
 
+In other words, the same as the main app target's build phases.
+
 {% include app-figure.md
 image="development/platform-integration/ios-app-clip/xcode-backend-embed.png"
 %}
-
-In other words, the same as the main app target's build phases.
 
 This ensures that your Flutter app and engine are embedded into the App Clip
 bundle.


### PR DESCRIPTION
Changes proposed in this pull request:

* Add more specific steps description for OC and Swift, avoid users create different language's target against the original target.
* Move sentences like `In other words, the same as the main app target's` to the position before screenshots, which will make users realized before they done reduplicate steps.

This case was recorded in hackers-mobile channel: https://discord.com/channels/608014603317936148/679803751414104087/763493383062552596