### PR TITLE
Fix incorrect secondary color property

### DIFF
--- a/src/docs/release/breaking-changes/theme-data-accent-properties.md
+++ b/src/docs/release/breaking-changes/theme-data-accent-properties.md
@@ -71,7 +71,7 @@ Code after migration:
 final ThemeData theme = ThemeData();
 MaterialApp(
   theme: theme.copyWith(
-    colorScheme: theme.colorScheme.copyWith(secondaryColor: myColor),
+    colorScheme: theme.colorScheme.copyWith(secondary: myColor),
   ),
   //...
 )


### PR DESCRIPTION
I believe this should be `secondary`, not `secondaryColor`. Autocomplete can't find a `secondaryColor` property on this class.