### PR TITLE
Add sysctl to macOS system requirements

### DIFF
--- a/src/docs/get-started/install/macos.md
+++ b/src/docs/get-started/install/macos.md
@@ -23,6 +23,7 @@ your development environment must meet these minimum requirements:
   - `git` 2.x
   - `mkdir`
   - `rm`
+  - `sysctl`
   - `unzip`
   - `which`
 


### PR DESCRIPTION
`sysctl` is required as of https://github.com/flutter/flutter/pull/67970

See also:
https://github.com/flutter/flutter/issues/71516