### PR TITLE
Adding CORS headers to cookbook image files

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -272,7 +272,8 @@
       { "source": "/go/api-for-transform-performance", "destination": "https://docs.google.com/document/d/1Fxdlf7JsA-yAwc_RNuboMG-vhIhchRBZGvDSwg5qR0A/edit?usp=sharing", "type": 301 }
     ],
     "headers": [
-      { "source": "/f/*.json", "headers": [{"key": "Access-Control-Allow-Origin", "value": "*"}] }
+      { "source": "/f/*.json", "headers": [{"key": "Access-Control-Allow-Origin", "value": "*"}] },
+      { "source": "/docs/cookbook/img-files/**", "headers": [{"key": "Access-Control-Allow-Origin", "value": "*"}] }
     ]
   }
 }


### PR DESCRIPTION
Without these header fields, the images will fail to load in apps using CanvasKit.