### PR TITLE
Add to macOS deployment a guide to build, package, and distribute app with Codemagic CLI tools

### DIFF
--- a/src/docs/deployment/macos.md
+++ b/src/docs/deployment/macos.md
@@ -249,7 +249,7 @@ private keys by executing the following command for each certificate:
 openssl pkcs12 -in <certificate_name>.p12 -nodes -nocerts | openssl rsa -out cert_key
 ```
 
-Or you can create a new private key by executing
+Or you can create a new private key by executing the following command:
 
 ```bash
 ssh-keygen -t rsa -b 2048 -m PEM -f cert_key -q -N ""

--- a/src/docs/deployment/macos.md
+++ b/src/docs/deployment/macos.md
@@ -409,7 +409,8 @@ app-store-connect publish \
 </li>
 <li markdown="1">
 
-As mentioned earlier, don't forget to set your login keychain as the default to avoid authentication issues
+As mentioned earlier, don't forget to set your login keychain
+as the default to avoid authentication issues
 with apps on your machine:
 ```bash
 keychain use-login

--- a/src/docs/deployment/macos.md
+++ b/src/docs/deployment/macos.md
@@ -212,7 +212,7 @@ For more details, see
 This step covers creating a build archive and uploading
 your build to App Store Connect using Flutter build commands 
 and [Codemagic CLI Tools][codemagic_cli_tools] executed in a terminal
-in the Flutter project directory
+in the Flutter project directory.
 
 <ol markdown="1">
 <li markdown="1">

--- a/src/docs/deployment/macos.md
+++ b/src/docs/deployment/macos.md
@@ -311,15 +311,14 @@ Set up a new temporary keychain to be used for code signing:
 keychain initialize
 ```
 
-{{site.alert.warning}}
-**Restore Login Keychain!**
-After running `keychain intialize` you **must** run
+{{site.alert.secondary}}
+  **Restore Login Keychain!**
+  After running `keychain initialize` you **must** run the following:<br>
 
-```bash
-keychain use-login
-```
+  `keychain use-login`
 
-in order set your login keychain as the default to avoid potential authentication issues with apps on your machine.
+  This sets your login keychain as the default to avoid potential
+  authentication issues with apps on your machine.
 {{site.alert.end}}
 
 </li>

--- a/src/docs/deployment/macos.md
+++ b/src/docs/deployment/macos.md
@@ -150,10 +150,10 @@ app's icons:
 1. Verify the icon has been replaced by running your app using
    `flutter run -d macos`.
 
-## Create a build archive
+## Create a build archive with Xcode
 
 This step covers creating a build archive and uploading
-your build to App Store Connect.
+your build to App Store Connect using Xcode.
 
 During development, you've been building, debugging, and testing
 with _debug_ builds. When you're ready to ship your app to users
@@ -206,6 +206,166 @@ on TestFlight, or go ahead and release your app to the App Store.
 For more details, see
 [Upload an app to App Store Connect][distributionguide_upload].
 
