### PR TITLE
Remove macOS 64-bit parenthetical

### DIFF
--- a/src/docs/get-started/install/macos.md
+++ b/src/docs/get-started/install/macos.md
@@ -14,7 +14,7 @@ next:
 To install and run Flutter,
 your development environment must meet these minimum requirements:
 
-- **Operating Systems**: macOS (64-bit)
+- **Operating Systems**: macOS
 - **Disk Space**: 2.8 GB (does not include disk space for IDE/tools).
 - **Tools**: Flutter uses `git` for installation and upgrade. We recommend
   installing [Xcode][], which includes `git`, but you can also 


### PR DESCRIPTION
The macOS installation instructions say that the machine needs to be capable of running 64-bit applications.  Macs that don't run 64-bit apps [which haven't been sold since 2007](https://apple.stackexchange.com/a/99644).

[There's some confusion](https://github.com/flutter/flutter/issues/74662#issuecomment-897039661) that `macOS (64-bit)` means only x86_64 Intel chips, and that the new ARM M1 macOS machines are unsupported, even though both are 64-bit.  Just remove the parenthesis.