### PR TITLE
Update navigate-with-arguments.md

### DIFF
--- a/src/docs/cookbook/navigation/navigate-with-arguments.md
+++ b/src/docs/cookbook/navigation/navigate-with-arguments.md
@@ -77,7 +77,7 @@ class ExtractArgumentsScreen extends StatelessWidget {
     // Extract the arguments from the current ModalRoute
     // settings and cast them as ScreenArguments.
     final ScreenArguments args =
-        ModalRoute.of(context)!.settings.arguments as ScreenArguments;
+        ModalRoute.of(context)?.settings.arguments as ScreenArguments;
 
     return Scaffold(
       appBar: AppBar(


### PR DESCRIPTION
!. in dart is not a thing. 

I'm sure the original author meant ?. to create null-aware access here.