### PR TITLE
Update validation example to use ScaffoldMessenger

### DIFF
--- a/src/docs/cookbook/forms/validation.md
+++ b/src/docs/cookbook/forms/validation.md
@@ -130,7 +130,7 @@ ElevatedButton(
       // If the form is valid, display a snackbar. In the real world,
       // you'd often call a server or save the information in a database.
 
-      ScaffoldMessenger.
+      ScaffoldMessenger
           .of(context)
           .showSnackBar(SnackBar(content: Text('Processing Data')));
     }
@@ -219,7 +219,7 @@ class MyCustomFormState extends State<MyCustomForm> {
                 // otherwise.
                 if (_formKey.currentState.validate()) {
                   // If the form is valid, display a Snackbar.
-                  Scaffold.of(context)
+                  ScaffoldMessenger.of(context)
                       .showSnackBar(SnackBar(content: Text('Processing Data')));
                 }
               },

--- a/src/docs/cookbook/forms/validation.md
+++ b/src/docs/cookbook/forms/validation.md
@@ -130,7 +130,7 @@ ElevatedButton(
       // If the form is valid, display a snackbar. In the real world,
       // you'd often call a server or save the information in a database.
 
-      Scaffold
+      ScaffoldMessenger.
           .of(context)
           .showSnackBar(SnackBar(content: Text('Processing Data')));
     }


### PR DESCRIPTION
The current example is using deprecated API. Changing Scaffold.of(context) to ScaffoldMessenger.of(context) fixes this.

Fixes [#5018](https://github.com/flutter/website/issues/5018)

Changes proposed in this pull request:

*  Changing Scaffold.of(context) to ScaffoldMessenger.of(context)

