### PR TITLE
Corrected Platform View Integration import

### DIFF
--- a/src/docs/development/platform-integration/platform-views.md
+++ b/src/docs/development/platform-integration/platform-views.md
@@ -425,7 +425,7 @@ do the following in `native_view_example.dart`:
 
 <!-- skip -->
 ```dart
-import 'package:flutter/widget.dart';
+import 'package:flutter/widgets.dart';
 ```
 </li>
 


### PR DESCRIPTION
### What
- Corrected the tutorial import line to use the correct `widgets.dart` file.