### PR TITLE
Adds tested null safe code excerpts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,11 @@ jobs:
         - TASK="./tool/check-code.sh"
         - CHANNEL=dev
 
+    - name: "Dev channel: null safety code check"
+      env:
+        - TASK="./tool/check-code.sh --null-safety"
+        - CHANNEL=dev
+
     - name: "Dev channel: jekyll build"
       env:
         - TASK="bundle exec jekyll build"
@@ -45,6 +50,11 @@ jobs:
     - name: "Beta channel: code check"
       env:
         - TASK="./tool/check-code.sh"
+        - CHANNEL=beta
+
+    - name: "Beta channel: null safety code check"
+      env:
+        - TASK="./tool/check-code.sh --null-safety"
         - CHANNEL=beta
 
     - name: "Beta channel: jekyll build"

--- a/build.excerpt.yaml
+++ b/build.excerpt.yaml
@@ -3,6 +3,11 @@ targets:
     sources:
       include:
         - examples/**
+        - null_safety_examples/**
+        # Some default includes that aren't really used here but will prevent
+        # false-negative warnings:
+        - $package$
+        - lib/$lib$
       exclude:
         - '**/.*/**'
         - '**/android/**'

--- a/null_safety_examples/README.md
+++ b/null_safety_examples/README.md
@@ -13,4 +13,4 @@ the repo root (`$PROJECT` represents the app project path, such as
 To learn more about setting up Flutter and running apps, see
 [flutter.dev/get-started][].
 
-[flutter.dev/get-started]: https://flutter.dev/docs/get-started
+[flutter.dev/get-started]: /docs/get-started

--- a/null_safety_examples/README.md
+++ b/null_safety_examples/README.md
@@ -1,0 +1,16 @@
+# Flutter null safety example apps
+
+To analyze, test and run individual apps, execute the following commands from
+the repo root (`$PROJECT` represents the app project path, such as
+`null_safety_examples/layout/base`):
+
+1. `flutter create --no-overwrite $PROJECT`
+1. `cd $PROJECT`
+1. `flutter analyze`
+1. `flutter test`
+1. `flutter run`
+
+To learn more about setting up Flutter and running apps, see
+[flutter.dev/get-started][].
+
+[flutter.dev/get-started]: https://flutter.dev/docs/get-started

--- a/null_safety_examples/basics/lib/main.dart
+++ b/null_safety_examples/basics/lib/main.dart
@@ -1,0 +1,36 @@
+// Copyright 2018 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: avoid_init_to_null
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(MyApp());
+
+// #docregion MyApp
+class MyApp extends StatelessWidget {
+  final int anInt = 3; // Cannot be null.
+  final int? aNullableInt = null; // Can be null.
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Nullable Fields Demo',
+      home: Scaffold(
+        appBar: AppBar(
+          title: Text('Nullable Fields Demo'),
+        ),
+        body: Center(
+          child: Column(
+            children: [
+              Text('anInt is $anInt.'),
+              Text('aNullableInt is $aNullableInt.'),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+// #enddocregion MyApp

--- a/null_safety_examples/basics/lib/main.dart
+++ b/null_safety_examples/basics/lib/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Flutter team. All rights reserved.
+// Copyright 2021 The Flutter team. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/null_safety_examples/basics/pubspec.yaml
+++ b/null_safety_examples/basics/pubspec.yaml
@@ -1,0 +1,17 @@
+name: null_safety_basics
+description: Some code to demonstrate null safety.
+version: 1.0.0
+
+environment:
+  sdk: '>=2.12.0-0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/null_safety_examples/layout/base/.gitignore
+++ b/null_safety_examples/layout/base/.gitignore
@@ -1,0 +1,46 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+**/ios/Flutter/.last_build_id
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+/build/
+
+# Web related
+lib/generated_plugin_registrant.dart
+
+# Symbolication related
+app.*.symbols
+
+# Obfuscation related
+app.*.map.json
+
+# Android Studio will place build artifacts here
+/android/app/debug
+/android/app/profile
+/android/app/release

