### PR TITLE
Fix title of scrolling page

### DIFF
--- a/src/docs/cookbook/testing/widget/scrolling.md
+++ b/src/docs/cookbook/testing/widget/scrolling.md
@@ -2,11 +2,11 @@
 title: Handle scrolling
 description: How to handle scrolling in a widget test.
 prev:
-title: Find widgets
-path: /docs/cookbook/testing/widget/finders
+  title: Find widgets
+  path: /docs/cookbook/testing/widget/finders
 next:
-title: Tap, drag, and enter text
-path: /docs/cookbook/testing/widget/tap-drag
+  title: Tap, drag, and enter text
+  path: /docs/cookbook/testing/widget/tap-drag
 ---
 
 <?code-excerpt path-base="cookbook/testing/widget/scrolling/"?>


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Fixes indentation in metadata of the scrolling page 

_Issues fixed by this PR (if any):_

The scrolling page previous and next sections were not indented. This causes the same title to appear twice in the recipes index:

(note the second-to-last link actually goes to the scrolling page)

![image](https://user-images.githubusercontent.com/9100419/139956219-82de0e03-c518-48a2-8e8b-5bdf3e1fb024.png)

And the scrolling page to have the incorrect title of "Tap, drag and enter text" with no previous/next links:

![image](https://user-images.githubusercontent.com/9100419/139956291-65434f19-5f6a-49c7-8510-cc5d67ccdb46.png)


## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
