### PR TITLE
Fix router sample url

### DIFF
--- a/src/docs/development/ui/navigation/deep-linking.md
+++ b/src/docs/development/ui/navigation/deep-linking.md
@@ -127,4 +127,4 @@ current set of pages when a new deep link is opened while the app is running.
 [intent filter]: https://developer.android.com/guide/components/intents-filters
 [plugin-linking]: https://medium.com/flutter-community/deep-links-and-flutter-applications-how-to-handle-them-properly-8c9865af9283
 [verify-android-links]: https://developer.android.com/training/app-links/verify-site-associations
-[router-sample]: https://github.com/flutter/samples/blob/master/navigation_and_routing/lib/nav_2/router.dart
+[router-sample]: https://github.com/flutter/samples/blob/master/navigation_and_routing/lib/router/router.dart


### PR DESCRIPTION
Fixes #5299

Navigator 2.0 have been renamed to Router in the samples repository. (https://github.com/flutter/samples/pull/712)
This pull request fixes the broken link in the ['Deep Linking'](https://flutter.dev/docs/development/ui/navigation/deep-linking) page according to the change.
