### PR TITLE
Document feature: Printing suggesting finders

### DIFF
--- a/src/docs/cookbook/testing/widget/finders.md
+++ b/src/docs/cookbook/testing/widget/finders.md
@@ -16,6 +16,10 @@ classes. While it's possible to write your own `Finder` classes,
 it's generally more convenient to locate widgets using the tools
 provided by the [`flutter_test`][] package.
 
+During a `flutter run` session on a widget test, you can also
+interactively tap parts of the screen for the Flutter tool to
+print the suggested [`Finder`]
+
 This recipe looks at the [`find`][] constant provided by
 the `flutter_test` package, and demonstrates how
 to work with some of the `Finders` it provides.


### PR DESCRIPTION
During a `flutter run` session on a widget test, tapping the screen while the app is idle will print suggested finders to the console.

It seems that documenting this feature got removed at some point: (https://github.com/flutter/website/commit/62a119a0831e5ea769e1e885ccd9421313ddde58#diff-119a4672ffea5f2bc6cf7bd54066b5fa4173db34d07c64b53ecd5db8df3b22c7L169)

I'm not sure if this is the best place for this blurb to go, perhaps elsewhere or in the summary section would be a better location. Feedback welcome!