### PR TITLE
Known null safety issues

### DIFF
--- a/src/docs/null-safety.md
+++ b/src/docs/null-safety.md
@@ -72,6 +72,9 @@ We're currently aware of the following issues:
   * Integration testing with
     [`flutter_driver`](/docs/cookbook/testing/integration/introduction)
     currently does not support null safety.
+    
+  * Depending on `flutter_driver` will limit your ability to pick up some
+    already migrated dependencies such as `args`, `archive`, and `crypto`.
 
 [Migrating to null safety]: {{site.dart-site}}/null-safety/migration-guide
 [FAQ]: {{site.dart-site}}/null-safety/faq

--- a/src/docs/null-safety.md
+++ b/src/docs/null-safety.md
@@ -35,6 +35,8 @@ class MyApp extends StatelessWidget {
 }
 ```
 
+## Resources
+
 To learn about null safety,
 read these pages:
 
@@ -54,6 +56,22 @@ check out these pages:
   in which only some libraries are null safe.
 * [FAQ][]:
   Questions that have come up during migration to null safety.
+  
+## Known issues
+
+Not all parts of the Flutter SDK support null safety yet,
+as some parts still need additional work to
+[migrate to null safety](https://dart.dev/null-safety/migration-guide).
+
+We're currently aware of the following issues:
+
+  * Migration of the pub.dev packages owned by the Flutter team
+    is in progress. See pub.dev for
+    [the current list](https://pub.dev/packages?q=publisher%3Aflutter.dev&null-safe=1).
+
+  * Integration testing with
+    [`flutter_driver`](https://flutter.dev/docs/cookbook/testing/integration/introduction)
+    currently does not support null safety.
 
 [Migrating to null safety]: {{site.dart-site}}/null-safety/migration-guide
 [FAQ]: {{site.dart-site}}/null-safety/faq

--- a/src/docs/null-safety.md
+++ b/src/docs/null-safety.md
@@ -61,7 +61,7 @@ check out these pages:
 
 Not all parts of the Flutter SDK support null safety yet,
 as some parts still need additional work to
-[migrate to null safety](https://dart.dev/null-safety/migration-guide).
+[migrate to null safety]({{site.dart-site}}/null-safety/migration-guide).
 
 We're currently aware of the following issues:
 

--- a/src/docs/null-safety.md
+++ b/src/docs/null-safety.md
@@ -67,7 +67,7 @@ We're currently aware of the following issues:
 
   * Migration of the pub.dev packages owned by the Flutter team
     is in progress. See pub.dev for
-    [the current list](https://pub.dev/packages?q=publisher%3Aflutter.dev&null-safe=1).
+    [the current list]({{site.pub}}/packages?q=publisher%3Aflutter.dev&null-safe=1).
 
   * Integration testing with
     [`flutter_driver`](/docs/cookbook/testing/integration/introduction)

--- a/src/docs/null-safety.md
+++ b/src/docs/null-safety.md
@@ -70,7 +70,7 @@ We're currently aware of the following issues:
     [the current list](https://pub.dev/packages?q=publisher%3Aflutter.dev&null-safe=1).
 
   * Integration testing with
-    [`flutter_driver`](https://flutter.dev/docs/cookbook/testing/integration/introduction)
+    [`flutter_driver`](/docs/cookbook/testing/integration/introduction)
     currently does not support null safety.
 
 [Migrating to null safety]: {{site.dart-site}}/null-safety/migration-guide


### PR DESCRIPTION
Add a new section with known null safety issues.

Corresponding Dart PR: https://github.com/dart-lang/site-www/pull/2948