### PR TITLE
Remove CupertinoSearchTextField from Widget Library

### DIFF
--- a/src/_data/catalog/widgets.json
+++ b/src/_data/catalog/widgets.json
@@ -506,16 +506,6 @@
     "image": "<img alt='' src='/images/widget-catalog/cupertino-scrollbar.png'>"
   },
   {
-    "name": "CupertinoSearchTextField",
-    "description": "An iOS-style search field.",
-    "categories": [
-      "Cupertino (iOS-style widgets)"
-    ],
-    "subcategories": [],
-    "link": "https://api.flutter.dev/flutter/cupertino/CupertinoSearchTextField-class.html",
-    "image": "<img alt='' src='/images/widget-catalog/cupertino-search-field.png'>"
-  },
-  {
     "name": "CupertinoSegmentedControl",
     "description": "An iOS-style segmented control. Used to select mutually exclusive options in a horizontal list.",
     "categories": [


### PR DESCRIPTION
Temporary fix to #5025 

Changes proposed in this pull request:

* Removes a widget with a non-functional link to the docs. 
* I can't seem to find a reference to this widget anywhere. Of course, it had to exist at some point for it to have been added in the first place. This is just a hotfix to take it off the site until something changes.
