### PR TITLE
Prefer using Uri.parse instead of Uri.http/Uri.https

### DIFF
--- a/null_safety_examples/cookbook/networking/fetch_data/lib/main.dart
+++ b/null_safety_examples/cookbook/networking/fetch_data/lib/main.dart
@@ -7,7 +7,7 @@ import 'package:http/http.dart' as http;
 // #docregion fetchAlbum
 Future<Album> fetchAlbum() async {
   final response =
-      await http.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
+      await http.get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1'));
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response,

--- a/null_safety_examples/cookbook/networking/fetch_data/lib/main_step1.dart
+++ b/null_safety_examples/cookbook/networking/fetch_data/lib/main_step1.dart
@@ -4,6 +4,6 @@ import 'package:http/http.dart' as http;
 
 // #docregion fetchAlbum
 Future<http.Response> fetchAlbum() {
-  return http.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
+  return http.get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1'));
 }
 // #enddocregion fetchAlbum

--- a/null_safety_examples/cookbook/networking/send_data/lib/main.dart
+++ b/null_safety_examples/cookbook/networking/send_data/lib/main.dart
@@ -7,7 +7,7 @@ import 'package:http/http.dart' as http;
 // #docregion createAlbum
 Future<Album> createAlbum(String title) async {
   final response = await http.post(
-    Uri.https('jsonplaceholder.typicode.com', 'albums'),
+    Uri.parse('https://jsonplaceholder.typicode.com/albums'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },

--- a/null_safety_examples/cookbook/testing/unit/mocking/lib/main.dart
+++ b/null_safety_examples/cookbook/testing/unit/mocking/lib/main.dart
@@ -7,7 +7,7 @@ import 'package:http/http.dart' as http;
 // #docregion fetchAlbum
 Future<Album> fetchAlbum(http.Client client) async {
   final response =
-      await client.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
+      await client.get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1'));
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response,

--- a/null_safety_examples/cookbook/testing/unit/mocking/test/fetch_album_test.dart
+++ b/null_safety_examples/cookbook/testing/unit/mocking/test/fetch_album_test.dart
@@ -18,7 +18,7 @@ void main() {
 
       // Use Mockito to return a successful response when it calls the
       // provided http.Client.
-      when(client.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1')))
+      when(client.get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1')))
           .thenAnswer((_) async => http.Response('{"userId": 1, "id": 2, "title": "mock"}', 200));
 
       expect(await fetchAlbum(client), isA<Album>());
@@ -29,7 +29,7 @@ void main() {
 
       // Use Mockito to return an unsuccessful response when it calls the
       // provided http.Client.
-      when(client.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1')))
+      when(client.get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1')))
           .thenAnswer((_) async => http.Response('Not Found', 404));
 
       expect(fetchAlbum(client), throwsException);

--- a/src/docs/cookbook/networking/fetch-data.md
+++ b/src/docs/cookbook/networking/fetch-data.md
@@ -61,7 +61,7 @@ This recipe covers how to fetch a sample album from the
 <?code-excerpt "lib/main_step1.dart (fetchAlbum)"?>
 ```dart
 Future<http.Response> fetchAlbum() {
-  return http.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
+  return http.get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1'));
 }
 ```
 
@@ -134,7 +134,7 @@ function to return a `Future<Album>`:
 ```dart
 Future<Album> fetchAlbum() async {
   final response =
-      await http.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
+      await http.get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1'));
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response,
@@ -252,7 +252,7 @@ import 'package:http/http.dart' as http;
 
 Future<Album> fetchAlbum() async {
   final response =
-      await http.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
+      await http.get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1'));
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response,
@@ -349,4 +349,3 @@ class _MyAppState extends State<MyApp> {
 [Mock dependencies using Mockito]: /docs/cookbook/testing/unit/mocking
 [JSON and serialization]: /docs/development/data-and-backend/json
 [`State`]: {{site.api}}/flutter/widgets/State-class.html
-

--- a/src/docs/cookbook/networking/send-data.md
+++ b/src/docs/cookbook/networking/send-data.md
@@ -58,7 +58,7 @@ by sending an album title to the
 ```dart
 Future<http.Response> createAlbum(String title) {
   return http.post(
-    Uri.https('jsonplaceholder.typicode.com', 'albums'),
+    Uri.parse('https://jsonplaceholder.typicode.com/albums'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },
@@ -135,7 +135,7 @@ function to return a `Future<Album>`:
 ```dart
 Future<Album> createAlbum(String title) async {
   final response = await http.post(
-    Uri.https('jsonplaceholder.typicode.com', 'albums'),
+    Uri.parse('https://jsonplaceholder.typicode.com/albums'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },
@@ -244,7 +244,7 @@ import 'package:http/http.dart' as http;
 
 Future<Album> createAlbum(String title) async {
   final response = await http.post(
-    Uri.https('jsonplaceholder.typicode.com', 'albums'),
+    Uri.parse('https://jsonplaceholder.typicode.com/albums'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },

--- a/src/docs/cookbook/testing/unit/mocking.md
+++ b/src/docs/cookbook/testing/unit/mocking.md
@@ -84,7 +84,7 @@ The function should now look like this:
 ```dart
 Future<Album> fetchAlbum(http.Client client) async {
   final response =
-      await client.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
+      await client.get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1'));
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response,
@@ -174,7 +174,7 @@ void main() {
 
       // Use Mockito to return a successful response when it calls the
       // provided http.Client.
-      when(client.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1')))
+      when(client.get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1')))
           .thenAnswer((_) async => http.Response('{"userId": 1, "id": 2, "title": "mock"}', 200));
 
       expect(await fetchAlbum(client), isA<Album>());
@@ -185,7 +185,7 @@ void main() {
 
       // Use Mockito to return an unsuccessful response when it calls the
       // provided http.Client.
-      when(client.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1')))
+      when(client.get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1')))
           .thenAnswer((_) async => http.Response('Not Found', 404));
 
       expect(fetchAlbum(client), throwsException);
@@ -220,7 +220,7 @@ import 'package:http/http.dart' as http;
 
 Future<Album> fetchAlbum(http.Client client) async {
   final response =
-      await client.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
+      await client.get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1'));
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response,
@@ -321,7 +321,7 @@ void main() {
 
       // Use Mockito to return a successful response when it calls the
       // provided http.Client.
-      when(client.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1')))
+      when(client.get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1')))
           .thenAnswer((_) async => http.Response('{"userId": 1, "id": 2, "title": "mock"}', 200));
 
       expect(await fetchAlbum(client), isA<Album>());
@@ -332,7 +332,7 @@ void main() {
 
       // Use Mockito to return an unsuccessful response when it calls the
       // provided http.Client.
-      when(client.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1')))
+      when(client.get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1')))
           .thenAnswer((_) async => http.Response('Not Found', 404));
 
       expect(fetchAlbum(client), throwsException);

--- a/src/docs/get-started/flutter-for/react-native-devs.md
+++ b/src/docs/get-started/flutter-for/react-native-devs.md
@@ -2002,7 +2002,7 @@ GET, POST, PUT, and DELETE.
 <!-- skip -->
 ```dart
 // Flutter
-final url = Uri.https('httpbin.org', 'ip');
+final url = Uri.parse('https://httpbin.org/ip');
 final httpClient = HttpClient();
 _getIPAddress() async {
   var request = await httpClient.getUrl(url);


### PR DESCRIPTION
Using `Uri.http`/`Uri.https` are *much* more error-prone than using
`Uri.parse`, and judging from various StackOverflow questions, quite
a number of people either misunderstand how to use them or would have
avoided their problem by using `Uri.parse`.  Examples:

* https://stackoverflow.com/q/66619895/
* https://stackoverflow.com/a/66608366/
* https://stackoverflow.com/q/67535694/
* https://stackoverflow.com/q/67628555/
* https://stackoverflow.com/q/67451865/

IMO, we should advocate using `Uri.parse` when possible, particularly
in tutorials, where using `Uri.http`/`Uri.https` directly is a
premature optimization.