### PR TITLE
Documenting how to configure the macOS App name

### DIFF
--- a/src/docs/deployment/macos.md
+++ b/src/docs/deployment/macos.md
@@ -120,20 +120,10 @@ For a detailed overview of app signing, see
 ## Configuring the app's name, bundle identifier and copyright
 
 The configuration for the product identifiers are centralized 
-in `macos/Runner/Configs/AppInfo.xcconfig`. For an example of how 
-this can be used, please see the the 
-[Desktop Photo Search sample's `AppInfo.xcconfig`][sample AppInfo.xcconfig].
-
-```
-// The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = Photo Search
-
-// The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.example.desktopPhotoSearch
-
-// The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2020 com.example. All rights reserved.
-```
+in `macos/Runner/Configs/AppInfo.xcconfig`. For the app's name,
+set `PRODUCT_NAME`, for the copyright set `PRODUCT_COPYRIGHT`,
+and finally set `PRODUCT_BUNDLE_IDENTIFIER` for the app's
+bundle identifier.
 
 ## Updating the app's version number
 
@@ -493,5 +483,4 @@ detailed overview of the process of releasing an app to the App Store.
 [distributionguide_submit]: https://help.apple.com/xcode/mac/current/#/dev067853c94
 [distributionguide_upload]: https://help.apple.com/xcode/mac/current/#/dev442d7f2ca
 [obfuscating your Dart code]: /docs/deployment/obfuscate
-[sample AppInfo.xcconfig]: https://github.com/flutter/samples/blob/master/experimental/desktop_photo_search/macos/Runner/Configs/AppInfo.xcconfig
 [TestFlight]: https://developer.apple.com/testflight/


### PR DESCRIPTION
Stuart, here's my first pass at documenting `macos/Runner/Configs/AppInfo.xcconfig`

fixes: https://github.com/flutter/website/issues/6289

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
