### PR TITLE
Migrated Internationalization documentation to null safety

### DIFF
--- a/null_safety_examples/internationalization/add_language/lib/main.dart
+++ b/null_safety_examples/internationalization/add_language/lib/main.dart
@@ -5,6 +5,7 @@ import 'nn_intl.dart';
 
 void main() {
   runApp(
+    // #docregion MaterialApp
     MaterialApp(
       localizationsDelegates: [
         GlobalWidgetsLocalizations.delegate,
@@ -15,6 +16,7 @@ void main() {
         const Locale('en', 'US'),
         const Locale('nn'),
       ],
+      // #enddocregion MaterialApp
       home: Home(),
     ),
   );

--- a/null_safety_examples/internationalization/add_language/lib/main.dart
+++ b/null_safety_examples/internationalization/add_language/lib/main.dart
@@ -16,9 +16,9 @@ void main() {
         const Locale('en', 'US'),
         const Locale('nn'),
       ],
-      // #enddocregion MaterialApp
       home: Home(),
     ),
+    // #enddocregion MaterialApp
   );
 }
 

--- a/null_safety_examples/internationalization/add_language/lib/nn_intl.dart
+++ b/null_safety_examples/internationalization/add_language/lib/nn_intl.dart
@@ -11,11 +11,13 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 ///
 /// These are not accurate and are just a clone of the date patterns for the
 /// `no` locale to demonstrate how one would write and use custom date patterns.
