### PR TITLE
Fix Width of Searchbar

### DIFF
--- a/src/_assets/css/_base.scss
+++ b/src/_assets/css/_base.scss
@@ -204,3 +204,10 @@ dd {
 .table-wrapper {
   overflow-x: auto;
 }
+
+.searchbar {
+  > * {
+    max-width: 640px;
+    width:100%
+  }
+}

--- a/src/search-all.html
+++ b/src/search-all.html
@@ -12,7 +12,7 @@ Use this search when you want results from multiple Flutter-related sites.
 Want only results from flutter.dev? <a href="/search">Search flutter.dev.</a>
 </p>
 
-<div class="d-flex">
+<div class="d-flex searchbar">
   <script async src="https://cse.google.com/cse.js?cx=011220921317074318178:deii8vtsimy"></script>
   <div class="gcse-search"></div>
 </div>

--- a/src/search.html
+++ b/src/search.html
@@ -8,7 +8,7 @@ toc: false
 Want results from additional Flutter-related sites, like api.flutter.dev and dart.dev?
 <a href="/search-all">Search more sites.</a>
 
-<div class="d-flex">
+<div class="d-flex searchbar">
   <script async src="https://cse.google.com/cse.js?cx=011220921317074318178:qhv1ojyoytz"></script>
   <div class="gcse-search"></div>
 </div>


### PR DESCRIPTION
NOTE: We love contributions, but we hate spam. If your PR doesn't improve flutter.dev, we'll close it and label it as `invalid`.

Related to #4016

Changes proposed in this pull request:

Brings over @johnpryan 's changes on the Dart website to the searchbar on /search and /search-all to fix the width problems.

Not sure if this the issue should be closed or not, because there are other changes listed on the issue that need to be made and I can't tell if they've already been done. 
