### PR TITLE
Move animated-container to code excerpts and enable null safety

### DIFF
--- a/null_safety_examples/cookbook/animation/animated_container/lib/main.dart
+++ b/null_safety_examples/cookbook/animation/animated_container/lib/main.dart
@@ -1,0 +1,76 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(AnimatedContainerApp());
+
+class AnimatedContainerApp extends StatefulWidget {
+  @override
+  _AnimatedContainerAppState createState() => _AnimatedContainerAppState();
+}
+
+class _AnimatedContainerAppState extends State<AnimatedContainerApp> {
+  // Define the various properties with default values. Update these properties
+  // when the user taps a FloatingActionButton.
+  double _width = 50;
+  double _height = 50;
+  Color _color = Colors.green;
+  BorderRadiusGeometry _borderRadius = BorderRadius.circular(8);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: Text('AnimatedContainer Demo'),
+        ),
+        body: Center(
+          // #docregion AnimatedContainer
+          child: AnimatedContainer(
+            // Use the properties stored in the State class.
+            width: _width,
+            height: _height,
+            decoration: BoxDecoration(
+              color: _color,
+              borderRadius: _borderRadius,
+            ),
+            // Define how long the animation should take.
+            duration: Duration(seconds: 1),
+            // Provide an optional curve to make the animation feel smoother.
+            curve: Curves.fastOutSlowIn,
+          ),
+          // #enddocregion AnimatedContainer
+        ),
+        // #docregion FAB
+        floatingActionButton: FloatingActionButton(
+          child: Icon(Icons.play_arrow),
+          // When the user taps the button
+          onPressed: () {
+            // Use setState to rebuild the widget with new values.
+            setState(() {
+              // Create a random number generator.
+              final random = Random();
+
+              // Generate a random width and height.
+              _width = random.nextInt(300).toDouble();
+              _height = random.nextInt(300).toDouble();
+
+              // Generate a random color.
+              _color = Color.fromRGBO(
+                random.nextInt(256),
+                random.nextInt(256),
+                random.nextInt(256),
+                1,
+              );
+
+              // Generate a random border radius.
+              _borderRadius =
+                  BorderRadius.circular(random.nextInt(100).toDouble());
+            });
+          },
+        ),
+        // #enddocregion FAB
+      ),
+    );
+  }
+}

--- a/null_safety_examples/cookbook/animation/animated_container/lib/starter.dart
+++ b/null_safety_examples/cookbook/animation/animated_container/lib/starter.dart
@@ -1,0 +1,24 @@
+// ignore_for_file: unused_field
+import 'package:flutter/material.dart';
+
+// #docregion Starter
+class AnimatedContainerApp extends StatefulWidget {
+  @override
+  _AnimatedContainerAppState createState() => _AnimatedContainerAppState();
+}
+
+class _AnimatedContainerAppState extends State<AnimatedContainerApp> {
+  // Define the various properties with default values. Update these properties
+  // when the user taps a FloatingActionButton.
+  double _width = 50;
+  double _height = 50;
+  Color _color = Colors.green;
+  BorderRadiusGeometry _borderRadius = BorderRadius.circular(8);
+
+  @override
+  Widget build(BuildContext context) {
+    // Fill this out in the next steps.
+    return Container();
+  }
+}
+// #enddocregion Starter

--- a/null_safety_examples/cookbook/animation/animated_container/pubspec.yaml
+++ b/null_safety_examples/cookbook/animation/animated_container/pubspec.yaml
@@ -1,0 +1,12 @@
+name: animated_container
+description: Sample code for cookbook.
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/src/docs/cookbook/animation/animated-container.md
+++ b/src/docs/cookbook/animation/animated-container.md
@@ -12,6 +12,8 @@ js:
     url: https://dartpad.dev/inject_embed.dart.js
 ---
 
+<?code-excerpt path-base="../null_safety_examples/cookbook/animation/animated_container/"?>
+
 The [`Container`][] class provides a convenient way
 to create a widget with specific properties:
 width, height, background color, padding, borders, and more.
@@ -47,7 +49,7 @@ radius. You can also define the default value of each property.
 These properties belong to a custom `State` class so they
 can be updated when the user taps a button.
 
-<!-- skip -->
+<?code-excerpt "lib/starter.dart (Starter)" remove="return Container();"?>
 ```dart
 class AnimatedContainerApp extends StatefulWidget {
   @override
@@ -75,7 +77,7 @@ Next, build the `AnimatedContainer` using the properties defined in the
 previous step. Furthermore, provide a `duration` that defines how long
 the animation should run.
 
-<!-- skip -->
+<?code-excerpt "lib/main.dart (AnimatedContainer)" replace="/^child: //g;/,$//g"?>
 ```dart
 AnimatedContainer(
   // Use the properties stored in the State class.
@@ -89,7 +91,7 @@ AnimatedContainer(
   duration: Duration(seconds: 1),
   // Provide an optional curve to make the animation feel smoother.
   curve: Curves.fastOutSlowIn,
-);
+)
 ```
 
 ## 3. Start the animation by rebuilding with new properties
@@ -107,7 +109,7 @@ A real app typically transitions between fixed values (for example,
 from a grey to a green background). For this app,
 generate new values each time the user taps the button.
 
-<!-- skip -->
+<?code-excerpt "lib/main.dart (FAB)" replace="/^floatingActionButton: //g;/,$//g"?>
 ```dart
 FloatingActionButton(
   child: Icon(Icons.play_arrow),
@@ -135,12 +137,13 @@ FloatingActionButton(
           BorderRadius.circular(random.nextInt(100).toDouble());
     });
   },
-);
+)
 ```
 
 ## Interactive example
 
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+<?code-excerpt "lib/main.dart"?>
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
 import 'dart:math';
 
 import 'package:flutter/material.dart';

--- a/src/docs/get-started/codelab.md
+++ b/src/docs/get-started/codelab.md
@@ -223,7 +223,7 @@ as well as many other open source packages, on [pub.dev][].
        flutter:
          sdk: flutter
        cupertino_icons: ^1.0.2
-    +  english_words: ^4.0.0
+    +  english_words: ^4.0.0-0
     ```
 
  2. While viewing the `pubspec.yaml` file in Android Studio's editor view,


### PR DESCRIPTION
Here I moved the example from the cookbook recipe animated-container.md to a project, used code excerpts to extract the code and enabled null safety in the dartpad.

cc. @sfshaza2 @RedBrogdon 