### PR TITLE
Add liblzma to Linux requirements

### DIFF
--- a/src/desktop.md
+++ b/src/desktop.md
@@ -87,6 +87,7 @@ you need the following in addition to the Flutter SDK:
 * [Ninja build][]
 * [pkg-config][]
 * libblkid
+* liblzma
 
 The easiest way to install the Flutter SDK along with these
 dependencies is by using [snapd][].
@@ -103,7 +104,7 @@ If `snapd` is unavailable on the Linux distro you're using,
 you might use the following command:
 
 ```terminal
-$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev libblkid-dev
+$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev libblkid-dev liblzma-dev
 ```
 
 [Clang]: https://clang.llvm.org/


### PR DESCRIPTION
Together with https://github.com/flutter/flutter/pull/70617, this fixes https://github.com/canonical/flutter-snap/issues/17.

Changes proposed in this pull request:

*  Add `liblzma` to the Linux requirements list.
* Update the suggested `apt-get install` command.