### PR TITLE
Migrate to null safety

### DIFF
--- a/src/docs/get-started/codelab-web.md
+++ b/src/docs/get-started/codelab-web.md
@@ -713,7 +713,7 @@ class AnimatedProgressIndicator extends StatefulWidget {
   final double value;
 
   AnimatedProgressIndicator({
-    @required this.value,
+    required this.value,
   });
 
   @override


### PR DESCRIPTION
I followed the instruction and got the following error.

```
> flutter run -d chrome
Launching lib\main.dart on Chrome in debug mode...
lib/main.dart:135:20: Error: The parameter 'value' can't have a value of 'null' because of its type 'double', but theimplicit default value is 'null'.
Try adding either an explicit non-'null' default value or the 'required' modifier.
    @required this.value,
                   ^^^^^
Waiting for connection from debug service on Chrome...             17.1s
Failed to compile application.
```

This modification solved this error.