### PR TITLE
Fix a broken link on the community page.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ We are also happy to accept your PRs to the
 even if it's just to fix a typo.
 
 For ways to get involved in the Flutter community or to learn about us,
-visit the [Flutter community](/community) page.
+visit the [Flutter community](https://flutter.dev/community) page.
 
 # Ways to contribute
 


### PR DESCRIPTION
Just a quick fix to a link that seems to be broken now; I made it specifically re-direct to the flutter..dev community page. 