### PR TITLE
Un-deprecate scrollable alert dialog by default

### DIFF
--- a/src/docs/release/breaking-changes/scrollable-alert-dialog.md
+++ b/src/docs/release/breaking-changes/scrollable-alert-dialog.md
@@ -1,9 +1,14 @@
 ---
-title: Scrollable AlertDialog
+title: Scrollable AlertDialog (No longer deprecated)
 description: AlertDialog should scroll automatically when it overflows.
 ---
 
 ## Summary
+
+Note: `AlertDialog.scrollable` is no longer deprecated since there is
+no backwards compatible way to have AlertDialog be scrollable by default.
+Instead, the parameter will remain and users will be able to set `scrollable`
+to true if they want a scrollable `AlertDialog`.
 
 An `AlertDialog` now scrolls automatically when it overflows.
 

--- a/src/docs/release/breaking-changes/scrollable-alert-dialog.md
+++ b/src/docs/release/breaking-changes/scrollable-alert-dialog.md
@@ -5,11 +5,12 @@ description: AlertDialog should scroll automatically when it overflows.
 
 ## Summary
 
-Note: `AlertDialog.scrollable` is no longer deprecated since there is
-no backwards compatible way to have AlertDialog be scrollable by default.
-Instead, the parameter will remain and users will be able to set `scrollable`
-to true if they want a scrollable `AlertDialog`.
-
+{{{site.alert.note}}
+  `AlertDialog.scrollable` is no longer deprecated because there is
+  no backwards-compatible way to make `AlertDialog` scrollable by default.
+  Instead, the parameter will remain and you can set `scrollable`
+  to true if you want a scrollable `AlertDialog`.
+{{site.alert.end}}
 An `AlertDialog` now scrolls automatically when it overflows.
 
 ## Context


### PR DESCRIPTION
Since scrollable AlertDialogs by default are not backwards-compatible, we're un-deprecating the `scrollable` parameter and keeping the existing behavior. 

Update to design doc: flutter.dev/go/scrollable-alert-dialog
Link to framework PR: https://github.com/flutter/flutter/pull/75138
Link to website PR (self-link): #5240