### PR TITLE
Typo fix in plugin-api-migration.md

### DIFF
--- a/src/docs/development/packages-and-plugins/plugin-api-migration.md
+++ b/src/docs/development/packages-and-plugins/plugin-api-migration.md
@@ -49,7 +49,7 @@ The following instructions outline the steps for supporting the new API:
    The easiest thing to do (if possible) is move the logic from
    `registerWith()` into a private method that both
    `registerWith()` and `onAttachedToEngine()` can call.
-   Either `registerWith()` or `onAttachToEngine()` will be called,
+   Either `registerWith()` or `onAttachedToEngine()` will be called,
    not both.
    <br><br>
    In addition, you should document all non-overridden public members


### PR DESCRIPTION
`onAttachToEngine` won't be called because the method doesn't exist.