### PR TITLE
Migrated widgets-intro.md to null safety

### DIFF
--- a/null_safety_examples/ui/widgets_intro/lib/main.dart
+++ b/null_safety_examples/ui/widgets_intro/lib/main.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(
+    Center(
+      child: Text(
+        'Hello, world!',
+        textDirection: TextDirection.ltr,
+      ),
+    ),
+  );
+}

--- a/null_safety_examples/ui/widgets_intro/lib/main_counter.dart
+++ b/null_safety_examples/ui/widgets_intro/lib/main_counter.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+class Counter extends StatefulWidget {
+  // This class is the configuration for the state. 
+  // It holds the values (in this case nothing) provided 
+  // by the parent and used by the build  method of the
+  // State. Fields in a Widget subclass are always marked
+  // "final".
+
+  @override
+  _CounterState createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> {
+  int _counter = 0;
+
+  void _increment() {
+    setState(() {
+      // This call to setState tells the Flutter framework
+      // that something has changed in this State, which
+      // causes it to rerun the build method below so that
+      // the display can reflect the updated values. If you
+      // change _counter without calling setState(), then
+      // the build method won't be called again, and so
+      // nothing would appear to happen.
+      _counter++;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // This method is rerun every time setState is called,
+    // for instance, as done by the _increment method above.
+    // The Flutter framework has been optimized to make
+    // rerunning build methods fast, so that you can just
+    // rebuild anything that needs updating rather than
+    // having to individually changes instances of widgets.
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        ElevatedButton(
+          onPressed: _increment,
+          child: Text('Increment'),
+        ),
+        SizedBox(width: 16),
+        Text('Count: $_counter'),
+      ],
+    );
+  }
+}
+
+void main() {
+  runApp(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: Counter(),
+        ),
+      ),
+    ),
+  );
+}

--- a/null_safety_examples/ui/widgets_intro/lib/main_counterdisplay.dart
+++ b/null_safety_examples/ui/widgets_intro/lib/main_counterdisplay.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+class CounterDisplay extends StatelessWidget {
+  CounterDisplay({required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text('Count: $count');
+  }
+}
+
+class CounterIncrementor extends StatelessWidget {
+  CounterIncrementor({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      child: Text('Increment'),
+    );
+  }
+}
+
+class Counter extends StatefulWidget {
+  @override
+  _CounterState createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> {
+  int _counter = 0;
+
+  void _increment() {
+    setState(() {
+      ++_counter;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        CounterIncrementor(onPressed: _increment),
+        SizedBox(width: 16),
+        CounterDisplay(count: _counter),
+      ],
+    );
+  }
+}
+
+void main() {
+  runApp(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: Counter(),
+        ),
+      ),
+    ),
+  );
+}

