### PR TITLE
Fix typo in constraints docs

### DIFF
--- a/src/docs/development/ui/layout/constraints.md
+++ b/src/docs/development/ui/layout/constraints.md
@@ -1790,7 +1790,7 @@ Row(
 ```
 
 Since `Row` won’t impose any constraints onto its children,
-it’s quite possible that the children might too big to fit
+it’s quite possible that the children might be too big to fit
 the available width of the `Row`. In this case, just like an
 `UnconstrainedBox`, the `Row` displays the "overflow warning".
 


### PR DESCRIPTION
Fix for a simple typo I discovered while reading [Understanding constraints](https://flutter.dev/docs/development/ui/layout/constraints).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [NA] I listed at least one issue that this PR fixes in the description above.
- [NA] I updated/added relevant documentation (doc comments with `///`).
- [NA] I added new tests to check the change I am making, or this PR is [test-exempt].
- [NA] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
