### PR TITLE
Minor correction in box-constraints.md

### DIFF
--- a/src/docs/development/ui/layout/box-constraints.md
+++ b/src/docs/development/ui/layout/box-constraints.md
@@ -103,7 +103,7 @@ they try to be as big as possible in that direction.
 In unbounded constraints,
 they try to fit their children in that direction.
 In this case, you cannot set `flex` on the children to
-anything other than 0 (the default).
+anything other than 0.
 In the widget library, this means that you cannot use
 [`Expanded`][] when the flex box is inside
 another flex box or inside a scrollable. If you do,


### PR DESCRIPTION
Please correct me If I am wrong, isn't the default value of `flex` assigned to 1?
References - 
https://api.flutter.dev/flutter/widgets/Flexible/Flexible.html
https://api.flutter.dev/flutter/widgets/Spacer/Spacer.html