### PR TITLE
Update architectural-overview.md

### DIFF
--- a/src/docs/resources/architectural-overview.md
+++ b/src/docs/resources/architectural-overview.md
@@ -426,7 +426,7 @@ final studentState = StudentState.of(context);
 
 The `of(context)` call takes the build context (a handle to the current widget
 location), and returns [the nearest ancestor in the
-tree]({{site.api}}/flutter/flutter/widgets/BuildContext/dependOnInheritedWidgetOfExactType.html)
+tree]({{site.api}}/flutter/widgets/BuildContext/dependOnInheritedWidgetOfExactType.html)
 that matches the `StudentState` type. `InheritedWidget`s also offer an
 `updateShouldNotify()` method, which Flutter calls to determine whether a state
 change should trigger a rebuild of child widgets that use it.


### PR DESCRIPTION
Update architectural-overview.md with correct resource address.

The original address contains another word flutter:
`https://api.flutter.dev/flutter/flutter/widgets/BuildContext/dependOnInheritedWidgetOfExactType.html`

Since it's wrong address, whoever click the page just getting the Page Not Found
![image](https://user-images.githubusercontent.com/13610283/138065012-fa5514ca-b59e-48fc-81d3-487a7d318eb7.png)

whereas the correct address is just one less word flutter, which is what I have changed:
`https://api.flutter.dev/flutter/widgets/BuildContext/dependOnInheritedWidgetOfExactType.html`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
