### PR TITLE
Revert "Add libblkid / liblzma / libgcrypt to Linux requirements"

### DIFF
--- a/src/desktop.md
+++ b/src/desktop.md
@@ -109,8 +109,6 @@ you need the following in addition to the Flutter SDK:
 * [GTK development headers][]
 * [Ninja build][]
 * [pkg-config][]
-* libblkid
-* liblzma
 
 The easiest way to install the Flutter SDK along with these
 dependencies is by using [snapd][].
@@ -127,7 +125,7 @@ If `snapd` is unavailable on the Linux distro you're using,
 you might use the following command:
 
 ```terminal
-$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev libblkid-dev liblzma-dev
+$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev
 ```
 
 [Clang]: https://clang.llvm.org/

--- a/src/desktop.md
+++ b/src/desktop.md
@@ -111,7 +111,6 @@ you need the following in addition to the Flutter SDK:
 * [pkg-config][]
 * libblkid
 * liblzma
-* libgcrypt
 
 The easiest way to install the Flutter SDK along with these
 dependencies is by using [snapd][].
@@ -128,7 +127,7 @@ If `snapd` is unavailable on the Linux distro you're using,
 you might use the following command:
 
 ```terminal
-$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev libblkid-dev liblzma-dev libgcrypt20-dev
+$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev libblkid-dev liblzma-dev
 ```
 
 [Clang]: https://clang.llvm.org/


### PR DESCRIPTION
Following on from [this conversation](https://github.com/flutter/flutter/pull/77926#issuecomment-799189661):

Please accept my sincerest apologies for this! The last few updates to `desktop.md` are actually only [required for the snap package](https://github.com/canonical/flutter-snap/commit/e2e65acc4516b03b396a1bc09dfdfe567b68960d) and thus should not have been made upstream. This PR reverts those changes.

See also: https://github.com/flutter/flutter/pull/78415