### PR TITLE
Separate plugin installation process by os

### DIFF
--- a/src/docs/get-started/editor.md
+++ b/src/docs/get-started/editor.md
@@ -51,7 +51,7 @@ Alternatively, you can also use IntelliJ:
 
 ## Install the Flutter and Dart plugins
 
-To install these:
+### Mac
 
   1. Start Android Studio.
   1. Open plugin preferences (**Configure > Plugins** as of
@@ -61,13 +61,11 @@ To install these:
   1. Click **Yes** when prompted to install the Dart plugin.
   1. Click **Restart** when prompted.
 
-{{site.alert.note}}
-  Prior to v3.6.3.0, access plugin preferences as follows:
-   1. Open plugin preferences (on MacOS go to **Preferences > Plugins**; 
-      on Windows & Linux go to **File > Settings > Plugins**).
+### Linux or Windows
+
+   1. Open plugin preferences (**File > Settings > Plugins**).
    1. Select **Marketplace**,  select the Flutter plugin and click
       **Install**.
-{{site.alert.end}}
 
 </div>
 <div class="tab-pane" id="vscode" role="tabpanel" aria-labelledby="vscode-tab" markdown="1">

--- a/src/docs/get-started/editor.md
+++ b/src/docs/get-started/editor.md
@@ -51,7 +51,11 @@ Alternatively, you can also use IntelliJ:
 
 ## Install the Flutter and Dart plugins
 
+The installation instructions vary by platform.
+
 ### Mac
+
+Use the following instructions for macos:
 
   1. Start Android Studio.
   1. Open plugin preferences (**Configure > Plugins** as of
@@ -115,4 +119,3 @@ For information on how to install and use the package, see the [lsp-dart documen
 [VS Code]: https://code.visualstudio.com/
 [Emacs]: https://www.gnu.org/software/emacs/download.html
 [lsp-dart documentation]: https://emacs-lsp.github.io/lsp-dart/
-

--- a/src/docs/get-started/editor.md
+++ b/src/docs/get-started/editor.md
@@ -67,6 +67,8 @@ Use the following instructions for macos:
 
 ### Linux or Windows
 
+Use the following instructions for Linux or WIndows:
+
    1. Open plugin preferences (**File > Settings > Plugins**).
    1. Select **Marketplace**,  select the Flutter plugin and click
       **Install**.


### PR DESCRIPTION
I'm a linux user and it took time to show plugin list.
I thins the information is not optional so I separate process by os.

Thank you.