### PR TITLE
(#6206) remove sitemap front matter prop from 404

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -3,7 +3,13 @@
     "public": "_site",
     "cleanUrls": true,
     "trailingSlash": false,
-    "ignore": [],
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "tool",
+      "src",
+      "**/node_modules/**"
+    ],
     "redirects": [
       { "source": "/accessibility", "destination": "/docs/development/accessibility-and-localization/accessibility", "type": 301 },
       { "source": "/adaptations", "destination": "/docs/resources/platform-adaptations", "type": 301 },
@@ -321,19 +327,14 @@
       { 
         "source": "/f/*.json", 
         "headers": [
-          {"key": "Access-Control-Allow-Origin", "value": "*"}] 
-        },
+          {"key": "Access-Control-Allow-Origin", "value": "*"}
+        ] 
+      },
       {
         "source": "**/*.@(jpg|jpeg|gif|png)",
         "headers": [
           { "key": "Cache-Control", "value": "max-age=3600" },
           { "key": "Access-Control-Allow-Origin", "value": "*" }
-        ]
-      }, 
-      {
-        "source": "404.html",
-        "headers": [
-          { "key": "Cache-Control", "value": "max-age=300" }
         ]
       }
     ]

--- a/src/404.html
+++ b/src/404.html
@@ -1,15 +1,15 @@
 ---
 title: Page not found
 layout: landing
-sitemap: false
 body_class: landing-page not-found
+permalink: /404.html
 ---
 
 <div class="not-found__wrapper">
   <h1>404</h1>
   <p>Sorry, we couldn’t find that page…</p>
-  <img src='404/dash_nest.png'' class='not-found__illo'>
-  <p>But Dash is here to help – maybe one of these will point you in the right direction?</p>
+  <img src='/assets/images/404/dash_nest.png' class='not-found__illo'>
+  <p>But Dash is here to help - maybe one of these will point you in the right direction?</p>
   <ul class="not-found__link-list">
     <li><a href="/">Homepage</a></li>
     <li><a href="https://pub.dev/">Package site</a></li>


### PR DESCRIPTION
- fixes #6206
- remove `sitemap` property from 404 front matter, which may be incompatible with Jekyll upgrade
- add permalink just for safety
- correct image path with updated tree