### PR TITLE
Updating travis, submodules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,33 +32,39 @@ jobs:
 
     - name: "Dev channel: code check"
       env:
-        - TASK="flutter/bin/flutter channel dev && ./tool/check-code.sh"
+        - TASK="./tool/check-code.sh"
         - ALLOW_FAILURE=true
+        - CHANNEL=dev
 
     - name: "Dev channel: jekyll build"
       env:
-        - TASK="flutter/bin/flutter channel dev && bundle exec jekyll build"
+        - TASK="bundle exec jekyll build"
         - ALLOW_FAILURE=true
+        - CHANNEL=dev
 
     - name: "Beta channel: code check"
       env:
-        - TASK="flutter/bin/flutter channel beta && ./tool/check-code.sh"
+        - TASK="./tool/check-code.sh"
         - ALLOW_FAILURE=true
+        - CHANNEL=beta
 
     - name: "Beta channel: jekyll build"
       env:
-        - TASK="flutter/bin/flutter channel beta && bundle exec jekyll build"
+        - TASK="bundle exec jekyll build"
         - ALLOW_FAILURE=true
+        - CHANNEL=beta
 
     - name: "Stable channel: code check"
       env:
-        - TASK="flutter/bin/flutter channel stable && ./tool/check-code.sh"
+        - TASK="./tool/check-code.sh"
         - ALLOW_FAILURE=true
+        - CHANNEL=stable
 
     - name: "Stable channel: jekyll build"
       env:
-        - TASK="flutter/bin/flutter channel stable && bundle exec jekyll build"
+        - TASK="bundle exec jekyll build"
         - ALLOW_FAILURE=true
+        - CHANNEL=stable
 
 allow_failures:
   -env: ALLOW_FAILURE=true
@@ -69,6 +75,7 @@ env:
     - TZ=US/Pacific # normalize build timestamp
 
 before_install:
+  - if [[! -z $CHANNEL]]; then ./flutter/bin/flutter channel $CHANNEL; fi
   - source ./tool/env-set.sh
   - ./tool/before-install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ env:
     - TZ=US/Pacific # normalize build timestamp
 
 before_install:
-  - if [[ ! -z $CHANNEL]]; then ./flutter/bin/flutter channel $CHANNEL; fi
+  - if [[ ! -z $CHANNEL ]]; then ./flutter/bin/flutter channel $CHANNEL; fi
   - source ./tool/env-set.sh
   - ./tool/before-install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,21 @@ cache:
   - $HOME/.rvm
   - node_modules
 
+jobs:
+  include:
+    - name: "Submodule Flutter version: code check"
+      env:
+        - TASK="./tool/check-code.sh"
+
+    - name: "Submodule Flutter version: jekyll build"
+      env:
+        - TASK="bundle exec jekyll build"
+
+
 env:
   global:
     - JEKYLL_ENV=production
     - TZ=US/Pacific # normalize build timestamp
-  matrix:
-    - TASK="./tool/check-code.sh"
-    - TASK="bundle exec jekyll build"
 
 before_install:
   - source ./tool/env-set.sh
@@ -34,7 +42,6 @@ before_install:
 
 install:
   - ./tool/install.sh
-  # - ./tool/shared/write-ci-info.sh -v
 
 script: $TASK
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,8 @@ jobs:
         - ALLOW_FAILURE=true
         - CHANNEL=stable
 
-allow_failures:
-  -env: ALLOW_FAILURE=true
+  allow_failures:
+  - env: ALLOW_FAILURE=true
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ env:
     - TZ=US/Pacific # normalize build timestamp
 
 before_install:
-  - if [[! -z $CHANNEL]]; then ./flutter/bin/flutter channel $CHANNEL; fi
+  - if [[ ! -z $CHANNEL]]; then ./flutter/bin/flutter channel $CHANNEL; fi
   - source ./tool/env-set.sh
   - ./tool/before-install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,41 +33,41 @@ jobs:
     - name: "Dev channel: code check"
       env:
         - TASK="./tool/check-code.sh"
-        - ALLOW_FAILURE=true
+        - ALLOW_FAILURES=true
         - CHANNEL=dev
 
     - name: "Dev channel: jekyll build"
       env:
         - TASK="bundle exec jekyll build"
-        - ALLOW_FAILURE=true
+        - ALLOW_FAILURES=true
         - CHANNEL=dev
 
     - name: "Beta channel: code check"
       env:
         - TASK="./tool/check-code.sh"
-        - ALLOW_FAILURE=true
+        - ALLOW_FAILURES=true
         - CHANNEL=beta
 
     - name: "Beta channel: jekyll build"
       env:
         - TASK="bundle exec jekyll build"
-        - ALLOW_FAILURE=true
+        - ALLOW_FAILURES=true
         - CHANNEL=beta
 
     - name: "Stable channel: code check"
       env:
         - TASK="./tool/check-code.sh"
-        - ALLOW_FAILURE=true
+        - ALLOW_FAILURES=true
         - CHANNEL=stable
 
     - name: "Stable channel: jekyll build"
       env:
         - TASK="bundle exec jekyll build"
-        - ALLOW_FAILURE=true
+        - ALLOW_FAILURES=true
         - CHANNEL=stable
 
   allow_failures:
-  - env: ALLOW_FAILURE=true
+    - env: ALLOW_FAILURES=true
 
 env:
   global:
@@ -75,9 +75,9 @@ env:
     - TZ=US/Pacific # normalize build timestamp
 
 before_install:
