### PR TITLE
Typo in website/src/docs/get-started/web.md

### DIFF
--- a/src/docs/get-started/web.md
+++ b/src/docs/get-started/web.md
@@ -171,7 +171,7 @@ with built files, including an `assets` directory,
 which need to be served together.
 
 You can also include `--web-renderer html`  or `--web-renderer canvaskit` to
-select between the HTML or CanvasKit renderers, respsectively. For more
+select between the HTML or CanvasKit renderers, respectively. For more
 information, see [Web renderers][].
 
 For more information, see


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix typo in line 174: respsectively -> respectively
