### PR TITLE
Remove "!" operator for currentState field

### DIFF
--- a/src/docs/cookbook/forms/validation.md
+++ b/src/docs/cookbook/forms/validation.md
@@ -220,7 +220,7 @@ class MyCustomFormState extends State<MyCustomForm> {
             child: ElevatedButton(
               onPressed: () {
                 // Validate returns true if the form is valid, or false otherwise.
-                if (_formKey.currentState!.validate()) {
+                if (_formKey.currentState?.validate() ?? false) {
                   // If the form is valid, display a snackbar. In the real world,
                   // you'd often call a server or save the information in a database.
                   ScaffoldMessenger.of(context)


### PR DESCRIPTION
I've created this PR because I believe that this shouldn't be in the official documentation. The reason is that as we know, use `!.` implies that we tell the compiler that we take responsibility that this attribute is not null. In my opinion this is a behavior that we always have to try to avoid. What is your opinion? I suggest to use the other solution `currentState?.validate ?? false`, by setting a default value in case of null