### PR TITLE
Suggestion for: Instructions on how to generate .pfx certificate for …

### DIFF
--- a/src/desktop.md
+++ b/src/desktop.md
@@ -317,7 +317,9 @@ from a Flutter desktop app, see the [Desktop Photo Search sample][].
 
 ###### Create a .pfx certificate.
 
-To publish on the Windows Store or Direct download with the help of MSIX Installer, you need to give your app a digital signature in form of a .pfx certificate. Use the following instructions to generate a self-signed .pfx certificate.
+To publish on the Windows Store or Direct download with the help of MSIX Installer,
+you need to give your app a digital signature in the form of a .pfx certificate.
+Use the following instructions to generate a self-signed .pfx certificate.
 
 * You would need to download [OpenSSL][] to generate your certificates.
 * Go to where you installed the OpenSSL. It can be:

--- a/src/desktop.md
+++ b/src/desktop.md
@@ -315,12 +315,18 @@ from a Flutter desktop app, see the [Desktop Photo Search sample][].
 [msix package]: {{site.pub}}/packages/msix
 [Desktop Photo Search sample]: {{site.github}}/flutter/samples/tree/master/experimental/desktop_photo_search
 
-###### Create a .pfx certificate.
+###### Create a self-signed .pfx certificate for local testing.
 
 For private deployment and testing with the help of MSIX Installer,
 you need to give your app a digital signature in the form of a .pfx certificate.
 
-For public deployment(Windows Store), .pfx certificate is not required.
+For deployment through the Windows Store, generating a .pfx certificate is not required. 
+The Windows Store handles creation and management of certificates for applications 
+distributed through the Windows Store.
+
+For distributing an application not through the Windows Store, but self hosted on a 
+website, can be done. But it requires a certificate signed by a Certificate Authority
+known by Windows.
 
 Use the following instructions to generate a self-signed .pfx certificate.
 
@@ -328,7 +334,7 @@ Use the following instructions to generate a self-signed .pfx certificate.
 1. Go to where you installed OpenSSL, for example:
    `C:\Program Files\OpenSSL-Win64\bin`.
 1. Set an environment variable so that you can access `OpenSSL` from anywhere:<br>
-   `make "C:\Program Files\OpenSSL-Win64\bin"`
+   `"C:\Program Files\OpenSSL-Win64\bin"`
 1.  Generate a private key as follows:<br>
       ```
       `openssl genrsa -out mykeyname.key 2048`

--- a/src/desktop.md
+++ b/src/desktop.md
@@ -317,8 +317,11 @@ from a Flutter desktop app, see the [Desktop Photo Search sample][].
 
 ###### Create a .pfx certificate.
 
-To publish on the Windows Store or Direct download with the help of MSIX Installer,
+For private deployment and testing with the help of MSIX Installer,
 you need to give your app a digital signature in the form of a .pfx certificate.
+
+For public deployment(Windows Store), .pfx certificate is not required.
+
 Use the following instructions to generate a self-signed .pfx certificate.
 
 1. If you haven't already, download the [OpenSSL][] toolkit to generate your certificates.
@@ -337,7 +340,8 @@ Use the following instructions to generate a self-signed .pfx certificate.
     6. Generate the `.pfx` file using the private key and CRT file:<br>
       `openssl pkcs12 -export -out CERTIFICATE.pfx -inkey mykeyname.key -in mycrtname.crt`
 
-You now have a `.pfx` certificate to use with the MSIX installer.
+Install the `.pfx` certificate first on the local machine in `Certificate store` as 
+`Trusted Root Certification Authorities` before installing the app.
       
 [OpenSSL]: https://slproweb.com/products/Win32OpenSSL.html
 

--- a/src/desktop.md
+++ b/src/desktop.md
@@ -322,14 +322,11 @@ you need to give your app a digital signature in the form of a .pfx certificate.
 Use the following instructions to generate a self-signed .pfx certificate.
 
 * You would need to download [OpenSSL][] to generate your certificates.
-* Go to where you installed the OpenSSL. It can be:
-    * C:\Program Files\OpenSSL-Win64\bin
-* Run cmd from this folder, that it looks like this in cmd.
-    * C:\Program Files\OpenSSL-Win64\bin>
-      or
-    * make “C:\Program Files\OpenSSL-Win64\bin” a environment path variable to access “OpenSSL” anywhere.
-* Now, use the following command:
-    * Generate a private key.
+1. Go to where you installed OpenSSL, for example:
+   `C:\Program Files\OpenSSL-Win64\bin`.
+1. Set an environment variable so that you can access `OpenSSL` from anywhere:<br>
+   `make "C:\Program Files\OpenSSL-Win64\bin"`
+1.  Generate a private key as follows:<br>
       ```
       openssl genrsa -out mykeyname.key 2048
       ```

--- a/src/desktop.md
+++ b/src/desktop.md
@@ -328,21 +328,16 @@ Use the following instructions to generate a self-signed .pfx certificate.
    `make "C:\Program Files\OpenSSL-Win64\bin"`
 1.  Generate a private key as follows:<br>
       ```
