### PR TITLE
Update sidenav.yml

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -36,7 +36,7 @@
     - title: Flutter Gallery [running app]
       permalink: https://flutter.github.io/gallery/
     - title: Flutter Gallery [repo]
-      permalink: https://github.com/flutter/flutter/tree/master/dev/integration_tests/flutter_gallery
+      permalink: https://github.com/flutter/gallery
     - title: Sample apps on GitHub
       permalink: https://flutter.github.io/samples/
     - title: Cookbook


### PR DESCRIPTION
The existing gallery link points to the old integration test version, which we've kept around for regression testing. I think any customer who is wanting to explore the code ought to be pointed to the updated link, which is the source used for the running app immediately above.

Ideally we'd include a link to the repo in the running app itself, so we don't need two separate links, but I'll save that for another day.

NOTE: We are freezing the website repo (as of Feb 24th 9am PT) while we work on some planned upgrades. Please don't submit any PRs until the website work is complete.

You can still file issues.

Thank you!
