### PR TITLE
Enable null safety by default in dart-pad in Navigation Basics cookbook recipe

### DIFF
--- a/src/docs/cookbook/navigation/navigation-basics.md
+++ b/src/docs/cookbook/navigation/navigation-basics.md
@@ -128,7 +128,7 @@ onPressed: () {
 
 ## Interactive example
 
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
 import 'package:flutter/material.dart';
 
 void main() {


### PR DESCRIPTION
I enabled null safety by default on the Navigation Basics recipe.

The rest of the recipe doesn't need changes for null-safety support.

@sfshaza2 @RedBrogdon 