### PR TITLE
Add notes to macOS distribution section

### DIFF
--- a/src/desktop.md
+++ b/src/desktop.md
@@ -321,7 +321,10 @@ and the other DLLs, and bundle them together in a zip file.
 
 #### macOS
 
-The `.app` is self-contained, and can be distributed as-is.
+The `.app` is self-contained, and can be distributed as-is. However, you should 
+read through the [macOS-specific support](#macos-specific-support) section below
+to understand about how Entitlements, the App Sandbox, and the Hardened Runtime
+impact your distributable application.
 
 #### Linux
 


### PR DESCRIPTION
I totally missed that there is a section on Hardened Runtime while attempting to build a macOS Flutter desktop app.
