### PR TITLE
Fix typo in sidenav

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -280,7 +280,7 @@
     - title: Testing
       permalink: /docs/testing
       match-page-url-exactly: true
-    - title: Integration testinng
+    - title: Integration testing
       permalink: /docs/testing/integration-tests
       match-page-url-exactly: true
 


### PR DESCRIPTION
Changes proposed in this pull request:

*  Fix typo: `Integration testinng` to `Integration testing`
