### PR TITLE
Add supported fonts to custom font page

### DIFF
--- a/src/docs/cookbook/design/fonts.md
+++ b/src/docs/cookbook/design/fonts.md
@@ -53,6 +53,15 @@ awesome_app/
     RobotoMono-Bold.ttf
 ```
 
+### Supported font formats
+
+Flutter supports the following font formats:
+
+* `.tff`
+* `.otf`
+
+Flutter does not support `.woff` and `.woff2` fonts for all platforms.
+
 ## 2. Declare the font in the pubspec
 
 Once you've identified a font, tell Flutter where to find it.


### PR DESCRIPTION
Fixes #5319

Changes proposed in this pull request:

*  Add list of supported font formats, `.tff` and `.otf`.
* Specifically mentions that `.woff` and `.woff2` are not supported, to prevent issues in the future.
