### PR TITLE
Fix typo for real in deferred-components.md

### DIFF
--- a/src/docs/perf/deferred-components.md
+++ b/src/docs/perf/deferred-components.md
@@ -366,6 +366,7 @@ The validator also checks for the following in the
   <string name="boxComponentName">boxComponent</string>
 </resources>
 ```
+</li>
 
 <li markdown="1">**`<projectDir>/android/<componentName>`**<br>
     An Android dynamic feature module for


### PR DESCRIPTION
Turns out https://github.com/flutter/website/pull/5809 was not the proper fix. The issue was a missing `/` in `</li>`.