### PR TITLE
Update "Parse JSON in the Background"

### DIFF
--- a/src/docs/cookbook/networking/background-parsing.md
+++ b/src/docs/cookbook/networking/background-parsing.md
@@ -113,7 +113,7 @@ List<Photo> parsePhotos(String responseBody) {
 
 Future<List<Photo>> fetchPhotos(http.Client client) async {
   final response =
-      await client.get('https://jsonplaceholder.typicode.com/photos');
+      await client.get(URI.parse('https://jsonplaceholder.typicode.com/photos'));
 
   return parsePhotos(response.body);
 }
@@ -135,7 +135,7 @@ run the `parsePhotos()` function in the background.
 ```dart
 Future<List<Photo>> fetchPhotos(http.Client client) async {
   final response =
-      await client.get('https://jsonplaceholder.typicode.com/photos');
+      await client.get(URI.parse('https://jsonplaceholder.typicode.com/photos'));
 
   // Use the compute function to run parsePhotos in a separate isolate.
   return compute(parsePhotos, response.body);
@@ -163,7 +163,7 @@ import 'package:http/http.dart' as http;
 
 Future<List<Photo>> fetchPhotos(http.Client client) async {
   final response =
-      await client.get('https://jsonplaceholder.typicode.com/photos');
+      await client.get(URI.parse('https://jsonplaceholder.typicode.com/photos'));
 
   // Use the compute function to run parsePhotos in a separate isolate.
   return compute(parsePhotos, response.body);

--- a/src/docs/cookbook/networking/background-parsing.md
+++ b/src/docs/cookbook/networking/background-parsing.md
@@ -41,7 +41,7 @@ dependencies:
   http: <latest_version>
 ```
 
-## 2z Make a network request
+## 2. Make a network request
 
 This example covers how to fetch a large JSON document
 that contains a list of 5000 photo objects from the

--- a/src/docs/cookbook/networking/background-parsing.md
+++ b/src/docs/cookbook/networking/background-parsing.md
@@ -41,7 +41,7 @@ dependencies:
   http: <latest_version>
 ```
 
-## 2. Make a network request
+## 2z Make a network request
 
 This example covers how to fetch a large JSON document
 that contains a list of 5000 photo objects from the
@@ -51,7 +51,7 @@ using the [`http.get()`][] method.
 <!-- skip -->
 ```dart
 Future<http.Response> fetchPhotos(http.Client client) async {
-  return client.get('https://jsonplaceholder.typicode.com/photos');
+  return client.get(URI.parse('https://jsonplaceholder.typicode.com/photos'));
 }
 ```
 


### PR DESCRIPTION
Fixes #5423
As recommended, updates all instances of `await client.get('https://jsonplaceholder.typicode.com/photos');` to `await client.get(URI.parse('https://jsonplaceholder.typicode.com/photos'));`

