### PR TITLE
Add go/tool-integration-test-support

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -258,7 +258,8 @@
       { "source": "/go/multiple-engines", "destination": "https://docs.google.com/document/d/1NwiZPWHd1te46eP2GWwIezDV9CdMQkODAMuF5kWdtLw", "type": 301 },
       { "source": "/go/web-renderer-options", "destination": "https://docs.google.com/document/d/1aY0iU16wf_sdT7nwfpjgT-IatHNfF3slTiYHKmxcIog", "type": 301 },
       { "source": "/go/update-scrollbars", "destination": "https://docs.google.com/document/d/1mRlc-sRyadE6301aZsD1LJkPG2B9K97Bg_GDHvFhMQI/edit?usp=sharing&resourcekey=0-v4Gk8H280RaPo5qClmDqpA", "type": 301 },
-      { "source": "/go/engine-rtree", "destination": "https://docs.google.com/document/d/1UGV0qerZ8o3eGrjm1axp0NoLWrT0KmTonMamb-xifEM/edit?usp=sharing&resourcekey=0-wh0paKk1H1vZbzxKxIj2jA", "type": 301 }
+      { "source": "/go/engine-rtree", "destination": "https://docs.google.com/document/d/1UGV0qerZ8o3eGrjm1axp0NoLWrT0KmTonMamb-xifEM/edit?usp=sharing&resourcekey=0-wh0paKk1H1vZbzxKxIj2jA", "type": 301 },
+      { "source": "/go/tool-integration-test-support", "destination": "https://docs.google.com/document/d/1jMMZpRAiQC2XTUFnzFsBrWwMsf7KyMuCScYgrJQJOV0/edit?resourcekey=0-ne9HbH1hXCHcIglomNfwtw", "type": 301 }
     ],
     "headers": [
       { "source": "/f/*.json", "headers": [{"key": "Access-Control-Allow-Origin", "value": "*"}] }


### PR DESCRIPTION
Changes proposed in this pull request:

Adding a go link to a design doc for supporting Integration Tests in the Flutter Tool.
