### PR TITLE
Remove Xcode 10 signing reference

### DIFF
--- a/src/docs/get-started/install/_ios-setup.md
+++ b/src/docs/get-started/install/_ios-setup.md
@@ -119,11 +119,8 @@ Follow the Xcode signing flow to provision your project:
       drop-down menu next to the run button.
    1. Select the `Runner` project in the left navigation panel.
    1. In the `Runner` target settings page,
-      make sure your Development Team is selected.
-      The UI varies depending on your version of Xcode.
-      * For Xcode 10, look under **General > Signing > Team**.
-      * For Xcode 11 and newer, look under
-      **Signing & Capabilities > Team**.
+      make sure your Development Team is selected
+      under **Signing & Capabilities > Team**.
 
       When you select a team,
       Xcode creates and downloads a Development Certificate,


### PR DESCRIPTION
Xcode 11 is the minimum allowed version as of https://github.com/flutter/flutter/pull/50315 in Flutter v1.16.3.  Remove Xcode 10 reference.