### PR TITLE
Add go/web-slot-content redirect.

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -238,6 +238,7 @@
       { "source": "/go/update-text-theme-api", "destination": "https://docs.google.com/document/d/1B1s4mm6OYM7mKQ3vZfSTI2HR_KljB78gN6oBHg_zYUs/edit", "type": 301 },
       { "source": "/go/web-plugins-layout", "destination": "https://docs.google.com/document/d/1PeS-QSAFydHXhjZrqkub-GRPMs83roh8VwhbUScWuGQ", "type": 301 },
       { "source": "/go/web-renderer-options", "destination": "https://docs.google.com/document/d/1aY0iU16wf_sdT7nwfpjgT-IatHNfF3slTiYHKmxcIog", "type": 301 },
+      { "source": "/go/web-slot-content", "destination": "https://docs.google.com/document/d/1U6aCSuzQsFpOP8_OseL-fwl2-MC2bxJAsgt2R_-sC30", "type": 301 },
       { "source": "/go/widget-tree-image-cache", "destination": "https://docs.google.com/document/d/1deEtxZk1VYRmzvkL4gTb3sEnjBrHejQkWObQ4yrP5jE/edit?pli=1#", "type": 301 },
       { "source": "/go/widgetspan-in-selectabletext", "destination": "https://docs.google.com/document/d/1nrVRytWVF-1hr8LvUKyENE5s074UInni9ZiColtIIxI", "type": 301 },
       { "source": "/go/wrap-popupmenu-with-safearea", "destination": "https://docs.google.com/document/d/15uBmyEKiOeYGYt1PuBVf4SFK5YhH07EP9ylWP-H9mVE/edit?usp=sharing", "type": 301 },


### PR DESCRIPTION
This PR follows the instructions atop the public design doc template to add a new go link to the flutter.dev page.