### PR TITLE
Add libgcrypt to Linux requirements

### DIFF
--- a/src/desktop.md
+++ b/src/desktop.md
@@ -98,6 +98,7 @@ you need the following in addition to the Flutter SDK:
 * [pkg-config][]
 * libblkid
 * liblzma
+* libgcrypt
 
 The easiest way to install the Flutter SDK along with these
 dependencies is by using [snapd][].
@@ -114,7 +115,7 @@ If `snapd` is unavailable on the Linux distro you're using,
 you might use the following command:
 
 ```terminal
-$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev libblkid-dev liblzma-dev
+$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev libblkid-dev liblzma-dev liblzma-dev libgcrypt20-dev
 ```
 
 [Clang]: https://clang.llvm.org/

--- a/src/desktop.md
+++ b/src/desktop.md
@@ -115,7 +115,7 @@ If `snapd` is unavailable on the Linux distro you're using,
 you might use the following command:
 
 ```terminal
-$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev libblkid-dev liblzma-dev liblzma-dev libgcrypt20-dev
+$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev libblkid-dev liblzma-dev libgcrypt20-dev
 ```
 
 [Clang]: https://clang.llvm.org/


### PR DESCRIPTION
Together with https://github.com/flutter/flutter/pull/77926, this fixes:
https://github.com/canonical/flutter-snap/issues/32
https://github.com/canonical/flutter-snap/issues/36
https://github.com/flutter/flutter/issues/77786
https://github.com/flutter/flutter/issues/77293

Changes proposed in this pull request:

*  Add `libgcrypt ` to the Linux requirements list.
* Update the suggested `apt-get install` command.