### PR TITLE
Revert ":memo: Philips Hue app links (Android & IOS) (#4799)"

### DIFF
--- a/src/_data/showcases.yml
+++ b/src/_data/showcases.yml
@@ -257,8 +257,6 @@
   logo_src: showcase/cards/philips_hue-logo.png
   logo_has_name: true
   learn_more_dropdown: true
-  app_store_link: https://apps.apple.com/us/app/philips-hue/id1055281310
-  play_store_link: https://play.google.com/store/apps/details?id=com.philips.lighting.hue2&hl=en
   learn_more_links:
     - link_item:
       link: https://www2.meethue.com/en-us/entertainment/sync-with-tv#get-the-app


### PR DESCRIPTION
This reverts commit 213f702d9ec6e1c9638e470a30533286a5a6fb3f.
See https://github.com/flutter/website/pull/4799#issuecomment-730300790 for more details