### PR TITLE
Remove mention of deleted messages

### DIFF
--- a/src/docs/development/ui/animations/overview.md
+++ b/src/docs/development/ui/animations/overview.md
@@ -260,8 +260,7 @@ itself.
 The animation controller can be given a lower and upper bound to
 animate between, and a duration.
 
-In the simple case (using `forward()`, `reverse()`, `play()`, or
-`resume()`), the animation controller simply does a linear
+In the simple case (using `forward()` or `reverse()`), the animation controller simply does a linear
 interpolation from the lower bound to the upper bound (or vice versa,
 for the reverse direction) over the given duration.
 


### PR DESCRIPTION
Remove mention of deleted messages from `AnimationController`.
`play()` and `resume()` was deleted in [this][1] commit.

[1]: https://github.com/flutter/flutter/commit/3bbeee7b540781ec3426a63a6094bcf9fdaf3527#diff-53e106ecf0f2ca5158f2dea5c0606e1a65b93662d1ecbcd09a292a36f172d823L125-L134