### PR TITLE
Remove linux/macOS conditionals from respective installer instructions

### DIFF
--- a/src/docs/get-started/install/_get-sdk-linux.md
+++ b/src/docs/get-started/install/_get-sdk-linux.md
@@ -1,11 +1,3 @@
-{% if os == 'linux' -%}
-  {% assign unzip = 'tar xf' -%}
-  {% assign file_ext = '.tar.xz' -%}
-{% else -%}
-  {% assign unzip = 'unzip' -%}
-  {% assign file_ext = '.zip' -%}
-{% endif -%}
-
 ## Get the Flutter SDK {#get-sdk}
 
 On Linux, you have two ways you can install Flutter.
@@ -52,13 +44,13 @@ install Flutter using the following steps.
 
       {% prettify shell %}
       $ cd ~/development
-      $ {{unzip}} ~/Downloads/[[download-latest-link-filename]]flutter_{{os}}_vX.X.X-{{site.sdk.channel}}{{file_ext}}[[/end]]
+      $ tar xf ~/Downloads/[[download-latest-link-filename]]flutter_{{os}}_vX.X.X-{{site.sdk.channel}}.tar.xz[[/end]]
       {% endprettify %}
     {% endcomment -%}
 
     ```terminal
     $ cd ~/development
-    $ {{unzip}} ~/Downloads/flutter_{{os}}_vX.X.X-{{site.sdk.channel}}{{file_ext}}
+    $ tar xf ~/Downloads/flutter_{{os}}_vX.X.X-{{site.sdk.channel}}.tar.xz
     ```
     
     If you don't want to install a fixed version of the installation bundle, 

--- a/src/docs/get-started/install/_get-sdk-mac.md
+++ b/src/docs/get-started/install/_get-sdk-mac.md
@@ -1,11 +1,3 @@
-{% if os == 'linux' -%}
-  {% assign unzip = 'tar xf' -%}
-  {% assign file_ext = '.tar.xz' -%}
-{% else -%}
-  {% assign unzip = 'unzip' -%}
-  {% assign file_ext = '.zip' -%}
-{% endif -%}
-
 ## Get the Flutter SDK {#get-sdk}
 
  1. Download the following installation bundle to get the latest
@@ -23,13 +15,13 @@
 
       {% prettify shell %}
       $ cd ~/development
-      $ {{unzip}} ~/Downloads/[[download-latest-link-filename]]flutter_{{os}}_vX.X.X-{{site.sdk.channel}}{{file_ext}}[[/end]]
+      $ unzip ~/Downloads/[[download-latest-link-filename]]flutter_{{os}}_vX.X.X-{{site.sdk.channel}}.zip[[/end]]
       {% endprettify %}
     {% endcomment -%}
 
     ```terminal
     $ cd ~/development
-    $ {{unzip}} ~/Downloads/flutter_{{os}}_vX.X.X-{{site.sdk.channel}}{{file_ext}}
+    $ unzip ~/Downloads/flutter_{{os}}_vX.X.X-{{site.sdk.channel}}.zip
     ```
     
  1. Add the `flutter` tool to your path:

--- a/src/docs/get-started/install/macos.md
+++ b/src/docs/get-started/install/macos.md
@@ -26,7 +26,7 @@ your development environment must meet these minimum requirements:
   for the new Apple Silicon architecture.
 {{site.alert.end}}
 
-{% include_relative _get-sdk.md %}
+{% include_relative _get-sdk-mac.md %}
 
 {% include_relative _path-mac.md %}
 


### PR DESCRIPTION
The macOS and Linux installer instructions were split with #4353.
Rename `_get-sdk.md` to  `_get-sdk-mac.md ` to make the platform explicit.  Remove the zip/tar conditionals.