### PR TITLE
Resolved conflicted documentation of android activity lifecycle events

### DIFF
--- a/src/docs/get-started/flutter-for/android-devs.md
+++ b/src/docs/get-started/flutter-for/android-devs.md
@@ -1346,18 +1346,14 @@ listening to the `didChangeAppLifecycleState()` change event.
 
 The observable lifecycle events are:
 
+* `detached` — The application is still hosted on a flutter engine but is detached from any host views.
 * `inactive` — The application is in an inactive state and is not receiving user
-  input. This event only works on iOS, as there is no equivalent event to map to
-  on Android.
+  input.
 * `paused` — The application is not currently visible to the user,
   not responding to user input, and running in the background.
   This is equivalent to `onPause()` in Android.
 * `resumed` — The application is visible and responding to user input.
   This is equivalent to `onPostResume()` in Android.
-* `suspending` — The application is suspended momentarily.
-  This is equivalent to `onStop` in Android;
-  it is not triggered on iOS as there is no equivalent
-  event to map to on iOS.
 
 For more details on the meaning of these states, see the
 [`AppLifecycleStatus` documentation][].


### PR DESCRIPTION
This PR updated the out dated documentation of [_Android activity lifecycle events_](https://flutter.dev/docs/get-started/flutter-for/android-devs#how-do-i-listen-to-android-activity-lifecycle-events) according to [_AppLifecycleState_](https://api.flutter.dev/flutter/dart-ui/AppLifecycleState-class.html)

Before change: 

<img width="572" alt="before" src="https://user-images.githubusercontent.com/35557794/112475955-63ddf200-8d97-11eb-8dc9-7a582224a404.png">

After change:

<img width="450" alt="after" src="https://user-images.githubusercontent.com/35557794/112475982-6d675a00-8d97-11eb-9eb0-cbfb38fdd431.png">



This PR resolves #5493 issue