### PR TITLE
Adding getx as a state management option

### DIFF
--- a/src/docs/development/data-and-backend/state-mgmt/options.md
+++ b/src/docs/development/data-and-backend/state-mgmt/options.md
@@ -121,6 +121,13 @@ Reactive state management that uses the Command Pattern and is based on `ValueNo
 * [Flutter Command package][] 
 * [RxCommand package][], `Stream` based implementation.
 
+## GetX
+
+A simplified reactive state management solution.
+
+* [GetX package][]
+* [Complete GetX State Management][], a video by Tadas Petra
+* [GetX Flutter Firebase Auth Example][], by Jeff McMorris
 
 [Flutter-Movie]: {{site.github}}/o1298098/Flutter-Movie
 [Fish-Redux-Source]: {{site.github}}/alibaba/fish-redux
@@ -136,6 +143,7 @@ Reactive state management that uses the Command Pattern and is based on `ValueNo
 [BloC Library]: https://felangel.github.io/bloc
 [Building a (large) Flutter app with Redux]: https://hillelcoren.com/2018/06/01/building-a-large-flutter-app-with-redux/
 [Building a TODO application (CRUD) in Flutter with Redux&mdash;Part 1]: https://www.youtube.com/watch?v=Wj216eSBBWs
+[Complete GetX State Management]: https://www.youtube.com/watch?v=CNpXbeI_slw
 [Fish-Redux–An assembled flutter application framework based on Redux]: {{site.github}}/alibaba/fish-redux/
 [Flutter Architecture Samples]: https://fluttersamples.com/
 [Flutter: State Management with Mobx]: https://www.youtube.com/watch?v=p-MUBLOEkCs
@@ -144,6 +152,7 @@ Reactive state management that uses the Command Pattern and is based on `ValueNo
 [Flutter Redux Thunk, an example]: {{site.medium}}/flutterpub/flutter-redux-thunk-27c2f2b80a3b
 [Flutter + Redux&mdash;How to make a shopping list app]: https://hackernoon.com/flutter-redux-how-to-make-shopping-list-app-1cd315e79b65
 [Getting started with MobX.dart]: https://mobx.netlify.com/getting-started
+[GetX Flutter Firebase Auth Example]: {{site.medium}}/@jeffmcmorris/getx-flutter-firebase-auth-example-b383c1dd1de2
 [InheritedWidget docs]: {{site.api}}/flutter/widgets/InheritedWidget-class.html
 [Inheriting Widgets]: {{site.medium}}/@mehmetf_71205/inheriting-widgets-b7ac56dbbeb1
 [Introduction to Redux in Flutter]: https://blog.novoda.com/introduction-to-redux-in-flutter/
@@ -153,6 +162,7 @@ Reactive state management that uses the Command Pattern and is based on `ValueNo
 [MobX.dart, Hassle free state-management for your Dart and Flutter apps]: {{site.github}}/mobxjs/mobx.dart
 [Pragmatic State Management in Flutter]: https://www.youtube.com/watch?v=d_m5csmrf7I
 [Provider package]: {{site.pub-pkg}}/provider
+[GetX package]: {{site.pub-pkg}}/get
 [Reactive Programming - Streams - BLoC - Practical Use Cases]: https://www.didierboelens.com/2018/12/reactive-programming---streams---bloc---practical-use-cases
 [Simple app state management]: /docs/development/data-and-backend/state-mgmt/simple
 [Using Flutter Inherited Widgets Effectively]: https://ericwindmill.com/articles/inherited_widget/


### PR DESCRIPTION
Changes proposed in this pull request:

* Adds the [GetX](https://pub.dev/packages/get) package as an option among state managers.
* **Currently GetX is the second most liked package on pub.dev**
* For newer developers, GetX can help simplify work with Flutter
* As a package user, I can attest that this package has greatly improved my productivity with Flutter
