### PR TITLE
Fix wrong parameter name

### DIFF
--- a/src/docs/development/platform-integration/platform-views.md
+++ b/src/docs/development/platform-integration/platform-views.md
@@ -195,7 +195,7 @@ import io.flutter.plugin.platform.PlatformViewFactory
 class NativeViewFactory : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
     override fun create(context: Context, viewId: Int, args: Any?): PlatformView {
         val creationParams = args as Map<String?, Any?>?
-        return NativeView(context, id, creationParams)
+        return NativeView(context, viewId, creationParams)
     }
 }
 ```


### PR DESCRIPTION
In the create method of the NativeViewFactory a wrong parameter name is used (id instead of viewId).

Changes proposed in this pull request:

*  Correct name of parameter id -> viewId
