### PR TITLE
Fix some unexpected text in short-titles

### DIFF
--- a/src/docs/development/accessibility-and-localization/index.md
+++ b/src/docs/development/accessibility-and-localization/index.md
@@ -1,5 +1,5 @@
 ---
 layout: toc
 title: Accessibility & internationalization
-short-title: a11y & i18n
+short-title: accessibility & localization
 ---

--- a/src/docs/development/accessibility-and-localization/internationalization.md
+++ b/src/docs/development/accessibility-and-localization/internationalization.md
@@ -1,6 +1,6 @@
 ---
 title: Internationalizing Flutter apps
-short-title: i18n
+short-title: localization
 description: How to internationalize your Flutter app.
 ---
 


### PR DESCRIPTION
Fix some unexpected text in short-titles. 

a11y &amp; 'i18n'
when it should show
'accessibility & localization'

the same with the value
'i18n'
that should be shown as
'localization'

