### PR TITLE
Adding skips to layout-basics_migrated.md

### DIFF
--- a/src/docs/codelabs/layout-basics_migrated.md
+++ b/src/docs/codelabs/layout-basics_migrated.md
@@ -809,6 +809,7 @@ Future<void> main() async {
   what fraction of the total remaining space each
   `Flexible` widget receives.
 
+  <!-- skip -->
   ```dart
   remainingSpace * (flex / totalOfAllFlexValues)
   ```
@@ -978,6 +979,7 @@ wrap a widget and force the widget to fill extra space.
 
   For example:
 
+  <!-- skip -->
   ```dart
   Expanded(child: BlueBox(),),
   ```
@@ -2131,6 +2133,7 @@ Future<void> main() async {
   </li>
 </ul>
 
+  <!-- skip -->
   ```dart
      Row(
        children: [
@@ -2365,6 +2368,7 @@ Future<void> main() async {
   so the contact information and icons are displayed below the
   name and title:
 
+  <!-- skip -->
   ```dart
 
      ],

--- a/src/docs/cookbook/networking/fetch-data.md
+++ b/src/docs/cookbook/networking/fetch-data.md
@@ -59,7 +59,7 @@ This recipe covers how to fetch a sample album from the
 <!-- skip -->
 ```dart
 Future<http.Response> fetchAlbum() {
-  return http.get(Uri.https('jsonplaceholder.typicode.com','albums/1'));
+  return http.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
 }
 ```
 
@@ -242,7 +242,7 @@ import 'package:http/http.dart' as http;
 
 Future<Album> fetchAlbum() async {
   final response =
-      await http.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1');
+      await http.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response,

--- a/src/docs/cookbook/networking/send-data.md
+++ b/src/docs/cookbook/networking/send-data.md
@@ -56,7 +56,7 @@ by sending an album title to the
 ```dart
 Future<http.Response> createAlbum(String title) {
   return http.post(
-    Uri.https('jsonplaceholder.typicode.com','albums'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },
@@ -133,7 +133,7 @@ function to return a `Future<Album>`:
 ```dart
 Future<Album> createAlbum(String title) async {
   final response = await http.post(
-    Uri.https('jsonplaceholder.typicode.com','albums'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },
@@ -243,7 +243,7 @@ import 'package:http/http.dart' as http;
 
 Future<Album> createAlbum(String title) async {
   final response = await http.post(
-    Uri.https('jsonplaceholder.typicode.com','albums'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },


### PR DESCRIPTION
This adds skip instructions to four Dart codeblocks in `layout-basics_migrated.md`. These are present in the original version but appear to have been lost in the migration (or were added to the original file during the process).

The missing skips were causing the blocks to be extracted and analyzed, which was in turn causing tests to fail in #5257.

This PR also fixes some additional errors from an earlier change to the networking cookbook, which were obscured by the already failing tests.