### PR TITLE
Migrate the fetch-data cookbook to null-safety

### DIFF
--- a/src/docs/cookbook/networking/fetch-data.md
+++ b/src/docs/cookbook/networking/fetch-data.md
@@ -95,7 +95,7 @@ class Album {
   final int id;
   final String title;
 
-  Album({this.userId, this.id, this.title});
+  Album({required this.userId, required this.id, required this.title});
 
   factory Album.fromJson(Map<String, dynamic> json) {
     return Album(
@@ -129,7 +129,7 @@ function to return a `Future<Album>`:
 import 'dart:convert';
 
 Future<Album> fetchAlbum() async {
-  final response = await http.get('https://jsonplaceholder.typicode.com/albums/1');
+  final response = await http.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response,
@@ -148,7 +148,7 @@ Now you've got a function that fetches an album from the internet.
 
 ## 4. Fetch the data
 
-Call the `fetch()` method in either the
+Call the `fetchAlbum()` method in either the
 [`initState()`][] or [`didChangeDependencies()`][]
 methods.
 
@@ -161,7 +161,7 @@ See [`State`][] for more details.
 <!-- skip -->
 ```dart
 class _MyAppState extends State<MyApp> {
-  Future<Album> futureAlbum;
+  late Future<Album> futureAlbum;
 
   @override
   void initState() {
@@ -190,10 +190,14 @@ You must provide two parameters:
 
 Note that `snapshot.hasData` only returns `true`
 when the snapshot contains a non-null data value.
-This is why the `fetchAlbum` function should throw an exception
+
+Because `fetchAlbum` can only return non-null values,
+the function should throw an exception
 even in the case of a "404 Not Found" server response.
-If `fetchAlbum` returns `null`
-then the spinner displays indefinitely.
+Throwing an exception sets the `snapshot.hasError` to `true`
+which can be used to display an error message.
+
+Otherwise, the spinner will be displayed.
 
 <!-- skip -->
 ```dart
@@ -201,7 +205,7 @@ FutureBuilder<Album>(
   future: futureAlbum,
   builder: (context, snapshot) {
     if (snapshot.hasData) {
-      return Text(snapshot.data.title);
+      return Text(snapshot.data!.title);
     } else if (snapshot.hasError) {
       return Text("${snapshot.error}");
     }
@@ -233,6 +237,7 @@ see the following recipes:
 
 ## Complete example
 
+<!-- skip -->
 ```dart
 import 'dart:async';
 import 'dart:convert';
@@ -260,7 +265,7 @@ class Album {
   final int id;
   final String title;
 
-  Album({this.userId, this.id, this.title});
+  Album({required this.userId, required this.id, required this.title});
 
   factory Album.fromJson(Map<String, dynamic> json) {
     return Album(
@@ -281,7 +286,7 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  Future<Album> futureAlbum;
+  late Future<Album> futureAlbum;
 
   @override
   void initState() {
@@ -305,7 +310,7 @@ class _MyAppState extends State<MyApp> {
             future: futureAlbum,
             builder: (context, snapshot) {
               if (snapshot.hasData) {
-                return Text(snapshot.data.title);
+                return Text(snapshot.data!.title);
               } else if (snapshot.hasError) {
                 return Text("${snapshot.error}");
               }


### PR DESCRIPTION
When I was fixing the Mocking cookbook recipe in https://github.com/flutter/website/pull/5492 I noticed that the "fetch-data" cookbook also had some issues.

In this PR I have fixed the outdated http code, as well as migrated the code example to null-safety.

I had to add `<!-- skip -->` annotation in one code example because we don't have a way to check null safe code in markdown yet. :cry: 

I've also updated the explanation on why we should throw an exception if the fetch data fails.

@sfshaza2 @RedBrogdon