### PR TITLE
Add Android splash migration docs

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -86,6 +86,7 @@
       { "source": "/go/android-embedding-dependencies", "destination": "https://docs.google.com/document/d/1vITp2mUZRa-cmll0sPH0zjNgPlyvOMx7awxPNRAPyic/edit", "type": 301 },
       { "source": "/go/android-embedding-move", "destination": "https://docs.google.com/document/d/1nQujwZfEe3QOHTyZn160eImpoJOYioADP09DtumcLcc/edit?ts=5d8041db#", "type": 301 },
       { "source": "/go/android-migration-summary", "destination": "https://docs.google.com/document/d/1wKspwf6LQu6uo32uQ9NcukfiKhLL4ButV9cwpjeb8QI", "type": 301 },
+      { "source": "/go/android-splash-migration", "destination": "https://flutter.dev/docs/development/ui/advanced/splash-screen#migrating-from-manifest-activity-defined-custom-splash-screens", "type": 301 },
       { "source": "/go/android-plugin-migration", "destination": "https://flutter.dev/docs/development/packages-and-plugins/plugin-api-migration", "type": 301 },
       { "source": "/go/android-project-migration", "destination": "https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects", "type": 301 },
       { "source": "/go/androidx-transition", "destination": "https://docs.google.com/document/d/1JnMxQinUeouuV5kcenoq03TsvLyn_xaHXIT_6c5b7nQ", "type": 301 },
@@ -269,7 +270,7 @@
       { "source": "/go/flutter-engine-extensions", "destination": "https://docs.google.com/document/d/1xG7jR4FserdW7TdwnklF3_lXUGmt4myPQjDGF3LFtCQ/edit?resourcekey=0-Iug4D2mWuyQI6suvC_2itw#", "type": 301 },
       { "source": "/go/plugin-support-for-custom-embeddings", "destination": "https://docs.google.com/document/d/1AJTHdC20JhD3viR4JWTghagIztqL5jg_R9NFQmnwAMw/edit?usp=sharing&resourcekey=0-qAECjzHKB5tM47azrVnH1w", "type": 301 },
       { "source": "/go/text-editing-model", "destination": "https://docs.google.com/document/d/1lkpg4dfVZif9NJ_dDQ01QkwQC3OqzhUFahhjgv_rcbM/edit#", "type": 301 },
-      
+
       { "source": "/hot-reload", "destination": "/docs/development/tools/hot-reload", "type": 301 },
       { "source": "/ide-setup", "destination": "/docs/get-started/editor", "type": 301 },
       { "source": "/images/intellij/hot-reload.gif", "destination": "https://raw.githubusercontent.com/flutter/website/master/src/_assets/image/tools/android-studio/hot-reload.gif", "type": 301 },

--- a/src/docs/development/ui/advanced/splash-screen.md
+++ b/src/docs/development/ui/advanced/splash-screen.md
@@ -188,8 +188,24 @@ class MainActivity : FlutterActivity() {
 Then, you can reimplement the first frame in Flutter that shows elements of your
 Android splash screen in the same positions on screen.
 
+### Migrating from Manifest / Activity defined custom splash screens
+
+{{site.alert.note}}
+  This is an upcoming change for Flutter 2.5.
+{{site.alert.end}}
+
+Previously, Android Flutter apps would either set
+`io.flutter.embedding.android.SplashScreenDrawable` in thier application
+manifest, or implement [`provideSplashScreen`][] within their Flutter Activity.
+This would be shown momentarily in between the time after the Android launch
+screen is shown and when Flutter has drawn the first frame. This is no longer
+needed and is deprecated – Flutter now automatically keeps the Android launch
+screen displayed until Flutter has drawn the first frame. Developers should
+instead remove usage of these APIs.
+
 [Android Splash Screens]: {{site.android-dev}}/about/versions/12/features/splash-screen
 [launch screen]: {{site.android-dev}}/topic/performance/vitals/launch-time#themed
 [pre-warming a `FlutterEngine`]: /docs/development/add-to-app/android/add-flutter-fragment#using-a-pre-warmed-flutterengine
+[`provideSplashScreen`]: https://api.flutter.dev/javadoc/io/flutter/embedding/android/SplashScreenProvider.html#provideSplashScreen--
 [must use an Xcode storyboard]: https://developer.apple.com/news/?id=03042020b
 [Human Interface Guidelines]: https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/launch-screen/


### PR DESCRIPTION
Add a small migration guide and a go link to `flutter.dev/go/android-splash-migration`

Related issue: flutter/flutter#85292

Fixes #6134