### PR TITLE
Minor formatting changes in docs

### DIFF
--- a/src/docs/development/data-and-backend/json.md
+++ b/src/docs/development/data-and-backend/json.md
@@ -419,7 +419,7 @@ appropriately.
 You might have code that has nested classes within a class.
 If that is the case, and you have tried to pass the class in JSON format
 as an argument to a service (such as Firebase, for example),
-you might have experienced an`Invalid argument` error.
+you might have experienced an `Invalid argument` error.
 
 Consider the following `Address` class:
 

--- a/src/docs/development/packages-and-plugins/developing-packages.md
+++ b/src/docs/development/packages-and-plugins/developing-packages.md
@@ -107,7 +107,7 @@ folder with the following content:
 **lib/hello.dart**
 : A starter app containing Dart code for the package.
 
-**.idea/modules.xml**, **.idea/modules.xml**, **.idea/workspace.xml**
+**.idea/modules.xml**, **.idea/workspace.xml**
 : A hidden folder containing configuration files
   for the IntelliJ IDEs.
 

--- a/src/docs/development/platform-integration/platform-channels.md
+++ b/src/docs/development/platform-integration/platform-channels.md
@@ -78,7 +78,7 @@ with very little 'boilerplate' code.
 The standard platform channels use a standard message codec that supports
 efficient binary serialization of simple JSON-like values, such as booleans,
 numbers, Strings, byte buffers, and Lists and Maps of these
-(see [`StandardMessageCodec`][]) for details).
+(see [`StandardMessageCodec`][] for details).
 The serialization and deserialization of these values to and from
 messages happens automatically when you send and receive values.
 

--- a/src/docs/development/platform-integration/platform-views.md
+++ b/src/docs/development/platform-integration/platform-views.md
@@ -55,7 +55,8 @@ and add the following build implementation:
 In your Dart file, for example `native_view_example.dart`,
 do the following:
 
-1. Add the following imports:
+<ol markdown="1">
+<li markdown="1">Add the following imports:
 
 <!-- skip -->
 ```dart
@@ -64,8 +65,9 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 ```
+</li>
 
-2. Implement a `build()` method:
+<li markdown="1">Implement a `build()` method:
 
 <!-- skip -->
 ```dart
@@ -99,6 +101,8 @@ Widget build(BuildContext context) {
   );
 }
 ```
+</li>
+</ol>
 
 For more information, see the API docs for:
 
@@ -111,14 +115,16 @@ For more information, see the API docs for:
 In your Dart file, for example `native_view_example.dart`,
 do the following:
 
-1. Add the following imports:
+<ol markdown="1">
+<li markdown="1">Add the following imports:
 
 <!-- skip -->
 ```dart
 import 'package:flutter/widget.dart';
 ```
+</li>
 
-2. Implement a `build()` method:
+<li markdown="1">Implement a `build()` method:
 
 <!-- skip -->
 ```dart
@@ -136,6 +142,8 @@ Widget build(BuildContext context) {
   );
 }
 ```
+</li>
+</ol>
 
 For more information, see the API docs for:
 
@@ -412,14 +420,16 @@ as shown in the following steps.
 In your Dart file, for example
 do the following in `native_view_example.dart`:
 
-1. Add the following imports:
+<ol markdown="1">
+<li markdown="1">Add the following imports:
 
 <!-- skip -->
 ```dart
 import 'package:flutter/widget.dart';
 ```
+</li>
 
-2. Implement a `build()` method:
+<li markdown="1">Implement a `build()` method:
 
 <!-- skip -->
 ```dart
@@ -437,6 +447,8 @@ Widget build(BuildContext context) {
   );
 }
 ```
+</li>
+</ol>
 
 For more information, see the API docs for:
 [`UIKitView`][].

--- a/src/docs/resources/platform-adaptations.md
+++ b/src/docs/resources/platform-adaptations.md
@@ -37,7 +37,7 @@ to the current platform.
 ### Navigation transitions
 
 On **Android**, the default [`Navigator.push()`][] transition
-is modeled after [`startActivity()`][]),
+is modeled after [`startActivity()`][],
 which generally has one bottom-up animation variant.
 
 On **iOS**:


### PR DESCRIPTION
- Minor formatting changes in docs
- Correct ordered list formatting
The reason to correct with \<ol\> instead of markdown syntax is to have
fewer diffs