### PR TITLE
Adding homebrew installation to documentation

### DIFF
--- a/src/docs/get-started/install/_get-sdk.md
+++ b/src/docs/get-started/install/_get-sdk.md
@@ -83,7 +83,8 @@ command again to verify that you’ve set everything up correctly.
 
 ### Downloading and installing with Homebrew
 
-If you have Homebrew installed on your machine, you can install Flutter using:
+If you have Homebrew installed on your machine,
+you can install Flutter using the following command:
 
 ```terminal
 $ brew install --cask flutter

--- a/src/docs/get-started/install/_get-sdk.md
+++ b/src/docs/get-started/install/_get-sdk.md
@@ -90,8 +90,8 @@ you can install Flutter using the following command:
 $ brew install --cask flutter
 ```
 
-Then, run `flutter doctor`. That will let you know if there are
-other dependencies you need to install to use Flutter (e.g. the Android SDK).
+Then, run `flutter doctor`. That lets you know if there are
+other dependencies you need to install to use Flutter, such as the Android SDK.
 
 ### Downloading straight from GitHub instead of using an archive
 

--- a/src/docs/get-started/install/_get-sdk.md
+++ b/src/docs/get-started/install/_get-sdk.md
@@ -81,6 +81,17 @@ process.
 Once you have installed any missing dependencies, run the `flutter doctor`
 command again to verify that you’ve set everything up correctly.
 
+### Downloading and installing with Homebrew
+
+If you have Homebrew installed on your machine, you can install Flutter using:
+
+```terminal
+$ brew install --cask flutter
+```
+
+Then, run `flutter doctor`. That will let you know if there are
+other dependencies you need to install to use Flutter (e.g. the Android SDK).
+
 ### Downloading straight from GitHub instead of using an archive
 
 _This is only suggested for advanced use cases._
@@ -106,7 +117,6 @@ $ flutter precache
 ```
 
 For additional download options, see `flutter help precache`.
-
 
 {% include_relative _analytics.md %}
 


### PR DESCRIPTION
I added a simple paragraph in the SDK page to show how to install Flutter using Homebrew, which is a preferred method for many developers using macOS.

See https://formulae.brew.sh/cask/flutter for details about the Homebrew cask.