### PR TITLE
Add short link for flutter lints migration guide

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -252,7 +252,8 @@
       { "source": "/go/sliver-workshop", "destination": "https://dartpad.dev/workshops.html?webserver=https://dartpad-workshops-io2021.web.app/getting_started_with_slivers", "type": 301 },
       { "source": "/go/inheritedwidget-workshop", "destination": "https://dartpad.dev/workshops.html?webserver=https://dartpad-workshops-io2021.web.app/inherited_widget", "type": 301 },
       { "source": "/go/federated-platforms", "destination": "https://docs.google.com/document/d/1z_4Z5JMTbk5c4FpayVAb-PTz2wLP-aSCirbieavT3Ws/edit?usp=sharing", "type": 301 },
-
+      { "source": "/go/lints-migration", "destination": "/docs/release/breaking-changes/flutter-lints-package", "type": 301 },
+      
       { "source": "/hot-reload", "destination": "/docs/development/tools/hot-reload", "type": 301 },
       { "source": "/ide-setup", "destination": "/docs/get-started/editor", "type": 301 },
       { "source": "/images/intellij/hot-reload.gif", "destination": "https://raw.githubusercontent.com/flutter/website/master/src/_assets/image/tools/android-studio/hot-reload.gif", "type": 301 },


### PR DESCRIPTION
To reference it in tool deprecation notices to nudge people to migrate.