### PR TITLE
Update flutter artifacts bucket

### DIFF
--- a/src/_assets/js/archive.js
+++ b/src/_assets/js/archive.js
@@ -6,7 +6,7 @@ var releasesToShow = 99999;
 // Fetches Flutter release JSON for the given OS and calls the callback once the data is available.
 var fetchFlutterReleases = function (os, callback, errorCallback) {
   // OS: windows, macos, linux
-  var url = "https://storage.googleapis.com/flutter_infra/releases/releases_" + os + ".json";
+  var url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_" + os + ".json";
   $.ajax({
     type: "GET",
     url: url,

--- a/src/_assets_old/js/archive.js
+++ b/src/_assets_old/js/archive.js
@@ -4,7 +4,7 @@ var releasesToShow = 5;
 // Fetches Flutter release JSON for the given OS and calls the callback once the data is available.
 var fetchFlutterReleases = function (os, callback, errorCallback) {
   // OS: windows, macos, linux
-  var url = "https://storage.googleapis.com/flutter_infra/releases/releases_" + os + ".json";
+  var url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_" + os + ".json";
   $.ajax({
     type: "GET",
     url: url,

--- a/src/community/china.md
+++ b/src/community/china.md
@@ -4,7 +4,7 @@ description: Where to find a version of the Flutter site that is localized to Si
 toc: true
 ---
 
-{% assign path = 'flutter_infra/releases/stable/windows/flutter_windows_v1.0.0-stable.zip' -%}
+{% assign path = 'flutter_infra_release/releases/stable/windows/flutter_windows_v1.0.0-stable.zip' -%}
 
 The Flutter community has made a Simplified Chinese version of the
 Flutter website available at


### PR DESCRIPTION
Flutter artifacts are moving to a different bucket owned by the flutter team.

Fixes go/fxb/64576

Changes proposed in this pull request:

*  Updates GCS bucket used to create the download links.

