### PR TITLE
Migrate delete-data.md to null safety

### DIFF
--- a/null_safety_examples/cookbook/networking/delete_data/lib/main.dart
+++ b/null_safety_examples/cookbook/networking/delete_data/lib/main.dart
@@ -1,0 +1,126 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+Future<Album> fetchAlbum() async {
+  final response = await http.get(
+    Uri.parse('https://jsonplaceholder.typicode.com/albums/1'),
+  );
+
+  if (response.statusCode == 200) {
+    // If the server did return a 200 OK response, then parse the JSON.
+    return Album.fromJson(jsonDecode(response.body));
+  } else {
+    // If the server did not return a 200 OK response, then throw an exception.
+    throw Exception('Failed to load album');
+  }
+}
+
+Future<Album> deleteAlbum(String id) async {
+  final http.Response response = await http.delete(
+    Uri.parse('https://jsonplaceholder.typicode.com/albums/$id'),
+    headers: <String, String>{
+      'Content-Type': 'application/json; charset=UTF-8',
+    },
+  );
+
+  if (response.statusCode == 200) {
+    // If the server did return a 200 OK response,
+    // then parse the JSON. After deleting,
+    // you'll get an empty JSON `{}` response.
+    // Don't return `null`, otherwise `snapshot.hasData`
+    // will always return false on `FutureBuilder`.
+    return Album.fromJson(jsonDecode(response.body));
+  } else {
+    // If the server did not return a "200 OK response",
+    // then throw an exception.
+    throw Exception('Failed to delete album.');
+  }
+}
+
+class Album {
+  final int id;
+  final String title;
+
+  Album({required this.id, required this.title});
+
+  factory Album.fromJson(Map<String, dynamic> json) {
+    return Album(
+      id: json['id'],
+      title: json['title'],
+    );
+  }
+}
+
+void main() {
+  runApp(MyApp());
+}
+
+class MyApp extends StatefulWidget {
+  MyApp({Key? key}) : super(key: key);
+
+  @override
+  _MyAppState createState() {
+    return _MyAppState();
+  }
+}
+
+class _MyAppState extends State<MyApp> {
+  late Future<Album> _futureAlbum;
+
+  @override
+  void initState() {
+    super.initState();
+    _futureAlbum = fetchAlbum();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Delete Data Example',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: Scaffold(
+        appBar: AppBar(
+          title: Text('Delete Data Example'),
+        ),
+        body: Center(
+          child: FutureBuilder<Album>(
+            future: _futureAlbum,
+            builder: (context, snapshot) {
+              // If the connection is done,
+              // check for response data or an error.
+              if (snapshot.connectionState == ConnectionState.done) {
+                if (snapshot.hasData) {
+                  return Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      Text('${snapshot.data?.title ?? 'Deleted'}'),
+                      ElevatedButton(
+                        child: Text('Delete Data'),
+                        onPressed: () {
+                          setState(() {
+                            _futureAlbum =
+                                deleteAlbum(snapshot.data.id.toString());
+                          });
+                        },
+                      ),
+                    ],
+                  );
+                } else if (snapshot.hasError) {
+                  return Text("${snapshot.error}");
+                }
+              }
+
+              // By default, show a loading spinner.
+              return CircularProgressIndicator();
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/null_safety_examples/cookbook/networking/delete_data/lib/main.dart
+++ b/null_safety_examples/cookbook/networking/delete_data/lib/main.dart
@@ -18,6 +18,7 @@ Future<Album> fetchAlbum() async {
   }
 }
 
+// #docregion deleteAlbum
 Future<Album> deleteAlbum(String id) async {
   final http.Response response = await http.delete(
     Uri.parse('https://jsonplaceholder.typicode.com/albums/$id'),
@@ -39,12 +40,13 @@ Future<Album> deleteAlbum(String id) async {
     throw Exception('Failed to delete album.');
   }
 }
+// #enddocregion deleteAlbum
 
 class Album {
-  final int id;
-  final String title;
+  final int? id;
+  final String? title;
 
-  Album({required this.id, required this.title});
+  Album({this.id, this.title});
 
   factory Album.fromJson(Map<String, dynamic> json) {
     return Album(
@@ -95,6 +97,7 @@ class _MyAppState extends State<MyApp> {
               // check for response data or an error.
               if (snapshot.connectionState == ConnectionState.done) {
                 if (snapshot.hasData) {
+                  // #docregion Column
                   return Column(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: <Widget>[
@@ -104,12 +107,13 @@ class _MyAppState extends State<MyApp> {
                         onPressed: () {
                           setState(() {
                             _futureAlbum =
-                                deleteAlbum(snapshot.data.id.toString());
+                                deleteAlbum(snapshot.data!.id.toString());
                           });
                         },
                       ),
                     ],
                   );
+                  // #enddocregion Column
                 } else if (snapshot.hasError) {
                   return Text("${snapshot.error}");
                 }

--- a/null_safety_examples/cookbook/networking/delete_data/lib/main_step1.dart
+++ b/null_safety_examples/cookbook/networking/delete_data/lib/main_step1.dart
@@ -1,0 +1,16 @@
+import 'dart:async';
+
+import 'package:http/http.dart' as http;
+
+// #docregion deleteAlbum
+Future<http.Response> deleteAlbum(String id) async {
+  final http.Response response = await http.delete(
+    Uri.parse('https://jsonplaceholder.typicode.com/albums/$id'),
+    headers: <String, String>{
+      'Content-Type': 'application/json; charset=UTF-8',
+    },
+  );
+
+  return response;
+}
+// #enddocregion deleteAlbum

--- a/null_safety_examples/cookbook/networking/delete_data/pubspec.yaml
+++ b/null_safety_examples/cookbook/networking/delete_data/pubspec.yaml
@@ -1,0 +1,13 @@
+name: delete_data
+description: Delete Data
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^0.13.3
+
+flutter:
+  uses-material-design: true

--- a/src/docs/cookbook/networking/delete-data.md
+++ b/src/docs/cookbook/networking/delete-data.md
@@ -49,7 +49,7 @@ use something you already know, for example `id = 1`.
 
 <?code-excerpt "lib/main_step1.dart (deleteAlbum)"?>
 ```dart
-Future<Response> deleteAlbum(String id) async {
+Future<http.Response> deleteAlbum(String id) async {
   final http.Response response = await http.delete(
     Uri.parse('https://jsonplaceholder.typicode.com/albums/$id'),
     headers: <String, String>{
@@ -80,7 +80,7 @@ using the `http.get()` method, and display it in the screen.
 You should now have a **Delete Data** button that,
 when pressed, calls the `deleteAlbum()` method.
 
-<?code-excerpt "lib/main.dart (Column)"?>
+<?code-excerpt "lib/main.dart (Column)" replace="/return //g"?>
 ```dart
 Column(
   mainAxisAlignment: MainAxisAlignment.center,
@@ -89,9 +89,10 @@ Column(
     ElevatedButton(
       child: Text('Delete Data'),
       onPressed: () {
-       setState(() {
-        _futureAlbum = deleteAlbum(snapshot.data.id.toString());
-      });
+        setState(() {
+          _futureAlbum =
+              deleteAlbum(snapshot.data!.id.toString());
+        });
       },
     ),
   ],
@@ -119,14 +120,15 @@ Future<Album> deleteAlbum(String id) async {
   );
 
   if (response.statusCode == 200) {
-    // If the server returned a 200 OK response,
+    // If the server did return a 200 OK response,
     // then parse the JSON. After deleting,
     // you'll get an empty JSON `{}` response.
-    // Don't return `null`, otherwise
-    // `snapshot.hasData` will always return false
-    // on `FutureBuilder`.
+    // Don't return `null`, otherwise `snapshot.hasData`
+    // will always return false on `FutureBuilder`.
     return Album.fromJson(jsonDecode(response.body));
   } else {
+    // If the server did not return a "200 OK response",
+    // then throw an exception.
     throw Exception('Failed to delete album.');
   }
 }
@@ -189,8 +191,8 @@ Future<Album> deleteAlbum(String id) async {
 }
 
 class Album {
-  final int id;
-  final String title;
+  final int? id;
+  final String? title;
 
   Album({this.id, this.title});
 
@@ -207,7 +209,7 @@ void main() {
 }
 
 class MyApp extends StatefulWidget {
-  MyApp({Key key}) : super(key: key);
+  MyApp({Key? key}) : super(key: key);
 
   @override
   _MyAppState createState() {
@@ -216,7 +218,7 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  Future<Album> _futureAlbum;
+  late Future<Album> _futureAlbum;
 
   @override
   void initState() {
@@ -252,7 +254,7 @@ class _MyAppState extends State<MyApp> {
                         onPressed: () {
                           setState(() {
                             _futureAlbum =
-                                deleteAlbum(snapshot.data.id.toString());
+                                deleteAlbum(snapshot.data!.id.toString());
                           });
                         },
                       ),

--- a/src/docs/cookbook/networking/delete-data.md
+++ b/src/docs/cookbook/networking/delete-data.md
@@ -9,6 +9,8 @@ next:
   path: /docs/cookbook/networking/fetch-data
 ---
 
+<?code-excerpt path-base="../null_safety_examples/cookbook/networking/delete_data/"?>
+
 This recipe covers how to delete data over
 the internet using the `http` package.
 
@@ -45,7 +47,7 @@ Note that this requires the `id` of the album that
 you want to delete. For this example,
 use something you already know, for example `id = 1`.
 
-<!-- skip -->
+<?code-excerpt "lib/main_step1.dart (deleteAlbum)"?>
 ```dart
 Future<Response> deleteAlbum(String id) async {
   final http.Response response = await http.delete(
@@ -78,7 +80,7 @@ using the `http.get()` method, and display it in the screen.
 You should now have a **Delete Data** button that,
 when pressed, calls the `deleteAlbum()` method.
 
-<!-- skip -->
+<?code-excerpt "lib/main.dart (Column)"?>
 ```dart
 Column(
   mainAxisAlignment: MainAxisAlignment.center,
@@ -106,7 +108,7 @@ Once the delete request has been made,
 you can return a response from the `deleteAlbum()`
 method to notify our screen that the data has been deleted.
 
-<!-- skip -->
+<?code-excerpt "lib/main.dart (deleteAlbum)"?>
 ```dart
 Future<Album> deleteAlbum(String id) async {
   final http.Response response = await http.delete(
@@ -142,6 +144,7 @@ Now you've got a function that deletes the data from the internet.
 
 ## Complete example
 
+<?code-excerpt "lib/main.dart"?>
 ```dart
 import 'dart:async';
 import 'dart:convert';


### PR DESCRIPTION
Migrated page to null safety.

I am not super convinced about the original solution which relied on having the Album attributes as null to show it as deleted, but I decided to not to change that now. 
