### PR TITLE
Redirect .html and external image request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ serve:
 		--incremental \
 		--trace
 
+# Test hosting locally with FB emulator
+emulate:
+	firebase emulators:start --only hosting
+
 
 # =================== Testing locally from host ==================
 # NOTE that these are for convenience of testing from outside of a container. 

--- a/firebase.json
+++ b/firebase.json
@@ -11,6 +11,8 @@
       "**/node_modules/**"
     ],
     "redirects": [
+      { "regex": "(?P<basename>.*).html", "destination": ":basename", "type": 301 },
+      { "source": "/images/catalog-widget-placeholder.png", "destination": "/assets/images/docs/catalog-widget-placeholder.png", "type": 301 },
       { "source": "/accessibility", "destination": "/docs/development/accessibility-and-localization/accessibility", "type": 301 },
       { "source": "/adaptations", "destination": "/docs/resources/platform-adaptations", "type": 301 },
       { "source": "/adaptive*", "destination": "/docs/development/ui/layout/adaptive-responsive", "type": 301 },
@@ -347,5 +349,10 @@
         ]
       }
     ]
+  },
+  "emulators": {
+    "hosting": {
+      "port": 5000
+    }
   }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -11,7 +11,8 @@
       "**/node_modules/**"
     ],
     "redirects": [
-      { "regex": "(?P<basename>.*).html", "destination": ":basename", "type": 301 },
+      { "regex": "(?P<basename>.*)\\.html$", "destination": ":basename", "type": 301 },
+      { "regex": "(?P<basename>.*)\\.$", "destination": ":basename", "type": 301 },
       { "source": "/images/catalog-widget-placeholder.png", "destination": "/assets/images/docs/catalog-widget-placeholder.png", "type": 301 },
       { "source": "/accessibility", "destination": "/docs/development/accessibility-and-localization/accessibility", "type": 301 },
       { "source": "/adaptations", "destination": "/docs/resources/platform-adaptations", "type": 301 },

--- a/src/docs/release/breaking-changes/index.md
+++ b/src/docs/release/breaking-changes/index.md
@@ -33,7 +33,7 @@ TBD
 [Introducing package:flutter_lints]: /docs/release/breaking-changes/flutter-lints-package
 [Replace AnimationSheetBuilder.display with collate]: /docs/release/breaking-changes/animation-sheet-builder-display
 [ThemeData's accent properties have been deprecated]: /docs/release/breaking-changes/theme-data-accent-properties
-[Transition of platform channel test interfaces to flutter_test package]: /docs/release/breaking-changes/"mock-platform-channels
+[Transition of platform channel test interfaces to flutter_test package]: /docs/release/breaking-changes/mock-platform-channels
 [Using HTML slots to render platform views in the web]: /docs/release/breaking-changes/platform-views-using-html-slots-web
 
 ### Reverted change in 2.2


### PR DESCRIPTION
- Fixes #6313
- Redirects all `*.html` urls to non-html version
- Redirects externally requested `/images/catalog-widget-placeholder.png` to new route
- Does *not* fix redirecting urls ending in `.` -  this one has proved a bit trickier with firebase.json redirects (open to suggestions/recommendations)
- Adds new `make emulate` command to test hosting/redirects locally

/cc @kwalrath 