--- a/null_safety_examples/layout/base/.metadata
+++ b/null_safety_examples/layout/base/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: ff03a9c362b10e637d6a62f07fffc4eb17f9ea7c
+  channel: master
+
+project_type: app

--- a/null_safety_examples/layout/base/README.md
+++ b/null_safety_examples/layout/base/README.md
@@ -1,0 +1,16 @@
+# base
+
+A new Flutter project.
+
+## Getting Started
+
+This project is a starting point for a Flutter application.
+
+A few resources to get you started if this is your first Flutter project:
+
+- [Lab: Write your first Flutter app](https://flutter.dev/docs/get-started/codelab)
+- [Cookbook: Useful Flutter samples](https://flutter.dev/docs/cookbook)
+
+For help getting started with Flutter, view our
+[online documentation](https://flutter.dev/docs), which offers tutorials,
+samples, guidance on mobile development, and a full API reference.

--- a/null_safety_examples/layout/base/README.md
+++ b/null_safety_examples/layout/base/README.md
@@ -8,9 +8,9 @@ This project is a starting point for a Flutter application.
 
 A few resources to get you started if this is your first Flutter project:
 
-- [Lab: Write your first Flutter app](https://flutter.dev/docs/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://flutter.dev/docs/cookbook)
+- [Lab: Write your first Flutter app](/docs/get-started/codelab)
+- [Cookbook: Useful Flutter samples](/docs/cookbook)
 
 For help getting started with Flutter, view our
-[online documentation](https://flutter.dev/docs), which offers tutorials,
+[online documentation](/docs), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.

--- a/null_safety_examples/layout/base/lib/main.dart
+++ b/null_safety_examples/layout/base/lib/main.dart
@@ -1,0 +1,29 @@
+// Copyright 2018 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(MyApp());
+
+// #docregion MyApp
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter layout demo',
+      home: Scaffold(
+        appBar: AppBar(
+          title: Text('Flutter layout demo'),
+        ),
+        // #docregion centered-text
+        body: Center(
+          // #docregion text
+          child: Text('Hello World'),
+          // #enddocregion text
+        ),
+        // #enddocregion centered-text
+      ),
+    );
+  }
+}

--- a/null_safety_examples/layout/base/lib/main.dart
+++ b/null_safety_examples/layout/base/lib/main.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Flutter team. All rights reserved.
+// Copyright 2021 The Flutter team. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/null_safety_examples/layout/base/pubspec.yaml
+++ b/null_safety_examples/layout/base/pubspec.yaml
@@ -1,6 +1,6 @@
 name: layout
 description: >
-  Sample app from "Building Layouts", https://flutter.io/docs/development/ui/layout.
+  Sample app from "Building Layouts", https://flutter.dev/docs/development/ui/layout.
 version: 1.0.0
 
 environment:

--- a/null_safety_examples/layout/base/pubspec.yaml
+++ b/null_safety_examples/layout/base/pubspec.yaml
@@ -1,0 +1,19 @@
+name: layout
+description: >
+  Sample app from "Building Layouts", https://flutter.io/docs/development/ui/layout.
+version: 1.0.0
+
+environment:
+  sdk: '>=2.12.0-0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^0.1.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/null_safety_examples/layout/base/test/widget_test.dart
+++ b/null_safety_examples/layout/base/test/widget_test.dart
@@ -1,0 +1,11 @@
+// Basic Flutter widget test. Learn more at https://flutter.io/docs/testing.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:layout/main.dart';
+
+void main() {
+  testWidgets('Codelab smoke test', (WidgetTester tester) async {
+    await tester.pumpWidget(new MyApp());
+    expect(find.text('Hello World'), findsOneWidget);
+  });
+}

--- a/null_safety_examples/layout/base/test/widget_test.dart
+++ b/null_safety_examples/layout/base/test/widget_test.dart
@@ -1,4 +1,4 @@
-// Basic Flutter widget test. Learn more at https://flutter.io/docs/testing.
+// Basic Flutter widget test. Learn more at https://flutter.dev/docs/testing.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:layout/main.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,11 +6,9 @@ environment:
 dev_dependencies:
   build_runner: ^1.1.2
   code_excerpt_updater:
-    git: https://github.com/chalin/code_excerpt_updater.git
-    # path: ../code_excerpt_updater
+    git: https://github.com/RedBrogdon/code_excerpt_updater.git
   code_excerpter:
-    git: https://github.com/chalin/code_excerpter.git
-    # path: ../code_excerpter
+    git: https://github.com/RedBrogdon/code_excerpter.git
   linkcheck: ^2.0.6
   yaml: ^2.1.15
   path: ^1.6.2

--- a/src/docs/null-safety.md
+++ b/src/docs/null-safety.md
@@ -5,7 +5,35 @@ description: Find out how to use non-nullable types in your Flutter code.
 
 Null safety is available in the Flutter beta channel,
 starting with build `1.24.0-10.2.pre`.
-You can now migrate your Flutter packages to use non-nullable types!
+You can now migrate your Flutter packages to use non-nullable types like this:
+
+<?code-excerpt "../null_safety_examples/basics/lib/main.dart (MyApp)"?>
+```dart
+class MyApp extends StatelessWidget {
+  final int anInt = 3; // Cannot be null.
+  final int? aNullableInt = null; // Can be null.
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Nullable Fields Demo',
+      home: Scaffold(
+        appBar: AppBar(
+          title: Text('Nullable Fields Demo'),
+        ),
+        body: Center(
+          child: Column(
+            children: [
+              Text('anInt is $anInt.'),
+              Text('aNullableInt is $aNullableInt.'),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
 
 To learn about null safety,
 read these pages:

--- a/tool/check-code.sh
+++ b/tool/check-code.sh
@@ -6,16 +6,16 @@ readonly rootDir="$(cd "$(dirname "$0")/.." && pwd)"
 
 [[ -z "$DART_SITE_ENV_DEFS" ]] && . ./tool/env-set.sh
 
-if [[ $1 == --clean ]]; then
-  shift;
-  (set -x; git clean -xdf ./example)
-fi
-
-if [[ $1 == --help || $1 == -h ]]; then
-  echo "Usage: $0 [--clean] [--no-test] [--filter=example-path-pattern]"
-  echo "  --filter pattern   Will skip example apps whose name does not match pattern."
-  exit 0
-fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --null-safety)  NULL_SAFETY=1; shift;;
+    --clean)        (set -x; git clean -xdf ./example); shift;;
+    -h|--help)      echo "Usage: $0 [--clean] [--no-test] [--filter=example-path-pattern] [--null-safety]"
+                    echo "  --filter pattern   Will skip example apps whose name does not match pattern."
+                    exit 0;;
+    *)              echo "ERROR: Unrecognized option: $1. Use --help for details."; exit 1;;
+  esac
+done
 
 errorMessage="
 Error: some code excerpts need to be refreshed. You'll need to
@@ -33,5 +33,9 @@ travis_fold start refresh_code_excerpts
 travis_fold end refresh_code_excerpts
 
 travis_fold start check_code
-  ./tool/build_check_deploy.sh --no-build --no-check-links $*
+  if [[ -n $NULL_SAFETY ]]; then
+    ./tool/build_check_deploy.sh --no-build --no-check-links --null-safety $*
+  else
+    ./tool/build_check_deploy.sh --no-build --no-check-links $*
+  fi
 travis_fold end check_code


### PR DESCRIPTION
* Adds a new `null_safety_examples` folder to the repo for null safe code examples.
  - Also adds two examples to the directory.
* Adds a flag to the testing scripts (code_check.sh on down) to allow for testing of these new examples.
  - Also removes a "legacy" flag that was no longer in use.
* Updates travis configuration to call scripts with the flag on the beta and dev channels.
* Adds a code excerpt to null-safety.md as a way to make sure excerpting of null safe code is working.

This PR does not touch the automatic extraction and testing of snippets as described in `/tool/extract.dart`. The comments in that file indicated that it's a deprecated pattern and new/updated snippets are meant to use the newer code excerpt packages, so I focused my effort on them.