+## Create a build archive with Codemagic CLI tools
+
+This step covers creating a build archive and uploading
+your build to App Store Connect using Flutter build commands 
+and [Codemagic CLI Tools][codemagic_cli_tools] in a terminal.
+
+<ol markdown="1">
+<li markdown="1">
+
+Install the Codemagic CLI tools:
+```bash
+pip3 install codemagic-cli-tools
+```
+
+</li>
+<li markdown="1">
+
+Create a private key used to create a macOS Apple Distribution Certificate:
+```bash
+ssh-keygen -t rsa -b 2048 -m PEM -f ~/Downloads/cert_key -q -N ""
+```
+
+</li>
+<li markdown="1">
+
+In order to make subsequent commands more concise, set the following environment variables for App Store Connect issuer id, key id, API key, and the private key created in the last step:
+```bash
+export APP_STORE_CONNECT_ISSUER_ID=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+export APP_STORE_CONNECT_KEY_IDENTIFIER=ABC1234567
+export APP_STORE_CONNECT_PRIVATE_KEY=`cat /path/to/app/store/connect/api/key/AuthKey_XXXYYYZZZ.p8`
+export CERTIFICATE_PRIVATE_KEY=`cat /path/to/certificate/private/key/cert_key`
+```
+
+</li>
+<li markdown="1">
+
+Fetch the code signing files from App Store Connect:
+```bash
+app-store-connect fetch-signing-files com.craastad.myMacosApp \
+    --platform MAC_OS \
+    --type MAC_APP_STORE \
+    --create
+```
+
+</li>
+<li markdown="1">
+
+Create a macOS Mac Installer Distribution certificate in App Store Connect for the locally generated private key. This will fail with a 409 error if you already have a Mac Installer Distribution certificate for the private key.  
+```bash
+app-store-connect create-certificate \
+    --type MAC_INSTALLER_DISTRIBUTION \
+    --save
+```
+
+</li>
+<li markdown="1">
+
+Fetch the macOS installer certificate:
+```bash
+app-store-connect list-certificates \
+    --type MAC_INSTALLER_DISTRIBUTION \
+    --save
+```
+
+</li>
+<li markdown="1">
+
+Set up keychain to be used for code signing:
+```bash
+keychain initialize
+```
+
+</li>
+<li markdown="1">
+
+Now add the fetched certificates to your keychain:
+```bash
+keychain add-certificates
+```
+
+</li>
+<li markdown="1">
+
+Update the Xcode project settings to use fetched code signing profiles: 
+```bash
+xcode-project use-profiles
+```
+
+</li>
+
+<li markdown="1">
+
+Install Flutter dependencies:
+```bash
+flutter packages pub get
+```
+
+</li>
+<li markdown="1">
+
+Install pod dependencies:
+```bash
+find . -name "Podfile" -execdir pod install \;
+```
+
+</li>
+<li markdown="1">
+
+Enable the Flutter macOS option:
+```bash
+flutter config --enable-macos-desktop
+```
+
+</li>
+<li markdown="1">
+
+Build the Flutter macOS project:
+```bash
+flutter build macos --release --build-name=1.0.41 --build-number=41
+```
+
+</li>
+<li markdown="1">
+
+Package the app:
+```bash
+APP_NAME=$(find $(pwd) -name "*macos*.app")
+PACKAGE_NAME=$(basename "$APP_NAME" .app).pkg
+xcrun productbuild --component "$APP_NAME" /Applications/ unsigned.pkg
+
+INSTALLER_CERT_NAME=$(keychain list-certificates \
+          | jq '.[]
+            | select(.common_name
+            | contains("Mac Developer Installer"))
+            | .common_name' \
+          | xargs)
+xcrun productsign --sign "$INSTALLER_CERT_NAME" unsigned.pkg "$PACKAGE_NAME"
+rm -f unsigned.pkg 
+```
+
+</li>
+<li markdown="1">
+
+Publish the packaged app to App Store Connect:
+```bash
+app-store-connect publish \
+    --path my_macos_app.pkg
+```
+
+</li>
+<li markdown="1">
+
+Finally, restore your login keychain as the default to avoid authentication issues with apps on your machine:
+```bash
+keychain use-login
+```
+
+</li>
+</ol>
+
 ## Distribute to registered devices
 
 [TestFlight][] is not available for distributing macOS apps
@@ -248,6 +408,7 @@ detailed overview of the process of releasing an app to the App Store.
 [appstoreconnect_guide]: https://developer.apple.com/support/app-store-connect/
 [appstoreconnect_guide_register]: https://help.apple.com/app-store-connect/#/dev2cd126805
 [appstoreconnect_login]: https://appstoreconnect.apple.com/
+[codemagic_cli_tools]: https://github.com/codemagic-ci-cd/cli-tools
 [codesigning_guide]: https://developer.apple.com/library/content/documentation/Security/Conceptual/CodeSigningGuide/Introduction/Introduction.html
 [Core Foundation Keys]: https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 [devportal_appids]: https://developer.apple.com/account/ios/identifier/bundle

--- a/src/docs/deployment/macos.md
+++ b/src/docs/deployment/macos.md
@@ -178,7 +178,8 @@ Finally, create a build archive and upload it to App Store Connect:
 <ol markdown="1">
 <li markdown="1">
 
-Open Xcode and select **Product > Archive**. Run `flutter build macos` to produce a build archive.
+Open Xcode and select **Product > Archive**. Run `flutter build macos` to
+produce a build archive.
 
 </li>
 <li markdown="1">
@@ -210,7 +211,8 @@ For more details, see
 
 This step covers creating a build archive and uploading
 your build to App Store Connect using Flutter build commands 
