### PR TITLE
Correct misspelled awhile

### DIFF
--- a/src/docs/get-started/codelab.md
+++ b/src/docs/get-started/codelab.md
@@ -168,7 +168,7 @@ where the Dart code lives.
 
     {{site.alert.tip}}
       The first time you run on a physical device,
-      it can take awhile to load.
+      it can take a while to load.
       Afterward, you can use hot reload for quick updates.
       **Save** also performs a hot reload if the app is running.
       When running an app directly from the console using


### PR DESCRIPTION
The adverbial awhile can't be used in the expression "Take a while"; the space is required.

See this website for an explanation:
https://blog.esllibrary.com/2017/05/04/a-while-vs-awhile/

This change was previously proposed in #6186 but was discarded there because of the website upgrade