### PR TITLE
print linkcheck-server.log if linkcheck fails

### DIFF
--- a/tool/check-links.sh
+++ b/tool/check-links.sh
@@ -93,7 +93,7 @@ fi
 # Don't check for external links 
 CMD="dart run linkcheck $ARGS--skip-file ./tool/config/linkcheck-skip-list.txt :$SERVE_PORT"
 echo "=> $CMD"
-$CMD 2>&1 | tee "linkcheck.log"
+$CMD 2>&1 | tee "linkcheck-server.log"
 STATUS=$?
 
 # When checking external links, give linkcheck 
@@ -109,5 +109,5 @@ if [[ $FAILWARN ]]; then
   echo "=> Exiting with status: $STATUS"
   exit $STATUS
 else
-  grep -qe '^\s*0 errors' "linkcheck.log"
+  grep -qe '^\s*0 errors' "linkcheck-server.log"
 fi


### PR DESCRIPTION
I don't see any references to `linkcheck.log`, so I think this was intended to be `linkcheck-server.log`. Since linkcheck is failing without any indication of what's happening, this might provide more information.