### PR TITLE
fix: breaking changes document pages with new line for version names

### DIFF
--- a/src/docs/release/breaking-changes/scaffold-messenger.md
+++ b/src/docs/release/breaking-changes/scaffold-messenger.md
@@ -176,7 +176,7 @@ rootScaffoldMessengerKey.currentState.removeCurrentSnackBar(mySnackBar);
 
 ## Timeline
 
-Landed in version: 1.23.0-13.0.pre
+Landed in version: 1.23.0-13.0.pre<br>
 In stable release: 2.0.0
 
 ## References

--- a/src/docs/release/breaking-changes/use-maxLengthEnforcement-instead-of-maxLengthEnforced.md
+++ b/src/docs/release/breaking-changes/use-maxLengthEnforcement-instead-of-maxLengthEnforced.md
@@ -194,7 +194,7 @@ For this reason, freeform fields should rarely use the `enforced` value and shou
 
 ## Timeline
 
-Landed in version: v1.26.0-1.0.pre
+Landed in version: v1.26.0-1.0.pre<br>
 In stable release: 2.0.0
 
 ## References


### PR DESCRIPTION
fix: breaking changes document pages with new line for version names between Landed in version and In stable release