### PR TITLE
Fixing broken references to null_safety_examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,12 +1,12 @@
-# Flutter null safety example apps
+# Flutter example apps
 
 To analyze, test and run individual apps, execute the following commands from
 the repo root (`$PROJECT` represents the app project path, such as
-`null_safety_examples/layout/lakes/step6`):
+`examples/layout/lakes/step6`):
 
 1. `flutter create --no-overwrite $PROJECT`
 2. `cd $PROJECT`
-3. `flutter analyze`
+3. `dart analyze`
 4. `flutter test`
 5. `flutter run`
 

--- a/examples/cookbook/plugins/play_video/lib/main_step3.dart
+++ b/examples/cookbook/plugins/play_video/lib/main_step3.dart
@@ -17,7 +17,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
 
   @override
   void initState() {
-    // Create an store the VideoPlayerController. The VideoPlayerController
+    // Create and store the VideoPlayerController. The VideoPlayerController
     // offers several different constructors to play videos from assets, files,
     // or the internet.
     _controller = VideoPlayerController.network(

--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -840,15 +840,15 @@ Rebuilding `l10n/messages_all.dart` requires two steps.
     to load the localized messages and `Intl.message()` to look them up.
 
 [78 languages]: {{site.api}}/flutter/flutter_localizations/GlobalMaterialLocalizations-class.html
-[`add_language`]: {{site.github}}/flutter/website/tree/master/null_safety_examples/internationalization/add_language/lib/main.dart
+[`add_language`]: {{site.github}}/flutter/website/tree/master/examples/internationalization/add_language/lib/main.dart
 [An alternative class for the app's localized resources]: #alternative-class
-[an example]: {{site.github}}/flutter/website/tree/master/null_safety_examples/internationalization/minimal
-[`intl_example`]: {{site.github}}/flutter/website/tree/master/null_safety_examples/internationalization/intl_example
-[`gen_l10n_example`]: {{site.github}}/flutter/website/tree/master/null_safety_examples/internationalization/gen_l10n_example
+[an example]: {{site.github}}/flutter/website/tree/master/examples/internationalization/minimal
+[`intl_example`]: {{site.github}}/flutter/website/tree/master/examples/internationalization/intl_example
+[`gen_l10n_example`]: {{site.github}}/flutter/website/tree/master/examples/internationalization/gen_l10n_example
 [flutter_localizations README]: {{site.github}}/flutter/flutter/blob/master/packages/flutter_localizations/lib/src/l10n/README.md
 [`GlobalMaterialLocalizations`]: {{site.api}}/flutter/flutter_localizations/GlobalMaterialLocalizations-class.html
 [`InheritedWidget`]: {{site.api}}/flutter/widgets/InheritedWidget-class.html
-[Internationalization based on the `intl` package]: {{site.github}}/flutter/website/tree/master/null_safety_examples/internationalization/intl_example
+[Internationalization based on the `intl` package]: {{site.github}}/flutter/website/tree/master/examples/internationalization/intl_example
 [Internationalization User's Guide]: /go/i18n-user-guide
 [`intl`]: {{site.pub-pkg}}/intl
 [`intl` tool]: #dart-tools
@@ -864,8 +864,8 @@ Rebuilding `l10n/messages_all.dart` requires two steps.
 [`MaterialApp`]: {{site.api}}/flutter/material/MaterialApp-class.html
 [`MaterialApp.onGenerateTitle`]: {{site.api}}/flutter/material/MaterialApp/onGenerateTitle.html
 [`MaterialLocalizations`]: {{site.api}}/flutter/material/MaterialLocalizations-class.html
-[`minimal`]: {{site.github}}/flutter/website/tree/master/null_safety_examples/internationalization/minimal
-[Minimal internationalization]: {{site.github}}/flutter/website/tree/master/null_safety_examples/internationalization/minimal
+[`minimal`]: {{site.github}}/flutter/website/tree/master/examples/internationalization/minimal
+[Minimal internationalization]: {{site.github}}/flutter/website/tree/master/examples/internationalization/minimal
 [Setting up an internationalized app]: #setting-up
 [`SynchronousFuture`]: {{site.api}}/flutter/foundation/SynchronousFuture-class.html
 [`supportedLocales`]: {{site.api}}/flutter/material/MaterialApp/supportedLocales.html

--- a/src/docs/development/ui/animations/tutorial.md
+++ b/src/docs/development/ui/animations/tutorial.md
@@ -6,7 +6,7 @@ diff2html: true
 ---
 
 {% assign api = '{{site.api}}/flutter' -%}
-{% capture examples -%} {{site.repo.this}}/tree/{{site.branch}}/null_safety_examples {%- endcapture -%}
+{% capture examples -%} {{site.repo.this}}/tree/{{site.branch}}/examples {%- endcapture -%}
 
 <?code-excerpt path-base="animation"?>
 

--- a/src/docs/development/ui/interactive.md
+++ b/src/docs/development/ui/interactive.md
@@ -5,7 +5,7 @@ short-title: Adding interactivity
 diff2html: true
 ---
 
-{% capture examples -%} {{site.repo.this}}/tree/{{site.branch}}/null_safety_examples {%- endcapture -%}
+{% capture examples -%} {{site.repo.this}}/tree/{{site.branch}}/examples {%- endcapture -%}
 
 {{site.alert.secondary}}
   <h4 class="no_toc">What you’ll learn</h4>

--- a/src/docs/development/ui/layout/building-adaptive-apps.md
+++ b/src/docs/development/ui/layout/building-adaptive-apps.md
@@ -17,7 +17,7 @@ multiplatform, but are fully platform adaptive.
 There are many considerations for developing platform-adaptive
 apps, but they fall into three major categories:
 
-* [Layout](#layout)
+* [Layout](#building-adaptive-layouts)
 * [Input](#input)
 * [Idioms and norms](#idioms-and-norms)
 

--- a/src/docs/development/ui/layout/index.md
+++ b/src/docs/development/ui/layout/index.md
@@ -7,8 +7,8 @@ diff2html: true
 
 {% assign api = site.api | append: '/flutter' -%}
 {% capture code -%} {{site.repo.this}}/tree/{{site.branch}}/src/_includes/code {%- endcapture -%}
-{% capture null_safety_examples -%} {{site.repo.this}}/tree/{{site.branch}}/null_safety_examples {%- endcapture -%}
-{% assign rawExFile = 'https://raw.githubusercontent.com/flutter/website/master/null_safety_examples' -%}
+{% capture examples -%} {{site.repo.this}}/tree/{{site.branch}}/examples {%- endcapture -%}
+{% assign rawExFile = 'https://raw.githubusercontent.com/flutter/website/master/examples' -%}
 {% capture demo -%} {{site.repo.flutter}}/tree/{{site.branch}}/dev/integration_tests/flutter_gallery/lib/demo {%- endcapture -%}
 
 <?code-excerpt path-base=""?>
@@ -223,8 +223,8 @@ color to white and the text to dark grey to mimic a Material app.
   That's it! When you run the app, you should see _Hello World_.
 
   App source code:
-  - [Material app]({{null_safety_examples}}/layout/base)
-  - [Non-Material app]({{null_safety_examples}}/layout/non_material)
+  - [Material app]({{examples}}/layout/base)
+  - [Non-Material app]({{examples}}/layout/non_material)
 </div>
 <div class="col-md-6">
   {% include app-figure.md img-class="site-mobile-screenshot border w-75"
@@ -341,7 +341,7 @@ space evenly between, before, and after each image.
 <div class="col-lg-4" markdown="1">
   {% asset ui/layout/row-spaceevenly-visual.png class="mw-100" alt="Row with 3 evenly spaced images" %}
 
-  **App source:** [row_column]({{null_safety_examples}}/layout/row_column)
+  **App source:** [row_column]({{examples}}/layout/row_column)
 </div>
 </div>
 
@@ -365,7 +365,7 @@ space evenly between, above, and below each image.
   );
   {% endprettify %}
 
-  **App source:** [row_column]({{null_safety_examples}}/layout/row_column)
+  **App source:** [row_column]({{examples}}/layout/row_column)
 </div>
 <div class="col-lg-4 text-center">
   {% asset ui/layout/column-visual.png class="mb-4" height="250px"
@@ -411,7 +411,7 @@ wrap each image with an `Expanded` widget.
   {% asset ui/layout/row-expanded-2-visual.png class="mw-100"
       alt="Row of 3 images that are too wide, but each is constrained to take only 1/3 of the space" %}
 
-  **App source:** [sizing]({{null_safety_examples}}/layout/sizing)
+  **App source:** [sizing]({{examples}}/layout/sizing)
 </div>
 </div>
 
@@ -446,11 +446,11 @@ the flex factor of the middle image to 2:
   {% asset ui/layout/row-expanded-visual.png class="mw-100"
       alt="Row of 3 images with the middle image twice as wide as the others" %}
 
-  **App source:** [sizing]({{null_safety_examples}}/layout/sizing)
+  **App source:** [sizing]({{examples}}/layout/sizing)
 </div>
 </div>
 
-[sizing]: {{null_safety_examples}}/layout/sizing
+[sizing]: {{examples}}/layout/sizing
 
 ### Packing widgets
 
@@ -479,7 +479,7 @@ uses this property to pack the star icons together.
   {% asset ui/layout/packed.png class="border mw-100"
       alt="Row of 5 stars, packed together in the middle of the row" %}
 
-  **App source:** [pavlova]({{null_safety_examples}}/layout/pavlova)
+  **App source:** [pavlova]({{examples}}/layout/pavlova)
 </div>
 </div>
 
@@ -663,7 +663,7 @@ body: Center(
   using **Window > Scale**.
 {{site.alert.end}}
 
-**App source:** [pavlova]({{null_safety_examples}}/layout/pavlova)
+**App source:** [pavlova]({{examples}}/layout/pavlova)
 
 [Pavlova image]: https://pixabay.com/en/photos/pavlova
 [Pixabay]: https://pixabay.com/en/photos/pavlova
@@ -783,7 +783,7 @@ Widget _buildImageRow(int imageIndex) => Row(
 You can find more `Container` examples in the [tutorial][]
 and the Flutter Gallery ([running app][], [repo][]).
 
-**App source:** [container]({{null_safety_examples}}/layout/container)
+**App source:** [container]({{examples}}/layout/container)
 
 <hr>
 
@@ -829,7 +829,7 @@ it automatically scrolls.
   Uses `GridView.extent` to create a grid with tiles a maximum
   150 pixels wide.
 
-  **App source:** [grid_and_list]({{null_safety_examples}}/layout/grid_and_list)
+  **App source:** [grid_and_list]({{examples}}/layout/grid_and_list)
 </div>
 <div class="col-lg-6" markdown="1">
   {% asset ui/layout/gridview-count-flutter-gallery.png class="mw-100"
@@ -892,7 +892,7 @@ its render box.
   `ListTile`s. A `Divider` separates the theaters from
   the restaurants.
 
-  **App source:** [grid_and_list]({{null_safety_examples}}/layout/grid_and_list)
+  **App source:** [grid_and_list]({{examples}}/layout/grid_and_list)
 </div>
 <div class="col-lg-6" markdown="1">
   {% asset ui/layout/listview-flutter-gallery.png class="border mw-100"
@@ -973,7 +973,7 @@ or partially overlap the base widget.
   The `Stack` offsets the text using the `alignment` property and
   `Alignment`s.
 
-  **App source:** [card_and_stack]({{null_safety_examples}}/layout/card_and_stack)
+  **App source:** [card_and_stack]({{examples}}/layout/card_and_stack)
 </div>
 <div class="col-lg-5" markdown="1">
   {% asset ui/layout/stack-flutter-gallery.png class="mw-100" alt="An image with a grey gradient across the top" %}
@@ -1059,7 +1059,7 @@ Specifying an unsupported value disables the drop shadow entirely.
   it with a `SizedBox`. A `Divider` separates the first
   and second `ListTiles`.
 
-  **App source:** [card_and_stack]({{null_safety_examples}}/layout/card_and_stack)
+  **App source:** [card_and_stack]({{examples}}/layout/card_and_stack)
 </div>
 <div class="col-lg-6" markdown="1">
   {% asset ui/layout/card-flutter-gallery.png class="mw-100"
@@ -1138,7 +1138,7 @@ and trailing icons. `ListTile` is most commonly used in
 
   A `Card` containing 3 `ListTiles`.
 
-  **App source:** [card_and_stack]({{null_safety_examples}}/layout/card_and_stack)
+  **App source:** [card_and_stack]({{examples}}/layout/card_and_stack)
 </div>
 <div class="col-lg-6" markdown="1">
   {% asset ui/layout/listtile-flutter-gallery.png class="border mw-100" height="200px"
@@ -1238,8 +1238,8 @@ The following resources might help when writing layout code.
 [Material Design]: {{site.material}}/design
 [Material Design palette]: {{site.material}}/design/color
 [Material library]: {{api}}/material/material-library.html
-[pubspec file]: {{null_safety_examples}}/layout/pavlova/pubspec.yaml
-[`pubspec.yaml` file]: {{null_safety_examples}}/layout/row_column/pubspec.yaml
+[pubspec file]: {{examples}}/layout/pavlova/pubspec.yaml
+[`pubspec.yaml` file]: {{examples}}/layout/row_column/pubspec.yaml
 [repo]: {{site.repo.flutter}}/tree/master/dev/integration_tests/flutter_gallery
 [`Row`]: {{api}}/widgets/Row-class.html
 [running app]: https://flutter.github.io/gallery/#/

--- a/src/docs/development/ui/layout/tutorial.md
+++ b/src/docs/development/ui/layout/tutorial.md
@@ -6,9 +6,9 @@ diff2html: true
 ---
 
 {% assign api = '{{site.api}}/flutter' -%}
-{% capture examples -%} {{site.repo.this}}/tree/{{site.branch}}/null_safety_examples {%- endcapture -%}
-{% assign rawExFile = 'https://raw.githubusercontent.com/flutter/website/master/null_safety_examples' -%}
-{% capture demo -%} {{site.repo.flutter}}/tree/{{site.branch}}/null_safety_examples/flutter_gallery/lib/demo {%- endcapture -%}
+{% capture examples -%} {{site.repo.this}}/tree/{{site.branch}}/examples {%- endcapture -%}
+{% assign rawExFile = 'https://raw.githubusercontent.com/flutter/website/master/examples' -%}
+{% capture demo -%} {{site.repo.flutter}}/tree/{{site.branch}}/examples/flutter_gallery/lib/demo {%- endcapture -%}
 
 <style>dl, dd { margin-bottom: 0; }</style>
 


### PR DESCRIPTION
There were some intra-repo and outbound GitHub links in the codebase that still referenced `null_safety_examples`. This PR cleans them up to the point that `grep -ir null_safety_examples` no longer reports anything outside of submodules.

Also included:

* A fix for a broken anchor link in the Adaptive Apps guide.
* A fix for the source-of-truth code for the excerpt changed in #5991, which should unbreak the build. 

Fixes #5998. 