### PR TITLE
Encourage people to use the tarball

### DIFF
--- a/src/docs/get-started/install/_get-sdk.md
+++ b/src/docs/get-started/install/_get-sdk.md
@@ -81,7 +81,7 @@ process.
 Once you have installed any missing dependencies, run the `flutter doctor`
 command again to verify that you’ve set everything up correctly.
 
-### Downloading straight from GitHub instead of using a tarball
+### Downloading straight from GitHub instead of using an archive
 
 _This is only suggested for advanced use cases._
 

--- a/src/docs/get-started/install/_get-sdk.md
+++ b/src/docs/get-started/install/_get-sdk.md
@@ -32,22 +32,6 @@
     $ {{unzip}} ~/Downloads/flutter_{{os}}_vX.X.X-{{site.sdk.channel}}{{file_ext}}
     ```
     
-    If you don't want to install a fixed version of the installation bundle, 
-    you can skip steps 1 and 2. 
-    Instead, get the source code from the [Flutter repo][]
-    on GitHub with the following command:
-    
-    ```terminal
-    $ git clone https://github.com/flutter/flutter.git
-    ```
-    
-    You can also change branches or tags as needed.
-    For example, to get just the stable version:
-    
-    ```terminal
-    $ git clone https://github.com/flutter/flutter.git -b stable --depth 1
-    ```
-    
  1. Add the `flutter` tool to your path:
 
     ```terminal
@@ -58,21 +42,7 @@
     _current_ terminal window only.
     To permanently add Flutter to your path, see
     [Update your path][].
-
- 1. Optionally, pre-download development binaries:
-
-    The `flutter` tool downloads platform-specific development binaries as
-    needed. For scenarios where pre-downloading these artifacts is preferable
-    (for example, in hermetic build environments,
-    or with intermittent network availability), iOS
-    and Android binaries can be downloaded ahead of time by running:
-
-    ```terminal
-    $ flutter precache
-    ```
-
-    For additional download options, see `flutter help precache`.
-
+    
 You are now ready to run Flutter commands!
 
 {{site.alert.note}}
@@ -110,6 +80,30 @@ process.
 
 Once you have installed any missing dependencies, run the `flutter doctor`
 command again to verify that you’ve set everything up correctly.
+
+### Downloading straight from GitHub instead of using a tarball
+
+_This is only suggested for advanced use cases._
+
+You can also use git directly instead of downloading the prepared tarball. For example,
+to download the stable branch:
+    
+```terminal
+$ git clone https://github.com/flutter/flutter.git -b stable
+```
+
+If you do this, you may also wish to pre-download development binaries that are included
+in the tarball (for example, you may wish to do this when setting up hermetic build environments,
+or if you only have intermittent network availability):
+
+```terminal
+$ flutter precache
+```
+
+For additional download options, see `flutter help precache`.
+
+The tarball includes the results of doing these steps, so it is generally the simpler option.
+
 
 {% include_relative _analytics.md %}
 

--- a/src/docs/get-started/install/_get-sdk.md
+++ b/src/docs/get-started/install/_get-sdk.md
@@ -85,24 +85,27 @@ command again to verify that you’ve set everything up correctly.
 
 _This is only suggested for advanced use cases._
 
-You can also use git directly instead of downloading the prepared tarball. For example,
+You can also use git directly instead of downloading the prepared archive. For example,
 to download the stable branch:
     
 ```terminal
 $ git clone https://github.com/flutter/flutter.git -b stable
 ```
 
-If you do this, you may also wish to pre-download development binaries that are included
-in the tarball (for example, you may wish to do this when setting up hermetic build environments,
-or if you only have intermittent network availability):
+[Update your path][], and run `flutter doctor`. That will let you know if there are
+other dependencies you need to install to use Flutter (e.g. the Android SDK).
+
+If you did not use the archive, Flutter will download necessary development binaries as they
+are needed (if you used the archive, they are included in the download). You may wish to
+pre-download these development binaries (for example, you may wish to do this when setting
+up hermetic build environments, or if you only have intermittent network availability). To
+do so, run the following command:
 
 ```terminal
 $ flutter precache
 ```
 
 For additional download options, see `flutter help precache`.
-
-The tarball includes the results of doing these steps, so it is generally the simpler option.
 
 
 {% include_relative _analytics.md %}


### PR DESCRIPTION
This also changes the order so that "flutter doctor" is recommended before "flutter precache". Some users were running into a situation where they didn't have the Android SDK installed at the time they ran "flutter precache" and that failed for them.