### PR TITLE
Add "required" to example for null-safety

### DIFF
--- a/src/docs/development/ui/widgets-intro.md
+++ b/src/docs/development/ui/widgets-intro.md
@@ -98,7 +98,7 @@ Below are some simple widgets that combine these and other widgets:
 import 'package:flutter/material.dart';
 
 class MyAppBar extends StatelessWidget {
-  MyAppBar({this.title});
+  MyAppBar({required this.title});
 
   // Fields in a Widget subclass are always marked "final".
 


### PR DESCRIPTION
The second example in this tutorial is almost entirely correct except for the compiler complaining of the title being possibly null. Simply adding the `required` keyword fixes the issue.