### PR TITLE
Add "awaits" to all "driver.close()"

### DIFF
--- a/examples/cookbook/testing/integration/introduction/test_driver/app_test.dart
+++ b/examples/cookbook/testing/integration/introduction/test_driver/app_test.dart
@@ -19,7 +19,7 @@ void main() {
 
     // Close the connection to the driver after the tests have completed.
     tearDownAll(() async {
-      driver.close();
+      await driver.close();
     });
 
     test('starts at 0', () async {

--- a/examples/integration_test/test_driver/before.dart
+++ b/examples/integration_test/test_driver/before.dart
@@ -11,7 +11,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      driver.close();
+      await driver.close();
     });
 
     test('tap on the floating action button; verify counter', () async {

--- a/src/docs/cookbook/testing/integration/introduction.md
+++ b/src/docs/cookbook/testing/integration/introduction.md
@@ -238,7 +238,7 @@ void main() {
 
     // Close the connection to the driver after the tests have completed.
     tearDownAll(() async {
-      driver.close();
+      await driver.close();
     });
 
     test('starts at 0', () async {

--- a/src/docs/cookbook/testing/integration/profiling.md
+++ b/src/docs/cookbook/testing/integration/profiling.md
@@ -174,7 +174,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      driver.close();
+      await driver.close();
     });
 
     test('verifies the list contains a specific item', () async {

--- a/src/docs/testing/integration-tests/index.md
+++ b/src/docs/testing/integration-tests/index.md
@@ -273,7 +273,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      driver.close();
+      await driver.close();
     });
 
     test('tap on the floating action button; verify counter', () async {


### PR DESCRIPTION
Fixes #1560
Adds "await" to all "driver.close()"'s that don't already have it.