### PR TITLE
Remove Documentation Link from Bottom of Widget Cards

### DIFF
--- a/src/_includes/catalogpage.html
+++ b/src/_includes/catalogpage.html
@@ -30,9 +30,6 @@
                         <a href="{{comp.link}}"><header class="card-title">{{comp.name}}</header></a>
                         <p class="card-text">{{comp.description}}</p>
                     </div>
-                    <div class="card-footer card-footer--transparent">
-                        <a href="{{comp.link}}">Documentation</a>
-                    </div>
                 </div>
             {% endif %}
         {% endfor %}
@@ -54,9 +51,6 @@
                                 <div class="card-body">
                                     <a href="{{comp.link}}"><header class="card-title">{{comp.name}}</header></a>
                                     <p class="card-text">{{comp.description}}</p>
-                                </div>
-                                <div class="card-footer card-footer--transparent">
-                                    <a href="{{comp.link}}">Documentation</a>
                                 </div>
                             </div>
                         {% endif %}

--- a/src/docs/reference/widgets.md
+++ b/src/docs/reference/widgets.md
@@ -30,9 +30,6 @@ our [videos](/docs/resources/videos) page.
             <a href="{{comp.link}}"><header class="card-title">{{comp.name}}</header></a>
             <p class="card-text">{{comp.description}}</p>
         </div>
-        <div class="card-footer card-footer--transparent">
-            <a href="{{comp.link}}">Documentation</a>
-        </div>
     </div>
 {% endfor %}
 </div>


### PR DESCRIPTION
Partially fixes #1495
Removes Documentation Footer on Widget Cards. Redundant as both the Image and the Title are already links to the documentation page.