### PR TITLE
hints updated for issue 1 in internationalization page feedback.

### DIFF
--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -189,7 +189,7 @@ project called `l10n.yaml` with the following content:
 
 6. To test the localization tool, run your application.
    You should see generated files in
-   `${FLUTTER_PROJECT}/flutter_gen/gen_l10n`.
+   `${FLUTTER_PROJECT}/.dart_tool/flutter_gen/gen_l10n`.
 
 7. Test the generated localizations in your app as follows:
 


### PR DESCRIPTION
Fixes #5032.

Changes proposed in this pull request:

*  hint 6 updated on the internationalization page.
* before:
  6. To test the localization tool, run your application. You should see generated files in 
${FLUTTER_PROJECT}/flutter_gen/gen_l10n.

* after changes:
6. To test the localization tool, run your application. You should see generated files in
   `${FLUTTER_PROJECT}/.dart_tool/flutter_gen/gen_l10n`.


