### PR TITLE
Removed web note from android-studio.md and vs-code.md

### DIFF
--- a/src/docs/development/tools/android-studio.md
+++ b/src/docs/development/tools/android-studio.md
@@ -130,13 +130,6 @@ Flutter-specific buttons on the right-hand side of the toolbar.
     When you connect devices, or start simulators,
     additional entries appear.
 
-{{site.alert.note}}
-  If you want to try running your app on the web,
-  but the **Chrome (web)** target doesn't appear in the
-  list of targets, make sure you've enabled web, as
-  described in [Building a web application][].
-{{site.alert.end}}
-
 ### Run app without breakpoints
 
  1. Click the **Play icon** in the toolbar, or invoke **Run > Run**.
@@ -399,7 +392,6 @@ Prior to filing new issues:
 
 When filing new issues, include the output of [`flutter doctor`][].
 
-[Building a web application]: /docs/get-started/web
 [DevTools]: /docs/development/tools/devtools
 [GitHub issue tracker]: {{site.repo.flutter}}-intellij/issues
 [JetBrains YouTrack]: https://youtrack.jetbrains.com/issues?q=%23dart%20%23Unresolved

--- a/src/docs/development/tools/vs-code.md
+++ b/src/docs/development/tools/vs-code.md
@@ -119,13 +119,6 @@ However, if you have multiple devices/simulators connected, click
 at the top of the screen. Select the device you want to use for
 running or debugging.
 
-{{site.alert.note}}
-  If you want to try running your app on the web,
-  but the **Chrome (web)** target doesn't appear in the
-  list of targets, make sure you've enabled web, as
-  described in [Building a web application][].
-{{site.alert.end}}
-
 ### Run app without breakpoints
 
  1. Click **Run > Start Without Debugging** in the
@@ -308,7 +301,6 @@ Prior to filing new issues:
 
 When filing new issues, include [flutter doctor][] output.
 
-[Building a web application]: /docs/get-started/web
 [Command Palette]: https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette
 [DevTools]: /docs/development/tools/devtools
 [flutter doctor]: /docs/resources/bug-reports/#provide-some-flutter-diagnostics


### PR DESCRIPTION
This PR removes the **"Web Note"** from **"Selecting a Target"** section in [Android Studio](https://flutter.dev/docs/development/tools/android-studio#selecting-a-target) and [VS-Code](https://flutter.dev/docs/development/tools/vs-code#selecting-a-target-device) tools.

Before change there was a note saying **"You need to enable web if Chrome(web) target doesn't exist"**  but now with flutter 2.0 you no longer have to enable web as it is already enabled.

This PR resolves [#5543 issue comment.](https://github.com/flutter/website/issues/5534#issuecomment-807901959)