-and [Codemagic CLI Tools][codemagic_cli_tools] in a terminal.
+and [Codemagic CLI Tools][codemagic_cli_tools] executed in a terminal
+in the Flutter project directory
 
 <ol markdown="1">
 <li markdown="1">
@@ -223,7 +225,11 @@ pip3 install codemagic-cli-tools
 </li>
 <li markdown="1">
 
-You'll need to generate an [App Store Connect API Key][appstoreconnect_api_key] with App Manager access to automate operations with App Store Connect. To make subsequent commands more concise, set the following environment variables from the new key: issuer id, key id, and API key file. 
+You'll need to generate an [App Store Connect API Key][appstoreconnect_api_key]
+with App Manager access to automate operations with App Store Connect. To make
+subsequent commands more concise, set the following environment variables from
+the new key: issuer id, key id, and API key file.
+
 ```bash
 export APP_STORE_CONNECT_ISSUER_ID=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
 export APP_STORE_CONNECT_KEY_IDENTIFIER=ABC1234567
@@ -233,9 +239,11 @@ export APP_STORE_CONNECT_PRIVATE_KEY=`cat /path/to/api/key/AuthKey_XXXYYYZZZ.p8`
 </li>
 <li markdown="1">
 
-You'll need to export or create a Mac App Distribution and a Mac Installer Distribution certificate to perform code signing and package a build archive.
+You'll need to export or create a Mac App Distribution and a Mac Installer
+Distribution certificate to perform code signing and package a build archive.
 
-If you have existing [certificates][devportal_certificates], you can export the private keys by executing the following command for each certificate:
+If you have existing [certificates][devportal_certificates], you can export the
+private keys by executing the following command for each certificate:
 
 ```bash
 openssl pkcs12 -in <certificate_name>.p12 -nodes -nocerts | openssl rsa -out cert_key
@@ -247,7 +255,9 @@ Or you can create a new private key by executing
 ssh-keygen -t rsa -b 2048 -m PEM -f cert_key -q -N ""
 ```
 
-and later have CLI tools automatically create a new Mac App Distribution and Mac Installer Distribution certificate. You can use the same private key for each new certificate.
+and later have CLI tools automatically create a new Mac App Distribution and
+Mac Installer Distribution certificate. You can use the same private key for
+each new certificate.
 
 </li>
 <li markdown="1">
@@ -255,14 +265,15 @@ and later have CLI tools automatically create a new Mac App Distribution and Mac
 Fetch the code signing files from App Store Connect
 
 ```bash
-app-store-connect fetch-signing-files com.craastad.myMacosApp \
+app-store-connect fetch-signing-files YOUR.APP.BUNDLE_ID \
     --platform MAC_OS \
     --type MAC_APP_STORE \
     --certificate-key=@file:/path/to/cert_key \
     --create
 ```
 
-Where `cert_key` is either your exported Mac App Distribution certificate private key or a new private key which will automatically generate a new certificate. 
+Where `cert_key` is either your exported Mac App Distribution certificate private key
+or a new private key which will automatically generate a new certificate. 
 
 </li>
 <li markdown="1">
@@ -299,11 +310,16 @@ Set up a new temporary keychain to be used for code signing:
 keychain initialize
 ```
 
-NB: after running this command you should run this command restore your login keychain as the default to avoid authentication issues with apps on your machine:
+{{site.alert.warning}}
+**Restore Login Keychain!**
+After running `keychain intialize` you **must** run
 
 ```bash
 keychain use-login
 ```
+
+in order set your login keychain as the default to avoid potential authentication issues with apps on your machine.
+{{site.alert.end}}
 
 </li>
 <li markdown="1">
@@ -346,6 +362,7 @@ find . -name "Podfile" -execdir pod install \;
 <li markdown="1">
 
 Enable the Flutter macOS option:
+
 ```bash
 flutter config --enable-macos-desktop
 ```
@@ -354,6 +371,7 @@ flutter config --enable-macos-desktop
 <li markdown="1">
 
 Build the Flutter macOS project:
+
 ```bash
 flutter build macos --release
 ```
