### PR TITLE
Remove references to shallow cloning

### DIFF
--- a/src/docs/get-started/install/_get-sdk-chromeos.md
+++ b/src/docs/get-started/install/_get-sdk-chromeos.md
@@ -48,7 +48,7 @@
     For example, to get just the stable version:
     
     ```terminal
-    $ git clone https://github.com/flutter/flutter.git -b stable --depth 1
+    $ git clone https://github.com/flutter/flutter.git -b stable
     ```
     
  1. Add the `flutter` tool to your path:

--- a/src/docs/get-started/install/_get-sdk-linux.md
+++ b/src/docs/get-started/install/_get-sdk-linux.md
@@ -74,7 +74,7 @@ install Flutter using the following steps.
     For example, to get just the stable version:
     
     ```terminal
-    $ git clone https://github.com/flutter/flutter.git -b stable --depth 1
+    $ git clone https://github.com/flutter/flutter.git -b stable
     ```
     
  1. Add the `flutter` tool to your path:


### PR DESCRIPTION
Shallow clones will break the Flutter CLI tool, as it assumes we have the entire git history.

For context, https://github.com/flutter/flutter/issues/80800