### PR TITLE
Fix code example var name in building-adaptive-apps.md

### DIFF
--- a/src/docs/development/ui/layout/building-adaptive-apps.md
+++ b/src/docs/development/ui/layout/building-adaptive-apps.md
@@ -263,7 +263,7 @@ from a vertical to a horizontal layout when the user isn’t on a handset:
 
 <!--skip-->
 ```dart
-bool useVerticalLayout = MediaQuery.of(context).size.width < 600;
+bool isHandset = MediaQuery.of(context).size.width < 600;
 return Flex(
   children: [...],
   direction: isHandset ?


### PR DESCRIPTION
The boolean name seems to have an incorrect name in a code example, since the variable referenced later when setting the direction is different (line 269). This PR changes the variable name so they match (when initialized and used).