-      openssl genrsa -out mykeyname.key 2048
-      ```
-    * Generate a CSR file with the help of the private key.
-      ```
-      openssl req -new -key mykeyname.key -out mycsrname.csr
-      ```
-    * Generate a CRT file with the help of the private key & CSR file.
-      ```
-      openssl x509 -in mycsrname.csr -out mycrtname.crt -req -signkey mykeyname.key -days 10000
-      ```
-    * Generate .pfx file with the help of the private key & CRT file.
-      ```
-      openssl pkcs12 -export -out CERTIFICATE.pfx -inkey mykeyname.key -in mycrtname.crt
-      ```
-There you have your .pfx certificate to use with MSIX Installer.
+      `openssl genrsa -out mykeyname.key 2048`
+    4. Generate a certificate signing request (CSR) file using the private key:<br>
+      `openssl req -new -key mykeyname.key -out mycsrname.csr`
+    5. Generate the signed certificate (CRT) file using the private key
+        and CSR file:<br>
+      `openssl x509 -in mycsrname.csr -out mycrtname.crt -req -signkey mykeyname.key -days 10000`
+    6. Generate the `.pfx` file using the private key and CRT file:<br>
+      `openssl pkcs12 -export -out CERTIFICATE.pfx -inkey mykeyname.key -in mycrtname.crt`
+
+You now have a `.pfx` certificate to use with the MSIX installer.
       
 [OpenSSL]: https://slproweb.com/products/Win32OpenSSL.html
 

--- a/src/desktop.md
+++ b/src/desktop.md
@@ -311,7 +311,7 @@ The easiest way to create an MSIX distribution for a Flutter project is to use
 the [`msix` pub package][msix package]. For an example of using the `msix` package
 from a Flutter desktop app, see the [Desktop Photo Search sample][].
 
-Instructions on [how to generate a .pfx certificate for MSIX distribution].
+Instructions on [how to generate a .pfx certificate for MSIX distribution][].
 
 [MSIX]: https://docs.microsoft.com/en-us/windows/msix/overview
 [msix package]: {{site.pub}}/packages/msix

--- a/src/desktop.md
+++ b/src/desktop.md
@@ -311,9 +311,12 @@ The easiest way to create an MSIX distribution for a Flutter project is to use
 the [`msix` pub package][msix package]. For an example of using the `msix` package
 from a Flutter desktop app, see the [Desktop Photo Search sample][].
 
+Instructions on [how to generate a .pfx certificate for MSIX distribution].
+
 [MSIX]: https://docs.microsoft.com/en-us/windows/msix/overview
 [msix package]: {{site.pub}}/packages/msix
 [Desktop Photo Search sample]: {{site.github}}/flutter/samples/tree/master/experimental/desktop_photo_search
+[how to generate a .pfx certificate for MSIX distribution]: https://sahajrana.medium.com/how-to-generate-a-pfx-certificate-for-flutter-windows-msix-lib-a860cdcebb8
 
 ##### Building your own zip file for Windows
 

--- a/src/desktop.md
+++ b/src/desktop.md
@@ -311,12 +311,41 @@ The easiest way to create an MSIX distribution for a Flutter project is to use
 the [`msix` pub package][msix package]. For an example of using the `msix` package
 from a Flutter desktop app, see the [Desktop Photo Search sample][].
 
-Instructions on [how to generate a .pfx certificate for MSIX distribution][].
-
 [MSIX]: https://docs.microsoft.com/en-us/windows/msix/overview
 [msix package]: {{site.pub}}/packages/msix
 [Desktop Photo Search sample]: {{site.github}}/flutter/samples/tree/master/experimental/desktop_photo_search
-[how to generate a .pfx certificate for MSIX distribution]: https://sahajrana.medium.com/how-to-generate-a-pfx-certificate-for-flutter-windows-msix-lib-a860cdcebb8
+
+###### Create a .pfx certificate.
+
+To publish on the Windows Store or Direct download with the help of MSIX Installer, you need to give your app a digital signature in form of a .pfx certificate. Use the following instructions to generate a self-signed .pfx certificate.
+
+* You would need to download [OpenSSL][] to generate your certificates.
+* Go to where you installed the OpenSSL. It can be:
+    * C:\Program Files\OpenSSL-Win64\bin
+* Run cmd from this folder, that it looks like this in cmd.
+    * C:\Program Files\OpenSSL-Win64\bin>
+      or
+    * make “C:\Program Files\OpenSSL-Win64\bin” a environment path variable to access “OpenSSL” anywhere.
+* Now, use the following command:
+    * Generate a private key.
+      ```
+      openssl genrsa -out mykeyname.key 2048
+      ```
+    * Generate a CSR file with the help of the private key.
+      ```
+      openssl req -new -key mykeyname.key -out mycsrname.csr
+      ```
+    * Generate a CRT file with the help of the private key & CSR file.
+      ```
+      openssl x509 -in mycsrname.csr -out mycrtname.crt -req -signkey mykeyname.key -days 10000
+      ```
+    * Generate .pfx file with the help of the private key & CRT file.
+      ```
+      openssl pkcs12 -export -out CERTIFICATE.pfx -inkey mykeyname.key -in mycrtname.crt
+      ```
+There you have your .pfx certificate to use with MSIX Installer.
+      
+[OpenSSL]: https://slproweb.com/products/Win32OpenSSL.html
 
 ##### Building your own zip file for Windows
 

--- a/src/desktop.md
+++ b/src/desktop.md
@@ -321,7 +321,7 @@ To publish on the Windows Store or Direct download with the help of MSIX Install
 you need to give your app a digital signature in the form of a .pfx certificate.
 Use the following instructions to generate a self-signed .pfx certificate.
 
-* You would need to download [OpenSSL][] to generate your certificates.
+1. If you haven't already, download the [OpenSSL][] toolkit to generate your certificates.
 1. Go to where you installed OpenSSL, for example:
    `C:\Program Files\OpenSSL-Win64\bin`.
 1. Set an environment variable so that you can access `OpenSSL` from anywhere:<br>


### PR DESCRIPTION
…MSIX distribution.

MSIX lib currently lacking, is the way to build the .pfx certificate that is kind of equal to the .keystore file in Android apps for signing Release build.
Without a .pfx certificate, you can't install the windows app on a computer with MSIX Installer. And on Internet, it is all confusing and out-dated.

So, I have created a simplified step-by-step post to generate .pfx certificate.
https://sahajrana.medium.com/how-to-generate-a-pfx-certificate-for-flutter-windows-msix-lib-a860cdcebb8
Hope it can help flutter devs through the documentation.

Edit: changed link from Reddit post to direct link to the Medium post.