### PR TITLE
Add migration guide for text field focus node change

### DIFF
--- a/src/docs/release/breaking-changes/editable-text-focus-attachment.md
+++ b/src/docs/release/breaking-changes/editable-text-focus-attachment.md
@@ -102,6 +102,6 @@ Relevant PRs:
 
 * [Move text editing Actions to EditableTextState][]
 
-[`EditableText`]: {{site.master.api}}/flutter/widgets/EditableText-class.html
+[`EditableText`]: {{site.master-api}}/flutter/widgets/EditableText-class.html
 [Move text editing Actions to EditableTextState]: {{site.github}}/flutter/flutter/pull/90684
 

--- a/src/docs/release/breaking-changes/editable-text-focus-attachment.md
+++ b/src/docs/release/breaking-changes/editable-text-focus-attachment.md
@@ -89,7 +89,7 @@ please refer to the documentation of the `EditableText` widget.
 
 ## Timeline
 
-Landed in version: xxx<br>
+Landed in version: 2.6.0-12.0.pre<br>
 In stable release: not yet
 Reverted in version: xxx  (OPTIONAL, delete if not used)
 

--- a/src/docs/release/breaking-changes/editable-text-focus-attachment.md
+++ b/src/docs/release/breaking-changes/editable-text-focus-attachment.md
@@ -11,15 +11,15 @@ description: EditableText.focusNode is no longer attached to EditableTextState's
 ## Context
 
 A text input field widget (`TextField`, for example) typically owns a `FocusNode`.
-When that `FocusNode` is the primary focus of the app, events such as key presses 
-will be sent to the `BuildContext` the `FocusNode` is attached to. 
+When that `FocusNode` is the primary focus of the app, events (such as key presses) 
+are sent to the `BuildContext` to which the `FocusNode` is attached. 
 
 The `FocusNode` also plays a roll in shortcut handling: The `Shortcuts` widget 
 translates key sequences into an `Intent`, and tries to find the first suitable 
