### PR TITLE
Add more information about didUpdateWidget to Web Codelab

### DIFF
--- a/src/docs/get-started/codelab-web.md
+++ b/src/docs/get-started/codelab-web.md
@@ -747,6 +747,7 @@ class _AnimatedProgressIndicatorState extends State<AnimatedProgressIndicator>
     _curveAnimation = _controller.drive(CurveTween(curve: Curves.easeIn));
   }
 
+  @override
   void didUpdateWidget(oldWidget) {
     super.didUpdateWidget(oldWidget);
     _controller.animateTo(widget.value);

--- a/src/docs/get-started/codelab-web.md
+++ b/src/docs/get-started/codelab-web.md
@@ -768,7 +768,7 @@ class _AnimatedProgressIndicatorState extends State<AnimatedProgressIndicator>
 ```
 
 The [didUpdateWidget][] function is called to 
-update our `AnimatedProgressIndicatorState` whenver
+update our `AnimatedProgressIndicatorState` whenever
 our `AnimatedProgressIndicator` changes.
 </li>
 

--- a/src/docs/get-started/codelab-web.md
+++ b/src/docs/get-started/codelab-web.md
@@ -109,7 +109,7 @@ $ flutter doctor
 
 It's okay if the Android toolchain, Android Studio,
 and the Xcode tools are not installed,
-since our app is intended for the web only.
+since the app is intended for the web only.
 If you later want this app to work on mobile,
 you will need to do additional installation and setup.
 </li>
@@ -767,9 +767,9 @@ class _AnimatedProgressIndicatorState extends State<AnimatedProgressIndicator>
 }
 ```
 
-The [didUpdateWidget][] function is called to 
-update our `AnimatedProgressIndicatorState` whenever
-our `AnimatedProgressIndicator` changes.
+The [`didUpdateWidget`][] function updates
+the `AnimatedProgressIndicatorState` whenever
+`AnimatedProgressIndicator` changes.
 </li>
 
 <li markdown="1">Use the new `AnimatedProgressIndicator`.<br>
@@ -1033,7 +1033,7 @@ Dart DevTools, or Flutter animations, see the following:
 [DevTools documentation]: /docs/development/tools/devtools
 [DevTools installed]: /docs/development/tools/devtools/overview#how-do-i-install-devtools
 [DartPad troubleshooting page]: {{site.dart-site}}/tools/dartpad/troubleshoot
-[didUpdateWidget][]: https://api.flutter.dev/flutter/widgets/State/didUpdateWidget.html
+[`didUpdateWidget`]: {{site.api}}/flutter/widgets/State/didUpdateWidget.html
 [editor]: /docs/get-started/editor
 [Effective Dart Style Guide]: {{site.dart-site}}/guides/language/effective-dart/style#dont-use-a-leading-underscore-for-identifiers-that-arent-private
 [Flutter cookbook]: /docs/cookbook

--- a/src/docs/get-started/codelab-web.md
+++ b/src/docs/get-started/codelab-web.md
@@ -766,6 +766,10 @@ class _AnimatedProgressIndicatorState extends State<AnimatedProgressIndicator>
   }
 }
 ```
+
+The [didUpdateWidget][] function is called to 
+update our `AnimatedProgressIndicatorState` whenver
+our `AnimatedProgressIndicator` changes.
 </li>
 
 <li markdown="1">Use the new `AnimatedProgressIndicator`.<br>
@@ -1029,6 +1033,7 @@ Dart DevTools, or Flutter animations, see the following:
 [DevTools documentation]: /docs/development/tools/devtools
 [DevTools installed]: /docs/development/tools/devtools/overview#how-do-i-install-devtools
 [DartPad troubleshooting page]: {{site.dart-site}}/tools/dartpad/troubleshoot
+[didUpdateWidget][]: https://api.flutter.dev/flutter/widgets/State/didUpdateWidget.html
 [editor]: /docs/get-started/editor
 [Effective Dart Style Guide]: {{site.dart-site}}/guides/language/effective-dart/style#dont-use-a-leading-underscore-for-identifiers-that-arent-private
 [Flutter cookbook]: /docs/cookbook


### PR DESCRIPTION
Fixes #5042

Changes proposed in this pull request:

* Adds information about `didUpdateWidget` and a link to the function's page.
* Annotates the code to show that this is an override.

I'm not super familiar with this function so please correct me if any of my explanation is incorrect.
