### PR TITLE
Update the test package documentation link

### DIFF
--- a/src/docs/cookbook/testing/unit/introduction.md
+++ b/src/docs/cookbook/testing/unit/introduction.md
@@ -188,4 +188,4 @@ flutter test --help
 
 [`flutter_test`]: {{site.api}}/flutter/flutter_test/flutter_test-library.html
 [`test`]: {{site.pub-pkg}}/test
-[test package documentation]: {{site.github}}/dart-lang/test/blob/master/README.md
+[test package documentation]: {{site.github}}/dart-lang/test

--- a/src/docs/cookbook/testing/unit/introduction.md
+++ b/src/docs/cookbook/testing/unit/introduction.md
@@ -188,4 +188,4 @@ flutter test --help
 
 [`flutter_test`]: {{site.api}}/flutter/flutter_test/flutter_test-library.html
 [`test`]: {{site.pub-pkg}}/test
-[test package documentation]: {{site.github}}/dart-lang/test
+[test package documentation]: {{site.pub}}/packages/test


### PR DESCRIPTION
Fixes https://github.com/dart-lang/test/issues/1497.

The readme this directed to before now just links to a different readme deeper in the repo. Rather than linking to the other one I think just pointing to the repo makes the most sense (least likely to become non-useful).