### PR TITLE
Prefer `const` literals as parameters of constructors on immutable classes

### DIFF
--- a/examples/internationalization/add_language/lib/main.dart
+++ b/examples/internationalization/add_language/lib/main.dart
@@ -7,14 +7,14 @@ void main() {
   runApp(
     // #docregion MaterialApp
     MaterialApp(
-      localizationsDelegates: [
+      localizationsDelegates: const [
         GlobalWidgetsLocalizations.delegate,
         GlobalMaterialLocalizations.delegate,
         NnMaterialLocalizations.delegate, // Add the newly created delegate
       ],
-      supportedLocales: [
-        const Locale('en', 'US'),
-        const Locale('nn'),
+      supportedLocales: const [
+        Locale('en', 'US'),
+        Locale('nn'),
       ],
       home: Home(),
     ),

--- a/examples/internationalization/gen_l10n_example/lib/examples.dart
+++ b/examples/internationalization/gen_l10n_example/lib/examples.dart
@@ -32,13 +32,13 @@ void examples(BuildContext context) {
 
   MaterialApp(
 // #docregion SupportedLocales
-    supportedLocales: [
-      const Locale.fromSubtags(languageCode: 'zh'), // generic Chinese 'zh'
-      const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans'), // generic simplified Chinese 'zh_Hans'
-      const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'), // generic traditional Chinese 'zh_Hant'
-      const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans', countryCode: 'CN'), // 'zh_Hans_CN'
-      const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant', countryCode: 'TW'), // 'zh_Hant_TW'
-      const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant', countryCode: 'HK'), // 'zh_Hant_HK'
+    supportedLocales: const [
+      Locale.fromSubtags(languageCode: 'zh'), // generic Chinese 'zh'
+      Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans'), // generic simplified Chinese 'zh_Hans'
+      Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'), // generic traditional Chinese 'zh_Hant'
+      Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans', countryCode: 'CN'), // 'zh_Hans_CN'
+      Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant', countryCode: 'TW'), // 'zh_Hant_TW'
+      Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant', countryCode: 'HK'), // 'zh_Hant_HK'
     ],
 // #enddocregion SupportedLocales
   );

--- a/examples/internationalization/gen_l10n_example/lib/main.dart
+++ b/examples/internationalization/gen_l10n_example/lib/main.dart
@@ -20,7 +20,7 @@ class MyApp extends StatelessWidget {
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
-      supportedLocales: [
+      supportedLocales: const [
         Locale('en', ''), // English, no country code
         Locale('es', ''), // Spanish, no country code
       ],

--- a/examples/internationalization/gen_l10n_example/lib/main.dart
+++ b/examples/internationalization/gen_l10n_example/lib/main.dart
@@ -14,15 +14,15 @@ class MyApp extends StatelessWidget {
 // #docregion MaterialApp
     return MaterialApp(
       title: 'Localizations Sample App',
-      localizationsDelegates: [
+      localizationsDelegates: const [
         AppLocalizations.delegate, // Add this line
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
       supportedLocales: [
-        const Locale('en', ''), // English, no country code
-        const Locale('es', ''), // Spanish, no country code
+        Locale('en', ''), // English, no country code
+        Locale('es', ''), // Spanish, no country code
       ],
       theme: ThemeData(
         primarySwatch: Colors.blue,

--- a/examples/internationalization/intl_example/lib/main.dart
+++ b/examples/internationalization/intl_example/lib/main.dart
@@ -109,14 +109,14 @@ class Demo extends StatelessWidget {
     return MaterialApp(
       onGenerateTitle: (BuildContext context) => DemoLocalizations.of(context).title,
 // #enddocregion MaterialAppTitleExample
-      localizationsDelegates: [
-        const DemoLocalizationsDelegate(),
+      localizationsDelegates: const [
+        DemoLocalizationsDelegate(),
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
       ],
-      supportedLocales: [
-        const Locale('en', ''),
-        const Locale('es', ''),
+      supportedLocales: const [
+        Locale('en', ''),
+        Locale('es', ''),
       ],
       // Watch out: MaterialApp creates a Localizations widget
       // with the specified delegates. DemoLocalizations.of()

--- a/examples/internationalization/minimal/lib/main.dart
+++ b/examples/internationalization/minimal/lib/main.dart
@@ -89,14 +89,14 @@ class Demo extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       onGenerateTitle: (BuildContext context) => DemoLocalizations.of(context).title,
-      localizationsDelegates: [
-        const DemoLocalizationsDelegate(),
+      localizationsDelegates: const [
+        DemoLocalizationsDelegate(),
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
       ],
-      supportedLocales: [
-        const Locale('en', ''),
-        const Locale('es', ''),
+      supportedLocales: const [
+        Locale('en', ''),
+        Locale('es', ''),
       ],
       // Watch out: MaterialApp creates a Localizations widget
       // with the specified delegates. DemoLocalizations.of()

--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -81,14 +81,14 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 ```dart
 return MaterialApp(
   title: 'Localizations Sample App',
-  localizationsDelegates: [
+  localizationsDelegates: const [
     GlobalMaterialLocalizations.delegate,
     GlobalWidgetsLocalizations.delegate,
     GlobalCupertinoLocalizations.delegate,
   ],
-  supportedLocales: [
-    const Locale('en', ''), // English, no country code
-    const Locale('es', ''), // Spanish, no country code
+  supportedLocales: const [
+    Locale('en', ''), // English, no country code
+    Locale('es', ''), // Spanish, no country code
   ],
   theme: ThemeData(
     primarySwatch: Colors.blue,
@@ -214,15 +214,15 @@ project called `l10n.yaml` with the following content:
    ```dart
    return MaterialApp(
      title: 'Localizations Sample App',
-     localizationsDelegates: [
+     localizationsDelegates: const [
        AppLocalizations.delegate, // Add this line
        GlobalMaterialLocalizations.delegate,
        GlobalWidgetsLocalizations.delegate,
        GlobalCupertinoLocalizations.delegate,
      ],
-     supportedLocales: [
-       const Locale('en', ''), // English, no country code
-       const Locale('es', ''), // Spanish, no country code
+     supportedLocales: const [
+       Locale('en', ''), // English, no country code
+       Locale('es', ''), // Spanish, no country code
      ],
      theme: ThemeData(
        primarySwatch: Colors.blue,
@@ -324,13 +324,13 @@ locales should include:
 
 <?code-excerpt "gen_l10n_example/lib/examples.dart (SupportedLocales)"?>
 ```dart
-supportedLocales: [
-  const Locale.fromSubtags(languageCode: 'zh'), // generic Chinese 'zh'
-  const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans'), // generic simplified Chinese 'zh_Hans'
-  const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'), // generic traditional Chinese 'zh_Hant'
-  const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans', countryCode: 'CN'), // 'zh_Hans_CN'
-  const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant', countryCode: 'TW'), // 'zh_Hant_TW'
-  const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant', countryCode: 'HK'), // 'zh_Hant_HK'
+supportedLocales: const [
+  Locale.fromSubtags(languageCode: 'zh'), // generic Chinese 'zh'
+  Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans'), // generic simplified Chinese 'zh_Hans'
+  Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'), // generic traditional Chinese 'zh_Hant'
+  Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans', countryCode: 'CN'), // 'zh_Hans_CN'
+  Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant', countryCode: 'TW'), // 'zh_Hant_TW'
+  Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant', countryCode: 'HK'), // 'zh_Hant_HK'
 ],
 ```
 
@@ -702,14 +702,14 @@ adds the `NnMaterialLocalizations` delegate instance to the app's
 <?code-excerpt "add_language/lib/main.dart (MaterialApp)"?>
 ```dart
 MaterialApp(
-  localizationsDelegates: [
+  localizationsDelegates: const [
     GlobalWidgetsLocalizations.delegate,
     GlobalMaterialLocalizations.delegate,
     NnMaterialLocalizations.delegate, // Add the newly created delegate
   ],
-  supportedLocales: [
-    const Locale('en', 'US'),
-    const Locale('nn'),
+  supportedLocales: const [
+    Locale('en', 'US'),
+    Locale('nn'),
   ],
   home: Home(),
 ),

--- a/src/docs/get-started/flutter-for/ios-devs.md
+++ b/src/docs/get-started/flutter-for/ios-devs.md
@@ -1197,14 +1197,14 @@ specify the `localizationsDelegates` and
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 MaterialApp(
- localizationsDelegates: [
+ localizationsDelegates: const [
    // Add app-specific localization delegate[s] here
    GlobalMaterialLocalizations.delegate,
    GlobalWidgetsLocalizations.delegate,
  ],
- supportedLocales: [
-    const Locale('en', 'US'), // English
-    const Locale('he', 'IL'), // Hebrew
+ supportedLocales: const [
+    Locale('en', 'US'), // English
+    Locale('he', 'IL'), // Hebrew
     // ... other locales the app supports
   ],
   // ...

--- a/src/docs/get-started/flutter-for/xamarin-forms-devs.md
+++ b/src/docs/get-started/flutter-for/xamarin-forms-devs.md
@@ -1352,14 +1352,14 @@ specify the `localizationsDelegates` and `supportedLocales` on the app widget:
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 MaterialApp(
- localizationsDelegates: [
+ localizationsDelegates: const [
    // Add app-specific localization delegate[s] here.
    GlobalMaterialLocalizations.delegate,
    GlobalWidgetsLocalizations.delegate,
  ],
- supportedLocales: [
-    const Locale('en', 'US'), // English
-    const Locale('he', 'IL'), // Hebrew
+ supportedLocales: const [
+    Locale('en', 'US'), // English
+    Locale('he', 'IL'), // Hebrew
     // ... other locales the app supports
   ],
   // ...


### PR DESCRIPTION
The current code samples give `Prefer const literals as parameters of constructors on @immutable classes.`.

This PR updates those warnings accordingly.