### PR TITLE
Add onFocus param to platform view factory

### DIFF
--- a/src/docs/development/platform-integration/platform-views.md
+++ b/src/docs/development/platform-integration/platform-views.md
@@ -94,6 +94,9 @@ Widget build(BuildContext context) {
         layoutDirection: TextDirection.ltr,
         creationParams: creationParams,
         creationParamsCodec: StandardMessageCodec(),
+        onFocus: () {
+          params.onFocusChanged(true);
+        } ,
       )
         ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
         ..create();


### PR DESCRIPTION
Without this param, focusing a platform view doesn't notify the framework.

Related issue: https://github.com/flutter/flutter/issues/86480