### PR TITLE
Fix pub.dev sentry_flutter docs url

### DIFF
--- a/src/docs/cookbook/maintenance/error-reporting.md
+++ b/src/docs/cookbook/maintenance/error-reporting.md
@@ -99,7 +99,7 @@ you can use the API to report errors to Sentry:
 await Sentry.captureException(exception, stackTrace: stackTrace);
 ```
 
-The complete API is available on [pub.dev][].
+For more information, see the [Sentry API][] docs on pub.dev.
 
 ## Learn more
 
@@ -116,5 +116,5 @@ see the [Sentry flutter example][] app.
 [Rollbar]: https://rollbar.com/
 [Sentry]: https://sentry.io/welcome/
 [`sentry_flutter`]: {{site.pub-pkg}}/sentry_flutter
-[pub.dev]: {{site.pub-pkg}}/documentation/sentry_flutter/latest/sentry_flutter/sentry_flutter-library.html
+[Sentry API]: {{site.pub-api}}/sentry_flutter/latest/sentry_flutter/sentry_flutter-library.html
 [Sentry's site]: https://docs.sentry.io/platforms/flutter/


### PR DESCRIPTION
`{{site.pub-pkg}}` appends `/packages` and breaks the URL

Sorry for the new PR, when trying to merge `main` into `patch-1`, it said that it was up to date although there was plenty of `diff`, old PR https://github.com/flutter/website/pull/6324