### PR TITLE
Add member variable to cached FlutterEngine Java example

### DIFF
--- a/src/docs/development/add-to-app/android/add-flutter-screen.md
+++ b/src/docs/development/add-to-app/android/add-flutter-screen.md
@@ -58,7 +58,7 @@ Make sure to use the following import:
 
 {% samplecode default-activity-launch %}
 {% sample Java %}
-<!--code-excerpt "ExistingActivity.java" title-->
+<? code-excerpt "ExistingActivity.java" title ?>
 ```java
 myButton.setOnClickListener(new OnClickListener() {
   @Override
@@ -70,7 +70,7 @@ myButton.setOnClickListener(new OnClickListener() {
 });
 ```
 {% sample Kotlin %}
-<!--code-excerpt "ExistingActivity.kt" title-->
+<? code-excerpt "ExistingActivity.kt" title ?>
 ```kotlin
 myButton.setOnClickListener {
   startActivity(
@@ -90,7 +90,7 @@ route in Flutter.
 
 {% samplecode custom-activity-launch %}
 {% sample Java %}
-<!--code-excerpt "ExistingActivity.java" title-->
+<? code-excerpt "ExistingActivity.java" title ?>
 ```java
 myButton.addOnClickListener(new OnClickListener() {
   @Override
@@ -105,7 +105,7 @@ myButton.addOnClickListener(new OnClickListener() {
 });
 ```
 {% sample Kotlin %}
-<!--code-excerpt "ExistingActivity.kt" title-->
+<? code-excerpt "ExistingActivity.kt" title ?>
 ```kotlin
 myButton.setOnClickListener {
   startActivity(
@@ -170,7 +170,7 @@ public class MyApplication extends Application {
 }
 ```
 {% sample Kotlin %}
-<!--code-excerpt "MyApplication.kt" title-->
+<? code-excerpt "MyApplication.kt" title ?>
 ```kotlin
 class MyApplication : Application() {
   lateinit var flutterEngine : FlutterEngine
@@ -223,7 +223,7 @@ builder:
 
 {% samplecode cached-engine-activity-launch %}
 {% sample Java %}
-<!--code-excerpt "ExistingActivity.java" title-->
+<? code-excerpt "ExistingActivity.java" title ?>
 ```java
 myButton.addOnClickListener(new OnClickListener() {
   @Override
@@ -237,7 +237,7 @@ myButton.addOnClickListener(new OnClickListener() {
 });
 ```
 {% sample Kotlin %}
-<!--code-excerpt "ExistingActivity.kt" title-->
+<? code-excerpt "ExistingActivity.kt" title ?>
 ```kotlin
 myButton.setOnClickListener {
   startActivity(
@@ -341,7 +341,7 @@ pass the appropriate `BackgroundMode` to the `IntentBuilder`:
 
 {% samplecode transparent-activity-launch %}
 {% sample Java %}
-<!--code-excerpt "ExistingActivity.java" title-->
+<? code-excerpt "ExistingActivity.java" title ?>
 ```java
 // Using a new FlutterEngine.
 startActivity(
@@ -361,7 +361,7 @@ startActivity(
 ```
 
 {% sample Kotlin %}
-<!--code-excerpt "ExistingActivity.kt" title-->
+<? code-excerpt "ExistingActivity.kt" title ?>
 ```kotlin
 // Using a new FlutterEngine.
 startActivity(

--- a/src/docs/development/add-to-app/android/add-flutter-screen.md
+++ b/src/docs/development/add-to-app/android/add-flutter-screen.md
@@ -149,6 +149,8 @@ The following example arbitrarily pre-warms a
 <!--code-excerpt "MyApplication.java" title-->
 ```java
 public class MyApplication extends Application {
+  public FlutterEngine flutterEngine;
+  
   @Override
   public void onCreate() {
     super.onCreate();

--- a/src/docs/development/add-to-app/android/add-flutter-screen.md
+++ b/src/docs/development/add-to-app/android/add-flutter-screen.md
@@ -146,7 +146,7 @@ The following example arbitrarily pre-warms a
 
 {% samplecode prewarm-engine %}
 {% sample Java %}
-<!--code-excerpt "MyApplication.java" title-->
+<? code-excerpt "MyApplication.java" title ?>
 ```java
 public class MyApplication extends Application {
   public FlutterEngine flutterEngine;


### PR DESCRIPTION
The Kotlin example has the `lateinit var flutterEngine` member variable shown but the Java version does not.

Also uncomments `code-excerpts` in `add-flutter-screen.md`.