### PR TITLE
Docs: Changed deprecated version of Scaffold.showSnackBar

### DIFF
--- a/src/docs/cookbook/gestures/dismissible.md
+++ b/src/docs/cookbook/gestures/dismissible.md
@@ -85,7 +85,7 @@ Dismissible(
     });
 
     // Show a snackbar. This snackbar could also contain "Undo" actions.
-    Scaffold
+    ScaffoldMessenger
         .of(context)
         .showSnackBar(SnackBar(content: Text("$item dismissed")));
   },
@@ -117,7 +117,7 @@ Dismissible(
       items.removeAt(index);
     });
 
-    Scaffold
+    ScaffoldMessenger
         .of(context)
         .showSnackBar(SnackBar(content: Text("$item dismissed")));
   },
@@ -180,7 +180,7 @@ class MyAppState extends State<MyApp> {
                 });
 
                 // Then show a snackbar.
-                Scaffold.of(context)
+                ScaffoldMessenger.of(context)
                     .showSnackBar(SnackBar(content: Text("$item dismissed")));
               },
               // Show a red background as the item is swiped away.


### PR DESCRIPTION
to ScaffoldMessenger.showSnackBar in Dismissible example

Fixes #5219.

Changes proposed in this pull request:

*  Changed deprecated version of Scaffold.showSnackBar to ScaffoldMessenger.showSnackBar