### PR TITLE
Update name of channel in Web FAQ

### DIFF
--- a/src/docs/development/platform-integration/web.md
+++ b/src/docs/development/platform-integration/web.md
@@ -137,7 +137,7 @@ Not currently.
 
 ### How can I compare notes with others who are playing with this feature?
 
-Check out the **#hackers-web-🌍** discussion board on [Discord][].
+Check out the **#web** discussion channel on [Discord][].
 Flutter engineers routinely read and respond on Discord.
 
 


### PR DESCRIPTION
Fixes #5418 
It seems someone updated the name of the channel on Discord that this FAQ referenced, then the channel name was changed again. This push fixes that and changes the channel name to match its current status.