### PR TITLE
Add to iOS deployment steps to build and distribute an app with Codemagic CLI tools

### DIFF
--- a/src/docs/perf/app-size.md
+++ b/src/docs/perf/app-size.md
@@ -191,7 +191,7 @@ Some other things you can do to make your app smaller are:
 [How big is the Flutter engine?]: /docs/resources/faq#how-big-is-the-flutter-engine
 [instructions]: /docs/deployment/ios
 [Xcode App Size Report]: https://developer.apple.com/documentation/xcode/reducing_your_app_s_size#3458589
-[iOS create build archive instructions]: /docs/deployment/ios#create-a-build-archive
+[iOS create build archive instructions]: /docs/deployment/ios#create-a-build-archive-with-xcode
 [Model ID / Hardware number]: https://en.wikipedia.org/wiki/List_of_iOS_devices#Models
 [Obfuscating Dart code]: /docs/deployment/obfuscate
 [Test drive]: /docs/get-started/test-drive


### PR DESCRIPTION
In continuation of https://github.com/flutter/website/pull/6085, I've added the steps to do iOS code signing with [Codemagic CLI Tools](https://github.com/codemagic-ci-cd/cli-tools). This enables Flutter developers to build and distribute an iOS app without opening the XCode UI and with full control of the code signing certificates.  I find using the command line tools is less error-prone than using the Xcode.