### PR TITLE
Migrated Navigate-with-arguments to null safety

### DIFF
--- a/null_safety_examples/cookbook/navigation/navigate_with_arguments/lib/main.dart
+++ b/null_safety_examples/cookbook/navigation/navigate_with_arguments/lib/main.dart
@@ -5,46 +5,50 @@ void main() => runApp(MyApp());
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    // #docregion Routes
+    // #docregion OnGenerateRoute
     return MaterialApp(
-        // Provide a function to handle named routes.
-        // Use this function to identify the named
-        // route being pushed, and create the correct
-        // Screen.
-        onGenerateRoute: (settings) {
-          // If you push the PassArguments route
-          if (settings.name == PassArgumentsScreen.routeName) {
-            // Cast the arguments to the correct
-            // type: ScreenArguments.
-            final ScreenArguments args = settings.arguments as ScreenArguments;
+      routes: {
+        ExtractArgumentsScreen.routeName: (context) => ExtractArgumentsScreen(),
+      },
+      // #enddocregion Routes
+      // Provide a function to handle named routes.
+      // Use this function to identify the named
+      // route being pushed, and create the correct
+      // Screen.
+      onGenerateRoute: (settings) {
+        // If you push the PassArguments route
+        if (settings.name == PassArgumentsScreen.routeName) {
+          // Cast the arguments to the correct
+          // type: ScreenArguments.
+          final ScreenArguments args = settings.arguments as ScreenArguments;
 
-            // Then, extract the required data from
-            // the arguments and pass the data to the
-            // correct screen.
-            return MaterialPageRoute(
-              builder: (context) {
-                return PassArgumentsScreen(
-                  title: args.title,
-                  message: args.message,
-                );
-              },
-            );
-          }
-          // The code only supports
-          // PassArgumentsScreen.routeName right now.
-          // Other values need to be implemented if we
-          // add them. The assertion here will help remind
-          // us of that higher up in the call stack, since
-          // this assertion would otherwise fire somewhere
-          // in the framework.
-          assert(false, 'Need to implement ${settings.name}');
-          return null;
-        },
-        title: 'Navigation with Arguments',
-        home: HomeScreen(),
-        routes: {
-          ExtractArgumentsScreen.routeName: (context) =>
-              ExtractArgumentsScreen(),
-        });
+          // Then, extract the required data from
+          // the arguments and pass the data to the
+          // correct screen.
+          return MaterialPageRoute(
+            builder: (context) {
+              return PassArgumentsScreen(
+                title: args.title,
+                message: args.message,
+              );
+            },
+          );
+        }
+        // The code only supports
+        // PassArgumentsScreen.routeName right now.
+        // Other values need to be implemented if we
+        // add them. The assertion here will help remind
+        // us of that higher up in the call stack, since
+        // this assertion would otherwise fire somewhere
+        // in the framework.
+        assert(false, 'Need to implement ${settings.name}');
+        return null;
+      },
+      // #enddocregion OnGenerateRoute
+      title: 'Navigation with Arguments',
+      home: HomeScreen(),
+    );
   }
 }
 
@@ -59,6 +63,7 @@ class HomeScreen extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
+            // #docregion PushNamed
             // A button that navigates to a named route.
             // The named route extracts the arguments
             // by itself.
@@ -79,6 +84,7 @@ class HomeScreen extends StatelessWidget {
                 );
               },
             ),
+            // #enddocregion PushNamed
             // A button that navigates to a named route.
             // For this route, extract the arguments in
             // the onGenerateRoute function and pass them
@@ -106,6 +112,7 @@ class HomeScreen extends StatelessWidget {
   }
 }
 
+// #docregion ExtractArgumentsScreen
 // A Widget that extracts the necessary arguments from
 // the ModalRoute.
 class ExtractArgumentsScreen extends StatelessWidget {
@@ -128,6 +135,7 @@ class ExtractArgumentsScreen extends StatelessWidget {
     );
   }
 }
+// #enddocregion ExtractArgumentsScreen
 
 // A Widget that accepts the necessary arguments via the
 // constructor.
@@ -162,6 +170,7 @@ class PassArgumentsScreen extends StatelessWidget {
   }
 }
 
+// #docregion ScreenArguments
 // You can pass any object to the arguments parameter.
 // In this example, create a class that contains both
 // a customizable title and message.
@@ -171,3 +180,4 @@ class ScreenArguments {
 
   ScreenArguments(this.title, this.message);
 }
+// #enddocregion ScreenArguments

