### PR TITLE
Explain why size component might be ignored in constraints.

### DIFF
--- a/src/docs/development/ui/layout/constraints.md
+++ b/src/docs/development/ui/layout/constraints.md
@@ -105,6 +105,11 @@ Flutter’s layout engine has a few important limitations:
   precisely define the size and position of any widget
   without taking into consideration the tree as a whole.
 
+* If a child wants a different size from its parent and 
+  the parent doesn't have enough information to align it,
+  then the child's size might be ignored.
+  **Be specific when defining alignment.**
+  
 ## Examples
 
 For an interactive experience, use the following DartPad.


### PR DESCRIPTION
NOTE: We love contributions, but we hate spam. If your PR doesn't improve flutter.dev, we'll close it and label it as `invalid`.

Fixes #4992

Changes proposed in this pull request:

*  Add section to "limitations" in the constraints page to tell users that parent widgets will ignore the size attribute of a child if it doesn't know how to align it. 
