### PR TITLE
remove homebrew instructions

### DIFF
--- a/src/docs/get-started/install/_get-sdk.md
+++ b/src/docs/get-started/install/_get-sdk.md
@@ -81,18 +81,6 @@ process.
 Once you have installed any missing dependencies, run the `flutter doctor`
 command again to verify that you’ve set everything up correctly.
 
-### Downloading and installing with Homebrew
-
-If you have Homebrew installed on your machine,
-you can install Flutter using the following command:
-
-```terminal
-$ brew install --cask flutter
-```
-
-Then, run `flutter doctor`. That lets you know if there are
-other dependencies you need to install to use Flutter, such as the Android SDK.
-
 ### Downloading straight from GitHub instead of using an archive
 
 _This is only suggested for advanced use cases._


### PR DESCRIPTION
This removes the instructions added in https://github.com/flutter/website/pull/6124/files. The validity of this cask is uncertain, so we should not be officially recommending it unless its security has been vetted.