### PR TITLE
Update iOS minimum version to 9.0

### DIFF
--- a/src/docs/deployment/ios.md
+++ b/src/docs/deployment/ios.md
@@ -111,9 +111,9 @@ In the **Build Settings** section:
 
 `iOS Deployment Target`
 : The minimum iOS version that your app supports.
-  Flutter supports iOS 8.0 and later. If your app includes
-  Objective-C or Swift code that makes use of APIs that
-  were unavailable in iOS 8, update this setting appropriately.
+  Flutter supports iOS 9.0 and later. If your app or plugins
+  include Objective-C or Swift code that makes use of APIs newer
+  than iOS 9, update this setting to the highest required version.
 
 The **General** tab of your project settings should resemble
 the following:

--- a/src/docs/development/add-to-app/ios/project-setup.md
+++ b/src/docs/development/add-to-app/ios/project-setup.md
@@ -14,7 +14,7 @@ For examples, see the iOS directories in the [add_to_app code samples][].
 Your development environment must meet the
 [macOS system requirements for Flutter][]
 with [Xcode installed][].
-Flutter supports iOS 8.0 and later.
+Flutter supports iOS 9.0 and later.
 Additionally, you will need [CocoaPods][]
 version 1.10 or later.
 


### PR DESCRIPTION
Default Flutter project has been 9.0 since https://github.com/flutter/flutter/pull/62902 in 1.22.0.  A migration will be forced with https://github.com/flutter/flutter/pull/85174 in 2.4.0-0.0.pre.

Part of https://github.com/flutter/flutter/issues/62879.