### PR TITLE
Document improved "Parse JSON in the background"

### DIFF
--- a/src/docs/cookbook/networking/background-parsing.md
+++ b/src/docs/cookbook/networking/background-parsing.md
@@ -123,7 +123,7 @@ Future<List<Photo>> fetchPhotos(http.Client client) async {
 
 If you run the `fetchPhotos()` function on a slower device,
 you might notice the app freezes for a brief moment as it parses and
-converts the JSON. This is jank, and you want to be rid of it.
+converts the JSON. This is jank, and you want to get rid of it.
 
 You can remove the jank by moving the parsing and conversion
 to a background isolate using the [`compute()`][]


### PR DESCRIPTION
Document improvement:
background-parsing.md 

Changes proposed in this pull request:

*   In "Parse JSON in the background", in the "4. Move this work to a separate isolate" title: "and you want to be rid of it" updated to "and you want to get rid of it"