### PR TITLE
Update web-images.md

### DIFF
--- a/src/docs/development/platform-integration/web-images.md
+++ b/src/docs/development/platform-integration/web-images.md
@@ -149,7 +149,7 @@ the HTML renderer instead of CanvasKit.
 [5]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas
 [6]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
 [7]: {{site.api}}/flutter/dart-ui/Image/toByteData.html
-[8]: {{site/api}}/flutter/rendering/OffsetLayer/toImage.html
+[8]: {{site.api}}/flutter/rendering/OffsetLayer/toImage.html
 [9]: {{site.api}}/flutter/dart-ui/Codec/getNextFrame.html
 [10]: {{site.api}}/flutter/dart-ui/Scene/toImage.html
 [11]: {{site.api}}/flutter/dart-ui/Image-class.html


### PR DESCRIPTION
fixes a CI warning:

`Liquid Warning: Liquid syntax error (line 146): Unexpected character / in "{{site/api}}" in docs/development/platform-integration/web-images.md`