### PR TITLE
Do some rejiggering of the url_strategies page

### DIFF
--- a/src/docs/development/ui/navigation/url-strategies.md
+++ b/src/docs/development/ui/navigation/url-strategies.md
@@ -3,35 +3,38 @@ title: Configuring the URL strategy on the web
 description: Use hash or path URL strategies on the web
 ---
 
-Flutter web apps support two ways of configuring URL-based navigation on the
-web:
+Flutter web apps support two ways of configuring
+URL-based navigation on the web:
 
-**Hash (default)**: Paths are read and written to the [hash fragment][].
+**Hash (default)**
+: Paths are read and written to the [hash fragment][].
   For example, `flutterexample.dev/#/path/to/screen`.
-**Path**:  Paths are read and written without a hash. For example,
+
+**Path**
+:  Paths are read and written without a hash. For example,
   `flutterexample.dev/path/to/screen`.
   
-These are set using the [setUrlStrategy][] API with either a [HashUrlStrategy][]
-or [PathUrlStrategy][].
+These are set using the [`setUrlStrategy`][] API with
+either a [`HashUrlStrategy`][] or [`PathUrlStrategy`][].
   
 ## Configuring the URL strategy
 
 {{site.alert.note}}
-  Flutter uses the hash (`/#/`) location strategy by default. These instructions
-  are only required if you would like to use the URL path strategy.
+  By default, Flutter uses the hash (`/#/`) location strategy.
+  These instructions are only required if you want to use
+  the URL path strategy.
+
+  Instead of using these setup instructions,
+  you can also use the [`url_strategy`][] package.
 {{site.alert.end}}
 
-{{site.alert.note}}
-  You can also try the [url_strategy package][] if you would like to skip this
-  setup.
-{{site.alert.end}}
+The `setUrlStrategy` API can only be called on the web.
+The following instructions show how to use a conditional
+import to call this function on the web,
+but not on other platforms.
 
-The `setUrlStrategy` API can only be called on the web. The following
-instructions show how to use a conditional import to call this function on the
-web, but not on other platforms.
-
-1. Include the `flutter_web_plugins` package and call the [setUrlStrategy][]
-  function before your app runs:
+1. Include the `flutter_web_plugins` package and call the
+   [`setUrlStrategy`][] function before your app runs:
 
 ```yaml
 dependencies:
@@ -39,14 +42,17 @@ dependencies:
     sdk: flutter
 ```
 
-2. Create a `lib/configure_nonweb.dart` file with the following:
+2. Create a `lib/configure_nonweb.dart` file with the
+   following code:
+
 ```dart
 void configureApp() {
   // No-op.
 }
 ```
 
-3. Create a `lib/configure_web.dart` file with the following:
+3. Create a `lib/configure_web.dart` file with the
+   following code:
 
 <!--skip-->
 ```dart
@@ -57,8 +63,9 @@ void configureApp() {
 }
 ```
 
-4. Open `lib/main.dart` and use a conditional import to import `configure_web.dart` when the `html` package
-  is available, and `configure_nonweb.dart` when it isn't:
+4. Open `lib/main.dart` and conditionally import
+   `configure_web.dart` when the `html` package
+   is available, or `configure_nonweb.dart` when it isn't:
 
 <!--skip-->
 ```dart
@@ -73,13 +80,15 @@ void main() {
 
 ## Hosting a Flutter app at a non-root location
 
-Update the `<base href="/">` tag in `web/index.html` to the path where
-your app is hosted. For example, to host your Flutter app at
+Update the `<base href="/">` tag in `web/index.html`
+to the path where your app is hosted.
+For example, to host your Flutter app at
 `myapp.dev/flutter_app`, change
 this tag to `<base href="/flutter_app">`.
 
-[Hash fragment]: https://en.wikipedia.org/wiki/Uniform_Resource_Locator#Syntax
-[setUrlStrategy]: {{site.master-api}}/flutter/flutter_web_plugins/setUrlStrategy.html
-[HashUrlStrategy]: {{site.master-api}}/flutter/flutter_web_plugins/HashUrlStrategy-class.html
-[PathUrlStrategy]: {{site.master-api}}/flutter/flutter_web_plugins/PathUrlStrategy-class.html
-[url_strategy package]: {{site.pub-pkg}}/url_strategy
+
+[hash fragment]: https://en.wikipedia.org/wiki/Uniform_Resource_Locator#Syntax
+[`HashUrlStrategy`]: {{site.api}}/flutter/flutter_web_plugins/HashUrlStrategy-class.html
+[`PathUrlStrategy`]: {{site.api}}/flutter/flutter_web_plugins/PathUrlStrategy-class.html
+[`setUrlStrategy`]: {{site.api}}/flutter/flutter_web_plugins/setUrlStrategy.html
+[`url_strategy`]: {{site.pub-pkg}}/url_strategy


### PR DESCRIPTION
This PR replaces another [that I closed](https://github.com/flutter/website/pull/5663). It changes the page to more closely follow the [Google Documentation Developer guidelines](https://developers.google.com/style). It also fixes the formatting of the definition list.