### PR TITLE
s/--remote/--recursive in git submodule update

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,13 @@ submodule-cloning techniques:
   this command from the repo root:<br>
 
   ```console
-  $ git submodule update --init --remote
+  $ git submodule update --init --recursive
   ```
 
 > NOTE: At any time during development you can use the `git submodule` command to
 > refresh submodules:<br>
 > ```console
-> $ git pull; git submodule update --init --remote
+> $ git pull; git submodule update --init --recursive
 > ```
 
 ### 3. Run installation scripts


### PR DESCRIPTION
[`--remote`][1] option will pull all the submodule's remote master
branch HEAD and not the current branch's recorded SHA-1.

~~So, instead of `--remote` option [`--recursive`][2] option is
appropriate because this repo has `examples/codelabs` submodule in the
depth deeper than it's root.~~

So, instead of `--remote` option [`--recursive`][2] option can be more 
appropriate as in future submodules may add another submodules.

~~In case of `dart-lang/site-www`, `git submodule update --init` is
sufficient because it doesn't have any submodule deeper than it's 
root.~~

In case of `dart-lang/site-www` also, 
`git submodule update --init --remote` should be 
`git submodule update --init --recursive`

[1]: https://git-scm.com/docs/git-submodule#Documentation/git-submodule.txt---remote
[2]: https://git-scm.com/docs/git-submodule#Documentation/git-submodule.txt---recursive