### PR TITLE
Make Gallery app and repo links consistent

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -34,7 +34,7 @@
 - title: Samples & tutorials
   children:
     - title: Flutter Gallery [running app]
-      permalink: https://flutter.github.io/gallery/
+      permalink: https://gallery.flutter.dev
     - title: Flutter Gallery [repo]
       permalink: https://github.com/flutter/gallery
     - title: Sample apps on GitHub

--- a/src/desktop.md
+++ b/src/desktop.md
@@ -743,9 +743,9 @@ Flokk [announcement blogpost][gskinner-flokk-blogpost], [repo][gskinner-flokk-re
 
 [`menubar`]: {{site.github}}/google/flutter-desktop-embedding/tree/master/plugins/menubar
 [Photo Search app]: {{site.repo.organization}}/samples/tree/master/experimental/desktop_photo_search
+[running web app]: https://gallery.flutter.dev
+[flutter-gallery-repo]: {{site.github}}/flutter/gallery
 [README]: {{site.github}}/flutter/gallery#flutter-gallery
-[flutter-gallery-repo]: {{site.github}}/flutter/flutter/tree/master/dev/integration_tests/flutter_gallery
 [gskinner-flokk-repo]: {{site.github}}/gskinnerTeam/flokk
 [gskinner-flokk-blogpost]: https://blog.gskinner.com/archives/2020/09/flokk-how-we-built-a-desktop-app-using-flutter.html
-[running web app]: https://flutter.github.io/gallery/#/
 [Write a Flutter desktop application]: https://codelabs.developers.google.com/codelabs/flutter-github-graphql-client/index.html

--- a/src/docs/development/ui/interactive.md
+++ b/src/docs/development/ui/interactive.md
@@ -813,8 +813,8 @@ Flutter Gallery [running app][], [repo][]
 [`pubspec.yaml`]: {{examples}}/layout/lakes/step6/pubspec.yaml
 [`Radio`]: {{site.api}}/flutter/material/Radio-class.html
 [`ElevatedButton`]: {{site.api}}/flutter/material/ElevatedButton-class.html
-[repo]: {{site.repo.flutter}}/tree/master/dev/integration_tests/flutter_gallery
-[running app]: https://flutter.github.io/gallery/#/
+[repo]: {{site.github}}/flutter/gallery
+[running app]: https://gallery.flutter.dev
 [set up]: /docs/get-started/install
 [`SizedBox`]: {{site.api}}/flutter/widgets/SizedBox-class.html
 [`Slider`]: {{site.api}}/flutter/material/Slider-class.html


### PR DESCRIPTION
Update all the references to Gallery app and repo to correct links.
Links on the page https://flutter.dev/docs/development/ui/layout have
explanations linked to old Gallery version so kept it unchanged.

Webpages affected -
https://flutter.dev/docs/development/ui/interactive#resources
https://flutter.dev/desktop#samples-and-codelabs
Side Navigation