### PR TITLE
Add Android job listing.

### DIFF
--- a/src/jobs/android.html
+++ b/src/jobs/android.html
@@ -1,0 +1,94 @@
+---
+title: Android Engineer
+---
+
+<p>The Flutter team is constantly looking to improve our fidelity on
+  our supported platforms. To that end, we’re seeking software
+  engineers to join our Android team. In the “Android Engineer” role, you’ll
+  be part of a team that makes Flutter on Android the absolute best it can
+  be, including:</p>
+
+<ul>
+  <li>Delivering outstanding performance.</li>
+  <li>Delighting developers with a simple but powerful developer
+    experience.</li>
+  <li>Making Flutter feel “native” on Android (e.g. by tying into system
+    preferences and accessibility, or by integrating with native performance
+    &amp; memory profiling tools).</li>
+  <li>Allowing seamless and efficient interoperability with native Android
+    views and libraries.</li>
+  <li>Encouraging the growth and quality of the Flutter Android plugin
+    ecosystem on pub.dev.</li>
+  <li>Nurturing a thriving community of contributions from open-source
+    developers by reviewing GitHub pull requests (PRs).</li>
+</ul>
+
+<h2>Job responsibilities</h2>
+
+<ol type="A">
+  <li>Simplify and improve the tooling required to build Flutter Android
+    apps.</li>
+  <li>Respond rapidly to Android platform updates (e.g. Android 12)</li>
+  <li>Minimize the memory and file-size footprint required by Flutter
+    Android apps.</li>
+  <li>Improve the interoperability between Flutter apps and Java/Kotlin
+    code.</li>
+  <li>Streamline Flutter’s mechanism for embedding native Android views or
+    communicating with native Android libraries.</li>
+  <li>Maintain and improve Flutter's core plugins (Ads, Maps, WebView,
+    In-App Purchase) on Android.</li>
+</ol>
+
+<h2>Job location</h2>
+
+<ul>
+<li>Mountain View, CA</li>
+</ul>
+
+<h2>Minimum qualifications</h2>
+
+<p><i>You must meet these minimum qualifications to apply
+   for this job</i></p>
+
+<p>
+<ul>
+  <li>Authorization to work in the United States (US citizenship
+    or work visa)</li>
+  <li>Native Android application development experience across a variety of
+    Android versions</li>
+  <li>Proficient in written and verbal English</li>
+  <li>Enjoys working in a team environment</li>
+  <li>Self-motivated and possesses a good work ethic</li>
+</ul>
+</p>
+
+<h2>Preferred qualifications:</h2>
+
+<p><i>Having these qualifications is a plus, but transferable
+  skills/experiences may be equally valuable</i></p>
+
+<p>
+<ul>
+  <li>Experience with Android performance profiling and memory tooling</li>
+  <li>Experience with Android build systems (e.g. Gradle)</li>
+  <li>Loves simple and elegant solutions to complex problems</li>
+  <li>Possesses a good sense of API design.</li>
+  <li>Ability to see how things might fail in unexpected ways.</li>
+  <li>Can efficiently navigate ambiguity by evaluating potential
+    solutions and weighing pros and cons</li>
+</ul>
+</p>
+
+<h2>To apply</h2>
+
+<p>
+Please send the following to
+<a href="mailto:flutter-jobs@google.com">flutter-jobs@google.com</a>:
+
+<ul>
+<li>A resume outlining your relevant experience
+<li>A short introduction describing why you think you’d
+    be a good fit for this position
+<li>The preferred method by which you’d like Google to contact you
+</ul>
+</p>

--- a/src/jobs/index.md
+++ b/src/jobs/index.md
@@ -5,9 +5,7 @@ description: Open job listings for the Flutter and Dart teams.
 
 We currently have the following job openings on the Flutter and Dart teams:
 
-* [Framework Engineer](/jobs/framework)
-* [iOS Engineer](/jobs/ios)
-* [Engine Web Engineer](/jobs/engine_web)
+* [Android Engineer](/jobs/android)
 * [Senior Technical Program Manager](/jobs/tpm)
 * [Developer Relations Engineer](/jobs/dre)
 * [Dart Platform Engineer](/jobs/dart_platform)


### PR DESCRIPTION
- Also, remove some positions from the index for which we've
  recently filled the roles (but leave the job details page up
  in case anyone's still referencing it).