### PR TITLE
Fix to 'unsecured connection not allowed'

### DIFF
--- a/src/docs/cookbook/networking/web-sockets.md
+++ b/src/docs/cookbook/networking/web-sockets.md
@@ -123,7 +123,7 @@ class MyApp extends StatelessWidget {
       title: title,
       home: MyHomePage(
         title: title,
-        channel: IOWebSocketChannel.connect('ws://echo.websocket.org'),
+        channel: IOWebSocketChannel.connect('wss://echo.websocket.org'),
       ),
     );
   }


### PR DESCRIPTION
IOWebSocketChannel.connect('ws://echo.websocket.org'), -> IOWebSocketChannel.connect('wss://echo.websocket.org'),

