### PR TITLE
Fix typo in layout-basics.md

### DIFF
--- a/src/docs/codelabs/layout-basics.md
+++ b/src/docs/codelabs/layout-basics.md
@@ -25,7 +25,7 @@ Widgets are the basic building blocks of a Flutter UI.
 As you progress through this codelab,
 you'll learn that almost everything in Flutter is a widget.
 A widget is an immutable object that describes a specific part of a UI.
-You'll also learn that Flutter widgets are composable, meaning,
+You'll also learn that Flutter widgets are composable, meaning
 that you can combine existing widgets to make more sophisticated widgets.
 At the end of this codelab,
 you'll get to apply what you've learned


### PR DESCRIPTION
Remove comma between "meaning" and "that".

From [this helpful article](https://jakubmarian.com/comma-before-that-and-which/):

> A good way to recognize [a dependent clause] is to try to enclose the clause in parentheses; if the sentence still makes sense, you should use commas (or parentheses) to separate the clause from the rest[.]

In the sentence:

> You’ll also learn that Flutter widgets are composable, meaning, *that you can combine existing widgets to make more sophisticated widgets*.

The sentence would not make sense if the part in italics was in parantheses.