### PR TITLE
Migrate returning-data.md to null safety

### DIFF
--- a/null_safety_examples/cookbook/navigation/returning_data/lib/main.dart
+++ b/null_safety_examples/cookbook/navigation/returning_data/lib/main.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(
+    MaterialApp(
+      title: 'Returning Data',
+      home: HomeScreen(),
+    ),
+  );
+}
+
+class HomeScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Returning Data Demo'),
+      ),
+      body: Center(child: SelectionButton()),
+    );
+  }
+}
+
+class SelectionButton extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: () {
+        _navigateAndDisplaySelection(context);
+      },
+      child: Text('Pick an option, any option!'),
+    );
+  }
+
+  // #docregion navigateAndDisplay
+  // A method that launches the SelectionScreen and awaits the result from
+  // Navigator.pop.
+  _navigateAndDisplaySelection(BuildContext context) async {
+    // Navigator.push returns a Future that completes after calling
+    // Navigator.pop on the Selection Screen.
+    final result = await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (context) => SelectionScreen()),
+    );
+
+    // After the Selection Screen returns a result, hide any previous snackbars
+    // and show the new result.
+    ScaffoldMessenger.of(context)
+      ..removeCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text("$result")));
+  }
+  // #enddocregion navigateAndDisplay
+}
+
+class SelectionScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Pick an option'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              // #docregion Yep
+              child: ElevatedButton(
+                onPressed: () {
+                  // Close the screen and return "Yep!" as the result.
+                  Navigator.pop(context, 'Yep!');
+                },
+                child: Text('Yep!'),
+              ),
+              // #enddocregion Yep
+            ),
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              // #docregion Nope
+              child: ElevatedButton(
+                onPressed: () {
+                  // Close the screen and return "Nope." as the result.
+                  Navigator.pop(context, 'Nope.');
+                },
+                child: Text('Nope.'),
+              ),
+              // #enddocregion Nope
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/null_safety_examples/cookbook/navigation/returning_data/lib/main_step2.dart
+++ b/null_safety_examples/cookbook/navigation/returning_data/lib/main_step2.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+// ignore_for_file: unused_local_variable
+
+void main() {
+  runApp(
+    MaterialApp(
+      title: 'Returning Data',
+      home: HomeScreen(),
+    ),
+  );
+}
+
+// #docregion HomeScreen
+class HomeScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Returning Data Demo'),
+      ),
+      // Create the SelectionButton widget in the next step.
+      body: Center(child: SelectionButton()),
+    );
+  }
+}
+// #enddocregion HomeScreen
+
+// #docregion SelectionButton
+class SelectionButton extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: () {
+        _navigateAndDisplaySelection(context);
+      },
+      child: Text('Pick an option, any option!'),
+    );
+  }
+
+  _navigateAndDisplaySelection(BuildContext context) async {
+    // Navigator.push returns a Future that completes after calling
+    // Navigator.pop on the Selection Screen.
+    final result = await Navigator.push(
+      context,
+      // Create the SelectionScreen in the next step.
+      MaterialPageRoute(builder: (context) => SelectionScreen()),
+    );
+  }
+}
+// #enddocregion SelectionButton
+
+// #docregion SelectionScreen
+class SelectionScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Pick an option'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              // #docregion Yep
+              child: ElevatedButton(
+                onPressed: () {
+                  // Pop here with "Yep"...
+                },
+                child: Text('Yep!'),
+              ),
+              // #enddocregion Yep
+            ),
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              // #docregion Nope
+              child: ElevatedButton(
+                onPressed: () {
+                  // Pop here with "Nope"...
+                },
+                child: Text('Nope.'),
+              ),
+              // #enddocregion Nope
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+// #enddocregion SelectionScreen

--- a/null_safety_examples/cookbook/navigation/returning_data/pubspec.yaml
+++ b/null_safety_examples/cookbook/navigation/returning_data/pubspec.yaml
@@ -1,0 +1,12 @@
+name: returning_data
+description: Returning data
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/src/docs/cookbook/navigation/returning-data.md
+++ b/src/docs/cookbook/navigation/returning-data.md
@@ -12,6 +12,8 @@ js:
     url: https://dartpad.dev/inject_embed.dart.js
 ---
 
+<?code-excerpt path-base="../null_safety_examples/cookbook/navigation/returning_data/"?>
+
 In some cases, you might want to return data from a new screen.
 For example, say you push a new screen that presents two options to a user.
 When the user taps an option, you want to inform the first screen
