### PR TITLE
Add content to docs/perf

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -312,6 +312,12 @@
         permalink: /docs/perf/rendering/ui-performance
       - title: Reduce shader compilation jank
         permalink: /docs/perf/rendering/shader
+    - title: Performance metrics
+      permalink: /docs/perf/metrics
+    - title: Frequently Asked Questions
+      permalink: /docs/perf/faq
+    - title: Appendix
+      permalink: /docs/perf/appendix
 
 - title: Deployment
   children:

--- a/src/docs/perf/appendix.md
+++ b/src/docs/perf/appendix.md
@@ -88,7 +88,7 @@ word or phrase could be interpreted differently by different people. You might
 interpret an OK frame rate to be 60 fps, while someone else might interpret it
 to be 30 fps.
 
-Numbers could still be noisy. For example, the measured time per frame might
+Numbers can still be noisy. For example, the measured time per frame might
 be a true computation time of this frame, plus a random amount of time (noise)
 that CPU/GPU spends on some unrelated work. Hence, the metric will fluctuate.
 Nevertheless, there’s no ambiguity of what the number means. And, there are
@@ -103,7 +103,7 @@ Performance numbers not only have unambiguous meanings, but they also have
 unambiguous comparisons. For example, there’s no doubt that 5 is greater than 4.
 On the other hand, it might be subjective to figure out whether excellent is
 better or worse than superb. Similarly, could you figure out whether epic is
-better than legendary? Actually, the phrase _strongly_ _exceeds_ _expectations_
+better than legendary? Actually, the phrase _strongly exceeds expectations_
 could be better than _superb_ in someone’s interpretation. It only becomes
 unambiguous and comparable after a definition that maps strongly exceeds
 expectations to 4 and superb to 5.
@@ -126,15 +126,15 @@ cost for chatting or face-to-face meetings.
 
 By having the same metrics to detect problems no matter how far away or how
 silent the users are, we can treat all issues fairly. That, in turn,
-allows us to focus on the right issues that have greater effects.
+allows us to focus on the right issues that have greater impact.
 
 ### How to make performance useful
 
-The following is a summary the 4 points that were discussed, from a slightly
-different perspctive:
+The following summarizes the 4 points discussed here, from a slightly different
+perspective:
 1. Make performance metrics easy to consume. Do not overwhelm the readers with a
    lot of numbers (or words). If there are many numbers, then try to summarize
