### PR TITLE
Includes download links for the Philips Hue app

### DIFF
--- a/src/_data/showcases.yml
+++ b/src/_data/showcases.yml
@@ -257,6 +257,8 @@
   logo_src: showcase/cards/philips_hue-logo.png
   logo_has_name: true
   learn_more_dropdown: true
+  app_store_link: https://apps.apple.com/app/philips-hue-bluetooth/id1456604186
+  play_store_link: https://play.google.com/store/apps/details?id=com.signify.hue.blue
   learn_more_links:
     - link_item:
       link: https://www2.meethue.com/en-us/entertainment/sync-with-tv#get-the-app


### PR DESCRIPTION
Hello everyone, everything good?

Aiming that most other applications have their respective links, I added the links to the Philips Hue application.

According to the official Philips Hue [website](https://www.philips-hue.com/en-us/explore-hue/apps/bluetooth#download-bluetooth-app), these are the links to the app.