--- a/null_safety_examples/ui/widgets_intro/lib/main_myappbar.dart
+++ b/null_safety_examples/ui/widgets_intro/lib/main_myappbar.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+class MyAppBar extends StatelessWidget {
+  MyAppBar({required this.title});
+
+  // Fields in a Widget subclass are always marked "final".
+
+  final Widget title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 56.0, // in logical pixels
+      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+      decoration: BoxDecoration(color: Colors.blue[500]),
+      // Row is a horizontal, linear layout.
+      child: Row(
+        // <Widget> is the type of items in the list.
+        children: <Widget>[
+          IconButton(
+            icon: Icon(Icons.menu),
+            tooltip: 'Navigation menu',
+            onPressed: null, // null disables the button
+          ),
+          // Expanded expands its child
+          // to fill the available space.
+          Expanded(
+            child: title,
+          ),
+          IconButton(
+            icon: Icon(Icons.search),
+            tooltip: 'Search',
+            onPressed: null,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class MyScaffold extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // Material is a conceptual piece
+    // of paper on which the UI appears.
+    return Material(
+      // Column is a vertical, linear layout.
+      child: Column(
+        children: <Widget>[
+          MyAppBar(
+            title: Text(
+              'Example title',
+              style: Theme.of(context) //
+                  .primaryTextTheme
+                  .headline6,
+            ),
+          ),
+          Expanded(
+            child: Center(
+              child: Text('Hello, world!'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+void main() {
+  runApp(MaterialApp(
+    title: 'My app', // used by the OS task switcher
+    home: SafeArea(
+      child: MyScaffold(),
+    ),
+  ));
+}

--- a/null_safety_examples/ui/widgets_intro/lib/main_mybutton.dart
+++ b/null_safety_examples/ui/widgets_intro/lib/main_mybutton.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+class MyButton extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        print('MyButton was tapped!');
+      },
+      child: Container(
+        height: 50.0,
+        padding: const EdgeInsets.all(8.0),
+        margin: const EdgeInsets.symmetric(horizontal: 8.0),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(5.0),
+          color: Colors.lightGreen[500],
+        ),
+        child: Center(
+          child: Text('Engage'),
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  runApp(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: MyButton(),
+        ),
+      ),
+    ),
+  );
+}

--- a/null_safety_examples/ui/widgets_intro/lib/main_shoppingitem.dart
+++ b/null_safety_examples/ui/widgets_intro/lib/main_shoppingitem.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+class Product {
+  const Product({required this.name});
+  final String name;
+}
+
+typedef void CartChangedCallback(Product product, bool inCart);
+
+class ShoppingListItem extends StatelessWidget {
+  ShoppingListItem({
+    required this.product,
+    required this.inCart,
+    required this.onCartChanged,
+  }) : super(key: ObjectKey(product));
+
+  final Product product;
+  final bool inCart;
+  final CartChangedCallback onCartChanged;
+
+  Color _getColor(BuildContext context) {
+    // The theme depends on the BuildContext because different
+    // parts of the tree can have different themes.
+    // The BuildContext indicates where the build is
+    // taking place and therefore which theme to use.
+
+    return inCart //
+        ? Colors.black54
+        : Theme.of(context).primaryColor;
+  }
+
+  TextStyle? _getTextStyle(BuildContext context) {
+    if (!inCart) return null;
+
+    return TextStyle(
+      color: Colors.black54,
+      decoration: TextDecoration.lineThrough,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      onTap: () {
+        onCartChanged(product, inCart);
+      },
+      leading: CircleAvatar(
+        backgroundColor: _getColor(context),
+        child: Text(product.name[0]),
+      ),
+      title: Text(product.name, style: _getTextStyle(context)),
+    );
+  }
+}
+
+void main() {
+  runApp(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: ShoppingListItem(
+            product: Product(name: 'Chips'),
+            inCart: true,
+            onCartChanged: (product, inCart) {},
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/null_safety_examples/ui/widgets_intro/lib/main_shoppinglist.dart
+++ b/null_safety_examples/ui/widgets_intro/lib/main_shoppinglist.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+class Product {
+  const Product({required this.name});
+  final String name;
+}
+
+typedef void CartChangedCallback(Product product, bool inCart);
+
+class ShoppingListItem extends StatelessWidget {
+  ShoppingListItem({
+    required this.product,
+    required this.inCart,
+    required this.onCartChanged,
+  }) : super(key: ObjectKey(product));
+
+  final Product product;
+  final bool inCart;
+  final CartChangedCallback onCartChanged;
+
+  Color _getColor(BuildContext context) {
+    // The theme depends on the BuildContext because different
+    // parts of the tree can have different themes.
+    // The BuildContext indicates where the build is
+    // taking place and therefore which theme to use.
+
+    return inCart //
+        ? Colors.black54
+        : Theme.of(context).primaryColor;
+  }
+
+  TextStyle? _getTextStyle(BuildContext context) {
+    if (!inCart) return null;
+
+    return TextStyle(
+      color: Colors.black54,
+      decoration: TextDecoration.lineThrough,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      onTap: () {
+        onCartChanged(product, inCart);
+      },
+      leading: CircleAvatar(
+        backgroundColor: _getColor(context),
+        child: Text(product.name[0]),
+      ),
+      title: Text(product.name, style: _getTextStyle(context)),
+    );
+  }
+}
+
+class ShoppingList extends StatefulWidget {
+  ShoppingList({Key? key, required this.products}) : super(key: key);
+
+  final List<Product> products;
+
+  // The framework calls createState the first time
+  // a widget appears at a given location in the tree.
+  // If the parent rebuilds and uses the same type of
+  // widget (with the same key), the framework re-uses
+  // the State object instead of creating a new State object.
+
+  @override
+  _ShoppingListState createState() => _ShoppingListState();
+}
+
+class _ShoppingListState extends State<ShoppingList> {
+  Set<Product> _shoppingCart = Set<Product>();
+
+  void _handleCartChanged(Product product, bool inCart) {
+    setState(() {
+      // When a user changes what's in the cart, you need
+      // to change _shoppingCart inside a setState call to
+      // trigger a rebuild.
+      // The framework then calls build, below,
+      // which updates the visual appearance of the app.
+
+      if (!inCart)
+        _shoppingCart.add(product);
+      else
+        _shoppingCart.remove(product);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Shopping List'),
+      ),
+      body: ListView(
+        padding: EdgeInsets.symmetric(vertical: 8.0),
+        children: widget.products.map((Product product) {
+          return ShoppingListItem(
+            product: product,
+            inCart: _shoppingCart.contains(product),
+            onCartChanged: _handleCartChanged,
+          );
+        }).toList(),
+      ),
+    );
+  }
+}
+
+void main() {
+  runApp(MaterialApp(
+    title: 'Shopping App',
+    home: ShoppingList(
+      products: <Product>[
+        Product(name: 'Eggs'),
+        Product(name: 'Flour'),
+        Product(name: 'Chocolate chips'),
+      ],
+    ),
+  ));
+}

--- a/null_safety_examples/ui/widgets_intro/lib/main_tutorial.dart
+++ b/null_safety_examples/ui/widgets_intro/lib/main_tutorial.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(MaterialApp(
+    title: 'Flutter Tutorial',
+    home: TutorialHome(),
+  ));
+}
+
+class TutorialHome extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // Scaffold is a layout for 
+    // the major Material Components.
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: Icon(Icons.menu),
+          tooltip: 'Navigation menu',
+          onPressed: null,
+        ),
+        title: Text('Example title'),
+        actions: <Widget>[
+          IconButton(
+            icon: Icon(Icons.search),
+            tooltip: 'Search',
+            onPressed: null,
+          ),
+        ],
+      ),
+      // body is the majority of the screen.
+      body: Center(
+        child: Text('Hello, world!'),
+      ),
+      floatingActionButton: FloatingActionButton(
+        tooltip: 'Add', // used by assistive technologies
+        child: Icon(Icons.add),
+        onPressed: null,
+      ),
+    );
+  }
+}

--- a/null_safety_examples/ui/widgets_intro/pubspec.yaml
+++ b/null_safety_examples/ui/widgets_intro/pubspec.yaml
@@ -1,0 +1,16 @@
+name: widgets_intro
+description: Sample state management code.
+
+version: 1.0.0+1
+
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  cupertino_icons: ^1.0.2
+
+flutter:
+  uses-material-design: true

--- a/src/docs/development/ui/widgets-intro.md
+++ b/src/docs/development/ui/widgets-intro.md
@@ -556,32 +556,40 @@ products offered for sale, and maintains a shopping cart for
 intended purchases. Start by defining the presentation class,
 `ShoppingListItem`:
 
+<?code-excerpt "lib/main_shoppingitem.dart"?>
 ```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
+import 'package:flutter/material.dart';
+
 class Product {
-  const Product({this.name});
+  const Product({required this.name});
   final String name;
 }
 
 typedef void CartChangedCallback(Product product, bool inCart);
 
 class ShoppingListItem extends StatelessWidget {
-  ShoppingListItem({this.product, this.inCart, this.onCartChanged})
-      : super(key: ObjectKey(product));
+  ShoppingListItem({
+    required this.product,
+    required this.inCart,
+    required this.onCartChanged,
+  }) : super(key: ObjectKey(product));
 
   final Product product;
   final bool inCart;
   final CartChangedCallback onCartChanged;
 
   Color _getColor(BuildContext context) {
-    // The theme depends on the BuildContext because different parts
-    // of the tree can have different themes.
+    // The theme depends on the BuildContext because different
+    // parts of the tree can have different themes.
     // The BuildContext indicates where the build is
     // taking place and therefore which theme to use.
 
-    return inCart ? Colors.black54 : Theme.of(context).primaryColor;
+    return inCart //
+        ? Colors.black54
+        : Theme.of(context).primaryColor;
   }
 
-  TextStyle _getTextStyle(BuildContext context) {
+  TextStyle? _getTextStyle(BuildContext context) {
     if (!inCart) return null;
 
     return TextStyle(
@@ -603,6 +611,22 @@ class ShoppingListItem extends StatelessWidget {
       title: Text(product.name, style: _getTextStyle(context)),
     );
   }
+}
+
+void main() {
+  runApp(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: ShoppingListItem(
+            product: Product(name: 'Chips'),
+            inCart: true,
+            onCartChanged: (product, inCart) {},
+          ),
+        ),
+      ),
+    ),
+  );
 }
 ```
 
@@ -635,17 +659,73 @@ built widgets and applies only the differences to the underlying
 
 Here's an example parent widget that stores mutable state:
 
+<?code-excerpt "lib/main_shoppinglist.dart"?>
 ```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
+import 'package:flutter/material.dart';
+
+class Product {
+  const Product({required this.name});
+  final String name;
+}
+
+typedef void CartChangedCallback(Product product, bool inCart);
+
+class ShoppingListItem extends StatelessWidget {
+  ShoppingListItem({
+    required this.product,
+    required this.inCart,
+    required this.onCartChanged,
+  }) : super(key: ObjectKey(product));
+
+  final Product product;
+  final bool inCart;
+  final CartChangedCallback onCartChanged;
+
+  Color _getColor(BuildContext context) {
+    // The theme depends on the BuildContext because different
+    // parts of the tree can have different themes.
+    // The BuildContext indicates where the build is
+    // taking place and therefore which theme to use.
+
+    return inCart //
+        ? Colors.black54
+        : Theme.of(context).primaryColor;
+  }
+
+  TextStyle? _getTextStyle(BuildContext context) {
+    if (!inCart) return null;
+
+    return TextStyle(
+      color: Colors.black54,
+      decoration: TextDecoration.lineThrough,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      onTap: () {
+        onCartChanged(product, inCart);
+      },
+      leading: CircleAvatar(
+        backgroundColor: _getColor(context),
+        child: Text(product.name[0]),
+      ),
+      title: Text(product.name, style: _getTextStyle(context)),
+    );
+  }
+}
+
 class ShoppingList extends StatefulWidget {
-  ShoppingList({Key key, this.products}) : super(key: key);
+  ShoppingList({Key? key, required this.products}) : super(key: key);
 
   final List<Product> products;
 
-  // The framework calls createState the first time a widget
-  // appears at a given location in the tree.
+  // The framework calls createState the first time
+  // a widget appears at a given location in the tree.
   // If the parent rebuilds and uses the same type of
-  // widget (with the same key), the framework re-uses the State object
-  // instead of creating a new State object.
+  // widget (with the same key), the framework re-uses
+  // the State object instead of creating a new State object.
 
   @override
   _ShoppingListState createState() => _ShoppingListState();
@@ -656,8 +736,9 @@ class _ShoppingListState extends State<ShoppingList> {
 
   void _handleCartChanged(Product product, bool inCart) {
     setState(() {
-      // When a user changes what's in the cart, you need to change
-      // _shoppingCart inside a setState call to trigger a rebuild.
+      // When a user changes what's in the cart, you need
+      // to change _shoppingCart inside a setState call to
+      // trigger a rebuild.
       // The framework then calls build, below,
       // which updates the visual appearance of the app.
 

--- a/src/docs/development/ui/widgets-intro.md
+++ b/src/docs/development/ui/widgets-intro.md
@@ -1,7 +1,12 @@
 ---
 title: Introduction to widgets
 description: Learn about Flutter's widgets.
+js:
+  - defer: true
+    url: https://dartpad.dev/inject_embed.dart.js
 ---
+
+<?code-excerpt path-base="../null_safety_examples/ui/widgets_intro/"?>
 
 {% assign api = site.api | append: '/flutter' -%}
 
@@ -26,7 +31,8 @@ tree to transition from one state to the next.
 The minimal Flutter app simply calls the [`runApp()`][]
 function with a widget:
 
-```dart
+<?code-excerpt "lib/main.dart"?>
+```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-310px:split-60:ga_id-starting_code:null_safety-true
 import 'package:flutter/material.dart';
 
 void main() {
@@ -94,11 +100,12 @@ of which the following are commonly used:
 
 Below are some simple widgets that combine these and other widgets:
 
-```dart
+<?code-excerpt "lib/main_myappbar.dart"?>
+```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
 import 'package:flutter/material.dart';
 
 class MyAppBar extends StatelessWidget {
-  MyAppBar({this.title});
+  MyAppBar({required this.title});
 
   // Fields in a Widget subclass are always marked "final".
 
@@ -119,7 +126,8 @@ class MyAppBar extends StatelessWidget {
             tooltip: 'Navigation menu',
             onPressed: null, // null disables the button
           ),
-          // Expanded expands its child to fill the available space.
+          // Expanded expands its child
+          // to fill the available space.
           Expanded(
             child: title,
           ),
@@ -137,7 +145,8 @@ class MyAppBar extends StatelessWidget {
 class MyScaffold extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    // Material is a conceptual piece of paper on which the UI appears.
+    // Material is a conceptual piece
+    // of paper on which the UI appears.
     return Material(
       // Column is a vertical, linear layout.
       child: Column(
@@ -145,7 +154,9 @@ class MyScaffold extends StatelessWidget {
           MyAppBar(
             title: Text(
               'Example title',
-              style: Theme.of(context).primaryTextTheme.headline6,
+              style: Theme.of(context) //
+                  .primaryTextTheme
+                  .headline6,
             ),
           ),
           Expanded(
@@ -217,7 +228,8 @@ also known as "routes". The `Navigator` lets you transition smoothly
 between screens of your application. Using the [`MaterialApp`][]
 widget is entirely optional but a good practice.
 
-```dart
+<?code-excerpt "lib/main_tutorial.dart"?>
+```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
 import 'package:flutter/material.dart';
 
 void main() {
@@ -230,7 +242,8 @@ void main() {
 class TutorialHome extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    // Scaffold is a layout for the major Material Components.
+    // Scaffold is a layout for
+    // the major Material Components.
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(
@@ -293,7 +306,10 @@ Most applications include some form of user interaction with the system.
 The first step in building an interactive application is to detect
 input gestures. See how that works by creating a simple button:
 
-```dart
+<?code-excerpt "lib/main_mybutton.dart"?>
+```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
+import 'package:flutter/material.dart';
+
 class MyButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -302,7 +318,7 @@ class MyButton extends StatelessWidget {
         print('MyButton was tapped!');
       },
       child: Container(
-        height: 36.0,
+        height: 50.0,
         padding: const EdgeInsets.all(8.0),
         margin: const EdgeInsets.symmetric(horizontal: 8.0),
         decoration: BoxDecoration(
@@ -315,6 +331,18 @@ class MyButton extends StatelessWidget {
       ),
     );
   }
+}
+
+void main() {
+  runApp(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: MyButton(),
+        ),
+      ),
+    ),
+  );
 }
 ```
 
@@ -349,12 +377,16 @@ this idea. `StatefulWidgets` are special widgets that know how to generate
 `State` objects, which are then used to hold state.
 Consider this basic example, using the [`ElevatedButton`][] mentioned earlier:
 
-```dart
+<?code-excerpt "lib/main_counter.dart"?>
+```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
+import 'package:flutter/material.dart';
+
 class Counter extends StatefulWidget {
-  // This class is the configuration for the state. It holds the
-  // values (in this case nothing) provided by the parent and used
-  // by the build  method of the State. Fields in a Widget
-  // subclass are always marked "final".
+  // This class is the configuration for the state.
+  // It holds the values (in this case nothing) provided
+  // by the parent and used by the build  method of the
+  // State. Fields in a Widget subclass are always marked
+  // "final".
 
   @override
   _CounterState createState() => _CounterState();
@@ -365,12 +397,13 @@ class _CounterState extends State<Counter> {
 
   void _increment() {
     setState(() {
-      // This call to setState tells the Flutter framework that
-      // something has changed in this State, which causes it to rerun
-      // the build method below so that the display can reflect the
-      // updated values. If you change _counter without calling
-      // setState(), then the build method won't be called again,
-      // and so nothing would appear to happen.
+      // This call to setState tells the Flutter framework
+      // that something has changed in this State, which
+      // causes it to rerun the build method below so that
+      // the display can reflect the updated values. If you
+      // change _counter without calling setState(), then
+      // the build method won't be called again, and so
+      // nothing would appear to happen.
       _counter++;
     });
   }
@@ -379,20 +412,34 @@ class _CounterState extends State<Counter> {
   Widget build(BuildContext context) {
     // This method is rerun every time setState is called,
     // for instance, as done by the _increment method above.
-    // The Flutter framework has been optimized to make rerunning
-    // build methods fast, so that you can just rebuild anything that
-    // needs updating rather than having to individually change
-    // instances of widgets.
+    // The Flutter framework has been optimized to make
+    // rerunning build methods fast, so that you can just
+    // rebuild anything that needs updating rather than
+    // having to individually changes instances of widgets.
     return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
         ElevatedButton(
           onPressed: _increment,
           child: Text('Increment'),
         ),
+        SizedBox(width: 16),
         Text('Count: $_counter'),
       ],
     );
   }
+}
+
+void main() {
+  runApp(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: Counter(),
+        ),
+      ),
+    ),
+  );
 }
 ```
 
@@ -419,9 +466,12 @@ The common parent that redirects this flow is the `State`.
 The following slightly more complex example shows how
 this works in practice:
 
-```dart
+<?code-excerpt "lib/main_counterdisplay.dart"?>
+```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
+import 'package:flutter/material.dart';
+
 class CounterDisplay extends StatelessWidget {
-  CounterDisplay({this.count});
+  CounterDisplay({required this.count});
 
   final int count;
 
@@ -432,7 +482,7 @@ class CounterDisplay extends StatelessWidget {
 }
 
 class CounterIncrementor extends StatelessWidget {
-  CounterIncrementor({this.onPressed});
+  CounterIncrementor({required this.onPressed});
 
   final VoidCallback onPressed;
 
@@ -461,11 +511,27 @@ class _CounterState extends State<Counter> {
 
   @override
   Widget build(BuildContext context) {
-    return Row(children: <Widget>[
-      CounterIncrementor(onPressed: _increment),
-      CounterDisplay(count: _counter),
-    ]);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        CounterIncrementor(onPressed: _increment),
+        SizedBox(width: 16),
+        CounterDisplay(count: _counter),
+      ],
+    );
   }
+}
+
+void main() {
+  runApp(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: Counter(),
+        ),
+      ),
+    ),
+  );
 }
 ```
 
@@ -490,7 +556,7 @@ products offered for sale, and maintains a shopping cart for
 intended purchases. Start by defining the presentation class,
 `ShoppingListItem`:
 
-```dart
+```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
 class Product {
   const Product({this.name});
   final String name;
@@ -569,8 +635,7 @@ built widgets and applies only the differences to the underlying
 
 Here's an example parent widget that stores mutable state:
 
-<!-- skip -->
-```dart
+```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
 class ShoppingList extends StatefulWidget {
   ShoppingList({Key key, this.products}) : super(key: key);
 


### PR DESCRIPTION
In this PR I have migrated the widgets-intro.md to null safety.

All code samples have been moved into a project in the `null_safety_examples` folder.

After a chat with @RedBrogdon we decided that it would be a good idea to use DartPads instead of plain code to show the readers the examples in action.

To do so, I had to adapt the code samples a bit, adding a main method, missing code, etc. as well as adjust the code wrapping so it looks good in the DartPad. I also set the dartpads to be "run false" so they don't run when the page loads automatically, like we did on other pages with lots of dartpads.

cc. @sfshaza2 

Live version: https://mb-flutter-dev-1.web.app/docs/development/ui/widgets-intro