### PR TITLE
Add refresh-code-excerpts as PHONY target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
-#!make
+#!/usr/bin/make -f
 include shared.env
 -include .env
 
 
-all: gen-env up down debug shell setup serve switch-channel test-channel check-code check-links test debug-test build build-image deploy stage clean reinstall purge
+all: gen-env up down debug shell setup serve switch-channel test-channel \
+	refresh-code-excerpts check-code check-links test debug-test build \
+	build-image deploy stage clean reinstall purge
 
-.DEFAULT_TARGET: up
+.DEFAULT_GOAL := up
 .PHONY: all
 
 


### PR DESCRIPTION
Also -
- `#!make` is an invalid shebang. Appropriate shebang should be
`#!/usr/bin/make -f`.
Reference - https://www.gnu.org/software/make/manual/html_node/Complex-Makefile.html#Complex-Makefile

- Rename `.DEFAULT_TARGET` to `.DEFAULT_GOAL`
Although the default target was running `up` target there is no mention
of `.DEFAULT_TARGET` anywhere in GNU Make manual.
Reference - https://www.gnu.org/software/make/manual/html_node/Special-Variables.html

- Multiline all prerequisites to improve readability.
Reference - https://www.gnu.org/software/make/manual/make.html#Splitting-Lines