@@ -31,7 +33,7 @@ method using the following steps:
 The home screen displays a button. When tapped,
 it launches the selection screen.
 
-<!-- skip -->
+<?code-excerpt "lib/main_step2.dart (HomeScreen)"?>
 ```dart
 class HomeScreen extends StatelessWidget {
   @override
@@ -54,7 +56,7 @@ Now, create the SelectionButton, which does the following:
   * Launches the SelectionScreen when it's tapped.
   * Waits for the SelectionScreen to return a result.
 
-<!-- skip -->
+<?code-excerpt "lib/main_step2.dart (SelectionButton)"?>
 ```dart
 class SelectionButton extends StatelessWidget {
   @override
@@ -67,8 +69,6 @@ class SelectionButton extends StatelessWidget {
     );
   }
 
-  // A method that launches the SelectionScreen and awaits the
-  // result from Navigator.pop.
   _navigateAndDisplaySelection(BuildContext context) async {
     // Navigator.push returns a Future that completes after calling
     // Navigator.pop on the Selection Screen.
@@ -91,6 +91,7 @@ screen know which button was tapped.
 This step defines the UI.
 The next step adds code to return data.
 
+<?code-excerpt "lib/main_step2.dart (SelectionScreen)"?>
 ```dart
 class SelectionScreen extends StatelessWidget {
   @override
@@ -116,7 +117,7 @@ class SelectionScreen extends StatelessWidget {
               padding: const EdgeInsets.all(8.0),
               child: ElevatedButton(
                 onPressed: () {
-                  // Pop here with "Nope"
+                  // Pop here with "Nope"...
                 },
                 child: Text('Nope.'),
               ),
@@ -139,28 +140,28 @@ Any result is returned to the `Future` in the SelectionButton.
 
 ### Yep button
 
-<!-- skip -->
+<?code-excerpt "lib/main.dart (Yep)" replace="/^child: //g;/,$//g"?>
 ```dart
 ElevatedButton(
   onPressed: () {
-    // The Yep button returns "Yep!" as the result.
+    // Close the screen and return "Yep!" as the result.
     Navigator.pop(context, 'Yep!');
   },
   child: Text('Yep!'),
-);
+)
 ```
 
 ### Nope button
 
-<!-- skip -->
+<?code-excerpt "lib/main.dart (Nope)" replace="/^child: //g;/,$//g"?>
 ```dart
 ElevatedButton(
   onPressed: () {
-    // The Nope button returns "Nope!" as the result.
-    Navigator.pop(context, 'Nope!');
+    // Close the screen and return "Nope." as the result.
+    Navigator.pop(context, 'Nope.');
   },
-  child: Text('Nope!'),
-);
+  child: Text('Nope.'),
+)
 ```
 
 ## 5. Show a snackbar on the home screen with the selection
@@ -171,9 +172,13 @@ you'll want to do something with the information that's returned.
 In this case, show a snackbar displaying the result by using the
 `_navigateAndDisplaySelection()` method in `SelectionButton`:
 
-<!-- skip -->
+<?code-excerpt "lib/main.dart (navigateAndDisplay)"?>
 ```dart
+// A method that launches the SelectionScreen and awaits the result from
+// Navigator.pop.
 _navigateAndDisplaySelection(BuildContext context) async {
+  // Navigator.push returns a Future that completes after calling
+  // Navigator.pop on the Selection Screen.
   final result = await Navigator.push(
     context,
     MaterialPageRoute(builder: (context) => SelectionScreen()),
@@ -189,14 +194,17 @@ _navigateAndDisplaySelection(BuildContext context) async {
 
 ## Interactive example
 
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+<?code-excerpt "lib/main.dart"?>
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(MaterialApp(
-    title: 'Returning Data',
-    home: HomeScreen(),
-  ));
+  runApp(
+    MaterialApp(
+      title: 'Returning Data',
+      home: HomeScreen(),
+    ),
+  );
 }
 
 class HomeScreen extends StatelessWidget {
@@ -265,7 +273,7 @@ class SelectionScreen extends StatelessWidget {
               padding: const EdgeInsets.all(8.0),
               child: ElevatedButton(
                 onPressed: () {
-                  // Close the screen and return "Nope!" as the result.
+                  // Close the screen and return "Nope." as the result.
                   Navigator.pop(context, 'Nope.');
                 },
                 child: Text('Nope.'),


### PR DESCRIPTION
Moved samples to external project and enabled null safety on dart pad.

cc. @sfshaza2 @RedBrogdon 