### PR TITLE
Few fixes in the link and emphasis

### DIFF
--- a/src/docs/get-started/flutter-for/ios-devs.md
+++ b/src/docs/get-started/flutter-for/ios-devs.md
@@ -1304,7 +1304,7 @@ The observable lifecycle events are:
   The iOS platform has no equivalent event.
 
 For more details on the meaning of these states, see
-[`AppLifecycleStatus` documentation][].
+[`AppLifecycleState` documentation][].
 
 ## Layouts
 
@@ -1599,7 +1599,7 @@ class _SampleAppPageState extends State<SampleAppPage> {
 }
 ```
 
-Instead of creating a "ListView", create a `ListView.builder` that
+Instead of creating a `ListView`, create a `ListView.builder` that
 takes two key parameters: the initial length of the list,
 and an `ItemBuilder` function.
 


### PR DESCRIPTION
1. Fixed the link "AppLifecycleStatus" to "AppLifecycleState"
2. Fixed the emphasis on 'ListView'



Changes proposed in this pull request:
1. Fixed the link "AppLifecycleStatus" to "AppLifecycleState"
2. Fixed the emphasis on 'ListView'
*  
* 
