### PR TITLE
Add preliminary to building iOS app

### DIFF
--- a/src/docs/deployment/ios.md
+++ b/src/docs/deployment/ios.md
@@ -9,6 +9,9 @@ Flutter app to the [App Store][appstore] and [TestFlight][].
 
 ## Preliminaries
 
+Xcode is required to build and release your app. You
+must use a device running macOS to follow this guide.
+
 Before beginning the process of releasing your app,
 ensure that it meets
 Apple's [App Review Guidelines][appreview].


### PR DESCRIPTION
Fixes #5880
Notes at the top of the preliminaries that a device running macOS is needed to follow the guide.