### PR TITLE
Fixing the broken img tag that actually shows up in text

### DIFF
--- a/src/docs/development/ui/animations/tutorial.md
+++ b/src/docs/development/ui/animations/tutorial.md
@@ -658,7 +658,7 @@ dirty as necessary, so you don't need to call `addListener()`.
 The widget tree for the [animate4][]
 example looks like this:
 
-<img src='/assets/images/docs/'ui/AnimatedBuilder-WidgetTree.png''
+<img src="/assets/images/docs/ui/AnimatedBuilder-WidgetTree.png"
     alt="AnimatedBuilder widget tree" class="d-block mx-auto" width="160px">
 
 Starting from the bottom of the widget tree, the code for rendering


### PR DESCRIPTION
Should fix #6422. I checked and the image is there: https://flutter.dev/assets/images/docs/ui/AnimatedBuilder-WidgetTree.png
