### PR TITLE
Update provider version

### DIFF
--- a/src/docs/development/data-and-backend/state-mgmt/simple.md
+++ b/src/docs/development/data-and-backend/state-mgmt/simple.md
@@ -201,7 +201,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  provider: ^4.3.3
+  provider: ^5.0.0
 
 dev_dependencies:
   # ...


### PR DESCRIPTION
Fixes #5858
Changes `provider` version to `5.0.0` from `4.3.3`. This should not necessitate changes to the code because the code doesn't use the parts of `provider` that were affected by the change to null safety. 