### PR TITLE
Update Github Actions node version and firebase-tools/superstatic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
       - run: mkdir -p $TMP
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - uses: ruby/setup-ruby@v1
         if: contains(matrix.task, 'build')
         with:
@@ -144,7 +144,7 @@ jobs:
       - run: mkdir -p $TMP
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           submodules: "recursive"
       - run: mkdir -p $TMP
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 14
       - uses: ruby/setup-ruby@v1
@@ -142,7 +142,7 @@ jobs:
         with:
           submodules: "recursive"
       - run: mkdir -p $TMP
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 14
       - uses: ruby/setup-ruby@v1

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   "devDependencies": {
     "canonical-path": "^1.0.0",
     "diff2html-cli": "^2.7.0",
-    "firebase-tools": "^7.6.2",
+    "firebase-tools": "^9.12.1",
     "fs-extra": "^7.0.1",
     "gulp": "^4.0.0",
     "gulp-cli": "^2.0.1",
     "gulp-imagemin": "^5.0.3",
-    "superstatic": "^6.0.4",
+    "superstatic": "^7.1.0",
     "yamljs": "^0.3.0",
     "yargs": "^12.0.5"
   }


### PR DESCRIPTION
This is a follow-up to https://github.com/flutter/website/commit/1840d4a2b16176824df4abcec76baee727334b01

It may be worth exploring updating the other npm dependencies since npm finds some vulnerabilities with them. But for now, I'm limiting the scope to what I know works and corresponds to the similar change in https://github.com/dart-lang/site-www/commit/77c6fef7b0875e7847a4085bf74f26f5175f1511