### PR TITLE
Migrated 'themes' cookbook to null safety

### DIFF
--- a/null_safety_examples/cookbook/design/themes/lib/main.dart
+++ b/null_safety_examples/cookbook/design/themes/lib/main.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final appName = 'Custom Themes';
+
+    // #docregion MaterialApp
+    return MaterialApp(
+      title: appName,
+      theme: ThemeData(
+        // Define the default brightness and colors.
+        brightness: Brightness.dark,
+        primaryColor: Colors.lightBlue[800],
+        accentColor: Colors.cyan[600],
+
+        // Define the default font family.
+        fontFamily: 'Georgia',
+
+        // Define the default TextTheme. Use this to specify the default
+        // text styling for headlines, titles, bodies of text, and more.
+        textTheme: TextTheme(
+          headline1: TextStyle(fontSize: 72.0, fontWeight: FontWeight.bold),
+          headline6: TextStyle(fontSize: 36.0, fontStyle: FontStyle.italic),
+          bodyText2: TextStyle(fontSize: 14.0, fontFamily: 'Hind'),
+        ),
+      ),
+      home: MyHomePage(
+        title: appName,
+      ),
+    );
+    // #enddocregion MaterialApp
+  }
+}
+
+class MyHomePage extends StatelessWidget {
+  final String title;
+
+  MyHomePage({Key? key, required this.title}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(title),
+      ),
+      body: Center(
+        // #docregion Container
+        child: Container(
+          color: Theme.of(context).accentColor,
+          child: Text(
+            'Text with a background color',
+            style: Theme.of(context).textTheme.headline6,
+          ),
+        ),
+        // #enddocregion Container
+      ),
+      floatingActionButton: Theme(
+        data: Theme.of(context).copyWith(
+          colorScheme:
+          Theme.of(context).colorScheme.copyWith(secondary: Colors.yellow),
+        ),
+        child: FloatingActionButton(
+          onPressed: null,
+          child: Icon(Icons.add),
+        ),
+      ),
+    );
+  }
+}

--- a/null_safety_examples/cookbook/design/themes/lib/theme.dart
+++ b/null_safety_examples/cookbook/design/themes/lib/theme.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+void theme(BuildContext context) {
+  // #docregion Theme
+  Theme(
+    // Create a unique theme with "ThemeData"
+    data: ThemeData(
+      accentColor: Colors.yellow,
+    ),
+    child: FloatingActionButton(
+      onPressed: () {},
+      child: Icon(Icons.add),
+    ),
+  );
+  // #enddocregion Theme
+
+  // #docregion ThemeCopyWith
+  Theme(
+    // Find and extend the parent theme using "copyWith". See the next
+    // section for more info on `Theme.of`.
+    data: Theme.of(context).copyWith(accentColor: Colors.yellow),
+    child: FloatingActionButton(
+      onPressed: null,
+      child: Icon(Icons.add),
+    ),
+  );
+  // #enddocregion ThemeCopyWith
+}

--- a/null_safety_examples/cookbook/design/themes/pubspec.yaml
+++ b/null_safety_examples/cookbook/design/themes/pubspec.yaml
@@ -1,0 +1,12 @@
+name: themes
+description: Sample code for themes cookbook recipe.
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/src/docs/cookbook/design/themes.md
+++ b/src/docs/cookbook/design/themes.md
@@ -13,6 +13,8 @@ js:
     url: https://dartpad.dev/inject_embed.dart.js
 ---
 
+<?code-excerpt path-base="../null_safety_examples/cookbook/design/themes"?>
+
 To share colors and font styles throughout an app, use themes.
 You can either define app-wide themes, or use `Theme` widgets
 that define the colors and font styles for a particular part
@@ -31,10 +33,10 @@ To share a Theme across an entire app, provide a
 
 If no `theme` is provided, Flutter creates a default theme for you.
 
-<!-- skip -->
+<?code-excerpt "lib/main.dart (MaterialApp)" replace="/return //g"?>
 ```dart
 MaterialApp(
-  title: title,
+  title: appName,
   theme: ThemeData(
     // Define the default brightness and colors.
     brightness: Brightness.dark,
@@ -51,7 +53,10 @@ MaterialApp(
       headline6: TextStyle(fontSize: 36.0, fontStyle: FontStyle.italic),
       bodyText2: TextStyle(fontSize: 14.0, fontFamily: 'Hind'),
     ),
-  )
+  ),
+  home: MyHomePage(
+    title: appName,
+  ),
 );
 ```
 
@@ -71,7 +76,7 @@ or extending the parent theme.
 If you don't want to inherit any application colors or font styles,
 create a `ThemeData()` instance and pass that to the `Theme` widget.
 
-<!-- skip -->
+<?code-excerpt "lib/theme.dart (Theme)"?>
 ```dart
 Theme(
   // Create a unique theme with "ThemeData"
@@ -90,7 +95,7 @@ Theme(
 Rather than overriding everything, it often makes sense to extend the parent
 theme. You can handle this by using the [`copyWith()`][] method.
 
-<!-- skip -->
+<?code-excerpt "lib/theme.dart (ThemeCopyWith)"?>
 ```dart
 Theme(
   // Find and extend the parent theme using "copyWith". See the next
@@ -116,7 +121,7 @@ If not, the app's theme is returned.
 In fact, the `FloatingActionButton` uses this technique to find the
 `accentColor`.
 
-<!-- skip -->
+<?code-excerpt "lib/main.dart (Container)" replace="/^child: //g"?>
 ```dart
 Container(
   color: Theme.of(context).accentColor,
@@ -124,12 +129,13 @@ Container(
     'Text with a background color',
     style: Theme.of(context).textTheme.headline6,
   ),
-);
+),
 ```
 
 ## Interactive example
 
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+<?code-excerpt "lib/main.dart"?>
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -171,7 +177,7 @@ class MyApp extends StatelessWidget {
 class MyHomePage extends StatelessWidget {
   final String title;
 
-  MyHomePage({Key key, @required this.title}) : super(key: key);
+  MyHomePage({Key? key, required this.title}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -191,7 +197,7 @@ class MyHomePage extends StatelessWidget {
       floatingActionButton: Theme(
         data: Theme.of(context).copyWith(
           colorScheme:
-              Theme.of(context).colorScheme.copyWith(secondary: Colors.yellow),
+          Theme.of(context).colorScheme.copyWith(secondary: Colors.yellow),
         ),
         child: FloatingActionButton(
           onPressed: null,


### PR DESCRIPTION
In this PR I have migrated the cookbook recipe for Themes to null safety.

I have created a project in null_safety_examples with the code and used code-excerpts to insert the samples.

As well I have enabled null safety on the embedded dart-pad.

@sfshaza2 @RedBrogdon 