### PR TITLE
Remove autogen of .env from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ all: gen-env up down debug shell setup serve switch-channel test-channel \
 # Usage: `make gen-env`
 .env:
 	touch $@
-	make genenv
 genenv: .env
 	@echo "DISABLE_TESTS=1" >> $<
 	@echo "FLUTTER_BRANCH=stable" >> $<


### PR DESCRIPTION
Autogeneration of the local `.env` file via the Makefile was canceling out the `FIREBASE_TOKEN` in the Github action. Removed. 