### PR TITLE
Fix Material Design color link

### DIFF
--- a/src/docs/development/ui/layout/index.md
+++ b/src/docs/development/ui/layout/index.md
@@ -1234,7 +1234,7 @@ The following resources might help when writing layout code.
 [`MainAxisAlignment`]: {{api}}/rendering/MainAxisAlignment-class.html
 [Material card]: {{site.material}}/design/components/cards.html
 [Material Design]: {{site.material}}/design
-[Material Design palette]: {{site.material}}/guidelines/style/color.html
+[Material Design palette]: {{site.material}}/design/color
 [Material library]: {{api}}/material/material-library.html
 [pubspec file]: {{null_safety_examples}}/layout/pavlova/pubspec.yaml
 [`pubspec.yaml` file]: {{null_safety_examples}}/layout/row_column/pubspec.yaml

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -2491,7 +2491,7 @@ and common widget properties.
 [`Axis`]: {{site.api}}/flutter/painting/Axis-class.html
 [`BuildContext`]: {{site.api}}/flutter/widgets/BuildContext-class.html
 [`Center`]: {{site.api}}/flutter/widgets/Center-class.html
-[color palette]: {{site.material}}/guidelines/style/color.html
+[color palette]: {{site.material}}/design/color
 [colors]: {{site.api}}/flutter/material/Colors-class.html
 [`Colors`]: {{site.api}}/flutter/material/Colors-class.html
 [`Column`]: {{site.api}}/flutter/widgets/Column-class.html


### PR DESCRIPTION
https://material.io/guidelines/style/color.html shows 404 page.
https://material.io/design/color seems to be the appropriate.