### PR TITLE
fix null-safety on hot-reload.md

### DIFF
--- a/src/docs/development/tools/hot-reload.md
+++ b/src/docs/development/tools/hot-reload.md
@@ -155,7 +155,7 @@ Before the change:
 <!-- skip -->
 ```dart
 class A<T> {
-  T i;
+  T? i;
 }
 ```
 
@@ -163,8 +163,8 @@ After the change:
 <!-- skip -->
 ```dart
 class A<T, V> {
-  T i;
-  V v;
+  T? i;
+  V? v;
 }
 ```
 
@@ -281,7 +281,7 @@ For example, either of the following solutions work:
 <!-- skip -->
 ```dart
 const bar = foo;    // Convert foo to a const...
-get bar => foo;     // ...or provide a getter.
+int get bar => foo;     // ...or provide a getter.
 ```
 
 For more information, read about the [differences


### PR DESCRIPTION
Here I fixed the hot-reload.md for null safety, I didn't create an external code project since the code is minimal. The changes has been done on-file and the short snippets where already "skipped".

On the changes, I think that `?` for the Generics example is fine, as it matches the previous code functionality, alternatives could be to mark them as `late` or a constructor (but I didn't want to add too much noise to the code snippet).

The `get bar => foo` complained that required a return type, so I used `int` as `foo` is declared as an int in a previous example.

cc. @sfshaza2 @RedBrogdon 