### PR TITLE
Update FAQ with ABI compatibility info

### DIFF
--- a/src/docs/resources/faq.md
+++ b/src/docs/resources/faq.md
@@ -680,6 +680,12 @@ We have seen Flutter apps run on some Chromebooks.
 We are tracking [issues related to running Flutter on
 Chromebooks][].
 
+### Is Flutter ABI compatible?
+
+Flutter and Dart do not offer application binary interface (ABI)
+compatibility. Offering ABI compatability is not a current
+goal for Flutter or Dart.
+
 ## Framework
 
 ### Why is the build() method on State, rather than StatefulWidget?


### PR DESCRIPTION
Fixes #6125

Adds a section about ABI compatibility to the FAQ. Hopefully this is a small enough change that we can merge it today. Otherwise I'm fine recreating this on the 23rd.