### PR TITLE
Fixes for dryLayout breaking change guide

### DIFF
--- a/src/docs/release/breaking-changes/renderbox-dry-layout.md
+++ b/src/docs/release/breaking-changes/renderbox-dry-layout.md
@@ -110,8 +110,6 @@ Relevant issues:
 Relevant PRs:
 * [Fixes Intrinsics for RenderParagraph and RenderWrap][]
 
-<!-- Master channel link: -->
-
 [`RenderBox`]: https://master-api.flutter.dev/flutter/rendering/RenderBox-class.html
 [`RenderBox.computeMinIntrinsicWidth`]: https://master-api.flutter.dev/flutter/rendering/RenderBox/computeMinIntrinsicWidth.html
 [`computeMinInstrinsicWidth`]: https://master-api.flutter.dev/flutter/rendering/RenderBox/computeMinIntrinsicWidth.html

--- a/src/docs/release/breaking-changes/renderbox-dry-layout.md
+++ b/src/docs/release/breaking-changes/renderbox-dry-layout.md
@@ -88,7 +88,7 @@ if the size of a `RenderBox` depends on the baseline metrics of its children.
 
 ## Timeline
 
-Landed in version: xxx<br>
+Landed in version: 1.25.0-4.0.pre<br>
 In stable release: not yet
 
 ## References
@@ -110,7 +110,8 @@ Relevant issues:
 Relevant PRs:
 * [Fixes Intrinsics for RenderParagraph and RenderWrap][]
 
-Master channel link:
+<!-- Master channel link: -->
+
 [`RenderBox`]: https://master-api.flutter.dev/flutter/rendering/RenderBox-class.html
 [`RenderBox.computeMinIntrinsicWidth`]: https://master-api.flutter.dev/flutter/rendering/RenderBox/computeMinIntrinsicWidth.html
 [`computeMinInstrinsicWidth`]: https://master-api.flutter.dev/flutter/rendering/RenderBox/computeMinIntrinsicWidth.html
@@ -120,5 +121,5 @@ Master channel link:
 [`RenderWrap`]: https://master-api.flutter.dev/flutter/rendering/RenderWrap-class.html
 [`RenderParagraph`]: https://master-api.flutter.dev/flutter/rendering/RenderParagraph-class.html
 
-[Issue 48679]: {{site.github}}/flutter/flutter/issues/48679]
+[Issue 48679]: {{site.github}}/flutter/flutter/issues/48679
 [Fixes Intrinsics for RenderParagraph and RenderWrap]: {{site.github}}/flutter/flutter/pull/70656

--- a/src/docs/release/breaking-changes/template.md
+++ b/src/docs/release/breaking-changes/template.md
@@ -107,10 +107,10 @@ If you need to link to the docs on the master channel,
 please include the following note and make sure that
 the URL includes the master link (as shown below).
 
-Stable channel link:
+<!-- Stable channel link: -->
 [`ClassName`]: {{site.api}}/flutter/[link_to_relevant_page].html
 
-Master channel link:
+<!-- Master channel link: -->
 [`ClassName`]: https://master-api.flutter.dev/flutter/[link_to_relevant_page].html
 
 [Issue xxxx]: {{site.github}}/flutter/flutter/issues/[link_to_actual_issue]


### PR DESCRIPTION
Currently, the guide doesn't render properly, see the list of links in https://flutter.dev/docs/release/breaking-changes/renderbox-dry-layout. This PR fixes that.

It also puts the `Stable channel link:` and `Master channel link:` line into comments in the template because those should never be included in the rendering output.