### PR TITLE
Update internationalization page text

### DIFF
--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -740,7 +740,7 @@ with a different i18n framework.
 
 Complete source code for the [`minimal`][] app.
 
-In the below exampole, the DemoLocalizations class 
+In the below example, the `DemoLocalizations` class 
 includes all of its translations directly in per language Maps.
 
 


### PR DESCRIPTION
Addresses #1473
While the aforementioned section in this issue is gone, this PR rewrites areas so they don't reference "DemoApp" which no longer exists. It also re-evaluates the usage of "DemoLocalizations" so users don't assume that it is a pre-defined class and don't need to pay attention to class names as much.