-  - if [[ ! -z $CHANNEL ]]; then ./flutter/bin/flutter channel $CHANNEL; fi
   - source ./tool/env-set.sh
   - ./tool/before-install.sh
+  - if [[ ! -z $CHANNEL ]]; then ./flutter/bin/flutter channel $CHANNEL; fi
 
 install:
   - ./tool/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: dart
 dart: stable
+os: linux
+dist: xenial
 
 # Flutter depends on /usr/lib/x86_64-linux-gnu/libstdc++.so.6 version GLIBCXX_3.4.18
 # https://github.com/flutter/flutter/issues/6207
@@ -33,41 +35,40 @@ jobs:
     - name: "Dev channel: code check"
       env:
         - TASK="./tool/check-code.sh"
-        - ALLOW_FAILURES=true
         - CHANNEL=dev
 
     - name: "Dev channel: jekyll build"
       env:
         - TASK="bundle exec jekyll build"
-        - ALLOW_FAILURES=true
         - CHANNEL=dev
 
     - name: "Beta channel: code check"
       env:
         - TASK="./tool/check-code.sh"
-        - ALLOW_FAILURES=true
         - CHANNEL=beta
 
     - name: "Beta channel: jekyll build"
       env:
         - TASK="bundle exec jekyll build"
-        - ALLOW_FAILURES=true
         - CHANNEL=beta
 
     - name: "Stable channel: code check"
       env:
         - TASK="./tool/check-code.sh"
-        - ALLOW_FAILURES=true
         - CHANNEL=stable
 
     - name: "Stable channel: jekyll build"
       env:
         - TASK="bundle exec jekyll build"
-        - ALLOW_FAILURES=true
         - CHANNEL=stable
 
   allow_failures:
-    - env: ALLOW_FAILURES=true
+    - name: "Submodule commit: code check"
+    - name: "Submodule commit: jekyll build"
+    - name: "Dev channel: code check"
+    - name: "Dev channel: jekyll build"
+    - name: "Beta channel: code check"
+    - name: "Beta channel: jekyll build"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,46 @@ cache:
 
 jobs:
   include:
-    - name: "Submodule Flutter version: code check"
+    - name: "Submodule commit: code check"
       env:
         - TASK="./tool/check-code.sh"
 
-    - name: "Submodule Flutter version: jekyll build"
+    - name: "Submodule commit: jekyll build"
       env:
         - TASK="bundle exec jekyll build"
 
+    - name: "Dev channel: code check"
+      env:
+        - TASK="flutter/bin/flutter channel dev && ./tool/check-code.sh"
+        - ALLOW_FAILURE=true
+
+    - name: "Dev channel: jekyll build"
+      env:
+        - TASK="flutter/bin/flutter channel dev && bundle exec jekyll build"
+        - ALLOW_FAILURE=true
+
+    - name: "Beta channel: code check"
+      env:
+        - TASK="flutter/bin/flutter channel beta && ./tool/check-code.sh"
+        - ALLOW_FAILURE=true
+
+    - name: "Beta channel: jekyll build"
+      env:
+        - TASK="flutter/bin/flutter channel beta && bundle exec jekyll build"
+        - ALLOW_FAILURE=true
+
+    - name: "Stable channel: code check"
+      env:
+        - TASK="flutter/bin/flutter channel stable && ./tool/check-code.sh"
+        - ALLOW_FAILURE=true
+
+    - name: "Stable channel: jekyll build"
+      env:
+        - TASK="flutter/bin/flutter channel stable && bundle exec jekyll build"
+        - ALLOW_FAILURE=true
+
+allow_failures:
+  -env: ALLOW_FAILURE=true
 
 env:
   global:

--- a/src/adoptawidget/index.md
+++ b/src/adoptawidget/index.md
@@ -113,14 +113,14 @@ directory](https://github.com/flutter/flutter/tree/master/dev/snippets/config/te
 
 ```dart
 /// {@tool sample --template=stateless_widget_scaffold_center}
-/// 
+///
 /// This is a comment explaining the snippet below:
 ///
 /// ```dart
 ///  Widget build(BuildContext context) {
 ///    return MyWidget(
 ///      color: Colors.green,
-///    ); 
+///    );
 ///  }
 /// ```
 /// {@end-tool}
@@ -135,14 +135,14 @@ directory](https://github.com/flutter/flutter/tree/master/dev/snippets/config/te
 
 ```dart
 /// {@tool dartpad --template=stateless_widget_material}
-/// 
+///
 /// This is a comment explaining the snippet below:
 ///
 /// ```dart
 ///  Widget build(BuildContext context) {
 ///    return MyWidget(
 ///      color: Colors.green,
-///    ); 
+///    );
 ///  }
 /// ```
 /// {@end-tool}
@@ -273,7 +273,7 @@ closes #1234
 {{site.alert.note}}
   If you are a first-time contributor to this repo, you will be asked to sign
   Google's [Contributor License
-  Agreement](https://cla.developers.google.com/about/google-corporate). 
+  Agreement](https://cla.developers.google.com/about/google-corporate).
 {{site.alert.end}}
 
 ## More resources


### PR DESCRIPTION
* Shards the travis configuration into eight jobs. The jekyll build and code check are each run on these four Flutter versions:
  - Whatever commit the submodule is checked in with
  - dev
  - beta
  - stable
* Stable is not allowed to fail, but the other versions are.
* Updates the Adopt-a-Widget page to remove some whitespace that was causing tests to fail.
* Updates the Flutter submodule to the latest stable commit.