### PR TITLE
Fixes the URL link.

### DIFF
--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -243,7 +243,7 @@ To see a sample Flutter app using this tool, please see
 [`gen_l10n_example`][].
 
 To localize your device app description, you can pass in the localized
-string into [MaterialApp.onGenerateTitle][]:
+string into [`MaterialApp.onGenerateTitle`][]:
 
   <!-- skip -->
   ```dart


### PR DESCRIPTION
The link of `MaterialApp.onGenerateTitle` is missed, this PR is trying to fix this.

cc/ @sfshaza2, Long time no see ;-) 