### PR TITLE
Fixed reference links for iOS + Android implementation of Switch class

### DIFF
--- a/src/docs/resources/architectural-overview.md
+++ b/src/docs/resources/architectural-overview.md
@@ -252,10 +252,10 @@ efficiently updates the user interface.
 
 Flutter has its own implementations of each UI control, rather than deferring to
 those provided by the system: for example, there is a pure [Dart
-implementation]({{site.api}}/flutter/material/Switch-class.html) of both the
+implementation]({{site.api}}/flutter/cupertino/CupertinoSwitch-class.html) of both the
 [iOS Switch
 control](https://developer.apple.com/design/human-interface-guidelines/ios/controls/switches/)
-and the [one for](https://material.io/develop/android/components/switches) the
+and the [one for]({{site.api}}/flutter/material/Switch-class.html) the
 [Android equivalent](https://material.io/develop/android/components/switches).
 
 This approach provides several benefits:


### PR DESCRIPTION
The links for each implementation of the Material Switch class and the Cupertino Switch class were mixed up