### PR TITLE
docs: Updated provider package version in state management docs.

### DIFF
--- a/src/docs/development/data-and-backend/state-mgmt/simple.md
+++ b/src/docs/development/data-and-backend/state-mgmt/simple.md
@@ -202,7 +202,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  provider: ^3.0.0
+  provider: ^4.0.0
 
 dev_dependencies:
   # ...


### PR DESCRIPTION
The documentation still used `provider^3.0.0`, whereas the tutorial and code examples depend on v4.
Updating the dependency resolves situations where methods like `BuildContext.watch` cannot be found when following the [state management tutorial](https://flutter.dev/docs/development/data-and-backend/state-mgmt/simple).


