### PR TITLE
Update building-adaptive-apps.md

### DIFF
--- a/src/development/ui/layout/building-adaptive-apps.md
+++ b/src/development/ui/layout/building-adaptive-apps.md
@@ -378,7 +378,7 @@ These constants can then be used in place of hard-coded numeric values:
 <!--skip-->
 ```dart
 return Padding(
-    insets: EdgeInsets.all(Insets.small), 
+    padding: EdgeInsets.all(Insets.small), 
     child: Text('Hello!', style: TextStyles.body1)
 )
 ```


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

In the `single source of truth for styling` section of the Building Adaptive Apps guide. The current padding widget has `insets` instead of `padding` argument, so I just changed it to padding.

Issues fixed by this PR (if any): N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
