### PR TITLE
Fix community page's incorrect nav bar active style

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -25,7 +25,7 @@
             <a class="nav-link{% if route contains '/showcase' %} active{% endif %}" href="/showcase">Showcase</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link{% if route contains '/community' %}active{% endif %}" href="/community">Community</a>
+            <a class="nav-link{% if route contains '/community' %} active{% endif %}" href="/community">Community</a>
           </li>
         </ul>
         <form action="/search/" class="site-header__search form-inline">


### PR DESCRIPTION
The `nav-link` and `active` classes weren't being applied properly due to a missing space.

Fixes https://github.com/flutter/website/issues/6209