### PR TITLE
Updated Flutter platform view demo for iOS Swift

### DIFF
--- a/src/docs/development/platform-integration/platform-views.md
+++ b/src/docs/development/platform-integration/platform-views.md
@@ -445,12 +445,12 @@ import UIKit
 
 class FLNativeViewFactory: NSObject, FlutterPlatformViewFactory {
     private var messenger: FlutterBinaryMessenger
-    
+
     init(messenger: FlutterBinaryMessenger) {
         self.messenger = messenger
         super.init()
     }
-    
+
     func create(
         withFrame frame: CGRect,
         viewIdentifier viewId: Int64,
@@ -466,7 +466,7 @@ class FLNativeViewFactory: NSObject, FlutterPlatformViewFactory {
 
 class FLNativeView: NSObject, FlutterPlatformView {
     private var _view: UIView
-    
+
     init(
         frame: CGRect,
         viewIdentifier viewId: Int64,
@@ -476,18 +476,18 @@ class FLNativeView: NSObject, FlutterPlatformView {
         _view = UIView()
         super.init()
     }
-    
+
     func view() -> UIView {
         // This function returns a UIView and you can add native iOS UI here.
         _view.backgroundColor = UIColor.blue
-        
+
         let nativeLabel = UILabel()
         nativeLabel.text = "Native text from iOS"
         nativeLabel.textColor = UIColor.white
         nativeLabel.textAlignment = .center
         nativeLabel.frame = _view.frame
         _view.addSubview(nativeLabel)
-        
+
         return _view
     }
 }

--- a/src/docs/development/platform-integration/platform-views.md
+++ b/src/docs/development/platform-integration/platform-views.md
@@ -475,20 +475,22 @@ class FLNativeView: NSObject, FlutterPlatformView {
     ) {
         _view = UIView()
         super.init()
+        // iOS views can be created here
+        createNativeView(view: _view)
     }
 
     func view() -> UIView {
-        // This function returns a UIView and you can add native iOS UI here.
-        _view.backgroundColor = UIColor.blue
+        return _view
+    }
 
+    func createNativeView(view _view: UIView){
+        _view.backgroundColor = UIColor.blue
         let nativeLabel = UILabel()
         nativeLabel.text = "Native text from iOS"
         nativeLabel.textColor = UIColor.white
         nativeLabel.textAlignment = .center
-        nativeLabel.frame = _view.frame
+        nativeLabel.frame = CGRect(x: 0, y: 0, width: 180, height: 48.0)
         _view.addSubview(nativeLabel)
-
-        return _view
     }
 }
 ```

--- a/src/docs/development/platform-integration/platform-views.md
+++ b/src/docs/development/platform-integration/platform-views.md
@@ -444,13 +444,13 @@ import Flutter
 import UIKit
 
 class FLNativeViewFactory: NSObject, FlutterPlatformViewFactory {
-    private weak var messenger: FlutterBinaryMessenger
-
+    private var messenger: FlutterBinaryMessenger
+    
     init(messenger: FlutterBinaryMessenger) {
-        super.init()
         self.messenger = messenger
+        super.init()
     }
-
+    
     func create(
         withFrame frame: CGRect,
         viewIdentifier viewId: Int64,
@@ -466,18 +466,28 @@ class FLNativeViewFactory: NSObject, FlutterPlatformViewFactory {
 
 class FLNativeView: NSObject, FlutterPlatformView {
     private var _view: UIView
-
+    
     init(
         frame: CGRect,
         viewIdentifier viewId: Int64,
         arguments args: Any?,
         binaryMessenger messenger: FlutterBinaryMessenger?
     ) {
-        super.init()
         _view = UIView()
+        super.init()
     }
-
+    
     func view() -> UIView {
+        // This function returns a UIView and you can add native iOS UI here.
+        _view.backgroundColor = UIColor.blue
+        
+        let nativeLabel = UILabel()
+        nativeLabel.text = "Native text from iOS"
+        nativeLabel.textColor = UIColor.white
+        nativeLabel.textAlignment = .center
+        nativeLabel.frame = _view.frame
+        _view.addSubview(nativeLabel)
+        
         return _view
     }
 }
@@ -497,12 +507,12 @@ import UIKit
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]?
     ) -> Bool {
-        GeneratedPluginRegistrant.register(withRegistry: self)
+        GeneratedPluginRegistrant.register(with: self)
 
         weak var registrar = self.registrar(forPlugin: "plugin-name")
 
-        let factory = FLNativeViewFactory(messenger: registrar?.messenger)
-        self.registrar(forPlugin: "<plugin-name>").register(
+        let factory = FLNativeViewFactory(messenger: registrar!.messenger())
+        self.registrar(forPlugin: "<plugin-name>")!.register(
             factory,
             withId: "<platform-view-type>")
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)


### PR DESCRIPTION
**FLNativeViewFactory.swift**
Calling `super.init()` before `_view = UIView()` causes errors, swapped.
Added demo on how [UIView](https://developer.apple.com/documentation/uikit/uiview) can be modified inside `view()` function.

**AppDelegate.swift**
Added unwrap on `registrar! `, and changed function call from `messenger` to `messenger()`
`GeneratedPluginRegistrant.register(with: self)` expected argument is `with` instead of `withRegistry`

**FLPlugin.swift**
Changed function call from `registrar.messenger` to `registrar.messenger()`

Expected output when demo is run on iOS:

<img width="359" alt="Screen Shot 2020-11-05 at 12 20 55 AM" src="https://user-images.githubusercontent.com/4143153/98137310-d2133c80-1efc-11eb-9104-7098fa9df132.png">

Fixes [#67393](https://github.com/flutter/flutter/issues/67393).

Changes proposed in this pull request:

Proposed changes mentioned above. Copy-pasting this iOS Swift sample should now run without issues on Xcode. 