### PR TITLE
Add desktop folders to gitignore

### DIFF
--- a/examples/_animation/.gitignore
+++ b/examples/_animation/.gitignore
@@ -4,5 +4,9 @@ pubspec.lock
 */**/android
 */**/ios
 */**/web
+*/**/linux
+*/**/macos
+*/**/windows
+*/**/winuwp
 */**/.gitignore
 */**/.metadata

--- a/examples/animation/.gitignore
+++ b/examples/animation/.gitignore
@@ -4,5 +4,9 @@ pubspec.lock
 */**/android
 */**/ios
 */**/web
+*/**/linux
+*/**/macos
+*/**/windows
+*/**/winuwp
 */**/.gitignore
 */**/.metadata

--- a/examples/layout/.gitignore
+++ b/examples/layout/.gitignore
@@ -4,5 +4,9 @@ pubspec.lock
 */**/android
 */**/ios
 */**/web
+*/**/linux
+*/**/macos
+*/**/windows
+*/**/winuwp
 */**/.gitignore
 */**/.metadata

--- a/examples/state_mgmt/.gitignore
+++ b/examples/state_mgmt/.gitignore
@@ -4,5 +4,9 @@ pubspec.lock
 */**/android
 */**/ios
 */**/web
+*/**/linux
+*/**/macos
+*/**/windows
+*/**/winuwp
 */**/.gitignore
 */**/.metadata

--- a/null_safety_examples/_animation/.gitignore
+++ b/null_safety_examples/_animation/.gitignore
@@ -4,5 +4,9 @@ pubspec.lock
 */**/android
 */**/ios
 */**/web
+*/**/linux
+*/**/macos
+*/**/windows
+*/**/winuwp
 */**/.gitignore
 */**/.metadata

--- a/null_safety_examples/animation/.gitignore
+++ b/null_safety_examples/animation/.gitignore
@@ -4,5 +4,9 @@ pubspec.lock
 */**/android
 */**/ios
 */**/web
+*/**/linux
+*/**/macos
+*/**/windows
+*/**/winuwp
 */**/.gitignore
 */**/.metadata

--- a/null_safety_examples/codelabs/add_flutter_to_android_app/.gitignore
+++ b/null_safety_examples/codelabs/add_flutter_to_android_app/.gitignore
@@ -11,3 +11,15 @@
 /build
 /captures
 .externalNativeBuild
+
+pubspec.lock
+
+*/**/android
+*/**/ios
+*/**/web
+*/**/linux
+*/**/macos
+*/**/windows
+*/**/winuwp
+*/**/.gitignore
+*/**/.metadata

--- a/null_safety_examples/cookbook/.gitignore
+++ b/null_safety_examples/cookbook/.gitignore
@@ -6,5 +6,7 @@ pubspec.lock
 */**/web
 */**/linux
 */**/macos
+*/**/windows
+*/**/winuwp
 */**/.gitignore
 */**/.metadata

--- a/null_safety_examples/internationalization/.gitignore
+++ b/null_safety_examples/internationalization/.gitignore
@@ -4,5 +4,9 @@ pubspec.lock
 */**/android
 */**/ios
 */**/web
+*/**/linux
+*/**/macos
+*/**/windows
+*/**/winuwp
 */**/.gitignore
 */**/.metadata

--- a/null_safety_examples/layout/.gitignore
+++ b/null_safety_examples/layout/.gitignore
@@ -4,5 +4,9 @@ pubspec.lock
 */**/android
 */**/ios
 */**/web
+*/**/linux
+*/**/macos
+*/**/windows
+*/**/winuwp
 */**/.gitignore
 */**/.metadata

--- a/null_safety_examples/state_mgmt/.gitignore
+++ b/null_safety_examples/state_mgmt/.gitignore
@@ -4,5 +4,9 @@ pubspec.lock
 */**/android
 */**/ios
 */**/web
+*/**/linux
+*/**/macos
+*/**/windows
+*/**/winuwp
 */**/.gitignore
 */**/.metadata


### PR DESCRIPTION
If the desktop support is enabled from `flutter config` then running `tool/code-check.sh` and `tool/code-check.sh --null-safety` creates desktop related folders for `examples/` and `null_safety_examples/`.
These desktop related folders can be ignored at the moment.