### PR TITLE
Document how to rename the generated Windows application

### DIFF
--- a/src/desktop.md
+++ b/src/desktop.md
@@ -425,6 +425,21 @@ Here are some options:
 * Collect all of the necessary pieces
   and build your own zip file.
 
+#### Changing the name of the generated binary
+
+To change the name of the generated Windows application, edit the 
+`BINARY_NAME` variable set on line 4 of `windows/CMakeLists.txt` in
+your Flutter project.
+
+```cmake
+cmake_minimum_required(VERSION 3.15)
+project(windows_desktop_app LANGUAGES CXX)
+
+set(BINARY_NAME "YourNewApp")  # Change this line
+
+cmake_policy(SET CMP0063 NEW)
+```
+
 #### MSIX packaging
 
 [MSIX][], Microsoft Windows' application package format,


### PR DESCRIPTION
This PR documents the process for renaming the generated Windows application for a Flutter Windows desktop app.

fixes: https://github.com/flutter/flutter/issues/92376

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
