### PR TITLE
Fix anchor for go/android-splash-migration

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -86,7 +86,7 @@
       { "source": "/go/android-embedding-dependencies", "destination": "https://docs.google.com/document/d/1vITp2mUZRa-cmll0sPH0zjNgPlyvOMx7awxPNRAPyic/edit", "type": 301 },
       { "source": "/go/android-embedding-move", "destination": "https://docs.google.com/document/d/1nQujwZfEe3QOHTyZn160eImpoJOYioADP09DtumcLcc/edit?ts=5d8041db#", "type": 301 },
       { "source": "/go/android-migration-summary", "destination": "https://docs.google.com/document/d/1wKspwf6LQu6uo32uQ9NcukfiKhLL4ButV9cwpjeb8QI", "type": 301 },
-      { "source": "/go/android-splash-migration", "destination": "https://flutter.dev/docs/development/ui/advanced/splash-screen#migrating-from-manifest-activity-defined-custom-splash-screens", "type": 301 },
+      { "source": "/go/android-splash-migration", "destination": "https://flutter.dev/docs/development/ui/advanced/splash-screen#migrating-from-manifest--activity-defined-custom-splash-screens", "type": 301 },
       { "source": "/go/android-plugin-migration", "destination": "https://flutter.dev/docs/development/packages-and-plugins/plugin-api-migration", "type": 301 },
       { "source": "/go/android-project-migration", "destination": "https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects", "type": 301 },
       { "source": "/go/androidx-transition", "destination": "https://docs.google.com/document/d/1JnMxQinUeouuV5kcenoq03TsvLyn_xaHXIT_6c5b7nQ", "type": 301 },


### PR DESCRIPTION
The anchor added in #6140 is incorrect