--- a/null_safety_examples/cookbook/navigation/navigate_with_arguments/lib/main.dart
+++ b/null_safety_examples/cookbook/navigation/navigate_with_arguments/lib/main.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+
+void main() => runApp(MyApp());
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+        // Provide a function to handle named routes.
+        // Use this function to identify the named
+        // route being pushed, and create the correct
+        // Screen.
+        onGenerateRoute: (settings) {
+          // If you push the PassArguments route
+          if (settings.name == PassArgumentsScreen.routeName) {
+            // Cast the arguments to the correct
+            // type: ScreenArguments.
+            final ScreenArguments args = settings.arguments as ScreenArguments;
+
+            // Then, extract the required data from
+            // the arguments and pass the data to the
+            // correct screen.
+            return MaterialPageRoute(
+              builder: (context) {
+                return PassArgumentsScreen(
+                  title: args.title,
+                  message: args.message,
+                );
+              },
+            );
+          }
+          // The code only supports
+          // PassArgumentsScreen.routeName right now.
+          // Other values need to be implemented if we
+          // add them. The assertion here will help remind
+          // us of that higher up in the call stack, since
+          // this assertion would otherwise fire somewhere
+          // in the framework.
+          assert(false, 'Need to implement ${settings.name}');
+          return null;
+        },
+        title: 'Navigation with Arguments',
+        home: HomeScreen(),
+        routes: {
+          ExtractArgumentsScreen.routeName: (context) =>
+              ExtractArgumentsScreen(),
+        });
+  }
+}
+
+class HomeScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Home Screen'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            // A button that navigates to a named route.
+            // The named route extracts the arguments
+            // by itself.
+            ElevatedButton(
+              child: Text("Navigate to screen that extracts arguments"),
+              onPressed: () {
+                // When the user taps the button,
+                // navigate to a named route and
+                // provide the arguments as an optional
+                // parameter.
+                Navigator.pushNamed(
+                  context,
+                  ExtractArgumentsScreen.routeName,
+                  arguments: ScreenArguments(
+                    'Extract Arguments Screen',
+                    'This message is extracted in the build method.',
+                  ),
+                );
+              },
+            ),
+            // A button that navigates to a named route.
+            // For this route, extract the arguments in
+            // the onGenerateRoute function and pass them
+            // to the screen.
+            ElevatedButton(
+              child: Text("Navigate to a named that accepts arguments"),
+              onPressed: () {
+                // When the user taps the button, navigate
+                // to a named route and provide the arguments
+                // as an optional parameter.
+                Navigator.pushNamed(
+                  context,
+                  PassArgumentsScreen.routeName,
+                  arguments: ScreenArguments(
+                    'Accept Arguments Screen',
+                    'This message is extracted in the onGenerateRoute function.',
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// A Widget that extracts the necessary arguments from
+// the ModalRoute.
+class ExtractArgumentsScreen extends StatelessWidget {
+  static const routeName = '/extractArguments';
+
+  @override
+  Widget build(BuildContext context) {
+    // Extract the arguments from the current ModalRoute
+    // settings and cast them as ScreenArguments.
+    final ScreenArguments args =
+        ModalRoute.of(context)!.settings.arguments as ScreenArguments;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(args.title),
+      ),
+      body: Center(
+        child: Text(args.message),
+      ),
+    );
+  }
+}
+
+// A Widget that accepts the necessary arguments via the
+// constructor.
+class PassArgumentsScreen extends StatelessWidget {
+  static const routeName = '/passArguments';
+
+  final String title;
+  final String message;
+
+  // This Widget accepts the arguments as constructor
+  // parameters. It does not extract the arguments from
+  // the ModalRoute.
+  //
+  // The arguments are extracted by the onGenerateRoute
+  // function provided to the MaterialApp widget.
+  const PassArgumentsScreen({
+    Key? key,
+    required this.title,
+    required this.message,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(title),
+      ),
+      body: Center(
+        child: Text(message),
+      ),
+    );
+  }
+}
+
+// You can pass any object to the arguments parameter.
+// In this example, create a class that contains both
+// a customizable title and message.
+class ScreenArguments {
+  final String title;
+  final String message;
+
+  ScreenArguments(this.title, this.message);
+}

--- a/null_safety_examples/cookbook/navigation/navigate_with_arguments/pubspec.yaml
+++ b/null_safety_examples/cookbook/navigation/navigate_with_arguments/pubspec.yaml
@@ -1,0 +1,12 @@
+name: navigate_with_arguments
+description: Use Form widget to perform form validation.
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/src/docs/cookbook/navigation/navigate-with-arguments.md
+++ b/src/docs/cookbook/navigation/navigate-with-arguments.md
@@ -12,6 +12,8 @@ js:
     url: https://dartpad.dev/inject_embed.dart.js
 ---
 
+<?code-excerpt path-base="../null_safety_examples/cookbook/navigation/navigate_with_arguments"?>
+
 The [`Navigator`][] provides the ability to navigate
 to a named route from any part of an app using
 a common identifier.
@@ -169,7 +171,8 @@ MaterialApp(
 
 ## Interactive example
 
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+<?code-excerpt "lib/main.dart"?>
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
 import 'package:flutter/material.dart';
 
 void main() => runApp(MyApp());
@@ -178,17 +181,20 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-        // Provide a function to handle named routes. Use this function to
-        // identify the named route being pushed, and create the correct
+        // Provide a function to handle named routes.
+        // Use this function to identify the named
+        // route being pushed, and create the correct
         // Screen.
         onGenerateRoute: (settings) {
           // If you push the PassArguments route
           if (settings.name == PassArgumentsScreen.routeName) {
-            // Cast the arguments to the correct type: ScreenArguments.
-            final ScreenArguments args = settings.arguments;
+            // Cast the arguments to the correct
+            // type: ScreenArguments.
+            final ScreenArguments args = settings.arguments as ScreenArguments;
 
-            // Then, extract the required data from the arguments and
-            // pass the data to the correct screen.
+            // Then, extract the required data from
+            // the arguments and pass the data to the
+            // correct screen.
             return MaterialPageRoute(
               builder: (context) {
                 return PassArgumentsScreen(
@@ -198,10 +204,13 @@ class MyApp extends StatelessWidget {
               },
             );
           }
-          // The code only supports PassArgumentsScreen.routeName right now.
-          // Other values need to be implemented if we add them. The assertion
-          // here will help remind us of that higher up in the call stack, since
-          // this assertion would otherwise fire somewhere in the framework.
+          // The code only supports
+          // PassArgumentsScreen.routeName right now.
+          // Other values need to be implemented if we
+          // add them. The assertion here will help remind
+          // us of that higher up in the call stack, since
+          // this assertion would otherwise fire somewhere
+          // in the framework.
           assert(false, 'Need to implement ${settings.name}');
           return null;
         },
@@ -225,13 +234,16 @@ class HomeScreen extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            // A button that navigates to a named route that. The named route
-            // extracts the arguments by itself.
+            // A button that navigates to a named route.
+            // The named route extracts the arguments
+            // by itself.
             ElevatedButton(
               child: Text("Navigate to screen that extracts arguments"),
               onPressed: () {
-                // When the user taps the button, navigate to a named route
-                // and provide the arguments as an optional parameter.
+                // When the user taps the button,
+                // navigate to a named route and
+                // provide the arguments as an optional
+                // parameter.
                 Navigator.pushNamed(
                   context,
                   ExtractArgumentsScreen.routeName,
@@ -242,14 +254,16 @@ class HomeScreen extends StatelessWidget {
                 );
               },
             ),
-            // A button that navigates to a named route. For this route, extract
-            // the arguments in the onGenerateRoute function and pass them
+            // A button that navigates to a named route.
+            // For this route, extract the arguments in
+            // the onGenerateRoute function and pass them
             // to the screen.
             ElevatedButton(
               child: Text("Navigate to a named that accepts arguments"),
               onPressed: () {
-                // When the user taps the button, navigate to a named route
-                // and provide the arguments as an optional parameter.
+                // When the user taps the button, navigate
+                // to a named route and provide the arguments
+                // as an optional parameter.
                 Navigator.pushNamed(
                   context,
                   PassArgumentsScreen.routeName,
@@ -267,15 +281,17 @@ class HomeScreen extends StatelessWidget {
   }
 }
 
-// A Widget that extracts the necessary arguments from the ModalRoute.
+// A Widget that extracts the necessary arguments from
+// the ModalRoute.
 class ExtractArgumentsScreen extends StatelessWidget {
   static const routeName = '/extractArguments';
 
   @override
   Widget build(BuildContext context) {
-    // Extract the arguments from the current ModalRoute settings and cast
-    // them as ScreenArguments.
-    final ScreenArguments args = ModalRoute.of(context).settings.arguments;
+    // Extract the arguments from the current ModalRoute
+    // settings and cast them as ScreenArguments.
+    final ScreenArguments args =
+        ModalRoute.of(context)!.settings.arguments as ScreenArguments;
 
     return Scaffold(
       appBar: AppBar(
@@ -288,22 +304,24 @@ class ExtractArgumentsScreen extends StatelessWidget {
   }
 }
 
-// A Widget that accepts the necessary arguments via the constructor.
+// A Widget that accepts the necessary arguments via the
+// constructor.
 class PassArgumentsScreen extends StatelessWidget {
   static const routeName = '/passArguments';
 
   final String title;
   final String message;
 
-  // This Widget accepts the arguments as constructor parameters. It does not
-  // extract the arguments from the ModalRoute.
+  // This Widget accepts the arguments as constructor
+  // parameters. It does not extract the arguments from
+  // the ModalRoute.
   //
-  // The arguments are extracted by the onGenerateRoute function provided to the
-  // MaterialApp widget.
+  // The arguments are extracted by the onGenerateRoute
+  // function provided to the MaterialApp widget.
   const PassArgumentsScreen({
-    Key key,
-    @required this.title,
-    @required this.message,
+    Key? key,
+    required this.title,
+    required this.message,
   }) : super(key: key);
 
   @override
@@ -319,8 +337,9 @@ class PassArgumentsScreen extends StatelessWidget {
   }
 }
 
-// You can pass any object to the arguments parameter. In this example,
-// create a class that contains both a customizable title and message.
+// You can pass any object to the arguments parameter.
+// In this example, create a class that contains both
+// a customizable title and message.
 class ScreenArguments {
   final String title;
   final String message;

--- a/src/docs/cookbook/navigation/navigate-with-arguments.md
+++ b/src/docs/cookbook/navigation/navigate-with-arguments.md
@@ -44,11 +44,11 @@ The `title` of the screen and a `message`.
 
 To pass both pieces of data, create a class that stores this information.
 
-<!-- skip -->
+<?code-excerpt "lib/main.dart (ScreenArguments)"?>
 ```dart
 // You can pass any object to the arguments parameter.
-// In this example, create a class that contains a customizable
-// title and message.
+// In this example, create a class that contains both
+// a customizable title and message.
 class ScreenArguments {
   final String title;
   final String message;
@@ -65,17 +65,19 @@ To access the `ScreenArguments`,
 use the [`ModalRoute.of()`][] method.
 This method returns the current route with the arguments.
 
-<!-- skip -->
+<?code-excerpt "lib/main.dart (ExtractArgumentsScreen)"?>
 ```dart
-// A widget that extracts the necessary arguments from the ModalRoute.
+// A Widget that extracts the necessary arguments from
+// the ModalRoute.
 class ExtractArgumentsScreen extends StatelessWidget {
   static const routeName = '/extractArguments';
 
   @override
   Widget build(BuildContext context) {
-    // Extract the arguments from the current ModalRoute settings and cast
-    // them as ScreenArguments.
-    final ScreenArguments args = ModalRoute.of(context).settings.arguments;
+    // Extract the arguments from the current ModalRoute
+    // settings and cast them as ScreenArguments.
+    final ScreenArguments args =
+        ModalRoute.of(context)!.settings.arguments as ScreenArguments;
 
     return Scaffold(
       appBar: AppBar(
@@ -94,13 +96,16 @@ class ExtractArgumentsScreen extends StatelessWidget {
 Next, add an entry to the `routes` provided to the `MaterialApp` widget. The
 `routes` define which widget should be created based on the name of the route.
 
-<!-- skip -->
+{% comment %}
+RegEx removes the return statement and adds the closing parenthesis at the end
+{% endcomment %}
+<?code-excerpt "lib/main.dart (Routes)" replace="/return //g;/$/\n)/g"?>
 ```dart
 MaterialApp(
   routes: {
     ExtractArgumentsScreen.routeName: (context) => ExtractArgumentsScreen(),
   },
-);
+)
 ```
 
 
@@ -112,15 +117,18 @@ Provide the arguments to the route via the `arguments` property. The
 `ExtractArgumentsScreen` extracts the `title` and `message` from these
 arguments.
 
-<!-- skip -->
+<?code-excerpt "lib/main.dart (PushNamed)"?>
 ```dart
-// A button that navigates to a named route. The named route
-// extracts the arguments by itself.
+// A button that navigates to a named route.
+// The named route extracts the arguments
+// by itself.
 ElevatedButton(
   child: Text("Navigate to screen that extracts arguments"),
   onPressed: () {
-    // When the user taps the button, navigate to a named route
-    // and provide the arguments as an optional parameter.
+    // When the user taps the button,
+    // navigate to a named route and
+    // provide the arguments as an optional
+    // parameter.
     Navigator.pushNamed(
       context,
       ExtractArgumentsScreen.routeName,
@@ -142,20 +150,26 @@ function and pass them to a widget.
 The `onGenerateRoute()` function creates the correct route based on the given
 `RouteSettings`.
 
-<!-- skip -->
+{% comment %}
+RegEx removes the return statement, removed "routes" property and adds the closing parenthesis at the end
+{% endcomment %}
+<?code-excerpt "lib/main.dart (OnGenerateRoute)" replace="/^return //g;/  routes:((.)*\n){3}//g;/$/\n)/g"?>
 ```dart
 MaterialApp(
-  // Provide a function to handle named routes. Use this function to
-  // identify the named route being pushed, and create the correct
-  // screen.
+  // Provide a function to handle named routes.
+  // Use this function to identify the named
+  // route being pushed, and create the correct
+  // Screen.
   onGenerateRoute: (settings) {
     // If you push the PassArguments route
     if (settings.name == PassArgumentsScreen.routeName) {
-      // Cast the arguments to the correct type: ScreenArguments.
-      final ScreenArguments args = settings.arguments;
+      // Cast the arguments to the correct
+      // type: ScreenArguments.
+      final ScreenArguments args = settings.arguments as ScreenArguments;
 
-      // Then, extract the required data from the arguments and
-      // pass the data to the correct screen.
+      // Then, extract the required data from
+      // the arguments and pass the data to the
+      // correct screen.
       return MaterialPageRoute(
         builder: (context) {
           return PassArgumentsScreen(
@@ -165,8 +179,17 @@ MaterialApp(
         },
       );
     }
+    // The code only supports
+    // PassArgumentsScreen.routeName right now.
+    // Other values need to be implemented if we
+    // add them. The assertion here will help remind
+    // us of that higher up in the call stack, since
+    // this assertion would otherwise fire somewhere
+    // in the framework.
+    assert(false, 'Need to implement ${settings.name}');
+    return null;
   },
-);
+)
 ```
 
 ## Interactive example
@@ -181,45 +204,45 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-        // Provide a function to handle named routes.
-        // Use this function to identify the named
-        // route being pushed, and create the correct
-        // Screen.
-        onGenerateRoute: (settings) {
-          // If you push the PassArguments route
-          if (settings.name == PassArgumentsScreen.routeName) {
-            // Cast the arguments to the correct
-            // type: ScreenArguments.
-            final ScreenArguments args = settings.arguments as ScreenArguments;
+      routes: {
+        ExtractArgumentsScreen.routeName: (context) => ExtractArgumentsScreen(),
+      },
+      // Provide a function to handle named routes.
+      // Use this function to identify the named
+      // route being pushed, and create the correct
+      // Screen.
+      onGenerateRoute: (settings) {
+        // If you push the PassArguments route
+        if (settings.name == PassArgumentsScreen.routeName) {
+          // Cast the arguments to the correct
+          // type: ScreenArguments.
+          final ScreenArguments args = settings.arguments as ScreenArguments;
 
-            // Then, extract the required data from
-            // the arguments and pass the data to the
-            // correct screen.
-            return MaterialPageRoute(
-              builder: (context) {
-                return PassArgumentsScreen(
-                  title: args.title,
-                  message: args.message,
-                );
-              },
-            );
-          }
-          // The code only supports
-          // PassArgumentsScreen.routeName right now.
-          // Other values need to be implemented if we
-          // add them. The assertion here will help remind
-          // us of that higher up in the call stack, since
-          // this assertion would otherwise fire somewhere
-          // in the framework.
-          assert(false, 'Need to implement ${settings.name}');
-          return null;
-        },
-        title: 'Navigation with Arguments',
-        home: HomeScreen(),
-        routes: {
-          ExtractArgumentsScreen.routeName: (context) =>
-              ExtractArgumentsScreen(),
-        });
+          // Then, extract the required data from
+          // the arguments and pass the data to the
+          // correct screen.
+          return MaterialPageRoute(
+            builder: (context) {
+              return PassArgumentsScreen(
+                title: args.title,
+                message: args.message,
+              );
+            },
+          );
+        }
+        // The code only supports
+        // PassArgumentsScreen.routeName right now.
+        // Other values need to be implemented if we
+        // add them. The assertion here will help remind
+        // us of that higher up in the call stack, since
+        // this assertion would otherwise fire somewhere
+        // in the framework.
+        assert(false, 'Need to implement ${settings.name}');
+        return null;
+      },
+      title: 'Navigation with Arguments',
+      home: HomeScreen(),
+    );
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/website/issues/5569#issuecomment-812397668

In this PR I migrated the navigate-with-arguments.md cookbook to null safety.

The code sample was moved to an external project in `null_safety_examples` and the column size for commends have been moved to fit better the dartpad code sample as well.

cc. @sfshaza2 @RedBrogdon 