### PR TITLE
Fixing path for auto-generated l10 files in l10n example

### DIFF
--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -187,7 +187,7 @@ Spanish translation of the same message:
 
 6. To test the localization tool, run your application.
 You should see generated files in
-`${FLUTTER_PROJECT}/flutter_gen/gen_l10n`.
+`${FLUTTER_PROJECT}/.dart_tool/flutter_gen/gen_l10n`.
 
 7. Test the generated localizations in your app as follows:
 


### PR DESCRIPTION
Actual auto-generated files are places inside `.dart_tool` folder

Changes proposed in this pull request:

*  Changed path to auto-generated l10n files in l10n example
