### PR TITLE
Language pass on use-maxLengthEnforcement-instead-of-maxLengthEnforced

### DIFF
--- a/src/docs/release/breaking-changes/use-maxLengthEnforcement-instead-of-maxLengthEnforced.md
+++ b/src/docs/release/breaking-changes/use-maxLengthEnforcement-instead-of-maxLengthEnforced.md
@@ -5,70 +5,55 @@ description: Introducing the MaxLengthEnforcement enum.
 
 ## Summary
 
-_If you don't use the `maxLength` or `maxLengthEnforced` properties in a
-`TextField`, `TextFormField`, or `CupertinoTextField`,
-or you don't care about the truncation behavior of an
-editable text field, you can stop reading._
-
-To control the behavior of `maxLength`
-in the `LengthLimitingTextInputFormatter`,
-use `maxLengthEnforcement` instead of `maxLengthEnforced`, which was deprecated.
+To control the behavior of `maxLength` in the `LengthLimitingTextInputFormatter`,
+use `maxLengthEnforcement` instead of the now-deprecated `maxLengthEnforced`.
 
 ## Context
 
 The `maxLengthEnforced` parameter was used to decide whether text fields should
-truncate the input value when it reaches the `maxLength` limit. Additionally,
-`TextField` and `TextFormField` will display a warning message in the
-characters counter when this parameter is set to false and the length of the
-user input exceeds `maxLength`.
+truncate the input value when it reaches the `maxLength` limit, or whether
+(for `TextField` and `TextFormField`) a warning message should instead be shown in the
+character count when the length of the user input exceeded `maxLength`.
 
 However, to enter CJK characters, some input methods require the user to enter
 a sequence of Latin characters into the text field, then turn this sequence
-into desired CJK characters
-(this process will later be referred to as *text composition*).
+into desired CJK characters (a referred to as *text composition*).
 The Latin sequence is usually longer than the resulting CJK characters,
-so setting a hard maximum character limit on a text field may give an
-unpleasant input experience if the user uses one of these input methods,
-as the user may not be able to finish the text composition normally due to the
-maxLength character limit.
+so setting a hard maximum character limit on a text field may mean
+the user is unable to finish the text composition normally due to the
+`maxLength` character limit.
 
-Text composition is generally used by the input method to indicate that the
-text within the highlighted composing region is being actively edited.
-It may also be used when entering regular Latin characters. For example,
-Gboard's English keyboard on Android
-(as with many other input methods on Android) puts the currently English word
+Text composition is also used by some input methods to indicate that the
+text within the highlighted composing region is being actively edited,
+even when entering Latin characters. For example, Gboard's English keyboard on Android
+(as with many other input methods on Android) puts the current word
 in a composing region.
 
-To improve the input experience in these scenarios, a new tri-state enum
-`MaxLengthEnforcement` was introduced, which describes supported strategies
-for handling active composing region when applying a
-`LengthLimitingTextInutFormatter`. This enum has been added to text fields to
-replace the `maxLengthEnforced` parameter. With the new enum parameter,
-developers can choose different strategies based on the type of the content
-the text field expects.
+To improve the input experience in these scenarios, a new tri-state enum,
+`MaxLengthEnforcement`, was introduced. Its values describe supported strategies
+for handling active composing regions when applying a
+`LengthLimitingTextInutFormatter`. A new `maxLengthEnforcement` parameter that uses
+this enum has been added to text fields to replace the boolean `maxLengthEnforced`
+parameter. With the new enum parameter, developers can choose different strategies
+based on the type of the content the text field expects.
 
-(For more information, see the docs for [`maxLength`][] and
-[`MaxLengthEnforcement`][].)
+For more information, see the docs for [`maxLength`][] and
+[`MaxLengthEnforcement`][].
 
 The default value of the `maxLengthEnforcement` parameter is inferred from the
-`TargetPlatform` of the application, to confirm to the platform's conventions.
+`TargetPlatform` of the application, to conform to the platform's conventions:
 
 ## Description of change
 
-* Added a `MaxLengthEnforcement` enum as a replacement for the now-deprecated
-  boolean `maxLengthEnforced` parameter on `TextField`, `TextFormField`,
-  `CupertinoTextField`, and `LengthLimitingTextInputFormatter` classes.
-* The default value of the maxLengthEnforced property is inferred based on the
-  target platform, to improve the input experience:
-  * Android, Windows: defaults to `MaxLengthEnforcement.enforced`.
-  * iOS, Web, MacOS, Linux, Fuchsia: defaults to
-    `MaxLengthEnforcement.truncateAfterCompositionEnds`.
+* Added a `maxLengthEnforcement` parameter using the new enum type `MaxLengthEnforcement`,
+  as a replacement for the now-deprecated boolean `maxLengthEnforced` parameter on
+  `TextField`, `TextFormField`, `CupertinoTextField`, and
+  `LengthLimitingTextInputFormatter` classes.
 
 ## Migration guide
 
