### PR TITLE
Update obsolete button references in website/examples and src/

### DIFF
--- a/examples/animation/implicit/container0/lib/main.dart
+++ b/examples/animation/implicit/container0/lib/main.dart
@@ -40,12 +40,8 @@ class AnimatedContainerDemo extends StatelessWidget {
                 ),
               ),
             ),
-            MaterialButton(
-              color: Theme.of(context).primaryColor,
-              child: Text(
-                'change',
-                style: TextStyle(color: Colors.white),
-              ),
+            ElevatedButton(
+              child: Text('change'),
               onPressed: () => null,
             ),
           ],

--- a/examples/animation/implicit/container1/lib/main.dart
+++ b/examples/animation/implicit/container1/lib/main.dart
@@ -52,12 +52,8 @@ class _AnimatedContainerDemoState extends State<AnimatedContainerDemo> {
                 ),
               ),
             ),
-            MaterialButton(
-              color: Theme.of(context).primaryColor,
-              child: Text(
-                'change',
-                style: TextStyle(color: Colors.white),
-              ),
+            ElevatedButton(
+              child: Text('change'),
               onPressed: () => null,
             ),
           ],

--- a/examples/animation/implicit/container10/lib/main.dart
+++ b/examples/animation/implicit/container10/lib/main.dart
@@ -63,12 +63,8 @@ class _AnimatedContainerDemoState extends State<AnimatedContainerDemo> {
                 duration: _duration,
               ),
             ),
-            MaterialButton(
-              color: Theme.of(context).primaryColor,
-              child: Text(
-                'change',
-                style: TextStyle(color: Colors.white),
-              ),
+            ElevatedButton(
+              child: Text('change'),
               onPressed: () => change(),
             ),
           ],

--- a/examples/animation/implicit/container2/lib/main.dart
+++ b/examples/animation/implicit/container2/lib/main.dart
@@ -52,12 +52,8 @@ class _AnimatedContainerDemoState extends State<AnimatedContainerDemo> {
                 ),
               ),
             ),
-            MaterialButton(
-              color: Theme.of(context).primaryColor,
-              child: Text(
-                'change',
-                style: TextStyle(color: Colors.white),
-              ),
+            ElevatedButton(
+              child: Text('change'),
               onPressed: () => null,
             ),
           ],

--- a/examples/animation/implicit/container3/lib/main.dart
+++ b/examples/animation/implicit/container3/lib/main.dart
@@ -60,12 +60,8 @@ class _AnimatedContainerDemoState extends State<AnimatedContainerDemo> {
                 ),
               ),
             ),
-            MaterialButton(
-              color: Theme.of(context).primaryColor,
-              child: Text(
-                'change',
-                style: TextStyle(color: Colors.white),
-              ),
+            ElevatedButton(
+              child: Text('change'),
               onPressed: () => null,
             ),
           ],

--- a/examples/animation/implicit/container4/lib/main.dart
+++ b/examples/animation/implicit/container4/lib/main.dart
@@ -60,12 +60,8 @@ class _AnimatedContainerDemoState extends State<AnimatedContainerDemo> {
                 ),
               ),
             ),
-            MaterialButton(
-              color: Theme.of(context).primaryColor,
-              child: Text(
-                'change',
-                style: TextStyle(color: Colors.white),
-              ),
+            ElevatedButton(
+              child: Text('change'),
               onPressed: () => change(),
             ),
           ],

--- a/examples/animation/implicit/container5/lib/main.dart
+++ b/examples/animation/implicit/container5/lib/main.dart
@@ -63,12 +63,8 @@ class _AnimatedContainerDemoState extends State<AnimatedContainerDemo> {
                 duration: _duration,
               ),
             ),
-            MaterialButton(
-              color: Theme.of(context).primaryColor,
-              child: Text(
-                'change',
-                style: TextStyle(color: Colors.white),
-              ),
+            ElevatedButton(
+              child: Text('change'),
               onPressed: () => change(),
             ),
           ],

--- a/examples/animation/implicit/container6/lib/main.dart
+++ b/examples/animation/implicit/container6/lib/main.dart
@@ -64,12 +64,8 @@ class _AnimatedContainerDemoState extends State<AnimatedContainerDemo> {
                 curve: Curves.easeInOutBack,
               ),
             ),
