### PR TITLE
Tweaking the contact info on the books page

### DIFF
--- a/src/docs/resources/books.md
+++ b/src/docs/resources/books.md
@@ -5,9 +5,11 @@ description: Extra, extra! Here's a collection of books about Flutter.
 
 Here's a collection of books about Flutter, in alphabetical order.
 If you find another one that we should add,
-[let us know][]{:.help-instruction}.
+[file an issue][] and (optionally)
+submit a PR ([sample][]) to add it yourself.
 
-[let us know]: {{site.github}}/flutter/website/issues
+[file an issue]: {{site.github}}/flutter/website/issues/new
+[sample]: {{site.github}}/flutter/website/pull/6019
 
 {% for book in site.data.books %}
 <div class="book-img-with-details row">


### PR DESCRIPTION
Fixes https://github.com/flutter/website/issues/6029

Staged:  https://sz-flutter.firebaseapp.com/docs/resources/books

@kwalrath, there's some HTML error in the page that I'm not seeing. The "sample" link isn't working. Not sure why...