### PR TITLE
Fix menu item name

### DIFF
--- a/src/docs/deployment/ios.md
+++ b/src/docs/deployment/ios.md
@@ -182,7 +182,7 @@ In Xcode, configure the app version and build:
 
 1. In Xcode, open `Runner.xcworkspace` in your app's `ios` folder.
 1. Select **Product > Scheme > Runner**.
-1. Select **Product > Destination > Generic iOS Device**.
+1. Select **Product > Destination > Any iOS Device**.
 1. Select **Runner** in the Xcode project navigator, then select the
    **Runner** target in the settings view sidebar.
 1. In the Identity section, update the **Version** to the user-facing


### PR DESCRIPTION
Changes proposed in this pull request:
*  Fix Xcode menu item name from "Generic iOS Device" to "Any iOS Device". That's what it shows in Xcode 12.1 for me:

<img width="599" alt="image" src="https://user-images.githubusercontent.com/1061209/97590660-c0aacb80-19f6-11eb-82bd-01eaf0aefb76.png">