+// #docregion Date
 const nnLocaleDatePatterns = {
   'd': 'd.',
   'E': 'ccc',
   'EEEE': 'cccc',
   'LLL': 'LLL',
+// #enddocregion Date
   'LLLL': 'LLLL',
   'M': 'L.',
   'Md': 'd.M.',
@@ -62,12 +64,14 @@ const nnLocaleDatePatterns = {
 ///
 /// These are not accurate and are just a clone of the date symbols for the
 /// `no` locale to demonstrate how one would write and use custom date symbols.
+// #docregion Date2
 const nnDateSymbols = {
   'NAME': 'nn',
   'ERAS': <dynamic>[
     'f.Kr.',
     'e.Kr.',
   ],
+// #enddocregion Date2
   'ERANAMES': <dynamic>[
     'før Kristus',
     'etter Kristus',
@@ -253,6 +257,7 @@ const nnDateSymbols = {
   ],
 };
 
+// #docregion Delegate
 class _NnMaterialLocalizationsDelegate
     extends LocalizationsDelegate<MaterialLocalizations> {
   const _NnMaterialLocalizationsDelegate();
@@ -283,6 +288,7 @@ class _NnMaterialLocalizationsDelegate
         // for 'en_US' instead.
         decimalFormat: intl.NumberFormat('#,##0.###', 'en_US'),
         twoDigitZeroPaddedFormat: intl.NumberFormat('00', 'en_US'),
+// #enddocregion Delegate
         // DateFormat here will use the symbols and patterns provided in the
         // `date_symbol_data_custom.initializeDateFormattingCustom` call above.
         // However, an alternative is to simply use a supported locale's
@@ -331,6 +337,7 @@ class NnMaterialLocalizations extends GlobalMaterialLocalizations {
           twoDigitZeroPaddedFormat: twoDigitZeroPaddedFormat,
         );
 
+// #docregion Getters
   @override
   String get moreButtonTooltip => r'More';
 
@@ -339,6 +346,7 @@ class NnMaterialLocalizations extends GlobalMaterialLocalizations {
 
   @override
   String get alertDialogLabel => r'Alert';
+// #enddocregion Getters
 
   @override
   String get anteMeridiemAbbreviation => r'AM';
@@ -401,12 +409,14 @@ class NnMaterialLocalizations extends GlobalMaterialLocalizations {
   // A custom drawer tooltip message.
   String get openAppDrawerTooltip => r'Custom Navigation Menu Tooltip';
 
+// #docregion Raw
   @override
   String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow of $rowCount';
 
   @override
   String get pageRowsInfoTitleApproximateRaw =>
       r'$firstRow–$lastRow of about $rowCount';
+// #enddocregion Raw
 
   @override
   String get pasteButtonLabel => r'PASTE';

--- a/null_safety_examples/internationalization/add_language/lib/nn_intl.dart
+++ b/null_safety_examples/internationalization/add_language/lib/nn_intl.dart
@@ -288,7 +288,6 @@ class _NnMaterialLocalizationsDelegate
         // for 'en_US' instead.
         decimalFormat: intl.NumberFormat('#,##0.###', 'en_US'),
         twoDigitZeroPaddedFormat: intl.NumberFormat('00', 'en_US'),
-// #enddocregion Delegate
         // DateFormat here will use the symbols and patterns provided in the
         // `date_symbol_data_custom.initializeDateFormattingCustom` call above.
         // However, an alternative is to simply use a supported locale's
@@ -307,6 +306,7 @@ class _NnMaterialLocalizationsDelegate
   @override
   bool shouldReload(_NnMaterialLocalizationsDelegate old) => false;
 }
+// #enddocregion Delegate
 
 /// A custom set of localizations for the 'nn' locale. In this example, only
 /// the value for openAppDrawerTooltip was modified to use a custom message as

--- a/null_safety_examples/internationalization/gen_l10n_example/lib/examples.dart
+++ b/null_safety_examples/internationalization/gen_l10n_example/lib/examples.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+// ignore_for_file: unused_local_variable
 
 void examples(BuildContext context) {
 // #docregion MaterialAppExample

--- a/null_safety_examples/internationalization/gen_l10n_example/lib/examples.dart
+++ b/null_safety_examples/internationalization/gen_l10n_example/lib/examples.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+void examples(BuildContext context) {
+// #docregion MaterialAppExample
+  MaterialApp(
+    title: 'Localizations Sample App',
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+  );
+// #enddocregion MaterialAppExample
+
+// #docregion LocaleResolution
+  MaterialApp(
+    localeResolutionCallback: (
+      Locale? locale,
+      Iterable<Locale> supportedLocales,
+    ) {
+      return locale;
+    },
+  );
+// #enddocregion LocaleResolution
+
+// #docregion Example
+  Text(AppLocalizations.of(context)!.helloWorld);
+// #enddocregion Example
+
+// #docregion MyLocale
+  Locale myLocale = Localizations.localeOf(context);
+// #enddocregion MyLocale
+
+  MaterialApp(
+// #docregion SupportedLocales
+    supportedLocales: [
+      const Locale.fromSubtags(languageCode: 'zh'), // generic Chinese 'zh'
+      const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans'), // generic simplified Chinese 'zh_Hans'
+      const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'), // generic traditional Chinese 'zh_Hant'
+      const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans', countryCode: 'CN'), // 'zh_Hans_CN'
+      const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant', countryCode: 'TW'), // 'zh_Hant_TW'
+      const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant', countryCode: 'HK'), // 'zh_Hant_HK'
+    ],
+// #enddocregion SupportedLocales
+  );
+}

--- a/null_safety_examples/internationalization/gen_l10n_example/lib/main.dart
+++ b/null_safety_examples/internationalization/gen_l10n_example/lib/main.dart
@@ -1,25 +1,30 @@
 import 'package:flutter/material.dart';
+// #docregion LocalizationDelegatesImport
 import 'package:flutter_localizations/flutter_localizations.dart';
+// #enddocregion LocalizationDelegatesImport
+// #docregion AppLocalizationsImport
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-
-void main() {
-  runApp(MyApp());
-}
+// #enddocregion AppLocalizationsImport
 
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+// #docregion LocalizationDelegates
+// #docregion AppLocalizations
     return MaterialApp(
       title: 'Localizations Sample App',
       localizationsDelegates: [
-        AppLocalizations.delegate,
+        AppLocalizations.delegate, // Add this line
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
       ],
+// #enddocregion AppLocalizations
       supportedLocales: [
-        const Locale('en', ''),
-        const Locale('es', ''),
+        const Locale('en', ''), // English, no country code
+        const Locale('es', ''), // Spanish, no country code
       ],
+// #enddocregion LocalizationDelegates
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
@@ -27,6 +32,7 @@ class MyApp extends StatelessWidget {
     );
   }
 }
+
 
 class MyHomePage extends StatefulWidget {
   @override
@@ -36,6 +42,7 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
+// #docregion Example
     return Scaffold(
       appBar: AppBar(
         // The [AppBar] title text should update its message
@@ -45,5 +52,10 @@ class _MyHomePageState extends State<MyHomePage> {
         title: Text(AppLocalizations.of(context)!.helloWorld),
       ),
     );
+// #enddocregion Example
   }
+}
+
+void main() {
+  runApp(MyApp());
 }

--- a/null_safety_examples/internationalization/gen_l10n_example/lib/main.dart
+++ b/null_safety_examples/internationalization/gen_l10n_example/lib/main.dart
@@ -11,8 +11,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-// #docregion LocalizationDelegates
-// #docregion AppLocalizations
+// #docregion MaterialApp
     return MaterialApp(
       title: 'Localizations Sample App',
       localizationsDelegates: [
@@ -21,17 +20,16 @@ class MyApp extends StatelessWidget {
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
-// #enddocregion AppLocalizations
       supportedLocales: [
         const Locale('en', ''), // English, no country code
         const Locale('es', ''), // Spanish, no country code
       ],
-// #enddocregion LocalizationDelegates
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
       home: MyHomePage(),
     );
+// #enddocregion MaterialApp
   }
 }
 

--- a/null_safety_examples/internationalization/gen_l10n_example/lib/main.dart
+++ b/null_safety_examples/internationalization/gen_l10n_example/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+
 // #docregion LocalizationDelegatesImport
 import 'package:flutter_localizations/flutter_localizations.dart';
+
 // #enddocregion LocalizationDelegatesImport
 // #docregion AppLocalizationsImport
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -33,7 +35,6 @@ class MyApp extends StatelessWidget {
   }
 }
 
-
 class MyHomePage extends StatefulWidget {
   @override
   _MyHomePageState createState() => _MyHomePageState();
@@ -42,7 +43,6 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
-// #docregion Example
     return Scaffold(
       appBar: AppBar(
         // The [AppBar] title text should update its message
@@ -52,7 +52,6 @@ class _MyHomePageState extends State<MyHomePage> {
         title: Text(AppLocalizations.of(context)!.helloWorld),
       ),
     );
-// #enddocregion Example
   }
 }
 

--- a/null_safety_examples/internationalization/gen_l10n_example/pubspec.yaml
+++ b/null_safety_examples/internationalization/gen_l10n_example/pubspec.yaml
@@ -4,14 +4,20 @@ description: Example of an internationalized Flutter app that uses `flutter gen-
 environment:
   sdk: '>=2.12.0 <3.0.0'
 
+# #docregion FlutterLocalizations
+# #docregion Intl
 dependencies:
   flutter:
     sdk: flutter
-  # Internationalization support.
-  flutter_localizations:
-    sdk: flutter
-  intl: any # Add this line
+  flutter_localizations: # Add this line
+    sdk: flutter         # Add this line
+# #enddocregion FlutterLocalizations
+  intl: ^0.17.0 # Add this line
+# #enddocregion Intl
 
+# #docregion Generate
+# The following section is specific to Flutter.
 flutter:
   generate: true # Add this line
+# #enddocregion Generate
   uses-material-design: true

--- a/null_safety_examples/internationalization/intl_example/lib/main.dart
+++ b/null_safety_examples/internationalization/intl_example/lib/main.dart
@@ -43,6 +43,7 @@ import 'package:intl/intl.dart';
 // https://pub.dev/packages/intl.
 import 'l10n/messages_all.dart';
 
+// #docregion DemoLocalizations
 class DemoLocalizations {
   DemoLocalizations(this.localeName);
 
@@ -72,6 +73,7 @@ class DemoLocalizations {
     );
   }
 }
+// #enddocregion DemoLocalizations
 
 class DemoLocalizationsDelegate extends LocalizationsDelegate<DemoLocalizations> {
   const DemoLocalizationsDelegate();
@@ -103,8 +105,10 @@ class DemoApp extends StatelessWidget {
 class Demo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+// #docregion MaterialAppTitleExample
     return MaterialApp(
       onGenerateTitle: (BuildContext context) => DemoLocalizations.of(context).title,
+// #enddocregion MaterialAppTitleExample
       localizationsDelegates: [
         const DemoLocalizationsDelegate(),
         GlobalMaterialLocalizations.delegate,

--- a/null_safety_examples/internationalization/minimal/lib/main.dart
+++ b/null_safety_examples/internationalization/minimal/lib/main.dart
@@ -26,6 +26,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart' show SynchronousFuture;
 import 'package:flutter_localizations/flutter_localizations.dart';
 
+// #docregion Demo
 class DemoLocalizations {
   DemoLocalizations(this.locale);
 
@@ -48,7 +49,9 @@ class DemoLocalizations {
     return _localizedValues[locale.languageCode]!['title']!;
   }
 }
+// #enddocregion Demo
 
+// #docregion Delegate
 class DemoLocalizationsDelegate extends LocalizationsDelegate<DemoLocalizations> {
   const DemoLocalizationsDelegate();
 
@@ -65,6 +68,7 @@ class DemoLocalizationsDelegate extends LocalizationsDelegate<DemoLocalizations>
   @override
   bool shouldReload(DemoLocalizationsDelegate old) => false;
 }
+// #enddocregion Delegate
 
 class DemoApp extends StatelessWidget {
   @override

--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -711,6 +711,8 @@ MaterialApp(
     const Locale('en', 'US'),
     const Locale('nn'),
   ],
+  home: Home(),
+),
 ```
 
 <a name="alternative-internationalization-workflows">

--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -136,6 +136,9 @@ following instructions to add localized text to your application.
 
 1. Add the `intl` package to the `pubspec.yaml` file:
 
+{% comment %}
+RegEx removes "# Add this line" from lines "flutter_localizations:" and "sdk: flutter"
+{% endcomment %}
    <?code-excerpt "gen_l10n_example/pubspec.yaml (Intl)" replace="/(?<!0) # Add this line//g" ?>
    ```yaml
    dependencies:
@@ -599,16 +602,24 @@ The date patterns and symbols of the locale will also need to
 be specified. In the source code, the date patterns and symbols
 are defined like this:
 
-<?code-excerpt "add_language/lib/nn_intl.dart (Date)"?>
+{% comment %}
+RegEx adds last two lines with commented out code and closing bracket.
+{% endcomment %}
+<?code-excerpt "add_language/lib/nn_intl.dart (Date)" replace="/  'LLL': 'LLL',/  'LLL': 'LLL',\n  \/\/ ...\n}/g"?>
 ```dart
 const nnLocaleDatePatterns = {
   'd': 'd.',
   'E': 'ccc',
   'EEEE': 'cccc',
   'LLL': 'LLL',
+  // ...
+}
 ```
 
-<?code-excerpt "add_language/lib/nn_intl.dart (Date2)"?>
+{% comment %}
+RegEx adds last two lines with commented out code and closing bracket.
+{% endcomment %}
+<?code-excerpt "add_language/lib/nn_intl.dart (Date2)" replace="/  ],/  ],\n  \/\/ ...\n}/g"?>
 ```dart
 const nnDateSymbols = {
   'NAME': 'nn',
@@ -616,6 +627,8 @@ const nnDateSymbols = {
     'f.Kr.',
     'e.Kr.',
   ],
+  // ...
+}
 ```
 
 These will need to be modified for the locale to use the correct

--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -219,69 +219,25 @@ project called `l10n.yaml` with the following content:
        GlobalCupertinoLocalizations.delegate,
      ],
    ```
+   
+8. Use AppLocalizations anywhere in your app.
+   Here, the translated message is used in a Text widget.
 
-   Test the generated localizations in your app as follows:
-
-   <!-- skip -->
+   <?code-excerpt "gen_l10n_example/lib/examples.dart (Example)"?>
    ```dart
-   // In your Material/Widget/CupertinoApp:
-   @override
-   Widget build(BuildContext context) {
-     return MaterialApp(
-       localizationsDelegates: AppLocalizations.localizationsDelegates, // Add this line
-       supportedLocales: AppLocalizations.supportedLocales, // Add this line
-       home: // ...
-     );
-   }
-   ```
-
-   <?code-excerpt "gen_l10n_example/lib/main.dart (Example)"?>
-   ```dart
-   return Scaffold(
-     appBar: AppBar(
-       // The [AppBar] title text should update its message
-       // according to the system locale of the target platform.
-       // Switching between English and Spanish locales should
-       // cause this text to update.
-       title: Text(AppLocalizations.of(context)!.helloWorld),
-     ),
-   );
+   Text(AppLocalizations.of(context)!.helloWorld);
    ```
    
-   <!-- skip -->
-   ```dart
-   import 'package:flutter_localizations/flutter_localizations.dart';
-   // import 'package:flutter_gen/gen_l10n/app_localizations.dart'; // remove the comment for this line
+9. You can also use the generated `localizationsDelegates` and `supportedLocales` list
+   instead of providing them manually.
 
-   // ...
-   
+   <?code-excerpt "gen_l10n_example/lib/examples.dart (MaterialAppExample)"?>
+   ```dart
    MaterialApp(
-     localizationsDelegates: [
-       // ... app-specific localization delegate[s] here
-       // AppLocalizations.delegate, // remove the comment for this line
-       GlobalMaterialLocalizations.delegate,
-       // ...
+     title: 'Localizations Sample App',
+     localizationsDelegates: AppLocalizations.localizationsDelegates,
+     supportedLocales: AppLocalizations.supportedLocales,
    );
-   // ...
-
-   // In your Material/Widget/CupertinoApp:
-   @override
-   Widget build(BuildContext context) {
-     return MaterialApp(
-       localizationsDelegates: AppLocalizations.localizationsDelegates, // Add this line
-       supportedLocales: AppLocalizations.supportedLocales, // Add this line
-       home: // ...
-     );
-   }
-
-   // ...
-
-   // Use AppLocalizations anywhere in your app.
-   // Here, the translated message is used in a Text widget.
-   Widget build(BuildContext context) {
-     // ...
-     return Text(AppLocalizations.of(context).helloWorld);
-   }
    ```
 
    This code generates a Text widget that displays "Hello World!"
@@ -296,17 +252,11 @@ To see a sample Flutter app using this tool, please see
 To localize your device app description, you can pass in the localized
 string into [`MaterialApp.onGenerateTitle`][]:
 
-  <!-- skip -->
-  ```dart
-  // In your Material/Widget/CupertinoApp:
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      onGenerateTitle: (BuildContext context) => AppLocalizations.of(context).appTitle,
-      // ...
-    );
-  }
-  ```
+<?code-excerpt "intl_example/lib/main.dart (MaterialAppTitleExample)"?>
+```dart
+return MaterialApp(
+  onGenerateTitle: (BuildContext context) => DemoLocalizations.of(context).title,
+```
 
 For more information about the localization tool,
 such as dealing with DateTime and handling plurals,
@@ -361,9 +311,8 @@ In order to fully express every variant of Chinese for the
 country codes `CN`, `TW`, and `HK`, the list of supported
 locales should include:
 
-<!-- skip -->
+<?code-excerpt "gen_l10n_example/lib/examples.dart (SupportedLocales)"?>
 ```dart
-// Full Chinese support for CN, TW, and HK
 supportedLocales: [
   const Locale.fromSubtags(languageCode: 'zh'), // generic Chinese 'zh'
   const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans'), // generic simplified Chinese 'zh_Hans'
@@ -409,7 +358,7 @@ and rebuilds it if the system's locale changes.
 You can always lookup an app's current locale with
 `Localizations.localeOf()`:
 
-<!-- skip -->
+<?code-excerpt "gen_l10n_example/lib/examples.dart (MyLocale)"?>
 ```dart
 Locale myLocale = Localizations.localeOf(context);
 ```
@@ -436,19 +385,16 @@ method can provide a [`localeResolutionCallback`][].
 For example, to have your app unconditionally accept
 whatever locale the user selects:
 
-<!-- skip -->
+<?code-excerpt "gen_l10n_example/lib/examples.dart (LocaleResolution)"?>
 ```dart
-class DemoApp extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-       localeResolutionCallback: (Locale locale, Iterable<Locale> supportedLocales) {
-         return locale;
-       }
-       // ...
-    );
-  }
-}
+MaterialApp(
+  localeResolutionCallback: (
+    Locale? locale,
+    Iterable<Locale> supportedLocales,
+  ) {
+    return locale;
+  },
+);
 ```
 
 ## How internationalization in Flutter works
@@ -536,21 +482,24 @@ It uses the `initializeMessages()` function
 generated by Dart's [`intl`][] package,
 [`Intl.message()`][], to look them up.
 
-<!-- skip -->
+<?code-excerpt "intl_example/lib/main.dart (DemoLocalizations)"?>
 ```dart
 class DemoLocalizations {
   DemoLocalizations(this.localeName);
 
   static Future<DemoLocalizations> load(Locale locale) {
-    final String name = locale.countryCode.isEmpty ? locale.languageCode : locale.toString();
+    final String name = locale.countryCode == null || locale.countryCode!.isEmpty
+        ? locale.languageCode
+        : locale.toString();
     final String localeName = Intl.canonicalizedLocale(name);
+
     return initializeMessages(localeName).then((_) {
       return DemoLocalizations(localeName);
     });
   }
 
   static DemoLocalizations of(BuildContext context) {
-    return Localizations.of<DemoLocalizations>(context, DemoLocalizations);
+    return Localizations.of<DemoLocalizations>(context, DemoLocalizations)!;
   }
 
   final String localeName;
@@ -607,18 +556,16 @@ The delegate class includes basic date and number format
 localizations. All of the other localizations are defined by `String`
 valued property getters in `NnMaterialLocalizations`, like this:
 
-<!-- skip -->
+<?code-excerpt "add_language/lib/nn_intl.dart (Getters)"?>
 ```dart
 @override
-String get backButtonTooltip => r'Back';
+String get moreButtonTooltip => r'More';
 
 @override
-String get cancelButtonLabel => r'CANCEL';
+String get aboutListTileTitleRaw => r'About $applicationName';
 
 @override
-String get closeButtonLabel => r'CLOSE';
-
-// etc..
+String get alertDialogLabel => r'Alert';
 ```
 
 These are the English translations, of course.
@@ -630,38 +577,37 @@ like `r'About $applicationName'`,
 because sometimes the strings contain variables with a `$` prefix.
 The variables are expanded by parameterized localization methods:
 
-<!-- skip -->
+<?code-excerpt "add_language/lib/nn_intl.dart (Raw)"?>
 ```dart
 @override
-String get aboutListTileTitleRaw => r'About $applicationName';
+String get pageRowsInfoTitleRaw => r'$firstRow–$lastRow of $rowCount';
 
 @override
-String aboutListTileTitle(String applicationName) {
-  final String text = aboutListTileTitleRaw;
-  return text.replaceFirst(r'$applicationName', applicationName);
-}
+String get pageRowsInfoTitleApproximateRaw =>
+    r'$firstRow–$lastRow of about $rowCount';
 ```
 
 The date patterns and symbols of the locale will also need to
 be specified. In the source code, the date patterns and symbols
 are defined like this:
 
-<!-- skip -->
+<?code-excerpt "add_language/lib/nn_intl.dart (Date)"?>
 ```dart
 const nnLocaleDatePatterns = {
   'd': 'd.',
   'E': 'ccc',
-  //...
-}
+  'EEEE': 'cccc',
+  'LLL': 'LLL',
+```
 
+<?code-excerpt "add_language/lib/nn_intl.dart (Date2)"?>
+```dart
 const nnDateSymbols = {
   'NAME': 'nn',
   'ERAS': <dynamic>[
     'f.Kr.',
     'e.Kr.',
   ],
-  // ...
-}
 ```
 
 These will need to be modified for the locale to use the correct
@@ -670,11 +616,13 @@ not share the same flexibility for number formatting, the formatting
 for an existing locale will have to be used as a substitute in
 `_NnMaterialLocalizationsDelegate`:
 
-<!-- skip -->
+<?code-excerpt "add_language/lib/nn_intl.dart (Delegate)" replace="/@(.|\n)*';\n\n//g;/    final (.|\n)*\);\n\n//g"?>
 ```dart
-class _NnMaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocalizations> {
-  // ...
-  @override
+class _NnMaterialLocalizationsDelegate
+    extends LocalizationsDelegate<MaterialLocalizations> {
+  const _NnMaterialLocalizationsDelegate();
+
+    @override
   Future<MaterialLocalizations> load(Locale locale) async {
     return SynchronousFuture<MaterialLocalizations>(
       NnMaterialLocalizations(
@@ -687,11 +635,6 @@ class _NnMaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLoc
         // for 'en_US' instead.
         decimalFormat: intl.NumberFormat('#,##0.###', 'en_US'),
         twoDigitZeroPaddedFormat: intl.NumberFormat('00', 'en_US'),
-        //...
-      ),
-    );
-  }
-}
 ```
 
 For more information about localization strings, see the
@@ -704,19 +647,18 @@ Here's some code that sets the app's language to Nynorsk and
 adds the `NnMaterialLocalizations` delegate instance to the app's
 `localizationsDelegates` list:
 
-<!-- skip -->
+<?code-excerpt "add_language/lib/main.dart (MaterialApp)"?>
 ```dart
 MaterialApp(
   localizationsDelegates: [
     GlobalWidgetsLocalizations.delegate,
     GlobalMaterialLocalizations.delegate,
-    NnMaterialLocalizations.delegate,
+    NnMaterialLocalizations.delegate, // Add the newly created delegate
   ],
   supportedLocales: [
-    const Locale('nn')
+    const Locale('en', 'US'),
+    const Locale('nn'),
   ],
-  home: ...
-)
 ```
 
 <a name="alternative-internationalization-workflows">
@@ -740,7 +682,7 @@ localizations, DemoLocalizations, includes all of its translations
 directly in per language Maps.
 
 
-<!-- skip -->
+<?code-excerpt "minimal/lib/main.dart (Demo)"?>
 ```dart
 class DemoLocalizations {
   DemoLocalizations(this.locale);
@@ -748,7 +690,7 @@ class DemoLocalizations {
   final Locale locale;
 
   static DemoLocalizations of(BuildContext context) {
-    return Localizations.of<DemoLocalizations>(context, DemoLocalizations);
+    return Localizations.of<DemoLocalizations>(context, DemoLocalizations)!;
   }
 
   static Map<String, Map<String, String>> _localizedValues = {
@@ -761,7 +703,7 @@ class DemoLocalizations {
   };
 
   String get title {
-    return _localizedValues[locale.languageCode]['title'];
+    return _localizedValues[locale.languageCode]!['title']!;
   }
 }
 ```
@@ -770,7 +712,7 @@ In the minimal app the `DemoLocalizationsDelegate` is slightly
 different. Its `load` method returns a [`SynchronousFuture`][]
 because no asynchronous loading needs to take place.
 
-<!-- skip -->
+<?code-excerpt "minimal/lib/main.dart (Delegate)"?>
 ```dart
 class DemoLocalizationsDelegate extends LocalizationsDelegate<DemoLocalizations> {
   const DemoLocalizationsDelegate();
@@ -780,6 +722,8 @@ class DemoLocalizationsDelegate extends LocalizationsDelegate<DemoLocalizations>
 
   @override
   Future<DemoLocalizations> load(Locale locale) {
+    // Returning a SynchronousFuture here because an async "load" operation
+    // isn't needed to produce an instance of DemoLocalizations.
     return SynchronousFuture<DemoLocalizations>(DemoLocalizations(locale));
   }
 

--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -77,12 +77,11 @@ Next, run `pub get packages`, then import the `flutter_localizations` library an
 import 'package:flutter_localizations/flutter_localizations.dart';
 ```
 
-<?code-excerpt "gen_l10n_example/lib/main.dart (LocalizationDelegates)" replace="/App.*//g"?>
+<?code-excerpt "gen_l10n_example/lib/main.dart (MaterialApp)" remove="AppLocalizations.delegate"?>
 ```dart
-return Material
-  title: 'Localizations Sample
+return MaterialApp(
+  title: 'Localizations Sample App',
   localizationsDelegates: [
-
     GlobalMaterialLocalizations.delegate,
     GlobalWidgetsLocalizations.delegate,
     GlobalCupertinoLocalizations.delegate,
@@ -91,6 +90,11 @@ return Material
     const Locale('en', ''), // English, no country code
     const Locale('es', ''), // Spanish, no country code
   ],
+  theme: ThemeData(
+    primarySwatch: Colors.blue,
+  ),
+  home: MyHomePage(),
+);
 ```
 
 After introducing the `flutter_localizations` package
@@ -203,7 +207,7 @@ project called `l10n.yaml` with the following content:
    import 'package:flutter_gen/gen_l10n/app_localizations.dart';
    ```
 
-   <?code-excerpt "gen_l10n_example/lib/main.dart (AppLocalizations)"?>
+   <?code-excerpt "gen_l10n_example/lib/main.dart (MaterialApp)"?>
    ```dart
    return MaterialApp(
      title: 'Localizations Sample App',
@@ -213,6 +217,15 @@ project called `l10n.yaml` with the following content:
        GlobalWidgetsLocalizations.delegate,
        GlobalCupertinoLocalizations.delegate,
      ],
+     supportedLocales: [
+       const Locale('en', ''), // English, no country code
+       const Locale('es', ''), // Spanish, no country code
+     ],
+     theme: ThemeData(
+       primarySwatch: Colors.blue,
+     ),
+     home: MyHomePage(),
+   );
    ```
    
 8. Use AppLocalizations anywhere in your app.

--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -100,14 +100,9 @@ one of the 78 supported locales. Widgets should be
 adapted to the localized messages, along with
 correct left-to-right and right-to-left layout.
 
-{% comment %}
-  The original code examples do not include arabic.
-{% endcomment %}
-
 Try switching the target platform's locale to
-Arabic (`ar`) and notice that the messages should
-be localized and widgets are laid out with
-right-to-left layout in mind.
+Spanish (`es`) and notice that the messages should
+be localized.
 
 Apps based on `WidgetsApp` are similar except that the
 `GlobalMaterialLocalizations.delegate` isn't needed.

--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -4,6 +4,8 @@ short-title: i18n
 description: How to internationalize your Flutter app.
 ---
 
+<?code-excerpt path-base="../null_safety_examples/internationalization"?>
+
 {{site.alert.secondary}}
   <h4 class="no_toc">What you’ll learn</h4>
 
@@ -58,6 +60,7 @@ this package supports 78 languages.
 To use flutter_localizations,
 add the package as a dependency to your `pubspec.yaml` file:
 
+<?code-excerpt "gen_l10n_example/pubspec.yaml (FlutterLocalizations)"?>
 ```yaml
 dependencies:
   flutter:
@@ -69,31 +72,25 @@ dependencies:
 Next, run `pub get packages`, then import the `flutter_localizations` library and specify
 `localizationsDelegates` and `supportedLocales` for `MaterialApp`:
 
-<!-- skip -->
+<?code-excerpt "gen_l10n_example/lib/main.dart (LocalizationDelegatesImport)"?>
 ```dart
 import 'package:flutter_localizations/flutter_localizations.dart';
-// TODO: uncomment the line below after codegen
-// import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+```
 
-// ...
+<?code-excerpt "gen_l10n_example/lib/main.dart (LocalizationDelegates)" replace="/App.*//g"?>
+```dart
+return Material
+  title: 'Localizations Sample
+  localizationsDelegates: [
 
-MaterialApp(
- localizationsDelegates: [
-   // ... app-specific localization delegate[s] here
-   // TODO: uncomment the line below after codegen
-   // AppLocalizations.delegate,
-   GlobalMaterialLocalizations.delegate,
-   GlobalWidgetsLocalizations.delegate,
-   GlobalCupertinoLocalizations.delegate,
- ],
- supportedLocales: [
-    const Locale('en', ''), // English, no country code
-    const Locale('ar', ''), // Arabic, no country code
-    const Locale.fromSubtags(languageCode: 'zh'), // Chinese *See Advanced Locales below*
-    // ... other locales the app supports
+    GlobalMaterialLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
   ],
-  // ...
-)
+  supportedLocales: [
+    const Locale('en', ''), // English, no country code
+    const Locale('es', ''), // Spanish, no country code
+  ],
 ```
 
 After introducing the `flutter_localizations` package
@@ -102,6 +99,11 @@ packages should now be correctly localized in
 one of the 78 supported locales. Widgets should be
 adapted to the localized messages, along with
 correct left-to-right and right-to-left layout.
+
+{% comment %}
+  The original code examples do not include arabic.
+{% endcomment %}
+
 Try switching the target platform's locale to
 Arabic (`ar`) and notice that the messages should
 be localized and widgets are laid out with
@@ -135,13 +137,14 @@ following instructions to add localized text to your application.
 
 1. Add the `intl` package to the `pubspec.yaml` file:
 
+   <?code-excerpt "gen_l10n_example/pubspec.yaml (Intl)" replace="/(?<!0) # Add this line//g" ?>
    ```yaml
    dependencies:
      flutter:
        sdk: flutter
      flutter_localizations:
        sdk: flutter
-     intl: ^0.16.1    # Add this line
+     intl: ^0.17.0 # Add this line
    ```
 
 2. Also, in the `pubspec.yaml` file, enable the `generate`
@@ -149,15 +152,17 @@ flag. This is added to the section of the pubspec that is
 specific to Flutter, and usually comes later in the pubspec
 file.
 
+   <?code-excerpt "gen_l10n_example/pubspec.yaml (Generate)"?>
    ```yaml
    # The following section is specific to Flutter.
    flutter:
-     generate: true    # Add this line
+     generate: true # Add this line
    ```
 
 3. Add a new yaml file to the root directory of the Flutter
 project called `l10n.yaml` with the following content:
 
+   <?code-excerpt "gen_l10n_example/l10n.yaml"?>
    ```yaml
    arb-dir: lib/l10n
    template-arb-file: app_en.arb
@@ -172,31 +177,77 @@ project called `l10n.yaml` with the following content:
 4. In `${FLUTTER_PROJECT}/lib/l10n`,
    add the `app_en.arb` template file. For example:
 
+   <?code-excerpt "gen_l10n_example/lib/l10n/app_en.arb"?>
    ```json
    {
-     "helloWorld": "Hello World!",
-     "@helloWorld": {
-       "description": "The conventional newborn programmer greeting"
-     }
+       "helloWorld": "Hello World!",
+       "@helloWorld": {
+         "description": "The conventional newborn programmer greeting"
+       }
    }
    ```
 
 5. Next, add an `app_es.arb` file in the same directory for
    Spanish translation of the same message:
 
+   <?code-excerpt "gen_l10n_example/lib/l10n/app_es.arb"?>
    ```json
    {
-     "helloWorld": "Hola Mundo!"
+       "helloWorld": "Hola Mundo!"
    }
    ```
 
 6. Now, run your app so that codegen takes place. You should see generated files in
    `${FLUTTER_PROJECT}/.dart_tool/flutter_gen/gen_l10n`.
 
-7. Remove the comment for the import statement on `app_localizations.dart` 
-   and `AppLocations.delegate` in your call to the constructor for 
-   `MaterialApp`. Test the generated localizations in your app as follows:
+7. Add the import statement on `app_localizations.dart` and `AppLocations.delegate` 
+   in your call to the constructor for `MaterialApp`.
 
+   <?code-excerpt "gen_l10n_example/lib/main.dart (AppLocalizationsImport)"?>
+   ```dart
+   import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+   ```
+
+   <?code-excerpt "gen_l10n_example/lib/main.dart (AppLocalizations)"?>
+   ```dart
+   return MaterialApp(
+     title: 'Localizations Sample App',
+     localizationsDelegates: [
+       AppLocalizations.delegate, // Add this line
+       GlobalMaterialLocalizations.delegate,
+       GlobalWidgetsLocalizations.delegate,
+       GlobalCupertinoLocalizations.delegate,
+     ],
+   ```
+
+   Test the generated localizations in your app as follows:
+
+   <!-- skip -->
+   ```dart
+   // In your Material/Widget/CupertinoApp:
+   @override
+   Widget build(BuildContext context) {
+     return MaterialApp(
+       localizationsDelegates: AppLocalizations.localizationsDelegates, // Add this line
+       supportedLocales: AppLocalizations.supportedLocales, // Add this line
+       home: // ...
+     );
+   }
+   ```
+
+   <?code-excerpt "gen_l10n_example/lib/main.dart (Example)"?>
+   ```dart
+   return Scaffold(
+     appBar: AppBar(
+       // The [AppBar] title text should update its message
+       // according to the system locale of the target platform.
+       // Switching between English and Spanish locales should
+       // cause this text to update.
+       title: Text(AppLocalizations.of(context)!.helloWorld),
+     ),
+   );
+   ```
+   
    <!-- skip -->
    ```dart
    import 'package:flutter_localizations/flutter_localizations.dart';


### PR DESCRIPTION
This was a tough one :) 

In this PR I have migrated the internationalization.md to null safety, as the projects that this document uses were already migrated the work has been mostly using code-excerpts to extract the right lines of code.

In some cases I had to add extra code to show different examples. One section had to be reworded a bit to show the example.
Mostly all the code is extracted in some way.

There is one part in which the doc asks the reader to switch the device to Arabic to see the locale at work, but there was no demo built showing that.

After chatting with @RedBrogdon about this, we decided to remove the mention to Arabic and instead mention that you can switch the device language to Spanish to check that the app text changes, as Spanish is already provided in the sample code.

@sfshaza2

Live version: https://mb-flutter-dev-1.firebaseapp.com/docs/development/accessibility-and-localization/internationalization