### PR TITLE
Fix broken markdown in 'Adding a Flutter screen to an Android app'

### DIFF
--- a/src/docs/development/add-to-app/android/add-flutter-screen.md
+++ b/src/docs/development/add-to-app/android/add-flutter-screen.md
@@ -48,11 +48,14 @@ in your app that you'd like. The following example shows
 `FlutterActivity` being launched from an `OnClickListener`.
 
 {{site.alert.note}}
-  Make sure to use the following import:
-  
-  <!--skip-->
-  ```dart
+Make sure to use the following import:
+
+<!--skip-->
+```dart
   import io.flutter.embedding.android.FlutterActivity;
+```
+{{site.alert.end}}
+
 {% samplecode default-activity-launch %}
 {% sample Java %}
 <!--code-excerpt "ExistingActivity.java" title-->
@@ -354,6 +357,7 @@ startActivity(
     .build(context)
 );
 ```
+
 {% sample Kotlin %}
 <!--code-excerpt "ExistingActivity.kt" title-->
 ```kotlin


### PR DESCRIPTION
Fixes issue reported in: https://github.com/flutter/website/issues/5511

Before:
![image](https://user-images.githubusercontent.com/2494376/112001512-53234700-8b1f-11eb-8512-80986ca5ef54.png)

After:
![image](https://user-images.githubusercontent.com/2494376/112001448-47378500-8b1f-11eb-8c93-67e4874115fc.png)

Also checked for null-safety issues but it is all Java and Kotlin code :)
