### PR TITLE
Remove reference to SafeArea widget in Hello world

### DIFF
--- a/src/docs/development/ui/widgets-intro.md
+++ b/src/docs/development/ui/widgets-intro.md
@@ -56,8 +56,6 @@ which means the text "Hello, world" ends up centered on screen.
 The text direction needs to be specified in this instance;
 when the `MaterialApp` widget is used,
 this is taken care of for you, as demonstrated later.
-A `SafeArea` widget is also used to properly pad the text
-so it appears below the display on the top of the screen.
 
 When writing an app, you'll commonly author new widgets that
 are subclasses of either [`StatelessWidget`][] or [`StatefulWidget`][],


### PR DESCRIPTION
The description of the SafeArea widget is inappropriate in the "Hello world" section since it is not used. It does appear later (see #5021).

Fixes #6365.
