### PR TITLE
Fix formatting typo in Deferred Components docs

### DIFF
--- a/src/docs/perf/deferred-components.md
+++ b/src/docs/perf/deferred-components.md
@@ -366,7 +366,6 @@ The validator also checks for the following in the
   <string name="boxComponentName">boxComponent</string>
 </resources>
 ```
-<li>
 
 <li markdown="1">**`<projectDir>/android/<componentName>`**<br>
     An Android dynamic feature module for


### PR DESCRIPTION
Extra bullet point was messing with formatting.