### PR TITLE
Fix flutter.dev/brand error

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -22,7 +22,8 @@
       { "source": "/showcase", "destination": "https://flutter.dev/showcase", "type": 301 },
       { "source": "/support", "destination": "https://flutter.dev/community", "type": 301 },
       { "source": "/docs/:rest*", "destination": "/:rest*", "type": 301 },
-
+      
+      { "source": "/brand","destination":"/brand/index","type":301 },
       { "source": "/accessibility", "destination": "/development/accessibility-and-localization/accessibility", "type": 301 },
       { "source": "/adaptations", "destination": "/resources/platform-adaptations", "type": 301 },
       { "source": "/adaptive*", "destination": "/development/ui/layout/adaptive-responsive", "type": 301 },


### PR DESCRIPTION
Removed the 404 error when you navigate to flutter.dev/brand by adding a route


