### PR TITLE
Update link to engine size dashboard to point to new storage bucket

### DIFF
--- a/src/docs/perf/faq.md
+++ b/src/docs/perf/faq.md
@@ -96,10 +96,10 @@ about evaluating and debugging Flutter's performance.
 * How do I see the breakdown of the Flutter engine size?
   * Visit the [binary size dashboard][], and replace the git
     hash in the URL with a recent commit hash from
-    [GitHub commits][].
+    [GitHub engine repository commits][].
 
-[binary size dashboard]: https://storage.googleapis.com/flutter_infra/flutter/c3976b3c7183f479717bffed3f640fb92afbd3dc/android-arm-release/sizes/index.html
-[GitHub commits]: {{site.github}}/flutter/engine/commits
+[binary size dashboard]: https://storage.googleapis.com/flutter_infra_release/flutter/241c87ad800beeab545ab867354d4683d5bfb6ce/android-arm-release/sizes/index.html
+[GitHub engine repository commits]: {{site.github}}/flutter/engine/commits
 
 * How can I take a screenshot of an app that is running and export it
   as a SKP file?


### PR DESCRIPTION
Storage URL was changed from `https://storage.googleapis.com/flutter_infra` to `https://storage.googleapis.com/flutter_infra_release`, see https://github.com/flutter/flutter/issues/75363.

Updated the example SHA to point to the last stable engine. Also clarified the SHA is for the engine repository, not the framework.

