### PR TITLE
Migration of "internationalization" examples to null safety

### DIFF
--- a/null_safety_examples/internationalization/.gitignore
+++ b/null_safety_examples/internationalization/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+pubspec.lock
+
+*/**/android
+*/**/ios
+*/**/web
+*/**/.gitignore
+*/**/.metadata

--- a/null_safety_examples/internationalization/README.md
+++ b/null_safety_examples/internationalization/README.md
@@ -1,0 +1,10 @@
+The samples in this folder used to be under `src/_includes/code`. Despite that,
+the sources were not being included anywhere. It is likely that the sources
+appear in some pages none-the-less. What needs to be done is the following:
+
+- Each app/sample needs to be fully reviewed (and potentially simplified).
+- If the sources are in fact being used in site pages, then they need to be
+  integrated as proper code excerpts. See [Code excerpts][] for details.
+- Each app/sample should be tested, at least with a smoke test.
+
+[Code excerpts]: https://github.com/dart-lang/site-shared/blob/master/doc/code-excerpts.md

--- a/null_safety_examples/internationalization/add_language/lib/main.dart
+++ b/null_safety_examples/internationalization/add_language/lib/main.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+import 'nn_intl.dart';
+
+void main() {
+  runApp(
+    MaterialApp(
+      localizationsDelegates: [
+        GlobalWidgetsLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        NnMaterialLocalizations.delegate, // Add the newly created delegate
+      ],
+      supportedLocales: [
+        const Locale('en', 'US'),
+        const Locale('nn'),
+      ],
+      home: Home(),
+    ),
+  );
+}
+
+class Home extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Localizations.override(
+      context: context,
+      locale: const Locale('nn'),
+      child: Scaffold(
+        appBar: AppBar(),
+        drawer: Drawer(
+          child: ListTile(
+            leading: const Icon(Icons.change_history),
+            title: const Text('Change history'),
+            onTap: () {
+              Navigator.pop(context); // close the drawer
+            },
+          ),
+        ),
+        body: const Center(
+          child: Padding(
+            padding: EdgeInsets.all(50.0),
+            child: Text(
+              'Long press hamburger icon in the app bar (aka the drawer menu)'
+              'to see a localized tooltip for the `nn` locale. '
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/null_safety_examples/internationalization/add_language/lib/nn_intl.dart
+++ b/null_safety_examples/internationalization/add_language/lib/nn_intl.dart
@@ -1,0 +1,607 @@
+import 'dart:async';
+
+import 'package:intl/intl.dart' as intl;
+import 'package:intl/date_symbols.dart' as intl;
+import 'package:intl/date_symbol_data_custom.dart' as date_symbol_data_custom;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+/// A custom set of date patterns for the `nn` locale.
+///
+/// These are not accurate and are just a clone of the date patterns for the
+/// `no` locale to demonstrate how one would write and use custom date patterns.
+const nnLocaleDatePatterns = {
+  'd': 'd.',
+  'E': 'ccc',
+  'EEEE': 'cccc',
+  'LLL': 'LLL',
+  'LLLL': 'LLLL',
+  'M': 'L.',
+  'Md': 'd.M.',
+  'MEd': 'EEE d.M.',
+  'MMM': 'LLL',
+  'MMMd': 'd. MMM',
+  'MMMEd': 'EEE d. MMM',
+  'MMMM': 'LLLL',
+  'MMMMd': 'd. MMMM',
+  'MMMMEEEEd': 'EEEE d. MMMM',
+  'QQQ': 'QQQ',
+  'QQQQ': 'QQQQ',
+  'y': 'y',
+  'yM': 'M.y',
+  'yMd': 'd.M.y',
+  'yMEd': 'EEE d.MM.y',
+  'yMMM': 'MMM y',
+  'yMMMd': 'd. MMM y',
+  'yMMMEd': 'EEE d. MMM y',
+  'yMMMM': 'MMMM y',
+  'yMMMMd': 'd. MMMM y',
+  'yMMMMEEEEd': 'EEEE d. MMMM y',
+  'yQQQ': 'QQQ y',
+  'yQQQQ': 'QQQQ y',
+  'H': 'HH',
+  'Hm': 'HH:mm',
+  'Hms': 'HH:mm:ss',
+  'j': 'HH',
+  'jm': 'HH:mm',
+  'jms': 'HH:mm:ss',
+  'jmv': 'HH:mm v',
+  'jmz': 'HH:mm z',
+  'jz': 'HH z',
+  'm': 'm',
+  'ms': 'mm:ss',
+  's': 's',
+  'v': 'v',
+  'z': 'z',
+  'zzzz': 'zzzz',
+  'ZZZZ': 'ZZZZ',
+};
+
+/// A custom set of date symbols for the `nn` locale.
+///
+/// These are not accurate and are just a clone of the date symbols for the
+/// `no` locale to demonstrate how one would write and use custom date symbols.
+const nnDateSymbols = {
+  'NAME': 'nn',
+  'ERAS': <dynamic>[
+    'f.Kr.',
+    'e.Kr.',
+  ],
+  'ERANAMES': <dynamic>[
+    'før Kristus',
+    'etter Kristus',
+  ],
+  'NARROWMONTHS': <dynamic>[
+    'J',
+    'F',
+    'M',
+    'A',
+    'M',
+    'J',
+    'J',
+    'A',
+    'S',
+    'O',
+    'N',
+    'D',
+  ],
+  'STANDALONENARROWMONTHS': <dynamic>[
+    'J',
+    'F',
+    'M',
+    'A',
+    'M',
+    'J',
+    'J',
+    'A',
+    'S',
+    'O',
+    'N',
+    'D',
+  ],
+  'MONTHS': <dynamic>[
+    'januar',
+    'februar',
+    'mars',
+    'april',
+    'mai',
+    'juni',
+    'juli',
+    'august',
+    'september',
+    'oktober',
+    'november',
+    'desember',
+  ],
+  'STANDALONEMONTHS': <dynamic>[
+    'januar',
+    'februar',
+    'mars',
+    'april',
+    'mai',
+    'juni',
+    'juli',
+    'august',
+    'september',
+    'oktober',
+    'november',
+    'desember',
+  ],
+  'SHORTMONTHS': <dynamic>[
+    'jan.',
+    'feb.',
+    'mar.',
+    'apr.',
+    'mai',
+    'jun.',
+    'jul.',
+    'aug.',
+    'sep.',
+    'okt.',
+    'nov.',
+    'des.',
+  ],
+  'STANDALONESHORTMONTHS': <dynamic>[
+    'jan',
+    'feb',
+    'mar',
+    'apr',
+    'mai',
+    'jun',
+    'jul',
+    'aug',
+    'sep',
+    'okt',
+    'nov',
+    'des',
+  ],
+  'WEEKDAYS': <dynamic>[
+    'søndag',
+    'mandag',
+    'tirsdag',
+    'onsdag',
+    'torsdag',
+    'fredag',
+    'lørdag',
+  ],
+  'STANDALONEWEEKDAYS': <dynamic>[
+    'søndag',
+    'mandag',
+    'tirsdag',
+    'onsdag',
+    'torsdag',
+    'fredag',
+    'lørdag',
+  ],
+  'SHORTWEEKDAYS': <dynamic>[
+    'søn.',
+    'man.',
+    'tir.',
+    'ons.',
+    'tor.',
+    'fre.',
+    'lør.',
+  ],
+  'STANDALONESHORTWEEKDAYS': <dynamic>[
+    'søn.',
+    'man.',
+    'tir.',
+    'ons.',
+    'tor.',
+    'fre.',
+    'lør.',
+  ],
+  'NARROWWEEKDAYS': <dynamic>[
+    'S',
+    'M',
+    'T',
+    'O',
+    'T',
+    'F',
+    'L',
+  ],
+  'STANDALONENARROWWEEKDAYS': <dynamic>[
+    'S',
+    'M',
+    'T',
+    'O',
+    'T',
+    'F',
+    'L',
+  ],
+  'SHORTQUARTERS': <dynamic>[
+    'K1',
+    'K2',
+    'K3',
+    'K4',
+  ],
+  'QUARTERS': <dynamic>[
+    '1. kvartal',
+    '2. kvartal',
+    '3. kvartal',
+    '4. kvartal',
+  ],
+  'AMPMS': <dynamic>[
+    'a.m.',
+    'p.m.',
+  ],
+  'DATEFORMATS': <dynamic>[
+    'EEEE d. MMMM y',
+    'd. MMMM y',
+    'd. MMM y',
+    'dd.MM.y',
+  ],
+  'TIMEFORMATS': <dynamic>[
+    'HH:mm:ss zzzz',
+    'HH:mm:ss z',
+    'HH:mm:ss',
+    'HH:mm',
+  ],
+  'AVAILABLEFORMATS': null,
+  'FIRSTDAYOFWEEK': 0,
+  'WEEKENDRANGE': <dynamic>[
+    5,
+    6,
+  ],
+  'FIRSTWEEKCUTOFFDAY': 3,
+  'DATETIMEFORMATS': <dynamic>[
+    '{1} {0}',
+    '{1} \'kl\'. {0}',
+    '{1}, {0}',
+    '{1}, {0}',
+  ],
+};
+
+class _NnMaterialLocalizationsDelegate
+    extends LocalizationsDelegate<MaterialLocalizations> {
+  const _NnMaterialLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => locale.languageCode == 'nn';
+
+  @override
+  Future<MaterialLocalizations> load(Locale locale) async {
+    final String localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+    // The locale (in this case `nn`) needs to be initialized into the custom
+    // date symbols and patterns setup that Flutter uses.
+    date_symbol_data_custom.initializeDateFormattingCustom(
+      locale: localeName,
+      patterns: nnLocaleDatePatterns,
+      symbols: intl.DateSymbols.deserializeFromMap(nnDateSymbols),
+    );
+
+    return SynchronousFuture<MaterialLocalizations>(
+      NnMaterialLocalizations(
+        localeName: localeName,
+        // The `intl` library's NumberFormat class is generated from CLDR data
+        // (see https://github.com/dart-lang/intl/blob/master/lib/number_symbols_data.dart).
+        // Unfortunately, there is no way to use a locale that isn't defined in
+        // this map and the only way to work around this is to use a listed
+        // locale's NumberFormat symbols. So, here we use the number formats
+        // for 'en_US' instead.
+        decimalFormat: intl.NumberFormat('#,##0.###', 'en_US'),
+        twoDigitZeroPaddedFormat: intl.NumberFormat('00', 'en_US'),
+        // DateFormat here will use the symbols and patterns provided in the
+        // `date_symbol_data_custom.initializeDateFormattingCustom` call above.
+        // However, an alternative is to simply use a supported locale's
+        // DateFormat symbols, similar to NumberFormat above.
+        fullYearFormat: intl.DateFormat('y', localeName),
+        compactDateFormat: intl.DateFormat('yMd', localeName),
+        shortDateFormat: intl.DateFormat('yMMMd', localeName),
+        mediumDateFormat: intl.DateFormat('EEE, MMM d', localeName),
+        longDateFormat: intl.DateFormat('EEEE, MMMM d, y', localeName),
+        yearMonthFormat: intl.DateFormat('MMMM y', localeName),
+        shortMonthDayFormat: intl.DateFormat('MMM d'),
+      ),
+    );
+  }
+
+  @override
+  bool shouldReload(_NnMaterialLocalizationsDelegate old) => false;
+}
+
+/// A custom set of localizations for the 'nn' locale. In this example, only
+/// the value for openAppDrawerTooltip was modified to use a custom message as
+/// an example. Everything else uses the American English (en_US) messages
+/// and formatting.
+class NnMaterialLocalizations extends GlobalMaterialLocalizations {
+  const NnMaterialLocalizations({
+    String localeName = 'nn',
+    @required intl.DateFormat fullYearFormat,
+    @required intl.DateFormat compactDateFormat,
+    @required intl.DateFormat shortDateFormat,
+    @required intl.DateFormat mediumDateFormat,
+    @required intl.DateFormat longDateFormat,
+    @required intl.DateFormat yearMonthFormat,
+    @required intl.DateFormat shortMonthDayFormat,
+    @required intl.NumberFormat decimalFormat,
+    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+  }) : super(
+          localeName: localeName,
+          fullYearFormat: fullYearFormat,
+          compactDateFormat: compactDateFormat,
+          shortDateFormat: shortDateFormat,
+          mediumDateFormat: mediumDateFormat,
+          longDateFormat: longDateFormat,
+          yearMonthFormat: yearMonthFormat,
+          shortMonthDayFormat: shortMonthDayFormat,
+          decimalFormat: decimalFormat,
+          twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
+        );
+
+  @override
+  String get moreButtonTooltip => r'More';
+
+  @override
+  String get aboutListTileTitleRaw => r'About $applicationName';
+
+  @override
+  String get alertDialogLabel => r'Alert';
+
+  @override
+  String get anteMeridiemAbbreviation => r'AM';
+
+  @override
+  String get backButtonTooltip => r'Back';
+
+  @override
+  String get cancelButtonLabel => r'CANCEL';
+
+  @override
+  String get closeButtonLabel => r'CLOSE';
+
+  @override
+  String get closeButtonTooltip => r'Close';
+
+  @override
+  String get collapsedIconTapHint => r'Expand';
+
+  @override
+  String get continueButtonLabel => r'CONTINUE';
+
+  @override
+  String get copyButtonLabel => r'COPY';
+
+  @override
+  String get cutButtonLabel => r'CUT';
+
+  @override
+  String get deleteButtonTooltip => r'Delete';
+
+  @override
+  String get dialogLabel => r'Dialog';
+
+  @override
+  String get drawerLabel => r'Navigation menu';
+
+  @override
+  String get expandedIconTapHint => r'Collapse';
+
+  @override
+  String get hideAccountsLabel => r'Hide accounts';
+
+  @override
+  String get licensesPageTitle => r'Licenses';
+
+  @override
+  String get modalBarrierDismissLabel => r'Dismiss';
+
+  @override
+  String get nextMonthTooltip => r'Next month';
+
+  @override
+  String get nextPageTooltip => r'Next page';
+
+  @override
+  String get okButtonLabel => r'OK';
+
+  @override
+  // A custom drawer tooltip message.
+  String get openAppDrawerTooltip => r'Custom Navigation Menu Tooltip';
+
+  @override
+  String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow of $rowCount';
+
+  @override
+  String get pageRowsInfoTitleApproximateRaw =>
+      r'$firstRow–$lastRow of about $rowCount';
+
+  @override
+  String get pasteButtonLabel => r'PASTE';
+
+  @override
+  String get popupMenuLabel => r'Popup menu';
+
+  @override
+  String get postMeridiemAbbreviation => r'PM';
+
+  @override
+  String get previousMonthTooltip => r'Previous month';
+
+  @override
+  String get previousPageTooltip => r'Previous page';
+
+  @override
+  String get refreshIndicatorSemanticLabel => r'Refresh';
+
+  @override
+  String get remainingTextFieldCharacterCountFew => null;
+
+  @override
+  String get remainingTextFieldCharacterCountMany => null;
+
+  @override
+  String get remainingTextFieldCharacterCountOne => r'1 character remaining';
+
+  @override
+  String get remainingTextFieldCharacterCountOther =>
+      r'$remainingCount characters remaining';
+
+  @override
+  String get remainingTextFieldCharacterCountTwo => null;
+
+  @override
+  String get remainingTextFieldCharacterCountZero => r'No characters remaining';
+
+  @override
+  String get reorderItemDown => r'Move down';
+
+  @override
+  String get reorderItemLeft => r'Move left';
+
+  @override
+  String get reorderItemRight => r'Move right';
+
+  @override
+  String get reorderItemToEnd => r'Move to the end';
+
+  @override
+  String get reorderItemToStart => r'Move to the start';
+
+  @override
+  String get reorderItemUp => r'Move up';
+
+  @override
+  String get rowsPerPageTitle => r'Rows per page:';
+
+  @override
+  ScriptCategory get scriptCategory => ScriptCategory.englishLike;
+
+  @override
+  String get searchFieldLabel => r'Search';
+
+  @override
+  String get selectAllButtonLabel => r'SELECT ALL';
+
+  @override
+  String get selectedRowCountTitleFew => null;
+
+  @override
+  String get selectedRowCountTitleMany => null;
+
+  @override
+  String get selectedRowCountTitleOne => r'1 item selected';
+
+  @override
+  String get selectedRowCountTitleOther => r'$selectedRowCount items selected';
+
+  @override
+  String get selectedRowCountTitleTwo => null;
+
+  @override
+  String get selectedRowCountTitleZero => r'No items selected';
+
+  @override
+  String get showAccountsLabel => r'Show accounts';
+
+  @override
+  String get showMenuTooltip => r'Show menu';
+
+  @override
+  String get signedInLabel => r'Signed in';
+
+  @override
+  String get tabLabelRaw => r'Tab $tabIndex of $tabCount';
+
+  @override
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.h_colon_mm_space_a;
+
+  @override
+  String get timePickerHourModeAnnouncement => r'Select hours';
+
+  @override
+  String get timePickerMinuteModeAnnouncement => r'Select minutes';
+
+  @override
+  String get viewLicensesButtonLabel => r'VIEW LICENSES';
+
+  @override
+  List<String> get narrowWeekdays =>
+      const <String>['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+
+  @override
+  int get firstDayOfWeekIndex => 0;
+
+  static const LocalizationsDelegate<MaterialLocalizations> delegate =
+      _NnMaterialLocalizationsDelegate();
+
+  @override
+  String get calendarModeButtonLabel => r'Switch to calendar';
+
+  @override
+  String get dateHelpText => r'mm/dd/yyyy';
+
+  @override
+  String get dateInputLabel => r'Enter Date';
+
+  @override
+  String get dateOutOfRangeLabel => r'Out of range.';
+
+  @override
+  String get datePickerHelpText => r'SELECT DATE';
+
+  @override
+  String get dateRangeEndDateSemanticLabelRaw => r'End date $fullDate';
+
+  @override
+  String get dateRangeEndLabel => r'End Date';
+
+  @override
+  String get dateRangePickerHelpText => 'SELECT RANGE';
+
+  @override
+  String get dateRangeStartDateSemanticLabelRaw => 'Start date \$fullDate';
+
+  @override
+  String get dateRangeStartLabel => 'Start Date';
+
+  @override
+  String get dateSeparator => '/';
+
+  @override
+  String get dialModeButtonLabel => 'Switch to dial picker mode';
+
+  @override
+  String get inputDateModeButtonLabel => 'Switch to input';
+
+  @override
+  String get inputTimeModeButtonLabel => 'Switch to text input mode';
+
+  @override
+  String get invalidDateFormatLabel => 'Invalid format.';
+
+  @override
+  String get invalidDateRangeLabel => 'Invalid range.';
+
+  @override
+  String get invalidTimeLabel => 'Enter a valid time';
+
+  @override
+  String get licensesPackageDetailTextOther => '\$licenseCount licenses';
+
+  @override
+  String get saveButtonLabel => 'SAVE';
+
+  @override
+  String get selectYearSemanticsLabel => 'Select year';
+
+  @override
+  String get timePickerDialHelpText => 'SELECT TIME';
+
+  @override
+  String get timePickerHourLabel => 'Hour';
+
+  @override
+  String get timePickerInputHelpText => 'ENTER TIME';
+
+  @override
+  String get timePickerMinuteLabel => 'Minute';
+
+  @override
+  String get unspecifiedDate => 'Date';
+
+  @override
+  String get unspecifiedDateRange => 'Date Range';
+}

--- a/null_safety_examples/internationalization/add_language/lib/nn_intl.dart
+++ b/null_safety_examples/internationalization/add_language/lib/nn_intl.dart
@@ -309,15 +309,15 @@ class _NnMaterialLocalizationsDelegate
 class NnMaterialLocalizations extends GlobalMaterialLocalizations {
   const NnMaterialLocalizations({
     String localeName = 'nn',
-    @required intl.DateFormat fullYearFormat,
-    @required intl.DateFormat compactDateFormat,
-    @required intl.DateFormat shortDateFormat,
-    @required intl.DateFormat mediumDateFormat,
-    @required intl.DateFormat longDateFormat,
-    @required intl.DateFormat yearMonthFormat,
-    @required intl.DateFormat shortMonthDayFormat,
-    @required intl.NumberFormat decimalFormat,
-    @required intl.NumberFormat twoDigitZeroPaddedFormat,
+    required intl.DateFormat fullYearFormat,
+    required intl.DateFormat compactDateFormat,
+    required intl.DateFormat shortDateFormat,
+    required intl.DateFormat mediumDateFormat,
+    required intl.DateFormat longDateFormat,
+    required intl.DateFormat yearMonthFormat,
+    required intl.DateFormat shortMonthDayFormat,
+    required intl.NumberFormat decimalFormat,
+    required intl.NumberFormat twoDigitZeroPaddedFormat,
   }) : super(
           localeName: localeName,
           fullYearFormat: fullYearFormat,
@@ -427,10 +427,10 @@ class NnMaterialLocalizations extends GlobalMaterialLocalizations {
   String get refreshIndicatorSemanticLabel => r'Refresh';
 
   @override
-  String get remainingTextFieldCharacterCountFew => null;
+  String? get remainingTextFieldCharacterCountFew => null;
 
   @override
-  String get remainingTextFieldCharacterCountMany => null;
+  String? get remainingTextFieldCharacterCountMany => null;
 
   @override
   String get remainingTextFieldCharacterCountOne => r'1 character remaining';
@@ -440,7 +440,7 @@ class NnMaterialLocalizations extends GlobalMaterialLocalizations {
       r'$remainingCount characters remaining';
 
   @override
-  String get remainingTextFieldCharacterCountTwo => null;
+  String? get remainingTextFieldCharacterCountTwo => null;
 
   @override
   String get remainingTextFieldCharacterCountZero => r'No characters remaining';
@@ -476,10 +476,10 @@ class NnMaterialLocalizations extends GlobalMaterialLocalizations {
   String get selectAllButtonLabel => r'SELECT ALL';
 
   @override
-  String get selectedRowCountTitleFew => null;
+  String? get selectedRowCountTitleFew => null;
 
   @override
-  String get selectedRowCountTitleMany => null;
+  String? get selectedRowCountTitleMany => null;
 
   @override
   String get selectedRowCountTitleOne => r'1 item selected';
@@ -488,7 +488,7 @@ class NnMaterialLocalizations extends GlobalMaterialLocalizations {
   String get selectedRowCountTitleOther => r'$selectedRowCount items selected';
 
   @override
-  String get selectedRowCountTitleTwo => null;
+  String? get selectedRowCountTitleTwo => null;
 
   @override
   String get selectedRowCountTitleZero => r'No items selected';

--- a/null_safety_examples/internationalization/add_language/pubspec.yaml
+++ b/null_safety_examples/internationalization/add_language/pubspec.yaml
@@ -2,7 +2,7 @@ name: add_language
 description: An i18n app example that adds a supported language
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/null_safety_examples/internationalization/add_language/pubspec.yaml
+++ b/null_safety_examples/internationalization/add_language/pubspec.yaml
@@ -1,0 +1,19 @@
+name: add_language
+description: An i18n app example that adds a supported language
+
+environment:
+  sdk: '>=2.10.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  intl: any # Take the version from Flutter.
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/null_safety_examples/internationalization/gen_l10n_example/README.md
+++ b/null_safety_examples/internationalization/gen_l10n_example/README.md
@@ -1,0 +1,15 @@
+# Flutter example apps
+
+To analyze, test and run this application, execute the following commands from
+the repo root (`$PROJECT` represents the app project path, such as
+`examples/layout/lakes/step6`):
+
+1. `flutter create --no-overwrite $PROJECT`
+1. `cd $PROJECT`
+1. `flutter analyze`
+1. `flutter run`
+
+To learn more about setting up Flutter and running apps, see
+[flutter.io/get-started][].
+
+[flutter.io/get-started]: https://flutter.io/docs/get-started

--- a/null_safety_examples/internationalization/gen_l10n_example/l10n.yaml
+++ b/null_safety_examples/internationalization/gen_l10n_example/l10n.yaml
@@ -1,0 +1,3 @@
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart

--- a/null_safety_examples/internationalization/gen_l10n_example/lib/l10n/app_en.arb
+++ b/null_safety_examples/internationalization/gen_l10n_example/lib/l10n/app_en.arb
@@ -1,0 +1,6 @@
+{
+    "helloWorld": "Hello World!",
+    "@helloWorld": {
+      "description": "The conventional newborn programmer greeting"
+    }
+}

--- a/null_safety_examples/internationalization/gen_l10n_example/lib/l10n/app_es.arb
+++ b/null_safety_examples/internationalization/gen_l10n_example/lib/l10n/app_es.arb
@@ -1,0 +1,3 @@
+{
+    "helloWorld": "Hola Mundo!"
+}

--- a/null_safety_examples/internationalization/gen_l10n_example/lib/main.dart
+++ b/null_safety_examples/internationalization/gen_l10n_example/lib/main.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+void main() {
+  runApp(MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Localizations Sample App',
+      localizationsDelegates: [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
+      supportedLocales: [
+        const Locale('en', ''),
+        const Locale('es', ''),
+      ],
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: MyHomePage(),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  @override
+  _MyHomePageState createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        // The [AppBar] title text should update its message
+        // according to the system locale of the target platform.
+        // Switching between English and Spanish locales should
+        // cause this text to update.
+        title: Text(AppLocalizations.of(context).helloWorld),
+      ),
+    );
+  }
+}

--- a/null_safety_examples/internationalization/gen_l10n_example/lib/main.dart
+++ b/null_safety_examples/internationalization/gen_l10n_example/lib/main.dart
@@ -42,7 +42,7 @@ class _MyHomePageState extends State<MyHomePage> {
         // according to the system locale of the target platform.
         // Switching between English and Spanish locales should
         // cause this text to update.
-        title: Text(AppLocalizations.of(context).helloWorld),
+        title: Text(AppLocalizations.of(context)!.helloWorld),
       ),
     );
   }

--- a/null_safety_examples/internationalization/gen_l10n_example/pubspec.yaml
+++ b/null_safety_examples/internationalization/gen_l10n_example/pubspec.yaml
@@ -1,0 +1,17 @@
+name: gen_l10n_example
+description: Example of an internationalized Flutter app that uses `flutter gen-l10n`
+
+environment:
+  sdk: '>=2.10.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  # Internationalization support.
+  flutter_localizations:
+    sdk: flutter
+  intl: any # Add this line
+
+flutter:
+  generate: true # Add this line
+  uses-material-design: true

--- a/null_safety_examples/internationalization/gen_l10n_example/pubspec.yaml
+++ b/null_safety_examples/internationalization/gen_l10n_example/pubspec.yaml
@@ -2,7 +2,7 @@ name: gen_l10n_example
 description: Example of an internationalized Flutter app that uses `flutter gen-l10n`
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/null_safety_examples/internationalization/intl_example/README.md
+++ b/null_safety_examples/internationalization/intl_example/README.md
@@ -1,0 +1,16 @@
+# Flutter example apps
+
+To analyze, test and run individual apps, execute the following commands from
+the repo root (`$PROJECT` represents the app project path, such as
+`examples/layout/lakes/step6`):
+
+1. `flutter create --no-overwrite $PROJECT`
+1. `cd $PROJECT`
+1. `flutter analyze`
+1. `flutter test`
+1. `flutter run`
+
+To learn more about setting up Flutter and running apps, see
+[flutter.io/get-started][].
+
+[flutter.io/get-started]: https://flutter.io/docs/get-started

--- a/null_safety_examples/internationalization/intl_example/analysis_options.yaml
+++ b/null_safety_examples/internationalization/intl_example/analysis_options.yaml
@@ -1,0 +1,8 @@
+include: package:flutter/analysis_options_user.yaml
+
+# TODO: Remove these excludes when https://github.com/flutter/flutter/issues/12726 is fixed.
+analyzer:
+  errors:
+    implementation_imports: ignore
+    non_constant_identifier_names: ignore
+    unused_element: ignore

--- a/null_safety_examples/internationalization/intl_example/lib/l10n/intl_en.arb
+++ b/null_safety_examples/internationalization/intl_example/lib/l10n/intl_en.arb
@@ -1,0 +1,7 @@
+{
+  "title": "Hello World",
+  "@title": {
+    "description": "Title for the Demo application",
+    "type": "text"
+  }
+}

--- a/null_safety_examples/internationalization/intl_example/lib/l10n/intl_es.arb
+++ b/null_safety_examples/internationalization/intl_example/lib/l10n/intl_es.arb
@@ -1,0 +1,7 @@
+{
+  "title": "Hola Mundo",
+  "@title": {
+    "description": "Title for the Demo application",
+    "type": "text"
+  }
+}

--- a/null_safety_examples/internationalization/intl_example/lib/l10n/intl_messages.arb
+++ b/null_safety_examples/internationalization/intl_example/lib/l10n/intl_messages.arb
@@ -1,0 +1,8 @@
+{
+  "title": "Hello World",
+  "@title": {
+    "description": "Title for the Demo application",
+    "type": "text",
+    "placeholders": {}
+  }
+}

--- a/null_safety_examples/internationalization/intl_example/lib/l10n/messages_all.dart
+++ b/null_safety_examples/internationalization/intl_example/lib/l10n/messages_all.dart
@@ -19,7 +19,7 @@ Map<String, LibraryLoader> _deferredLibraries = {
   'messages': () => Future.value(null),
 };
 
-MessageLookupByLibrary _findExact(localeName) {
+MessageLookupByLibrary? _findExact(localeName) {
   switch (localeName) {
     case 'en':
       return messages_en.messages;
@@ -48,7 +48,7 @@ bool _messagesExistFor(String locale) {
   }
 }
 
-MessageLookupByLibrary _findGeneratedMessagesFor(locale) {
+MessageLookupByLibrary? _findGeneratedMessagesFor(locale) {
   var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor,
       onFailure: (_) => null);
   if (actualLocale == null) return null;

--- a/null_safety_examples/internationalization/intl_example/lib/l10n/messages_all.dart
+++ b/null_safety_examples/internationalization/intl_example/lib/l10n/messages_all.dart
@@ -1,0 +1,56 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that looks up messages for specific locales by
+// delegating to the appropriate library.
+
+import 'dart:async';
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+import 'package:intl/src/intl_helpers.dart';
+
+import 'messages_en.dart' as messages_en;
+import 'messages_es.dart' as messages_es;
+import 'messages_messages.dart' as messages_messages;
+
+typedef Future<dynamic> LibraryLoader();
+Map<String, LibraryLoader> _deferredLibraries = {
+  'en': () => Future.value(null),
+  'es': () => Future.value(null),
+  'messages': () => Future.value(null),
+};
+
+MessageLookupByLibrary _findExact(localeName) {
+  switch (localeName) {
+    case 'en':
+      return messages_en.messages;
+    case 'es':
+      return messages_es.messages;
+    case 'messages':
+      return messages_messages.messages;
+    default:
+      return null;
+  }
+}
+
+/// User programs should call this before using [localeName] for messages.
+Future initializeMessages(String localeName) async {
+  var lib = _deferredLibraries[Intl.canonicalizedLocale(localeName)];
+  await (lib == null ? Future.value(false) : lib());
+  initializeInternalMessageLookup(() => CompositeMessageLookup());
+  messageLookup.addLocale(localeName, _findGeneratedMessagesFor);
+}
+
+bool _messagesExistFor(String locale) {
+  try {
+    return _findExact(locale) != null;
+  } catch (e) {
+    return false;
+  }
+}
+
+MessageLookupByLibrary _findGeneratedMessagesFor(locale) {
+  var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor,
+      onFailure: (_) => null);
+  if (actualLocale == null) return null;
+  return _findExact(actualLocale);
+}

--- a/null_safety_examples/internationalization/intl_example/lib/l10n/messages_en.dart
+++ b/null_safety_examples/internationalization/intl_example/lib/l10n/messages_en.dart
@@ -1,0 +1,22 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a en locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = MessageLookup();
+
+final _keepAnalysisHappy = Intl.defaultLocale;
+
+typedef MessageIfAbsent(String message_str, List args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  get localeName => 'en';
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => {
+    "title" : MessageLookupByLibrary.simpleMessage("Hello World")
+  };
+}

--- a/null_safety_examples/internationalization/intl_example/lib/l10n/messages_es.dart
+++ b/null_safety_examples/internationalization/intl_example/lib/l10n/messages_es.dart
@@ -1,0 +1,22 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a es locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = MessageLookup();
+
+final _keepAnalysisHappy = Intl.defaultLocale;
+
+typedef MessageIfAbsent(String message_str, List args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  get localeName => 'es';
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => {
+    "title" : MessageLookupByLibrary.simpleMessage("Hola Mundo")
+  };
+}

--- a/null_safety_examples/internationalization/intl_example/lib/l10n/messages_messages.dart
+++ b/null_safety_examples/internationalization/intl_example/lib/l10n/messages_messages.dart
@@ -1,0 +1,22 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a messages locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = MessageLookup();
+
+final _keepAnalysisHappy = Intl.defaultLocale;
+
+typedef MessageIfAbsent(String message_str, List args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  get localeName => 'messages';
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => {
+    "title" : MessageLookupByLibrary.simpleMessage("Hello World")
+  };
+}

--- a/null_safety_examples/internationalization/intl_example/lib/main.dart
+++ b/null_safety_examples/internationalization/intl_example/lib/main.dart
@@ -1,0 +1,126 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// A simple example of localizing a Flutter app written with the
+// Dart intl package (see https://pub.dartlang.org/packages/intl).
+//
+// Spanish and English (locale language codes 'en' and 'es') are
+// supported.
+
+// The pubspec.yaml file must include flutter_localizations and the
+// Dart intl packages in its dependencies section. For example:
+//
+// dependencies:
+//   flutter:
+//   sdk: flutter
+//  flutter_localizations:
+//    sdk: flutter
+//  intl: 0.15.1
+//  intl_translation: 0.15.0
+
+// If you run this app with the device's locale set to anything but
+// English or Spanish, the app's locale will be English. If you
+// set the device's locale to Spanish, the app's locale will be
+// Spanish.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart';
+
+// This file was generated in two steps, using the Dart intl tools. With the
+// app's root directory (the one that contains pubspec.yaml) as the current
+// directory:
+//
+// flutter pub get
+// flutter pub pub run intl_translation:extract_to_arb --output-dir=lib/l10n lib/main.dart
+// flutter pub pub run intl_translation:generate_from_arb --output-dir=lib/l10n --no-use-deferred-loading lib/main.dart lib/l10n/intl_*.arb
+//
+// The second command generates intl_messages.arb and the third generates
+// messages_all.dart. There's more about this process in
+// https://pub.dev/packages/intl.
+import 'l10n/messages_all.dart';
+
+class DemoLocalizations {
+  DemoLocalizations(this.localeName);
+
+  static Future<DemoLocalizations> load(Locale locale) {
+    final String name = locale.countryCode.isEmpty ? locale.languageCode : locale.toString();
+    final String localeName = Intl.canonicalizedLocale(name);
+
+    return initializeMessages(localeName).then((_) {
+      return DemoLocalizations(localeName);
+    });
+  }
+
+  static DemoLocalizations of(BuildContext context) {
+    return Localizations.of<DemoLocalizations>(context, DemoLocalizations);
+  }
+
+  final String localeName;
+
+  String get title {
+    return Intl.message(
+      'Hello World',
+      name: 'title',
+      desc: 'Title for the Demo application',
+      locale: localeName,
+    );
+  }
+}
+
+class DemoLocalizationsDelegate extends LocalizationsDelegate<DemoLocalizations> {
+  const DemoLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => ['en', 'es'].contains(locale.languageCode);
+
+  @override
+  Future<DemoLocalizations> load(Locale locale) => DemoLocalizations.load(locale);
+
+  @override
+  bool shouldReload(DemoLocalizationsDelegate old) => false;
+}
+
+class DemoApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(DemoLocalizations.of(context).title),
+      ),
+      body: Center(
+        child: Text(DemoLocalizations.of(context).title),
+      ),
+    );
+  }
+}
+
+class Demo extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      onGenerateTitle: (BuildContext context) => DemoLocalizations.of(context).title,
+      localizationsDelegates: [
+        const DemoLocalizationsDelegate(),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
+      supportedLocales: [
+        const Locale('en', ''),
+        const Locale('es', ''),
+      ],
+      // Watch out: MaterialApp creates a Localizations widget
+      // with the specified delegates. DemoLocalizations.of()
+      // will only find the app's Localizations widget if its
+      // context is a child of the app.
+      home: DemoApp(),
+    );
+  }
+}
+
+void main() {
+  runApp(Demo());
+}

--- a/null_safety_examples/internationalization/intl_example/lib/main.dart
+++ b/null_safety_examples/internationalization/intl_example/lib/main.dart
@@ -47,7 +47,9 @@ class DemoLocalizations {
   DemoLocalizations(this.localeName);
 
   static Future<DemoLocalizations> load(Locale locale) {
-    final String name = locale.countryCode.isEmpty ? locale.languageCode : locale.toString();
+    final String name = locale.countryCode == null || locale.countryCode!.isEmpty
+        ? locale.languageCode
+        : locale.toString();
     final String localeName = Intl.canonicalizedLocale(name);
 
     return initializeMessages(localeName).then((_) {
@@ -56,7 +58,7 @@ class DemoLocalizations {
   }
 
   static DemoLocalizations of(BuildContext context) {
-    return Localizations.of<DemoLocalizations>(context, DemoLocalizations);
+    return Localizations.of<DemoLocalizations>(context, DemoLocalizations)!;
   }
 
   final String localeName;

--- a/null_safety_examples/internationalization/intl_example/pubspec.yaml
+++ b/null_safety_examples/internationalization/intl_example/pubspec.yaml
@@ -1,0 +1,20 @@
+name: intl_example
+description: Example of a Flutter app using the intl library services.
+
+environment:
+  sdk: '>=2.10.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  intl:
+  intl_translation:
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/null_safety_examples/internationalization/intl_example/pubspec.yaml
+++ b/null_safety_examples/internationalization/intl_example/pubspec.yaml
@@ -2,7 +2,7 @@ name: intl_example
 description: Example of a Flutter app using the intl library services.
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:
@@ -10,7 +10,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   intl:
-  intl_translation:
+#  intl_translation:
 
 dev_dependencies:
   flutter_test:

--- a/null_safety_examples/internationalization/intl_example/pubspec.yaml
+++ b/null_safety_examples/internationalization/intl_example/pubspec.yaml
@@ -10,7 +10,6 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   intl:
-#  intl_translation:
 
 dev_dependencies:
   flutter_test:

--- a/null_safety_examples/internationalization/minimal/lib/main.dart
+++ b/null_safety_examples/internationalization/minimal/lib/main.dart
@@ -32,7 +32,7 @@ class DemoLocalizations {
   final Locale locale;
 
   static DemoLocalizations of(BuildContext context) {
-    return Localizations.of<DemoLocalizations>(context, DemoLocalizations);
+    return Localizations.of<DemoLocalizations>(context, DemoLocalizations)!;
   }
 
   static Map<String, Map<String, String>> _localizedValues = {
@@ -45,7 +45,7 @@ class DemoLocalizations {
   };
 
   String get title {
-    return _localizedValues[locale.languageCode]['title'];
+    return _localizedValues[locale.languageCode]!['title']!;
   }
 }
 

--- a/null_safety_examples/internationalization/minimal/lib/main.dart
+++ b/null_safety_examples/internationalization/minimal/lib/main.dart
@@ -1,0 +1,108 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// A simple "rough and ready" example of localizing a Flutter app.
+// Spanish and English (locale language codes 'en' and 'es') are
+// supported.
+
+// The pubspec.yaml file must include flutter_localizations in its
+// dependencies section. For example:
+//
+// dependencies:
+//   flutter:
+//     sdk: flutter
+//   flutter_localizations:
+//     sdk: flutter
+
+// If you run this app with the device's locale set to anything but
+// English or Spanish, the app's locale will be English. If you
+// set the device's locale to Spanish, the app's locale will be
+// Spanish.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart' show SynchronousFuture;
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+class DemoLocalizations {
+  DemoLocalizations(this.locale);
+
+  final Locale locale;
+
+  static DemoLocalizations of(BuildContext context) {
+    return Localizations.of<DemoLocalizations>(context, DemoLocalizations);
+  }
+
+  static Map<String, Map<String, String>> _localizedValues = {
+    'en': {
+      'title': 'Hello World',
+    },
+    'es': {
+      'title': 'Hola Mundo',
+    },
+  };
+
+  String get title {
+    return _localizedValues[locale.languageCode]['title'];
+  }
+}
+
+class DemoLocalizationsDelegate extends LocalizationsDelegate<DemoLocalizations> {
+  const DemoLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => ['en', 'es'].contains(locale.languageCode);
+
+  @override
+  Future<DemoLocalizations> load(Locale locale) {
+    // Returning a SynchronousFuture here because an async "load" operation
+    // isn't needed to produce an instance of DemoLocalizations.
+    return SynchronousFuture<DemoLocalizations>(DemoLocalizations(locale));
+  }
+
+  @override
+  bool shouldReload(DemoLocalizationsDelegate old) => false;
+}
+
+class DemoApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(DemoLocalizations.of(context).title),
+      ),
+      body: Center(
+        child: Text(DemoLocalizations.of(context).title),
+      ),
+    );
+  }
+}
+
+class Demo extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      onGenerateTitle: (BuildContext context) => DemoLocalizations.of(context).title,
+      localizationsDelegates: [
+        const DemoLocalizationsDelegate(),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
+      supportedLocales: [
+        const Locale('en', ''),
+        const Locale('es', ''),
+      ],
+      // Watch out: MaterialApp creates a Localizations widget
+      // with the specified delegates. DemoLocalizations.of()
+      // will only find the app's Localizations widget if its
+      // context is a child of the app.
+      home: DemoApp(),
+    );
+  }
+}
+
+void main() {
+  runApp(Demo());
+}

--- a/null_safety_examples/internationalization/minimal/pubspec.yaml
+++ b/null_safety_examples/internationalization/minimal/pubspec.yaml
@@ -2,7 +2,7 @@ name: l10n_example
 description: A minimal example of a localized Flutter app
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/null_safety_examples/internationalization/minimal/pubspec.yaml
+++ b/null_safety_examples/internationalization/minimal/pubspec.yaml
@@ -1,0 +1,14 @@
+name: l10n_example
+description: A minimal example of a localized Flutter app
+
+environment:
+  sdk: '>=2.10.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
In this PR I migrate the small projects inside the internationalization folder in the examples to null safety.

Most code changes are due to the fact that `Localizations.of<..>` returns a nullable type. I decided to use the "bang operator" to force it to not being nullable, since the original code wasn't taking care of null cases, but also IMO a null value in localizations would mean a bug in code, so failing silently would be counterproductive. I want to hear your opinion on this :)

To test the code, I run the examples as a Flutter web app, as there were no tests in the files.

@sfshaza2 @RedBrogdon