### PR TITLE
Fixed spelling

### DIFF
--- a/src/desktop.md
+++ b/src/desktop.md
@@ -15,7 +15,7 @@ macOS, or Linux platforms, or you can create your own.
   This page covers desktop support,
   which is available as a beta release for
   Windows (Win32), macOS and Linux. The Windows UWP
-  support is available as a alpha release. Beta
+  support is available as an alpha release. Beta
   support still has notable feature gaps,
   including accessibility support. Meanwhile, the
   Windows UWP alpha release is still in


### PR DESCRIPTION
Changed 'a' to 'an' in the beta warning.