-handler for that `Intent` starting from the `BuildContext` the `FocusNode` attaches 
-to, to the root of the widget tree. This means an `Actions` widget (which provides 
-handlers for differetn `Intent`s) will not be able to handle any shortcut `Intent`s 
-when the `BuildContext` that thas the primary focus is above it in the tree.
+handler for that `Intent` starting from the `BuildContext` to which the `FocusNode` 
+is attached, to the root of the widget tree. This means an `Actions` widget (that provides 
+handlers for different `Intent`s) won't be able to handle any shortcut `Intent`s 
+when the `BuildContext` that has the primary focus is above it in the tree.
 
 Previously for `EditableText`, the `FocusNode` was attached to the `BuildContext`
 of `EditableTextState`. Any `Actions` widgets defined in `EditableTextState` (which 
@@ -53,16 +53,16 @@ field or a selectable text field like so:
 
 Then please read on and consider following the migration steps to avoid breakages.
 
-If you're not sure if a codebase needs migration, search for `is EditableText`,
-`as EditableText`, `is EditableTextState` and `as EditableTextState` and verify
-any of the search result are doing typecheck/typecast on a `FocusNode.context`.
-If there is then migration is needed.
+If you're not sure whether a codebase needs migration, search for `is EditableText`,
+`as EditableText`, `is EditableTextState`, and `as EditableTextState` and verify if
+any of the search results are doing a typecheck or typecast on a `FocusNode.context`.
+If so, then migration is needed.
 
-To avoid doing typecheck or downcasting the `BuildContext` associated with the
-`FocusNode` of interest, depending on the actual capabilities the codebase is
+To avoid performing a typecheck, or downcasting the `BuildContext` associated with the
+`FocusNode` of interest, and depending on the actual capabilities the codebase is
 trying to invoke from the given `FocusNode`, fire an `Intent` from that
 `BuildContext`. For instance, if you wish to update the text of the currently focused
-`TextField` to a specific value:
+`TextField` to a specific value, see the following example:
 
 Code before migration:
 
@@ -85,13 +85,12 @@ if (focusedContext != null) {
 ```
 
 For a comprehensive list of `Intent`s supported by the `EditableText` widget,
-please refer to the documentation of the `EditableText` widget.
+refer to the documentation of the `EditableText` widget.
 
 ## Timeline
 
 Landed in version: 2.6.0-12.0.pre<br>
 In stable release: not yet
-Reverted in version: xxx  (OPTIONAL, delete if not used)
 
 ## References
 
@@ -103,6 +102,6 @@ Relevant PRs:
 
 * [Move text editing Actions to EditableTextState][]
 
-[`EditableText`]: https://master-api.flutter.dev/flutter/widgets/EditableText-class.html
+[`EditableText`]: {{site.master.api}}/flutter/widgets/EditableText-class.html
 [Move text editing Actions to EditableTextState]: {{site.github}}/flutter/flutter/pull/90684
 

--- a/src/docs/release/breaking-changes/editable-text-focus-attachment.md
+++ b/src/docs/release/breaking-changes/editable-text-focus-attachment.md
@@ -1,0 +1,100 @@
+---
+title: TextField FocusNode attach location change
+description: EditableText.focusNode is no longer attached to EditableTextState's BuildContext
+---
+
+## Summary
+
+`EditableText.focusNode` is now attached to a dedicated `Focus` widget within
+`EditableText`.
+
+## Context
+
+A `FocusNode` is typically attached to the `BuildContext` of a focusable widget,
+and is used to represent and control the focus state of that widget. 
+
+In Flutter's keyboard event handling system, the user `Intent` behind a key press
+(or a sequence of key presses), such as delete or insert text, is fired from the
+`FocusNode` that currently has the primary focus, and propagates upwards in the
+widget tree until it finds the first available handler. In the context of text
+editing, text editing `Intent` handlers are typically defined in
+`EditableTextState`, and that means the `FocusNode` needs to be attached below
+(in terms of the locations in the widget tree) `EditableTextState`, so when the
+app user presses <kbd>DEL</kbd> or some other keys in the current text field, the
+corresponding handler defined in `EditableTextState` can be found.
+
+## Description of change
+
+`EditableTextState` now creates a dedicated `Focus` widget to host `EditableText.focusNode`.
+This does not involve any public API changes but breaks codebases relying on that
+particular implementation detail to tell if a `FocusNode` is associated with a
+text input field.
+
+This change shouldn't break any builds but can introduce runtime issues, or
+cause existing tests to fail.
+
+## Migration guide
+
+The `EditableText` widget takes a `FocusNode` as a paramter, which was
+previously attached to its `EditableText`'s `BuildContext`. If you are relying
+on runtime typecheck to find out if a `FocusNode` is attached to a text input
+field or a selectable text field like so:
+
+- `focusNode.context.widget is EditableText`
+- `(focusNode.context as StatefulElement).state as EditableTextState`
+
+Then please read on and consider following the migration steps to avoid breakages.
+
+If you're not sure if a codebase needs migration, search for `is EditableText`,
+`as EditableText`, `is EditableTextState` and `as EditableTextState` and verify
+any of the search result are doing typecheck/typecast on a `FocusNode.context`.
+If there is then migration is needed.
+
+To avoid doing typecheck or downcasting the `BuildContext` associated with the
+`FocusNode` of interest, depending on the actual capabilities the codebase is
+trying to invoke from the given `FocusNode`, fire an `Intent` from that
+`BuildContext`. For instance, if you wish to update the text of the currently focused
+`TextField` to a specic value:
+
+Code before migration:
+
+<!-- skip -->
+```dart
+final Widget? focusedWidget = primaryFocus?.context?.widget;
+if (focusedWidget is EditableText) {
+  widget.controller.text = 'Updated Text';
+}
+```
+
+Code after migration:
+
+<!-- skip -->
+```dart
+final BuildContext? focusedContext = primaryFocus?.context;
+if (focusedContext != null) {
+  Actions.maybeInvoke(focusedContext, ReplaceTextIntent('UpdatedText'));
+}
+```
+
+For a comprehensive list of `Intent`s supported by the `EditableText` widget,
+please refer to the documentation of the `EditableText` widget.
+
+## Timeline
+
+Landed in version: xxx<br>
+In stable release: not yet
+Reverted in version: xxx  (OPTIONAL, delete if not used)
+
+## References
+
+API documentation:
+
+* [`EditableText`][]
+
+Relevant PRs:
+
+* [Move text editing Actions to EditableTextState][]
+
+[`EditableText`]: https://master-api.flutter.dev/flutter/widgets/EditableText-class.html
+[Move text editing Actions to EditableTextState]: {{site.github}}/flutter/flutter/pull/90684
+

--- a/src/docs/release/breaking-changes/editable-text-focus-attachment.md
+++ b/src/docs/release/breaking-changes/editable-text-focus-attachment.md
@@ -5,7 +5,7 @@ description: EditableText.focusNode is no longer attached to EditableTextState's
 
 ## Summary
 
-`EditableText.focusNode` is now attached to a dedicated `Focus` widget within
+`EditableText.focusNode` is now attached to a dedicated `Focus` widget below
 `EditableText`.
 
 ## Context
@@ -16,13 +16,13 @@ will be sent to the `BuildContext` the `FocusNode` is attached to.
 
 The `FocusNode` also plays a roll in shortcut handling: The `Shortcuts` widget 
 translates key sequences into an `Intent`, and tries to find the first suitable 
-handler of the `Intent` starting from the `BuildContext` the `FocusNode` attaches 
-to, to the root of the widget tree. This means an `Actions` widget will not be able
-to handle any shortcut `Intent` when the `BuildContext` that thas the primary
-focus is above it in the tree.
+handler for that `Intent` starting from the `BuildContext` the `FocusNode` attaches 
+to, to the root of the widget tree. This means an `Actions` widget (which provides 
+handlers for differetn `Intent`s) will not be able to handle any shortcut `Intent`s 
+when the `BuildContext` that thas the primary focus is above it in the tree.
 
 Previously for `EditableText`, the `FocusNode` was attached to the `BuildContext`
-of `EditableTextState`. Any `Actions` widget defined in `EditableTextState` (which 
+of `EditableTextState`. Any `Actions` widgets defined in `EditableTextState` (which 
 will be inflated below the `BuildContext` of the `EditableTextState`) couldn't 
 handle shortcuts even when that `EditableText` was focused, for the reason stated 
 above.
@@ -62,7 +62,7 @@ To avoid doing typecheck or downcasting the `BuildContext` associated with the
 `FocusNode` of interest, depending on the actual capabilities the codebase is
 trying to invoke from the given `FocusNode`, fire an `Intent` from that
 `BuildContext`. For instance, if you wish to update the text of the currently focused
-`TextField` to a specic value:
+`TextField` to a specific value:
 
 Code before migration:
 

--- a/src/docs/release/breaking-changes/editable-text-focus-attachment.md
+++ b/src/docs/release/breaking-changes/editable-text-focus-attachment.md
@@ -10,27 +10,35 @@ description: EditableText.focusNode is no longer attached to EditableTextState's
 
 ## Context
 
-A `FocusNode` is typically attached to the `BuildContext` of a focusable widget,
-and is used to represent and control the focus state of that widget. 
+A text input field widget (`TextField`, for example) typically owns a `FocusNode`.
+When that `FocusNode` is the primary focus of the app, events such as key presses 
+will be sent to the `BuildContext` the `FocusNode` is attached to. 
 
-In Flutter's keyboard event handling system, the user `Intent` behind a key press
-(or a sequence of key presses), such as delete or insert text, is fired from the
-`FocusNode` that currently has the primary focus, and propagates upwards in the
-widget tree until it finds the first available handler. In the context of text
-editing, text editing `Intent` handlers are typically defined in
-`EditableTextState`, and that means the `FocusNode` needs to be attached below
-(in terms of the locations in the widget tree) `EditableTextState`, so when the
-app user presses <kbd>DEL</kbd> or some other keys in the current text field, the
-corresponding handler defined in `EditableTextState` can be found.
+The `FocusNode` also plays a roll in shortcut handling: The `Shortcuts` widget 
+translates key sequences into an `Intent`, and tries to find the first suitable 
+handler of the `Intent` starting from the `BuildContext` the `FocusNode` attaches 
+to, to the root of the widget tree. This means an `Actions` widget will not be able
+to handle any shortcut `Intent` when the `BuildContext` that thas the primary
+focus is above it in the tree.
+
+Previously for `EditableText`, the `FocusNode` was attached to the `BuildContext`
+of `EditableTextState`. Any `Actions` widget defined in `EditableTextState` (which 
+will be inflated below the `BuildContext` of the `EditableTextState`) couldn't 
+handle shortcuts even when that `EditableText` was focused, for the reason stated 
+above.
 
 ## Description of change
 
 `EditableTextState` now creates a dedicated `Focus` widget to host `EditableText.focusNode`.
-This does not involve any public API changes but breaks codebases relying on that
-particular implementation detail to tell if a `FocusNode` is associated with a
+This allows `EditableTextState`s to define handlers for shortcut `Intent`s. For 
+instance, `EditableText` now has a handler that handles the "deleteCharacter" intent
+when the <kbd>DEL<kbd> key is pressed.
+
+This change does not involve any public API changes but breaks codebases relying on 
+that particular implementation detail to tell if a `FocusNode` is associated with a
 text input field.
 
-This change shouldn't break any builds but can introduce runtime issues, or
+This change does not break any builds but can introduce runtime issues, or
 cause existing tests to fail.
 
 ## Migration guide


### PR DESCRIPTION
This is for the breaking change that will be introduced by https://github.com/flutter/flutter/pull/90684. I'm planning to merge that pull request soon since the migration needs to be done as a g3fix.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
