### PR TITLE
Document the "flutter sdk-path" snap command

### DIFF
--- a/src/docs/get-started/install/_get-sdk-linux.md
+++ b/src/docs/get-started/install/_get-sdk-linux.md
@@ -24,6 +24,14 @@ or at the command line:
 $ sudo snap install flutter --classic
 ```
 
+{{site.alert.note}}
+  Once the snap is installed, you can use the following command to display your Flutter SDK path:
+
+  ```sh
+  $ flutter sdk-path
+  ```
+{{site.alert.end}}
+
 ### Install Flutter manually
 
 If you don't have `snapd`, or can't use it, you can


### PR DESCRIPTION
Together with https://github.com/canonical/flutter-snap/commit/7c12b8737e58e3c99d5ad514a3498b77944a9ad0, this fixes the first half of https://github.com/canonical/flutter-snap/issues/19.

Changes proposed in this pull request:

* Add a note after snap install instructions on how one can find their Flutter SDK path.