### PR TITLE
Enable null-safety on tabs.md

### DIFF
--- a/null_safety_examples/cookbook/design/tabs/lib/main.dart
+++ b/null_safety_examples/cookbook/design/tabs/lib/main.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(TabBarDemo());
+}
+
+class TabBarDemo extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: DefaultTabController(
+        length: 3,
+        child: Scaffold(
+          appBar: AppBar(
+            bottom: TabBar(
+              tabs: [
+                Tab(icon: Icon(Icons.directions_car)),
+                Tab(icon: Icon(Icons.directions_transit)),
+                Tab(icon: Icon(Icons.directions_bike)),
+              ],
+            ),
+            title: Text('Tabs Demo'),
+          ),
+          body: TabBarView(
+            children: [
+              Icon(Icons.directions_car),
+              Icon(Icons.directions_transit),
+              Icon(Icons.directions_bike),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/null_safety_examples/cookbook/design/tabs/pubspec.yaml
+++ b/null_safety_examples/cookbook/design/tabs/pubspec.yaml
@@ -1,0 +1,12 @@
+name: tabs
+description: Sample code for tabs cookbook recipe.
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/src/docs/cookbook/design/tabs.md
+++ b/src/docs/cookbook/design/tabs.md
@@ -12,6 +12,8 @@ js:
     url: https://dartpad.dev/inject_embed.dart.js
 ---
 
+<?code-excerpt path-base="../null_safety_examples/cookbook/design/tabs/"?>
+
 Working with tabs is a common pattern in apps that follow the
 Material Design guidelines.
 Flutter includes a convenient way to create tab layouts as part of
@@ -101,6 +103,7 @@ TabBarView(
 
 ## Interactive example
 
+<?code-excerpt "lib/main.dart"?>
 ```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
 import 'package:flutter/material.dart';
 

--- a/src/docs/cookbook/design/tabs.md
+++ b/src/docs/cookbook/design/tabs.md
@@ -101,7 +101,7 @@ TabBarView(
 
 ## Interactive example
 
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
 import 'package:flutter/material.dart';
 
 void main() {


### PR DESCRIPTION
No code changes required for null safety support, so simply adding the null_safety flag to the dartpad and extracting the code snippet to a project.

cc. @sfshaza2 @RedBrogdon 