### PR TITLE
Add note for xcarchive command available in dev channel

### DIFF
--- a/src/docs/deployment/ios.md
+++ b/src/docs/deployment/ios.md
@@ -188,16 +188,42 @@ In Xcode, configure the app version and build:
 
 Finally, create a build archive and upload it to App Store Connect:
 
-1. Select **Product > Archive** to produce a build archive.
-1. In the sidebar of the Xcode Organizer window, select your iOS app,
-   then select the build archive you just produced.
-1. Click the **Validate App** button. If any issues are reported,
-   address them and produce another build. You can reuse the same
-   build ID until you upload an archive.
-1. After the archive has been successfully validated, click
-   **Distribute App**. You can follow the status of your build in the
-   Activities tab of your app's details page on
-   [App Store Connect][appstoreconnect_login].
+<ol markdown="1">
+<li markdown="1">
+
+Select **Product > Archive** to produce a build archive.
+
+{{site.alert.note}}
+  On Flutter version 1.23.0-18.0.pre and later
+  you can create an archive by running
+  `flutter build xcarchive`. Then open
+  `build/ios/archive/MyApp.xcarchive` in
+  Xcode to validate and distribute your app.
+{{site.alert.end}}
+
+</li>
+<li markdown="1">
+
+In the sidebar of the Xcode Organizer window, select your iOS app,
+then select the build archive you just produced.
+
+</li>
+<li markdown="1">
+
+Click the **Validate App** button. If any issues are reported,
+address them and produce another build. You can reuse the same
+build ID until you upload an archive.
+
+</li>
+<li markdown="1">
+
+After the archive has been successfully validated, click
+**Distribute App**. You can follow the status of your build in the
+Activities tab of your app's details page on
+[App Store Connect][appstoreconnect_login].
+
+</li>
+</ol>
 
 You should receive an email within 30 minutes notifying you that
 your build has been validated and is available to release to testers


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/67598 has reached the dev channel.
Add a note to the [iOS deployment docs](https://flutter.dev/docs/deployment/ios#create-a-build-archive).

Part of https://github.com/flutter/website/issues/4852.

The inlined `site.alert.note` required `<ol>` to keep the numbering.