### PR TITLE
Remove reference to flutter version command

### DIFF
--- a/src/docs/development/tools/sdk/upgrading.md
+++ b/src/docs/development/tools/sdk/upgrading.md
@@ -84,17 +84,6 @@ You can also ask questions on the [Flutter dev mailing list][flutter-dev].
 Aside from subscribing to receive announcements,
 we'd love to hear from you!
 
-
-## Selecting a specific version
-
-If you have a specific version of Flutter that you'd like to switch to,
-you can use the `flutter version` command:
-
-```terminal
-$ flutter version v1.9.1+hotfix.3
-```
-
-
 [Flutter SDK releases]: /docs/development/tools/sdk/releases
 [release channels]: {{site.github}}/flutter/flutter/wiki/Flutter-build-release-channels
 [flutter-announce]: {{site.groups}}/forum/#!forum/flutter-announce


### PR DESCRIPTION
Fixes #4935

Changes proposed in this pull request:

*  Remove the section in the "Upgrading Flutter" page that discusses `flutter version`. The page already has a note that tells users how to properly switch to a specific version. Thus, there's no reason to continue presenting this outdated information. 
