### PR TITLE
Added learn more cta to Green tea card

### DIFF
--- a/src/_data/showcases.yml
+++ b/src/_data/showcases.yml
@@ -285,6 +285,7 @@
     An internal customer management app used widely by Google sales that
     provides rich visualizations for tracking sales targets.
   logo_src: showcase/cards/green_tea-logo.png
+  learn_more_cta: Learn more
   logo_has_name: true
   learn_more_link: https://www.flutterx.com/google-greentea
   card_image: showcase/cards/green_tea-top@.jpg


### PR DESCRIPTION
Missing learn more link on the website for green tea app under https://flutter.dev/showcase.
<img width="325" alt="greentea" src="https://user-images.githubusercontent.com/35456759/96145611-065d9380-0f23-11eb-8b19-97c0d5e5571e.png">
