### PR TITLE
Fix testing-toc include

### DIFF
--- a/src/_includes/docs/testing-toc.md
+++ b/src/_includes/docs/testing-toc.md
@@ -1,19 +1,18 @@
 {% comment %}
-  Generates a list of testing recipes for the given type. The type corresponds
-  to the name of the directory under cookbook/testing/*.
+  Generates a list of testing recipes for the given type. The type 
+  corresponds to the name of the directory under cookbook/testing/*.
 
   Usage: {% include docs/testing_toc.md type='unit' %}
 {% endcomment -%}
-
 {% assign dir = 'cookbook/testing/' | append: include.type %}
-
 {% assign recipes = site.pages | where_exp:"item", "item.dir contains dir" | sort: 'title' %}
 
-{% for recipe in recipes -%}
+{% for recipe in recipes %}
 {% comment %}
-  Exclude index pages (all other pages will end in `.html`).
-{% endcomment -%}
-{% if recipe.url contains '.html' -%}
+  Omit the index page for the given type
+{% endcomment %}
+{% assign frag = recipe.url | split: '/' | last %}
+{% if frag != include.type %}
 - [{{ recipe.title }}]({{ recipe.url }})
-{% endif -%}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
- Fixes #6308
- Upgrades liquid logic to not rely on `.html` when filtering `site.pages`

/cc @kwalrath 