### PR TITLE
Update migration guide for ScaffoldMessenger

### DIFF
--- a/src/docs/release/breaking-changes/scaffold-messenger.md
+++ b/src/docs/release/breaking-changes/scaffold-messenger.md
@@ -20,7 +20,8 @@ errors if `showSnackBar` would be called in the course of executing an asynchron
 The `ScaffoldMessenger` now handles `SnackBar`s in order to persist across routes and always be
 displayed on the current `Scaffold`. By default, a root `ScaffoldMessenger` is included in the
 `MaterialApp`, but you can create your own controlled scope for the `ScaffoldMessenger` to further
-control _which_ `Scaffold`s receive your `SnackBar`s. 
+control _which_ `Scaffold`s receive your `SnackBar`s. The scope is particularly important when
+working with nested `Scaffolds`s, discussed further below.
 
 
 ## Description of change
@@ -95,6 +96,22 @@ Typically, the ScaffoldMessenger widget is introduced by the MaterialApp
 at the top of your application widget tree.
 ```
 
+The `ScaffoldMessenger` will also assert if attempting to show `SnackBar`s to nested `Scaffold`s. If
+a nested set of `Scaffold`s were to share the same `ScaffoldMessenger`, then duplicate `SnackBar`s
+could appear in your UI. In order to control the scope of `SnackBar`s and which `Scaffold`s receive
+them, place a `ScaffoldMessenger` in between. When tryin to present a `SnackBar` in this situation,
+the follow assertion error will be thrown:
+
+```
+Nested Scaffolds have registered with the ScaffoldMessenger.
+If nested Scaffolds were to share the same ScaffoldMessenger, then
+all would receive a SnackBar at the same time, resulting in multiple
+SnackBars in your UI.
+This is typically resolved by putting a ScaffoldMessenger in
+between the levels of nested Scaffolds. Doing so will set a separate
+SnackBar scope for these Scaffolds.'
+```
+
 ## Migration guide
 
 Code before migration:
@@ -103,8 +120,8 @@ Code before migration:
 ```dart
 // The ScaffoldState of the current context was used for managing SnackBars.
 Scaffold.of(context).showSnackBar(mySnackBar);
-Scaffold.of(context).hideCurrentSnackBar(mySnackBar);
-Scaffold.of(context).removeCurrentSnackBar(mySnackBar);
+Scaffold.of(context).hideCurrentSnackBar();
+Scaffold.of(context).removeCurrentSnackBar();
 
 // If a Scaffold.key is specified, the ScaffoldState can be directly
 // accessed without first obtaining it from a BuildContext via
@@ -117,9 +134,8 @@ Scaffold(
 );
 
 scaffoldKey.currentState.showSnackBar(mySnackBar);
-scaffoldKey.currentState.hideCurrentSnackBar(mySnackBar);
-scaffoldKey.currentState.removeCurrentSnackBar(mySnackBar);
-
+scaffoldKey.currentState.hideCurrentSnackBar();
+scaffoldKey.currentState.removeCurrentSnackBar();
 ```
 
 Code after migration:
@@ -128,8 +144,8 @@ Code after migration:
 ```dart
 // The ScaffoldMessengerState of the current context is used for managing SnackBars.
 ScaffoldMessenger.of(context).showSnackBar(mySnackBar);
-ScaffoldMessenger.of(context).hideCurrentSnackBar(mySnackBar);
-ScaffoldMessenger.of(context).removeCurrentSnackBar(mySnackBar);
+ScaffoldMessenger.of(context).hideCurrentSnackBar();
+ScaffoldMessenger.of(context).removeCurrentSnackBar();
 
 // If a ScaffoldMessenger.key is specified, the ScaffoldMessengerState can be directly
 // accessed without first obtaining it from a BuildContext via
@@ -142,8 +158,8 @@ ScaffoldMessenger(
 )
 
 scaffoldMessengerKey.currentState.showSnackBar(mySnackBar);
-scaffoldMessengerKey.currentState.hideCurrentSnackBar(mySnackBar);
-scaffoldMessengerKey.currentState.removeCurrentSnackBar(mySnackBar);
+scaffoldMessengerKey.currentState.hideCurrentSnackBar();
+scaffoldMessengerKey.currentState.removeCurrentSnackBar();
 
 // The root ScaffoldMessenger can also be accessed by providing a key to 
 // MaterialApp.scaffoldMessengerKey. This way, the ScaffoldMessengerState can be directly accessed
@@ -156,8 +172,8 @@ MaterialApp(
 )
 
 rootScaffoldMessengerKey.currentState.showSnackBar(mySnackBar);
-rootScaffoldMessengerKey.currentState.hideCurrentSnackBar(mySnackBar);
-rootScaffoldMessengerKey.currentState.removeCurrentSnackBar(mySnackBar);
+rootScaffoldMessengerKey.currentState.hideCurrentSnackBar();
+rootScaffoldMessengerKey.currentState.removeCurrentSnackBar();
 ```
 
 ## Timeline

--- a/src/docs/release/breaking-changes/scaffold-messenger.md
+++ b/src/docs/release/breaking-changes/scaffold-messenger.md
@@ -103,9 +103,9 @@ them, place a `ScaffoldMessenger` in between. When trying to present a `SnackBar
 the follow assertion error will be thrown:
 
 ```
-The `ScaffoldManager` throws an assertion error when attempting to show a `SnackBar` to nested
+The `ScaffoldMessenger` throws an assertion error when attempting to show a `SnackBar` to nested
 `Scaffold`s, which would display duplicate `SnackBar`s if allowed.
-To fix this, insert  a`SnackBar` between each nested `Scaffold` to set a separate scope for each.
+To fix this, insert  a`ScaffoldMessenger` between each nested `Scaffold` to set a separate scope for each.
 ```
 
 ## Migration guide

