### PR TITLE
Make the buildTypes block directions more clear

### DIFF
--- a/src/docs/deployment/android.md
+++ b/src/docs/deployment/android.md
@@ -183,7 +183,7 @@ by editing the `[project]/android/app/build.gradle` file.
 
 </li>
 
-<li markdown="1"> Replace the `buildTypes` block:
+<li markdown="1"> Find the `buildTypes` block:
 
 ```
    buildTypes {
@@ -196,7 +196,7 @@ by editing the `[project]/android/app/build.gradle` file.
    }
 ```
 
-   With the signing configuration info:
+   And replace it with the following signing configuration info:
 
 ```
    signingConfigs {


### PR DESCRIPTION
I taught a Flutter class last term and I helped several students prepare their apps for publishing. The "Replace the buildTypes" instructions were confusing for them. It looks like the given block is what you are supposed to copy and use to replace something (especially since there is a copy button). However, the actual meaning is that you are supposed to find that block and then replace it with the next given block. This PR seeks to make that meaning more clear.