### PR TITLE
Fix 'long' typo

### DIFF
--- a/src/docs/release/breaking-changes/theme-data-accent-properties.md
+++ b/src/docs/release/breaking-changes/theme-data-accent-properties.md
@@ -47,7 +47,7 @@ library no longer uses them.
 
 ### Application theme
 
-[`ThemeData`][] values no long need to specify accentColor,
+[`ThemeData`][] values no longer need to specify accentColor,
 accentColorBrightness, accentIconTheme, or accentTextTheme.
 
 To configure the appearance of the material components in about the


### PR DESCRIPTION
The word 'long' does not make grammatical sense in this sentence and should instead be 'longer'.