### PR TITLE
Fix RenderBox dry layout links

### DIFF
--- a/src/docs/release/breaking-changes/renderbox-dry-layout.md
+++ b/src/docs/release/breaking-changes/renderbox-dry-layout.md
@@ -110,7 +110,6 @@ Relevant issues:
 Relevant PRs:
 * [Fixes Intrinsics for RenderParagraph and RenderWrap][]
 
-Master channel link:
 [`RenderBox`]: https://master-api.flutter.dev/flutter/rendering/RenderBox-class.html
 [`RenderBox.computeMinIntrinsicWidth`]: https://master-api.flutter.dev/flutter/rendering/RenderBox/computeMinIntrinsicWidth.html
 [`computeMinInstrinsicWidth`]: https://master-api.flutter.dev/flutter/rendering/RenderBox/computeMinIntrinsicWidth.html


### PR DESCRIPTION
Changes proposed in this pull request:

*  Fixes the links in the RenderBox dry layout breaking change doc.
*  Removes the "Master channel link" note as there already is the included note above (`{% include master-api.md %}`).

Here is how the links look at this moment:
![image](https://user-images.githubusercontent.com/19204050/106401504-5c940b00-641c-11eb-81c8-cd2857771a1b.png)

Markdown links at the bottom of the doc need a preceding empty line.

cc @goderbauer 
