### PR TITLE
Add stable channel null-safety code check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,10 @@ jobs:
             sdk: stable
             task: tool/check-code.sh
             experimental: false
+          - name: "Stable channel: null safety code check"
+            sdk: stable
+            task: tool/check-code.sh --null-safety
+            experimental: false
           - name: "Stable channel: jekyll build"
             sdk: stable
             task: bundle exec jekyll build


### PR DESCRIPTION
Issue described in #5782

430d75c commit will fail the job because the following examples need to be corrected.

- null_safety_examples/cookbook/animation/page_route_animation
- null_safety_examples/cookbook/animation/physics_simulation
- null_safety_examples/cookbook/networking/fetch_data
- null_safety_examples/cookbook/persistence/reading_writing_files