### PR TITLE
Adding warning about hot reload unavailabe in web

### DIFF
--- a/src/docs/get-started/web.md
+++ b/src/docs/get-started/web.md
@@ -153,6 +153,12 @@ $ flutter run -d chrome
 The `flutter run` command launches the application using the
 [development compiler] in a Chrome browser.
 
+{{site.alert.warning}}
+  **Hot reload not still supported**
+  At the current beta state, Flutter web only support **hot restart**,
+  no support for **hot reload** is available yet.
+{{site.alert.end}}
+
 ### Build
 
 Run the following command to generate a release build:

--- a/src/docs/get-started/web.md
+++ b/src/docs/get-started/web.md
@@ -154,9 +154,9 @@ The `flutter run` command launches the application using the
 [development compiler] in a Chrome browser.
 
 {{site.alert.warning}}
-  **Hot reload not still supported**
-  At the current beta state, Flutter web only support **hot restart**,
-  no support for **hot reload** is available yet.
+  **Hot reload not supported on web**
+  Currently, Flutter web supports **hot restart**,
+  but not **hot reload**.
 {{site.alert.end}}
 
 ### Build

--- a/src/web.md
+++ b/src/web.md
@@ -15,6 +15,11 @@ and you don’t need a browser plug-in.
   If you experience a problem that hasn't yet been reported, please
   [file an issue][] and make sure that "web" appears in the title.
 {{site.alert.end}}
+{{site.alert.warning}}
+  **Hot reload not still supported**
+  At the current beta state, Flutter web only support **hot restart**,
+  no support for **hot reload** is available yet.
+{{site.alert.end}}
 
 <img src="/images/Dart-framework-v-browser-framework.png"
      alt="showing Flutter architecture for C++ vs Flutter for web"


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/75437

Changes proposed in this pull request:

According to the [hot reload docs](https://flutter.dev/docs/development/tools/hot-reload#how-to-perform-a-hot-reload), only hot restart is available on web, this PR propose adding some warnings on web related docs to warn about that.
