### PR TITLE
docs(platform-integration): added pattern to note alert

### DIFF
--- a/src/docs/development/platform-integration/platform-channels.md
+++ b/src/docs/development/platform-integration/platform-channels.md
@@ -67,9 +67,11 @@ enable receiving method calls and sending back a
 result. These classes allow you to develop a platform plugin
 with very little 'boilerplate' code.
 
-*Note*: If desired, method calls can also be sent in the reverse direction,
-with the platform acting as client to methods implemented in Dart.
-A concrete example of this is the [`quick_actions`][] plugin.
+{{site.alert.note}}
+  If desired, method calls can also be sent in the reverse direction,
+  with the platform acting as client to methods implemented in Dart.
+  A concrete example of this is the [`quick_actions`][] plugin.
+{{site.alert.end}}
 
 ### Platform channel data types support and codecs {#codec}
 


### PR DESCRIPTION
Changes proposed in this pull request:
*  Added pattern note styles to [Writing custom platform-specific code](https://flutter.dev/docs/development/platform-integration/platform-channels#architecture) section

Before:
![before_note_alert](https://user-images.githubusercontent.com/43169851/106309514-0028c400-6241-11eb-8931-db681b541608.png)

After:
![after_note_alert](https://user-images.githubusercontent.com/43169851/106309604-1fbfec80-6241-11eb-9c1c-a4ee65a525b5.png)

Thanks! 💙 


