### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_page_issue.yml
+++ b/.github/ISSUE_TEMPLATE/1_page_issue.yml
@@ -1,0 +1,42 @@
+name: Page issue
+description: Help improve a flutter.dev page
+body:
+  - type: markdown
+    attributes:
+      value: |
+          _Found a typo? You can fix it yourself by going to the page source and clicking the pencil icon. Or finish creating this issue._
+  - type: input
+    id: page-url
+    attributes:
+      label: Page URL
+      placeholder: "Example: https://flutter.dev/docs"
+    validations:
+      required: true
+  - type: input
+    id: page-source
+    attributes:
+      label: Page source
+      placeholder: (Provided automatically by the in-page bug link)
+    validations:
+      required: false
+  - type: textarea
+    id: problem
+    attributes:
+      label: Describe the problem
+      placeholder: A clear and concise description of what's wrong.
+    validations:
+      required: true
+  - type: textarea
+    id: fix
+    attributes:
+      label: Expected fix
+      placeholder: A clear and concise description of how you think we should fix the problem.
+    validations:
+      required: false
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional context
+      placeholder: Anything else we should know about the problem?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/2_topic_request.yml
+++ b/.github/ISSUE_TEMPLATE/2_topic_request.yml
@@ -1,0 +1,18 @@
+name: Topic request
+description: What information should be on flutter.dev but isn't covered well (or at all)?
+labels: [new page/topic request]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What information is missing?
+      placeholder: A clear and concise description of what you expected to find on flutter.dev, but didn't.
+    validations:
+      required: true
+  - type: textarea
+    id: fix
+    attributes:
+      label: How would you like us to fix this problem?
+      placeholder: Let us know where you'd expect to see this missing information.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/3_design_issue.yml
+++ b/.github/ISSUE_TEMPLATE/3_design_issue.yml
@@ -1,0 +1,25 @@
+name: Site appearance or accessibility issue
+description: How can we improve the CSS or page design of flutter.dev?
+labels: [design]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Describe the problem
+      placeholder: A clear and concise description of the issue, preferably with a screenshot.
+    validations:
+      required: true
+  - type: textarea
+    id: fix
+    attributes:
+      label: Expected fix
+      placeholder: A clear and concise description of how you think we should fix the problem.
+    validations:
+      required: false
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional context
+      placeholder: Helpful examples, screenshots, or descriptions go here. If you're interested in helping us fix the issue, let us know!
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/4_infrastructure.yml
+++ b/.github/ISSUE_TEMPLATE/4_infrastructure.yml
@@ -1,0 +1,26 @@
+name: Site infrastructure issue
+description: |
+    Report a problem with the build, repo, or something else that's a problem for people who work on flutter.dev
+labels: [infrastructure]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Describe the problem
+      placeholder: A clear and concise description of the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: fix
+    attributes:
+      label: Expected fix
+      placeholder: A clear and concise description of how you think we should fix the problem.
+    validations:
+      required: false
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional context
+      placeholder: Helpful examples, screenshots, or descriptions go here.
+    validations:
+      required: false


### PR DESCRIPTION
These are the same as the dart-lang/site-www issue templates, but with dart.dev changed to flutter.dev and a sample URL changed.