### PR TITLE
Re-add liblzma to Linux requirements

### DIFF
--- a/src/desktop.md
+++ b/src/desktop.md
@@ -116,6 +116,7 @@ you need the following in addition to the Flutter SDK:
 * [GTK development headers][]
 * [Ninja build][]
 * [pkg-config][]
+* liblzma
 
 The easiest way to install the Flutter SDK along with these
 dependencies is by using [snapd][].
@@ -132,7 +133,7 @@ If `snapd` is unavailable on the Linux distro you're using,
 you might use the following command:
 
 ```terminal
-$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev
+$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
 ```
 
 [Clang]: https://clang.llvm.org/

--- a/src/docs/get-started/install/_linux-desktop-setup.md
+++ b/src/docs/get-started/install/_linux-desktop-setup.md
@@ -27,11 +27,12 @@ you need the following in addition to the Flutter SDK:
 * [GTK development headers][]
 * [Ninja build][]
 * [pkg-config][]
+* liblzma
 
 Run the following command
 
 ```terminal
-$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev
+$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
 ```
 
 [Clang]: https://clang.llvm.org/


### PR DESCRIPTION
(**NOTE:** This was fixed before, but was incorrectly reverted in https://github.com/flutter/website/pull/5504)

Together with https://github.com/flutter/flutter/pull/84710, this fixes https://github.com/canonical/flutter-snap/issues/17.

Changes proposed in this pull request:

*  Add `liblzma` to the Linux requirements list.
* Update the suggested `apt-get install` command.