### PR TITLE
Correct integration_test pub dependency

### DIFF
--- a/src/docs/testing/integration-tests/index.md
+++ b/src/docs/testing/integration-tests/index.md
@@ -53,7 +53,8 @@ Add `integration_test`, `flutter_test`, and optionally `flutter_driver` to your
 pubspec.yaml file:
 
 ```yaml
-integration_test: ^1.0.0
+integration_test:
+  sdk: flutter
 flutter_test:
   sdk: flutter
 flutter_driver:


### PR DESCRIPTION
integration_test is now shipped as part of the SDK