### PR TITLE
Fix example with SafeArea

### DIFF
--- a/src/docs/development/ui/widgets-intro.md
+++ b/src/docs/development/ui/widgets-intro.md
@@ -163,7 +163,6 @@ void main() {
   runApp(MaterialApp(
     title: 'My app', // used by the OS task switcher
     home: SafeArea( // needed for proper padding
-      top: true, // automatically pad the top of the app
       child: MyScaffold(),
     ),
   ));

--- a/src/docs/development/ui/widgets-intro.md
+++ b/src/docs/development/ui/widgets-intro.md
@@ -163,6 +163,7 @@ void main() {
   runApp(MaterialApp(
     title: 'My app', // used by the OS task switcher
     home: SafeArea( // needed for proper padding
+      top: true, // automatically pad the top of the app
       child: MyScaffold(),
     ),
   ));

--- a/src/docs/development/ui/widgets-intro.md
+++ b/src/docs/development/ui/widgets-intro.md
@@ -50,6 +50,8 @@ which means the text "Hello, world" ends up centered on screen.
 The text direction needs to be specified in this instance;
 when the `MaterialApp` widget is used,
 this is taken care of for you, as demonstrated later.
+A `SafeArea` widget is also used to properly pad the text
+so it appears below the display on the top of the screen.
 
 When writing an app, you'll commonly author new widgets that
 are subclasses of either [`StatelessWidget`][] or [`StatefulWidget`][],
@@ -160,7 +162,9 @@ class MyScaffold extends StatelessWidget {
 void main() {
   runApp(MaterialApp(
     title: 'My app', // used by the OS task switcher
-    home: MyScaffold(),
+    home: SafeArea( // needed for proper padding
+      child: MyScaffold(),
+    ),
   ));
 }
 ```

--- a/src/docs/development/ui/widgets-intro.md
+++ b/src/docs/development/ui/widgets-intro.md
@@ -162,7 +162,7 @@ class MyScaffold extends StatelessWidget {
 void main() {
   runApp(MaterialApp(
     title: 'My app', // used by the OS task switcher
-    home: SafeArea( // needed for proper padding
+    home: SafeArea(
       child: MyScaffold(),
     ),
   ));


### PR DESCRIPTION
Fixes #2395

Changes proposed in this pull request:

*  Wraps an example on the "Introduction to widgets" page in a `SafeArea` widget to make it look normal if the example is copied.
* Adds some explanation about what `SafeArea` does to tell users why it is there. Doesn't go in-depth about what the widget does.
