### PR TITLE
Add site.alert.version-note

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -115,6 +115,9 @@ alert:
   note: >-
     <aside class="alert alert-info" role="alert" markdown="1">
     <i class="fas fa-info-circle"></i> **Note:**
+  version-note: >-
+    <aside class="alert alert-info" role="alert" markdown="1">
+    <i class="fas fa-code-branch"></i> **Version note:**
   secondary: >-
     <aside class="alert alert-secondary" role="alert" markdown="1">
   tip: >-


### PR DESCRIPTION
As promised in #5195, this change enables flutter.dev to support version notes, like dart.dev does. I tested the change locally.