### PR TITLE
Testing pages patch

### DIFF
--- a/examples/cookbook/networking/fetch_data/lib/main.dart
+++ b/examples/cookbook/networking/fetch_data/lib/main.dart
@@ -61,8 +61,8 @@ class _MyAppState extends State<MyApp> {
     super.initState();
     futureAlbum = fetchAlbum();
   }
-// #enddocregion State
 
+  // #enddocregion State
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -94,4 +94,6 @@ class _MyAppState extends State<MyApp> {
       ),
     );
   }
+  // #docregion State
 }
+// #enddocregion State

--- a/examples/cookbook/plugins/play_video/lib/main_step3.dart
+++ b/examples/cookbook/plugins/play_video/lib/main_step3.dart
@@ -17,7 +17,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
 
   @override
   void initState() {
-    // Create an store the VideoPlayerController. The VideoPlayerController
+    // Create and store the VideoPlayerController. The VideoPlayerController
     // offers several different constructors to play videos from assets, files,
     // or the internet.
     _controller = VideoPlayerController.network(

--- a/examples/cookbook/testing/unit/mocking/test/fetch_album_test.dart
+++ b/examples/cookbook/testing/unit/mocking/test/fetch_album_test.dart
@@ -1,17 +1,19 @@
-// #docregion mockClient
 import 'package:flutter_test/flutter_test.dart';
+// #docregion mockClient
 import 'package:http/http.dart' as http;
-import 'package:mocking/main.dart';
 import 'package:mockito/annotations.dart';
+// #enddocregion mockClient
 import 'package:mockito/mockito.dart';
+import 'package:mocking/main.dart';
 
 import 'fetch_album_test.mocks.dart';
+// #docregion mockClient
 
 // Generate a MockClient using the Mockito package.
 // Create new instances of this class in each test.
 @GenerateMocks([http.Client])
 void main() {
-// #enddocregion mockClient
+  // #enddocregion mockClient
   group('fetchAlbum', () {
     test('returns an Album if the http call completes successfully', () async {
       final client = MockClient();
@@ -35,4 +37,6 @@ void main() {
       expect(fetchAlbum(client), throwsException);
     });
   });
+  // #docregion mockClient
 }
+// #enddocregion mockClient

--- a/src/docs/cookbook/networking/fetch-data.md
+++ b/src/docs/cookbook/networking/fetch-data.md
@@ -173,6 +173,9 @@ class _MyAppState extends State<MyApp> {
     super.initState();
     futureAlbum = fetchAlbum();
   }
+
+  // ···
+}
 ```
 
 This Future is used in the next step.

--- a/src/docs/cookbook/testing/unit/mocking.md
+++ b/src/docs/cookbook/testing/unit/mocking.md
@@ -119,20 +119,16 @@ and return different http responses in each test.
 The generated mocks will be located in `fetch_album_test.mocks.dart`.
 Import this file to use them.
 
-<?code-excerpt "test/fetch_album_test.dart (mockClient)"?>
+<?code-excerpt "test/fetch_album_test.dart (mockClient)" plaster="none"?>
 ```dart
-import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:mocking/main.dart';
 import 'package:mockito/annotations.dart';
-import 'package:mockito/mockito.dart';
-
-import 'fetch_album_test.mocks.dart';
 
 // Generate a MockClient using the Mockito package.
 // Create new instances of this class in each test.
 @GenerateMocks([http.Client])
 void main() {
+}
 ```
 
 Next, generate the mocks running the following command:
@@ -158,9 +154,9 @@ Mockito:
 ```dart
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:mocking/main.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:mocking/main.dart';
 
 import 'fetch_album_test.mocks.dart';
 
@@ -305,9 +301,9 @@ class _MyAppState extends State<MyApp> {
 ```dart
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:mocking/main.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:mocking/main.dart';
 
 import 'fetch_album_test.mocks.dart';
 

--- a/src/docs/cookbook/testing/widget/finders.md
+++ b/src/docs/cookbook/testing/widget/finders.md
@@ -13,14 +13,14 @@ next:
 
 {% assign api = site.api | append: '/flutter' -%}
 
-To locate widgets in a test environment, use the `Finder`
+To locate widgets in a test environment, use the [`Finder`][]
 classes. While it's possible to write your own `Finder` classes,
 it's generally more convenient to locate widgets using the tools
 provided by the [`flutter_test`][] package.
 
 During a `flutter run` session on a widget test, you can also
 interactively tap parts of the screen for the Flutter tool to
-print the suggested [`Finder`].
+print the suggested `Finder`.
 
 This recipe looks at the [`find`][] constant provided by
 the `flutter_test` package, and demonstrates how
@@ -157,7 +157,7 @@ void main() {
 }
 ```
 
-
+[`Finder`]: {{api}}/flutter_test/Finder-class.html
 [`CommonFinders` documentation]: {{api}}/flutter_test/CommonFinders-class.html
 [`find`]: {{api}}/flutter_test/find-constant.html
 [`flutter_test`]: {{api}}/flutter_test/flutter_test-library.html

--- a/src/docs/cookbook/testing/widget/introduction.md
+++ b/src/docs/cookbook/testing/widget/introduction.md
@@ -290,7 +290,7 @@ class MyWidget extends StatelessWidget {
 
 
 [`find()`]: {{api}}/flutter_test/find-constant.html
-[`find.text()`]: {{api}}/flutter_test/CommonFinders-class.html
+[`find.text()`]: {{api}}/flutter_test/CommonFinders/text.html
 [`findsNothing`]: {{api}}/flutter_test/findsNothing-constant.html
 [`findsOneWidget`]: {{api}}/flutter_test/findsOneWidget-constant.html
 [`findsNWidgets`]: {{api}}/flutter_test/findsNWidgets.html


### PR DESCRIPTION
- Fix check failure in flutter/website#5991
- Fix `find.text()` hyperlink
- Show only required imports in Step 3 of mocking.md
- Make code look complete in fetch-data.md
- Fix `Finder` class hyperlink