### PR TITLE
Update integration_test version number in the Project Setup code snippet

### DIFF
--- a/src/docs/testing/integration-tests/index.md
+++ b/src/docs/testing/integration-tests/index.md
@@ -53,7 +53,7 @@ Add `integration_test`, `flutter_test`, and optionally `flutter_driver` to your
 pubspec.yaml file:
 
 ```yaml
-integration_test: ^0.9.0
+integration_test: ^1.0.0
 flutter_test:
   sdk: flutter
 flutter_driver:


### PR DESCRIPTION
Changes proposed in this pull request:

*  Update integration_test version number to the latest stable version in the Project Setup code snippet. Anyone using the snippet can directly get the stable version without having to upgrade later.
