### PR TITLE
docs: Removed web-app inside get-started and removed its include_relative from terminal.

### DIFF
--- a/src/docs/get-started/test-drive/_androidstudio.md
+++ b/src/docs/get-started/test-drive/_androidstudio.md
@@ -2,8 +2,6 @@
 
 ## Create the app {#create-app}
 
-{% include_relative _web-app.md  %}
-
  1. Open the IDE and select **Create New Flutter Project**.
  1. Select **Flutter Application** as the project type. Then click **Next**.
  1. Verify the Flutter SDK path specifies the SDK’s location

--- a/src/docs/get-started/test-drive/_terminal.md
+++ b/src/docs/get-started/test-drive/_terminal.md
@@ -2,8 +2,6 @@
 
 ## Create the app  {#create-app}
 
-{% include_relative _web-app.md  %}
-
 Use the `flutter create` command to create a new project:
 
 ```terminal

--- a/src/docs/get-started/test-drive/_vscode.md
+++ b/src/docs/get-started/test-drive/_vscode.md
@@ -2,8 +2,6 @@
 
 ## Create the app {#create-app}
 
-{% include_relative _web-app.md  %}
-
   1. Invoke **View > Command Palette**.
   1. Type "flutter", and select the **Flutter: New Application Project**.
   1. Enter a project name, such as `myapp`, and press **Enter**.

--- a/src/docs/get-started/test-drive/_web-app.md
+++ b/src/docs/get-started/test-drive/_web-app.md
@@ -1,8 +1,0 @@
-{{site.alert.secondary}}
-  **Do you want to run your Flutter app on the web?**
-  The web version of Flutter is available on the beta channel.
-  To try it out, check out the
-  [Write your first Flutter app for the web][] codelab.
-{{site.alert.end}}
-
-[Write your first Flutter app for the web]: /docs/get-started/web


### PR DESCRIPTION
Fixes #5579 

As flutter web is inside the stable channel there is no need for an alert about web version being inside the beta channel.