### PR TITLE
Add note that insecure http ban has been reverted

### DIFF
--- a/src/docs/release/breaking-changes/network-policy-ios-android.md
+++ b/src/docs/release/breaking-changes/network-policy-ios-android.md
@@ -15,6 +15,13 @@ Insecure HTTP is not allowed by platform: <host>
 
 Use HTTPS instead.
 
+{{site.alert.important}}
+  This change over-restricted HTTP access on local networks beyond the
+  restrictions imposed by mobile platforms ([flutter/flutter#72723](https://github.com/flutter/flutter/issues/72723)).
+
+  This change has since been reverted.
+{{site.alert.end}}
+
 ## Context
 
 Starting with Android [API 28][] and [iOS 9][],
@@ -99,7 +106,8 @@ We **do not** recommend you do this for your release builds.
 ## Timeline
 
 Landed in version: 1.23<br>
-In stable release: 2.0.0
+In stable release: 2.0.0<br>
+Reverted in version: 2.2.0?
 
 ## References
 


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/72723

This is maybe a case study for a new use case. How should we keep track of breaking change reverts and the version it got reverted in.