### PR TITLE
Rearrange order of "Flutter" in page `<title/>`

### DIFF
--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -1,9 +1,11 @@
 {% assign cache_bust = site.time|date:'?v=%s' %}
+{% assign page_url = page.url | regex_replace: '/index$|/index.html$|\.html$|/$' -%}
+
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>{{ site.title }}{% if page.title %} | {{ page.title }}{% endif %}</title>
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
     <link rel="icon" href="/assets/images/shared/brand/flutter/icon/64.png" />
     <link rel="apple-touch-icon" href="/assets/images/shared/brand/flutter/logo/flutter-logomark-320px.png" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
@@ -28,7 +30,6 @@
       </script>
     {% endif %}
 
-    {% assign page_url = page.url | regex_replace: '/index$|/index.html$|\.html$|/$' -%}
     {% assign desc = page.description %}
     {% assign og_image = page.image | default: layout.image | default: site.default_share_image %}
 

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 ---
-title: Flutter - Beautiful native apps in record time
+title: Beautiful native apps in record time
 layout: landing
 body_class: landing-page homepage
 homepage: true


### PR DESCRIPTION
- Fixes #6312
- Move "Flutter" to end of title
- Update `index.html` home page, removing "Flutter" for consistency

/cc @kwalrath 