-   them into a smaller set of numbers (for exmaple, summarize many numbers into
+   them into a smaller set of numbers (for example, summarize many numbers into
    a single average number). Only notify readers when the numbers change
    significantly (for example, automatic alerts on spikes or regressions).
 

--- a/src/docs/perf/appendix.md
+++ b/src/docs/perf/appendix.md
@@ -1,0 +1,173 @@
+---
+title: Some more thoughts on performance
+description: What is performance, and why is performance importnat.
+---
+
+# What is performance?
+
+Performance is a set of quantifiable properties of a performer.
+
+In our context, it’s not the execution of an action itself (as the performance
+in performing arts). It’s “how well something/someone performs”. Hence it has an
+adjective word “performant”.
+
+While the “how well” part can in general be described in natural languages, in
+our limited scope, we only focus on something that’s quantifiable as a real
+number, which includes integers, and 0/1 binaries as special cases.
+Natural-language descriptions are still very important. For example, a news
+article that heavily criticizes Flutter’s performance by just using words
+without any numbers could still be devastating. The limited scope is chosen only
+because of our limited resources.
+
+For example, the 500-word quarterly performance summary is not in our scope. But
+if the quarterly performance is summarized in one word which has only 5 options,
+say “need-improvement, meet-expectations, exceed-expectations,
+strongly-exceed-expectations, superb”, then it’s within our scope as we can map
+those 5 options to 1, 2, 3, 4, 5.
+
+Take that to an extreme, all the correctness unit tests are within our scope as
+we can describe the code change's test performance as either 0 fail or 1 pass.
+If a performance is only described as either bad (e.g., janky) or good (e.g.,
+smooth), it’s within that binary scope too.
+
+The required quantity to describe the performance is often referred to as the
+metric.
+
+To navigate through countless performance issues and metrics, we can categorize
+based on performers.
+
+For example, most content here is about the Flutter app performance where the
+performer is a Flutter app. Infra performance is also important to Flutter where
+the performers are build bots and CI task runners: they heavily affect how fast
+Flutter can land some code changes to improve the app performance. Flutter team
+performance has the engineers inside the Flutter team as performers. Flutter
+community performance has the open-source community as the performer, and the
+performance metric could be the median time to close a community Github pull
+request.
+
+Here we intentionally broadens the scope to include performance issues other
+than just app performance issues because they can share many tools regardless of
+who the performers are. For example, Flutter app performance and infra
+performance may share the same dashboard and similar alert mechanisms.
+
+Broadening the scope also allows us to include performers that are traditionally
+easy to ignore. Documents performance is such an example. The performer could be
+an API doc of the SDK, and a metric could be: what's the percentage of readers
+who find it useful?
+
+Besides zooming out, categorizing performers also allows us to zoom in. For
+example, within the Flutter app performance issues, sometimes the performers can
+be further subdivided. There are Flutter framework performance issues which are
+usually blamed on a single framework commit version. There could also be Flutter
+engine performance issues or Skia performance issues that can be further
+pin-pointed down to a single engine or Skia commit.
+
+# Why is performance important?
+
+Answering this question is not only crucial for validating the work in
+performance, but also for guiding the performance work to be more useful. An
+answer for “why is performance important” is often also an answer for “how to
+make performance useful”.
+
+Simply speaking, performance is important and useful because in our scope it has
+to have quantifiable properties or metrics. That implies:
+1. Performance report is easy to consume.
+2. Performance has little ambiguity.
+3. Performance is comparable and convertible.
+4. Performance is more fair.
+
+Note they don't mean that non-performance or non-measurable issues or
+descriptions are not important. They're to high-light the scenarios where
+performance can be more useful.
+
+## 1. Performance report is easy to consume
+
+Performance metrics are numbers. Reading a number is much easier than reading a
+passage. For example, it probably takes an engineer 1 second to consume the
+performance rating as a number from 1 to 5. It probably takes the same person at
+least 1 minute to read the full 500-word feedback summary.
+
+If there are many numbers, it’s easy to summarize or visualize them for quick
+consumption. For example, one can quickly consume millions of numbers by looking
+at its histogram, average, quantiles, and so on. If a metric has a history of
+thousands of data points, one can easily plot a timeline to read its trend.
+
+On the other hand, having N number of 500-word texts almost guarantees an N-time
+cost to consume those texts. It would be a daunting task to analyze thousands of
+historical descriptions, each of which has 500 words.
+
+## 2. Performance has little ambiguity
+
+Another advantage of having performance as a set of numbers is its unambiguity.
+When we measure an animation to have a performance of 20ms per frame, or 50fps,
+there’s little room for different interpretations on the numbers themselves. On
+the other hand, to describe the same animation in words, someone may call it
+smooth, while someone else may complain that it’s laggy. Similarly, the same
+word or phrase could be interpreted differently by different people. One might
+interpret an “Ok frame rate” to be 60fps, while someone else may interpret it to
+be 30fps.
+
+Numbers could still be noisy. For example, the measured “time per frame” might
+be a true “computation time of this frame”, plus a noisy “random time that
+CPU/GPU spends on some unrelated work”. Hence the metric will fluctuate.
+Nevertheless, there’s no ambiguity of what the number means. And there are also
+rigorous theory and tested tools to handle such noise. For example, one could
+take multiple measurements to estimate the distribution of a random variable.
+One could take the average of many measurements to cancel the noise by [the law
+of large numbers][1].
+
+## 3. Performance is comparable and convertible
+
+Performance numbers have not only unambiguous meanings, but also unambiguous
+comparisons. For example, there’s no doubt that 5 is greater than 4. On the
+other hand, it may be subjective to figure out whether “excellent” is better or
+worse than “superb”. Similarly, could you figure out whether “epic” is better
+than “legendary”? Actually, the word “strongly-exceeds-expectation” could be
+better than “superb” in someone’s interpretation. It only becomes unambiguous
+and comparable after a definition that maps “strongly-exceeds-expectation” to 4,
+and “superb” to 5.
+
+Numbers are also easily convertible using formulas and functions. For example,
+60 fps can be converted to 16.67ms per frame. A frame render time x (ms)  can be
+converted to a binary indicator `isSmooth = [x <= 16] = (x <= 16 ? 1 :0)`. Such
+conversion can be compounded/chained so we can get a large variety of quantities
+using a single measurement without any added noise or ambiguity. The converted
+quantity can then be used for further comparisons and consumption. Such
+conversions are almost impossible if we’re dealing with natural languages.
+
+## 4. Performance is more fair
+
+If issues rely on verbose words to be discovered, then an unfair advantages are
+given to people who are (1) more verbose, or more willing to chat or write; (2)
+closer to the development team, who has a larger bandwidth and lower cost for
+chatting or face-to-face meetings.
+
+By having the same metrics to detect problems no matter how far or how silent
+the users are, we’re given a more fair treatment to all issues. That in turn
+allows us to focus on the right issues that have wider impacts.
+
+## How to make performance useful
+
+Now let's summarize the 3 points above from a slightly different perspctive:
+1. Make performance metrics easy to consume. Do not overwhelm the readers with a
+   ton of numbers (or words). If there are many numbers, try to summarize them
+   into a smaller set of numbers (e.g., summarize many numbers into a single
+   average number). Only notify readers when the numbers change significantly
+   (e.g., auto alerts on spikes/regressions).
+
+2. Make performance metrics as unambiguous as possible. Define the unit that the
+   number is using. Precisely describe how the number is measured. Make the
+   number easily reproducible. When there’s a lot of noise, try to show the full
+   distribution, or cancel out the noise as much as possible by aggregating many
+   noisy measurements.
+
+3. Make it easy to compare performance. For example, provide a timeline to
+   compare the current version with the old version. Provide ways and tools to
+   convert one metric to another. For example, if we can convert both memory
+   increase and fps drop into the number of users dropped or revenue loss in
+   dollars, we can then compare them and make an informed trade-off.
+
+4. Make performance metrics monitor as wide a population as possible, so no one
+   is left behind.
+
+[1]: https://en.wikipedia.org/wiki/Law_of_large_numbers

--- a/src/docs/perf/appendix.md
+++ b/src/docs/perf/appendix.md
@@ -7,155 +7,135 @@ description: What is performance, and why is performance important
 
 Performance is a set of quantifiable properties of a performer.
 
-In this context, performance isn't the execution of an action itself; 
+In this context, performance isn't the execution of an action itself;
 it’s how well something or someone performs. Therefore, we use the adjective
  _performant_.
 
-While the _how_ _well_ part can, in general, be described in natural languages, 
+While the _how well_ part can, in general, be described in natural languages,
 in our limited scope, the focus is on something that is quantifiable as a real
 number. Real numbers include integers and 0/1 binaries as special cases.
 Natural language descriptions are still very important. For example, a news
 article that heavily criticizes Flutter’s performance by just using words
-without any numbers (a quantifiable value) could still be devastating. The 
-limited scope is chosen only because of our limited resources.
+without any numbers (a quantifiable value) could still be meaningful, and it
+could have great impacts. The limited scope is chosen only because of our
+limited resources.
 
-For example, the 500-word quarterly performance summary isn't in our scope. But,
-if the quarterly performance is summarized by rank, and there are only five  
-options, for example, needs improvement, meets expectations, exceeds 
-expectations, strongly exceeds expectations, and superb, then it’s within 
-scope because you can map those five options to values (1, 2, 3, 4, 5).
-
-Take that to an extreme, and all the correctness unit tests are within our 
-scope because the test performance of the code changes can be described as 
-either 0 (fail) or 1 (pass). If performance is only described as either bad 
-(such as, janky) or good (such as, smooth), it’s within that binary scope too.
-
-The required quantity to describe performance is often referred to as a 
+The required quantity to describe performance is often referred to as a
 metric.
 
 To navigate through countless performance issues and metrics, you can categorize
 based on performers.
 
-For example, most of the content on this website is about the Flutter app 
-performance, where the performer is a Flutter app. Infra performance is also 
-important to Flutter, where the performers are build bots and CI task runners: 
-they heavily affect how fast Flutter can incorporate code changes, to improve 
-the app's performance. Flutter team performance has the engineers inside the 
-Flutter team as performers. Flutter community performance has the open source 
-community as the performer, and the performance metric could be the median time 
-to close a community GitHub pull request.
+For example, most of the content on this website is about the Flutter app
+performance, where the performer is a Flutter app. Infra performance is also
+important to Flutter, where the performers are build bots and CI task runners:
+they heavily affect how fast Flutter can incorporate code changes, to improve
+the app's performance.
 
 Here, the scope was intentionally broadened to include performance issues other
 than just app performance issues because they can share many tools regardless of
 who the performers are. For example, Flutter app performance and infra
 performance might share the same dashboard and similar alert mechanisms.
 
-Broadening the scope also allows performers to be included that traditionally 
-are easy to ignore. Document performance is such an example. The performer 
+Broadening the scope also allows performers to be included that traditionally
+are easy to ignore. Document performance is such an example. The performer
 could be an API doc of the SDK, and a metric could be: the percentage of readers
 who find the API doc useful.
-
-Besides zooming out, categorizing performers also allows you to zoom in. For
-example, within the Flutter app performance issues, sometimes the performers can
-be further subdivided. There are Flutter framework performance issues, which are
-usually blamed on a single framework commit version. There could also be Flutter
-engine performance issues or Skia performance issues that can be further
-pinpointed to a single engine or Skia commit.
 
 ## Why is performance important?
 
 Answering this question is not only crucial for validating the work in
-performance, but also for guiding the performance work in order to be more 
-useful. The answer to “why is performance important?” often is also the answer 
+performance, but also for guiding the performance work in order to be more
+useful. The answer to “why is performance important?” often is also the answer
 to “how is performance useful?”
 
-Simply speaking, performance is important and useful because, in the scope, 
+Simply speaking, performance is important and useful because, in the scope,
 performance must have quantifiable properties or metrics. This implies:
 1. A performance report is easy to consume.
 2. Performance has little ambiguity.
 3. Performance is comparable and convertible.
 4. Performance is fair.
 
-Not that non-performance, or non-measurable issues or descriptions are not 
-important. They're meant to highlight the scenarios where performance can be 
+Not that non-performance, or non-measurable issues or descriptions are not
+important. They're meant to highlight the scenarios where performance can be
 more useful.
 
 ### 1. A performance report is easy to consume
 
 Performance metrics are numbers. Reading a number is much easier than reading a
 passage. For example, it probably takes an engineer 1 second to consume the
-performance rating as a number from 1 to 5. It probably takes the same engineer 
+performance rating as a number from 1 to 5. It probably takes the same engineer
 at least 1 minute to read the full, 500-word feedback summary.
 
 If there are many numbers, it’s easy to summarize or visualize them for quick
-consumption. For example, you can quickly consume millions of numbers by 
-looking at its histogram, average, quantiles, and so on. If a metric has a 
-history of thousands of data points, then you can easily plot a timeline to 
+consumption. For example, you can quickly consume millions of numbers by
+looking at its histogram, average, quantiles, and so on. If a metric has a
+history of thousands of data points, then you can easily plot a timeline to
 read its trend.
 
-On the other hand, having _n_ number of 500-word texts almost guarantees an 
-_n_-time cost to consume those texts. It would be a daunting task to analyze 
+On the other hand, having _n_ number of 500-word texts almost guarantees an
+_n_-time cost to consume those texts. It would be a daunting task to analyze
 thousands of historical descriptions, each having 500 words.
 
 ### 2. Performance has little ambiguity
 
 Another advantage of having performance as a set of numbers is its unambiguity.
-When you want an animation to have a performance of 20 ms per frame or 
+When you want an animation to have a performance of 20 ms per frame or
 50 fps, there’s little room for different interpretations about the numbers. On
 the other hand, to describe the same animation in words, someone might call it
-good, while someone else might complain that it’s bad. Similarly, the same 
+good, while someone else might complain that it’s bad. Similarly, the same
 word or phrase could be interpreted differently by different people. You might
-interpret an OK frame rate to be 60 fps, while someone else might interpret it 
+interpret an OK frame rate to be 60 fps, while someone else might interpret it
 to be 30 fps.
 
 Numbers could still be noisy. For example, the measured time per frame might
-be a true computation time of this frame, plus a random amount of time (noise) 
+be a true computation time of this frame, plus a random amount of time (noise)
 that CPU/GPU spends on some unrelated work. Hence, the metric will fluctuate.
-Nevertheless, there’s no ambiguity of what the number means. And, there are 
-also rigorous theory and testing tools to handle such noise. For example, you 
-could take multiple measurements to estimate the distribution of a random 
-variable, or you could take the average of many measurements to eliminate the 
+Nevertheless, there’s no ambiguity of what the number means. And, there are
+also rigorous theory and testing tools to handle such noise. For example, you
+could take multiple measurements to estimate the distribution of a random
+variable, or you could take the average of many measurements to eliminate the
 noise by [the law of large numbers][1].
 
 ### 3. Performance is comparable and convertible
 
-Performance numbers not only have unambiguous meanings, but they also have 
-unambiguous comparisons. For example, there’s no doubt that 5 is greater than 4. 
-On the other hand, it might be subjective to figure out whether excellent is 
-better or worse than superb. Similarly, could you figure out whether epic is 
-better than legendary? Actually, the phrase _strongly_ _exceeds_ _expectations_ 
-could be better than _superb_ in someone’s interpretation. It only becomes 
-unambiguous and comparable after a definition that maps strongly exceeds 
+Performance numbers not only have unambiguous meanings, but they also have
+unambiguous comparisons. For example, there’s no doubt that 5 is greater than 4.
+On the other hand, it might be subjective to figure out whether excellent is
+better or worse than superb. Similarly, could you figure out whether epic is
+better than legendary? Actually, the phrase _strongly_ _exceeds_ _expectations_
+could be better than _superb_ in someone’s interpretation. It only becomes
+unambiguous and comparable after a definition that maps strongly exceeds
 expectations to 4 and superb to 5.
 
 Numbers are also easily convertible using formulas and functions. For example,
-60 fps can be converted to 16.67 ms per frame. A frame's rendering 
-time _x_ (ms) can be converted to a binary indicator 
-`isSmooth = [x <= 16] = (x <= 16 ? 1 :0)`. Such conversion can be compounded or 
-chained, so you can get a large variety of quantities using a single 
-measurement without any added noise or ambiguity. The converted quantity can 
-then be used for further comparisons and consumption. Such conversions are 
+60 fps can be converted to 16.67 ms per frame. A frame's rendering
+time _x_ (ms) can be converted to a binary indicator
+`isSmooth = [x <= 16] = (x <= 16 ? 1 :0)`. Such conversion can be compounded or
+chained, so you can get a large variety of quantities using a single
+measurement without any added noise or ambiguity. The converted quantity can
+then be used for further comparisons and consumption. Such conversions are
 almost impossible if you're dealing with natural languages.
 
 ### 4. Performance is fair
 
-If issues rely on verbose words to be discovered, then an unfair advantage is 
-given to people who are more verbose (more willing to chat or write) or those 
-who are closer to the development team, who have a larger bandwidth and lower 
+If issues rely on verbose words to be discovered, then an unfair advantage is
+given to people who are more verbose (more willing to chat or write) or those
+who are closer to the development team, who have a larger bandwidth and lower
 cost for chatting or face-to-face meetings.
 
-By having the same metrics to detect problems no matter how far away or how 
+By having the same metrics to detect problems no matter how far away or how
 silent the users are, we can treat all issues fairly. That, in turn,
 allows us to focus on the right issues that have greater effects.
 
 ### How to make performance useful
 
-The following is a summary the 4 points that were discussed, from a slightly 
+The following is a summary the 4 points that were discussed, from a slightly
 different perspctive:
 1. Make performance metrics easy to consume. Do not overwhelm the readers with a
-   lot of numbers (or words). If there are many numbers, then try to summarize 
-   them into a smaller set of numbers (for exmaple, summarize many numbers into 
-   a single average number). Only notify readers when the numbers change 
+   lot of numbers (or words). If there are many numbers, then try to summarize
+   them into a smaller set of numbers (for exmaple, summarize many numbers into
+   a single average number). Only notify readers when the numbers change
    significantly (for example, automatic alerts on spikes or regressions).
 
 2. Make performance metrics as unambiguous as possible. Define the unit that the
@@ -170,7 +150,7 @@ different perspctive:
    increase and fps drops into the number of users dropped or revenue lost in
    dollars, then we can compare them and make an informed trade-off.
 
-4. Make performance metrics monitor a population that is as wide as possible, 
+4. Make performance metrics monitor a population that is as wide as possible,
    so no one is left behind.
 
 [1]: https://en.wikipedia.org/wiki/Law_of_large_numbers

--- a/src/docs/perf/appendix.md
+++ b/src/docs/perf/appendix.md
@@ -1,173 +1,176 @@
 ---
-title: Some more thoughts on performance
-description: What is performance, and why is performance importnat.
+title: More thoughts about performance
+description: What is performance, and why is performance important
 ---
 
 ## What is performance?
 
 Performance is a set of quantifiable properties of a performer.
 
-In our context, it’s not the execution of an action itself (as the performance
-in performing arts). It’s “how well something/someone performs”. Hence it has an
-adjective word “performant”.
+In this context, performance isn't the execution of an action itself; 
+it’s how well something or someone performs. Therefore, we use the adjective
+ _performant_.
 
-While the “how well” part can in general be described in natural languages, in
-our limited scope, we only focus on something that’s quantifiable as a real
-number, which includes integers, and 0/1 binaries as special cases.
-Natural-language descriptions are still very important. For example, a news
+While the _how_ _well_ part can, in general, be described in natural languages, 
+in our limited scope, the focus is on something that is quantifiable as a real
+number. Real numbers include integers and 0/1 binaries as special cases.
+Natural language descriptions are still very important. For example, a news
 article that heavily criticizes Flutter’s performance by just using words
-without any numbers could still be devastating. The limited scope is chosen only
-because of our limited resources.
+without any numbers (a quantifiable value) could still be devastating. The 
+limited scope is chosen only because of our limited resources.
 
-For example, the 500-word quarterly performance summary is not in our scope. But
-if the quarterly performance is summarized in one word which has only 5 options,
-say “need-improvement, meet-expectations, exceed-expectations,
-strongly-exceed-expectations, superb”, then it’s within our scope as we can map
-those 5 options to 1, 2, 3, 4, 5.
+For example, the 500-word quarterly performance summary isn't in our scope. But,
+if the quarterly performance is summarized by rank, and there are only five  
+options, for example, needs improvement, meets expectations, exceeds 
+expectations, strongly exceeds expectations, and superb, then it’s within 
+scope because you can map those five options to values (1, 2, 3, 4, 5).
 
-Take that to an extreme, all the correctness unit tests are within our scope as
-we can describe the code change's test performance as either 0 fail or 1 pass.
-If a performance is only described as either bad (e.g., janky) or good (e.g.,
-smooth), it’s within that binary scope too.
+Take that to an extreme, and all the correctness unit tests are within our 
+scope because the test performance of the code changes can be described as 
+either 0 (fail) or 1 (pass). If performance is only described as either bad 
+(such as, janky) or good (such as, smooth), it’s within that binary scope too.
 
-The required quantity to describe the performance is often referred to as the
+The required quantity to describe performance is often referred to as a 
 metric.
 
-To navigate through countless performance issues and metrics, we can categorize
+To navigate through countless performance issues and metrics, you can categorize
 based on performers.
 
-For example, most content here is about the Flutter app performance where the
-performer is a Flutter app. Infra performance is also important to Flutter where
-the performers are build bots and CI task runners: they heavily affect how fast
-Flutter can land some code changes to improve the app performance. Flutter team
-performance has the engineers inside the Flutter team as performers. Flutter
-community performance has the open-source community as the performer, and the
-performance metric could be the median time to close a community Github pull
-request.
+For example, most of the content on this website is about the Flutter app 
+performance, where the performer is a Flutter app. Infra performance is also 
+important to Flutter, where the performers are build bots and CI task runners: 
+they heavily affect how fast Flutter can incorporate code changes, to improve 
+the app's performance. Flutter team performance has the engineers inside the 
+Flutter team as performers. Flutter community performance has the open source 
+community as the performer, and the performance metric could be the median time 
+to close a community GitHub pull request.
 
-Here we intentionally broadens the scope to include performance issues other
+Here, the scope was intentionally broadened to include performance issues other
 than just app performance issues because they can share many tools regardless of
 who the performers are. For example, Flutter app performance and infra
-performance may share the same dashboard and similar alert mechanisms.
+performance might share the same dashboard and similar alert mechanisms.
 
-Broadening the scope also allows us to include performers that are traditionally
-easy to ignore. Documents performance is such an example. The performer could be
-an API doc of the SDK, and a metric could be: what's the percentage of readers
-who find it useful?
+Broadening the scope also allows performers to be included that traditionally 
+are easy to ignore. Document performance is such an example. The performer 
+could be an API doc of the SDK, and a metric could be: the percentage of readers
+who find the API doc useful.
 
-Besides zooming out, categorizing performers also allows us to zoom in. For
+Besides zooming out, categorizing performers also allows you to zoom in. For
 example, within the Flutter app performance issues, sometimes the performers can
-be further subdivided. There are Flutter framework performance issues which are
+be further subdivided. There are Flutter framework performance issues, which are
 usually blamed on a single framework commit version. There could also be Flutter
 engine performance issues or Skia performance issues that can be further
-pin-pointed down to a single engine or Skia commit.
+pinpointed to a single engine or Skia commit.
 
 ## Why is performance important?
 
 Answering this question is not only crucial for validating the work in
-performance, but also for guiding the performance work to be more useful. An
-answer for “why is performance important” is often also an answer for “how to
-make performance useful”.
+performance, but also for guiding the performance work in order to be more 
+useful. The answer to “why is performance important?” often is also the answer 
+to “how is performance useful?”
 
-Simply speaking, performance is important and useful because in our scope it has
-to have quantifiable properties or metrics. That implies:
-1. Performance report is easy to consume.
+Simply speaking, performance is important and useful because, in the scope, 
+performance must have quantifiable properties or metrics. This implies:
+1. A performance report is easy to consume.
 2. Performance has little ambiguity.
 3. Performance is comparable and convertible.
-4. Performance is more fair.
+4. Performance is fair.
 
-Note they don't mean that non-performance or non-measurable issues or
-descriptions are not important. They're to high-light the scenarios where
-performance can be more useful.
+Not that non-performance, or non-measurable issues or descriptions are not 
+important. They're meant to highlight the scenarios where performance can be 
+more useful.
 
-### 1. Performance report is easy to consume
+### 1. A performance report is easy to consume
 
 Performance metrics are numbers. Reading a number is much easier than reading a
 passage. For example, it probably takes an engineer 1 second to consume the
-performance rating as a number from 1 to 5. It probably takes the same person at
-least 1 minute to read the full 500-word feedback summary.
+performance rating as a number from 1 to 5. It probably takes the same engineer 
+at least 1 minute to read the full, 500-word feedback summary.
 
 If there are many numbers, it’s easy to summarize or visualize them for quick
-consumption. For example, one can quickly consume millions of numbers by looking
-at its histogram, average, quantiles, and so on. If a metric has a history of
-thousands of data points, one can easily plot a timeline to read its trend.
+consumption. For example, you can quickly consume millions of numbers by 
+looking at its histogram, average, quantiles, and so on. If a metric has a 
+history of thousands of data points, then you can easily plot a timeline to 
+read its trend.
 
-On the other hand, having N number of 500-word texts almost guarantees an N-time
-cost to consume those texts. It would be a daunting task to analyze thousands of
-historical descriptions, each of which has 500 words.
+On the other hand, having _n_ number of 500-word texts almost guarantees an 
+_n_-time cost to consume those texts. It would be a daunting task to analyze 
+thousands of historical descriptions, each having 500 words.
 
 ### 2. Performance has little ambiguity
 
 Another advantage of having performance as a set of numbers is its unambiguity.
-When we measure an animation to have a performance of 20ms per frame, or 50fps,
-there’s little room for different interpretations on the numbers themselves. On
-the other hand, to describe the same animation in words, someone may call it
-smooth, while someone else may complain that it’s laggy. Similarly, the same
-word or phrase could be interpreted differently by different people. One might
-interpret an “Ok frame rate” to be 60fps, while someone else may interpret it to
-be 30fps.
+When you want an animation to have a performance of 20 ms per frame or 
+50 fps, there’s little room for different interpretations about the numbers. On
+the other hand, to describe the same animation in words, someone might call it
+good, while someone else might complain that it’s bad. Similarly, the same 
+word or phrase could be interpreted differently by different people. You might
+interpret an OK frame rate to be 60 fps, while someone else might interpret it 
+to be 30 fps.
 
-Numbers could still be noisy. For example, the measured “time per frame” might
-be a true “computation time of this frame”, plus a noisy “random time that
-CPU/GPU spends on some unrelated work”. Hence the metric will fluctuate.
-Nevertheless, there’s no ambiguity of what the number means. And there are also
-rigorous theory and tested tools to handle such noise. For example, one could
-take multiple measurements to estimate the distribution of a random variable.
-One could take the average of many measurements to cancel the noise by [the law
-of large numbers][1].
+Numbers could still be noisy. For example, the measured time per frame might
+be a true computation time of this frame, plus a random amount of time (noise) 
+that CPU/GPU spends on some unrelated work. Hence, the metric will fluctuate.
+Nevertheless, there’s no ambiguity of what the number means. And, there are 
+also rigorous theory and testing tools to handle such noise. For example, you 
+could take multiple measurements to estimate the distribution of a random 
+variable, or you could take the average of many measurements to eliminate the 
+noise by [the law of large numbers][1].
 
 ### 3. Performance is comparable and convertible
 
-Performance numbers have not only unambiguous meanings, but also unambiguous
-comparisons. For example, there’s no doubt that 5 is greater than 4. On the
-other hand, it may be subjective to figure out whether “excellent” is better or
-worse than “superb”. Similarly, could you figure out whether “epic” is better
-than “legendary”? Actually, the word “strongly-exceeds-expectation” could be
-better than “superb” in someone’s interpretation. It only becomes unambiguous
-and comparable after a definition that maps “strongly-exceeds-expectation” to 4,
-and “superb” to 5.
+Performance numbers not only have unambiguous meanings, but they also have 
+unambiguous comparisons. For example, there’s no doubt that 5 is greater than 4. 
+On the other hand, it might be subjective to figure out whether excellent is 
+better or worse than superb. Similarly, could you figure out whether epic is 
+better than legendary? Actually, the phrase _strongly_ _exceeds_ _expectations_ 
+could be better than _superb_ in someone’s interpretation. It only becomes 
+unambiguous and comparable after a definition that maps strongly exceeds 
+expectations to 4 and superb to 5.
 
 Numbers are also easily convertible using formulas and functions. For example,
-60 fps can be converted to 16.67ms per frame. A frame render time x (ms)  can be
-converted to a binary indicator `isSmooth = [x <= 16] = (x <= 16 ? 1 :0)`. Such
-conversion can be compounded/chained so we can get a large variety of quantities
-using a single measurement without any added noise or ambiguity. The converted
-quantity can then be used for further comparisons and consumption. Such
-conversions are almost impossible if we’re dealing with natural languages.
+60 fps can be converted to 16.67 ms per frame. A frame's rendering 
+time _x_ (ms) can be converted to a binary indicator 
+`isSmooth = [x <= 16] = (x <= 16 ? 1 :0)`. Such conversion can be compounded or 
+chained, so you can get a large variety of quantities using a single 
+measurement without any added noise or ambiguity. The converted quantity can 
+then be used for further comparisons and consumption. Such conversions are 
+almost impossible if you're dealing with natural languages.
 
-### 4. Performance is more fair
+### 4. Performance is fair
 
-If issues rely on verbose words to be discovered, then an unfair advantages are
-given to people who are (1) more verbose, or more willing to chat or write; (2)
-closer to the development team, who has a larger bandwidth and lower cost for
-chatting or face-to-face meetings.
+If issues rely on verbose words to be discovered, then an unfair advantage is 
+given to people who are more verbose (more willing to chat or write) or those 
+who are closer to the development team, who have a larger bandwidth and lower 
+cost for chatting or face-to-face meetings.
 
-By having the same metrics to detect problems no matter how far or how silent
-the users are, we’re given a more fair treatment to all issues. That in turn
-allows us to focus on the right issues that have wider impacts.
+By having the same metrics to detect problems no matter how far away or how 
+silent the users are, we can treat all issues fairly. That, in turn,
+allows us to focus on the right issues that have greater effects.
 
 ### How to make performance useful
 
-Now let's summarize the 3 points above from a slightly different perspctive:
+The following is a summary the 4 points that were discussed, from a slightly 
+different perspctive:
 1. Make performance metrics easy to consume. Do not overwhelm the readers with a
-   ton of numbers (or words). If there are many numbers, try to summarize them
-   into a smaller set of numbers (e.g., summarize many numbers into a single
-   average number). Only notify readers when the numbers change significantly
-   (e.g., auto alerts on spikes/regressions).
+   lot of numbers (or words). If there are many numbers, then try to summarize 
+   them into a smaller set of numbers (for exmaple, summarize many numbers into 
+   a single average number). Only notify readers when the numbers change 
+   significantly (for example, automatic alerts on spikes or regressions).
 
 2. Make performance metrics as unambiguous as possible. Define the unit that the
    number is using. Precisely describe how the number is measured. Make the
    number easily reproducible. When there’s a lot of noise, try to show the full
-   distribution, or cancel out the noise as much as possible by aggregating many
+   distribution, or eliminate the noise as much as possible by aggregating many
    noisy measurements.
 
 3. Make it easy to compare performance. For example, provide a timeline to
    compare the current version with the old version. Provide ways and tools to
    convert one metric to another. For example, if we can convert both memory
-   increase and fps drop into the number of users dropped or revenue loss in
-   dollars, we can then compare them and make an informed trade-off.
+   increase and fps drops into the number of users dropped or revenue lost in
+   dollars, then we can compare them and make an informed trade-off.
 
-4. Make performance metrics monitor as wide a population as possible, so no one
-   is left behind.
+4. Make performance metrics monitor a population that is as wide as possible, 
+   so no one is left behind.
 
 [1]: https://en.wikipedia.org/wiki/Law_of_large_numbers

--- a/src/docs/perf/appendix.md
+++ b/src/docs/perf/appendix.md
@@ -3,7 +3,7 @@ title: Some more thoughts on performance
 description: What is performance, and why is performance importnat.
 ---
 
-# What is performance?
+## What is performance?
 
 Performance is a set of quantifiable properties of a performer.
 
@@ -62,7 +62,7 @@ usually blamed on a single framework commit version. There could also be Flutter
 engine performance issues or Skia performance issues that can be further
 pin-pointed down to a single engine or Skia commit.
 
-# Why is performance important?
+## Why is performance important?
 
 Answering this question is not only crucial for validating the work in
 performance, but also for guiding the performance work to be more useful. An
@@ -80,7 +80,7 @@ Note they don't mean that non-performance or non-measurable issues or
 descriptions are not important. They're to high-light the scenarios where
 performance can be more useful.
 
-## 1. Performance report is easy to consume
+### 1. Performance report is easy to consume
 
 Performance metrics are numbers. Reading a number is much easier than reading a
 passage. For example, it probably takes an engineer 1 second to consume the
@@ -96,7 +96,7 @@ On the other hand, having N number of 500-word texts almost guarantees an N-time
 cost to consume those texts. It would be a daunting task to analyze thousands of
 historical descriptions, each of which has 500 words.
 
-## 2. Performance has little ambiguity
+### 2. Performance has little ambiguity
 
 Another advantage of having performance as a set of numbers is its unambiguity.
 When we measure an animation to have a performance of 20ms per frame, or 50fps,
@@ -116,7 +116,7 @@ take multiple measurements to estimate the distribution of a random variable.
 One could take the average of many measurements to cancel the noise by [the law
 of large numbers][1].
 
-## 3. Performance is comparable and convertible
+### 3. Performance is comparable and convertible
 
 Performance numbers have not only unambiguous meanings, but also unambiguous
 comparisons. For example, there’s no doubt that 5 is greater than 4. On the
@@ -135,7 +135,7 @@ using a single measurement without any added noise or ambiguity. The converted
 quantity can then be used for further comparisons and consumption. Such
 conversions are almost impossible if we’re dealing with natural languages.
 
-## 4. Performance is more fair
+### 4. Performance is more fair
 
 If issues rely on verbose words to be discovered, then an unfair advantages are
 given to people who are (1) more verbose, or more willing to chat or write; (2)
@@ -146,7 +146,7 @@ By having the same metrics to detect problems no matter how far or how silent
 the users are, we’re given a more fair treatment to all issues. That in turn
 allows us to focus on the right issues that have wider impacts.
 
-## How to make performance useful
+### How to make performance useful
 
 Now let's summarize the 3 points above from a slightly different perspctive:
 1. Make performance metrics easy to consume. Do not overwhelm the readers with a

--- a/src/docs/perf/faq.md
+++ b/src/docs/perf/faq.md
@@ -1,15 +1,15 @@
 ---
-title: Frequently Asked Questions
-description: Frequently asked questions about Flutter performance.
+title: Frequently asked questions
+description: Frequently asked questions about Flutter performance
 ---
 
-- What performance dashboards have metrics that are related with Flutter?
+- Which performance dashboards have metrics that are related to Flutter?
   - https://flutter-dashboard.appspot.com/
   - https://flutter-flutter-perf.skia.org/t/?subset=regressions
   - https://flutter-engine-perf.skia.org/t/?subset=regressions
   - https://flutter-dashboard.appspot.com/benchmarks.html (to be retired)
 
-- How to add a benchmark to Flutter?
+- How do I add a benchmark to Flutter?
   - https://github.com/flutter/flutter/wiki/How-to-write-a-render-speed-test-for-Flutter
   - https://github.com/flutter/flutter/wiki/How-to-write-a-memory-test-for-Flutter
 
@@ -24,50 +24,52 @@ description: Frequently asked questions about Flutter performance.
   - https://ui.perfetto.dev/
   - https://www.speedscope.app/
 
-- My Flutter app looks janky or stutters, how to fix it?
+- My Flutter app looks janky or stutters. How do I fix it?
   - https://flutter.dev/docs/perf/rendering
 
-- What are some performance-costly operations that I need to be careful about?
+- What are some costly performance operations that I need to be careful with?
   - `Opacity`, `Clip.antiAliasWithSaveLayer`, or anything that triggers
     saveLayer
   - `ImageFilter`
   - https://flutter.dev/docs/perf/rendering/best-practices
 
-- How do I tell which Widgets in my Flutter app are rebuilt in each frame?
+- How do I tell which widgets in my Flutter app are rebuilt in each frame?
   - Make `debugProfileBuildsEnabled` true in [widgets/debug.dart][debug.dart].
-  - Or hack the `performRebuild` function in
+  - Change the `performRebuild` function in
     [widgets/framework.dart][framework.dart] to ignore
     `debugProfileBuildsEnabled` and always call
     `Timeline.startSync(...)/finish`.
-  - If you use IntelliJ, a GUI view of this data is available. Check "show
-    widget rebuild information" and you will see which widgets rebuilt visually
-    in your IDE.
+  - If you use IntelliJ, a GUI view of this data is available. Select 
+    **show widget rebuild information**, and you will see which widgets 
+    rebuild visually in your IDE.
 
-- How do I query the target FPS (of the display)?
+- How do I query the target frames per second (of the display)?
   - https://github.com/flutter/flutter/wiki/Engine-specific-Service-Protocol-extensions#get-the-display-refresh-rate-_fluttergetdisplayrefreshrate
 
-- How to solve my app’s janky animations caused by an expensive Dart async
-  function call that’s blocking the UI thread?
+- How to solve my app’s poor animations caused by an expensive Dart async
+  function call that is blocking the UI thread?
   - Spawn another isoalte using
     https://api.flutter.dev/flutter/foundation/compute.html
 
-- How to measure my Flutter app’s package size that a user has to download?
+- How do I determine my Flutter app’s package size that will be downloaded by a 
+  user?
   - https://flutter.dev/docs/perf/app-size
 
-- How to see the breakdown of Flutter engine size?
-  - Go to
+- How do I see the breakdown of the Flutter engine size?
+  - Visit 
     https://storage.googleapis.com/flutter_infra/flutter/c3976b3c7183f479717bffed3f640fb92afbd3dc/android-arm-release/sizes/index.html,
-    replace the git hash in the URL with any recent commit hash from
+    and replace the git hash in the URL with a recent commit hash from
     https://github.com/flutter/engine/commits.
 
-- How can I take a screenshot of a running app and export it as an skp file?
+- How can I take a screenshot of an app that is running and export it as a SKP 
+  file?
   - Run `flutter screenshot --type=skia --observotry-uri=...`
-  - Some known issues of SKP screenshot:
-    - Doesn’t record images in real devices [#21237](https://github.com/flutter/flutter/issues/21237)
-  - To analyze and visualize the skp file, visit https://debugger.skia.org/.
+  - Known issue of a SKP screenshot:
+    - Doesn’t record images in real devices [#21237](https://github.com/flutter/flutter/issues/21237).
+  - To analyze and visualize the SKP file, visit https://debugger.skia.org/.
 
 - How do I retrieve the shader persistent cache from a device?
-  - On Android, you can do the following
+  - On Android, you can do the following:
     ```
     adb shell
     run-as <com.your_app_package_name>
@@ -75,7 +77,7 @@ description: Frequently asked questions about Flutter performance.
     adb pull <some_public_folder/your_folder>
     ```
 
-- How to trace in Fuchsia?
+- How do I perform a trace in Fuchsia?
   - https://fuchsia.dev/fuchsia-src/development/tracing/usage-guide
 
 [tracing]:

--- a/src/docs/perf/faq.md
+++ b/src/docs/perf/faq.md
@@ -1,0 +1,92 @@
+---
+title: Frequently Asked Questions
+description: Frequently asked questions about Flutter performance.
+---
+
+- What performance dashboards have metrics that are related with Flutter?
+  - https://flutter-dashboard.appspot.com/
+  - https://flutter-flutter-perf.skia.org/t/?subset=regressions
+  - https://flutter-engine-perf.skia.org/t/?subset=regressions
+  - https://flutter-dashboard.appspot.com/benchmarks.html (to be retired)
+
+- How to add a benchmark to Flutter?
+  - https://github.com/flutter/flutter/wiki/How-to-write-a-render-speed-test-for-Flutter
+  - https://github.com/flutter/flutter/wiki/How-to-write-a-memory-test-for-Flutter
+
+- What are some tools for capturing and analyzing performance metrics?
+  - [Dart DevTools](https://flutter.dev/docs/development/tools/devtools/)
+  - [Apple instruments](https://en.wikipedia.org/wiki/Instruments_(software))
+  - [Linux perf](https://en.wikipedia.org/wiki/Perf_(Linux))
+  - [Chrome tracing (enter `about:tracing` in your Chrome URL field)][tracing]
+  - [Android systrace (`adb systrace`)][systrace]
+  - [Fuchsia `fx traceutil`][traceutil]
+  - [Dart observatory](https://dart-lang.github.io/observatory/)
+  - https://ui.perfetto.dev/
+  - https://www.speedscope.app/
+
+- My Flutter app looks janky or stutters, how to fix it?
+  - https://flutter.dev/docs/perf/rendering
+
+- What are some performance-costly operations that I need to be careful about?
+  - `Opacity`, `Clip.antiAliasWithSaveLayer`, or anything that triggers
+    saveLayer
+  - `ImageFilter`
+  - https://flutter.dev/docs/perf/rendering/best-practices
+
+- How do I tell which Widgets in my Flutter app are rebuilt in each frame?
+  - Make `debugProfileBuildsEnabled` true in [widgets/debug.dart][debug.dart].
+  - Or hack the `performRebuild` function in
+    [widgets/framework.dart][framework.dart] to ignore
+    `debugProfileBuildsEnabled` and always call
+    `Timeline.startSync(...)/finish`.
+  - If you use IntelliJ, a GUI view of this data is available. Check "show
+    widget rebuild information" and you will see which widgets rebuilt visually
+    in your IDE.
+
+- How do I query the target FPS (of the display)?
+  - https://github.com/flutter/flutter/wiki/Engine-specific-Service-Protocol-extensions#get-the-display-refresh-rate-_fluttergetdisplayrefreshrate
+
+- How to solve my app’s janky animations caused by an expensive Dart async
+  function call that’s blocking the UI thread?
+  - Spawn another isoalte using
+    https://api.flutter.dev/flutter/foundation/compute.html
+
+- How to measure my Flutter app’s package size that a user has to download?
+  - https://flutter.dev/docs/perf/app-size
+
+- How to see the breakdown of Flutter engine size?
+  - Go to
+    https://storage.googleapis.com/flutter_infra/flutter/c3976b3c7183f479717bffed3f640fb92afbd3dc/android-arm-release/sizes/index.html,
+    replace the git hash in the URL with any recent commit hash from
+    https://github.com/flutter/engine/commits.
+
+- How can I take a screenshot of a running app and export it as an skp file?
+  - Run `flutter screenshot --type=skia --observotry-uri=...`
+  - Some known issues of SKP screenshot:
+    - Doesn’t record images in real devices [#21237](https://github.com/flutter/flutter/issues/21237)
+  - To analyze and visualize the skp file, visit https://debugger.skia.org/.
+
+- How do I retrieve the shader persistent cache from a device?
+  - On Android, you can do the following
+    ```
+    adb shell
+    run-as <com.your_app_package_name>
+    cp <your_folder> <some_public_folder, e.g., /sdcard> -r
+    adb pull <some_public_folder/your_folder>
+    ```
+
+- How to trace in Fuchsia?
+  - https://fuchsia.dev/fuchsia-src/development/tracing/usage-guide
+
+[tracing]:
+https://www.chromium.org/developers/how-tos/trace-event-profiling-tool
+
+[systrace]: https://developer.android.com/studio/profile/systrace
+
+[traceutil]: https://fuchsia.dev/fuchsia-src/development/tracing/usage-guide
+
+[debug.dart]:
+https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/widgets/debug.dart
+
+[framework.dart]:
+https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/widgets/framework.dart

--- a/src/docs/perf/faq.md
+++ b/src/docs/perf/faq.md
@@ -48,7 +48,7 @@ description: Frequently asked questions about Flutter performance
 
 - How to solve my app’s poor animations caused by an expensive Dart async
   function call that is blocking the UI thread?
-  - Spawn another isoalte using
+  - Spawn another isolate using
     https://api.flutter.dev/flutter/foundation/compute.html
 
 - How do I determine my Flutter app’s package size that will be downloaded by a

--- a/src/docs/perf/faq.md
+++ b/src/docs/perf/faq.md
@@ -35,12 +35,12 @@ description: Frequently asked questions about Flutter performance
 
 - How do I tell which widgets in my Flutter app are rebuilt in each frame?
   - Make `debugProfileBuildsEnabled` true in [widgets/debug.dart][debug.dart].
-  - Change the `performRebuild` function in
+  - Alternatively, change the `performRebuild` function in
     [widgets/framework.dart][framework.dart] to ignore
     `debugProfileBuildsEnabled` and always call
     `Timeline.startSync(...)/finish`.
-  - If you use IntelliJ, a GUI view of this data is available. Select 
-    **show widget rebuild information**, and you will see which widgets 
+  - If you use IntelliJ, a GUI view of this data is available. Select
+    **show widget rebuild information**, and you will see which widgets
     rebuild visually in your IDE.
 
 - How do I query the target frames per second (of the display)?
@@ -51,17 +51,17 @@ description: Frequently asked questions about Flutter performance
   - Spawn another isoalte using
     https://api.flutter.dev/flutter/foundation/compute.html
 
-- How do I determine my Flutter app’s package size that will be downloaded by a 
+- How do I determine my Flutter app’s package size that will be downloaded by a
   user?
   - https://flutter.dev/docs/perf/app-size
 
 - How do I see the breakdown of the Flutter engine size?
-  - Visit 
+  - Visit
     https://storage.googleapis.com/flutter_infra/flutter/c3976b3c7183f479717bffed3f640fb92afbd3dc/android-arm-release/sizes/index.html,
     and replace the git hash in the URL with a recent commit hash from
     https://github.com/flutter/engine/commits.
 
-- How can I take a screenshot of an app that is running and export it as a SKP 
+- How can I take a screenshot of an app that is running and export it as a SKP
   file?
   - Run `flutter screenshot --type=skia --observotry-uri=...`
   - Known issue of a SKP screenshot:

--- a/src/docs/perf/index.md
+++ b/src/docs/perf/index.md
@@ -1,38 +1,43 @@
 ---
 title: Performance
-description: Evaluating the performance of your app from several angles.
+description: Evaluating the performance of your app from several angles
 ---
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/PKGguGUwSYE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/PKGguGUwSYE" 
+frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; 
+picture-in-picture" allowfullscreen></iframe>
 [Flutter performance basics](https://www.youtube.com/watch?v=PKGguGUwSYE)
 
-What is performance? Why is performance important? How to improve performance?
+What is performance? Why is performance important? How do I improve performance?
 
-We aim at answering those 3 questions (mainly the 3rd one), and all questions
-related to them. This would hopefully serve as the single entry-point, or the
-root node of a tree of resources that address any needs about performance.
+Our goal is to answer those three questions (mainly the third one), and 
+anything related to them. This document should serve as the single entry 
+point or the root node of a tree of resources that addresses any questions 
+that you have about performance.
 
-The answers to the first 2 questions are mostly philosophical, and less
-immediately helpful to many developers who visit this page with speicifc
-performance issues to solve. Hence we'll leave them to
-[appendix](/docs/perf/appendix).
+The answers to the first two questions are mostly philosophical, and not as 
+helpful to many developers who visit this page with speicifc
+performance issues that need to be solved. Therefore, the answers to those 
+questions are in the [appendix](/docs/perf/appendix).
 
-To improve the performance, we first need metrics: some measurable numbers to
-verify the problems and improvements. In [metrics](/docs/perf/metrics) page,
-we'll show what metrics are currently used, and what tools and APIs are
-available to get them.
+To improve performance, you first need metrics: some measurable numbers to
+verify the problems and improvements. In the [metrics](/docs/perf/metrics) 
+page, you'll see which metrics are currently used, and which tools and APIs 
+are available to get the metrics.
 
-We then collect a list of [Frequently Asked Questions](/docs/perf/faq), so you
-can find if the questions or problems have been encountered before, and what
-existing solutions there are. (Alternatively, you may check the Flutter Github
-issue database with the [performance][performance] label.)
+There is a list of [Frequently asked questions](/docs/perf/faq), 
+so you can find out if the questions you have or the problems you're having 
+were already answered or encountered, and whether there are existing solutions. 
+(Alternatively, you can check the Flutter GitHub issue database using the
+ [performance][performance] label.)
 
-Finally, we divide performance issues into 4 categories. They correspond to the
-4 labels we used in Flutter Github issue data base: "[perf: speed][speed]",
-"[perf: memory][memory]", "[perf: app size][size]", "[perf: energy][energy]".
+Finally, the performance issues are divided into four categories. They 
+correspond to the four labels that are used in the Flutter GitHub issue 
+database: "[perf: speed][speed]", "[perf: memory][memory]", 
+"[perf: app size][size]", "[perf: energy][energy]".
 
-We'll organize the rest content using those 4 categories as below. (Note that
-these docs are in process of being expanded.)
+The rest of the content is organized using those four categories. (Note that
+these docs are in the process of being expanded.)
 
 <!--
 Let's put "speed" (rendering) first as it's the most popular performance issue
@@ -40,7 +45,7 @@ category.
 -->
 ## Speed
 
-Are your animations janky (not smooth)? Learn how to
+Are your animations janky (not smooth)? Learn how to 
 evaluate and fix rendering issues.
 
 [Improving rendering performance](/docs/perf/rendering)
@@ -50,23 +55,25 @@ Do your apps take a long time to open? We'll also cover the startup speed issue
 in some future pages.
 {% endcomment %}
 
-## App size
-
-How to measure your app's size. The smaller the size,
-the quicker it is to download.
-
-[Measuring your app's size][]
-
-{% comment %}
 
 ## Memory
 
 [Using memory wisely](/docs/perf/memory)
 
+
+## App size
+
+How to measure your app's size. The smaller the size, the quicker it is to 
+download.
+
+[Measuring your app's size][]
+
+{% comment %}
+
+
 ## Energy
 
-How to ensure a longer battery life when running
-your app.
+How to ensure a longer battery life when running your app.
 
 [Preserving your battery](/docs/perf/power)
 

--- a/src/docs/perf/index.md
+++ b/src/docs/perf/index.md
@@ -6,10 +6,49 @@ description: Evaluating the performance of your app from several angles.
 <iframe width="560" height="315" src="https://www.youtube.com/embed/PKGguGUwSYE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 [Flutter performance basics](https://www.youtube.com/watch?v=PKGguGUwSYE)
 
-There are different ways to evaluate performance.
-These docs deal with the following areas
-where performance can be evaluated and improved.
-(Note that these docs are in process of being expanded.)
+What is performance? Why is performance important? How to improve performance?
+
+We aim at answering those 3 questions (mainly the 3rd one), and all questions
+related to them. This would hopefully serve as the single entry-point, or the
+root node of a tree of resources that address any needs about performance.
+
+The answers to the first 2 questions are mostly philosophical, and less
+immediately helpful to many developers who visit this page with speicifc
+performance issues to solve. Hence we'll leave them to
+[appendix](/docs/perf/appendix).
+
+To improve the performance, we first need metrics: some measurable numbers to
+verify the problems and improvements. In [metrics](docs/perf/metrics) page,
+we'll show what metrics are currently used, and what tools and APIs are
+available to get them.
+
+We then collect a list of [Frequently Asked Questions](docs/perf/faq), so you
+can find if the questions or problems have been encountered before, and what
+existing solutions there are. (Alternatively, you may check the Flutter Github
+issue database with the [performance][performance] label.)
+
+Finally, we divide performance issues into 4 categories. They correspond to the
+4 labels we used in Flutter Github issue data base: "[perf: speed][speed]",
+"[perf: memory][memory]", "[perf: app size][size]", "[perf: energy][energy]".
+
+We'll organize the rest content using those 4 categories as below. (Note that
+these docs are in process of being expanded.)
+
+<!--
+Let's put "speed" (rendering) first as it's the most popular performance issue
+category.
+-->
+## Speed
+
+Are your animations janky (not smooth)? Learn how to
+evaluate and fix rendering issues.
+
+[Improving rendering performance](/docs/perf/rendering)
+
+{% comment %}
+Do your apps take a long time to open? We'll also cover the startup speed issue
+in some future pages.
+{% endcomment %}
 
 ## App size
 
@@ -24,7 +63,7 @@ the quicker it is to download.
 
 [Using memory wisely](/docs/perf/memory)
 
-## Power usage
+## Energy
 
 How to ensure a longer battery life when running
 your app.
@@ -33,12 +72,14 @@ your app.
 
 {% endcomment %}
 
-## Rendering performance
-
-Are your animations janky (not smooth)? Learn how to
-evaluate and fix rendering issues.
-
-[Improving rendering performance](/docs/perf/rendering)
-
-
 [Measuring your app's size]: /docs/perf/app-size
+
+[speed]: https://github.com/flutter/flutter/issues?q=is%3Aopen+label%3A%22perf%3A+speed%22+sort%3Aupdated-asc+
+
+[energy]: https://github.com/flutter/flutter/issues?q=is%3Aopen+label%3A%22perf%3A+energy%22+sort%3Aupdated-asc+
+
+[memory]: https://github.com/flutter/flutter/issues?q=is%3Aopen+label%3A%22perf%3A+memory%22+sort%3Aupdated-asc+
+
+[size]: https://github.com/flutter/flutter/issues?q=is%3Aopen+label%3A%22perf%3A+app+size%22+sort%3Aupdated-asc+
+
+[performance]: https://github.com/flutter/flutter/issues?q=+label%3A%22severe%3A+performance%22

--- a/src/docs/perf/index.md
+++ b/src/docs/perf/index.md
@@ -18,11 +18,11 @@ performance issues to solve. Hence we'll leave them to
 [appendix](/docs/perf/appendix).
 
 To improve the performance, we first need metrics: some measurable numbers to
-verify the problems and improvements. In [metrics](docs/perf/metrics) page,
+verify the problems and improvements. In [metrics](/docs/perf/metrics) page,
 we'll show what metrics are currently used, and what tools and APIs are
 available to get them.
 
-We then collect a list of [Frequently Asked Questions](docs/perf/faq), so you
+We then collect a list of [Frequently Asked Questions](/docs/perf/faq), so you
 can find if the questions or problems have been encountered before, and what
 existing solutions there are. (Alternatively, you may check the Flutter Github
 issue database with the [performance][performance] label.)

--- a/src/docs/perf/metrics.md
+++ b/src/docs/perf/metrics.md
@@ -1,46 +1,48 @@
 ---
 title: Performance metrics
-description: What metrics Flutter has, and what tools/APIs to get them.
+description: Flutter metrics, and which tools and APIs are used to 
+get them
 ---
 
-- Start-up time to first frame
+- Startup time to the first frame
   - Check the time when
-    [WidgetsBinding.instance.firstFrameRasterized][firstFrameRasterized] becomes
-    true.
+    [WidgetsBinding.instance.firstFrameRasterized][firstFrameRasterized] 
+	is true.
   - See
     https://flutter-flutter-perf.skia.org/e/?queries=sub_result%3DtimeToFirstFrameRasterizedMicros.
 
 - Frame buildDuration, rasterDuration, and totalSpan
   - See `FrameTiming` in
-    https://api.flutter.dev/flutter/dart-ui/FrameTiming-class.html
+    https://api.flutter.dev/flutter/dart-ui/FrameTiming-class.html.
 
-- Stats of frame buildDuration (`*_frame_build_time_millis`)
-  - We recommend monitoring 4 stats: average, 90th percentile, 99th
+- Statistics of frame buildDuration (`*_frame_build_time_millis`)
+  - We recommend monitoring four stats: average, 90th percentile, 99th
     percentile, and worst frame build time.
-  - See, e.g., those [metrics][transition_build] for
+  - See, for example, [metrics][transition_build] for the 
     `flutter_gallery__transition_perf` test.
 
-- Stats of frame rasterDuration (`*_frame_build_time_millis`)
-  - We recommend monitoring 4 stats: average, 90th percentile, 99th
+- Statistics of frame rasterDuration (`*_frame_build_time_millis`)
+  - We recommend monitoring four stats: average, 90th percentile, 99th
     percentile, and worst frame build time.
-  - See, e.g., those [metrics][transition_raster] for
+  - See, for example, [metrics][transition_raster] for the 
     `flutter_gallery__transition_perf` test.
 
-- CPU/GPU usage (a good approximate for the energy use)
-  - They're currently only available through trace events. See
+- CPU/GPU usage (a good approximation for energy use)
+  - The usage is currently only available through trace events. See
     [profiling_summarizer.dart][profiling_summarizer].
-  - See those [metrics][cpu_gpu] for the `simple_animation_perf_ios` test.
+  - See [metrics][cpu_gpu] for the `simple_animation_perf_ios` test.
 
 - release_size_bytes to approximately measure the size of a Flutter app
   - See [basic_material_app_android][], [basic_material_app_ios][],
     [hello_world_android][], [hello_world_ios][], [flutter_gallery_android][],
     [flutter_gallery_ios][] tests.
-  - Their [metrics][size_perf] in the dashboard.
-  - For how to measure the size more accurately, please reference
+  - See [metrics][size_perf] in the dashboard.
+  - For how to measure the size more accurately, see 
     https://flutter.dev/docs/perf/app-size.
 
-For a complete list of performance metrics Flutter measured per commit, go to
-the following sites, click "Query", and filter "test" and "sub_result" fields.
+For a complete list of performance metrics Flutter measured per commit, visit 
+the following sites, click **Query**, and filter the **test** and 
+**sub_result** fields:
   - https://flutter-flutter-perf.skia.org/e/
   - https://flutter-engine-perf.skia.org/e/
 

--- a/src/docs/perf/metrics.md
+++ b/src/docs/perf/metrics.md
@@ -1,0 +1,78 @@
+---
+title: Performance metrics
+description: What metrics Flutter has, and what tools/APIs to get them.
+---
+
+- Start-up time to first frame
+  - Check the time when
+    [WidgetsBinding.instance.firstFrameRasterized][firstFrameRasterized] becomes
+    true.
+  - See
+    https://flutter-flutter-perf.skia.org/e/?queries=sub_result%3DtimeToFirstFrameRasterizedMicros.
+
+- Frame buildDuration, rasterDuration, and totalSpan
+  - See `FrameTiming` in
+    https://api.flutter.dev/flutter/dart-ui/FrameTiming-class.html
+
+- Stats of frame buildDuration (`*_frame_build_time_millis`)
+  - We recommend monitoring 4 stats: average, 90th percentile, 99th
+    percentile, and worst frame build time.
+  - See, e.g., those [metrics][transition_build] for
+    `flutter_gallery__transition_perf` test.
+
+- Stats of frame rasterDuration (`*_frame_build_time_millis`)
+  - We recommend monitoring 4 stats: average, 90th percentile, 99th
+    percentile, and worst frame build time.
+  - See, e.g., those [metrics][transition_raster] for
+    `flutter_gallery__transition_perf` test.
+
+- CPU/GPU usage (a good approximate for the energy use)
+  - They're currently only available through trace events. See
+    [profiling_summarizer.dart][profiling_summarizer].
+  - See those [metrics][cpu_gpu] for the `simple_animation_perf_ios` test.
+
+- release_size_bytes to approximately measure the size of a Flutter app
+  - See [basic_material_app_android][], [basic_material_app_ios][],
+    [hello_world_android][], [hello_world_ios][], [flutter_gallery_android][],
+    [flutter_gallery_ios][] tests.
+  - Their [metrics][size_perf] in the dashboard.
+  - For how to measure the size more accurately, please reference
+    https://flutter.dev/docs/perf/app-size.
+
+For a complete list of performance metrics Flutter measured per commit, go to
+the following sites, click "Query", and filter "test" and "sub_result" fields.
+  - https://flutter-flutter-perf.skia.org/e/
+  - https://flutter-engine-perf.skia.org/e/
+
+[firstFrameRasterized]:
+https://api.flutter.dev/flutter/widgets/WidgetsBinding/firstFrameRasterized.html
+
+[transition_build]:
+https://flutter-flutter-perf.skia.org/e/?queries=sub_result%3D90th_percentile_frame_build_time_millis%26sub_result%3D99th_percentile_frame_build_time_millis%26sub_result%3Daverage_frame_build_time_millis%26sub_result%3Dworst_frame_build_time_millis%26test%3Dflutter_gallery__transition_perf
+
+[transition_raster]:
+https://flutter-flutter-perf.skia.org/e/?queries=sub_result%3D90th_percentile_frame_rasterizer_time_millis%26sub_result%3D99th_percentile_frame_rasterizer_time_millis%26sub_result%3Daverage_frame_rasterizer_time_millis%26sub_result%3Dworst_frame_rasterizer_time_millis%26test%3Dflutter_gallery__transition_perf
+
+[profiling_summarizer]:
+https://github.com/flutter/flutter/blob/master/packages/flutter_driver/lib/src/driver/profiling_summarizer.dart
+
+[cpu_gpu]:
+https://flutter-flutter-perf.skia.org/e/?queries=sub_result%3Daverage_cpu_usage%26sub_result%3Daverage_gpu_usage%26test%3Dsimple_animation_perf_ios
+
+[basic_material_app_android]:
+https://github.com/flutter/flutter/blob/master/dev/devicelab/bin/tasks/basic_material_app_android__compile.dart
+
+[basic_material_app_ios]:
+https://github.com/flutter/flutter/blob/master/dev/devicelab/bin/tasks/basic_material_app_ios__compile.dart
+
+[hello_world_android]:
+https://github.com/flutter/flutter/blob/master/dev/devicelab/bin/tasks/hello_world_android__compile.dart
+
+[hello_world_ios]:
+https://github.com/flutter/flutter/blob/master/dev/devicelab/bin/tasks/hello_world_ios__compile.dart
+
+[flutter_gallery_android]: https://github.com/flutter/flutter/blob/master/dev/devicelab/bin/tasks/flutter_gallery_android__compile.dart
+
+[flutter_gallery_ios]: https://github.com/flutter/flutter/blob/master/dev/devicelab/bin/tasks/flutter_gallery_ios__compile.dart
+
+[size_perf]: https://flutter-flutter-perf.skia.org/e/?queries=sub_result%3Drelease_size_bytes%26test%3Dbasic_material_app_android__compile%26test%3Dbasic_material_app_ios__compile%26test%3Dhello_world_android__compile%26test%3Dhello_world_ios__compile%26test%3Dflutter_gallery_ios__compile%26test%3Dflutter_gallery_android__compile


### PR DESCRIPTION
This is an attempt to port the content from go/flutter-performance doc
to our public pages.
