### PR TITLE
Change deferred components Application class to v2 embedding migrated class

### DIFF
--- a/src/docs/perf/deferred-components.md
+++ b/src/docs/perf/deferred-components.md
@@ -74,12 +74,12 @@ dependencies {
     Both of these tasks can be accomplished by setting
     the `android:name` property on the application in
     `android/app/src/main/AndroidManifest.xml` to
-    `io.flutter.app.FlutterPlayStoreSplitApplication`:
+    `io.flutter.embedding.android.FlutterPlayStoreSplitApplication`:
 
 ```xml
 <manifest ...
   <application
-     android:name="io.flutter.app.FlutterPlayStoreSplitApplication"
+     android:name="io.flutter.embedding.android.FlutterPlayStoreSplitApplication"
         ...
   </application>
 </manifest>


### PR DESCRIPTION
Since https://github.com/flutter/engine/pull/29241 landed, we should now use the new class under `io.flutter.embedding.android.FlutterPlayStoreSplitApplication` as the v1 embedding version is to be removed (see https://github.com/flutter/engine/pull/29248)

This changes the documentation to reflect this.
