### PR TITLE
Updated integration_test package in pubspec.yaml

### DIFF
--- a/examples/integration_test/pubspec.yaml
+++ b/examples/integration_test/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  integration_test: ^0.9.0
+  integration_test: ^1.0.1
   flutter_test:
     sdk: flutter
   flutter_driver:


### PR DESCRIPTION
Updater integration_test package in pubspec.yaml from 0.9.0 to 1.0.1 (latest stable) in integration_test example.

NOTE: We love contributions, but we hate spam. If your PR doesn't improve flutter.dev, we'll close it and label it as `invalid`.

Fixes #<issue number>.

Changes proposed in this pull request:

*  
* 
