### PR TITLE
fixed flutter.dev/brand error

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -17,12 +17,13 @@
       { "regex": "^\/(javadoc(\/.*)?)", "destination": "https://api.flutter.dev/:1", "type": 301 },
       { "regex": "(?P<basename>.*)\\.html$", "destination": ":basename", "type": 301 },
       { "regex": "(?P<basename>.*)\\.$", "destination": ":basename", "type": 301 },
-
+     
       { "source": "/community", "destination": "https://flutter.dev/community", "type": 301 },
       { "source": "/showcase", "destination": "https://flutter.dev/showcase", "type": 301 },
       { "source": "/support", "destination": "https://flutter.dev/community", "type": 301 },
       { "source": "/docs/:rest*", "destination": "/:rest*", "type": 301 },
 
+      { "source": "/brand","destination":"/brand/index","type":301 },
       { "source": "/accessibility", "destination": "/development/accessibility-and-localization/accessibility", "type": 301 },
       { "source": "/adaptations", "destination": "/resources/platform-adaptations", "type": 301 },
       { "source": "/adaptive*", "destination": "/development/ui/layout/adaptive-responsive", "type": 301 },


### PR DESCRIPTION
Added a route for the brand page which didn't work before.Showed a 404 error.The correct route for the brand page has been added.When you navigate to flutter.dev/brand it should render the appropriate brand page


