### PR TITLE
Add IDs to the install cards

### DIFF
--- a/src/docs/get-started/install/index.md
+++ b/src/docs/get-started/install/index.md
@@ -11,7 +11,7 @@ Select the operating system on which you are installing Flutter:
 
 <div class="card-deck mb-8">
 {% for os in page.os-list %}
-  <a class="card" href="/docs/get-started/install/{{os | remove: ' ' | downcase}}">
+  <a class="card" id="install-{{os | downcase}}" href="/docs/get-started/install/{{os | remove: ' ' | downcase}}">
     <div class="card-body">
       <header class="card-title text-center m-0">
         <span class="d-block h1">


### PR DESCRIPTION
I'd like to add an ID to each of the OS cards on the `https://flutter.dev/docs/get-started/install` page, so that I can track the click events on these cards more precisely via Google Tag Manager. 

![image](https://user-images.githubusercontent.com/11873270/110430412-3556dc00-8061-11eb-9277-0384006e555a.png)

For instance, "Install On Windows Button" tag will be triggered if there's a click on class=`card` with id=`install-windows`. The current setup only fires when users click on the text. 

Reference: "Clicks on any element" section on [this GTM document](https://support.google.com/tagmanager/answer/6106716?hl=en).