### PR TITLE
Update url-strategies.md

### DIFF
--- a/src/docs/development/ui/navigation/url-strategies.md
+++ b/src/docs/development/ui/navigation/url-strategies.md
@@ -90,7 +90,7 @@ Update the `<base href="/">` tag in `web/index.html`
 to the path where your app is hosted.
 For example, to host your Flutter app at
 `myapp.dev/flutter_app`, change
-this tag to `<base href="/flutter_app">`.
+this tag to `<base href="/flutter_app/">`.
 
 
 [hash fragment]: https://en.wikipedia.org/wiki/Uniform_Resource_Locator#Syntax


### PR DESCRIPTION
Regarding [<base>: The Document Base URL element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base#examples) the base href has to end with a "/".