### PR TITLE
Link from release notes to hotfixes page

### DIFF
--- a/src/docs/development/tools/sdk/release-notes/index.md
+++ b/src/docs/development/tools/sdk/release-notes/index.md
@@ -4,12 +4,16 @@ short-title: release notes
 description: Release notes for Flutter for prior releases.
 ---
 
-Release notes for the following releases to the stable channel:
+This page links to announcements and release notes for
+releases to the stable channel.
+For information about bug-fix releases like 1.22.1, see
+[Hotfixes to the Stable Channel][].
+
+[Hotfixes to the Stable Channel]: https://github.com/flutter/flutter/wiki/Hotfixes-to-the-Stable-Channel
 
 * 1.22.0
   * [1.22.0 announcement][]
   * [1.22.0 release notes & change log][] 
-
 * 1.20.0
   * [1.20.0 announcement][]
   * [1.20.0 release notes & change log][]

--- a/src/docs/development/tools/sdk/release-notes/release-notes-1.22.0.md
+++ b/src/docs/development/tools/sdk/release-notes/release-notes-1.22.0.md
@@ -3,10 +3,14 @@ title: Flutter 1.22.0 release notes
 short-title: 1.22.0 release notes
 description: Release notes for Flutter 1.22.0.
 ---
+
+This page has release notes for 1.22.0.
+For information about subsequent bug-fix releases, see
+[Hotfixes to the Stable Channel][].
+
+[Hotfixes to the Stable Channel]: https://github.com/flutter/flutter/wiki/Hotfixes-to-the-Stable-Channel
+
 ## Merged PRs by labels for `flutter/flutter` 
-
-
-
 
 ### framework - 428 pull request(s)
 


### PR DESCRIPTION
We've been getting 404s for the 1.21.1 release, so clearly some people want information about non-x.x.0 releases. This change should help people find the info they want.