### PR TITLE
Redirecting workshop link to correct video.

### DIFF
--- a/src/docs/codelabs/index.md
+++ b/src/docs/codelabs/index.md
@@ -202,7 +202,7 @@ Learn how to use Flutter with other technologies.
 [Build a Photo Sharing app with Google Photos and Flutter]: {{site.codelabs}}/codelabs/google-photos-sharing
 [Build voice bots for Android with Dialogflow and Flutter]: {{site.codelabs}}/codelabs/dialogflow-flutter?hl=en&continue=https%3A%2F%2Fcodelabs.developers.google.com%2F#0
 [Build voice bots for mobile with Dialogflow and Flutter]: {{site.youtube-site}}/watch?v=O7JfSF3CJ84
-[firebase-ws]: {{site.youtube-site}}/watch?v=4wunbF29Kkg
+[firebase-ws]: {{site.youtube-site}}/watch?v=wUSkeTaBonA
 [Get to know Firebase for Flutter]: https://firebase.google.com/learn/codelabs/firebase-get-to-know-flutter
 [Multi-platform Firestore Flutter]: {{site.codelabs}}/codelabs/friendlyeats-flutter/
 


### PR DESCRIPTION
This changes the link for the Firebase workshop to point to the edited, "final" copy.

This will fix #6190. 