### PR TITLE
Fixed little typo

### DIFF
--- a/src/docs/development/ui/advanced/splash-screen.md
+++ b/src/docs/development/ui/advanced/splash-screen.md
@@ -194,7 +194,7 @@ Android splash screen in the same positions on screen.
 {{site.alert.end}}
 
 Previously, Android Flutter apps would either set
-`io.flutter.embedding.android.SplashScreenDrawable` in thier application
+`io.flutter.embedding.android.SplashScreenDrawable` in their application
 manifest, or implement [`provideSplashScreen`][] within their Flutter Activity.
 This would be shown momentarily in between the time after the Android launch
 screen is shown and when Flutter has drawn the first frame. This is no longer


### PR DESCRIPTION
In the page: https://flutter.dev/docs/development/ui/advanced/splash-screen#migrating-from-manifest--activity-defined-custom-splash-screens there is a little typo 😄 . 