### PR TITLE
Includes read more on the eBay app

### DIFF
--- a/src/_data/showcases.yml
+++ b/src/_data/showcases.yml
@@ -293,6 +293,7 @@
     The eBay Motors app is a powerful tool for browsing,
     buying, and selling vehicles directly from consumers’ phones.
   logo_src: showcase/cards/ebay-logo.png
+  learn_more_cta: Learn more
   learn_more_link: https://pages.ebay.com/motors/motorsapp
   app_store_link: https://apps.apple.com/us/app/ebay-motors/id1456156090
   play_store_link: https://play.google.com/store/apps/details?id=com.ebay.motorsapp


### PR DESCRIPTION
Hello everyone, everything good?

I noticed a small bug in the showcase section, the eBay app was not showing the "Learn more" call to action.

![before](https://user-images.githubusercontent.com/17712401/103452055-31e25580-4caa-11eb-809e-bf98af8027ac.png)

In this PR, I corrected this by inserting the call to action as it should:

![after](https://user-images.githubusercontent.com/17712401/103452084-65bd7b00-4caa-11eb-934b-215cb863a74a.png)