### PR TITLE
Docs integration test

### DIFF
--- a/src/docs/testing/integration-tests/index.md
+++ b/src/docs/testing/integration-tests/index.md
@@ -139,7 +139,7 @@ In a separate process, run `flutter_drive`:
 
 ```
 flutter drive \
-  --driver=test_driver/integration_test_driver_driver.dart \
+  --driver=test_driver/integration_test_driver.dart \
   --target=integration_test/counter_test.dart \
   -d web-server
 ```

--- a/src/docs/testing/integration-tests/index.md
+++ b/src/docs/testing/integration-tests/index.md
@@ -102,7 +102,7 @@ integration_test/
 test/
   # Other unit tests go here.
 test_driver/
-  integration_test.dart
+  integration_test_driver.dart
 ```
 
 See also:
@@ -117,13 +117,13 @@ These tests can be launched with the `flutter drive` command, where
 
 ```bash
 flutter drive \
-  --driver=test_driver/integration_test.dart \
+  --driver=test_driver/integration_test_driver.dart \
   --target=integration_test/foo_test.dart \
   -d <DEVICE_ID>
 ```
 
 This runs the tests in `foo_test.dart` via the adapter in
-`test_driver/integration_test.dart`.
+`test_driver/integration_test_driver.dart`.
 
 
 ### Running in a browser 
@@ -139,7 +139,7 @@ In a separate process, run `flutter_drive`:
 
 ```
 flutter drive \
-  --driver=test_driver/integration_test_driver.dart \
+  --driver=test_driver/integration_test_driver_driver.dart \
   --target=integration_test/counter_test.dart \
   -d web-server
 ```


### PR DESCRIPTION


![image](https://user-images.githubusercontent.com/56479665/102643414-3d4f6000-4185-11eb-9e32-69b979a5fd05.png)
Here docs says to create `integration_test_driver.dart`. So here https://flutter.dev/docs/testing/integration-tests#directory-structure should be something like this 
![image](https://user-images.githubusercontent.com/56479665/102643631-8c959080-4185-11eb-8a71-d7ba339f0d4d.png)

The same thing for command as well !