### PR TITLE
Removing submodules from format/analyze/test checks

### DIFF
--- a/tool/build_check_deploy.sh
+++ b/tool/build_check_deploy.sh
@@ -174,9 +174,13 @@ if [[ -n $CHECK_CODE ]]; then
       if [[ -n "$FILTER" && ! $sample =~ $FILTER ]]; then
         echo "Example: $sample - skipped because of filter"
         continue;
+      elif [[ "$(cd $sample ; git rev-parse --show-superproject-working-tree)" ]]; then
+        echo "Example: $sample - skipped because it's in a sumbodule."
+        continue;
       else
         echo "Example: $sample"
       fi
+
       if [[ -n $TEST && -d "$sample/test" ]]; then
         # Only hydrate the sample if we're going to test it.
         (


### PR DESCRIPTION
Removes submodules from the normal format/analyze/test done on all projects in the `examples` folder. This work makes sense for local examples, but it's wasted effort on the submodules, which have their own CI in their repos.

It also sidesteps the issue caused by the new, null-safe cookbook code in flutter/codelabs, which caused tests to fail in #5242.