### PR TITLE
fixed broken link in README.md within example

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,4 +1,4 @@
-Code snippets extracted using [tool/extract.dart](tool/extract.dart), are saved
+Code snippets extracted using [tool/extract.dart](https://github.com/flutter/website/blob/master/tool/extract.dart), are saved
 into [example.g](example.g). The Yaml files in this folder are copied into
 [example.g](example.g), then the snippets are run through the analyzer and
 formatter.


### PR DESCRIPTION
Fixed the broken link(extract.dart) in README.md within example. The example.g link in the file is still broken and I was unable to find the file in the repo to fix the broken link. Maybe the file is renamed? 