### PR TITLE
Update _initial-route-cached-engine.md

### DIFF
--- a/src/docs/development/add-to-app/android/_initial-route-cached-engine.md
+++ b/src/docs/development/add-to-app/android/_initial-route-cached-engine.md
@@ -45,7 +45,7 @@ class MyApplication : Application() {
     // Instantiate a FlutterEngine.
     flutterEngine = FlutterEngine(this)
     // Configure an initial route.
-    flutterEngine.navigationChannel.initialRoute = "your/route/here";
+    flutterEngine.navigationChannel.setInitialRoute("your/route/here");
     // Start executing Dart code to pre-warm the FlutterEngine.
     flutterEngine.dartExecutor.executeDartEntrypoint(
       DartExecutor.DartEntrypoint.createDefault()


### PR DESCRIPTION
There is no method called **initialRoute** in the **navigationChannel**. In Kotlin should be called the **setInitialRoute**, passing the route as parameter as you can see below:

```
 public void setInitialRoute(@NonNull String initialRoute) {
    Log.v(TAG, "Sending message to set initial route to '" + initialRoute + "'");
    channel.invokeMethod("setInitialRoute", initialRoute);
  }
```