### PR TITLE
Fix formatting of url-strategies.md

### DIFF
--- a/src/docs/development/ui/navigation/url-strategies.md
+++ b/src/docs/development/ui/navigation/url-strategies.md
@@ -7,11 +7,11 @@ Flutter web apps support two ways of configuring URL-based navigation on the
 web:
 
 **Hash (default)**: Paths are read and written to the [hash fragment][].
-  For example, `flutterexample.dev/#/path/to/screen`.
+  For example, `flutterexample.dev/#/path/to/screen`. <br>
 **Path**:  Paths are read and written without a hash. For example,
   `flutterexample.dev/path/to/screen`.
   
-These are set using the [setUrlStrategy][] API with either a [HashUrlStrategy][]
+These are set using the [setUrlStrategy()][] API with either a [HashUrlStrategy][]
 or [PathUrlStrategy][].
   
 ## Configuring the URL strategy
@@ -26,50 +26,52 @@ or [PathUrlStrategy][].
   setup.
 {{site.alert.end}}
 
-The `setUrlStrategy` API can only be called on the web. The following
+The `setUrlStrategy()` API can only be called on the web. The following
 instructions show how to use a conditional import to call this function on the
 web, but not on other platforms.
 
-1. Include the `flutter_web_plugins` package and call the [setUrlStrategy][]
-  function before your app runs:
+ 1. Include the `flutter_web_plugins` package and call the [setUrlStrategy()][] 
+    function before your app runs:
 
-```yaml
-dependencies:
-  flutter_web_plugins:
-    sdk: flutter
-```
+    ```yaml
+    dependencies:
+      flutter_web_plugins:
+        sdk: flutter
+    ```
 
-2. Create a `lib/configure_nonweb.dart` file with the following:
-```dart
-void configureApp() {
-  // No-op.
-}
-```
+ 2. Create a `lib/configure_nonweb.dart` file with the following:
 
-3. Create a `lib/configure_web.dart` file with the following:
+    ```dart
+    void configureApp() {
+      // No-op.
+    }
+    ```
 
-<!--skip-->
-```dart
-import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+ 3. Create a `lib/configure_web.dart` file with the following:
 
-void configureApp() {
-  setUrlStrategy(PathUrlStrategy());
-}
-```
+    <!--skip-->
+    ```dart
+    import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+    
+    void configureApp() {
+      setUrlStrategy(PathUrlStrategy());
+    }
+    ```
 
-4. Open `lib/main.dart` and use a conditional import to import `configure_web.dart` when the `html` package
-  is available, and `configure_nonweb.dart` when it isn't:
+ 4. Open `lib/main.dart` and use a conditional import to import 
+    `configure_web.dart` when the `html` package is available, and 
+    `configure_nonweb.dart` when it isn't:
 
-<!--skip-->
-```dart
-import 'package:flutter/material.dart';
-import 'configure_nonweb.dart' if (dart.library.html) 'configure_web.dart';
-
-void main() {
-  configureApp();
-  runApp(MyApp());
-}
-```
+    <!--skip-->
+    ```dart
+    import 'package:flutter/material.dart';
+    import 'configure_nonweb.dart' if (dart.library.html) 'configure_web.dart';
+    
+    void main() {
+      configureApp();
+      runApp(MyApp());
+    }
+    ```
 
 ## Hosting a Flutter app at a non-root location
 
@@ -79,7 +81,7 @@ your app is hosted. For example, to host your Flutter app at
 this tag to `<base href="/flutter_app">`.
 
 [Hash fragment]: https://en.wikipedia.org/wiki/Uniform_Resource_Locator#Syntax
-[setUrlStrategy]: {{site.master-api}}/flutter/flutter_web_plugins/setUrlStrategy.html
-[HashUrlStrategy]: {{site.master-api}}/flutter/flutter_web_plugins/HashUrlStrategy-class.html
-[PathUrlStrategy]: {{site.master-api}}/flutter/flutter_web_plugins/PathUrlStrategy-class.html
+[setUrlStrategy()]: {{site.api}}/flutter/flutter_web_plugins/setUrlStrategy.html
+[HashUrlStrategy]: {{site.api}}/flutter/flutter_web_plugins/HashUrlStrategy-class.html
+[PathUrlStrategy]: {{site.api}}/flutter/flutter_web_plugins/PathUrlStrategy-class.html
 [url_strategy package]: {{site.pub-pkg}}/url_strategy


### PR DESCRIPTION
1. Fix ordered list formatting.
2. Add a `<br>`.
3. Add parenthesis for setUrlStrategy method.
4. Remove master-api references.