### PR TITLE
Subscribe page: enable double opt for certain country codes

### DIFF
--- a/src/assets/js/subscribe.js
+++ b/src/assets/js/subscribe.js
@@ -1117,11 +1117,11 @@ submitEl.disabled = true;
 
 
 // Enable the submit button only when the checkbox is checked.
-devUpdatesElem.addEventListener("change", function() {
+devUpdatesElem.addEventListener("change", function () {
     if (this.checked) {
         submitEl.disabled = false;
     } else {
-        submitEl.disabled= true;
+        submitEl.disabled = true;
     }
 });
 
@@ -1158,8 +1158,17 @@ function submitForm() {
         data.FlutterDevUpdates = devUpdatesElem.checked == true ? "true" : "false";
     }
 
-    sendRequest(data);
+    if (isDoubleOptIn(countryEl.value)) {
+        console.log("double opt-in");
+        console.log(JSON.stringify(data));
+    }
 
+
+}
+
+function isDoubleOptIn(countryCode) {
+    let countries = ["AT", "DE", "GR", "LU", "NO"];
+    return countries.includes(countryCode);
 }
 
 function sendRequest(data) {

--- a/src/assets/js/subscribe.js
+++ b/src/assets/js/subscribe.js
@@ -1159,11 +1159,10 @@ function submitForm() {
     }
 
     if (isDoubleOptIn(countryEl.value)) {
-        console.log("double opt-in");
-        console.log(JSON.stringify(data));
+        data.FlutterDevUpdates = "unconfirmed";
     }
 
-
+    sendRequest(data);
 }
 
 function isDoubleOptIn(countryCode) {


### PR DESCRIPTION
Austria, Germany, Greece, Luxembourg, and Norway now require double-opt-in consent. 