### PR TITLE
Updated names from Xcode settings

### DIFF
--- a/src/docs/deployment/ios.md
+++ b/src/docs/deployment/ios.md
@@ -104,9 +104,9 @@ In the **Signing & Capabilities** section:
   account. If required, select **Add Account...**,
   then update this setting.
 
-In the **Deployment Info** section:
+In the **Build Settings** section:
 
-`Deployment Target`
+`iOS Deployment Target`
 : The minimum iOS version that your app supports.
   Flutter supports iOS 8.0 and later. If your app includes
   Objective-C or Swift code that makes use of APIs that


### PR DESCRIPTION
Changes proposed in this pull request:
*  It's "Build Settings, not "Deployment Info".
* It's "iOS Deployment Target", not just "Deployment Target".

Here's a screenshot from Xcode 12.1:

<img width="683" alt="image" src="https://user-images.githubusercontent.com/1061209/97566104-3a828b00-19de-11eb-8541-01b49fa62b79.png">

