### PR TITLE
Correct TabBar Reference

### DIFF
--- a/src/docs/cookbook/design/tabs.md
+++ b/src/docs/cookbook/design/tabs.md
@@ -152,6 +152,6 @@ class TabBarDemo extends StatelessWidget {
 [`DefaultTabController`]: {{site.api}}/flutter/material/DefaultTabController-class.html
 [material library]: {{site.api}}/flutter/material/material-library.html
 [`Tab`]: {{site.api}}/flutter/material/Tab-class.html
-[`TabBar`]: {{site.api}}/flutter/material/TabController-class.html
+[`TabBar`]: {{site.api}}/flutter/material/TabBar-class.html
 [`TabBarView`]: {{site.api}}/flutter/material/TabBarView-class.html
 [`TabController`]: {{site.api}}/flutter/material/TabController-class.html


### PR DESCRIPTION
This PR corrects the TabBar reference in the Work with tabs cookbook to point to the [TabBar](https://api.flutter.dev/flutter/material/TabBar-class.html) class instead of [TabController](https://api.flutter.dev/flutter/material/TabController-class.html)