### PR TITLE
fix AVD Manager instruction in Test drive page

### DIFF
--- a/src/docs/get-started/test-drive/_androidstudio.md
+++ b/src/docs/get-started/test-drive/_androidstudio.md
@@ -23,7 +23,7 @@ contains a simple demo app that uses [Material Components][].
     ![Main IntelliJ toolbar][]{:.mw-100}
  1. In the **target selector**, select an Android device for running the app.
     If none are listed as available,
-    select **Tools> Android > AVD Manager** and create one there.
+    select **Tools > AVD Manager** and create one there.
     For details, see [Managing AVDs][].
  1. Click the run icon in the toolbar, or invoke the menu item **Run > Run**.
 


### PR DESCRIPTION
Page https://flutter.dev/docs/get-started/test-drive
Fixes https://github.com/flutter/website/issues/5972

Current instructions **Tools> Android > AVD Manager**

It is now  **Tools > AVD Manager**
![126495600-c606981e-c1df-4996-afff-959ac5a0cbf4](https://user-images.githubusercontent.com/48603081/126499052-2da9eba1-7949-40b3-afa2-913949673e69.png)
