### PR TITLE
Mark `dart:ffi` as stable

### DIFF
--- a/src/docs/development/platform-integration/c-interop.md
+++ b/src/docs/development/platform-integration/c-interop.md
@@ -23,7 +23,7 @@ that implements 32-bit addition and then
 exposes it through a Dart plugin named "native_add".
 
 {{ site.alert.version-note }}
-  As of Dart 2.12 beta, FFi has been marked as 1.0,
+  As of Dart 2.12 beta, FFI has been marked as 1.0,
   and will be fully stable once a 2.12 stable SDK is
   released.
 {{ site.alert.end }}

--- a/src/docs/development/platform-integration/c-interop.md
+++ b/src/docs/development/platform-integration/c-interop.md
@@ -22,6 +22,12 @@ In this walkthrough, you'll create a C function
 that implements 32-bit addition and then
 exposes it through a Dart plugin named "native_add".
 
+{{ site.alert.version-note }}
+  As of Dart 2.12 beta, FFi has been marked as 1.0,
+  and will be fully stable once a 2.12 stable SDK is
+  released.
+{{ site.alert.end }}
+
 ### Dynamic vs static linking
 
 A native library can be linked into an app either

--- a/src/docs/development/platform-integration/c-interop.md
+++ b/src/docs/development/platform-integration/c-interop.md
@@ -22,11 +22,6 @@ In this walkthrough, you'll create a C function
 that implements 32-bit addition and then
 exposes it through a Dart plugin named "native_add".
 
-{{ site.alert.note }}
-  The dart:ffi library is [in beta][ffi issue],
-  and breaking API changes might still happen.
-{{ site.alert.end }}
-
 ### Dynamic vs static linking
 
 A native library can be linked into an app either


### PR DESCRIPTION
Should be merged when https://dart-review.googlesource.com/c/sdk/+/179765 is merged.