### PR TITLE
Changed order to match VS Code Steps

### DIFF
--- a/src/docs/get-started/test-drive/_vscode.md
+++ b/src/docs/get-started/test-drive/_vscode.md
@@ -4,8 +4,8 @@
 
   1. Invoke **View > Command Palette**.
   1. Type "flutter", and select the **Flutter: New Application Project**.
-  1. Enter a project name, such as `myapp`, and press **Enter**.
   1. Create or select the parent directory for the new project folder.
+  1. Enter a project name, such as `myapp`, and press **Enter**.
   1. Wait for project creation to complete and the `main.dart`
      file to appear.
 


### PR DESCRIPTION
I was following the [guide](https://flutter.dev/docs/get-started/test-drive?tab=vscode#create-app) to create my first app using VS Code and I noticed that the order of some steps were switched.

This PR attends to set the order that VS Code actually followed.