### PR TITLE
Fix Google developers codelabs URL

### DIFF
--- a/src/docs/codelabs/index.md
+++ b/src/docs/codelabs/index.md
@@ -198,7 +198,7 @@ We also recommend the following online class:
 
 {{site.alert.note}}
   If you have trouble viewing any of the codelabs
-  on `codelabs.google.developer.com`, try 
+  on [`codelabs.developers.google.com`](https://codelabs.developers.google.com/), try 
   [this mirror of the Flutter codelabs][].
 {{site.alert.end}}
 


### PR DESCRIPTION
The Google Developers code labs URL is broken. 
This PR corrects it and making the label link to the website.