### PR TITLE
Add "building adaptive apps" to sidenav

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -65,6 +65,8 @@
               permalink: /docs/development/ui/layout/tutorial
             - title: Creating adaptive and responsive apps
               permalink: /docs/development/ui/layout/adaptive-responsive
+            - title: Building adaptive apps
+              permalink: /docs/development/ui/layout/building-adaptive-apps
             - title: Understanding constraints
               permalink: /docs/development/ui/layout/constraints
             - title: Box constraints


### PR DESCRIPTION
Fixes #6317

Adds "building adaptive apps" to the sidenav of the layouts section.
Should we make sure that more pages aren't accidentally left out of the sidenav?