### PR TITLE
Change link to Flutter web samples

### DIFF
--- a/src/web.md
+++ b/src/web.md
@@ -89,5 +89,5 @@ The following resources can help you get started:
 [Preparing an app for web release]: /docs/deployment/web
 [Progressive Web Application]: https://developers.google.com/web/progressive-web-apps/
 [web FAQ]: /docs/development/platform-integration/web
-[web samples for Flutter]: https://flutter.github.io/samples/
+[web samples for Flutter]: https://flutter.github.io/samples/#?platform=web
 [Web renderers]: /docs/development/tools/web-renderers


### PR DESCRIPTION
Make it a deep link that actually filters to web samples and not all samples