### PR TITLE
Made the simple Flutter logo to Image Link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Flutter logo][]
+[![Flutter logo]](https://flutter.dev)
 # [Flutter][] website 
 
 [![Build Status][]][Repo on GitHub Actions]


### PR DESCRIPTION
Change the simple Flutter logo in README.md file to a clickable image link, which now opens flutter official website (https://flutter.dev/)

Before changes - it was opening the Flutter logo file (64.png)
![Screenshot (82)](https://user-images.githubusercontent.com/51878265/131860136-6db61ae3-0179-4c9f-80c6-0d19b7d7c6e2.png)

After changes - Flutter official website (https://flutter.dev/)
![Screenshot (83)](https://user-images.githubusercontent.com/51878265/131860718-13d17a35-e7c1-4875-9835-8e26ca1056a0.png)


