### PR TITLE
Correct PATH modification instructions

### DIFF
--- a/src/docs/get-started/install/_path-linux-chromeos.md
+++ b/src/docs/get-started/install/_path-linux-chromeos.md
@@ -10,7 +10,7 @@ all terminal sessions are machine-specific.
 Typically you add a line to a file that is executed
 whenever you open a new window. For example:
 
- 1. Determine the directory where you placed the Flutter SDK.
+ 1. Determine the path of your clone of the Flutter SDK.
     You need this in Step 3.
  2. Open (or create) the `rc` file for your shell.
     For example, Linux uses the Bash shell by default,
@@ -18,11 +18,11 @@ whenever you open a new window. For example:
     If you are using a different shell, the file path
     and filename will be different on your machine.
  3. Add the following line and change
-    `[PATH_TO_FLUTTER_GIT_DIRECTORY]` to be
-    the path where you cloned Flutter's git repo:
+    `[PATH_OF_FLUTTER_GIT_DIRECTORY]` to be
+    the path of your clone of the Flutter git repo:
 
     ```terminal
-    $ export PATH="$PATH:[PATH_TO_FLUTTER_GIT_DIRECTORY]/flutter/bin"
+    $ export PATH="$PATH:[PATH_OF_FLUTTER_GIT_DIRECTORY]/bin"
     ```
 
  4. Run `source $HOME/.<rc file>`
@@ -50,7 +50,7 @@ the path when using the above directions. When this occurs,
 you can change the environment variables file directly.
 These instructions require administrator privileges:
 
-   1. Determine the directory where you placed the Flutter SDK.
+   1. Determine the path of your clone of the Flutter SDK.
 
    2. Locate the `etc` directory at the root of the system,
       and open the `profile` file with root privileges.
@@ -65,7 +65,7 @@ These instructions require administrator privileges:
       if [ "`id -u`" -eq 0 ]; then
          PATH="..."
       else
-         PATH="/usr/local/bin:...:[PATH_TO_FLUTTER_GIT_DIRECTORY]/flutter/bin"
+         PATH="/usr/local/bin:...:[PATH_OF_FLUTTER_GIT_DIRECTORY]/bin"
       fi
       export PATH
       ```

--- a/src/docs/get-started/install/_path-mac.md
+++ b/src/docs/get-started/install/_path-mac.md
@@ -10,7 +10,7 @@ all terminal sessions are machine-specific.
 Typically you add a line to a file that is executed
 whenever you open a new window. For example:
 
- 1. Determine the directory where you placed the Flutter SDK.
+ 1. Determine the path of your clone of the Flutter SDK.
     You need this in Step 3.
  2. Open (or create) the `rc` file for your shell.
     Typing `echo $SHELL` in your Terminal tells you
@@ -21,11 +21,11 @@ whenever you open a new window. For example:
     If you're using a different shell, the file path
     and filename will be different on your machine.
  3. Add the following line and change
-    `[PATH_TO_FLUTTER_GIT_DIRECTORY]` to be
-    the path where you cloned Flutter's git repo:
+    `[PATH_OF_FLUTTER_GIT_DIRECTORY]` to be
+    the path of your clone of the Flutter git repo:
 
     ```terminal
-    $ export PATH="$PATH:[PATH_TO_FLUTTER_GIT_DIRECTORY]/flutter/bin"
+    $ export PATH="$PATH:[PATH_OF_FLUTTER_GIT_DIRECTORY]/bin"
     ```
 
  4. Run `source $HOME/.<rc file>`


### PR DESCRIPTION
Previously we asked users to modify their path as follows:

    export PATH="$PATH:[PATH_TO_FLUTTER_GIT_DIRECTORY]/flutter/bin"

The correct location is just `bin` relative to the main Flutter
directory, so the correct instructions should be:

    export PATH="$PATH:[PATH_TO_FLUTTER_GIT_DIRECTORY]/bin"

I've also made some minor wording changes to remove any ambiguity that
`PATH_TO_FLUTTER_GIT_DIRECTORY` is actually the path of the cloned
`flutter` repo and not the path into which the clone was landed.

This was a potential source of confusion/ambiguity since the initial
install instructions do suggest they run the following command to
temporarily add Flutter to their PATH after the initial install.

    export PATH="$PATH:`pwd`/flutter/bin"

Credit for spotting this error goes to [christiannc on StackOverflow][so].

[so]: https://stackoverflow.com/questions/66713077/setting-up-flutter-in-terminal-yields-a-command-not-found-message/66716562#66716562