### PR TITLE
Enable null-safety in dartpad for network-image.md

### DIFF
--- a/src/docs/cookbook/images/network-image.md
+++ b/src/docs/cookbook/images/network-image.md
@@ -46,7 +46,7 @@ the following recipes:
 
 ## Interactive example
 
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
 import 'package:flutter/material.dart';
 
 void main() => runApp(MyApp());


### PR DESCRIPTION
No code changes necessary to enable null safety, the rest of snippets were very small as well.

cc. @sfshaza2 @RedBrogdon 