### PR TITLE
Fix some npm vulnerabilities, and sh issue with Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,12 +46,12 @@ ENV PATH="/app/flutter/bin:$PATH"
 # Used if wanting to build the container with a different branch
 # e.g. `make FLUTTER_BRANCH=dev build`
 # This is not to be confused with the $TEST_TARGET_CHANNEL
-RUN if [[ -z $FLUTTER_BRANCH && "$FLUTTER_BRANCH" != "stable" ]]; then \
-      cd flutter; \
-      git fetch; \
-      git remote set-branches origin $FLUTTER_BRANCH; \
-      git fetch --depth 1 origin $FLUTTER_BRANCH; \
-      git checkout $FLUTTER_BRANCH --; \
+RUN if test -n "$FLUTTER_BRANCH" -a "$FLUTTER_BRANCH" != "stable" ; then \
+      cd flutter && \
+      git fetch && \
+      git remote set-branches origin "$FLUTTER_BRANCH" && \
+      git fetch --depth 1 origin "$FLUTTER_BRANCH" && \
+      git checkout "$FLUTTER_BRANCH" -- && \
       git pull; \
     fi
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "bootstrap-scss": "^4.6.0",
-    "diff2html-cli": "^2.7.0",
+    "diff2html-cli": "^5.1.11",
     "font-awesome": "^4.7.0"
-  },
-  "devDependencies": {}
+  }
 }


### PR DESCRIPTION
When building the site for testing locally, I noticed that NPM printed the following:

```
8 vulnerabilities (2 low, 2 moderate, 2 high, 2 critical)
```

So I updated the `package.json` dependencies to skip past the vulnerabilities (it now reports zero).

I also noticed that the `Dockerfile` had an error in it that likely was causing it to not switch to different flutter branches. It was saying:

```
Step 24/29 : RUN if [[ -z $FLUTTER_BRANCH && "$FLUTTER_BRANCH" != "stable" ]]; then       cd flutter;       git fetch;       git remote set-branches origin $FLUTTER_BRANCH;       git fetch --depth 1 origin $FLUTTER_BRANCH;       git checkout $FLUTTER_BRANCH --;       git pull;     fi
 ---> Running in 646a6cf1ad7d
/bin/sh: 1: [[: not found
```

So I fixed the `Dockerfile` too. It also probably was continuing to run subsequent steps in the command even if one of them failed, so I switched it from using `;` to `&&`.