-            MaterialButton(
-              color: Theme.of(context).primaryColor,
-              child: Text(
-                'change',
-                style: TextStyle(color: Colors.white),
-              ),
+            ElevatedButton(
+              child: Text('change'),
               onPressed: () => change(),
             ),
           ],

--- a/examples/animation/implicit/container9/lib/main.dart
+++ b/examples/animation/implicit/container9/lib/main.dart
@@ -40,12 +40,8 @@ class AnimatedContainerDemo extends StatelessWidget {
                 ),
               ),
             ),
-            MaterialButton(
-              color: Theme.of(context).primaryColor,
-              child: Text(
-                'change',
-                style: TextStyle(color: Colors.white),
-              ),
+            ElevatedButton(
+              child: Text('change'),
               onPressed: () => null,
             ),
           ],

--- a/examples/animation/implicit/opacity0/lib/main.dart
+++ b/examples/animation/implicit/opacity0/lib/main.dart
@@ -11,7 +11,7 @@ class FadeInDemo extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(children: <Widget>[
       Image.network(owl_url),
-      MaterialButton(
+      TextButton(
           child: Text(
             'Show Details',
             style: TextStyle(color: Colors.blueAccent),

--- a/examples/animation/implicit/opacity1/lib/main.dart
+++ b/examples/animation/implicit/opacity1/lib/main.dart
@@ -15,7 +15,7 @@ class _FadeInDemoState extends State<FadeInDemo> {
   Widget build(BuildContext context) {
     return Column(children: <Widget>[
       Image.network(owl_url),
-      MaterialButton(
+      TextButton(
           child: Text(
             'Show Details',
             style: TextStyle(color: Colors.blueAccent),

--- a/examples/animation/implicit/opacity10/lib/main.dart
+++ b/examples/animation/implicit/opacity10/lib/main.dart
@@ -17,7 +17,7 @@ class _FadeInDemoState extends State<FadeInDemo> {
   Widget build(BuildContext context) {
     return Column(children: <Widget>[
       Image.network(owl_url),
-      MaterialButton(
+      TextButton(
         child: Text(
           'Show Details',
           style: TextStyle(color: Colors.blueAccent),

--- a/examples/animation/implicit/opacity2/lib/main.dart
+++ b/examples/animation/implicit/opacity2/lib/main.dart
@@ -15,7 +15,7 @@ class _FadeInDemoState extends State<FadeInDemo> {
   Widget build(BuildContext context) {
     return Column(children: <Widget>[
       Image.network(owl_url),
-      MaterialButton(
+      TextButton(
           child: Text(
             'Show Details',
             style: TextStyle(color: Colors.blueAccent),

--- a/examples/animation/implicit/opacity3/lib/main.dart
+++ b/examples/animation/implicit/opacity3/lib/main.dart
@@ -17,7 +17,7 @@ class _FadeInDemoState extends State<FadeInDemo> {
   Widget build(BuildContext context) {
     return Column(children: <Widget>[
       Image.network(owl_url),
-      MaterialButton(
+      TextButton(
           child: Text(
             'Show Details',
             style: TextStyle(color: Colors.blueAccent),

--- a/examples/animation/implicit/opacity4/lib/main.dart
+++ b/examples/animation/implicit/opacity4/lib/main.dart
@@ -17,7 +17,7 @@ class _FadeInDemoState extends State<FadeInDemo> {
   Widget build(BuildContext context) {
     return Column(children: <Widget>[
       Image.network(owl_url),
-      MaterialButton(
+      TextButton(
           child: Text(
             'Show Details',
             style: TextStyle(color: Colors.blueAccent),

--- a/examples/animation/implicit/opacity5/lib/main.dart
+++ b/examples/animation/implicit/opacity5/lib/main.dart
@@ -17,7 +17,7 @@ class _FadeInDemoState extends State<FadeInDemo> {
   Widget build(BuildContext context) {
     return Column(children: <Widget>[
       Image.network(owl_url),
-      MaterialButton(
+      TextButton(
         child: Text(
           'Show Details',
           style: TextStyle(color: Colors.blueAccent),

--- a/examples/animation/implicit/opacity9/lib/main.dart
+++ b/examples/animation/implicit/opacity9/lib/main.dart
@@ -11,7 +11,7 @@ class FadeInDemo extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(children: <Widget>[
       Image.network(owl_url),
-      MaterialButton(
+      TextButton(
           child: Text(
             'Show Details',
             style: TextStyle(color: Colors.blueAccent),

--- a/src/_includes/implicit-animations/fade-in-complete.md
+++ b/src/_includes/implicit-animations/fade-in-complete.md
@@ -15,7 +15,7 @@ class _FadeInDemoState extends State<FadeInDemo> {
   Widget build(BuildContext context) {
     return Column(children: <Widget>[
       Image.network(owl_url),
-      MaterialButton(
+      TextButton(
         child: Text(
           'Show details',
           style: TextStyle(color: Colors.blueAccent),

--- a/src/_includes/implicit-animations/fade-in-starter-code.md
+++ b/src/_includes/implicit-animations/fade-in-starter-code.md
@@ -13,7 +13,7 @@ class _FadeInDemoState extends State<FadeInDemo> {
   Widget build(BuildContext context) {
     return Column(children: <Widget>[
       Image.network(owl_url),
-      MaterialButton(
+      TextButton(
           child: Text(
             'Show details',
             style: TextStyle(color: Colors.blueAccent),

--- a/src/_includes/implicit-animations/shape-shifting-complete.md
+++ b/src/_includes/implicit-animations/shape-shifting-complete.md
@@ -61,12 +61,8 @@ class _AnimatedContainerDemoState extends State<AnimatedContainerDemo> {
                 duration: _duration,
               ),
             ),
-            MaterialButton(
-              color: Theme.of(context).primaryColor,
-              child: Text(
-                'change',
-                style: TextStyle(color: Colors.white),
-              ),
+            ElevatedButton(
+              child: Text('change'),
               onPressed: () => change(),
             ),
           ],

--- a/src/_includes/implicit-animations/shape-shifting-starter-code.md
+++ b/src/_includes/implicit-animations/shape-shifting-starter-code.md
@@ -49,12 +49,8 @@ class _AnimatedContainerDemoState extends State<AnimatedContainerDemo> {
                 ),
               ),
             ),
-            MaterialButton(
-              color: Theme.of(context).primaryColor,
-              child: Text(
-                'change',
-                style: TextStyle(color: Colors.white),
-              ),
+            ElevatedButton(
+              child: Text('change'),
               onPressed: () => null,
             ),
           ],

--- a/src/_packages/dartpad_picker/web/dartpad_picker_main.dart
+++ b/src/_packages/dartpad_picker/web/dartpad_picker_main.dart
@@ -63,12 +63,8 @@ class _CounterState extends State<Counter> {
             Padding(
                 padding: const EdgeInsets.all(8.0),
                 child: Center(child: Text('$val'))),
-            MaterialButton(
-              color: Theme.of(context).primaryColor,
-              child: Text(
-                'Add',
-                style: TextStyle(color: Colors.white),
-              ),
+            ElevatedButton(
+              child: Text('Add'),
               onPressed: () => change(),
             ),
           ],

--- a/src/docs/codelabs/implicit-animations.md
+++ b/src/docs/codelabs/implicit-animations.md
@@ -142,7 +142,7 @@ the starting value for `opacity` to zero:
 
 Configure the animation to trigger when the user clicks the **Show details**
 button. To do this, change `opacity` state using the `onPressed()` handler for
-`MaterialButton`. To make the `FadeInDemo` widget become fully visible when
+`TextlButton`. To make the `FadeInDemo` widget become fully visible when
 the user clicks the **Show details** button, use the `onPressed()` handler
 to set `opacity` to 1:
 
@@ -153,7 +153,7 @@ to set `opacity` to 1:
 @@ -18,11 +18,14 @@
      return Column(children: <Widget>[
        Image.network(owl_url),
-       MaterialButton(
+       TextButton(
 -          child: Text(
 -            'Show Details',
 -            style: TextStyle(color: Colors.blueAccent),
@@ -361,7 +361,7 @@ between the old and new values:
 +                duration: _duration,
                ),
              ),
-             MaterialButton(
+             TextButton(
 ```
 
 ### Shape-shifting (complete)
@@ -400,7 +400,7 @@ and watch how the animation changes when you pass the
 +                curve: Curves.easeInOutBack,
                ),
              ),
-             MaterialButton(
+             ElevatedButton(
 ```
 
 Now that you have passed `easeInOutBack` as the value for `curve` to

--- a/src/docs/codelabs/implicit-animations.md
+++ b/src/docs/codelabs/implicit-animations.md
@@ -327,10 +327,10 @@ invoke the `change()` method in the `onPressed()` handler:
 ```diff
 --- container3/lib/main.dart
 +++ container4/lib/main.dart
-@@ -66,7 +66,7 @@
-                 'change',
-                 style: TextStyle(color: Colors.white),
-               ),
+@@ -62,7 +62,7 @@
+             ),
+             ElevatedButton(
+               child: Text('change'),
 -              onPressed: () => null,
 +              onPressed: () => change(),
              ),
@@ -361,7 +361,7 @@ between the old and new values:
 +                duration: _duration,
                ),
              ),
-             TextButton(
+             ElevatedButton(
 ```
 
 ### Shape-shifting (complete)

--- a/src/docs/development/ui/layout/constraints.md
+++ b/src/docs/development/ui/layout/constraints.md
@@ -82,7 +82,7 @@ The negotiation goes something like this:
 
 **Widget**: "Very well. My first child has position `x: 5` and `y: 5`,
    and my second child has `x: 80` and `y: 25`."
- 
+
 **Widget**: "Hey parent, I’ve decided that my size is going to be `300`
    pixels wide, and `60` pixels tall."
 
@@ -306,9 +306,12 @@ class Button extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialButton(
-        color: isSelected ? Colors.grey : Colors.grey[800],
-        child: Text(exampleNumber.toString(), style: TextStyle(color: Colors.white)),
+    return TextButton(
+        style: TextButton.styleFrom(
+          primary: Colors.white,
+          backgroundColor: isSelected ? Colors.grey : Colors.grey[800],
+        ),
+        child: Text(exampleNumber.toString()),
         onPressed: () {
           Scrollable.ensureVisible(
             context,
@@ -1212,9 +1215,9 @@ in the previous example.
 ```dart
 ConstrainedBox(
    constraints: BoxConstraints(
-      minWidth: 70, 
+      minWidth: 70,
       minHeight: 70,
-      maxWidth: 150, 
+      maxWidth: 150,
       maxHeight: 150,
    ),
    child: Container(color: Colors.red, width: 10, height: 10),
@@ -1240,13 +1243,13 @@ to also assume the size of the screen, thus ignoring its
 Center(
    child: ConstrainedBox(
       constraints: BoxConstraints(
-         minWidth: 70, 
+         minWidth: 70,
          minHeight: 70,
-         maxWidth: 150, 
+         maxWidth: 150,
          maxHeight: 150,
       ),
       child: Container(color: Colors.red, width: 10, height: 10),
-   )    
+   )
 )
 ```
 
@@ -1267,13 +1270,13 @@ so it ends up having 70 (the minimum).
 Center(
   child: ConstrainedBox(
      constraints: BoxConstraints(
-        minWidth: 70, 
+        minWidth: 70,
         minHeight: 70,
-        maxWidth: 150, 
+        maxWidth: 150,
         maxHeight: 150,
         ),
      child: Container(color: Colors.red, width: 1000, height: 1000),
-  )  
+  )
 )
 ```
 
@@ -1294,13 +1297,13 @@ so it ends up having 150 (the maximum).
 Center(
    child: ConstrainedBox(
       constraints: BoxConstraints(
-         minWidth: 70, 
+         minWidth: 70,
          minHeight: 70,
-         maxWidth: 150, 
+         maxWidth: 150,
          maxHeight: 150,
       ),
       child: Container(color: Colors.red, width: 100, height: 100),
-   ) 
+   )
 )
 ```
 
@@ -1384,8 +1387,8 @@ with no warnings given.
 ```dart
 UnconstrainedBox(
    child: Container(
-      color: Colors.red, 
-      width: double.infinity, 
+      color: Colors.red,
+      width: double.infinity,
       height: 100,
    )
 )
@@ -1408,9 +1411,9 @@ the following message: `BoxConstraints forces an infinite width.`
 UnconstrainedBox(
    child: LimitedBox(
       maxWidth: 100,
-      child: Container( 
+      child: Container(
          color: Colors.red,
-         width: double.infinity, 
+         width: double.infinity,
          height: 100,
       )
    )
@@ -1520,7 +1523,7 @@ and breaks the line so that it fits the screen.
 ```dart
 FittedBox(
    child: Container(
-      height: 20.0, 
+      height: 20.0,
       width: double.infinity,
    )
 )
@@ -1812,12 +1815,12 @@ Here is an example:
 
 Article by Marcelo Glasberg
 
-Marcelo originally published this content as 
+Marcelo originally published this content as
 [Flutter: The Advanced Layout Rule Even Beginners Must Know][]
 on Medium. We loved it and asked that he allow us to publish
 in on flutter.dev, to which he graciously agreed. Thanks, Marcelo!
 You can find Marcelo on [GitHub][] and [pub.dev][].
-  
+
 Also, thanks to [Simon Lightfoot][] for creating the
 header image at the top of the article.
 
@@ -1829,4 +1832,3 @@ header image at the top of the article.
 [pub.dev]: {{site.pub}}/publishers/glasberg.dev/packages
 [Simon Lightfoot]: {{site.github}}/slightfoot
 [this GitHub repo]: {{site.github}}/marcglasberg/flutter_layout_article
-

--- a/src/docs/get-started/flutter-for/android-devs.md
+++ b/src/docs/get-started/flutter-for/android-devs.md
@@ -190,10 +190,12 @@ The following example shows how to display a simple widget with padding:
         title: Text("Sample App"),
       ),
       body: Center(
-        child: MaterialButton(
+        child: ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            padding: EdgeInsets.only(left: 20.0, right: 30.0),
+          ),
           onPressed: () {},
           child: Text('Hello'),
-          padding: EdgeInsets.only(left: 10.0, right: 10.0),
         ),
       ),
     );
@@ -256,7 +258,7 @@ class _SampleAppPageState extends State<SampleAppPage> {
     if (toggle) {
       return Text('Toggle One');
     } else {
-      return MaterialButton(onPressed: () {}, child: Text('Toggle Two'));
+      return ElevatedButton(onPressed: () {}, child: Text('Toggle Two'));
     }
   }
 

--- a/src/docs/get-started/flutter-for/xamarin-forms-devs.md
+++ b/src/docs/get-started/flutter-for/xamarin-forms-devs.md
@@ -353,10 +353,12 @@ Widget build(BuildContext context) {
       title: Text("Sample App"),
     ),
     body: Center(
-      child: MaterialButton(
+      child: ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          padding: EdgeInsets.only(left: 20.0, right: 30.0),
+        ),
         onPressed: () {},
         child: Text('Hello'),
-        padding: EdgeInsets.only(left: 10.0, right: 10.0),
       ),
     ),
   );


### PR DESCRIPTION
Replaced obsolete example references to MaterialButton per https://github.com/flutter/flutter/pull/59702.

My editor removes trailing whitespace, so that happened as well. Hopefully that's a safe change.

### Substitutions

```dart
MaterialButton(
  color: Theme.of(context).primaryColor,
  child: Text(
    'change',
    style: TextStyle(color: Colors.white),
  ),
  ...
)
```
becomes
```dart
ElevatedButton(
  child: Text('change'),
  ...
)
```

```dart
MaterialButton(
  child: Text(
    'Show Details',
    style: TextStyle(color: Colors.blueAccent),
    ...
)
```
becomes
```dart
TextButton(
  child: Text(
    'Show Details',
    style: TextStyle(color: Colors.blueAccent),
    ...
)
```

And in src/docs/development/ui/layout/constraints.md:
```dart
MaterialButton(
  color: isSelected ? Colors.grey : Colors.grey[800],
  child: Text(exampleNumber.toString(), style: TextStyle(color: Colors.white)),
  ...
)
```
becomes
```dart
TextButton(
  style: TextButton.styleFrom(
    primary: Colors.white,
    backgroundColor: isSelected ? Colors.grey : Colors.grey[800],
  ),
  child: Text(exampleNumber.toString()),
  ...
)
```

