### PR TITLE
Fix links to internationalization example

### DIFF
--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -202,7 +202,7 @@ project called `l10n.yaml` with the following content:
 6. Now, run your app so that codegen takes place. You should see generated files in
    `${FLUTTER_PROJECT}/.dart_tool/flutter_gen/gen_l10n`.
 
-7. Add the import statement on `app_localizations.dart` and `AppLocalizations.delegate` 
+7. Add the import statement on `app_localizations.dart` and `AppLocalizations.delegate`
    in your call to the constructor for `MaterialApp`.
 
    <?code-excerpt "gen_l10n_example/lib/main.dart (AppLocalizationsImport)"?>
@@ -230,7 +230,7 @@ project called `l10n.yaml` with the following content:
      home: MyHomePage(),
    );
    ```
-   
+
 8. Use AppLocalizations anywhere in your app.
    Here, the translated message is used in a Text widget.
 
@@ -238,7 +238,7 @@ project called `l10n.yaml` with the following content:
    ```dart
    Text(AppLocalizations.of(context)!.helloWorld);
    ```
-   
+
 9. You can also use the generated `localizationsDelegates` and `supportedLocales` list
    instead of providing them manually.
 
@@ -840,15 +840,15 @@ Rebuilding `l10n/messages_all.dart` requires two steps.
     to load the localized messages and `Intl.message()` to look them up.
 
 [78 languages]: {{site.api}}/flutter/flutter_localizations/GlobalMaterialLocalizations-class.html
-[`add_language`]: {{site.github}}/flutter/website/tree/master/examples/internationalization/add_language/lib/main.dart
+[`add_language`]: {{site.github}}/flutter/website/tree/master/null_safety_examples/internationalization/add_language/lib/main.dart
 [An alternative class for the app's localized resources]: #alternative-class
-[an example]: {{site.github}}/flutter/website/tree/master/examples/internationalization/minimal
-[`intl_example`]: {{site.github}}/flutter/website/tree/master/examples/internationalization/intl_example
-[`gen_l10n_example`]: {{site.github}}/flutter/website/tree/master/examples/internationalization/gen_l10n_example
+[an example]: {{site.github}}/flutter/website/tree/master/null_safety_examples/internationalization/minimal
+[`intl_example`]: {{site.github}}/flutter/website/tree/master/null_safety_examples/internationalization/intl_example
+[`gen_l10n_example`]: {{site.github}}/flutter/website/tree/master/null_safety_examples/internationalization/gen_l10n_example
 [flutter_localizations README]: {{site.github}}/flutter/flutter/blob/master/packages/flutter_localizations/lib/src/l10n/README.md
 [`GlobalMaterialLocalizations`]: {{site.api}}/flutter/flutter_localizations/GlobalMaterialLocalizations-class.html
 [`InheritedWidget`]: {{site.api}}/flutter/widgets/InheritedWidget-class.html
-[Internationalization based on the `intl` package]: {{site.github}}/flutter/website/tree/master/examples/internationalization/intl_example
+[Internationalization based on the `intl` package]: {{site.github}}/flutter/website/tree/master/null_safety_examples/internationalization/intl_example
 [Internationalization User's Guide]: /go/i18n-user-guide
 [`intl`]: {{site.pub-pkg}}/intl
 [`intl` tool]: #dart-tools
@@ -864,8 +864,8 @@ Rebuilding `l10n/messages_all.dart` requires two steps.
 [`MaterialApp`]: {{site.api}}/flutter/material/MaterialApp-class.html
 [`MaterialApp.onGenerateTitle`]: {{site.api}}/flutter/material/MaterialApp/onGenerateTitle.html
 [`MaterialLocalizations`]: {{site.api}}/flutter/material/MaterialLocalizations-class.html
-[`minimal`]: {{site.github}}/flutter/website/tree/master/examples/internationalization/minimal
-[Minimal internationalization]: {{site.github}}/flutter/website/tree/master/examples/internationalization/minimal
+[`minimal`]: {{site.github}}/flutter/website/tree/master/null_safety_examples/internationalization/minimal
+[Minimal internationalization]: {{site.github}}/flutter/website/tree/master/null_safety_examples/internationalization/minimal
 [Setting up an internationalized app]: #setting-up
 [`SynchronousFuture`]: {{site.api}}/flutter/foundation/SynchronousFuture-class.html
 [`supportedLocales`]: {{site.api}}/flutter/material/MaterialApp/supportedLocales.html


### PR DESCRIPTION
The example was removed from its old location in https://github.com/flutter/website/pull/5819, but is still referenced on https://flutter.dev/docs/development/accessibility-and-localization/internationalization at that old location. This updates the page to the new location.

/cc @RedBrogdon @sfshaza2 

Also, I thought we had a link checker? Should it have caught this?