### PR TITLE
Add full macOS deployment walkthrough hint

### DIFF
--- a/src/desktop.md
+++ b/src/desktop.md
@@ -565,8 +565,8 @@ impact your distributable application.
 [Build and release a macOS app][] provides a more detailed
 step-by-step walkthrough.
 
-[distribute it through the macOS App Store]: https://developer.apple.com/macos/submit/
-[documentation on notarizing macOS Applications]: https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution
+[distribute it through the macOS App Store]: {{site.apple-dev}}/macos/submit/
+[documentation on notarizing macOS Applications]:{{site.apple-dev}}/documentation/xcode/notarizing_macos_software_before_distribution
 [on distributing an application through the App Store]: https://help.apple.com/xcode/mac/current/#/dev067853c94
 [Build and release a macOS app]: /docs/deployment/macos
 


### PR DESCRIPTION
This PR adds a hint for developers that seek deployment of an macOS app about a [setp-by-step walkthrough](https://flutter.dev/docs/deployment/macos) and provides the appropriate link on the main [Desktop site](https://flutter.dev/desktop).

Fixes #6390

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [NA] I updated/added relevant documentation (doc comments with `///`).
- [NA] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