--- a/src/docs/release/breaking-changes/scaffold-messenger.md
+++ b/src/docs/release/breaking-changes/scaffold-messenger.md
@@ -99,7 +99,7 @@ at the top of your application widget tree.
 The `ScaffoldMessenger` will also assert if attempting to show `SnackBar`s to nested `Scaffold`s. If
 a nested set of `Scaffold`s were to share the same `ScaffoldMessenger`, then duplicate `SnackBar`s
 could appear in your UI. In order to control the scope of `SnackBar`s and which `Scaffold`s receive
-them, place a `ScaffoldMessenger` in between. When tryin to present a `SnackBar` in this situation,
+them, place a `ScaffoldMessenger` in between. When trying to present a `SnackBar` in this situation,
 the follow assertion error will be thrown:
 
 ```

--- a/src/docs/release/breaking-changes/scaffold-messenger.md
+++ b/src/docs/release/breaking-changes/scaffold-messenger.md
@@ -105,7 +105,7 @@ the follow assertion error will be thrown:
 ```
 The `ScaffoldMessenger` throws an assertion error when attempting to show a `SnackBar` to nested
 `Scaffold`s, which would display duplicate `SnackBar`s if allowed.
-To fix this, insert  a`ScaffoldMessenger` between each nested `Scaffold` to set a separate scope for each.
+To fix this, insert a `ScaffoldMessenger` between each nested `Scaffold` to set a separate scope for each.
 ```
 
 ## Migration guide

--- a/src/docs/release/breaking-changes/scaffold-messenger.md
+++ b/src/docs/release/breaking-changes/scaffold-messenger.md
@@ -103,13 +103,9 @@ them, place a `ScaffoldMessenger` in between. When trying to present a `SnackBar
 the follow assertion error will be thrown:
 
 ```
-Nested Scaffolds have registered with the ScaffoldMessenger.
-If nested Scaffolds were to share the same ScaffoldMessenger, then
-all would receive a SnackBar at the same time, resulting in multiple
-SnackBars in your UI.
-This is typically resolved by putting a ScaffoldMessenger in
-between the levels of nested Scaffolds. Doing so will set a separate
-SnackBar scope for these Scaffolds.'
+The `ScaffoldManager` throws an assertion error when attempting to show a `SnackBar` to nested
+`Scaffold`s, which would display duplicate `SnackBar`s if allowed.
+To fix this, insert  a`SnackBar` between each nested `Scaffold` to set a separate scope for each.
 ```
 
 ## Migration guide
@@ -199,10 +195,10 @@ Relevant PRs:
 * [ScaffoldMessenger][]
 * [ScaffoldMessenger Migration][]
 
-[`Scaffold`]: https://master-api.flutter.dev/flutter/scaffold-class.html
-[`ScaffoldMessenger`]: https://master-api.flutter.dev/flutter/scaffoldmessenger-class.html
-[`SnackBar`]: https://master-api.flutter.dev/flutter/snackbar-class.html
-[`MaterialApp`]: https://master-api.flutter.dev/flutter/materialapp-class.html
+[`Scaffold`]: https://master-api.flutter.dev/flutter/material/scaffold-class.html
+[`ScaffoldMessenger`]: https://master-api.flutter.dev/flutter/material/scaffoldmessenger-class.html
+[`SnackBar`]: https://master-api.flutter.dev/flutter/material/snackbar-class.html
+[`MaterialApp`]: https://master-api.flutter.dev/flutter/material/materialapp-class.html
 [Issue #57218]: {{site.github}}/flutter/flutter/issues/57218
 [Issue #62921]: {{site.github}}/flutter/flutter/issues/62921
 [ScaffoldMessenger]: {{site.github}}/flutter/flutter/pull/64101

--- a/src/docs/release/breaking-changes/scaffold-messenger.md
+++ b/src/docs/release/breaking-changes/scaffold-messenger.md
@@ -21,7 +21,7 @@ The `ScaffoldMessenger` now handles `SnackBar`s in order to persist across route
 displayed on the current `Scaffold`. By default, a root `ScaffoldMessenger` is included in the
 `MaterialApp`, but you can create your own controlled scope for the `ScaffoldMessenger` to further
 control _which_ `Scaffold`s receive your `SnackBar`s. The scope is particularly important when
-working with nested `Scaffolds`s, discussed further below.
+working with nested `Scaffold`s, discussed further below.
 
 
 ## Description of change


### PR DESCRIPTION
This updates the migration guide for ScaffoldMessenger after feedback from customers that are migrating.
We're adding an assertion error in https://github.com/flutter/flutter/pull/70227 to detect nested Scaffolds and be more helpful in these cases with ScaffoldMessenger.

While I was here I also noticed and error in the migration code and fixed it. :)

More context: https://github.com/flutter/flutter/issues/69929