### PR TITLE
Tell users to set FLUTTER_ROOT env variable

### DIFF
--- a/src/docs/deployment/cd.md
+++ b/src/docs/deployment/cd.md
@@ -46,6 +46,8 @@ delivery from a local machine.
 
 1. Install fastlane `gem install fastlane` or `brew install fastlane`.
 Visit the [fastlane docs][fastlane] for more info.
+1. Create an environment variable named `FLUTTER_ROOT`,
+and set it to the root directory of your Flutter SDK.
 1. Create your Flutter project, and when ready, make sure that your project builds via
     * ![Android](/images/cd/android.png) `flutter build appbundle`; and
     * ![iOS](/images/cd/ios.png) `flutter build ios --release --no-codesign`.

--- a/src/docs/deployment/cd.md
+++ b/src/docs/deployment/cd.md
@@ -47,7 +47,8 @@ delivery from a local machine.
 1. Install fastlane `gem install fastlane` or `brew install fastlane`.
 Visit the [fastlane docs][fastlane] for more info.
 1. Create an environment variable named `FLUTTER_ROOT`,
-and set it to the root directory of your Flutter SDK.
+    and set it to the root directory of your Flutter SDK.
+    (This is required for the scripts that deploy for iOS.)
 1. Create your Flutter project, and when ready, make sure that your project builds via
     * ![Android](/images/cd/android.png) `flutter build appbundle`; and
     * ![iOS](/images/cd/ios.png) `flutter build ios --release --no-codesign`.


### PR DESCRIPTION
Fixes #5851

Adds an important step to the build instructions, by telling to user to create and set the FLUTTER_ROOT environment variable.