### PR TITLE
docs/deployment/cd:  Add usage of --dart-define

### DIFF
--- a/src/docs/deployment/cd.md
+++ b/src/docs/deployment/cd.md
@@ -117,7 +117,8 @@ untrusted, you won't be leaving your credentials like your Play Store service
 account JSON or your iTunes distribution certificate on the server.
 
 Continuous Integration (CI) systems generally support encrypted environment 
-variables to store private data.
+variables to store private data. You can pass these environment variables 
+using `--dart-define MY_VAR=MY_VALUE` while building the app.
 
 **Take precaution not to re-echo those variable values back onto the console in
 your test scripts**. Those variables are also not available in pull requests


### PR DESCRIPTION
Environment variables are important while building the apps for production but the use of --dart-define isn't documented on the main website. This can lead to a bad developer experience. 

This issue was reported in https://github.com/flutter/flutter/issues/81283