### PR TITLE
Add deprecation lifetime to website

### DIFF
--- a/src/docs/resources/compatibility.md
+++ b/src/docs/resources/compatibility.md
@@ -38,6 +38,13 @@ break them overnight. This is independent of our compatibility policy
 which is exclusively based on whether submitted tests fail, as
 described above.
 
+Deprecated APIs are removed after a migration grace period. This grace
+period is one calendar year after being released on the stable channel,
+or after 4 stable releases, whichever is longer.
+
+When a deprecation does reach end of life, we follow the same procedures
+listed above for making breaking changes in removing the deprecated API.
+
 
 ## Dart and other libraries used by Flutter
 


### PR DESCRIPTION
An updated deprecation policy has been published. This change will update the website to reflect it. :)

Public Design doc: https://docs.google.com/document/d/1Gc3ecrMghzc7WU4pgzKB8uBaTPpRdWfozn0otBbxR7s/edit?ts=5fa1e61f
Public announcement: https://groups.google.com/g/flutter-announce/c/b11MPSUohyY
Deprecation policy on the wiki: https://github.com/flutter/flutter/wiki/Tree-hygiene#deprecation