### PR TITLE
Hide Excess Description on Widget Cards

### DIFF
--- a/src/_includes/catalogpage.html
+++ b/src/_includes/catalogpage.html
@@ -28,7 +28,7 @@
                     </a>
                     <div class="card-body">
                         <a href="{{comp.link}}"><header class="card-title">{{comp.name}}</header></a>
-                        <p class="card-text">{{comp.description}}</p>
+                        <p class="card-text">{{comp.description | truncatewords: 25}}</p>
                     </div>
                 </div>
             {% endif %}
@@ -50,7 +50,7 @@
                                 </a>
                                 <div class="card-body">
                                     <a href="{{comp.link}}"><header class="card-title">{{comp.name}}</header></a>
-                                    <p class="card-text">{{comp.description}}</p>
+                                    <p class="card-text">{{comp.description | truncatewords: 25}}</p>
                                 </div>
                             </div>
                         {% endif %}

--- a/src/_includes/catalogpage.html
+++ b/src/_includes/catalogpage.html
@@ -28,7 +28,7 @@
                     </a>
                     <div class="card-body">
                         <a href="{{comp.link}}"><header class="card-title">{{comp.name}}</header></a>
-                        <p class="card-text">{{comp.description | truncatewords: 25}}</p>
+                        <p class="card-text">{{ comp.description | truncatewords: 25 }}</p>
                     </div>
                 </div>
             {% endif %}
@@ -50,7 +50,7 @@
                                 </a>
                                 <div class="card-body">
                                     <a href="{{comp.link}}"><header class="card-title">{{comp.name}}</header></a>
-                                    <p class="card-text">{{comp.description | truncatewords: 25}}</p>
+                                    <p class="card-text">{{ comp.description | truncatewords: 25 }}</p>
                                 </div>
                             </div>
                         {% endif %}

--- a/src/docs/reference/widgets.md
+++ b/src/docs/reference/widgets.md
@@ -28,7 +28,7 @@ our [videos](/docs/resources/videos) page.
         </a>
         <div class="card-body">
             <a href="{{comp.link}}"><header class="card-title">{{comp.name}}</header></a>
-            <p class="card-text">{{comp.description}}</p>
+            <p class="card-text">{{comp.description | truncatewords: 25}}</p>
         </div>
     </div>
 {% endfor %}

--- a/src/docs/reference/widgets.md
+++ b/src/docs/reference/widgets.md
@@ -28,7 +28,7 @@ our [videos](/docs/resources/videos) page.
         </a>
         <div class="card-body">
             <a href="{{comp.link}}"><header class="card-title">{{comp.name}}</header></a>
-            <p class="card-text">{{comp.description | truncatewords: 25}}</p>
+            <p class="card-text">{{ comp.description | truncatewords: 25 }}</p>
         </div>
     </div>
 {% endfor %}


### PR DESCRIPTION
Fully resolves #1495
Truncates description of Widget card descriptions at 25 words. This is my first time working with Liquid so hopefully this works. 