### PR TITLE
Create Sliver Category in Widgets Catalog

### DIFF
--- a/src/_data/catalog/index.json
+++ b/src/_data/catalog/index.json
@@ -49,7 +49,7 @@
       }, 
       {
         "name": "Sliver widgets", 
-        "description": "These widgets take a portion of a CustomScrollview and apply a layout to that portion."
+        "description": "These widgets take a portion of a CustomScrollView and apply a layout to that portion."
       }
     ],
     "id": "layout"

--- a/src/_data/catalog/index.json
+++ b/src/_data/catalog/index.json
@@ -46,6 +46,10 @@
       {
         "name": "Multi-child layout widgets",
         "description": "These widgets take multiple children and arrange them in different ways."
+      }, 
+      {
+        "name": "Sliver widgets", 
+        "description": "These widgets take a portion of a CustomScrollview and apply a layout to that portion."
       }
     ],
     "id": "layout"

--- a/src/_data/catalog/widgets.json
+++ b/src/_data/catalog/widgets.json
@@ -1495,7 +1495,7 @@
   },
   {
     "name": "SliverFixedExtentList",
-    "description": "",
+    "description": "A sliver that places multiple box children with the same main axis extent in a linear array.",
     "categories": [],
     "subcategories": [
       "Sliver widgets"
@@ -1505,7 +1505,7 @@
   },
   {
     "name": "SliverGrid",
-    "description": "",
+    "description": "A sliver that places multiple box children in a two dimensional arrangement.",
     "categories": [],
     "subcategories": [
       "Sliver widgets"
@@ -1515,7 +1515,7 @@
   },
   {
     "name": "SliverList",
-    "description": "",
+    "description": "A sliver that places multiple box children in a linear array along the main axis.",
     "categories": [],
     "subcategories": [
       "Sliver widgets"
@@ -1525,7 +1525,7 @@
   },
   {
     "name": "SliverPadding",
-    "description": "",
+    "description": "A sliver that applies padding on each side of another sliver.",
     "categories": [],
     "subcategories": [
       "Sliver widgets"

--- a/src/_data/catalog/widgets.json
+++ b/src/_data/catalog/widgets.json
@@ -549,7 +549,8 @@
     "name": "CupertinoSliverNavigationBar",
     "description": "An iOS-styled navigation bar with iOS-11-style large titles using slivers.",
     "categories": [
-      "Cupertino (iOS-style widgets)"
+      "Cupertino (iOS-style widgets)",
+      "Sliver widgets"
     ],
     "subcategories": [],
     "link": "https://api.flutter.dev/flutter/cupertino/CupertinoSliverNavigationBar-class.html",
@@ -639,7 +640,8 @@
     "name": "CustomScrollView",
     "description": "A ScrollView that creates custom scroll effects using slivers.",
     "categories": [
-      "Scrolling"
+      "Scrolling",
+      "Sliver widgets"
     ],
     "subcategories": [],
     "link": "https://api.flutter.dev/flutter/widgets/CustomScrollView-class.html",
@@ -1483,7 +1485,8 @@
     "description": "A material design app bar that integrates with a CustomScrollView.",
     "categories": [],
     "subcategories": [
-      "App structure and navigation"
+      "App structure and navigation",
+      "Sliver widgets"
     ],
     "link": "https://api.flutter.dev/flutter/material/SliverAppBar-class.html",
     "image": "<img alt='' src='/images/widget-catalog/material-app-bar.png'>"

--- a/src/_data/catalog/widgets.json
+++ b/src/_data/catalog/widgets.json
@@ -1494,6 +1494,46 @@
     "image": "<img alt='' src='/images/widget-catalog/material-app-bar.png'>"
   },
   {
+    "name": "SliverFixedExtentList",
+    "description": "",
+    "categories": [],
+    "subcategories": [
+      "Sliver widgets"
+    ],
+    "link": "https://api.flutter.dev/flutter/widgets/SliverFixedExtentList-class.html",
+    "image": "<img alt='' src='/images/catalog-widget-placeholder.png'>"
+  },
+  {
+    "name": "SliverGrid",
+    "description": "",
+    "categories": [],
+    "subcategories": [
+      "Sliver widgets"
+    ],
+    "link": "https://api.flutter.dev/flutter/widgets/SliverGrid-class.html",
+    "image": "<img alt='' src='/images/catalog-widget-placeholder.png'>"
+  },
+  {
+    "name": "SliverList",
+    "description": "",
+    "categories": [],
+    "subcategories": [
+      "Sliver widgets"
+    ],
+    "link": "https://api.flutter.dev/flutter/widgets/SliverList-class.html",
+    "image": "<img alt='' src='/images/catalog-widget-placeholder.png'>"
+  },
+  {
+    "name": "SliverPadding",
+    "description": "",
+    "categories": [],
+    "subcategories": [
+      "Sliver widgets"
+    ],
+    "link": "https://api.flutter.dev/flutter/widgets/SliverPadding-class.html",
+    "image": "<img alt='' src='/images/catalog-widget-placeholder.png'>"
+  },
+  {
     "name": "SnackBar",
     "description": "A lightweight message with an optional action which briefly displays at the bottom of the screen.",
     "categories": [],

--- a/src/_data/catalog/widgets.json
+++ b/src/_data/catalog/widgets.json
@@ -1494,6 +1494,26 @@
     "image": "<img alt='' src='/images/widget-catalog/material-app-bar.png'>"
   },
   {
+    "name": "SliverChildBuilderDelegate",
+    "description": "A delegate that supplies children for slivers using a builder callback.",
+    "categories": [],
+    "subcategories": [
+      "Sliver widgets"
+    ],
+    "link": "https://api.flutter.dev/flutter/widgets/SliverChildBuilderDelegate-class.html",
+    "image": "<img alt='' src='/images/catalog-widget-placeholder.png'>"
+  },
+  {
+    "name": "SliverChildListDelegate",
+    "description": "A delegate that supplies children for slivers using an explicit list.",
+    "categories": [],
+    "subcategories": [
+      "Sliver widgets"
+    ],
+    "link": "https://api.flutter.dev/flutter/widgets/SliverChildListDelegate-class.html",
+    "image": "<img alt='' src='/images/catalog-widget-placeholder.png'>"
+  },
+  {
     "name": "SliverFixedExtentList",
     "description": "A sliver that places multiple box children with the same main axis extent in a linear array.",
     "categories": [],
@@ -1531,6 +1551,26 @@
       "Sliver widgets"
     ],
     "link": "https://api.flutter.dev/flutter/widgets/SliverPadding-class.html",
+    "image": "<img alt='' src='/images/catalog-widget-placeholder.png'>"
+  },
+  {
+    "name": "SliverPersistentHeader",
+    "description": "A sliver whose size varies when the sliver is scrolled to the edge of the viewport opposite the sliver's GrowthDirection.",
+    "categories": [],
+    "subcategories": [
+      "Sliver widgets"
+    ],
+    "link": "https://api.flutter.dev/flutter/widgets/SliverPersistentHeader-class.html",
+    "image": "<img alt='' src='/images/catalog-widget-placeholder.png'>"
+  },
+  {
+    "name": "SliverToBoxAdapter",
+    "description": "A sliver that contains a single box widget.",
+    "categories": [],
+    "subcategories": [
+      "Sliver widgets"
+    ],
+    "link": "https://api.flutter.dev/flutter/widgets/SliverToBoxAdapter-class.html",
     "image": "<img alt='' src='/images/catalog-widget-placeholder.png'>"
   },
   {

--- a/src/_data/catalog/widgets.json
+++ b/src/_data/catalog/widgets.json
@@ -549,10 +549,11 @@
     "name": "CupertinoSliverNavigationBar",
     "description": "An iOS-styled navigation bar with iOS-11-style large titles using slivers.",
     "categories": [
-      "Cupertino (iOS-style widgets)",
+      "Cupertino (iOS-style widgets)"
+    ],
+    "subcategories": [
       "Sliver widgets"
     ],
-    "subcategories": [],
     "link": "https://api.flutter.dev/flutter/cupertino/CupertinoSliverNavigationBar-class.html",
     "image": "<img alt='' src='/images/widget-catalog/cupertino-sliver-navigation-bar.png'>"
   },
@@ -640,10 +641,11 @@
     "name": "CustomScrollView",
     "description": "A ScrollView that creates custom scroll effects using slivers.",
     "categories": [
-      "Scrolling",
+      "Scrolling"
+    ],
+    "subcategories": [
       "Sliver widgets"
     ],
-    "subcategories": [],
     "link": "https://api.flutter.dev/flutter/widgets/CustomScrollView-class.html",
     "image": "<img alt='' src='/images/catalog-widget-placeholder.png'>"
   },


### PR DESCRIPTION
Fixes #3813

Changes proposed in this pull request:

*  Creates a "Sliver widgets" section in the Layout Widgets part of the Widgets Catalog
*  Adds a variety of widgets to this section, including widgets that already exist on different parts of the catalog, widgets suggested by the issue, and new widgets entirely. 
