### PR TITLE
Use note formatting for link to hotfix wiki

### DIFF
--- a/src/docs/development/tools/sdk/release-notes/index.md
+++ b/src/docs/development/tools/sdk/release-notes/index.md
@@ -48,4 +48,4 @@ releases to the stable channel.
 [1.5.4]: release-notes/release-notes-1.5.4
 [1.2.1]: release-notes/release-notes-1.2.1
 
-[Hotfixes to the Stable Channel]: https://github.com/flutter/flutter/wiki/Hotfixes-to-the-Stable-Channel
+[Hotfixes to the Stable Channel]: {{site.github}}/flutter/flutter/wiki/Hotfixes-to-the-Stable-Channel

--- a/src/docs/development/tools/sdk/release-notes/index.md
+++ b/src/docs/development/tools/sdk/release-notes/index.md
@@ -6,10 +6,9 @@ description: Release notes for Flutter for prior releases.
 
 This page links to announcements and release notes for
 releases to the stable channel.
-For information about bug-fix releases see
-[Hotfixes to the Stable Channel][].
 
-[Hotfixes to the Stable Channel]: https://github.com/flutter/flutter/wiki/Hotfixes-to-the-Stable-Channel
+{{site.alert.note}} For information about bug-fix releases see
+[Hotfixes to the Stable Channel][]. {{site.alert.end}}
 
 * 2.2.0
   * [2.2.0 announcement][]
@@ -46,3 +45,5 @@ For information about bug-fix releases see
 [1.7.8]: release-notes/release-notes-1.7.8
 [1.5.4]: release-notes/release-notes-1.5.4
 [1.2.1]: release-notes/release-notes-1.2.1
+
+[Hotfixes to the Stable Channel]: https://github.com/flutter/flutter/wiki/Hotfixes-to-the-Stable-Channel

--- a/src/docs/development/tools/sdk/release-notes/index.md
+++ b/src/docs/development/tools/sdk/release-notes/index.md
@@ -7,8 +7,10 @@ description: Release notes for Flutter for prior releases.
 This page links to announcements and release notes for
 releases to the stable channel.
 
-{{site.alert.note}} For information about bug-fix releases see
-[Hotfixes to the Stable Channel][]. {{site.alert.end}}
+{{site.alert.note}}
+  For information about bug-fix releases, see
+  [Hotfixes to the Stable Channel][] on the Flutter wiki.
+{{site.alert.end}}
 
 * 2.2.0
   * [2.2.0 announcement][]


### PR DESCRIPTION
Use note formatting to more clearly highlight the stable hotfixes location, to make it easier for folk to spot. See https://twitter.com/luke_pighetti/status/1399789107908419587 for evidence of confusion today.