### PR TITLE
Update link for `devicePixelRatio`

### DIFF
--- a/src/docs/development/ui/assets-and-images.md
+++ b/src/docs/development/ui/assets-and-images.md
@@ -494,7 +494,8 @@ For more details, see
 [`ImageStream`]: {{site.api}}/flutter/painting/ImageStream-class.html
 [Android Developer Guide]: {{site.android-dev}}/training/multiscreen/screendensities
 [`AssetManager`]: {{site.android-dev}}/reference/android/content/res/AssetManager
-[device pixel ratio]: {{site.api}}/flutter/dart-ui/Window/devicePixelRatio.html
+[device pixel ratio]: {{site.api}}/flutter/dart-ui/FlutterView/devicePixelRatio.html
+[Device pixel ratio]: {{site.api}}/flutter/dart-ui/FlutterView/devicePixelRatio.html
 [drawables]: {{site.android-dev}}/guide/topics/resources/drawable-resource
 [`FlutterPluginRegistrar`]: {{site.api}}/objcdoc/Protocols/FlutterPluginRegistrar.html
 [`FlutterView`]: {{site.api}}/javadoc/io/flutter/view/FlutterView.html
@@ -516,4 +517,3 @@ For more details, see
 [MediaQueryData.size]: {{site.api}}/flutter/widgets/MediaQueryData/size.html
 [MaterialApp]: {{site.api}}/flutter/material/MaterialApp-class.html
 [CupertinoApp]: {{site.api}}/flutter/cupertino/CupertinoApp-class.html
-[Device pixel ratio]: {{site.api}}/flutter/dart-ui/Window/devicePixelRatio.html

--- a/src/docs/get-started/flutter-for/android-devs.md
+++ b/src/docs/get-started/flutter-for/android-devs.md
@@ -1208,7 +1208,7 @@ are placed in an assets folder for Flutter.
 Flutter follows a simple density-based format like iOS. Assets might be `1.0x`,
 `2.0x`, `3.0x`, or any other multiplier. Flutter doesn't have `dp`s but there
 are logical pixels, which are basically the same as device-independent pixels.
-The so-called [devicePixelRatio][]
+The so-called [`devicePixelRatio`][]
 expresses the ratio of physical pixels in a single logical pixel.
 
 The equivalent to Android's density buckets are:
@@ -2292,7 +2292,7 @@ see the [`firebase_messaging`][] plugin documentation.
 [Cupertino widgets]: /docs/development/ui/widgets/cupertino
 [Custom Paint]: {{site.so}}/questions/46241071/create-signature-area-for-mobile-app-in-dart-flutter
 [developing packages and plugins]: /docs/development/packages-and-plugins/developing-packages
-[devicePixelRatio]: {{site.api}}/flutter/dart-ui/Window/devicePixelRatio.html
+[`devicePixelRatio`]: {{site.api}}/flutter/dart-ui/FlutterView/devicePixelRatio.html
 [DevTools]: /docs/development/tools/devtools
 [existing plugin]: {{site.pub}}/flutter/
 [`flutter_facebook_login`]: {{site.pub}}/packages/flutter_facebook_login

--- a/src/docs/get-started/flutter-for/ios-devs.md
+++ b/src/docs/get-started/flutter-for/ios-devs.md
@@ -2206,7 +2206,7 @@ plugin documentation.
 [Cupertino library]: {{site.api}}/flutter/cupertino/cupertino-library.html
 [Cupertino widgets]: /docs/development/ui/widgets/cupertino
 [developing packages and plugins]: /docs/development/packages-and-plugins/developing-packages
-[`devicePixelRatio`]: {{site.api}}/flutter/dart-ui/Window/devicePixelRatio.html
+[`devicePixelRatio`]: {{site.api}}/flutter/dart-ui/FlutterView/devicePixelRatio.html
 [DevTools]: /docs/development/tools/devtools
 [existing plugin]: {{site.pub}}/flutter
 [`firebase_admob`]: {{site.pub-pkg}}/firebase_admob

--- a/src/docs/get-started/flutter-for/xamarin-forms-devs.md
+++ b/src/docs/get-started/flutter-for/xamarin-forms-devs.md
@@ -2480,7 +2480,7 @@ For more information on using the Firebase Cloud Messaging API, see the
 [`cloud_firestore`]: {{site.pub}}/packages/cloud_firestore
 [composing]: /docs/resources/architectural-overview#composition
 [Cupertino widgets]: /docs/development/ui/widgets/cupertino
-[`devicePixelRatio`]: {{site.api}}/flutter/dart-ui/Window/devicePixelRatio.html
+[`devicePixelRatio`]: {{site.api}}/flutter/dart-ui/FlutterView/devicePixelRatio.html
 [developing packages and plugins]: /docs/development/packages-and-plugins/developing-packages
 [DevTools]: /docs/development/tools/devtools/overview
 [existing plugin]: {{site.pub}}/flutter


### PR DESCRIPTION
`devicePixelRatio` is now in `FlutterView` class.
`Window` class was edited to `FlutterView` class in the commit -
https://github.com/flutter/engine/commit/6bc70e4a114ff4c01b60c77bae754bace5683f6d