### PR TITLE
Adding developing-packages page to a go link

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -252,6 +252,7 @@
       { "source": "/go/delegate-route-transitions", "destination": "https://docs.google.com/document/d/10C5VbqhU7FkkDSVlcVZmrl8UyL7nw4CeL4QdPKMjsEk/edit?usp=sharing", "type": 301 },
       { "source": "/go/default-scroll-action", "destination": "https://docs.google.com/document/d/1SJvom6k4YW4EtFIY4VpAhAOH-jWhRkHVfpVsOBB56KM/edit?usp=sharing", "type": 301 },
       { "source": "/go/deprecation-lifetime", "destination": "https://docs.google.com/document/d/1Gc3ecrMghzc7WU4pgzKB8uBaTPpRdWfozn0otBbxR7s/edit?usp=sharing", "type": 301 }
+      { "source": "/go/developing-plugins", "destination": "https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin", "type": 301 }
     ],
     "headers": [
       { "source": "/f/*.json", "headers": [{"key": "Access-Control-Allow-Origin", "value": "*"}] }


### PR DESCRIPTION
Partially fixes https://github.com/flutter/flutter/issues/70492.

Changes proposed in this pull request:

*  Added a go link to https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin
This go link url can be used to the command line output for `flutter create -t plugin`.
Example:
```
You need to update plugin_name_21/pubspec.yaml to support android. See the following for details:
https://flutter.dev/go/developing-plugins
```

Finally, this is a clever way to use the Flutter go links.  :)