### PR TITLE
Add macOS deployment link to side nav

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -348,6 +348,8 @@
       permalink: /docs/deployment/android
     - title: Build and release an iOS app
       permalink: /docs/deployment/ios
+    - title: Build and release a macOS app
+      permalink: /docs/deployment/macos
     - title: Build and release a Linux app
       permalink: /docs/deployment/linux
     - title: Build and release a web app


### PR DESCRIPTION
The macOS deployment instructions were added to the side nav in #5893, but was lost in #6188.
Add it back.