### PR TITLE
Address i18n doc fixes

### DIFF
--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -195,8 +195,19 @@ project called `l10n.yaml` with the following content:
 
    <!-- skip -->
    ```dart
-   import 'package:flutter_localizations/flutter_localizations.dart';
    import 'package:flutter_gen/gen_l10n/app_localizations.dart'; // Add this line
+
+   // ...
+
+   // In your Material/Widget/CupertinoApp:
+   @override
+   Widget build(BuildContext context) {
+     return MaterialApp(
+       localizationsDelegates: AppLocalizations.localizationsDelegates, // Add this line
+       supportedLocales: AppLocalizations.supportedLocales, // Add this line
+       home: // ...
+     );
+   }
 
    // ...
 
@@ -216,6 +227,21 @@ project called `l10n.yaml` with the following content:
 
 To see a sample Flutter app using this tool, please see
 [`gen_l10n_example`][].
+
+To localize your device app description, you can pass in the localized
+string into [MaterialApp.onGenerateTitle][]:
+
+  <!-- skip -->
+  ```dart
+  // In your Material/Widget/CupertinoApp:
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      onGenerateTitle: (BuildContext context) => AppLocalizations.of(context).appTitle,
+      // ...
+    );
+  }
+  ```
 
 For more information about the localization tool,
 such as dealing with DateTime and handling plurals,
@@ -720,6 +746,7 @@ Rebuilding `l10n/messages_all.dart` requires two steps.
 [`LocalizationsDelegate`]: {{site.api}}/flutter/widgets/LocalizationsDelegate-class.html
 [material-global]: {{site.api}}/flutter/flutter_localizations/GlobalMaterialLocalizations-class.html
 [`MaterialApp`]: {{site.api}}/flutter/material/MaterialApp-class.html
+[`MaterialApp.onGenerateTitle`]: {{site.api}}/flutter/material/MaterialApp/onGenerateTitle.html
 [`MaterialLocalizations`]: {{site.api}}/flutter/material/MaterialLocalizations-class.html
 [`minimal`]: {{site.github}}/flutter/website/tree/master/examples/internationalization/minimal
 [Minimal internationalization]: {{site.github}}/flutter/website/tree/master/examples/internationalization/minimal


### PR DESCRIPTION
Fixes remaining issues addressed in https://github.com/flutter/website/issues/5062.

1. Remove unnecessary import in the app. Since the import is only needed for additional customization in the flutter app, it's not necessary for the purposes of the tutorial.
2. Added a link and snippet regarding `onGenerateTitle`, which is helpful for Android apps when the task manager needs a localized name to use to refer to the Flutter app.