### PR TITLE
Added supported platforms test matrix, linked to sidebar and FAQ.

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -16,6 +16,7 @@
     "xster-staging": "flutter-website-staging-6f2ad",
     "jr": "flutter-website-jr-stagi-988d4",
     "add-to-app-2019": "add-to-app-2019",
-    "kf6gpe": "kf6gpe-flutter-staging"
+    "kf6gpe": "kf6gpe-flutter-staging",
+    "staging": "kf6gpe-flutter-staging"
   }
 }

--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -135,6 +135,8 @@
     - title: Platform integration
       permalink: /docs/development/platform-integration
       children:
+        - title: Supported platforms
+          permalink: /docs/development/tools/sdk/release-notes/supported-platforms
         - title: Adding iOS App Clip support
           permalink: /docs/development/platform-integration/ios-app-clip
         - title: Apple Watch support

--- a/src/docs/development/tools/sdk/release-notes/supported-platforms.md
+++ b/src/docs/development/tools/sdk/release-notes/supported-platforms.md
@@ -1,0 +1,76 @@
+---
+title: Supported platforms
+short-title: Supported platforms
+description: The platforms that Flutter supports by platform version.
+---
+
+## How we define a supported platform
+
+As of Flutter 1.20, we define three tiers of support for the 
+platforms on which Flutter runs:
+1. Supported Google-tested platforms, which are platforms the Flutter team at 
+Google tests in continuous integration at every commit. 
+For these platforms, we also run post-commit  tests before 
+rolling from the master channel to the dev channel. 
+1. Best effort platforms, supported community testing, which are 
+platforms we believe we support through coding practices 
+and ad-hoc testing, but rely on the community for testing.
+1. Unsupported platforms, which are platforms that may work,
+but that the development team does not directly test or support.
+
+
+### Supported Google-tested platforms
+
+|Platform|Version              |
+|-------|----------------------|
+|Android|Android SDK 29        |
+|Android|Android SDK 28        |
+|Android|Android SDK 27        |
+|Android|Android SDK 26        |
+|Android|Android SDK 25        |
+|Android|Android SDK 24        |
+|Android|Android SDK 23        |
+|Android|Android SDK 21        |
+|Android|Android SDK 19        |
+|iOS    | 14 (all)             |
+|iOS    | 13.3-13.7            |
+|iOS    | 13.0                 |
+|iOS    | 12.4 & 12.4.1        |
+|iOS    | 9.3.6                |
+|Web    | Chrome 84            |
+|Web    | Firefox 72.0         |
+|Web    | Safari / Catalina    |
+|Web    | Edge 1.2.0           |
+|Windows| Windows 10           |
+|macOS  | El Capitan & greater |
+|Linux  | Debian 10            |
+
+
+### Best effort platforms tested by the community
+
+|Platform|Version       |
+|-------|---------------|
+|Android|Android SDK 30 |
+|Android|Android SDK 22 |
+|Android|Android SDK 20 |
+|Android|Android SDK 18 |
+|Android|Android SDK 17 |
+|Android|Android SDK 16 |
+|iOS    |iOS 13.1       |
+|iOS    |iOS 12.1-12.3  |
+|iOS    |iOS 10 (all)   |
+|iOS    |iOS 9.0        |
+|iOS    |iOS 8 (all)    |
+|Windows|Windows 8      |
+|Windows|Windows 7      |
+|Linux  | Debian & below |
+
+### Unsupported platforms
+
+|Platform|Version              |
+|--------|---------------------|
+|Android|Android SDK 15 & below|
+|iOS    |iOS 7 & below         |
+|Windows|Windows Vista & below |
+|Windows|Any 32-bit platform   |   
+|macOS  | Yosemite & below     |

--- a/src/docs/resources/faq.md
+++ b/src/docs/resources/faq.md
@@ -401,7 +401,9 @@ on the edge.
   as well as with Android emulators and the iOS simulator.
 
 * We test on a variety of low-end to high-end phones and tablets,
-  but we don't yet have an official device compatibility guarantee.
+  For a detailed list of platform supports by version and
+  an explanation of our support policy, see 
+  [supported platforms].
 
 ### Does Flutter run on the web?
 
@@ -997,3 +999,4 @@ follow Apple's [guidelines][] for App Store submission.
 [web instructions]: /docs/get-started/web
 [`Widget`]: {{site.api}}/flutter/widgets/Widget-class.html
 [widgets]: /docs/development/ui/widgets
+[supported platfomrs]: /docs/development/tools/sdk/release-notes/supported-platforms].


### PR DESCRIPTION
Changes proposed in this pull request:

*  Adds a page with the matrix of platforms on which we test [here](https://kf6gpe-flutter-staging.firebaseapp.com/docs/development/tools/sdk/release-notes/supported-platforms)
*  Adds a link to that page on the sidebar under "Platform integration".
*  Adds a link to that page from the FAQ page.

Deployed to a staging instance https://kf6gpe-flutter-staging.firebaseapp.com/ for review. 
