### PR TITLE
Remove Duplicate Command in flutter-cli.md

### DIFF
--- a/src/docs/reference/flutter-cli.md
+++ b/src/docs/reference/flutter-cli.md
@@ -58,11 +58,10 @@ The following table shows which commands you can use with the `flutter` tool:
 | downgrade | `flutter downgrade` | Downgrade Flutter to the last active version for the current channel. |
 | drive | `flutter drive` | Runs Flutter Driver tests for the current project. |
 | emulators | `flutter emulators` | List, launch and create emulators. |
-| format | `flutter format <DART_FILE>` | Format one or more dart files. |
+| format  | `flutter format <DIRECTORY|DART_FILE>` | Formats Flutter source code.<br>Use instead of [`dartfmt`][]. | 
 | gen-l10n | `flutter gen-l10n <DIRECTORY>` | Generate localizations for the Flutter project. |
 | install | `flutter install -d <DEVICE_ID>` | Install a Flutter app on an attached device. |
 | logs | `flutter logs` | Show log output for running Flutter apps. | 
-| format  | `flutter format <DIRECTORY|DART_FILE>` | Formats Flutter source code.<br>Use instead of [`dartfmt`][]. | 
 | precache | `flutter precache <ARGUMENTS>` | Populates the Flutter tool's cache of binary artifacts. |
 | pub     | `flutter pub <PUB_COMMAND>`       | Works with packages.<br>Use instead of [`pub`][]. | 
 | run     | `flutter run <DART_FILE>`         | Runs a Flutter program. | 


### PR DESCRIPTION
i found duplicate command in `flutter-cli.md`
deleted duplicates and re-order them to alphabetical


![image](https://user-images.githubusercontent.com/42999044/105577282-de03f180-5dbb-11eb-9c81-7f2f91628c08.png)


if you need another amendment, please leave a comment

there are two ways to represent more than one option, which one should i choose?
- `flutter format <DIRECTORY|DART_FILE>`
- `flutter format [<DIRECTORY|DART_FILE>]`