### PR TITLE
Removed obsolete button references from src/docs, examples

### DIFF
--- a/examples/internationalization/add_language/lib/main.dart
+++ b/examples/internationalization/add_language/lib/main.dart
@@ -341,7 +341,7 @@ class Home extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Center(
-        child: RaisedButton(
+        child: ElevatedButton(
           onPressed: () {
             // This would fail if localizations were not provided for the
             // app's locale. Although only a few Material widgets display

--- a/examples/state_mgmt/simple/lib/main.dart
+++ b/examples/state_mgmt/simple/lib/main.dart
@@ -59,7 +59,7 @@ class _Menu extends StatelessWidget {
       appBar: AppBar(title: Text('Simple state management')),
       body: Wrap(
         children: _routes.keys
-            .map((name) => FlatButton(
+            .map((name) => TextButton(
                 onPressed: () => Navigator.pushNamed(context, name),
                 child: Text(name)))
             .toList(growable: false),

--- a/examples/state_mgmt/simple/lib/src/passing_callbacks.dart
+++ b/examples/state_mgmt/simple/lib/src/passing_callbacks.dart
@@ -43,7 +43,7 @@ class MyListItem extends StatelessWidget {
     return Row(
       children: [
         Text('Item!'),
-        FlatButton(
+        TextButton(
           onPressed: () => callback(item),
           child: Text("Add"),
         ),

--- a/examples/state_mgmt/simple/lib/src/performance.dart
+++ b/examples/state_mgmt/simple/lib/src/performance.dart
@@ -89,7 +89,7 @@ class MyHomepage extends StatelessWidget {
 class NonRebuilding_Good extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return FlatButton(
+    return TextButton(
       onPressed: () => _onPressed(context),
       child: Text("Add"),
     );

--- a/examples/state_mgmt/simple/lib/src/provider.dart
+++ b/examples/state_mgmt/simple/lib/src/provider.dart
@@ -97,7 +97,7 @@ class MyCatalogItem extends StatelessWidget {
     return Row(
       children: [
         Text(item.name),
-        FlatButton(
+        TextButton(
           onPressed: () => myTapHandler(context),
           child: Text("Add ${item.name}"),
         ),

--- a/examples/state_mgmt/simple/test/widget_test.dart
+++ b/examples/state_mgmt/simple/test/widget_test.dart
@@ -19,7 +19,7 @@ void main() {
     await _visitPage(tester, '/callbacks');
     await _visitPage(tester, '/perf');
 
-    expect(await find.byType(FlatButton).evaluate().length, 4,
+    expect(await find.byType(TextButton).evaluate().length, 4,
         reason: "Smoke test was expecting a different number of pages to test. "
             "Please make sure you visit all the pages above.");
   });

--- a/src/docs/cookbook/animation/page-route-animation.md
+++ b/src/docs/cookbook/animation/page-route-animation.md
@@ -58,7 +58,7 @@ class Page1 extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(),
       body: Center(
-        child: RaisedButton(
+        child: ElevatedButton(
           child: Text('Go!'),
           onPressed: () {
             Navigator.of(context).push(_createRoute());
@@ -234,7 +234,7 @@ class Page1 extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(),
       body: Center(
-        child: RaisedButton(
+        child: ElevatedButton(
           child: Text('Go!'),
           onPressed: () {
             Navigator.of(context).push(_createRoute());

--- a/src/docs/cookbook/design/snackbars.md
+++ b/src/docs/cookbook/design/snackbars.md
@@ -115,7 +115,7 @@ class SnackBarPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: RaisedButton(
+      child: ElevatedButton(
         onPressed: () {
           final snackBar = SnackBar(
             content: Text('Yay! A SnackBar!'),

--- a/src/docs/cookbook/forms/validation.md
+++ b/src/docs/cookbook/forms/validation.md
@@ -66,7 +66,7 @@ class MyCustomFormState extends State<MyCustomForm> {
       key: _formKey,
       child: Column(
         children: <Widget>[
-              // Add TextFormFields and RaisedButton here.
+              // Add TextFormFields and ElevatedButton here.
         ]
      )
     );
@@ -123,7 +123,7 @@ If it isn't (the text field has no content) display the error message.
 
 <!-- skip -->
 ```dart
-RaisedButton(
+ElevatedButton(
   onPressed: () {
     // Validate returns true if the form is valid, otherwise false.
     if (_formKey.currentState.validate()) {
@@ -213,7 +213,7 @@ class MyCustomFormState extends State<MyCustomForm> {
           ),
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 16.0),
-            child: RaisedButton(
+            child: ElevatedButton(
               onPressed: () {
                 // Validate returns true if the form is valid, or false
                 // otherwise.

--- a/src/docs/cookbook/gestures/handling-taps.md
+++ b/src/docs/cookbook/gestures/handling-taps.md
@@ -51,7 +51,7 @@ GestureDetector(
      button, see the [Add Material touch ripples][] recipe.
   2. Although this example creates a custom button,
      Flutter includes a handful of button implementations, such as:
-     [`RaisedButton`][], [`FlatButton`][], and
+     [`ElevatedButton`][], [`TextButton`][], and
      [`CupertinoButton`][].
 
 ## Interactive example
@@ -121,6 +121,6 @@ class MyButton extends StatelessWidget {
 
 [Add Material touch ripples]: /docs/cookbook/gestures/ripples
 [`CupertinoButton`]: {{site.api}}/flutter/cupertino/CupertinoButton-class.html
-[`FlatButton`]: {{site.api}}/flutter/material/FlatButton-class.html
+[`TextButton`]: {{site.api}}/flutter/material/TextButton-class.html
 [`GestureDetector`]: {{site.api}}/flutter/widgets/GestureDetector-class.html
-[`RaisedButton`]: {{site.api}}/flutter/material/RaisedButton-class.html
+[`ElevatedButton`]: {{site.api}}/flutter/material/ElevatedButton-class.html

--- a/src/docs/cookbook/navigation/named-routes.md
+++ b/src/docs/cookbook/navigation/named-routes.md
@@ -46,7 +46,7 @@ class FirstScreen extends StatelessWidget {
         title: Text('First Screen'),
       ),
       body: Center(
-        child: RaisedButton(
+        child: ElevatedButton(
           child: Text('Launch screen'),
           onPressed: () {
             // Navigate to the second screen when tapped.
@@ -65,7 +65,7 @@ class SecondScreen extends StatelessWidget {
         title: Text("Second Screen"),
       ),
       body: Center(
-        child: RaisedButton(
+        child: ElevatedButton(
           onPressed: () {
             // Navigate back to first screen when tapped.
           },
@@ -168,7 +168,7 @@ class FirstScreen extends StatelessWidget {
         title: Text('First Screen'),
       ),
       body: Center(
-        child: RaisedButton(
+        child: ElevatedButton(
           child: Text('Launch screen'),
           onPressed: () {
             // Navigate to the second screen using a named route.
@@ -188,7 +188,7 @@ class SecondScreen extends StatelessWidget {
         title: Text("Second Screen"),
       ),
       body: Center(
-        child: RaisedButton(
+        child: ElevatedButton(
           onPressed: () {
             // Navigate back to the first screen by popping the current route
             // off the stack.

--- a/src/docs/cookbook/navigation/navigate-with-arguments.md
+++ b/src/docs/cookbook/navigation/navigate-with-arguments.md
@@ -114,7 +114,7 @@ arguments.
 ```dart
 // A button that navigates to a named route. The named route
 // extracts the arguments by itself.
-RaisedButton(
+ElevatedButton(
   child: Text("Navigate to screen that extracts arguments"),
   onPressed: () {
     // When the user taps the button, navigate to a named route
@@ -227,7 +227,7 @@ class HomeScreen extends StatelessWidget {
           children: <Widget>[
             // A button that navigates to a named route that. The named route
             // extracts the arguments by itself.
-            RaisedButton(
+            ElevatedButton(
               child: Text("Navigate to screen that extracts arguments"),
               onPressed: () {
                 // When the user taps the button, navigate to a named route
@@ -245,7 +245,7 @@ class HomeScreen extends StatelessWidget {
             // A button that navigates to a named route. For this route, extract
             // the arguments in the onGenerateRoute function and pass them
             // to the screen.
-            RaisedButton(
+            ElevatedButton(
               child: Text("Navigate to a named that accepts arguments"),
               onPressed: () {
                 // When the user taps the button, navigate to a named route

--- a/src/docs/cookbook/navigation/navigation-basics.md
+++ b/src/docs/cookbook/navigation/navigation-basics.md
@@ -54,7 +54,7 @@ class FirstRoute extends StatelessWidget {
         title: Text('First Route'),
       ),
       body: Center(
-        child: RaisedButton(
+        child: ElevatedButton(
           child: Text('Open route'),
           onPressed: () {
             // Navigate to second route when tapped.
@@ -73,7 +73,7 @@ class SecondRoute extends StatelessWidget {
         title: Text("Second Route"),
       ),
       body: Center(
-        child: RaisedButton(
+        child: ElevatedButton(
           onPressed: () {
             // Navigate back to first route when tapped.
           },
@@ -146,7 +146,7 @@ class FirstRoute extends StatelessWidget {
         title: Text('First Route'),
       ),
       body: Center(
-        child: RaisedButton(
+        child: ElevatedButton(
           child: Text('Open route'),
           onPressed: () {
             Navigator.push(
@@ -168,7 +168,7 @@ class SecondRoute extends StatelessWidget {
         title: Text("Second Route"),
       ),
       body: Center(
-        child: RaisedButton(
+        child: ElevatedButton(
           onPressed: () {
             Navigator.pop(context);
           },

--- a/src/docs/cookbook/navigation/returning-data.md
+++ b/src/docs/cookbook/navigation/returning-data.md
@@ -59,7 +59,7 @@ Now, create the SelectionButton, which does the following:
 class SelectionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return RaisedButton(
+    return ElevatedButton(
       onPressed: () {
         _navigateAndDisplaySelection(context);
       },
@@ -105,7 +105,7 @@ class SelectionScreen extends StatelessWidget {
           children: <Widget>[
             Padding(
               padding: const EdgeInsets.all(8.0),
-              child: RaisedButton(
+              child: ElevatedButton(
                 onPressed: () {
                   // Pop here with "Yep"...
                 },
@@ -114,7 +114,7 @@ class SelectionScreen extends StatelessWidget {
             ),
             Padding(
               padding: const EdgeInsets.all(8.0),
-              child: RaisedButton(
+              child: ElevatedButton(
                 onPressed: () {
                   // Pop here with "Nope"
                 },
@@ -141,7 +141,7 @@ Any result is returned to the `Future` in the SelectionButton.
 
 <!-- skip -->
 ```dart
-RaisedButton(
+ElevatedButton(
   onPressed: () {
     // The Yep button returns "Yep!" as the result.
     Navigator.pop(context, 'Yep!');
@@ -154,7 +154,7 @@ RaisedButton(
 
 <!-- skip -->
 ```dart
-RaisedButton(
+ElevatedButton(
   onPressed: () {
     // The Nope button returns "Nope!" as the result.
     Navigator.pop(context, 'Nope!');
@@ -214,7 +214,7 @@ class HomeScreen extends StatelessWidget {
 class SelectionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return RaisedButton(
+    return ElevatedButton(
       onPressed: () {
         _navigateAndDisplaySelection(context);
       },
@@ -253,7 +253,7 @@ class SelectionScreen extends StatelessWidget {
           children: <Widget>[
             Padding(
               padding: const EdgeInsets.all(8.0),
-              child: RaisedButton(
+              child: ElevatedButton(
                 onPressed: () {
                   // Close the screen and return "Yep!" as the result.
                   Navigator.pop(context, 'Yep!');
@@ -263,7 +263,7 @@ class SelectionScreen extends StatelessWidget {
             ),
             Padding(
               padding: const EdgeInsets.all(8.0),
-              child: RaisedButton(
+              child: ElevatedButton(
                 onPressed: () {
                   // Close the screen and return "Nope!" as the result.
                   Navigator.pop(context, 'Nope.');

--- a/src/docs/cookbook/networking/delete-data.md
+++ b/src/docs/cookbook/networking/delete-data.md
@@ -54,7 +54,7 @@ Future<Response> deleteAlbum(String id) async {
       'Content-Type': 'application/json; charset=UTF-8',
     },
   );
-  
+
   return response;
 }
 ```
@@ -84,7 +84,7 @@ Column(
   mainAxisAlignment: MainAxisAlignment.center,
   children: <Widget>[
     Text('${snapshot.data?.title ?? 'Deleted'}'),
-    RaisedButton(
+    ElevatedButton(
       child: Text('Delete Data'),
       onPressed: () {
        setState(() {
@@ -104,7 +104,7 @@ the same data that you fetched from the internet.
 ### Returning a response from the deleteAlbum() method
 Once the delete request has been made,
 you can return a response from the `deleteAlbum()`
-method to notify our screen that the data has been deleted. 
+method to notify our screen that the data has been deleted.
 
 <!-- skip -->
 ```dart
@@ -243,7 +243,7 @@ class _MyAppState extends State<MyApp> {
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: <Widget>[
                       Text('${snapshot.data?.title ?? 'Deleted'}'),
-                      RaisedButton(
+                      ElevatedButton(
                         child: Text('Delete Data'),
                         onPressed: () {
                           setState(() {
@@ -285,4 +285,3 @@ class _MyAppState extends State<MyApp> {
 [Mock dependencies using Mockito]: /docs/cookbook/testing/unit/mocking
 [JSON and serialization]: /docs/development/data-and-backend/json
 [`State`]: {{site.api}}/flutter/widgets/State-class.html
-

--- a/src/docs/cookbook/networking/send-data.md
+++ b/src/docs/cookbook/networking/send-data.md
@@ -38,7 +38,7 @@ Import the `http` package.
 import 'package:http/http.dart' as http;
 ```
 
-If you develop for android, add the following permission inside manifest tag in the AndroidManifest.xml file located at android/app/src/main. 
+If you develop for android, add the following permission inside manifest tag in the AndroidManifest.xml file located at android/app/src/main.
 
 ```xml
 <uses-permission android:name="android.permission.INTERNET"/>
@@ -159,11 +159,11 @@ server to create an album.
 ## 4. Get a title from user input
 
 Next, create a `TextField` to enter a title and
-a `RaisedButton` to send data to server.
+a `ElevatedButton` to send data to server.
 Also define a `TextEditingController` to read the
 user input from a `TextField`.
 
-When the `RaisedButton` is pressed, the `_futureAlbum`
+When the `ElevatedButton` is pressed, the `_futureAlbum`
 is set to the value returned by `createAlbum()` method.
 
 <!-- skip -->
@@ -178,7 +178,7 @@ Column(
         decoration: InputDecoration(hintText: 'Enter Title'),
       ),
     ),
-    RaisedButton(
+    ElevatedButton(
       child: Text('Create Data'),
       onPressed: () {
         setState(() {
@@ -312,7 +312,7 @@ class _MyAppState extends State<MyApp> {
                       controller: _controller,
                       decoration: InputDecoration(hintText: 'Enter Title'),
                     ),
-                    RaisedButton(
+                    ElevatedButton(
                       child: Text('Create Data'),
                       onPressed: () {
                         setState(() {
@@ -356,4 +356,3 @@ class _MyAppState extends State<MyApp> {
 [Mock dependencies using Mockito]: /docs/cookbook/testing/unit/mocking
 [JSON and serialization]: /docs/development/data-and-backend/json
 [`State`]: {{site.api}}/flutter/widgets/State-class.html
-

--- a/src/docs/cookbook/networking/update-data.md
+++ b/src/docs/cookbook/networking/update-data.md
@@ -177,12 +177,12 @@ the data from the internet.
 
 ## 5. Update the existing title from user input
 
-Create a `TextField` to enter a title and a `RaisedButton`
+Create a `TextField` to enter a title and a `ElevatedButton`
 to update the data on server.
 Also define a `TextEditingController` to
 read the user input from a `TextField`.
 
-When the `RaisedButton` is pressed,
+When the `ElevatedButton` is pressed,
 the `_futureAlbum` is set to the value returned by
 `updateAlbum()` method.
 
@@ -198,7 +198,7 @@ Column(
         decoration: InputDecoration(hintText: 'Enter Title'),
       ),
     ),
-    RaisedButton(
+    ElevatedButton(
       child: Text('Update Data'),
       onPressed: () {
         setState(() {
@@ -361,7 +361,7 @@ class _MyAppState extends State<MyApp> {
                         controller: _controller,
                         decoration: InputDecoration(hintText: 'Enter Title'),
                       ),
-                      RaisedButton(
+                      ElevatedButton(
                         child: Text('Update Data'),
                         onPressed: () {
                           setState(() {
@@ -401,4 +401,3 @@ class _MyAppState extends State<MyApp> {
 [JSON and serialization]: /docs/development/data-and-backend/json
 [Mock dependencies using Mockito]: /docs/cookbook/testing/unit/mocking
 [`State`]: {{site.api}}/flutter/widgets/State-class.html
-

--- a/src/docs/development/packages-and-plugins/using-packages.md
+++ b/src/docs/development/packages-and-plugins/using-packages.md
@@ -201,9 +201,9 @@ run `flutter pub upgrade`
 (**Upgrade dependencies** in IntelliJ or Android Studio)
 to retrieve the highest available version of the package
 that is allowed by the version constraint specified in
-`pubspec.yaml`. 
-Note that this is a different command from 
-`flutter upgrade` or `flutter update-packages`, 
+`pubspec.yaml`.
+Note that this is a different command from
+`flutter upgrade` or `flutter update-packages`,
 which both update Flutter itself.
 
 ### Dependencies on unpublished packages
@@ -367,7 +367,7 @@ To use this plugin:
       Widget build(BuildContext context) {
         return Scaffold(
           body: Center(
-            child: RaisedButton(
+            child: ElevatedButton(
               onPressed: launchURL,
               child: Text('Show Flutter homepage'),
             ),

--- a/src/docs/development/platform-integration/platform-channels.md
+++ b/src/docs/development/platform-integration/platform-channels.md
@@ -199,7 +199,7 @@ state in a string, and a button for refreshing the value.
         child: Column(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: [
-            RaisedButton(
+            ElevatedButton(
               child: Text('Get Battery Level'),
               onPressed: _getBatteryLevel,
             ),

--- a/src/docs/development/ui/advanced/gestures.md
+++ b/src/docs/development/ui/advanced/gestures.md
@@ -144,7 +144,7 @@ To listen to gestures from the widgets layer, use a
 
 If you're using Material Components,
 many of those widgets already respond to taps or gestures.
-For example, [`IconButton`][] and [`FlatButton`][]
+For example, [`IconButton`][] and [`TextButton`][]
 respond to presses (taps), and [`ListView`][]
 responds to swipes to trigger scrolling.
 If you are not using those widgets, but you want the
@@ -189,7 +189,7 @@ can be treated as a drag and the user won't need to wait for
 further gesture disambiguation.
 
 
-[`FlatButton`]: {{site.api}}/flutter/material/FlatButton-class.html
+[`TextButton`]: {{site.api}}/flutter/material/TextButton-class.html
 [`GestureDetector`]: {{site.api}}/flutter/widgets/GestureDetector-class.html
 [`IconButton`]: {{site.api}}/flutter/material/IconButton-class.html
 [`InkWell`]: {{site.api}}/flutter/material/InkWell-class.html

--- a/src/docs/development/ui/interactive.md
+++ b/src/docs/development/ui/interactive.md
@@ -741,11 +741,11 @@ the prefabricated widgets. Here's a partial list:
 
 * [`Checkbox`][]
 * [`DropdownButton`][]
-* [`FlatButton`][]
+* [`TextButton`][]
 * [`FloatingActionButton`][]
 * [`IconButton`][]
 * [`Radio`][]
-* [`RaisedButton`][]
+* [`ElevatedButton`][]
 * [`Slider`][]
 * [`Switch`][]
 * [`TextField`][]
@@ -781,7 +781,7 @@ Flutter Gallery [running app][], [repo][]
 [Dart language tour]: {{site.dart-site}}/guides/language/language-tour
 [Debugging Flutter apps]: /docs/testing/debugging
 [`DropdownButton`]: {{site.api}}/flutter/material/DropdownButton-class.html
-[`FlatButton`]: {{site.api}}/flutter/material/FlatButton-class.html
+[`TextButton`]: {{site.api}}/flutter/material/TextButton-class.html
 [`FloatingActionButton`]: {{site.api}}/flutter/material/FloatingActionButton-class.html
 [Flutter API documentation]: {{site.api}}
 [Flutter cookbook]: /docs/cookbook
@@ -812,7 +812,7 @@ Flutter Gallery [running app][], [repo][]
 [`meta.dart`]: {{site.pub}}/packages/meta
 [`pubspec.yaml`]: {{examples}}/layout/lakes/step6/pubspec.yaml
 [`Radio`]: {{site.api}}/flutter/material/Radio-class.html
-[`RaisedButton`]: {{site.api}}/flutter/material/RaisedButton-class.html
+[`ElevatedButton`]: {{site.api}}/flutter/material/ElevatedButton-class.html
 [repo]: {{site.repo.flutter}}/tree/master/dev/integration_tests/flutter_gallery
 [running app]: https://flutter.github.io/gallery/#/
 [set up]: /docs/get-started/install
@@ -825,4 +825,3 @@ Flutter Gallery [running app][], [repo][]
 [`TextField`]: {{site.api}}/flutter/material/TextField-class.html
 [`Text`]: {{site.api}}/flutter/widgets/Text-class.html
 [`widget`]: {{site.api}}/flutter/widgets/State/widget.html
-

--- a/src/docs/development/ui/widgets-intro.md
+++ b/src/docs/development/ui/widgets-intro.md
@@ -167,7 +167,7 @@ void main() {
 
 Be sure to have a `uses-material-design: true` entry in the `flutter`
 section of your `pubspec.yaml` file. It allows you to use the predefined
-set of [Material icons][]. It's generally a good idea to include this line 
+set of [Material icons][]. It's generally a good idea to include this line
 if you are using the Materials library.
 
 ```yaml
@@ -324,7 +324,7 @@ including taps, drags, and scales.
 
 Many widgets use a [`GestureDetector`][] to provide
 optional callbacks for other widgets. For example, the
-[`IconButton`][], [`RaisedButton`][], and
+[`IconButton`][], [`ElevatedButton`][], and
 [`FloatingActionButton`][] widgets have [`onPressed()`][]
 callbacks that are triggered when the user taps the widget.
 
@@ -343,7 +343,7 @@ to react in more interesting ways to user input&mdash;applications
 typically carry some state. Flutter uses `StatefulWidgets` to capture
 this idea. `StatefulWidgets` are special widgets that know how to generate
 `State` objects, which are then used to hold state.
-Consider this basic example, using the [`RaisedButton`][] mentioned earlier:
+Consider this basic example, using the [`ElevatedButton`][] mentioned earlier:
 
 ```dart
 class Counter extends StatefulWidget {
@@ -381,7 +381,7 @@ class _CounterState extends State<Counter> {
     // instances of widgets.
     return Row(
       children: <Widget>[
-        RaisedButton(
+        ElevatedButton(
           onPressed: _increment,
           child: Text('Increment'),
         ),
@@ -434,7 +434,7 @@ class CounterIncrementor extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return RaisedButton(
+    return ElevatedButton(
       onPressed: onPressed,
       child: Text('Increment'),
     );
@@ -765,10 +765,10 @@ For more information, see the [`GlobalKey`][] API.
 [Material icons]: https://design.google.com/icons/
 [`MaterialApp`]: {{api}}/material/MaterialApp-class.html
 [`Navigator`]: {{api}}/widgets/Navigator-class.html
-[`onPressed()`]: {{api}}/material/RaisedButton-class.html#onPressed
+[`onPressed()`]: {{api}}/material/ElevatedButton-class.html#onPressed
 [`onTap()`]: {{api}}/widgets/GestureDetector-class.html#onTap
 [`Positioned`]: {{api}}/widgets/Positioned-class.html
-[`RaisedButton`]: {{api}}/material/RaisedButton-class.html
+[`ElevatedButton`]: {{api}}/material/ElevatedButton-class.html
 [React]: https://reactjs.org
 [`RenderObject`]: {{api}}/rendering/RenderObject-class.html
 [`Row`]: {{api}}/widgets/Row-class.html

--- a/src/docs/get-started/codelab-web.md
+++ b/src/docs/get-started/codelab-web.md
@@ -214,9 +214,15 @@ class _SignUpFormState extends State<SignUpForm> {
               decoration: InputDecoration(hintText: 'Username'),
             ),
           ),
-          FlatButton(
-            color: Colors.blue,
-            textColor: Colors.white,
+          TextButton(
+            style: ButtonStyle(
+              foregroundColor: MaterialStateColor.resolveWith((Set<MaterialState> states) {
+                return states.contains(MaterialState.disabled) ? null : Colors.white;
+              }),
+              backgroundColor: MaterialStateColor.resolveWith((Set<MaterialState> states) {
+                return states.contains(MaterialState.disabled) ? null : Colors.blue;
+              }),
+            ),
             onPressed: null,
             child: Text('Sign up'),
           ),
@@ -321,14 +327,14 @@ and create a method to display it.
 `_SignUpFormState` class. This is the part of the code
 that builds the SignUp button.
 Notice how the button is defined:
-It’s a `FlatButton` with a blue background,
+It’s a `TextButton` with a blue background,
 white text that says **Sign up** and, when pressed,
 does nothing.
 </li>
 
 <li markdown="1">Update the `onPressed` property.<br>
 Change the `onPressed` property to call the (non-existent)
-method that will display the welcome screen. 
+method that will display the welcome screen.
 
 Change `onPressed: null` to the following:
 
@@ -465,9 +471,15 @@ screen only when the form is completely filled in:
 <!-- skip -->
 ```dart
 ...
-FlatButton(
-  color: Colors.blue,
-  textColor: Colors.white,
+TextButton(
+  style: ButtonStyle(
+    foregroundColor: MaterialStateColor.resolveWith((Set<MaterialState> states) {
+      return states.contains(MaterialState.disabled) ? null : Colors.white;
+    }),
+    backgroundColor: MaterialStateColor.resolveWith((Set<MaterialState> states) {
+      return states.contains(MaterialState.disabled) ? null : Colors.blue;
+    }),
+  ),
   onPressed: _formProgress == 1 ? _showWelcomeScreen : null, // UPDATED
   child: Text('Sign up'),
 ),
@@ -518,8 +530,8 @@ but becomes enabled when all three text fields contain
   ```dart
   onPressed: _formProgress == 1 ? _showWelcomeScreen : null,
   ```
-  This is a Dart conditional assignment and has the syntax: 
-  `condition ? expression1 : expression2`. 
+  This is a Dart conditional assignment and has the syntax:
+  `condition ? expression1 : expression2`.
   If the expression `_formProgress == 1` is true, the entire expression results
   in the value on the left hand side of the `:`, which is the
   `_showWelcomeScreen` method in this case.
@@ -771,7 +783,7 @@ with this new `AnimatedProgressIndicator`:
 ```
 
 This widget uses an `AnimatedBuilder` to animate the
-progress indicator to the latest value. 
+progress indicator to the latest value.
 </li>
 
 <li markdown="1">Run the app.<br>
@@ -894,9 +906,15 @@ class _SignUpFormState extends State<SignUpForm> {
               decoration: InputDecoration(hintText: 'Username'),
             ),
           ),
-          FlatButton(
-            color: Colors.blue,
-            textColor: Colors.white,
+          TextButton(
+            style: ButtonStyle(
+              foregroundColor: MaterialStateColor.resolveWith((Set<MaterialState> states) {
+                return states.contains(MaterialState.disabled) ? null : Colors.white;
+              }),
+              backgroundColor: MaterialStateColor.resolveWith((Set<MaterialState> states) {
+                return states.contains(MaterialState.disabled) ? null : Colors.blue;
+              }),
+            ),
             onPressed: _formProgress == 1 ? _showWelcomeScreen : null,
             child: Text('Sign up'),
           ),

--- a/src/docs/get-started/flutter-for/android-devs.md
+++ b/src/docs/get-started/flutter-for/android-devs.md
@@ -455,8 +455,8 @@ but you provide a different behavior&mdash;for example,
 custom layout logic.
 
 For example, how do you build a `CustomButton` that takes a label in
-the constructor? Create a CustomButton that composes a `RaisedButton` with
-a label, rather than by extending `RaisedButton`:
+the constructor? Create a CustomButton that composes a `ElevatedButton` with
+a label, rather than by extending `ElevatedButton`:
 
 <!-- skip -->
 ```dart
@@ -467,7 +467,7 @@ class CustomButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return RaisedButton(onPressed: () {}, child: Text(label));
+    return ElevatedButton(onPressed: () {}, child: Text(label));
   }
 }
 ```
@@ -1524,13 +1524,13 @@ the method 'setOnClickListener'.
 In Flutter there are two ways of adding touch listeners:
 
  1. If the Widget supports event detection, pass a function to it and handle it
-    in the function. For example, the RaisedButton has an `onPressed` parameter:
+    in the function. For example, the ElevatedButton has an `onPressed` parameter:
 
     <!-- skip -->
     ```dart
     @override
     Widget build(BuildContext context) {
-      return RaisedButton(
+      return ElevatedButton(
           onPressed: () {
             print("click");
           },
@@ -2230,7 +2230,7 @@ void main() {
     MaterialApp(
       home: Scaffold(
         body: Center(
-          child: RaisedButton(
+          child: ElevatedButton(
             onPressed: _incrementCounter,
             child: Text('Increment Counter'),
           ),

--- a/src/docs/get-started/flutter-for/ios-devs.md
+++ b/src/docs/get-started/flutter-for/ios-devs.md
@@ -463,7 +463,7 @@ Flutter, build a custom widget by
 
 For example, how do you build a `CustomButton` that takes a label in
 the constructor? Create a CustomButton that composes a
-`RaisedButton` with a label, rather than by extending `RaisedButton`:
+`ElevatedButton` with a label, rather than by extending `ElevatedButton`:
 
 <!-- skip -->
 ```dart
@@ -474,7 +474,7 @@ class CustomButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return RaisedButton(onPressed: () {}, child: Text(label));
+    return ElevatedButton(onPressed: () {}, child: Text(label));
   }
 }
 ```
@@ -1641,13 +1641,13 @@ In Flutter, there are two ways of adding touch listeners:
 
  1. If the widget supports event detection, pass a function to it,
     and handle the event in the function. For example, the
-    `RaisedButton` widget has an `onPressed` parameter:
+    `ElevatedButton` widget has an `onPressed` parameter:
 
     <!-- skip -->
     ```dart
     @override
     Widget build(BuildContext context) {
-      return RaisedButton(
+      return ElevatedButton(
         onPressed: () {
           print("click");
         },

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -558,7 +558,7 @@ reusable widget as shown in the `build` function in the following example.
 ```dart
 // Flutter
 class CustomCard extends StatelessWidget {
-  CustomCard({@required this.index, @required 
+  CustomCard({@required this.index, @required
      this.onPress});
 
   final index;
@@ -570,7 +570,7 @@ class CustomCard extends StatelessWidget {
       child: Column(
         children: <Widget>[
           Text('Card $index'),
-          FlatButton(
+          TextButton(
             child: const Text('Press'),
             onPressed: this.onPress,
           ),
@@ -796,7 +796,7 @@ style, touch handling, and accessibility controls.
 
 In Flutter, you can use the core layout widgets in the `Widgets`
 library, such as [`Container`][], [`Column`][],
-[`Row`][], and [`Center`][].  
+[`Row`][], and [`Center`][].
 For more information, see the [Layout Widgets][] catalog.
 
 ### What is the equivalent of `FlatList` or `SectionList`?
@@ -1084,7 +1084,7 @@ make sure to set `uses-material-design: true` in
 the project's `pubspec.yaml` file.
 This ensures that the `MaterialIcons` font,
 which displays the icons, is included in your app.
-In general, if you intend to use the Material library, 
+In general, if you intend to use the Material library,
 you should include this line.
 
 ```yaml
@@ -1319,7 +1319,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
             ),
             Padding(
               padding: EdgeInsets.only(top: 70.0),
-              child: RaisedButton(
+              child: ElevatedButton(
                 onPressed: toggleBlinkState,
                 child: (toggleState
                   ?( Text('Blink'))
@@ -1480,7 +1480,7 @@ class CustomCard extends StatelessWidget {
     child: Column(
       children: <Widget>[
         Text('Card $index'),
-        FlatButton(
+        TextButton(
           child: const Text('Press'),
           onPressed: this.onPress,
         ),
@@ -1802,7 +1802,7 @@ such as `Drawers`, `AppBars`, and `SnackBars`.
 The `Drawer` widget is a Material Design panel that slides
 in horizontally from the edge of a `Scaffold` to show navigation
 links in an application. You can
-provide a [`RaisedButton`][], a [`Text`][] widget,
+provide a [`ElevatedButton`][], a [`Text`][] widget,
 or a list of items to display as the child to the `Drawer` widget.
 In the following example, the [`ListTile`][]
 widget provides the navigation on tap.
@@ -2059,7 +2059,7 @@ TextField(
     hintText: 'Type something', labelText: 'Text Field '
   ),
 ),
-RaisedButton(
+ElevatedButton(
   child: Text('Submit'),
   onPressed: () {
     showDialog(
@@ -2114,7 +2114,7 @@ Form(
           labelText: 'Email',
         ),
       ),
-      RaisedButton(
+      ElevatedButton(
         onPressed: _submit,
         child: Text('Login'),
       ),
@@ -2410,11 +2410,11 @@ and common widget properties.
 <div class="table-wrapper" markdown="1">
 | React Native Component                                                                    | Flutter Widget                                                                                             | Description                                                                                                                            |
 | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| [`Button`](https://facebook.github.io/react-native/docs/button.html)                        | [`RaisedButton`][]                           | A basic raised button.                                                                              |
+| [`Button`](https://facebook.github.io/react-native/docs/button.html)                        | [`ElevatedButton`][]                           | A basic raised button.                                                                              |
 |                                                                                           |  onPressed [required]                                                                                        | The callback when the button is tapped or otherwise activated.                                                          |
 |                                                                                           | Child                                                                              | The button's label.                                                                                                      |
 |                                                                                           |                                                                                                            |                                                                                                                                        |
-| [`Button`](https://facebook.github.io/react-native/docs/button.html)                        | [`FlatButton`][]                               | A basic flat button.                                                                                                         |
+| [`Button`](https://facebook.github.io/react-native/docs/button.html)                        | [`TextButton`][]                               | A basic flat button.                                                                                                         |
 |                                                                                           |  onPressed [required]                                                                                        | The callback when the button is tapped or otherwise activated.                                                            |
 |                                                                                           | Child                                                                              | The button's label.                                                                                                      |
 |                                                                                           |                                                                                                            |                                                                                                                                        |
@@ -2523,7 +2523,7 @@ and common widget properties.
 [Flutter Widget Index]: /docs/reference/widgets
 [`FlutterLogo`]: {{site.api}}/flutter/material/FlutterLogo-class.html
 [`Form`]: {{site.api}}/flutter/widgets/Form-class.html
-[`FlatButton`]: {{site.api}}/flutter/material/FlatButton-class.html
+[`TextButton`]: {{site.api}}/flutter/material/TextButton-class.html
 [functions]: {{site.dart-site}}/guides/language/language-tour#functions
 [`Future`]: {{site.dart-site}}/tutorials/language/futures
 [`GestureDetector`]: {{site.api}}/flutter/widgets/GestureDetector-class.html
@@ -2552,7 +2552,7 @@ and common widget properties.
 [`PanResponder`]: https://facebook.github.io/react-native/docs/panresponder.html
 [pub.dev]: {{site.pub}}
 [`Radio`]: {{site.api}}/flutter/material/Radio-class.html
-[`RaisedButton`]: {{site.api}}/flutter/material/RaisedButton-class.html
+[`ElevatedButton`]: {{site.api}}/flutter/material/ElevatedButton-class.html
 [`RefreshIndicator`]: {{site.api}}/flutter/material/RefreshIndicator-class.html
 [`Route`]: {{site.api}}/flutter/widgets/Route-class.html
 [`Row`]: {{site.api}}/flutter/widgets/Row-class.html
@@ -2587,4 +2587,3 @@ and common widget properties.
 [variables]: {{site.dart-site}}/guides/language/language-tour#variables
 [`WidgetBuilder`]: {{site.api}}/flutter/widgets/WidgetBuilder.html
 [Write Your First Flutter App, Part 1]: {{site.codelabs}}/codelabs/first-flutter-app-pt1
-

--- a/src/docs/get-started/flutter-for/xamarin-forms-devs.md
+++ b/src/docs/get-started/flutter-for/xamarin-forms-devs.md
@@ -630,8 +630,8 @@ It is somewhat similar to implementing a custom control based off a
 custom logic.
 
 For example, how do you build a `CustomButton` that takes a label in
-the constructor? Create a CustomButton that composes a `RaisedButton`
-with a label, rather than by extending `RaisedButton`:
+the constructor? Create a CustomButton that composes a `ElevatedButton`
+with a label, rather than by extending `ElevatedButton`:
 
 <!-- skip -->
 ```dart
@@ -642,7 +642,7 @@ class CustomButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return RaisedButton(onPressed: () {}, child: Text(label));
+    return ElevatedButton(onPressed: () {}, child: Text(label));
   }
 }
 ```
@@ -1583,14 +1583,14 @@ tied to this event. Alternatively you would use the
 `TapGestureRecognizer`. In Flutter there are two very similar ways:
 
  1. If the widget supports event detection, pass a function to it and
-    handle it in the function. For example, the RaisedButton has an
+    handle it in the function. For example, the ElevatedButton has an
     `onPressed` parameter:
 
     <!-- skip -->
     ```dart
     @override
     Widget build(BuildContext context) {
-      return RaisedButton(
+      return ElevatedButton(
           onPressed: () {
             print("click");
           },
@@ -2509,4 +2509,3 @@ For more information on using the Firebase Cloud Messaging API, see the
 [Write your first Flutter app, part 1]: {{site.codelabs}}/codelabs/first-flutter-app-pt1
 [Write your first Flutter app, part 2]: {{site.codelabs}}/codelabs/first-flutter-app-pt2
 [write your own]: /docs/development/packages-and-plugins/developing-packages
-

--- a/src/docs/release/breaking-changes/layout-builder-optimization.md
+++ b/src/docs/release/breaking-changes/layout-builder-optimization.md
@@ -101,7 +101,7 @@ class _CounterState extends State<Counter> {
       child: LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
           return _ResizingBox(
-            FlatButton(
+            TextButton(
                 onPressed: () {
                   _counter++;
                 },
@@ -198,7 +198,7 @@ class _CounterState extends State<Counter> {
       child: LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
           return _ResizingBox(
-            FlatButton(
+            TextButton(
                 onPressed: () {
                   setState(() {
                     _counter++;

--- a/src/docs/release/breaking-changes/overlay-entry-rebuilds.md
+++ b/src/docs/release/breaking-changes/overlay-entry-rebuilds.md
@@ -53,7 +53,7 @@ class FooState extends State<Foo> {
   String buttonLabel = 'Click Me';
   @override
   Widget build(BuildContext context) {
-    return RaisedButton(
+    return ElevatedButton(
       onPressed: () async {
         // Illegal state modification that should be wrapped in setState.
         buttonLabel = await Navigator.pushNamed(context, '/bar');
@@ -72,7 +72,7 @@ class FooState extends State<Foo> {
   String buttonLabel = 'Click Me';
   @override
   Widget build(BuildContext context) {
-    return RaisedButton(
+    return ElevatedButton(
       onPressed: () async {
         final newLabel = await Navigator.pushNamed(context, '/bar');
         setState(() {

--- a/src/docs/release/breaking-changes/scrollable-alert-dialog.md
+++ b/src/docs/release/breaking-changes/scrollable-alert-dialog.md
@@ -145,8 +145,8 @@ AlertDialog(
     child: Text('Scrollable content', textScaleFactor: 5),
   ),
   actions: <Widget>[
-    FlatButton(child: Text('Button 1'), onPressed: () {}),
-    FlatButton(child: Text('Button 2'), onPressed: () {}),
+    TextButton(child: Text('Button 1'), onPressed: () {}),
+    TextButton(child: Text('Button 2'), onPressed: () {}),
   ],
 )
 ```
@@ -159,8 +159,8 @@ AlertDialog(
   title: Text('Very, very large title', textScaleFactor: 5),
   content: Text('Very, very large content', textScaleFactor: 5),
   actions: <Widget>[
-    FlatButton(child: Text('Button 1'), onPressed: () {}),
-    FlatButton(child: Text('Button 2'), onPressed: () {}),
+    TextButton(child: Text('Button 1'), onPressed: () {}),
+    TextButton(child: Text('Button 2'), onPressed: () {}),
   ],
 )
 ```

--- a/src/docs/resources/architectural-overview.md
+++ b/src/docs/resources/architectural-overview.md
@@ -224,7 +224,7 @@ class MyApp extends StatelessWidget {
                 children: [
                   Text('Hello World'),
                   SizedBox(height: 20),
-                  RaisedButton(
+                  ElevatedButton(
                     onPressed: () {
                       print('Click!');
                     },

--- a/src/docs/resources/faq.md
+++ b/src/docs/resources/faq.md
@@ -174,9 +174,9 @@ We measure our [test coverage][] on every commit.
 
 ### Does Flutter come with debugging tools?
 
-While Flutter doesn't ship with debugging tools, 
-there are many tools available that 
-can help you debug your Flutter application. 
+While Flutter doesn't ship with debugging tools,
+there are many tools available that
+can help you debug your Flutter application.
 Learn more about [debugging with Flutter][].
 
 ### Does Flutter come with a dependency injection framework or solution?
@@ -506,7 +506,7 @@ Rather than having each widget provide a large number of parameters,
 Flutter embraces composition. Widgets are built out of smaller
 widgets that you can reuse and combine in novel ways to make
 custom widgets. For example, rather than subclassing a generic
-button widget, `RaisedButton` combines a Material widget with a
+button widget, `ElevatedButton` combines a Material widget with a
 `GestureDetector` widget. The Material widget provides the visual
 design and the `GestureDetector` widget provides the interaction design.
 
@@ -692,8 +692,7 @@ In no particular order:
   small objects with narrow scopes of behavior, composed together to
   obtain more complicated effects. Most widgets in the Flutter widget
   library are built in this way. For example, the Material
-  [`FlatButton`][] class is built using a [`MaterialButton`][]
-  class, which itself is built using
+  [`TextButton`][] class is built using
   an [`IconTheme`][], an [`InkWell`][], a [`Padding`][],
   a [`Center`][], a [`Material`][],
   an [`AnimatedDefaultTextStyle`][], and a [`ConstrainedBox`][].
@@ -964,7 +963,7 @@ that Flutter apps can be deployed to Apple's App Store.
 [example of using isolates with Flutter]: {{site.github}}/flutter/flutter/blob/master/examples/layers/services/isolate.dart
 [example project]: {{site.github}}/flutter/flutter/tree/master/examples/platform_channel
 [Executing Dart in the Background with Flutter Plugins and Geofencing]: {{site.flutter-medium}}/executing-dart-in-the-background-with-flutter-plugins-and-geofencing-2b3e40a1a124
-[`FlatButton`]: {{site.api}}/flutter/material/FlatButton-class.html
+[`TextButton`]: {{site.api}}/flutter/material/TextButton-class.html
 [Flutter 1.0: Google's Portable UI Toolkit]: https://developers.googleblog.com/2018/12/flutter-10-googles-portable-ui-toolkit.html
 [flutter_view]: {{site.github}}/flutter/flutter/tree/master/examples/flutter_view
 [`Future`]: {{site.api}}/flutter/dart-async/Future-class.html

--- a/src/docs/testing/code-debugging.md
+++ b/src/docs/testing/code-debugging.md
@@ -142,7 +142,7 @@ class AppHome extends StatelessWidget {
   Widget build(BuildContext context) {
     return Material(
       child: Center(
-        child: FlatButton(
+        child: TextButton(
           onPressed: () {
             debugDumpApp();
           },
@@ -216,7 +216,7 @@ I/flutter ( 6559):                                           └_InkFeature([Glo
 I/flutter ( 6559):                                            └AnimatedDefaultTextStyle(duration: 200ms; inherit: false; color: Color(0xdd000000); family: "Roboto"; size: 14.0; weight: 400; baseline: alphabetic; state: _AnimatedDefaultTextStyleState(427742350; ticker inactive))
 I/flutter ( 6559):                                             └DefaultTextStyle(inherit: false; color: Color(0xdd000000); family: "Roboto"; size: 14.0; weight: 400; baseline: alphabetic)
 I/flutter ( 6559):                                              └Center(alignment: Alignment.center; renderObject: RenderPositionedBox)
-I/flutter ( 6559):                                               └FlatButton()
+I/flutter ( 6559):                                               └TextButton()
 I/flutter ( 6559):                                                └MaterialButton(state: _MaterialButtonState(398724090))
 I/flutter ( 6559):                                                 └ConstrainedBox(BoxConstraints(88.0<=w<=Infinity, h=36.0); renderObject: RenderConstrainedBox relayoutBoundary=up1)
 I/flutter ( 6559):                                                  └AnimatedDefaultTextStyle(duration: 200ms; inherit: false; color: Color(0xdd000000); family: "Roboto"; size: 14.0; weight: 500; baseline: alphabetic; state: _AnimatedDefaultTextStyleState(315134664; ticker inactive))
@@ -244,7 +244,7 @@ widgets' build functions. For example,
 
 Since the `debugDumpApp()` call is invoked when the button changes
 from being pressed to being released, it coincides with the
-[`FlatButton`][] object calling [`setState()`][]
+[`TextButton`][] object calling [`setState()`][]
 and thus marking itself dirty. That is why, when you look at the dump you
 should see that specific object marked as "dirty". You can also see what
 gesture listeners have been registered; in this case, a single
@@ -508,7 +508,7 @@ I/flutter ( 6559):            ╎                   │ widthFactor: expand
 I/flutter ( 6559):            ╎                   │ heightFactor: expand
 I/flutter ( 6559):            ╎                   │
 I/flutter ( 6559):            ╎                   └─child: RenderConstrainedBox relayoutBoundary=up1
-I/flutter ( 6559):            ╎                     │ creator: ConstrainedBox ← MaterialButton ← FlatButton ← Center ←
+I/flutter ( 6559):            ╎                     │ creator: ConstrainedBox ← MaterialButton ← TextButton ← Center ←
 I/flutter ( 6559):            ╎                     │   DefaultTextStyle ← AnimatedDefaultTextStyle ←
 I/flutter ( 6559):            ╎                     │   _InkFeature-[GlobalKey ink renderer] ←
 I/flutter ( 6559):            ╎                     │   NotificationListener<LayoutChangedNotification> ← DecoratedBox
@@ -522,7 +522,7 @@ I/flutter ( 6559):            ╎                     └─child: RenderSemanti
 I/flutter ( 6559):            ╎                       │ creator: _GestureSemantics ← RawGestureDetector ← GestureDetector
 I/flutter ( 6559):            ╎                       │   ← InkWell ← IconTheme ← DefaultTextStyle ←
 I/flutter ( 6559):            ╎                       │   AnimatedDefaultTextStyle ← ConstrainedBox ← MaterialButton ←
-I/flutter ( 6559):            ╎                       │   FlatButton ← Center ← DefaultTextStyle ← ⋯
+I/flutter ( 6559):            ╎                       │   TextButton ← Center ← DefaultTextStyle ← ⋯
 I/flutter ( 6559):            ╎                       │ parentData: <none>
 I/flutter ( 6559):            ╎                       │ constraints: BoxConstraints(88.0<=w<=411.4, h=36.0)
 I/flutter ( 6559):            ╎                       │ size: Size(98.0, 36.0)
@@ -531,7 +531,7 @@ I/flutter ( 6559):            ╎                       └─child: RenderPoint
 I/flutter ( 6559):            ╎                         │ creator: Listener ← _GestureSemantics ← RawGestureDetector ←
 I/flutter ( 6559):            ╎                         │   GestureDetector ← InkWell ← IconTheme ← DefaultTextStyle ←
 I/flutter ( 6559):            ╎                         │   AnimatedDefaultTextStyle ← ConstrainedBox ← MaterialButton ←
-I/flutter ( 6559):            ╎                         │   FlatButton ← Center ← ⋯
+I/flutter ( 6559):            ╎                         │   TextButton ← Center ← ⋯
 I/flutter ( 6559):            ╎                         │ parentData: <none>
 I/flutter ( 6559):            ╎                         │ constraints: BoxConstraints(88.0<=w<=411.4, h=36.0)
 I/flutter ( 6559):            ╎                         │ size: Size(98.0, 36.0)
@@ -601,9 +601,9 @@ sets its child's constraints to a loose version of this:
 there is room for the padding, and thus the [`RenderConstrainedBox`][]
 has a loose constraint of `BoxConstraints(0.0<=w<=395.4,
 0.0<=h<=667.4)`. This object, which the `creator` field tells us is
-probably part of the [`FlatButton`][]'s definition,
+probably part of the [`TextButton`][]'s definition,
 sets a minimum width of 88 pixels on its contents and a
-specific height of 36.0. (This is the `FlatButton` class implementing
+specific height of 36.0. (This is the `TextButton` class implementing
 the Material Design guidelines regarding button dimensions.)
 
 The inner-most `RenderPositionedBox` loosens the constraints again,
@@ -945,7 +945,7 @@ effect by using a [`GridPaper`][] widget directly.
 [`Center`]: {{site.api}}/flutter/widgets/Center-class.html
 [`RenderPadding`]: {{site.api}}/flutter/rendering/RenderPadding-class.html
 [`RenderConstrainedBox`]: {{site.api}}/flutter/rendering/RenderConstrainedBox-class.html
-[`FlatButton`]: {{site.api}}/flutter/material/FlatButton-class.html
+[`TextButton`]: {{site.api}}/flutter/material/TextButton-class.html
 [frame callback]: {{site.api}}/flutter/scheduler/SchedulerBinding/addPersistentFrameCallback.html
 [render-fill]: {{site.api}}/flutter/rendering/Layer/debugFillProperties.html
 [widget-fill]: {{site.api}}/flutter/widgets/Widget/debugFillProperties.html

--- a/src/docs/testing/oem-debuggers.md
+++ b/src/docs/testing/oem-debuggers.md
@@ -229,14 +229,14 @@ class _MyHomePageState extends State<MyHomePage> {
               padding: EdgeInsets.all(16.0),
               child: Text(toLaunch),
             ),
-            RaisedButton(
+            ElevatedButton(
               onPressed: () => setState(() {
                     _launched = _launchInBrowser(toLaunch);
                   }),
               child: Text('Launch in browser'),
             ),
             Padding(padding: EdgeInsets.all(16.0)),
-            RaisedButton(
+            ElevatedButton(
               onPressed: () => setState(() {
                     _launched = _launchInWebViewOrVC(toLaunch);
                   }),


### PR DESCRIPTION
Replaced uses of FlatButton with TextButton, RaisedButton with ElevatedButton, and OutlineButton with OutlinedButton per https://github.com/flutter/flutter/pull/59702.