### PR TITLE
Explain why the Debugger tab is missing.

### DIFF
--- a/src/docs/development/tools/devtools/debugger.md
+++ b/src/docs/development/tools/devtools/debugger.md
@@ -7,6 +7,10 @@ description: How to use DevTools' source-level debugger.
   The debugger works with all Flutter and Dart applications.
 {{site.alert.end}}
 
+{{site.alert.note}}
+  DevTools hides the Debugger tab if the app was launched from VS Code because VS Code has a built-in debugger.
+{{site.alert.end}}
+
 ## Getting started
 
 DevTools includes a full source-level debugger, supporting


### PR DESCRIPTION
Add "Note: DevTools hides the Debugger tab if the app was launched from VS Code because VS Code has a built-in debugger."