-_Use the default behavior for the current platform is recommended, since it
-won't break someone that is not surposed to input like the behavior that
-developers has defined._
+_Using the default behavior for the current platform is recommended, since
+this will be the behavior most familiar to the user._
 
 ### Default values of `maxLengthEnforcement`
 
@@ -76,16 +61,22 @@ developers has defined._
   these platforms is enforced. The inputting value will be truncated whether
   the user is entering with composition or not.
 * iOS, MacOS: `MaxLengthEnforcement.truncateAfterCompositionEnds`.
-  iOS and MacOS has no default behavior and it requires users implement the
-  behavior themselves. Allow the composition to exceed to avoid breaking CJK
-  input.
-* Web, Linux, Fuchsia: `MaxLengthEnforcement.truncateAfterCompositionEnds`.
-  These platforms allow the composition to exceed by default.
+  These platforms do not have a "maximum length" feature and therefore require
+  that developers implement the behavior themselves. No standard convention seems
+  to have evolved on these platforms. We have chosen to allow the composition to
+  exceed the maximum length to avoid breaking CJK input.
+* Web and Linux: `MaxLengthEnforcement.truncateAfterCompositionEnds`.
+  While there is no standard on these platforms (and many implementation exist with
+  conflicting behavior), the common convention seems to be to allow the composition
+  to exceed the maximum length by default.
+* Fuchsia: `MaxLengthEnforcement.truncateAfterCompositionEnds`.
+  There is no platform convention on this platform yet, so we have chosen to
+  default to the convention that is least likely to result in data loss.
 
 ### To enforce the limit all the time
 
 To enforce the limit that always truncate the value when it reaches the limit
-(e.g. entering verfication code), use `MaxLengthEnforcement.enforced` in
+(e.g. entering a verification code), use `MaxLengthEnforcement.enforced` in
 editable text fields.
 
 _This option may give suboptimal user experience when used with input methods
@@ -163,23 +154,23 @@ Code after migration:
 
 <!-- skip -->
 ```dart
-CupertinoTextField(
-  // Leave it not set.
-)
+CupertinoTextField()
 ```
 
 ### To enforce the limit, but not for composing text
 
 To avoid truncating text while the user is inputting text via composition,
 specify `MaxLengthEnforcement.truncateAfterCompositionEnds`. This behavior
-allows some Chinese, Japanese, and Korean (CJK) characters to temporarily
+allows input methods that use composing regions larger than the resulting text,
+as is common for example with Chinese, Japanese, and Korean (CJK) text, to temporarily
 ignore the limit until editing is complete.
 
 _Gboard's English keyboard on Android (and many other Android input methods)
-creates a composing region for the current English word being entered. When
-used in a `truncateAfterCompositionEnds` text field, the user may not be
+creates a composing region for the word being entered. When
+used in a `truncateAfterCompositionEnds` text field, the user will not be
 stopped right away at the `maxLength` limit. Consider the `enforced` option
-if the text field does not expect CJK characters on a phonetic keyboard._
+if you are confident that the text field will not be used with input methods
+that use temporarily long composing regions such as CJK text._
 
 Code for the implementation:
 
@@ -187,9 +178,19 @@ Code for the implementation:
 ```dart
 TextField(
   maxLength: 6,
-  maxLengthEnforcement: MaxLengthEnforcement.truncateAfterCompositionEnds, // <-- Temporarily lift the limit
+  maxLengthEnforcement: MaxLengthEnforcement.truncateAfterCompositionEnds, // Temporarily lifts the limit.
 )
 ```
+
+### Be wary of assuming input will not use composing regions
+
+It is tempting when targeting a particular locale to assume that all users will be satisfied with input
+from that locale. For example, forum software targeting an English-language community might be assumed
+to only need to deal with English text. However, this kind of assumption is often incorrect. For example,
+maybe the English-language forum participants will want to discuss Japanese anime or Vietnamese cooking.
+Maybe one of the participants is Korean and prefers to express their name in their native ideographs.
+For this reason, freeform fields should rarely use the `enforced` value and should instead prefer the
+`truncateAfterCompositionEnds` value if at all possible.
 
 ## Timeline
 


### PR DESCRIPTION
Just some editing to clean up some of the language.

Also adds a section that talks about why assuming English is dangerous.
