### PR TITLE
Add CupertinoSearchTextField to Cupertino widget library

### DIFF
--- a/src/_data/catalog/widgets.json
+++ b/src/_data/catalog/widgets.json
@@ -506,6 +506,16 @@
     "image": "<img alt='' src='/images/widget-catalog/cupertino-scrollbar.png'>"
   },
   {
+    "name": "CupertinoSearchTextField",
+    "description": "An iOS-style search field.",
+    "categories": [
+      "Cupertino (iOS-style widgets)"
+    ],
+    "subcategories": [],
+    "link": "https://api.flutter.dev/flutter/cupertino/CupertinoSearchTextField-class.html",
+    "image": "<img alt='' src='/images/widget-catalog/cupertino-search-field.png'>"
+  },
+  {
     "name": "CupertinoSegmentedControl",
     "description": "An iOS-style segmented control. Used to select mutually exclusive options in a horizontal list.",
     "categories": [


### PR DESCRIPTION
Waiting for https://github.com/flutter/website/pull/4928 to merge before this is merged.

Adds a tile to the cupertino widget library.

<img width="314" alt="cupertino-search-field" src="https://user-images.githubusercontent.com/11810973/97487178-bebf0a80-1919-11eb-88d1-2dbd5fae0cfe.png">

