### PR TITLE
Fix broken link in FAQ

### DIFF
--- a/src/docs/resources/faq.md
+++ b/src/docs/resources/faq.md
@@ -158,7 +158,7 @@ that offer dependency injection and service location, such as [injectable][],
 ### What technology is Flutter built with?
 
 Flutter is built with C, C++, Dart, and Skia (a 2D rendering engine). See this
-[diagram][] for a better picture of the main components. For a more detailed
+[architecture diagram][] for a better picture of the main components. For a more detailed
 description of the layered architecture of Flutter, read the [architectural
 overview].
 


### PR DESCRIPTION
Fixes #5187

Changes proposed in this pull request:

*  Fix a link that was accidentally broken on the FAQ by a past commit. It used to be `[architecture diagram]`, but was changed to just `[diagram]`. This reverts that change. 