### PR TITLE
Add docs about selecting web renderer at runtime

### DIFF
--- a/src/docs/development/tools/web-renderers.md
+++ b/src/docs/development/tools/web-renderers.md
@@ -37,6 +37,17 @@ flutter build web --web-renderer canvaskit
 This flag is ignored when a non-browser (mobile or desktop) device
 target is selected.
 
+## Runtime configuration
+
+Web renderer can be selected at runtime before the app is loaded:
+
+* Build the app with the `auto` (default) option.
+* Set `window.flutterWebRenderer` to `"canvaskit"` or `"html"` before the app
+  is loaded (e.g. before `main.dart.js` script).
+
+Web renderer in Flutter is initialized at engine startup and can not be changed
+at runtime after that.
+
 ## Choosing which option to use
 
 Choose the `auto` option (default) if you are optimizing for download size on

--- a/src/docs/development/tools/web-renderers.md
+++ b/src/docs/development/tools/web-renderers.md
@@ -58,8 +58,8 @@ To override the web renderer at runtime:
   <script src="main.dart.js" type="application/javascript"></script>
 ```
 
-Web renderer in Flutter is initialized at engine startup and can not be changed
-at runtime after that.
+The web renderer can't be changed after the Flutter engine startup process
+begins in `main.dart.js`.
 
 ## Choosing which option to use
 

--- a/src/docs/development/tools/web-renderers.md
+++ b/src/docs/development/tools/web-renderers.md
@@ -39,7 +39,7 @@ target is selected.
 
 ## Runtime configuration
 
-Web renderer can be selected at runtime before the app is loaded:
+To override the web renderer at runtime:
 
 * Build the app with the `auto` (default) option.
 * Set `window.flutterWebRenderer` to `"canvaskit"` or `"html"` before the app

--- a/src/docs/development/tools/web-renderers.md
+++ b/src/docs/development/tools/web-renderers.md
@@ -41,9 +41,22 @@ target is selected.
 
 To override the web renderer at runtime:
 
-* Build the app with the `auto` (default) option.
-* Set `window.flutterWebRenderer` to `"canvaskit"` or `"html"` before the app
-  is loaded (e.g. before `main.dart.js` script).
+* Build the app with the `auto` option.
+* Insert a `<script>` tag  in `web/index.html` file before the `main.dart.js`
+  script.
+* Set `window.flutterWebRenderer` to `"canvaskit"` or `"html"`:
+
+```html
+  <script type="text/javascript">
+    let useHtml = // ...
+    if(useHtml) {
+      window.flutterWebRenderer = "html";
+    } else {
+      window.flutterWebRenderer = "canvaskit";
+    }
+  </script>
+  <script src="main.dart.js" type="application/javascript"></script>
+```
 
 Web renderer in Flutter is initialized at engine startup and can not be changed
 at runtime after that.


### PR DESCRIPTION
A the moment there is an ability to choose web renderer in Flutter at runtime using `window.flutterWebRenderer` global variable. We already using this setting for our project and it seems that some other people do so:

* [Choose your Flutter web renderer](https://www.reddit.com/r/FlutterDev/comments/kq4vsi/choose_your_flutter_web_renderer/)
* [How to use Skia / CanvasKit in Flutter Web?](https://stackoverflow.com/questions/64583461/how-to-use-skia-canvaskit-in-flutter-web/64583462)

I based this PR on @yjbanov [answer](https://github.com/flutter/flutter/issues/76652#issuecomment-786086430). Can we have this option documented or this is just an experimental setting not intended for production usage?
