### PR TITLE
Missing localizationsDelegates

### DIFF
--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -78,6 +78,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 MaterialApp(
  localizationsDelegates: [
    // ... app-specific localization delegate[s] here
+   AppLocalizations.delegate,
    GlobalMaterialLocalizations.delegate,
    GlobalWidgetsLocalizations.delegate,
    GlobalCupertinoLocalizations.delegate,


### PR DESCRIPTION
Example not working without localizationsDelegates AppLocalizations.delegate

NOTE: We love contributions, but we hate spam. If your PR doesn't improve flutter.dev, we'll close it and label it as `invalid`.

Fixes #<issue number>.

Changes proposed in this pull request:

*  
* 
