### PR TITLE
Enabled null safety in lists cookbook examples

### DIFF
--- a/src/docs/cookbook/lists/basic-list.md
+++ b/src/docs/cookbook/lists/basic-list.md
@@ -45,7 +45,7 @@ ListView(
 
 ## Interactive example
 
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
 import 'package:flutter/material.dart';
 
 void main() => runApp(MyApp());

--- a/src/docs/cookbook/lists/grid-lists.md
+++ b/src/docs/cookbook/lists/grid-lists.md
@@ -43,7 +43,7 @@ GridView.count(
 
 ## Interactive example
 
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/docs/cookbook/lists/horizontal-list.md
+++ b/src/docs/cookbook/lists/horizontal-list.md
@@ -51,7 +51,7 @@ ListView(
 
 ## Interactive example
 
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
 import 'package:flutter/material.dart';
 
 void main() => runApp(MyApp());


### PR DESCRIPTION
These pages required no code changes for enabling null safety on the dartpads. Made them in a single PR to avoid excessive noise.

cc. @sfshaza2 @RedBrogdon 