### PR TITLE
Typo fix

### DIFF
--- a/src/docs/development/tools/devtools/debugger.md
+++ b/src/docs/development/tools/devtools/debugger.md
@@ -16,7 +16,7 @@ When you open the debugger tab, you should see the source for the main
 entry-point for your app loaded in the debugger.
 
 In order to browse around more of your application sources, click **Libraries**
-(top right) or us the hot key command `⌘ + P` / `ctrl + P`. This will open the
+(top right) or use the hot key command `⌘ + P` / `ctrl + P`. This will open the
 libraries window and allow you to search for other source files.
 
 ![Screenshot of the debugger tab]({% asset tools/devtools/debugger_screenshot.png @path %}){:width="100%"}


### PR DESCRIPTION
`us` -> `use`