@@ -364,12 +382,12 @@ flutter build macos --release
 Package the app:
 
 ```bash
-APP_NAME=$(find $(pwd) -name "*macos*.app")
+APP_NAME=$(find $(pwd) -name "*.app")
 PACKAGE_NAME=$(basename "$APP_NAME" .app).pkg
 xcrun productbuild --component "$APP_NAME" /Applications/ unsigned.pkg
 
 INSTALLER_CERT_NAME=$(keychain list-certificates \
-          | jq '.[]
+          | jq '.[0]
             | select(.common_name
             | contains("Mac Developer Installer"))
             | .common_name' \
@@ -385,13 +403,14 @@ Publish the packaged app to App Store Connect:
 
 ```bash
 app-store-connect publish \
-    --path my_macos_app.pkg
+    --path "$PACKAGE_NAME"
 ```
 
 </li>
 <li markdown="1">
 
-Don't forget to restore your login keychain as the default to avoid authentication issues with apps on your machine:
+As mentioned earlier, don't forget to set your login keychain as the default to avoid authentication issues
+with apps on your machine:
 ```bash
 keychain use-login
 ```

--- a/src/docs/deployment/macos.md
+++ b/src/docs/deployment/macos.md
@@ -278,7 +278,8 @@ or a new private key which will automatically generate a new certificate.
 </li>
 <li markdown="1">
 
-If you do not have a Mac Installer Distribution certificate, you can create a new certificate by executing  
+If you do not have a Mac Installer Distribution certificate,
+you can create a new certificate by executing the following:
 
 ```bash
 app-store-connect create-certificate \

--- a/src/docs/deployment/macos.md
+++ b/src/docs/deployment/macos.md
@@ -239,7 +239,7 @@ export APP_STORE_CONNECT_PRIVATE_KEY=`cat /path/to/api/key/AuthKey_XXXYYYZZZ.p8`
 </li>
 <li markdown="1">
 
-You'll need to export or create a Mac App Distribution and a Mac Installer
+You need to export or create a Mac App Distribution and a Mac Installer
 Distribution certificate to perform code signing and package a build archive.
 
 If you have existing [certificates][devportal_certificates], you can export the

--- a/src/docs/deployment/macos.md
+++ b/src/docs/deployment/macos.md
@@ -273,7 +273,7 @@ app-store-connect fetch-signing-files YOUR.APP.BUNDLE_ID \
 ```
 
 Where `cert_key` is either your exported Mac App Distribution certificate private key
-or a new private key which will automatically generate a new certificate. 
+or a new private key which automatically generates a new certificate. 
 
 </li>
 <li markdown="1">

--- a/src/docs/deployment/macos.md
+++ b/src/docs/deployment/macos.md
@@ -262,7 +262,7 @@ each new certificate.
 </li>
 <li markdown="1">
 
-Fetch the code signing files from App Store Connect
+Fetch the code signing files from App Store Connect:
 
 ```bash
 app-store-connect fetch-signing-files YOUR.APP.BUNDLE_ID \

--- a/src/docs/deployment/macos.md
+++ b/src/docs/deployment/macos.md
@@ -288,7 +288,7 @@ app-store-connect create-certificate \
     --save
 ```
 
-with `cert_key` of the private key you created earlier.
+Use `cert_key` of the private key you created earlier.
 
 </li>
 <li markdown="1">

--- a/src/docs/deployment/macos.md
+++ b/src/docs/deployment/macos.md
@@ -255,7 +255,7 @@ Or you can create a new private key by executing the following command:
 ssh-keygen -t rsa -b 2048 -m PEM -f cert_key -q -N ""
 ```
 
-and later have CLI tools automatically create a new Mac App Distribution and
+Later, you can have CLI tools automatically create a new Mac App Distribution and
 Mac Installer Distribution certificate. You can use the same private key for
 each new certificate.
 


### PR DESCRIPTION
[Codemagic CLI tools](https://github.com/codemagic-ci-cd/cli-tools) is an open-source python command-line utility that enables Flutter developers to distribute a macOS app without opening the XCode UI and with full control of the code signing certificates. The commands download the code signing certificates into a separate temporary keychain isolated from the user login keychain (unlike Xcode). I find using the command line tools is less error-prone than using the Xcode (in which I usually need to delete all my certificates and create a new one every time I archive the app).

The _Package the app_ step is a little cumbersome because of the need to move files around and look up the installer cert from the keychain with jq. This could possibly be simplified in a future Codemagic CLI tool command.