### PR TITLE
[Proposal] update the URLs of the doc site to absolute path

### DIFF
--- a/src/_includes/docs/performance.md
+++ b/src/_includes/docs/performance.md
@@ -5,4 +5,4 @@
   see [Using the Performance view][].
 {{site.alert.end}}
 
-[Using the Performance view]: /development/tools/devtools/performance
+[Using the Performance view]: {{site.url}}/development/tools/devtools/performance

--- a/src/_includes/docs/run-profile.md
+++ b/src/_includes/docs/run-profile.md
@@ -20,5 +20,5 @@ build modes. For more details, see [Flutter's build modes][].
   see [Measuring your app's size][].
 {{site.alert.end}}
 
-[Flutter's build modes]: /testing/build-modes
-[Measuring your app's size]: /perf/app-size
+[Flutter's build modes]: {{site.url}}/testing/build-modes
+[Measuring your app's size]: {{site.url}}/perf/app-size

--- a/src/ads/index.md
+++ b/src/ads/index.md
@@ -14,7 +14,7 @@ including banner (inline and overlay),
 interstitial, rewarded video, native ads,
 and adaptive banner.
 
-![Pic showing different types of ads](/assets/images/ads/GoogleMobileAdTypes.png){:width="100%"}
+![Pic showing different types of ads]({{site.url}}/assets/images/ads/GoogleMobileAdTypes.png){:width="100%"}
 
 The following video tutorial,
 [Monetizing apps with Flutter][],

--- a/src/apprentice-giveaway/index.md
+++ b/src/apprentice-giveaway/index.md
@@ -6,7 +6,7 @@ description: You can have free online access to Flutter Apprentice book through 
 We’re giving you FREE access to Flutter Apprentice from
 October 6, 2021 through January 6, 2022.
 
-![Screenshot of book cover](/assets/images/homepage/apprentice-cover.png)
+![Screenshot of book cover]({{site.url}}/assets/images/homepage/apprentice-cover.png)
 
 Flutter is partnering with [Razeware][],
 the team behind the Ray Wenderlich tutorial series,
@@ -25,7 +25,7 @@ For more information, watch the following video:
 
 <iframe width="560" height="315" src="{{site.youtube-site}}/embed/NVzIALG7CUc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-![Image of Dash with the book](/assets/images/homepage/DashWithApprenticeBook.png){:width="100%"}
+![Image of Dash with the book]({{site.url}}/assets/images/homepage/DashWithApprenticeBook.png){:width="100%"}
 
 ## How to sign up!
 
@@ -49,7 +49,7 @@ and we’ll see you along the way!
     </div>
 </section>
 
-![Image of Professor Dash](/assets/images/homepage/smart-dash.png)
+![Image of Professor Dash]({{site.url}}/assets/images/homepage/smart-dash.png)
 
 ---
 

--- a/src/brand/index.md
+++ b/src/brand/index.md
@@ -5,7 +5,7 @@ title: Flutter Brand Guidelines
 The "Flutter" name and logo are trademarks owned by Google.
 These Brand Guidelines describe the appropriate uses of the Flutter
 trademarks by members of the developer community who have obtained our
-consent to use the trademarks pursuant to the [Flutter Terms of Service](/tos).
+consent to use the trademarks pursuant to the [Flutter Terms of Service]({{site.url}}/tos).
 These guidelines will ensure that the Flutter trademarks are used in a
 manner that promotes Google's mission to provide a free and open source
 SDK for crafting high-quality native interfaces on iOS and

--- a/src/codelabs/explicit-animations.md
+++ b/src/codelabs/explicit-animations.md
@@ -760,10 +760,10 @@ the `value` property to a new value.
 [`AnimationController` concepts]: #animationcontroller-concepts
 [Create your first explicit animation with AnimationController]: #create-your-first-explicit-animation-with-animationcontroller
 [Material app]: {{site.api}}/flutter/material/MaterialApp-class.html
-[performance profiling]: /perf/rendering/ui-performance
-[implicit animations]: /development/ui/animations/implicit-animations
+[performance profiling]: {{site.url}}/perf/rendering/ui-performance
+[implicit animations]: {{site.url}}/development/ui/animations/implicit-animations
 [make a Flutter app]: {{site.codelabs}}/codelabs/first-flutter-app-pt1
-[stateful widgets]: /development/ui/interactive#stateful-and-stateless-widgets
+[stateful widgets]: {{site.url}}/development/ui/interactive#stateful-and-stateless-widgets
 [step 1]: #1-use-a-tickerprovider-mixin
 [`SingleTickerProviderStateMixin`]: {{site.api}}/flutter/widgets/SingleTickerProviderStateMixin-mixin.html
 

--- a/src/codelabs/implicit-animations.md
+++ b/src/codelabs/implicit-animations.md
@@ -451,8 +451,8 @@ here are some suggestions for where to go next:
 [AnimatedContainer]: {{site.api}}/flutter/widgets/AnimatedContainer-class.html
 [AnimatedOpacity]: {{site.api}}/flutter/widgets/AnimatedOpacity-class.html
 [animation library]: {{site.api}}/flutter/animation/animation-library.html
-[animations tutorial]: /development/ui/animations/tutorial
-[codelab]: /codelabs
+[animations tutorial]: {{site.url}}/development/ui/animations/tutorial
+[codelab]: {{site.url}}/codelabs
 [curve]: {{site.api}}/flutter/animation/Curve-class.html
 [DartPad troubleshooting page]: {{site.dart-site}}/tools/dartpad/troubleshoot
 [DartPad]: {{site.dartpad}}
@@ -461,7 +461,7 @@ here are some suggestions for where to go next:
 [fade-in complete]: #fade-in-complete
 [fade-in starter code]: #fade-in-starter-code
 [Fade-in text effect]: #example-fade-in-text-effect
-[hero animations]: /development/ui/animations/hero-animations
+[hero animations]: {{site.url}}/development/ui/animations/hero-animations
 [ImplicitlyAnimatedWidget]: {{site.api}}/flutter/widgets/ImplicitlyAnimatedWidget-class.html
 [linear animation curve]: {{site.api}}/flutter/animation/Curves/linear-constant.html
 [linear curve]: {{site.api}}/flutter/animation/Curves/linear-constant.html
@@ -472,5 +472,5 @@ here are some suggestions for where to go next:
 [shape-shifting complete]: #shape-shifting-complete
 [Shape-shifting effect]: #example-shape-shifting-effect
 [shape-shifting starter code]: #shape-shifting-starter-code
-[staggered animations]: /development/ui/animations/staggered-animations
-[stateful widgets]: /development/ui/interactive#stateful-and-stateless-widgets
+[staggered animations]: {{site.url}}/development/ui/animations/staggered-animations
+[stateful widgets]: {{site.url}}/development/ui/interactive#stateful-and-stateless-widgets

--- a/src/codelabs/index.md
+++ b/src/codelabs/index.md
@@ -57,10 +57,10 @@ one of these codelabs:
 
 [Building beautiful UIs with Flutter]: {{site.codelabs}}/codelabs/flutter
 [Building your first Flutter app]: {{site.youtube-site}}/watch?v=Z6KZ3cTGBWw
-[codelab on docs.flutter.dev]: /get-started/codelab
+[codelab on docs.flutter.dev]: {{site.url}}/get-started/codelab
 [Write your First Flutter app, part 1]: {{site.codelabs}}/codelabs/first-flutter-app-pt1
 [Write your First Flutter app, part 2]: {{site.codelabs}}/codelabs/first-flutter-app-pt2
-[Write your first Flutter app on the web]: /get-started/codelab-web
+[Write your first Flutter app on the web]: {{site.url}}/get-started/codelab-web
 
 ## Next steps
 
@@ -81,7 +81,7 @@ one of these codelabs:
 
 [Dart null safety in Action]: {{site.youtube-site}}/watch?v=HdKwuHQvArY
 [inherited-widget-ws]: {{site.youtube-site}}/watch?v=LFcGPS6cGrY
-[low-level state management]: /development/data-and-backend/state-mgmt/options#inheritedwidget--inheritedmodel
+[low-level state management]: {{site.url}}/development/data-and-backend/state-mgmt/options#inheritedwidget--inheritedmodel
 [Null safety codelab]: {{site.dart-site}}/codelabs/null-safety
 
 ## Designing a Flutter UI
@@ -132,11 +132,11 @@ like layout and animations:
   products by the selected category.
 
 [animations]: {{site.pub}}/packages/animations
-[Basic Flutter layout concepts]: /codelabs/layout-basics
+[Basic Flutter layout concepts]: {{site.url}}/codelabs/layout-basics
 [Building Beautiful Transitions with Material Motion for Flutter]: {{site.codelabs}}/codelabs/material-motion-flutter
 [Building scrolling experiences in Flutter]: {{site.youtube-site}}/watch?v=YY-_yrZdjGc
 [How to debug layout issues with the Flutter Inspector]: {{site.flutter-medium}}/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db
-[Implicit animations]: /codelabs/implicit-animations
+[Implicit animations]: {{site.url}}/codelabs/implicit-animations
 [MDC-101 Flutter: Material Components (MDC) Basics]: {{site.codelabs}}/codelabs/mdc-101-flutter
 [MDC-102 Flutter: Material Structure and Layout]: {{site.codelabs}}/codelabs/mdc-102-flutter
 [MDC-103 Flutter: Material Theming with Color, Shape, Elevation, and Type]: {{site.codelabs}}/codelabs/mdc-103-flutter

--- a/src/codelabs/layout-basics.md
+++ b/src/codelabs/layout-basics.md
@@ -1915,7 +1915,7 @@ techniques that you've learned, why not apply
 those skills into building a Flutter UI that
 displays a business card!
 
- ![Completed business card](/assets/images/docs/codelab/layout/businesscarddisplay1.png){:width="400px"}{:.text-center}
+ ![Completed business card]({{site.url}}/assets/images/docs/codelab/layout/businesscarddisplay1.png){:width="400px"}{:.text-center}
 
 You'll break down Flutter's layout into parts,
 which is how you'd create a Flutter UI in the real world.
@@ -1925,7 +1925,7 @@ you'll implement a `Column` that contains the name and title.
 Then you'll wrap the `Column` in a `Row` that contains the icon,
 which is positioned to the left of the name and title.
 
- ![Completed business card](/assets/images/docs/codelab/layout/businesscarddisplay2.png){:width="400px"}{:.text-center}
+ ![Completed business card]({{site.url}}/assets/images/docs/codelab/layout/businesscarddisplay2.png){:width="400px"}{:.text-center}
 
 In [Part 2](#part-2), you'll wrap the `Row` in a `Column`,
 so the code contains a `Column` within a `Row` within a `Column`.
@@ -1935,13 +1935,13 @@ Finally, you'll add the contact information
 to the outermost `Column`'s list of children,
 so it's displayed below the name, title, and icon.
 
- ![Completed business card](/assets/images/docs/codelab/layout/businesscarddisplay3.png){:width="400px"}{:.text-center}
+ ![Completed business card]({{site.url}}/assets/images/docs/codelab/layout/businesscarddisplay3.png){:width="400px"}{:.text-center}
 
 In [Part 3](#part-3), you'll finish building
 the business card display by adding four more icons,
 which are positioned below the contact information.
 
- ![Completed business card](/assets/images/docs/codelab/layout/businesscarddisplay4.png){:width="400px"}{:.text-center}
+ ![Completed business card]({{site.url}}/assets/images/docs/codelab/layout/businesscarddisplay4.png){:width="400px"}{:.text-center}
 
 ### Part 1
 {:.no_toc}
@@ -3361,12 +3361,12 @@ You can download Flutter from the [install][] page.
 
 
 
-[Building layouts]: /development/ui/layout
+[Building layouts]: {{site.url}}/development/ui/layout
 [Cupertino]: {{site.api}}/flutter/cupertino/CupertinoApp-class.html
 [DartPad issue]: {{site.github}}/dart-lang/dart-pad/issues/new
 [Flutter's YouTube channel]: {{site.youtube-site}}/channel/UCwXdFgeE9KYzlDdR7TG9cMw
 [GitHub]: {{site.repo.this}}/tree/master/examples/layout/sizing/images
-[install]: /get-started/install
+[install]: {{site.url}}/get-started/install
 [Material]: {{site.api}}/flutter/material/MaterialApp-class.html
 [Material Color palette]: {{site.api}}/flutter/material/Colors-class.html
 [Material Icon library]: {{site.api}}/flutter/material/Icons-class.html

--- a/src/community/china.md
+++ b/src/community/china.md
@@ -11,7 +11,7 @@ Flutter website available at
 [https://flutter.cn](https://flutter.cn).
 
 If you’d like to install Flutter using an [installation
-bundle](/development/tools/sdk/releases),
+bundle]({{site.url}}/development/tools/sdk/releases),
 you can replace the domain of the original URL with a trusted mirror
 to speed it up. For example:
 
@@ -52,7 +52,7 @@ $ flutter doctor
 ```
 
 After these steps, you should be able to continue
-[setting up Flutter](/get-started/editor) normally.
+[setting up Flutter]({{site.url}}/get-started/editor) normally.
 From here on, packages fetched by `flutter pub get` are
 downloaded from `flutter-io.cn` in any shell where `PUB_HOSTED_URL`
 and `FLUTTER_STORAGE_BASE_URL` are set.

--- a/src/cookbook/animation/opacity-animation.md
+++ b/src/cookbook/animation/opacity-animation.md
@@ -231,6 +231,6 @@ class _MyHomePageState extends State<MyHomePage> {
 </noscript>
 
 [`AnimatedOpacity`]: {{site.api}}/flutter/widgets/AnimatedOpacity-class.html
-[Gestures]: /cookbook#gestures
+[Gestures]: {{site.url}}/cookbook#gestures
 [`StatefulWidget`]: {{site.api}}/flutter/widgets/StatefulWidget-class.html
 [`setState()`]: {{site.api}}/flutter/widgets/State/setState.html

--- a/src/cookbook/design/drawer.md
+++ b/src/cookbook/design/drawer.md
@@ -212,7 +212,7 @@ class MyHomePage extends StatelessWidget {
 
 [`Drawer`]: {{site.api}}/flutter/material/Drawer-class.html
 [`DrawerHeader`]: {{site.api}}/flutter/material/DrawerHeader-class.html
-[list recipes]: /cookbook#lists
+[list recipes]: {{site.url}}/cookbook#lists
 [`ListTile`]: {{site.api}}/flutter/material/ListTile-class.html
 [`ListView`]: {{site.api}}/flutter/widgets/ListView-class.html
 [material library]: {{site.api}}/flutter/material/material-library.html

--- a/src/cookbook/design/fonts.md
+++ b/src/cookbook/design/fonts.md
@@ -247,10 +247,10 @@ class MyHomePage extends StatelessWidget {
 }
 ```
 
-![Custom Fonts Demo](/assets/images/docs/cookbook/fonts.png){:.site-mobile-screenshot}
+![Custom Fonts Demo]({{site.url}}/assets/images/docs/cookbook/fonts.png){:.site-mobile-screenshot}
 
 
-[Export fonts from a package]: /cookbook/design/package-fonts
+[Export fonts from a package]: {{site.url}}/cookbook/design/package-fonts
 [`fontFamily`]: {{site.api}}/flutter/painting/TextStyle/fontFamily.html
 [`fontStyle`]: {{site.api}}/flutter/painting/TextStyle/fontStyle.html
 [`FontStyle`]: {{site.api}}/flutter/dart-ui/FontStyle-class.html
@@ -259,4 +259,4 @@ class MyHomePage extends StatelessWidget {
 [Google Fonts]: https://fonts.google.com
 [google_fonts]: {{site.pub-pkg}}/google_fonts
 [`TextStyle`]: {{site.api}}/flutter/painting/TextStyle-class.html
-[Using Themes to share colors and font styles]: /cookbook/design/themes
+[Using Themes to share colors and font styles]: {{site.url}}/cookbook/design/themes

--- a/src/cookbook/design/orientation.md
+++ b/src/cookbook/design/orientation.md
@@ -142,6 +142,6 @@ class OrientationList extends StatelessWidget {
 </noscript>
 
 
-[Creating a grid list]: /cookbook/lists/grid-lists
+[Creating a grid list]: {{site.url}}/cookbook/lists/grid-lists
 [`Orientation`]: {{site.api}}/flutter/widgets/Orientation-class.html
 [`OrientationBuilder`]: {{site.api}}/flutter/widgets/OrientationBuilder-class.html

--- a/src/cookbook/design/package-fonts.md
+++ b/src/cookbook/design/package-fonts.md
@@ -166,7 +166,7 @@ class MyHomePage extends StatelessWidget {
 }
 ```
 
-![Package Fonts Demo](/assets/images/docs/cookbook/package-fonts.png){:.site-mobile-screenshot}
+![Package Fonts Demo]({{site.url}}/assets/images/docs/cookbook/package-fonts.png){:.site-mobile-screenshot}
 
 [Google Fonts]: https://fonts.google.com
 [google_fonts]: {{site.pub-pkg}}/google_fonts

--- a/src/cookbook/design/snackbars.md
+++ b/src/cookbook/design/snackbars.md
@@ -151,7 +151,7 @@ class SnackBarPage extends StatelessWidget {
 </noscript>
 
 
-[Gestures]: /cookbook#gestures
+[Gestures]: {{site.url}}/cookbook#gestures
 [`Scaffold`]: {{site.api}}/flutter/material/Scaffold-class.html
 [`SnackBar`]: {{site.api}}/flutter/material/SnackBar-class.html
 [material library]: {{site.api}}/flutter/material/material-library.html

--- a/src/cookbook/effects/download-button.md
+++ b/src/cookbook/effects/download-button.md
@@ -24,7 +24,7 @@ multiple visual states, based on the status of an app download.
 
 The following animation shows the app's behavior:
 
-![The download button cycles through its stages](/assets/images/docs/cookbook/effects/DownloadButton.gif){:.site-mobile-screenshot}
+![The download button cycles through its stages]({{site.url}}/assets/images/docs/cookbook/effects/DownloadButton.gif){:.site-mobile-screenshot}
 
 ## Define a new stateful widget
 

--- a/src/cookbook/effects/drag-a-widget.md
+++ b/src/cookbook/effects/drag-a-widget.md
@@ -24,7 +24,7 @@ is paying for it.
 
 The following animation shows the app's behavior:
 
-![Ordering the food by dragging it to the person](/assets/images/docs/cookbook/effects/DragAUIElement.gif){:.site-mobile-screenshot}
+![Ordering the food by dragging it to the person]({{site.url}}/assets/images/docs/cookbook/effects/DragAUIElement.gif){:.site-mobile-screenshot}
 
 This recipe begins with a prebuilt list of menu items and
 a row of customers.

--- a/src/cookbook/effects/expandable-fab.md
+++ b/src/cookbook/effects/expandable-fab.md
@@ -24,7 +24,7 @@ those critical actions.
 
 The following animation shows the app's behavior:
 
-![Expanding and collapsing the FAB](/assets/images/docs/cookbook/effects/ExpandingFAB.gif){:.site-mobile-screenshot}
+![Expanding and collapsing the FAB]({{site.url}}/assets/images/docs/cookbook/effects/ExpandingFAB.gif){:.site-mobile-screenshot}
 
 ## Create an ExpandableFab widget
 

--- a/src/cookbook/effects/gradient-bubbles.md
+++ b/src/cookbook/effects/gradient-bubbles.md
@@ -21,7 +21,7 @@ gradient backgrounds for the chat bubbles.
 
 The following animation shows the app's behavior:
 
-![Scrolling the gradient chat bubbles](/assets/images/docs/cookbook/effects/GradientBubbles.gif){:.site-mobile-screenshot}
+![Scrolling the gradient chat bubbles]({{site.url}}/assets/images/docs/cookbook/effects/GradientBubbles.gif){:.site-mobile-screenshot}
 
 ## Understand the challenge
 

--- a/src/cookbook/effects/nested-nav.md
+++ b/src/cookbook/effects/nested-nav.md
@@ -36,7 +36,7 @@ generally preferable when developing software.
 
 The following animation shows the app's behavior:
 
-![Gif showing the nested "setup" flow](/assets/images/docs/cookbook/effects/NestedNavigator.gif){:.site-mobile-screenshot}
+![Gif showing the nested "setup" flow]({{site.url}}/assets/images/docs/cookbook/effects/NestedNavigator.gif){:.site-mobile-screenshot}
 
 In this recipe, you implement a four-page IoT setup
 flow that maintains its own navigation nested beneath

--- a/src/cookbook/effects/parallax-scrolling.md
+++ b/src/cookbook/effects/parallax-scrolling.md
@@ -28,7 +28,7 @@ the images within each card slide down.
 
 The following animation shows the app's behavior: 
 
-![Parallax scrolling](/assets/images/docs/cookbook/effects/ParallaxScrolling.gif){:.site-mobile-screenshot}
+![Parallax scrolling]({{site.url}}/assets/images/docs/cookbook/effects/ParallaxScrolling.gif){:.site-mobile-screenshot}
 
 ## Create a list to hold the parallax items
 

--- a/src/cookbook/effects/photo-filter-carousel.md
+++ b/src/cookbook/effects/photo-filter-carousel.md
@@ -18,7 +18,7 @@ filter selection carousel.
 
 The following animation shows the app's behavior:
 
-![Photo Filter Carousel](/assets/images/docs/cookbook/effects/PhotoFilterCarousel.gif){:.site-mobile-screenshot}
+![Photo Filter Carousel]({{site.url}}/assets/images/docs/cookbook/effects/PhotoFilterCarousel.gif){:.site-mobile-screenshot}
 
 This recipe begins with the photo and filters
 already in place. Filters are applied with the

--- a/src/cookbook/effects/shimmer-loading.md
+++ b/src/cookbook/effects/shimmer-loading.md
@@ -22,7 +22,7 @@ the shapes that approximate the type of content that is loading.
 
 The following animation shows the app's behavior:
 
-![Gif showing the UI loading](/assets/images/docs/cookbook/effects/UILoadingAnimation.gif){:.site-mobile-screenshot}
+![Gif showing the UI loading]({{site.url}}/assets/images/docs/cookbook/effects/UILoadingAnimation.gif){:.site-mobile-screenshot}
 
 This recipe begins with the content widgets defined and positioned.
 There is also a Floating Action Button (FAB) in the bottom-right
@@ -182,7 +182,7 @@ By temporarily commenting out the image URLs,
 you can see the two ways your UI renders.
 
 
-![Gif showing the shimmer animation](/assets/images/docs/cookbook/effects/LoadingShimmer.gif){:.site-mobile-screenshot}
+![Gif showing the shimmer animation]({{site.url}}/assets/images/docs/cookbook/effects/LoadingShimmer.gif){:.site-mobile-screenshot}
 
 The next goal is to paint all of the colored areas
 with a single gradient that looks like a shimmer.

--- a/src/cookbook/effects/staggered-menu-animation.md
+++ b/src/cookbook/effects/staggered-menu-animation.md
@@ -24,7 +24,7 @@ in at the bottom.
 
 The following animation shows the app's behavior:
 
-![Staggered Menu Animation Example](/assets/images/docs/cookbook/effects/StaggeredMenuAnimation.gif){:.site-mobile-screenshot}
+![Staggered Menu Animation Example]({{site.url}}/assets/images/docs/cookbook/effects/StaggeredMenuAnimation.gif){:.site-mobile-screenshot}
 
 ## Create the menu without animations
 
@@ -191,7 +191,7 @@ used to calculate the individual animation times.
 
 The desired animation times are shown in the following diagram:
 
-![Animation Timing Diagram](/assets/images/docs/cookbook/effects/TimingDiagram.png){:.site-mobile-screenshot}
+![Animation Timing Diagram]({{site.url}}/assets/images/docs/cookbook/effects/TimingDiagram.png){:.site-mobile-screenshot}
 
 To animate a value during a subsection of a larger animation,
 Flutter provides the `Interval` class.

--- a/src/cookbook/effects/typing-indicator.md
+++ b/src/cookbook/effects/typing-indicator.md
@@ -20,7 +20,7 @@ speech bubble typing indicator that animates in and out of view.
 
 The following animation shows the app's behavior:
 
-![The typing indicator is turned on and off](/assets/images/docs/cookbook/effects/TypingIndicator.gif){:.site-mobile-screenshot}
+![The typing indicator is turned on and off]({{site.url}}/assets/images/docs/cookbook/effects/TypingIndicator.gif){:.site-mobile-screenshot}
 
 ## Define the typing indicator widget
 
@@ -794,5 +794,5 @@ class FakeMessage extends StatelessWidget {
 }
 ```
 
-[explicit animation]: /development/ui/animations#tween-animation
-[staggered animation]: /development/ui/animations/staggered-animations
+[explicit animation]: {{site.url}}/development/ui/animations#tween-animation
+[staggered animation]: {{site.url}}/development/ui/animations/staggered-animations

--- a/src/cookbook/forms/focus.md
+++ b/src/cookbook/forms/focus.md
@@ -236,7 +236,7 @@ class _MyCustomFormState extends State<MyCustomForm> {
 
 [fix has landed]: {{site.repo.flutter}}/pull/50372
 [`FocusNode`]: {{site.api}}/flutter/widgets/FocusNode-class.html
-[Forms]: /cookbook#forms
+[Forms]: {{site.url}}/cookbook#forms
 [flutter/flutter@bf551a3]: {{site.repo.flutter}}/commit/bf551a31fe7ef45c854a219686b6837400bfd94c
 [Issue 52221]: {{site.repo.flutter}}/issues/52221
 [`requestFocus()`]: {{site.api}}/flutter/widgets/FocusNode/requestFocus.html

--- a/src/cookbook/forms/text-input.md
+++ b/src/cookbook/forms/text-input.md
@@ -124,11 +124,11 @@ For more information on input validation, see the
 [Building a form with validation][] recipe.
 
 
-[Building a form with validation]: /cookbook/forms/validation/
+[Building a form with validation]: {{site.url}}/cookbook/forms/validation/
 [`decoration`]: {{site.api}}/flutter/material/TextField/decoration.html
 [`Form`]: {{site.api}}/flutter/widgets/Form-class.html
 [`FormField`]: {{site.api}}/flutter/widgets/FormField-class.html
-[Handle changes to a text field]: /cookbook/forms/text-field-changes/
+[Handle changes to a text field]: {{site.url}}/cookbook/forms/text-field-changes/
 [`InputDecoration`]: {{site.api}}/flutter/material/InputDecoration-class.html
 [`TextField`]: {{site.api}}/flutter/material/TextField-class.html
 [`TextFormField`]: {{site.api}}/flutter/material/TextFormField-class.html

--- a/src/cookbook/gestures/dismissible.md
+++ b/src/cookbook/gestures/dismissible.md
@@ -208,4 +208,4 @@ class MyAppState extends State<MyApp> {
 
 
 [`Dismissible`]: {{site.api}}/flutter/widgets/Dismissible-class.html
-[Working with long lists]: /cookbook/lists/long-lists
+[Working with long lists]: {{site.url}}/cookbook/lists/long-lists

--- a/src/cookbook/gestures/handling-taps.md
+++ b/src/cookbook/gestures/handling-taps.md
@@ -128,7 +128,7 @@ class MyButton extends StatelessWidget {
 </noscript>
 
 
-[Add Material touch ripples]: /cookbook/gestures/ripples
+[Add Material touch ripples]: {{site.url}}/cookbook/gestures/ripples
 [`CupertinoButton`]: {{site.api}}/flutter/cupertino/CupertinoButton-class.html
 [`TextButton`]: {{site.api}}/flutter/material/TextButton-class.html
 [`GestureDetector`]: {{site.api}}/flutter/widgets/GestureDetector-class.html

--- a/src/cookbook/images/fading-in-images.md
+++ b/src/cookbook/images/fading-in-images.md
@@ -73,7 +73,7 @@ class MyApp extends StatelessWidget {
 }
 ```
 
-![Fading In Image Demo](/assets/images/docs/cookbook/fading-in-images.gif){:.site-mobile-screenshot}
+![Fading In Image Demo]({{site.url}}/assets/images/docs/cookbook/fading-in-images.gif){:.site-mobile-screenshot}
 
 ## From asset bundle
 
@@ -132,10 +132,10 @@ class MyApp extends StatelessWidget {
 }
 ```
 
-![Asset fade-in](/assets/images/docs/cookbook/fading-in-asset-demo.gif){:.site-mobile-screenshot}
+![Asset fade-in]({{site.url}}/assets/images/docs/cookbook/fading-in-asset-demo.gif){:.site-mobile-screenshot}
 
 
-[Adding assets and images]: /development/ui/assets-and-images
+[Adding assets and images]: {{site.url}}/development/ui/assets-and-images
 [`FadeInImage`]: {{site.api}}/flutter/widgets/FadeInImage-class.html
 [`FadeInImage.assetNetwork()`]: {{site.api}}/flutter/widgets/FadeInImage/FadeInImage.assetNetwork.html
 [`transparent_image`]: {{site.pub-pkg}}/transparent_image

--- a/src/cookbook/images/network-image.md
+++ b/src/cookbook/images/network-image.md
@@ -76,7 +76,7 @@ class MyApp extends StatelessWidget {
 </noscript>
 
 
-[Fade in images with a placeholder]: /cookbook/images/fading-in-images
+[Fade in images with a placeholder]: {{site.url}}/cookbook/images/fading-in-images
 [`Image`]: {{site.api}}/flutter/widgets/Image-class.html
 [`Image.network()`]: {{site.api}}/flutter/widgets/Image/Image.network.html
-[Work with cached images]: /cookbook/images/cached-images
+[Work with cached images]: {{site.url}}/cookbook/images/cached-images

--- a/src/cookbook/index.md
+++ b/src/cookbook/index.md
@@ -9,111 +9,111 @@ reference to help you build up an application.
 
 
 ## Animation
-- [Animate a page route transition](/cookbook/animation/page-route-animation)
-- [Animate a widget using a physics simulation](/cookbook/animation/physics-simulation)
-- [Animate the properties of a container](/cookbook/animation/animated-container)
-- [Fade a widget in and out](/cookbook/animation/opacity-animation)
+- [Animate a page route transition]({{site.url}}/cookbook/animation/page-route-animation)
+- [Animate a widget using a physics simulation]({{site.url}}/cookbook/animation/physics-simulation)
+- [Animate the properties of a container]({{site.url}}/cookbook/animation/animated-container)
+- [Fade a widget in and out]({{site.url}}/cookbook/animation/opacity-animation)
 
 
 ## Design
-- [Add a Drawer to a screen](/cookbook/design/drawer)
-- [Display a snackbar](/cookbook/design/snackbars)
-- [Export fonts from a package](/cookbook/design/package-fonts)
-- [Update the UI based on orientation](/cookbook/design/orientation)
-- [Use a custom font](/cookbook/design/fonts)
-- [Use themes to share colors and font styles](/cookbook/design/themes)
-- [Work with tabs](/cookbook/design/tabs)
+- [Add a Drawer to a screen]({{site.url}}/cookbook/design/drawer)
+- [Display a snackbar]({{site.url}}/cookbook/design/snackbars)
+- [Export fonts from a package]({{site.url}}/cookbook/design/package-fonts)
+- [Update the UI based on orientation]({{site.url}}/cookbook/design/orientation)
+- [Use a custom font]({{site.url}}/cookbook/design/fonts)
+- [Use themes to share colors and font styles]({{site.url}}/cookbook/design/themes)
+- [Work with tabs]({{site.url}}/cookbook/design/tabs)
 
 
 ## Effects
-- [Create a download button](/cookbook/effects/download-button)
-- [Create a nested navigation flow](/cookbook/effects/nested-nav)
-- [Create a photo filter carousel](/cookbook/effects/photo-filter-carousel)
-- [Create a scrolling parallax effect](/cookbook/effects/parallax-scrolling)
-- [Create a shimmer loading effect](/cookbook/effects/shimmer-loading)
-- [Create a staggered menu animation](/cookbook/effects/staggered-menu-animation)
-- [Create a typing indicator](/cookbook/effects/typing-indicator)
-- [Create an expandable FAB](/cookbook/effects/expandable-fab)
-- [Create gradient chat bubbles](/cookbook/effects/gradient-bubbles)
-- [Drag a UI element](/cookbook/effects/drag-a-widget)
+- [Create a download button]({{site.url}}/cookbook/effects/download-button)
+- [Create a nested navigation flow]({{site.url}}/cookbook/effects/nested-nav)
+- [Create a photo filter carousel]({{site.url}}/cookbook/effects/photo-filter-carousel)
+- [Create a scrolling parallax effect]({{site.url}}/cookbook/effects/parallax-scrolling)
+- [Create a shimmer loading effect]({{site.url}}/cookbook/effects/shimmer-loading)
+- [Create a staggered menu animation]({{site.url}}/cookbook/effects/staggered-menu-animation)
+- [Create a typing indicator]({{site.url}}/cookbook/effects/typing-indicator)
+- [Create an expandable FAB]({{site.url}}/cookbook/effects/expandable-fab)
+- [Create gradient chat bubbles]({{site.url}}/cookbook/effects/gradient-bubbles)
+- [Drag a UI element]({{site.url}}/cookbook/effects/drag-a-widget)
 
 
 ## Forms
-- [Build a form with validation](/cookbook/forms/validation)
-- [Create and style a text field](/cookbook/forms/text-input)
-- [Focus and text fields](/cookbook/forms/focus)
-- [Handle changes to a text field](/cookbook/forms/text-field-changes)
-- [Retrieve the value of a text field](/cookbook/forms/retrieve-input)
+- [Build a form with validation]({{site.url}}/cookbook/forms/validation)
+- [Create and style a text field]({{site.url}}/cookbook/forms/text-input)
+- [Focus and text fields]({{site.url}}/cookbook/forms/focus)
+- [Handle changes to a text field]({{site.url}}/cookbook/forms/text-field-changes)
+- [Retrieve the value of a text field]({{site.url}}/cookbook/forms/retrieve-input)
 
 
 ## Gestures
-- [Add Material touch ripples](/cookbook/gestures/ripples)
-- [Handle taps](/cookbook/gestures/handling-taps)
-- [Implement swipe to dismiss](/cookbook/gestures/dismissible)
+- [Add Material touch ripples]({{site.url}}/cookbook/gestures/ripples)
+- [Handle taps]({{site.url}}/cookbook/gestures/handling-taps)
+- [Implement swipe to dismiss]({{site.url}}/cookbook/gestures/dismissible)
 
 
 ## Images
-- [Display images from the internet](/cookbook/images/network-image)
-- [Fade in images with a placeholder](/cookbook/images/fading-in-images)
-- [Work with cached images](/cookbook/images/cached-images)
+- [Display images from the internet]({{site.url}}/cookbook/images/network-image)
+- [Fade in images with a placeholder]({{site.url}}/cookbook/images/fading-in-images)
+- [Work with cached images]({{site.url}}/cookbook/images/cached-images)
 
 
 ## Lists
-- [Create a grid list](/cookbook/lists/grid-lists)
-- [Create a horizontal list](/cookbook/lists/horizontal-list)
-- [Create lists with different types of items](/cookbook/lists/mixed-list)
-- [Place a floating app bar above a list](/cookbook/lists/floating-app-bar)
-- [Use lists](/cookbook/lists/basic-list)
-- [Work with long lists](/cookbook/lists/long-lists)
+- [Create a grid list]({{site.url}}/cookbook/lists/grid-lists)
+- [Create a horizontal list]({{site.url}}/cookbook/lists/horizontal-list)
+- [Create lists with different types of items]({{site.url}}/cookbook/lists/mixed-list)
+- [Place a floating app bar above a list]({{site.url}}/cookbook/lists/floating-app-bar)
+- [Use lists]({{site.url}}/cookbook/lists/basic-list)
+- [Work with long lists]({{site.url}}/cookbook/lists/long-lists)
 
 
 ## Maintenance
-- [Report errors to a service](/cookbook/maintenance/error-reporting)
+- [Report errors to a service]({{site.url}}/cookbook/maintenance/error-reporting)
 
 
 ## Navigation
-- [Animate a widget across screens](/cookbook/navigation/hero-animations)
-- [Navigate to a new screen and back](/cookbook/navigation/navigation-basics)
-- [Navigate with named routes](/cookbook/navigation/named-routes)
-- [Pass arguments to a named route](/cookbook/navigation/navigate-with-arguments)
-- [Return data from a screen](/cookbook/navigation/returning-data)
-- [Send data to a new screen](/cookbook/navigation/passing-data)
+- [Animate a widget across screens]({{site.url}}/cookbook/navigation/hero-animations)
+- [Navigate to a new screen and back]({{site.url}}/cookbook/navigation/navigation-basics)
+- [Navigate with named routes]({{site.url}}/cookbook/navigation/named-routes)
+- [Pass arguments to a named route]({{site.url}}/cookbook/navigation/navigate-with-arguments)
+- [Return data from a screen]({{site.url}}/cookbook/navigation/returning-data)
+- [Send data to a new screen]({{site.url}}/cookbook/navigation/passing-data)
 
 
 ## Networking
-- [Delete data on the internet](/cookbook/networking/delete-data)
-- [Fetch data from the internet](/cookbook/networking/fetch-data)
-- [Make authenticated requests](/cookbook/networking/authenticated-requests)
-- [Parse JSON in the background](/cookbook/networking/background-parsing)
-- [Send data to the internet](/cookbook/networking/send-data)
-- [Update data over the internet](/cookbook/networking/update-data)
-- [Work with WebSockets](/cookbook/networking/web-sockets)
+- [Delete data on the internet]({{site.url}}/cookbook/networking/delete-data)
+- [Fetch data from the internet]({{site.url}}/cookbook/networking/fetch-data)
+- [Make authenticated requests]({{site.url}}/cookbook/networking/authenticated-requests)
+- [Parse JSON in the background]({{site.url}}/cookbook/networking/background-parsing)
+- [Send data to the internet]({{site.url}}/cookbook/networking/send-data)
+- [Update data over the internet]({{site.url}}/cookbook/networking/update-data)
+- [Work with WebSockets]({{site.url}}/cookbook/networking/web-sockets)
 
 
 ## Persistence
-- [Persist data with SQLite](/cookbook/persistence/sqlite)
-- [Read and write files](/cookbook/persistence/reading-writing-files)
-- [Store key-value data on disk](/cookbook/persistence/key-value)
+- [Persist data with SQLite]({{site.url}}/cookbook/persistence/sqlite)
+- [Read and write files]({{site.url}}/cookbook/persistence/reading-writing-files)
+- [Store key-value data on disk]({{site.url}}/cookbook/persistence/key-value)
 
 
 ## Plugins
-- [Play and pause a video](/cookbook/plugins/play-video)
-- [Take a picture using the camera](/cookbook/plugins/picture-using-camera)
+- [Play and pause a video]({{site.url}}/cookbook/plugins/play-video)
+- [Take a picture using the camera]({{site.url}}/cookbook/plugins/picture-using-camera)
 
 
 ## Testing
 
 ### Integration
-- [An introduction to integration testing](/cookbook/testing/integration/introduction)
-- [Performance profiling](/cookbook/testing/integration/profiling)
+- [An introduction to integration testing]({{site.url}}/cookbook/testing/integration/introduction)
+- [Performance profiling]({{site.url}}/cookbook/testing/integration/profiling)
 
 ### Unit
-- [An introduction to unit testing](/cookbook/testing/unit/introduction)
-- [Mock dependencies using Mockito](/cookbook/testing/unit/mocking)
+- [An introduction to unit testing]({{site.url}}/cookbook/testing/unit/introduction)
+- [Mock dependencies using Mockito]({{site.url}}/cookbook/testing/unit/mocking)
 
 
 ### Widget
-- [An introduction to widget testing](/cookbook/testing/widget/introduction)
-- [Find widgets](/cookbook/testing/widget/finders)
-- [Handle scrolling](/cookbook/testing/widget/scrolling)
-- [Tap, drag, and enter text](/cookbook/testing/widget/tap-drag)
+- [An introduction to widget testing]({{site.url}}/cookbook/testing/widget/introduction)
+- [Find widgets]({{site.url}}/cookbook/testing/widget/finders)
+- [Handle scrolling]({{site.url}}/cookbook/testing/widget/scrolling)
+- [Tap, drag, and enter text]({{site.url}}/cookbook/testing/widget/tap-drag)

--- a/src/cookbook/navigation/hero-animations.md
+++ b/src/cookbook/navigation/hero-animations.md
@@ -220,6 +220,6 @@ class DetailScreen extends StatelessWidget {
 </noscript>
 
 
-[Handle taps]: /cookbook/gestures/handling-taps
+[Handle taps]: {{site.url}}/cookbook/gestures/handling-taps
 [`Hero`]: {{site.api}}/flutter/widgets/Hero-class.html
-[Navigate to a new screen and back]: /cookbook/navigation/navigation-basics
+[Navigate to a new screen and back]: {{site.url}}/cookbook/navigation/navigation-basics

--- a/src/cookbook/navigation/named-routes.md
+++ b/src/cookbook/navigation/named-routes.md
@@ -236,7 +236,7 @@ class SecondScreen extends StatelessWidget {
 
 
 [`MaterialApp`]: {{site.api}}/flutter/material/MaterialApp-class.html
-[Navigate to a new screen and back]: /cookbook/navigation/navigation-basics
+[Navigate to a new screen and back]: {{site.url}}/cookbook/navigation/navigation-basics
 [`Navigator`]: {{site.api}}/flutter/widgets/Navigator-class.html
 [`Navigator.pop()`]: {{site.api}}/flutter/widgets/Navigator/pop.html
 [`Navigator.pushNamed()`]: {{site.api}}/flutter/widgets/Navigator/pushNamed.html

--- a/src/cookbook/navigation/passing-data.md
+++ b/src/cookbook/navigation/passing-data.md
@@ -445,4 +445,4 @@ class DetailScreen extends StatelessWidget {
 [`Navigator.push()`]: {{site.api}}/flutter/widgets/Navigator/push.html
 [`onTap()`]: {{site.api}}/flutter/material/ListTile/onTap.html
 [`RouteSettings`]: {{site.api}}/flutter/widgets/RouteSettings-class.html
-[Use lists]: /cookbook/lists/basic-list
+[Use lists]: {{site.url}}/cookbook/lists/basic-list

--- a/src/cookbook/networking/authenticated-requests.md
+++ b/src/cookbook/networking/authenticated-requests.md
@@ -81,6 +81,6 @@ class Album {
 ```
 
 
-[Fetching data from the internet]: /cookbook/networking/fetch-data
+[Fetching data from the internet]: {{site.url}}/cookbook/networking/fetch-data
 [`http`]: {{site.pub-pkg}}/http
 [`HttpHeaders`]: {{site.dart.api}}/stable/dart-io/HttpHeaders-class.html

--- a/src/cookbook/networking/background-parsing.md
+++ b/src/cookbook/networking/background-parsing.md
@@ -283,10 +283,10 @@ class PhotosList extends StatelessWidget {
 }
 ```
 
-![Isolate demo](/assets/images/docs/cookbook/isolate.gif){:.site-mobile-screenshot}
+![Isolate demo]({{site.url}}/assets/images/docs/cookbook/isolate.gif){:.site-mobile-screenshot}
 
 [`compute()`]: {{site.api}}/flutter/foundation/compute-constant.html
-[Fetch data from the internet]: /cookbook/networking/fetch-data
+[Fetch data from the internet]: {{site.url}}/cookbook/networking/fetch-data
 [`http`]: {{site.pub-pkg}}/http
 [`http.get()`]: {{site.pub-api}}/http/latest/http/get.html
 [Isolate]: {{site.api}}/flutter/dart-isolate/Isolate-class.html

--- a/src/cookbook/networking/delete-data.md
+++ b/src/cookbook/networking/delete-data.md
@@ -276,7 +276,7 @@ class _MyAppState extends State<MyApp> {
 }
 ```
 
-[Fetch Data]: /cookbook/networking/fetch-data
+[Fetch Data]: {{site.url}}/cookbook/networking/fetch-data
 [ConnectionState]: {{site.api}}/flutter/widgets/ConnectionState-class.html
 [`didChangeDependencies()`]: {{site.api}}/flutter/widgets/State/didChangeDependencies.html
 [`Future`]: {{site.api}}/flutter/dart-async/Future-class.html
@@ -286,8 +286,8 @@ class _MyAppState extends State<MyApp> {
 [`http.delete()`]: {{site.pub-api}}/http/latest/http/delete.html
 [`http` package]: {{site.pub-pkg}}/http/install
 [`InheritedWidget`]: {{site.api}}/flutter/widgets/InheritedWidget-class.html
-[Introduction to unit testing]: /cookbook/testing/unit/introduction
+[Introduction to unit testing]: {{site.url}}/cookbook/testing/unit/introduction
 [`initState()`]: {{site.api}}/flutter/widgets/State/initState.html
-[Mock dependencies using Mockito]: /cookbook/testing/unit/mocking
-[JSON and serialization]: /development/data-and-backend/json
+[Mock dependencies using Mockito]: {{site.url}}/cookbook/testing/unit/mocking
+[JSON and serialization]: {{site.url}}/development/data-and-backend/json
 [`State`]: {{site.api}}/flutter/widgets/State-class.html

--- a/src/cookbook/networking/fetch-data.md
+++ b/src/cookbook/networking/fetch-data.md
@@ -346,8 +346,8 @@ class _MyAppState extends State<MyApp> {
 [`http.get()`]: {{site.pub-api}}/http/latest/http/get.html
 [`http` package]: {{site.pub-pkg}}/http/install
 [`InheritedWidget`]: {{site.api}}/flutter/widgets/InheritedWidget-class.html
-[Introduction to unit testing]: /cookbook/testing/unit/introduction
+[Introduction to unit testing]: {{site.url}}/cookbook/testing/unit/introduction
 [`initState()`]: {{site.api}}/flutter/widgets/State/initState.html
-[Mock dependencies using Mockito]: /cookbook/testing/unit/mocking
-[JSON and serialization]: /development/data-and-backend/json
+[Mock dependencies using Mockito]: {{site.url}}/cookbook/testing/unit/mocking
+[JSON and serialization]: {{site.url}}/development/data-and-backend/json
 [`State`]: {{site.api}}/flutter/widgets/State-class.html

--- a/src/cookbook/networking/send-data.md
+++ b/src/cookbook/networking/send-data.md
@@ -354,16 +354,16 @@ class _MyAppState extends State<MyApp> {
 
 [ConnectionState]: {{site.api}}/flutter/widgets/ConnectionState-class.html
 [`didChangeDependencies()`]: {{site.api}}/flutter/widgets/State/didChangeDependencies.html
-[Fetch Data]: /cookbook/networking/fetch-data
+[Fetch Data]: {{site.url}}/cookbook/networking/fetch-data
 [`Future`]: {{site.api}}/flutter/dart-async/Future-class.html
 [`FutureBuilder`]: {{site.api}}/flutter/widgets/FutureBuilder-class.html
 [`http`]: {{site.pub-pkg}}/http
 [`http.post()`]: {{site.pub-api}}/http/latest/http/post.html
 [`http` package]: {{site.pub-pkg}}/http/install
 [`InheritedWidget`]: {{site.api}}/flutter/widgets/InheritedWidget-class.html
-[Introduction to unit testing]: /cookbook/testing/unit/introduction
+[Introduction to unit testing]: {{site.url}}/cookbook/testing/unit/introduction
 [`initState()`]: {{site.api}}/flutter/widgets/State/initState.html
 [JSONPlaceholder]: https://jsonplaceholder.typicode.com/
-[Mock dependencies using Mockito]: /cookbook/testing/unit/mocking
-[JSON and serialization]: /development/data-and-backend/json
+[Mock dependencies using Mockito]: {{site.url}}/cookbook/testing/unit/mocking
+[JSON and serialization]: {{site.url}}/development/data-and-backend/json
 [`State`]: {{site.api}}/flutter/widgets/State-class.html

--- a/src/cookbook/networking/update-data.md
+++ b/src/cookbook/networking/update-data.md
@@ -397,7 +397,7 @@ class _MyAppState extends State<MyApp> {
 
 [ConnectionState]: {{site.api}}/flutter/widgets/ConnectionState-class.html
 [`didChangeDependencies()`]: {{site.api}}/flutter/widgets/State/didChangeDependencies.html
-[Fetch data]: /cookbook/networking/fetch-data
+[Fetch data]: {{site.url}}/cookbook/networking/fetch-data
 [`Future`]: {{site.api}}/flutter/dart-async/Future-class.html
 [`FutureBuilder`]: {{site.api}}/flutter/widgets/FutureBuilder-class.html
 [JSONPlaceholder]: https://jsonplaceholder.typicode.com/
@@ -405,8 +405,8 @@ class _MyAppState extends State<MyApp> {
 [`http.put()`]: {{site.pub-api}}/http/latest/http/put.html
 [`http` package]: {{site.pub}}/packages/http/install
 [`InheritedWidget`]: {{site.api}}/flutter/widgets/InheritedWidget-class.html
-[Introduction to unit testing]: /cookbook/testing/unit/introduction
+[Introduction to unit testing]: {{site.url}}/cookbook/testing/unit/introduction
 [`initState()`]: {{site.api}}/flutter/widgets/State/initState.html
-[JSON and serialization]: /development/data-and-backend/json
-[Mock dependencies using Mockito]: /cookbook/testing/unit/mocking
+[JSON and serialization]: {{site.url}}/development/data-and-backend/json
+[Mock dependencies using Mockito]: {{site.url}}/cookbook/testing/unit/mocking
 [`State`]: {{site.api}}/flutter/widgets/State-class.html

--- a/src/cookbook/networking/web-sockets.md
+++ b/src/cookbook/networking/web-sockets.md
@@ -200,7 +200,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 }
 ```
-![Web sockets demo](/assets/images/docs/cookbook/web-sockets.gif){:.site-mobile-screenshot}
+![Web sockets demo]({{site.url}}/assets/images/docs/cookbook/web-sockets.gif){:.site-mobile-screenshot}
 
 
 [`Stream`]: {{site.api}}/flutter/dart-async/Stream-class.html

--- a/src/cookbook/testing/integration/introduction.md
+++ b/src/cookbook/testing/integration/introduction.md
@@ -257,6 +257,6 @@ flutter drive \
 [Download GeckoDriver]: {{site.github}}/mozilla/geckodriver/releases
 [flutter_driver]: {{site.api}}/flutter/flutter_driver/flutter_driver-library.html
 [integration_test]: {{site.repo.flutter}}/tree/master/packages/integration_test
-[Integration testing]: /testing/integration-tests
+[Integration testing]: {{site.url}}/testing/integration-tests
 [`SerializableFinders`]: {{site.api}}/flutter/flutter_driver/CommonFinders-class.html
 [`ValueKey`]: {{site.api}}/flutter/foundation/ValueKey-class.html

--- a/src/cookbook/testing/integration/profiling.md
+++ b/src/cookbook/testing/integration/profiling.md
@@ -206,7 +206,7 @@ void main() {
 
 [chrome://tracing]: chrome://tracing
 [`FlutterDriver`]: {{site.api}}/flutter/flutter_driver/FlutterDriver-class.html
-[Scrolling]: /cookbook/testing/widget/scrolling
+[Scrolling]: {{site.url}}/cookbook/testing/widget/scrolling
 [`Timeline`]: {{site.api}}/flutter/flutter_driver/Timeline-class.html
 [`TimelineSummary`]: {{site.api}}/flutter/flutter_driver/TimelineSummary-class.html
 [`traceAction()`]: {{site.api}}/flutter/flutter_driver/FlutterDriver/traceAction.html

--- a/src/cookbook/testing/unit/mocking.md
+++ b/src/cookbook/testing/unit/mocking.md
@@ -351,6 +351,6 @@ the Mockito library and the concept of mocking. For more information,
 see the documentation provided by the [Mockito package][].
 
 
-[Fetch data from the internet]: /cookbook/networking/fetch-data
-[Introduction to unit testing]: /cookbook/testing/unit/introduction
+[Fetch data from the internet]: {{site.url}}/cookbook/networking/fetch-data
+[Introduction to unit testing]: {{site.url}}/cookbook/testing/unit/introduction
 [Mockito package]: {{site.pub-pkg}}/mockito

--- a/src/cookbook/testing/widget/finders.md
+++ b/src/cookbook/testing/widget/finders.md
@@ -161,4 +161,4 @@ void main() {
 [`CommonFinders` documentation]: {{api}}/flutter_test/CommonFinders-class.html
 [`find`]: {{api}}/flutter_test/find-constant.html
 [`flutter_test`]: {{api}}/flutter_test/flutter_test-library.html
-[Introduction to widget testing]: /cookbook/testing/widget/introduction
+[Introduction to widget testing]: {{site.url}}/cookbook/testing/widget/introduction

--- a/src/cookbook/testing/widget/introduction.md
+++ b/src/cookbook/testing/widget/introduction.md
@@ -297,9 +297,9 @@ class MyWidget extends StatelessWidget {
 [`findsWidgets`]: {{api}}/flutter_test/findsWidgets-constant.html
 [`matchesGoldenFile`]: {{api}}/flutter_test/matchesGoldenFile.html
 [`Finder`]: {{api}}/flutter_test/Finder-class.html
-[Finding widgets in a widget test]: /cookbook/testing/widget/finders
+[Finding widgets in a widget test]: {{site.url}}/cookbook/testing/widget/finders
 [`flutter_test`]: {{api}}/flutter_test/flutter_test-library.html
-[introduction to unit testing]: /cookbook/testing/unit/introduction
+[introduction to unit testing]: {{site.url}}/cookbook/testing/unit/introduction
 [`Matcher`]: {{api}}/package-matcher_matcher/Matcher-class.html
 [`pumpWidget()`]: {{api}}/flutter_test/WidgetTester/pumpWidget.html
 [`tester.pump(Duration duration)`]: {{api}}/flutter_test/TestWidgetsFlutterBinding/pump.html

--- a/src/cookbook/testing/widget/scrolling.md
+++ b/src/cookbook/testing/widget/scrolling.md
@@ -159,4 +159,4 @@ flutter test test/widget_test.dart
 [`WidgetTester`]: {{site.api}}/flutter/flutter_test/WidgetTester-class.html
 [`ListView.builder`]: {{site.api}}/flutter/widgets/ListView/ListView.builder.html
 [`scrollUntilVisible()`]: {{site.api}}/flutter/flutter_test/WidgetController/scrollUntilVisible.html
-[Work with long lists]: /cookbook/lists/long-lists
+[Work with long lists]: {{site.url}}/cookbook/lists/long-lists

--- a/src/cookbook/testing/widget/tap-drag.md
+++ b/src/cookbook/testing/widget/tap-drag.md
@@ -294,14 +294,14 @@ class _TodoListState extends State<TodoList> {
 }
 ```
 
-[Create a basic list]: /cookbook/lists/basic-list
-[Create and style a text field]: /cookbook/forms/text-input
+[Create a basic list]: {{site.url}}/cookbook/lists/basic-list
+[Create and style a text field]: {{site.url}}/cookbook/forms/text-input
 [`drag()`]: {{api}}/flutter_test/WidgetController/drag.html
 [`enterText()`]: {{api}}/flutter_test/WidgetTester/enterText.html
-[Finding widgets in a widget test]: /cookbook/testing/widget/finders
-[Handle taps]: /cookbook/gestures/handling-taps
-[Implement swipe to dismiss]: /cookbook/gestures/dismissible
-[Introduction to widget testing]: /cookbook/testing/widget/introduction
+[Finding widgets in a widget test]: {{site.url}}/cookbook/testing/widget/finders
+[Handle taps]: {{site.url}}/cookbook/gestures/handling-taps
+[Implement swipe to dismiss]: {{site.url}}/cookbook/gestures/dismissible
+[Introduction to widget testing]: {{site.url}}/cookbook/testing/widget/introduction
 [`pump()`]: {{api}}/flutter_test/WidgetTester/pump.html
 [`pumpAndSettle()`]: {{api}}/flutter_test/WidgetTester/pumpAndSettle.html
 [`tap()`]: {{api}}/flutter_test/WidgetController/tap.html

--- a/src/dash/index.md
+++ b/src/dash/index.md
@@ -5,7 +5,7 @@ description: Learn more about the Flutter and Dart mascot, Dash.
 
 This is Dash:
 
-![Dash by herself](/assets/images/dash/Dash.png){:width="50%"}<br>
+![Dash by herself]({{site.url}}/assets/images/dash/Dash.png){:width="50%"}<br>
 
 Dash is the mascot for the Dart language and the Flutter framework.
 
@@ -14,9 +14,9 @@ Dash is the mascot for the Dart language and the Flutter framework.
   [Dashatar][], a Flutter app for web and mobile!
 {{site.alert.end}}
 
-![A sample of Dashatars](/assets/images/dash/Dashatars.png){:width="100%"}<br>
+![A sample of Dashatars]({{site.url}}/assets/images/dash/Dashatars.png){:width="100%"}<br>
 
-![GIF of Dash fainting created for Flutter Engage](/assets/images/dash/dash-fainting.gif)
+![GIF of Dash fainting created for Flutter Engage]({{site.url}}/assets/images/dash/dash-fainting.gif)
 
 [Dashatar]: https://dashatar-dev.web.app/#/
 
@@ -58,11 +58,11 @@ That's right, Dash was originally a
 
 Here are some early mockups and one of the first prototypes:
 
-![1st mockup made by Novicell.dk](/assets/images/dash/early-dash-sketches.png){:width="35%"} ![2nd mockup by Squishable.com](/assets/images/dash/early-dash-sketches2.jpg){:width="35%"}<br>
+![1st mockup made by Novicell.dk]({{site.url}}/assets/images/dash/early-dash-sketches.png){:width="35%"} ![2nd mockup by Squishable.com]({{site.url}}/assets/images/dash/early-dash-sketches2.jpg){:width="35%"}<br>
 
-![Prototype 1](/assets/images/dash/early-dash-sketches3.jpg){:width="35%"} ![Playing with embroidery ideas](/assets/images/dash/early-dash-sketches4.jpg){:width="35%"}<br>
+![Prototype 1]({{site.url}}/assets/images/dash/early-dash-sketches3.jpg){:width="35%"} ![Playing with embroidery ideas]({{site.url}}/assets/images/dash/early-dash-sketches4.jpg){:width="35%"}<br>
 
-![First prototype](/assets/images/dash/early-dash-sketches5.jpg){:width="50%"}<br>
+![First prototype]({{site.url}}/assets/images/dash/early-dash-sketches5.jpg){:width="50%"}<br>
 The first prototype had uneven eyes
 
 [event website]: https://events.dartlang.org/2018/dartconf/
@@ -73,7 +73,7 @@ Early on, a hummingbird image was created for the Dart team
 to use for presentations and the web.
 The hummingbird represents that Dart is a speedy language.
 
-![Early hummingbird drawing](/assets/images/dash/DartHummingbird.jpg){:width="35%"}<br>
+![Early hummingbird drawing]({{site.url}}/assets/images/dash/DartHummingbird.jpg){:width="35%"}<br>
 
 However, hummingbirds are pointed and angular
 and we wanted a cuddly plushy, so we chose a round
@@ -84,7 +84,7 @@ the tail shape, the tuft of hair, the eyes...all the
 little details. The vendor sent the specs to two
 manufacturers who returned the prototypes some weeks later.
 
-![The first Dash prototypes](/assets/images/dash/dash-prototypes.jpg){:width="35%"} ![The first Dash prototypes](/assets/images/dash/dash-prototypes2.jpg){:width="35%"}<br>
+![The first Dash prototypes]({{site.url}}/assets/images/dash/dash-prototypes.jpg){:width="35%"} ![The first Dash prototypes]({{site.url}}/assets/images/dash/dash-prototypes2.jpg){:width="35%"}<br>
 
 Introducing Dash at the January 2018 Dart Conference:
 <iframe width="541" height="350" src="{{ site.youtube-site }}/embed/R5vIUjRZaZA" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
@@ -102,10 +102,10 @@ They were eagerly adopted by Dart _and_ Flutter enthusiasts.
 The people have spoken,
 so Dash is now the mascot for Flutter **and** Dart.
 
-![Dash 1.0](/assets/images/dash/dash-1.0.jpg){:width="35%"}<br>
+![Dash 1.0]({{site.url}}/assets/images/dash/dash-1.0.jpg){:width="35%"}<br>
 Dash 1.0
 
-![Piles of Dashes awaiting conference goers](/assets/images/dash/dash-conference-swag.jpg){:width="50%"}<br>
+![Piles of Dashes awaiting conference goers]({{site.url}}/assets/images/dash/dash-conference-swag.jpg){:width="50%"}<br>
 Conference swag
 
 Since the creation of Dash 1.0, we've made two more versions.
@@ -116,10 +116,10 @@ Dash 2.1 is a smaller size and has a few more color
 tweaks. The smaller size is easier to ship,
 and fits better in a claw machine!
 
-![Dash 2.0 and 2.1](/assets/images/dash/BigDashAndLittleDash.png){:width="50%"}<br>
+![Dash 2.0 and 2.1]({{site.url}}/assets/images/dash/BigDashAndLittleDash.png){:width="50%"}<br>
 Dash 2.0 and 2.1
 
-![Flutter Interact claw machine](/assets/images/dash/DashClawMachine.png){:width="50%"}<br>
+![Flutter Interact claw machine]({{site.url}}/assets/images/dash/DashClawMachine.png){:width="50%"}<br>
 
 ## Dash facts
 
@@ -130,14 +130,14 @@ Dash 2.0 and 2.1
   **Please, don't depict Dash with a curved beak.**
 * We also have Mega-Dash, a life-sized mascot
   who is currently resting in a locked-down Google office.<br>
-![Mega-Dash in the office](/assets/images/dash/MegaDashChilling.png){:width="50%"}<br>
+![Mega-Dash in the office]({{site.url}}/assets/images/dash/MegaDashChilling.png){:width="50%"}<br>
   Mega-Dash made her
   first appearance at the [Flutter Interact][] event
   in Brooklyn, New York, on December 11, 2019.<br>
 <iframe width="560" height="315" src="{{site.youtube-site}}/embed/EgBMGDtHZhE" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 * We also have a Dash puppet that Shams made from
   one of the first plushies.
-![Nilay and the Dash puppet](/assets/images/dash/NilayDashPuppet.png){:width="50%"}<br>
+![Nilay and the Dash puppet]({{site.url}}/assets/images/dash/NilayDashPuppet.png){:width="50%"}<br>
   A number of our YouTube videos feature the Dash puppet,
   voiced by Emily Fortuna, one of our early (and much loved)
   Flutter Developer Advocates.
@@ -147,10 +147,10 @@ Dash 2.0 and 2.1
 I haven't been able to figure out how to play the mp4 file...
 * Here is a sound recording of Dash's chirp, by Kathy Walrath,
   the Dart writer.
-![Dash's chirp](/assets/images/dash/DartDartDarrrrrrt.mp4){:width="50%"}<br>
+![Dash's chirp]({{site.url}}/assets/images/dash/DartDartDarrrrrrt.mp4){:width="50%"}<br>
 {% endcomment %}
 
-!["Born to Hot Reload" jacket](/assets/images/dash/ShamsDashJacket.png){:width="35%"}<br>
+!["Born to Hot Reload" jacket]({{site.url}}/assets/images/dash/ShamsDashJacket.png){:width="35%"}<br>
 
 [Flutter Interact]: {{site.developers}}/events/flutter-interact
 [Instagram account]: https://www.instagram.com/dash_the_dartlang_plushy/

--- a/src/deployment/android.md
+++ b/src/deployment/android.md
@@ -551,10 +551,10 @@ The resulting app bundle or APK files are located in
 [manifesttag]: {{site.android-dev}}/guide/topics/manifest/manifest-element
 [multidex-docs]: {{site.android-dev}}/studio/build/multidex
 [multidex-keep]: {{site.android-dev}}/studio/build/multidex#multidexkeepfile-property
-[obfuscating your Dart code]: /deployment/obfuscate
+[obfuscating your Dart code]: {{site.url}}/deployment/obfuscate
 [official Play Store documentation]: https://support.google.com/googleplay/android-developer/answer/7384423?hl=en
 [permissiontag]: {{site.android-dev}}/guide/topics/manifest/uses-permission-element
-[Platform Views]: /development/platform-integration/platform-views
+[Platform Views]: {{site.url}}/development/platform-integration/platform-views
 [play]: {{site.android-dev}}/distribute/googleplay/start
 [plugin]: {{site.android-dev}}/studio/releases/gradle-plugin
 [R8]: {{site.android-dev}}/studio/build/shrink-code

--- a/src/deployment/cd.md
+++ b/src/deployment/cd.md
@@ -52,31 +52,31 @@ Visit the [fastlane docs][fastlane] for more info.
     and set it to the root directory of your Flutter SDK.
     (This is required for the scripts that deploy for iOS.)
 1. Create your Flutter project, and when ready, make sure that your project builds via
-    * ![Android](/assets/images/docs/cd/android.png) `flutter build appbundle`; and
-    * ![iOS](/assets/images/docs/cd/ios.png) `flutter build ios --release --no-codesign`.
+    * ![Android]({{site.url}}/assets/images/docs/cd/android.png) `flutter build appbundle`; and
+    * ![iOS]({{site.url}}/assets/images/docs/cd/ios.png) `flutter build ios --release --no-codesign`.
 1. Initialize the fastlane projects for each platform.
-    * ![Android](/assets/images/docs/cd/android.png) In your `[project]/android`
+    * ![Android]({{site.url}}/assets/images/docs/cd/android.png) In your `[project]/android`
     directory, run `fastlane init`.
-    * ![iOS](/assets/images/docs/cd/ios.png) In your `[project]/ios` directory,
+    * ![iOS]({{site.url}}/assets/images/docs/cd/ios.png) In your `[project]/ios` directory,
     run `fastlane init`.
 1. Edit the `Appfile`s to ensure they have adequate metadata for your app.
-    * ![Android](/assets/images/docs/cd/android.png) Check that `package_name` in
+    * ![Android]({{site.url}}/assets/images/docs/cd/android.png) Check that `package_name` in
     `[project]/android/fastlane/Appfile` matches your package name in AndroidManifest.xml.
-    * ![iOS](/assets/images/docs/cd/ios.png) Check that `app_identifier` in
+    * ![iOS]({{site.url}}/assets/images/docs/cd/ios.png) Check that `app_identifier` in
     `[project]/ios/fastlane/Appfile` also matches Info.plist's bundle identifier. Fill in
     `apple_id`, `itc_team_id`, `team_id` with your respective account info.
 1. Set up your local login credentials for the stores.
-    * ![Android](/assets/images/docs/cd/android.png) Follow the [Supply setup steps][]
+    * ![Android]({{site.url}}/assets/images/docs/cd/android.png) Follow the [Supply setup steps][]
     and ensure that `fastlane supply init` successfully syncs data from your
     Play Store console. _Treat the .json file like your password and do not check
     it into any public source control repositories._
-    * ![iOS](/assets/images/docs/cd/ios.png) Your iTunes Connect username is already
+    * ![iOS]({{site.url}}/assets/images/docs/cd/ios.png) Your iTunes Connect username is already
     in your `Appfile`'s `apple_id` field. Set the `FASTLANE_PASSWORD` shell
     environment variable with your iTunes Connect password. Otherwise, you'll be
     prompted when uploading to iTunes/TestFlight.
 1. Set up code signing.
-    * ![Android](/assets/images/docs/cd/android.png) Follow the [Android app signing steps][].
-    * ![iOS](/assets/images/docs/cd/ios.png) On iOS, create and sign using a
+    * ![Android]({{site.url}}/assets/images/docs/cd/android.png) Follow the [Android app signing steps][].
+    * ![iOS]({{site.url}}/assets/images/docs/cd/ios.png) On iOS, create and sign using a
       distribution certificate instead of a development certificate when you're
       ready to test and deploy using TestFlight or App Store.
         * Create and download a distribution certificate in your
@@ -84,13 +84,13 @@ Visit the [fastlane docs][fastlane] for more info.
         * `open [project]/ios/Runner.xcworkspace/` and select the distribution
           certificate in your target's settings pane.
 1. Create a `Fastfile` script for each platform.
-    * ![Android](/assets/images/docs/cd/android.png) On Android, follow the
+    * ![Android]({{site.url}}/assets/images/docs/cd/android.png) On Android, follow the
       [fastlane Android beta deployment guide][].
       Your edit could be as simple as adding a `lane` that calls
       `upload_to_play_store`.
       Set the `aab` argument to `../build/app/outputs/bundle/release/app-release.aab`
       to use the app bundle `flutter build` already built.
-    * ![iOS](/assets/images/docs/cd/ios.png) On iOS, follow the
+    * ![iOS]({{site.url}}/assets/images/docs/cd/ios.png) On iOS, follow the
       [fastlane iOS beta deployment guide][].
       Your edit could be as simple as adding a `lane` that calls `build_ios_app` with
       `export_method: 'app-store'` and `upload_to_testflight`. On iOS an extra
@@ -103,13 +103,13 @@ process to a continuous integration (CI) system.
 ### Running deployment locally
 
 1. Build the release mode app.
-    * ![Android](/assets/images/docs/cd/android.png) `flutter build appbundle`.
-    * ![iOS](/assets/images/docs/cd/ios.png) `flutter build ios --release --no-codesign`.
+    * ![Android]({{site.url}}/assets/images/docs/cd/android.png) `flutter build appbundle`.
+    * ![iOS]({{site.url}}/assets/images/docs/cd/ios.png) `flutter build ios --release --no-codesign`.
     No need to sign now since fastlane will sign when archiving.
 1. Run the Fastfile script on each platform.
-    * ![Android](/assets/images/docs/cd/android.png) `cd android` then
+    * ![Android]({{site.url}}/assets/images/docs/cd/android.png) `cd android` then
     `fastlane [name of the lane you created]`.
-    * ![iOS](/assets/images/docs/cd/ios.png) `cd ios` then
+    * ![iOS]({{site.url}}/assets/images/docs/cd/ios.png) `cd ios` then
     `fastlane [name of the lane you created]`.
 
 ### Cloud build and deploy setup
@@ -132,7 +132,7 @@ request that prints these secrets out. Be careful with interactions with these
 secrets in pull requests that you accept and merge.
 
 1. Make login credentials ephemeral.
-    * ![Android](/assets/images/docs/cd/android.png) On Android:
+    * ![Android]({{site.url}}/assets/images/docs/cd/android.png) On Android:
         * Remove the `json_key_file` field from `Appfile` and store the string
           content of the JSON in your CI system's encrypted variable. 
           Read the environment variable directly in your `Fastfile`.
@@ -148,7 +148,7 @@ secrets in pull requests that you accept and merge.
           ```bash
           echo "$PLAY_STORE_UPLOAD_KEY" | base64 --decode > [path to your upload keystore]
           ```
-    * ![iOS](/assets/images/docs/cd/ios.png) On iOS:
+    * ![iOS]({{site.url}}/assets/images/docs/cd/ios.png) On iOS:
         * Move the local environment variable `FASTLANE_PASSWORD` to use
           encrypted environment variables on the CI system.
         * The CI system needs access to your distribution certificate.
@@ -190,7 +190,7 @@ secrets in pull requests that you accept and merge.
          * `bundle exec fastlane [name of the lane]`
 
 
-[Android app signing steps]: /deployment/android#signing-the-app
+[Android app signing steps]: {{site.url}}/deployment/android#signing-the-app
 [Appcircle]: https://appcircle.io/blog/guide-to-automated-mobile-ci-cd-for-flutter-projects-with-appcircle/
 [Apple Developer Account console]: {{site.apple-dev}}/account/ios/certificate/
 [Bitrise]: https://devcenter.bitrise.io/getting-started/getting-started-with-flutter-apps/

--- a/src/deployment/ios.md
+++ b/src/deployment/ios.md
@@ -118,7 +118,7 @@ In the **Build Settings** section:
 The **General** tab of your project settings should resemble
 the following:
 
-![Xcode Project Settings](/assets/images/docs/releaseguide/xcode_settings.png){:width="100%"}
+![Xcode Project Settings]({{site.url}}/assets/images/docs/releaseguide/xcode_settings.png){:width="100%"}
 
 For a detailed overview of app signing, see
 [Create, export, and delete signing certificates][appsigning].
@@ -470,5 +470,5 @@ detailed overview of the process of releasing an app to the App Store.
 [distributionguide_submit]: https://help.apple.com/xcode/mac/current/#/dev067853c94
 [distributionguide_testflight]: https://help.apple.com/xcode/mac/current/#/dev2539d985f
 [distributionguide_upload]: https://help.apple.com/xcode/mac/current/#/dev442d7f2ca
-[obfuscating your Dart code]: /deployment/obfuscate
+[obfuscating your Dart code]: {{site.url}}/deployment/obfuscate
 [TestFlight]: {{site.apple-dev}}/testflight/

--- a/src/deployment/macos.md
+++ b/src/deployment/macos.md
@@ -112,7 +112,7 @@ In the **Signing & Capabilities** section:
 The **General** tab of your project settings should resemble
 the following:
 
-![Xcode Project Settings](/assets/images/docs/releaseguide/macos_xcode_settings.png){:width="100%"}
+![Xcode Project Settings]({{site.url}}/assets/images/docs/releaseguide/macos_xcode_settings.png){:width="100%"}
 
 For a detailed overview of app signing, see
 [Create, export, and delete signing certificates][appsigning].
@@ -482,5 +482,5 @@ detailed overview of the process of releasing an app to the App Store.
 [distributionguide_macos]: https://help.apple.com/xcode/mac/current/#/dev295cc0fae
 [distributionguide_submit]: https://help.apple.com/xcode/mac/current/#/dev067853c94
 [distributionguide_upload]: https://help.apple.com/xcode/mac/current/#/dev442d7f2ca
-[obfuscating your Dart code]: /deployment/obfuscate
+[obfuscating your Dart code]: {{site.url}}/deployment/obfuscate
 [TestFlight]: {{site.apple-dev}}/testflight/

--- a/src/deployment/obfuscate.md
+++ b/src/deployment/obfuscate.md
@@ -109,10 +109,10 @@ expect(foo.runtimeType.toString(), equals('Foo'))
 ```
 
 
-[Build and release a web app]: /deployment/web
+[Build and release a web app]: {{site.url}}/deployment/web
 [Code obfuscation]: https://en.wikipedia.org/wiki/Obfuscation_(software)
-[in alpha]: /desktop
-[Measuring your app's size]: /perf/app-size
+[in alpha]: {{site.url}}/desktop
+[Measuring your app's size]: {{site.url}}/perf/app-size
 [minified]: https://en.wikipedia.org/wiki/Minification_(programming)
 [obfuscation instructions]: {{site.repo.flutter}}/wiki/Obfuscating-Dart-Code
-[release build]: /testing/build-modes
+[release build]: {{site.url}}/testing/build-modes

--- a/src/deployment/web.md
+++ b/src/deployment/web.md
@@ -124,11 +124,11 @@ PWA support remains a work in progress,
 so please [give us feedback][] if you see something that doesn’t look right.
 
 [dhttpd]: {{site.pub}}/packages/dhttpd
-[Displaying images on the web]: /development/platform-integration/web-images
+[Displaying images on the web]: {{site.url}}/development/platform-integration/web-images
 [Firebase Hosting]: {{site.firebase}}/docs/hosting
 [GitHub Pages]: https://pages.github.com/
 [give us feedback]: {{site.repo.flutter}}/issues/new?title=%5Bweb%5D:+%3Cdescribe+issue+here%3E&labels=%E2%98%B8+platform-web&body=Describe+your+issue+and+include+the+command+you%27re+running,+flutter_web%20version,+browser+version
 [Google Cloud Hosting]: https://cloud.google.com/solutions/smb/web-hosting/
 [`iframe`]: https://html.com/tags/iframe/
-[Web renderers]: /development/tools/web-renderers
+[Web renderers]: {{site.url}}/development/tools/web-renderers
 

--- a/src/desktop/index.md
+++ b/src/desktop/index.md
@@ -75,11 +75,11 @@ you need the following software:
   for more details.
 
 [Android Studio]: {{site.android-dev}}/studio/install
-[Flutter SDK]: /get-started/install
-[install the Flutter and Dart plugins]: /get-started/editor
+[Flutter SDK]: {{site.url}}/get-started/install
+[install the Flutter and Dart plugins]: {{site.url}}/get-started/editor
 [IntelliJ IDEA]: https://www.jetbrains.com/idea/download/
-[setting up an editor]: /get-started/editor
-[Visual Studio Code]: /development/tools/vs-code
+[setting up an editor]: {{site.url}}/get-started/editor
+[Visual Studio Code]: {{site.url}}/development/tools/vs-code
 
 ### Additional Windows requirements
 
@@ -266,7 +266,7 @@ Once you've configured your environment for desktop
 support, you can create and run a desktop application
 either in the IDE or from the command line.
 
-[creating a new Flutter project]: /get-started/test-drive
+[creating a new Flutter project]: {{site.url}}/get-started/test-drive
 
 #### Using an IDE
 
@@ -280,7 +280,7 @@ From the device pulldown, select **windows (desktop)**,
 **macOS (desktop)**, or **linux (desktop)**
 and run your application to see it launch on the desktop.
 
-[web support]: /get-started/web
+[web support]: {{site.url}}/get-started/web
 
 #### From the command line
 
@@ -583,7 +583,7 @@ step-by-step walkthrough.
 [distribute it through the macOS App Store]: {{site.apple-dev}}/macos/submit/
 [documentation on notarizing macOS Applications]:{{site.apple-dev}}/documentation/xcode/notarizing_macos_software_before_distribution
 [on distributing an application through the App Store]: https://help.apple.com/xcode/mac/current/#/dev067853c94
-[Build and release a macOS app]: /deployment/macos
+[Build and release a macOS app]: {{site.url}}/deployment/macos
 
 ### Linux
 
@@ -627,7 +627,7 @@ to the [Snap Store][], see
 As the tooling solidifies, stay tuned for updates
 on other ways to distribute a Linux desktop app.
 
-[Build and release a Linux application to the Snap Store]: /deployment/linux
+[Build and release a Linux application to the Snap Store]: {{site.url}}/deployment/linux
 
 ## Add desktop support to an existing Flutter app
 
@@ -784,7 +784,7 @@ provide an interface to platform-specific services.)
 [`path_provider`]: {{site.pub}}/packages/path_provider
 [`shared_preferences`]: {{site.pub}}/packages/shared_preferences
 [`url_launcher`]: {{site.pub}}/packages/url_launcher
-[using packages]: /development/packages-and-plugins/using-packages
+[using packages]: {{site.url}}/development/packages-and-plugins/using-packages
 [windows packages]: {{site.pub}}/flutter/packages?platform=windows
 
 ### Writing a plugin
@@ -822,9 +822,9 @@ about endorsed plugins, see the following resources:
   recent enhancements to Flutter's plugin support.
 * [Federated Plugin proposal][]
 
-[Developing packages and plugins]: /development/packages-and-plugins/developing-packages
-[Federated Plugin proposal]: /go/federated-plugins
-[Federated plugins]: /development/packages-and-plugins/developing-packages#federated-plugins
+[Developing packages and plugins]: {{site.url}}/development/packages-and-plugins/developing-packages
+[Federated Plugin proposal]: {{site.url}}/go/federated-plugins
+[Federated plugins]: {{site.url}}/development/packages-and-plugins/developing-packages#federated-plugins
 [How to write a Flutter web plugin, part 2]: {{site.flutter-medium}}/how-to-write-a-flutter-web-plugin-part-2-afdddb69ece6
 [Modern Flutter Plugin Development]: {{site.flutter-medium}}/modern-flutter-plugin-development-4c3ee015cf5a
 

--- a/src/development/accessibility-and-localization/internationalization.md
+++ b/src/development/accessibility-and-localization/internationalization.md
@@ -861,7 +861,7 @@ Rebuilding `l10n/messages_all.dart` requires two steps.
 [`GlobalMaterialLocalizations`]: {{site.api}}/flutter/flutter_localizations/GlobalMaterialLocalizations-class.html
 [`InheritedWidget`]: {{site.api}}/flutter/widgets/InheritedWidget-class.html
 [Internationalization based on the `intl` package]: {{site.repo.this}}/tree/master/examples/internationalization/intl_example
-[Internationalization User's Guide]: /go/i18n-user-guide
+[Internationalization User's Guide]: {{site.url}}/go/i18n-user-guide
 [`intl`]: {{site.pub-pkg}}/intl
 [`intl` tool]: #dart-tools
 [`Intl.message()`]: {{site.pub-api}}/intl/latest/intl/Intl/message.html

--- a/src/development/add-to-app/android/add-flutter-fragment.md
+++ b/src/development/add-to-app/android/add-flutter-fragment.md
@@ -591,7 +591,7 @@ surrounding `Activity`.
 
 [`Fragment`]: https://developer.android.com/guide/components/fragments
 [`FlutterFragment`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterFragment.html
-[using a `FlutterActivity`]: /development/add-to-app/android/add-flutter-screen
+[using a `FlutterActivity`]: {{site.url}}/development/add-to-app/android/add-flutter-screen
 [`FlutterEngine`]: {{site.api}}/javadoc/io/flutter/embedding/engine/FlutterEngine.html
 [`FlutterEngineCache`]: {{site.api}}/javadoc/io/flutter/embedding/engine/FlutterEngineCache.html
-[splash screen guide]: /development/ui/advanced/splash-screen
+[splash screen guide]: {{site.url}}/development/ui/advanced/splash-screen

--- a/src/development/add-to-app/android/project-setup.md
+++ b/src/development/add-to-app/android/project-setup.md
@@ -319,8 +319,8 @@ You can follow the next steps in the [Adding a Flutter screen to an Android app]
 
 
 [`abiFilters`]: https://developer.android.com/reference/tools/gradle-api/4.2/com/android/build/api/dsl/Ndk#abiFilters:kotlin.collections.MutableSet
-[Adding a Flutter screen to an Android app]: /development/add-to-app/android/add-flutter-screen
+[Adding a Flutter screen to an Android app]: {{site.url}}/development/add-to-app/android/add-flutter-screen
 [Flutter plugin]: https://plugins.jetbrains.com/plugin/9212-flutter
 [local repository]: https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:maven_local
-[only supports]: /resources/faq#what-devices-and-os-versions-does-flutter-run-on
-[Using Flutter in China]: /community/china
+[only supports]: {{site.url}}/resources/faq#what-devices-and-os-versions-does-flutter-run-on
+[Using Flutter in China]: {{site.url}}/community/china

--- a/src/development/add-to-app/debugging.md
+++ b/src/development/add-to-app/debugging.md
@@ -61,4 +61,4 @@ Select the device on which the Flutter module runs so `flutter attach` filters f
 {% include docs/app-figure.md image="development/add-to-app/debugging/intellij-attach.png" caption="flutter attach via IntelliJ" %}
 
 
-[debugging functionalities]: /testing/debugging
+[debugging functionalities]: {{site.url}}/testing/debugging

--- a/src/development/add-to-app/index.md
+++ b/src/development/add-to-app/index.md
@@ -134,7 +134,7 @@ see our API usage guides at the following links:
 
 [add-to-app GitHub Samples repository]: {{site.github}}/flutter/samples/tree/master/add_to_app
 [Android Archive (AAR)]: {{site.android-dev}}/studio/projects/android-library
-[Android plugin APIs]: /development/packages-and-plugins/plugin-api-migration
+[Android plugin APIs]: {{site.url}}/development/packages-and-plugins/plugin-api-migration
 [Flutter plugins]: {{site.pub}}/flutter
 [`FlutterActivity`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterActivity.html
 [java-engine]: {{site.api}}/javadoc/io/flutter/embedding/engine/FlutterEngine.html
@@ -145,5 +145,5 @@ see our API usage guides at the following links:
 [`FlutterViewController`]: {{site.api}}/objcdoc/Classes/FlutterViewController.html
 [iOS Framework]: {{site.apple-dev}}/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/WhatAreFrameworks.html
 [maintained by the Flutter team]: {{site.repo.plugins}}/tree/master/packages
-[migrated to the V2 plugins APIs]: /development/packages-and-plugins/plugin-api-migration
-[multiple Flutters]: /development/add-to-app/multiple-flutters
+[migrated to the V2 plugins APIs]: {{site.url}}/development/packages-and-plugins/plugin-api-migration
+[multiple Flutters]: {{site.url}}/development/add-to-app/multiple-flutters

--- a/src/development/add-to-app/ios/add-flutter-screen.md
+++ b/src/development/add-to-app/ios/add-flutter-screen.md
@@ -492,13 +492,13 @@ in any way you'd like, before presenting the Flutter UI using a
 
 [`FlutterEngine`]: {{site.api}}/objcdoc/Classes/FlutterEngine.html
 [`FlutterViewController`]: {{site.api}}/objcdoc/Classes/FlutterViewController.html
-[Loading sequence and performance]: /development/add-to-app/performance
+[Loading sequence and performance]: {{site.url}}/development/add-to-app/performance
 [local_auth]: {{site.pub}}/packages/local_auth
-[Navigation and routing]: /development/ui/navigation
+[Navigation and routing]: {{site.url}}/development/ui/navigation
 [Navigator]: {{site.api}}/flutter/widgets/Navigator-class.html
 [`NavigatorState`]: {{site.api}}/flutter/widgets/NavigatorState-class.html
 [`openURL`]: {{site.apple-dev}}/documentation/uikit/uiapplicationdelegate/1623112-application
-[platform channels]: /development/platform-integration/platform-channels
+[platform channels]: {{site.url}}/development/platform-integration/platform-channels
 [`popRoute()`]: {{site.api}}/objcdoc/Classes/FlutterViewController.html#/c:objc(cs)FlutterViewController(im)popRoute
 [`pushRoute()`]: {{site.api}}/objcdoc/Classes/FlutterViewController.html#/c:objc(cs)FlutterViewController(im)pushRoute:
 [`runApp`]: {{site.api}}/flutter/widgets/runApp.html

--- a/src/development/add-to-app/ios/project-setup.md
+++ b/src/development/add-to-app/ios/project-setup.md
@@ -439,19 +439,19 @@ Repeat for any iOS unit test targets.
 You can now [add a Flutter screen][] to your existing application.
 
 [add_to_app code samples]: {{site.github}}/flutter/samples/tree/master/add_to_app
-[add a Flutter screen]: /development/add-to-app/ios/add-flutter-screen
-[Android Studio/IntelliJ]: /development/tools/android-studio
-[build modes of Flutter]: /testing/build-modes
-[embed the frameworks]: /development/add-to-app/ios/project-setup#embed-the-frameworks
+[add a Flutter screen]: {{site.url}}/development/add-to-app/ios/add-flutter-screen
+[Android Studio/IntelliJ]: {{site.url}}/development/tools/android-studio
+[build modes of Flutter]: {{site.url}}/testing/build-modes
+[embed the frameworks]: {{site.url}}/development/add-to-app/ios/project-setup#embed-the-frameworks
 [CocoaPods]: https://cocoapods.org/
 [CocoaPods getting started guide]: https://guides.cocoapods.org/using/using-cocoapods.html
-[debugging functionalities such as hot-reload and DevTools]: /development/add-to-app/debugging
+[debugging functionalities such as hot-reload and DevTools]: {{site.url}}/development/add-to-app/debugging
 [Embed with CocoaPods and Flutter tools]: #option-a---embed-with-cocoapods-and-the-flutter-sdk
-[increases your app size]: /resources/faq#how-big-is-the-flutter-engine
-[macOS system requirements for Flutter]: /get-started/install/macos#system-requirements
+[increases your app size]: {{site.url}}/resources/faq#how-big-is-the-flutter-engine
+[macOS system requirements for Flutter]: {{site.url}}/get-started/install/macos#system-requirements
 [On iOS 14 and higher]: {{site.apple-dev}}/news/?id=0oi77447
 [Podfile target]: https://guides.cocoapods.org/syntax/podfile.html#target
 [static or dynamic frameworks]: {{site.so}}/questions/32591878/ios-is-it-a-static-or-a-dynamic-framework
-[VS Code]: /development/tools/vs-code
+[VS Code]: {{site.url}}/development/tools/vs-code
 [XCFrameworks]: {{site.apple-dev}}/documentation/xcode_release_notes/xcode_11_release_notes
-[Xcode installed]: /get-started/install/macos#install-xcode
+[Xcode installed]: {{site.url}}/get-started/install/macos#install-xcode

--- a/src/development/add-to-app/multiple-flutters.md
+++ b/src/development/add-to-app/multiple-flutters.md
@@ -103,11 +103,11 @@ on both Android and iOS on [GitHub][].
 [GitHub]: {{site.repo.samples}}/tree/master/add_to_app/multiple_flutters
 [`FlutterActivity`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterActivity.html
 [`FlutterViewController`]: {{site.api}}/objcdoc/Classes/FlutterViewController.html
-[performance characteristics]: /development/add-to-app/performance
-[docs.flutter.dev/go/multiple-flutters]: /go/multiple-flutters
+[performance characteristics]: {{site.url}}/development/add-to-app/performance
+[docs.flutter.dev/go/multiple-flutters]: {{site.url}}/go/multiple-flutters
 [Issue 72009]: {{site.repo.flutter}}/issues/72009
 [Pigeon]: {{site.pub}}/packages/pigeon
-[platform channels]: /development/platform-integration/platform-channels
-[platform views]: /development/platform-integration/platform-views
+[platform channels]: {{site.url}}/development/platform-integration/platform-channels
+[platform views]: {{site.url}}/development/platform-integration/platform-views
 [Android API]: https://cs.opensource.google/flutter/engine/+/master:shell/platform/android/io/flutter/embedding/engine/FlutterEngineGroup.java
 [iOS API]: https://cs.opensource.google/flutter/engine/+/master:shell/platform/darwin/ios/framework/Headers/FlutterEngineGroup.h

--- a/src/development/add-to-app/performance.md
+++ b/src/development/add-to-app/performance.md
@@ -213,7 +213,7 @@ see [multiple Flutters][].
 [`Intent`]: {{site.android-dev}}/reference/android/content/Intent.html
 [ios-engine]: {{site.api}}/objcdoc/Classes/FlutterEngine.html
 [`Layer`]: {{site.api}}/flutter/rendering/Layer-class.html
-[multiple Flutters]: /development/add-to-app/multiple-flutters
+[multiple Flutters]: {{site.url}}/development/add-to-app/multiple-flutters
 [`runApp()`]: {{site.api}}/flutter/widgets/runApp.html
 [`runWithEntrypoint:`]: {{site.api}}/objcdoc/Classes/FlutterEngine.html#/c:objc(cs)FlutterEngine(im)runWithEntrypoint:
 [snapshot]: {{site.github}}/dart-lang/sdk/wiki/Snapshots

--- a/src/development/data-and-backend/json.md
+++ b/src/development/data-and-backend/json.md
@@ -361,7 +361,7 @@ When creating `json_serializable` classes the first time,
 you'll get errors similar to what is shown in the image below.
 
 ![IDE warning when the generated code for a model class does not exist
-yet.](/assets/images/docs/json/ide_warning.png){:.mw-100}
+yet.]({{site.url}}/assets/images/docs/json/ide_warning.png){:.mw-100}
 
 These errors are entirely normal and are simply because the generated code for
 the model class does not exist yet. To resolve this, run the code
@@ -535,8 +535,8 @@ For more information, see the following resources:
 [code generation libraries]: #code-generation
 [`dart:convert`]: {{site.dart.api}}/{{site.dart.sdk.channel}}/dart-convert
 [`explicitToJson`]: {{site.pub}}/documentation/json_annotation/latest/json_annotation/JsonSerializable/explicitToJson.html
-[Flutter Favorite]: /development/packages-and-plugins/favorites
-[json background parsing]: /cookbook/networking/background-parsing
+[Flutter Favorite]: {{site.url}}/development/packages-and-plugins/favorites
+[json background parsing]: {{site.url}}/cookbook/networking/background-parsing
 [`JsonCodec`]: {{site.dart.api}}/{{site.dart.sdk.channel}}/dart-convert/JsonCodec-class.html
 [`JsonSerializable`]: {{site.pub}}/documentation/json_annotation/latest/json_annotation/JsonSerializable-class.html
 [`json_annotation`]: {{site.pub}}/packages/json_annotation

--- a/src/development/data-and-backend/networking.md
+++ b/src/development/data-and-backend/networking.md
@@ -29,7 +29,7 @@ manifest (`AndroidManifest.xml `):
 
 For a practical sample of various networking tasks (incl. fetching data,
 WebSockets, and parsing data in the background) see the 
-[networking cookbook](/cookbook#networking).
+[networking cookbook]({{site.url}}/cookbook#networking).
 
 [declare]: {{site.android-dev}}/training/basics/network-ops/connecting
 [`http`]: {{site.pub-pkg}}/http

--- a/src/development/data-and-backend/state-mgmt/declarative.md
+++ b/src/development/data-and-backend/state-mgmt/declarative.md
@@ -46,4 +46,4 @@ this style of programming might not seem as intuitive as the
 imperative style. This is why this section is here. Read on.
 
 
-[get started guide]: /get-started/flutter-for/declarative
+[get started guide]: {{site.url}}/get-started/flutter-for/declarative

--- a/src/development/data-and-backend/state-mgmt/intro.md
+++ b/src/development/data-and-backend/state-mgmt/intro.md
@@ -25,4 +25,4 @@ and many questions to think about.
 In the following pages,
 you will learn the basics of dealing with state in Flutter apps.
 
-[list of different approaches]: /development/data-and-backend/state-mgmt/options
+[list of different approaches]: {{site.url}}/development/data-and-backend/state-mgmt/options

--- a/src/development/data-and-backend/state-mgmt/options.md
+++ b/src/development/data-and-backend/state-mgmt/options.md
@@ -28,7 +28,7 @@ Things to review before selecting an approach.
 
 
 [Flutter Architecture Samples]: https://fluttersamples.com/
-[Introduction to state management]: /development/data-and-backend/state-mgmt/intro
+[Introduction to state management]: {{site.url}}/development/data-and-backend/state-mgmt/intro
 [Pragmatic State Management in Flutter]: {{site.youtube-site}}/watch?v=d_m5csmrf7I
 
 ## Provider
@@ -43,7 +43,7 @@ A recommended approach.
 
 [Making sense of all those Flutter Providers]: {{site.medium}}/flutter-community/making-sense-all-of-those-flutter-providers-e842e18f45dd?sk=7859a73fac0ca414a0e911b0322e8589
 [Provider package]: {{site.pub-pkg}}/provider
-[Simple app state management]: /development/data-and-backend/state-mgmt/simple
+[Simple app state management]: {{site.url}}/development/data-and-backend/state-mgmt/simple
 [You might not need Redux: The Flutter edition]: https://proandroiddev.com/you-might-not-need-redux-the-flutter-edition-9c11eba006d7
 
 ## Riverpod
@@ -66,7 +66,7 @@ The low-level approach to use for widget-specific, ephemeral state.
 * [Adding interactivity to your Flutter app][], a Flutter tutorial
 * [Basic state management in Google Flutter][], by Agung Surya
 
-[Adding interactivity to your Flutter app]: /development/ui/interactive
+[Adding interactivity to your Flutter app]: {{site.url}}/development/ui/interactive
 [Basic state management in Google Flutter]: {{site.medium}}/@agungsurya/basic-state-management-in-google-flutter-6ee73608f96d
 
 ## InheritedWidget &amp; InheritedModel

--- a/src/development/data-and-backend/state-mgmt/simple.md
+++ b/src/development/data-and-backend/state-mgmt/simple.md
@@ -466,7 +466,7 @@ master these skills.
 
 [built with `provider`]: {{site.github}}/flutter/samples/tree/master/provider_counter
 [check out the example]: {{site.github}}/flutter/samples/tree/master/provider_shopper
-[declarative UI programming]: /development/data-and-backend/state-mgmt/declarative
-[ephemeral and app state]: /development/data-and-backend/state-mgmt/ephemeral-vs-app
-[options page]: /development/data-and-backend/state-mgmt/options
-[widget testing]: /testing#widget-tests
+[declarative UI programming]: {{site.url}}/development/data-and-backend/state-mgmt/declarative
+[ephemeral and app state]: {{site.url}}/development/data-and-backend/state-mgmt/ephemeral-vs-app
+[options page]: {{site.url}}/development/data-and-backend/state-mgmt/options
+[widget testing]: {{site.url}}/testing#widget-tests

--- a/src/development/ios-14.md
+++ b/src/development/ios-14.md
@@ -46,7 +46,7 @@ iOS 14][], a permission dialog box must now be accepted for
 each application in order to enable Flutter debugging
 functionalities such as hot-reload and DevTools.
 
-![Screenshot of "allow network connections" dialog](/assets/images/docs/development/device-connect.png)
+![Screenshot of "allow network connections" dialog]({{site.url}}/assets/images/docs/development/device-connect.png)
 
 This affects debug and profile builds only and won't
 appear in release builds. The permission can also be allowed
@@ -58,7 +58,7 @@ to re-enable flutter attach for debug builds on physical
 devices on iOS 14.
 
 [local network permissions in iOS 14]: {{site.apple-dev}}/news/?id=0oi77447
-[add-to-app project setup guide]: /development/add-to-app/ios/project-setup#local-network-privacy-permissions
+[add-to-app project setup guide]: {{site.url}}/development/add-to-app/ios/project-setup#local-network-privacy-permissions
 
 ## Launching debug Flutter without a host computer
 

--- a/src/development/packages-and-plugins/developing-packages.md
+++ b/src/development/packages-and-plugins/developing-packages.md
@@ -629,23 +629,23 @@ PENDING
 [Effective Dart Documentation]: {{site.dart-site}}/guides/language/effective-dart/documentation
 [federated plugins]: #federated-plugins
 [`fluro`]: {{site.pub}}/packages/fluro
-[Flutter editor]: /get-started/editor
+[Flutter editor]: {{site.url}}/get-started/editor
 [Flutter Favorites]: {{site.pub}}/flutter/favorites
-[Flutter Favorites program]: /development/packages-and-plugins/favorites
+[Flutter Favorites program]: {{site.url}}/development/packages-and-plugins/favorites
 [Gradle Documentation]: https://docs.gradle.org/current/userguide/tutorial_using_tasks.html
 [How to Write a Flutter Web Plugin, Part 1]: {{site.flutter-medium}}/how-to-write-a-flutter-web-plugin-5e26c689ea1
 [How To Write a Flutter Web Plugin, Part 2]: {{site.flutter-medium}}/how-to-write-a-flutter-web-plugin-part-2-afdddb69ece6
 [issue #33302]: {{site.repo.flutter}}/issues/33302
 [`LICENSE`]: #adding-licenses-to-the-license-file
 [`path`]: {{site.pub}}/packages/path
-[platform channel]: /development/platform-integration/platform-channels
+[platform channel]: {{site.url}}/development/platform-integration/platform-channels
 [pub.dev]: {{site.pub}}
 [publishing docs]: {{site.dart-site}}/tools/pub/publishing
 [publishing is forever]: {{site.dart-site}}/tools/pub/publishing#publishing-is-forever
-[Supporting the new Android plugins APIs]: /development/packages-and-plugins/plugin-api-migration
+[Supporting the new Android plugins APIs]: {{site.url}}/development/packages-and-plugins/plugin-api-migration
 [supported-platforms]: #plugin-platforms
 [test your plugin]: #testing-your-plugin
-[Testing your plugin]: /development/packages-and-plugins/plugin-api-migration#testing-your-plugin
-[unit tests]: /testing#unit-tests
+[Testing your plugin]: {{site.url}}/development/packages-and-plugins/plugin-api-migration#testing-your-plugin
+[unit tests]: {{site.url}}/testing#unit-tests
 [`url_launcher`]: {{site.pub}}/packages/url_launcher
 [Writing a good plugin]: {{site.flutter-medium}}/writing-a-good-flutter-plugin-1a561b986c9c

--- a/src/development/packages-and-plugins/favorites.md
+++ b/src/development/packages-and-plugins/favorites.md
@@ -3,7 +3,7 @@ title: Flutter Favorite program
 description: Guidelines for identifying a plugin or package as a Flutter Favorite.
 ---
 
-![The Flutter Favorite program logo](/assets/images/docs/development/packages-and-plugins/FlutterFavoriteLogo.png){:width="20%"}
+![The Flutter Favorite program logo]({{site.url}}/assets/images/docs/development/packages-and-plugins/FlutterFavoriteLogo.png){:width="20%"}
 
 The aim of the **Flutter Favorite** program is to identify
 packages and plugins that you should first consider when
@@ -118,5 +118,5 @@ You can see the complete list of
 [committee chair]: mailto:csells@google.com
 [Flutter Favorite packages]: {{site.pub}}/flutter/favorites
 [Overall package score]: {{site.pub}}/help
-[pubspec.yaml format]: /development/packages-and-plugins/developing-packages#plugin-platforms
+[pubspec.yaml format]: {{site.url}}/development/packages-and-plugins/developing-packages#plugin-platforms
 [Verified publisher]: {{site.dart-site}}/tools/pub/verified-publishers

--- a/src/development/packages-and-plugins/plugin-api-migration.md
+++ b/src/development/packages-and-plugins/plugin-api-migration.md
@@ -374,5 +374,5 @@ a non-UI configuration.
 [`PluginRegistry.Registrar`]: {{site.api}}/javadoc/io/flutter/plugin/common/PluginRegistry.Registrar.html
 [`PluginRegistry.Registrar.activity()`]: {{site.api}}/javadoc/io/flutter/plugin/common/PluginRegistry.Registrar.html#activity--
 [`ServiceAware`]: {{site.api}}/javadoc/io/flutter/embedding/engine/plugins/service/ServiceAware.html
-[Upgrading pre 1.12 Android projects]: /go/android-project-migration
+[Upgrading pre 1.12 Android projects]: {{site.url}}/go/android-project-migration
 [verified publisher]: {{site.dart-site}}/tools/pub/verified-publishers

--- a/src/development/packages-and-plugins/using-packages.md
+++ b/src/development/packages-and-plugins/using-packages.md
@@ -410,22 +410,22 @@ To use this plugin:
    displaying the homepage for flutter.dev.
 
 
-[Adding assets and images]: /development/ui/assets-and-images
+[Adding assets and images]: {{site.url}}/development/ui/assets-and-images
 [Android plugins]: {{site.pub}}/flutter/packages?platform=android
 [`battery`]: {{site.pub-pkg}}/battery
 [*caret syntax*]: {{site.dart-site}}/tools/pub/dependencies#caret-syntax
 [CocoaPods]: https://guides.cocoapods.org/syntax/podspec.html#dependency
 [`css_colors`]: {{site.pub-pkg}}/css_colors
 [css_colors example]: #css-example
-[write a custom package]: /development/packages-and-plugins/developing-packages
-[developing packages]: /development/packages-and-plugins/developing-packages
+[write a custom package]: {{site.url}}/development/packages-and-plugins/developing-packages
+[developing packages]: {{site.url}}/development/packages-and-plugins/developing-packages
 [`fluro`]: {{site.pub-pkg}}/fluro
 [Flutter Favorites]: {{site.pub}}/flutter/favorites
-[Flutter Favorites program]: /development/packages-and-plugins/favorites
+[Flutter Favorites program]: {{site.url}}/development/packages-and-plugins/favorites
 [Flutter landing page]: {{site.pub}}/flutter
 [FlutterFire]: {{site.repo.plugins}}/blob/master/FlutterFire.md
 [Gradle modules]: https://docs.gradle.org/current/userguide/declaring_dependencies.html
-[`http`]: /cookbook/networking/fetch-data
+[`http`]: {{site.url}}/cookbook/networking/fetch-data
 [Installing tab]: {{site.pub-pkg}}/css_colors/install
 [iOS plugins]: {{site.pub}}/flutter/packages?platform=ios
 [lockfile]: {{site.dart-site}}/tools/pub/glossary#lockfile

--- a/src/development/platform-integration/apple-watch.md
+++ b/src/development/platform-integration/apple-watch.md
@@ -19,7 +19,7 @@ In the menu, select **File > New > Target**. Once the dialog opens, select
 **watchOS** at the top and click **Watch App for iOS App**. Click **Next**, 
 enter a product name, and select **Enter**.
 
-![Adding an Apple Watch target](/assets/images/docs/AppleWatchTarget.png){:width="70%"}
+![Adding an Apple Watch target]({{site.url}}/assets/images/docs/AppleWatchTarget.png){:width="70%"}
 
 
 [Creating an iOS Bitcode enabled app]: {{site.repo.flutter}}/wiki/Creating-an-iOS-Bitcode-enabled-app-(experimental)

--- a/src/development/platform-integration/c-interop.md
+++ b/src/development/platform-integration/c-interop.md
@@ -428,7 +428,7 @@ When creating a release archive (IPA) the symbols are stripped by Xcode.
 [`DynamicLibrary.process`]: {{site.dart.api}}/dev/dart-ffi/DynamicLibrary/DynamicLibrary.process.html
 [FFI]: https://en.wikipedia.org/wiki/Foreign_function_interface
 [ffi issue]: {{site.github}}/dart-lang/sdk/issues/34452
-[Upgrading Flutter]: /development/tools/sdk/upgrading
-[Flutter macOS Desktop]: /desktop
+[Upgrading Flutter]: {{site.url}}/development/tools/sdk/upgrading
+[Flutter macOS Desktop]: {{site.url}}/desktop
 [Android guidelines]: {{site.android-dev}}/topic/performance/reduce-apk-size#extract-false
 

--- a/src/development/platform-integration/ios-app-clip.md
+++ b/src/development/platform-integration/ios-app-clip.md
@@ -393,11 +393,11 @@ For example:
 `flutter attach --debug-uri <copied URI>`
 
 
-[add-to-app]: /development/add-to-app
+[add-to-app]: {{site.url}}/development/add-to-app
 [#65451]: {{site.repo.flutter}}/issues/65451
 [#71098]: {{site.repo.flutter}}/issues/71098
 [official Apple documentation]: {{site.apple-dev}}/documentation/app_clips/creating_an_app_clip_with_xcode#3604097
-[iOS add-to-app APIs]: /development/add-to-app/ios/add-flutter-screen
-[custom Flutter route]: /development/add-to-app/ios/add-flutter-screen#route
+[iOS add-to-app APIs]: {{site.url}}/development/add-to-app/ios/add-flutter-screen
+[custom Flutter route]: {{site.url}}/development/add-to-app/ios/add-flutter-screen#route
 [App Clip sample]: {{site.github}}/flutter/samples/tree/master/ios_app_clip
 [Testing Your App Clip's Launch Experience]: {{site.apple-dev}}/documentation/app_clips/testing_your_app_clip_s_launch_experience

--- a/src/development/platform-integration/platform-channels.md
+++ b/src/development/platform-integration/platform-channels.md
@@ -46,7 +46,7 @@ Messages are passed between the client (UI)
 and host (platform) using platform
 channels as illustrated in this diagram:
 
-![Platform channels architecture](/assets/images/docs/PlatformChannels.png){:width="100%"}
+![Platform channels architecture]({{site.url}}/assets/images/docs/PlatformChannels.png){:width="100%"}
 
 Messages and responses are passed asynchronously,
 to ensure the user interface remains responsive.
@@ -786,8 +786,8 @@ DispatchQueue.main.async {
 [`cloud_firestore`]: {{site.github}}/FirebaseExtended/flutterfire/blob/master/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/utils/firestore_message_codec.dart
 [`dart:html` library]: {{site.dart.api}}/dart-html/dart-html-library.html
 [defaultTargetPlatform]: {{site.api}}/flutter/foundation/defaultTargetPlatform.html
-[developing packages]: /development/packages-and-plugins/developing-packages
-[plugins]: /development/packages-and-plugins/developing-packages#plugin
+[developing packages]: {{site.url}}/development/packages-and-plugins/developing-packages
+[plugins]: {{site.url}}/development/packages-and-plugins/developing-packages#plugin
 [dispatch queue]: {{site.apple-dev}}/documentation/dispatch/dispatchqueue
 [`/examples/platform_channel/`]: {{site.repo.flutter}}/tree/master/examples/platform_channel
 [`/examples/platform_channel_swift/`]: {{site.repo.flutter}}/tree/master/examples/platform_channel_swift
@@ -796,15 +796,15 @@ DispatchQueue.main.async {
 [`MethodChannel`]: {{site.api}}/flutter/services/MethodChannel-class.html
 [`MethodChannelAndroid`]: {{site.api}}/javadoc/io/flutter/plugin/common/MethodChannel.html
 [`MethodChanneliOS`]: {{site.api}}/objcdoc/Classes/FlutterMethodChannel.html
-[Platform adaptations]: /resources/platform-adaptations
-[publishing packages]: /development/packages-and-plugins/developing-packages#publish
+[Platform adaptations]: {{site.url}}/resources/platform-adaptations
+[publishing packages]: {{site.url}}/development/packages-and-plugins/developing-packages#publish
 [`quick_actions`]: {{site.pub}}/packages/quick_actions
 [section on threading]: #channels-and-platform-threading
 [`StandardMessageCodec`]: {{site.api}}/flutter/services/StandardMessageCodec-class.html
 [`StringCodec`]: {{site.api}}/flutter/services/StringCodec-class.html
 [the main thread]: {{site.apple-dev}}/documentation/uikit?language=objc
 [the UI thread]: {{site.android-dev}}/guide/components/processes-and-threads#Threads
-[using packages]: /development/packages-and-plugins/using-packages
+[using packages]: {{site.url}}/development/packages-and-plugins/using-packages
 [Pigeon]: {{site.pub-pkg}}/pigeon
 [Pigeon pub.dev page]: {{site.pub-pkg}}/pigeon
 [sending structured typesafe messages]: #pigeon

--- a/src/development/platform-integration/platform-views.md
+++ b/src/development/platform-integration/platform-views.md
@@ -771,7 +771,7 @@ For more information, see:
 [`FlutterPlugin`]: {{site.api}}/javadoc/io/flutter/embedding/engine/plugins/FlutterPlugin.html
 [`FlutterTextureRegistry`]: {{site.api}}/objcdoc/Protocols/FlutterTextureRegistry.html
 [performance]: #performance
-[plugin migration guide]: /development/packages-and-plugins/plugin-api-migration
+[plugin migration guide]: {{site.url}}/development/packages-and-plugins/plugin-api-migration
 [`PlatformView`]: {{site.api}}/javadoc/io/flutter/plugin/platform/PlatformView.html
 [`PlatformViewFactory`]: {{site.api}}/javadoc/io/flutter/plugin/platform/PlatformViewFactory.html
 [`PlatformViewLink`]: {{site.api}}/flutter/widgets/PlatformViewLink-class.html

--- a/src/development/platform-integration/web-images.md
+++ b/src/development/platform-integration/web-images.md
@@ -180,7 +180,7 @@ the HTML renderer instead of CanvasKit.
 [9]: {{site.api}}/flutter/dart-ui/Codec/getNextFrame.html
 [10]: {{site.api}}/flutter/dart-ui/Scene/toImage.html
 [11]: {{site.api}}/flutter/dart-ui/Image-class.html
-[12]: /development/ui/assets-and-images
+[12]: {{site.url}}/development/ui/assets-and-images
 [13]: {{site.api}}/flutter/widgets/Image/Image.memory.html
 [14]: {{site.api}}/flutter/widgets/Image/Image.asset.html
 [15]: {{site.api}}/flutter/widgets/Image/Image.network.html

--- a/src/development/platform-integration/web.md
+++ b/src/development/platform-integration/web.md
@@ -149,27 +149,27 @@ Flutter engineers routinely read and respond on Discord.
 
 
 [Analyzing performance]: {{site.developers}}/web/tools/chrome-devtools/evaluate-performance
-[building a web app with Flutter]: /get-started/web
+[building a web app with Flutter]: {{site.url}}/get-started/web
 [Chrome DevTools]: {{site.developers}}/web/tools/chrome-devtools
-[Creating responsive apps]: /development/ui/layout/adaptive-responsive
-[Debugging]: /development/tools/devtools/debugger
+[Creating responsive apps]: {{site.url}}/development/ui/layout/adaptive-responsive
+[Debugging]: {{site.url}}/development/tools/devtools/debugger
 [Discord]: https://discord.gg/N7Yshp4
 [file an issue]: {{site.repo.flutter}}/issues/new?title=[web]:+%3Cdescribe+issue+here%3E&labels=%E2%98%B8+platform-web&body=Describe+your+issue+and+include+the+command+you%27re+running,+flutter_web%20version,+browser+version
-[Flutter DevTools]: /development/tools/devtools/overview
-[Flutter's production quality support for the web]: /web
+[Flutter DevTools]: {{site.url}}/development/tools/devtools/overview
+[Flutter's production quality support for the web]: {{site.url}}/web
 [Generating event timeline]: {{site.developers}}/web/tools/chrome-devtools/evaluate-performance/performance-reference
 [`http`]: {{site.pub}}/packages/http
 [`iframe`]: https://html.com/tags/iframe/
 [Issue 32248]: {{site.repo.flutter}}/issues/32248
-[Logging]: /development/tools/devtools/logging
-[Preparing a web app for release]: /deployment/web
-[Running Flutter inspector]: /development/tools/devtools/inspector
+[Logging]: {{site.url}}/development/tools/devtools/logging
+[Preparing a web app for release]: {{site.url}}/deployment/web
+[Running Flutter inspector]: {{site.url}}/development/tools/devtools/inspector
 [Upgrading from package:flutter_web to the Flutter SDK]: {{site.repo.flutter}}/wiki/Upgrading-from-package:flutter_web-to-the-Flutter-SDK
-[widget tests]: /testing#widget-tests
+[widget tests]: {{site.url}}/testing#widget-tests
 [pub.dev]: {{site.pub}}/flutter/packages?platform=web
-[Web support for Flutter]: /web
+[Web support for Flutter]: {{site.url}}/web
 [write your own plugins]: {{site.flutter-medium}}/how-to-write-a-flutter-web-plugin-5e26c689ea1
-[run your web apps in any supported browser]: /get-started/web#create-and-run
-[Integration testing]: /testing/integration-tests#running-in-a-browser
-[internationalizing a Flutter mobile app]: /resources/faq#how-do-i-do-internationalization-i18n-localization-l10n-and-accessibility-a11y-in-flutter
+[run your web apps in any supported browser]: {{site.url}}/get-started/web#create-and-run
+[Integration testing]: {{site.url}}/testing/integration-tests#running-in-a-browser
+[internationalizing a Flutter mobile app]: {{site.url}}/resources/faq#how-do-i-do-internationalization-i18n-localization-l10n-and-accessibility-a11y-in-flutter
 [documentation for conditional imports]: {{site.dart-site}}/guides/libraries/create-library-packages#conditionally-importing-and-exporting-library-files

--- a/src/development/tools/android-studio.md
+++ b/src/development/tools/android-studio.md
@@ -14,7 +14,7 @@ description: How to develop Flutter apps in Android Studio or other IntelliJ pro
 
 ## Installation and setup
 
-Follow the [Set up an editor](/get-started/editor?tab=androidstudio)
+Follow the [Set up an editor]({{site.url}}/get-started/editor?tab=androidstudio)
 instructions to install the Dart and Flutter plugins.
 
 ### Updating the plugins<a name="updating"/>
@@ -85,7 +85,7 @@ The Flutter plugin performs code analysis that enables the following:
 * Viewing all current source code problems
   (**View > Tool Windows > Dart Analysis**).
   Any analysis issues are shown in the Dart Analysis pane:<br>
-  ![Dart Analysis pane](/assets/images/docs/tools/android-studio/dart-analysis.png){:width="90%"}
+  ![Dart Analysis pane]({{site.url}}/assets/images/docs/tools/android-studio/dart-analysis.png){:width="90%"}
 
 ## Running and debugging
 
@@ -110,7 +110,7 @@ The Flutter plugin performs code analysis that enables the following:
 
 Running and debugging are controlled from the main toolbar:
 
-![Main IntelliJ toolbar](/assets/images/docs/tools/android-studio/main-toolbar.png){:width="90%"}
+![Main IntelliJ toolbar]({{site.url}}/assets/images/docs/tools/android-studio/main-toolbar.png){:width="90%"}
 
 ### Selecting a target
 
@@ -163,7 +163,7 @@ information, start the app in **Debug** mode, and then open
 the Performance tool window using
 **View > Tool Windows > Flutter Performance**.
 
-![Flutter performance window](/assets/images/docs/tools/android-studio/widget-rebuild-info.png){:width="90%"}
+![Flutter performance window]({{site.url}}/assets/images/docs/tools/android-studio/widget-rebuild-info.png){:width="90%"}
 
 To see the stats about which widgets are being rebuilt, and how often,
 click **Show widget rebuild information** in the **Performance** pane.
@@ -235,7 +235,7 @@ The assist can be invoked by clicking the lightbulb, or by using the
 keyboard shortcut (`Alt`+`Enter` on Linux and Windows,
 `Option`+`Return` on macOS), as illustrated here:
 
-![IntelliJ editing assists](/assets/images/docs/tools/android-studio/assists.gif){:width="100%"}
+![IntelliJ editing assists]({{site.url}}/assets/images/docs/tools/android-studio/assists.gif){:width="100%"}
 
 Quick Fixes are similar, only they are shown with a piece of code has an error
 and they can assist in correcting it. They are indicated with a red lightbulb.
@@ -261,7 +261,7 @@ Live templates can be used to speed up entering typical code structures.
 They are invoked by typing their prefix, and then selecting it in the code
 completion window:
 
-![IntelliJ live templates](/assets/images/docs/tools/android-studio/templates.gif){:width="100%"}
+![IntelliJ live templates]({{site.url}}/assets/images/docs/tools/android-studio/templates.gif){:width="100%"}
 
 The Flutter plugin includes the following templates:
 
@@ -288,7 +288,7 @@ Keyboard mappings can be changed in the IDE Preferences/Settings: Select
 *Keymap*, then enter _flutter_ into the search box in the upper right corner.
 Right click the binding you want to change and _Add Keyboard Shortcut_.
 
-![IntelliJ settings keymap](/assets/images/docs/tools/android-studio/keymap-settings-flutter-plugin.png){:width="100%"}
+![IntelliJ settings keymap]({{site.url}}/assets/images/docs/tools/android-studio/keymap-settings-flutter-plugin.png){:width="100%"}
 
 ### Hot reload vs. hot restart
 
@@ -392,15 +392,15 @@ Prior to filing new issues:
 
 When filing new issues, include the output of [`flutter doctor`][].
 
-[DevTools]: /development/tools/devtools
+[DevTools]: {{site.url}}/development/tools/devtools
 [GitHub issue tracker]: {{site.repo.flutter}}-intellij/issues
 [JetBrains YouTrack]: https://youtrack.jetbrains.com/issues?q=%23dart%20%23Unresolved
-[`flutter doctor`]: /resources/bug-reports#provide-some-flutter-diagnostics
-[Flutter IDE cheat sheet, MacOS version]: /resources/Flutter-IntelliJ-cheat-sheet-MacOS.pdf
-[Flutter IDE cheat sheet, Windows & Linux version]: /resources/Flutter-IntelliJ-cheat-sheet-WindowsLinux.pdf
-[Debugging Flutter apps]: /testing/debugging
+[`flutter doctor`]: {{site.url}}/resources/bug-reports#provide-some-flutter-diagnostics
+[Flutter IDE cheat sheet, MacOS version]: {{site.url}}/resources/Flutter-IntelliJ-cheat-sheet-MacOS.pdf
+[Flutter IDE cheat sheet, Windows & Linux version]: {{site.url}}/resources/Flutter-IntelliJ-cheat-sheet-WindowsLinux.pdf
+[Debugging Flutter apps]: {{site.url}}/testing/debugging
 [Flutter plugin README]: {{site.repo.flutter}}-intellij/blob/master/README.md
 ["project view"]: {{site.android-dev}}/studio/projects/#ProjectView
 [let us know]: {{site.repo.this}}/issues/new
-[Running DevTools from Android Studio]: /development/tools/devtools/android-studio
-[Timeline view]: /development/tools/devtools/performance
+[Running DevTools from Android Studio]: {{site.url}}/development/tools/devtools/android-studio
+[Timeline view]: {{site.url}}/development/tools/devtools/performance

--- a/src/development/tools/devtools/_profiler.md
+++ b/src/development/tools/devtools/_profiler.md
@@ -45,7 +45,7 @@ frame represents the amount of time it consumed the CPU. Stack frames
 that consume a lot of CPU time may be a good place to look for possible
 performance improvements.
 
-![Screenshot of a flame chart](/assets/images/docs/tools/devtools/cpu_profiler_flame_chart.png){:width="100%"}
+![Screenshot of a flame chart]({{site.url}}/assets/images/docs/tools/devtools/cpu_profiler_flame_chart.png){:width="100%"}
 
 ### Call tree
 
@@ -65,7 +65,7 @@ meaning that a method can be expanded to show its _callees_.
 <dd>File path for the method call site.</dd>
 </dl>
 
-![Screenshot of a call tree table](/assets/images/docs/tools/devtools/cpu_profiler_call_tree.png){:width="100%"}
+![Screenshot of a call tree table]({{site.url}}/assets/images/docs/tools/devtools/cpu_profiler_call_tree.png){:width="100%"}
 
 ### Bottom up
 
@@ -99,4 +99,4 @@ In this table, a method can be expanded to show its _callers_.
 <dt markdown="1">**Source**</dt>
 <dd markdown="1">File path for the method call site.
 
-![Screenshot of a bottom up table](/assets/images/docs/tools/devtools/cpu_profiler_bottom_up.png){:width="100%"}
+![Screenshot of a bottom up table]({{site.url}}/assets/images/docs/tools/devtools/cpu_profiler_bottom_up.png){:width="100%"}

--- a/src/development/tools/devtools/android-studio.md
+++ b/src/development/tools/devtools/android-studio.md
@@ -28,7 +28,7 @@ you can start DevTools using one of the following:
 * Select the **Open DevTools** action from the **More Actions**
   menu in the Flutter Inspector view.
 
-![screenshot of Open DevTools button](/assets/images/docs/tools/devtools/android_studio_open_devtools.png){:width="100%"}
+![screenshot of Open DevTools button]({{site.url}}/assets/images/docs/tools/devtools/android_studio_open_devtools.png){:width="100%"}
 
 ## Launch DevTools from an action
 

--- a/src/development/tools/devtools/app-size.md
+++ b/src/development/tools/devtools/app-size.md
@@ -39,13 +39,13 @@ optimize Dart code and track down size issues.
 If DevTools is already connected to a running application,
 navigate to the "App Size" tab.
 
-![Screenshot of app size tab](/assets/images/docs/tools/devtools/app_size_tab.png)
+![Screenshot of app size tab]({{site.url}}/assets/images/docs/tools/devtools/app_size_tab.png)
 
 If DevTools is not connected to a running application, you can
 access the tool from the landing page that appears once you have launched
 DevTools (see [installation instructions][]).
 
-![Screenshot of app size access on landing page](/assets/images/docs/tools/devtools/app_size_access_landing_page.png){:width="100%"}
+![Screenshot of app size access on landing page]({{site.url}}/assets/images/docs/tools/devtools/app_size_access_landing_page.png){:width="100%"}
 
 ## Analysis tab
 
@@ -56,7 +56,7 @@ and you can view code attribution data
 (for example, why a piece of code is included in your compiled
 application) using the dominator tree and call graph.
 
-![Screenshot of app size analysis](/assets/images/docs/tools/devtools/app_size_analysis.png){:width="100%"}
+![Screenshot of app size analysis]({{site.url}}/assets/images/docs/tools/devtools/app_size_analysis.png){:width="100%"}
 
 ### Loading a size file
 
@@ -64,7 +64,7 @@ When you open the Analysis tab, you'll see instructions
 to load an app size file. Drag and drop an app size
 file into the dialog, and click "Analyze Size".
 
-![Screenshot of app size analysis loading screen](/assets/images/docs/tools/devtools/app_size_load_analysis.png){:width="100%"}
+![Screenshot of app size analysis loading screen]({{site.url}}/assets/images/docs/tools/devtools/app_size_load_analysis.png){:width="100%"}
 
 See [Generating size files][] below for information on
 generating size files.
@@ -92,7 +92,7 @@ the visual root of the treemap.
 To navigate back, or up a level, use the breadcrumb
 navigator at the top of the treemap.
 
-![Screenshot of treemap breadcrumb navigator](/assets/images/docs/tools/devtools/treemap_breadcrumbs.png){:width="100%"}
+![Screenshot of treemap breadcrumb navigator]({{site.url}}/assets/images/docs/tools/devtools/treemap_breadcrumbs.png){:width="100%"}
 
 ### Dominator tree and call graph
 
@@ -138,7 +138,7 @@ For example, if you are analyzing your app size and find
 an unexpected package included in your compiled app, you can
 use the dominator tree to trace the package to its root source.
 
-![Screenshot of code size dominator tree](/assets/images/docs/tools/devtools/code_size_dominator_tree.png){:width="100%"}
+![Screenshot of code size dominator tree]({{site.url}}/assets/images/docs/tools/devtools/code_size_dominator_tree.png){:width="100%"}
 
 #### Using the call graph
 
@@ -173,7 +173,7 @@ This information is useful for understanding the
 fine-grained dependencies of between pieces of your code
 (packages, libraries, classes, functions).
 
-![Screenshot of code size call graph](/assets/images/docs/tools/devtools/code_size_call_graph.png){:width="100%"}
+![Screenshot of code size call graph]({{site.url}}/assets/images/docs/tools/devtools/code_size_call_graph.png){:width="100%"}
 
 #### Should I use the dominator tree or the call graph?
 
@@ -207,7 +207,7 @@ changes to your code. You can visualize the
 difference between the two data sets
 using the treemap and table.
 
-![Screenshot of app size diff](/assets/images/docs/tools/devtools/app_size_diff.png){:width="100%"}
+![Screenshot of app size diff]({{site.url}}/assets/images/docs/tools/devtools/app_size_diff.png){:width="100%"}
 
 ### Loading size files
 
@@ -217,7 +217,7 @@ files. Again, these files need to be generated from
 the same application. Drag and drop these files into
 their respective dialogs, and click **Analyze Diff**.
 
-![Screenshot of app size diff loading screen](/assets/images/docs/tools/devtools/app_size_load_diff.png){:width="100%"}
+![Screenshot of app size diff loading screen]({{site.url}}/assets/images/docs/tools/devtools/app_size_load_diff.png){:width="100%"}
 
 See [Generating size files][] below for information
 on generating these files.
@@ -263,5 +263,5 @@ For more information, see [App Size Documentation][].
 [Generating size files]: #generating-size-files
 [Analysis tab]: #analysis-tab
 [Diff tab]: #diff-tab
-[installation instructions]: /development/tools/devtools/overview#install-devtools
-[App Size Documentation]: /perf/app-size#breaking-down-the-size
+[installation instructions]: {{site.url}}/development/tools/devtools/overview#install-devtools
+[App Size Documentation]: {{site.url}}/perf/app-size#breaking-down-the-size

--- a/src/development/tools/devtools/cli.md
+++ b/src/development/tools/devtools/cli.md
@@ -74,7 +74,7 @@ Chrome browser window and navigating to `http://localhost:9100`.
 
 Once DevTools opens, you should see a connect dialog:
 
-![Screenshot of a logging view](/assets/images/docs/tools/devtools/connect_dialog.png){:width="100%"}
+![Screenshot of a logging view]({{site.url}}/assets/images/docs/tools/devtools/connect_dialog.png){:width="100%"}
 
 Paste the URL you got from running your app (in this example,
 `http://127.0.0.1:50976/Swm0bjIe0ks=/`) into the connect dialog

--- a/src/development/tools/devtools/debugger.md
+++ b/src/development/tools/devtools/debugger.md
@@ -23,7 +23,7 @@ In order to browse around more of your application sources, click **Libraries**
 (top right) or use the hot key command `⌘ + P` / `ctrl + P`. This will open the
 libraries window and allow you to search for other source files.
 
-![Screenshot of the debugger tab](/assets/images/docs/tools/devtools/debugger_screenshot.png){:width="100%"}
+![Screenshot of the debugger tab]({{site.url}}/assets/images/docs/tools/devtools/debugger_screenshot.png){:width="100%"}
 
 ## Setting breakpoints
 
@@ -81,11 +81,11 @@ whether or not the breakpoint was caught by application code.
 When performing a hot restart for a Flutter application,
 user breakpoints are cleared.
 
-[Logging view]: /development/tools/devtools/logging
+[Logging view]: {{site.url}}/development/tools/devtools/logging
 
 ## Other resources
 
 For more information on debugging and profiling, see the
 [Debugging][] page.
 
-[Debugging]: /testing/debugging
+[Debugging]: {{site.url}}/testing/debugging

--- a/src/development/tools/devtools/inspector.md
+++ b/src/development/tools/devtools/inspector.md
@@ -22,7 +22,7 @@ trees, and can be used for the following:
 * understanding existing layouts
 * diagnosing layout issues
 
-![Screenshot of the Flutter inspector window](/assets/images/docs/tools/devtools/inspector_screenshot.png){:width="100%"}
+![Screenshot of the Flutter inspector window]({{site.url}}/assets/images/docs/tools/devtools/inspector_screenshot.png){:width="100%"}
 
 ## Get started
 
@@ -44,23 +44,23 @@ inspector's toolbar. When space is limited, the icon is
 used as the visual version of the label.
 
 <dl markdown="1">
-<dt markdown="1">![Select widget mode icon](/assets/images/docs/tools/devtools/select-widget-mode-icon.png){:width="20px"} **Select widget mode**</dt>
+<dt markdown="1">![Select widget mode icon]({{site.url}}/assets/images/docs/tools/devtools/select-widget-mode-icon.png){:width="20px"} **Select widget mode**</dt>
 <dd markdown="1">Enable this button in order to select
     a widget on the device to inspect it. For more information,
     see [Inspecting a widget](#inspecting-a-widget).
-<dt markdown="1">![Refresh tree icon](/assets/images/docs/tools/devtools/refresh-tree-icon.png){:width="20px"} **Refresh tree**</dt>
+<dt markdown="1">![Refresh tree icon]({{site.url}}/assets/images/docs/tools/devtools/refresh-tree-icon.png){:width="20px"} **Refresh tree**</dt>
 <dd>Reload the current widget info.</dd>
-<dt markdown="1">![Slow animations icon](/assets/images/docs/tools/devtools/slow-animations-icon.png){:width="20px"} **[Slow animations][]**</dt>
+<dt markdown="1">![Slow animations icon]({{site.url}}/assets/images/docs/tools/devtools/slow-animations-icon.png){:width="20px"} **[Slow animations][]**</dt>
 <dd>Run animations 5 times slower to help fine-tune them.</dd>
-<dt markdown="1">![Show guidelines mode icon](/assets/images/docs/tools/devtools/debug-paint-mode-icon.png){:width="20px"} **[Show guidelines][]**</dt>
+<dt markdown="1">![Show guidelines mode icon]({{site.url}}/assets/images/docs/tools/devtools/debug-paint-mode-icon.png){:width="20px"} **[Show guidelines][]**</dt>
 <dd>Overlay guidelines to assist with fixing layout issues.</dd>
-<dt markdown="1">![Show baselines icon](/assets/images/docs/tools/devtools/paint-baselines-icon.png){:width="20px"} **[Show baselines][]**</dt>
+<dt markdown="1">![Show baselines icon]({{site.url}}/assets/images/docs/tools/devtools/paint-baselines-icon.png){:width="20px"} **[Show baselines][]**</dt>
 <dd>Show baselines, which are used for aligning text.
     Can be useful for checking if text is aligned.</dd>
-<dt markdown="1">![Highlight repaints icon](/assets/images/docs/tools/devtools/repaint-rainbow-icon.png){:width="20px"} **[Highlight repaints][]**</dt>
+<dt markdown="1">![Highlight repaints icon]({{site.url}}/assets/images/docs/tools/devtools/repaint-rainbow-icon.png){:width="20px"} **[Highlight repaints][]**</dt>
 <dd>Show borders that change color when elements repaint.
     Useful for finding unnecessary repaints.</dd>
-<dt markdown="1">![Highlight oversized images icon](/assets/images/docs/tools/devtools/invert_oversized_images_icon.png){:width="20px"} **[Highlight oversized images][]**</dt>
+<dt markdown="1">![Highlight oversized images icon]({{site.url}}/assets/images/docs/tools/devtools/invert_oversized_images_icon.png){:width="20px"} **[Highlight oversized images][]**</dt>
 <dd>Highlights images that are using too much memory
     by inverting colors and flipping them.</dd>
 
@@ -130,14 +130,14 @@ standard  "yellow-tape" pattern, as you might see on a running
 device. These visualizations aim to improve understanding of
 why overflow errors occur as well as how to fix them.
 
-![The Layout Explorer showing errors and device inspector](/assets/images/docs/tools/devtools/layout_explorer_errors_and_device.gif){:width="100%"}
+![The Layout Explorer showing errors and device inspector]({{site.url}}/assets/images/docs/tools/devtools/layout_explorer_errors_and_device.gif){:width="100%"}
 
 Clicking a widget in the layout explorer mirrors
 the selection on the on-device inspector. **Select Widget Mode**
 needs to be enabled for this. To enable it,
 click on the **Select Widget Mode** button in the inspector.
 
-![The Select Widget Mode button in the inspector](/assets/images/docs/tools/devtools/select_widget_mode_devtools_alpha.png)
+![The Select Widget Mode button in the inspector]({{site.url}}/assets/images/docs/tools/devtools/select_widget_mode_devtools_alpha.png)
 
 For some properties, like flex factor, flex fit, and alignment,
 you can modify the value via dropdown lists in the explorer.
@@ -158,7 +158,7 @@ such as [`mainAxisSize`][], [`textDirection`][], and
 
 ###### mainAxisAlignment
 
-![The Layout Explorer changing main axis alignment](/assets/images/docs/tools/devtools/layout_explorer_main_axis_alignment.gif){:width="100%"}
+![The Layout Explorer changing main axis alignment]({{site.url}}/assets/images/docs/tools/devtools/layout_explorer_main_axis_alignment.gif){:width="100%"}
 
 Supported values:
 
@@ -172,7 +172,7 @@ Supported values:
 
 ###### crossAxisAlignment
 
-![The Layout Explorer changing cross axis alignment](/assets/images/docs/tools/devtools/layout_explorer_cross_axis_alignment.gif){:width="100%"}
+![The Layout Explorer changing cross axis alignment]({{site.url}}/assets/images/docs/tools/devtools/layout_explorer_cross_axis_alignment.gif){:width="100%"}
 
 Supported values:
 
@@ -184,7 +184,7 @@ Supported values:
 
 ###### FlexParentData.flex
 
-![The Layout Explorer changing flex factor](/assets/images/docs/tools/devtools/layout_explorer_flex.gif){:width="100%"}
+![The Layout Explorer changing flex factor]({{site.url}}/assets/images/docs/tools/devtools/layout_explorer_flex.gif){:width="100%"}
 
 Layout Explorer supports 7 flex options in the UI
 (null, 0, 1, 2, 3, 4, 5), but technically the flex
@@ -192,7 +192,7 @@ factor of a flex widget’s child can be any int.
 
 ###### Flexible.fit
 
-![The Layout Explorer changing fit](/assets/images/docs/tools/devtools/layout_explorer_fit.gif){:width="100%"}
+![The Layout Explorer changing fit]({{site.url}}/assets/images/docs/tools/devtools/layout_explorer_fit.gif){:width="100%"}
 
 Layout Explorer supports the two different types of
 [`FlexFit`][]: `loose` and `tight`.
@@ -204,7 +204,7 @@ in the Layout Explorer. You can see size, constraint, and padding
 information for both the selected widget and its nearest upstream
 RenderObject.
 
-![The Layout Explorer fixed size tool](/assets/images/docs/tools/devtools/layout_explorer_fixed_layout.png)
+![The Layout Explorer fixed size tool]({{site.url}}/assets/images/docs/tools/devtools/layout_explorer_fixed_layout.png)
 
 ## Visual debugging
 
@@ -239,8 +239,8 @@ The following links provide more info.
 
 The following screen recordings show before and after slowing an animation.
 
-![Screen recording showing normal animation speed](/assets/images/docs/tools/devtools/debug-toggle-slow-animations-disabled.gif)
-![Screen recording showing slowed animation speed](/assets/images/docs/tools/devtools/debug-toggle-slow-animations-enabled.gif)
+![Screen recording showing normal animation speed]({{site.url}}/assets/images/docs/tools/devtools/debug-toggle-slow-animations-disabled.gif)
+![Screen recording showing slowed animation speed]({{site.url}}/assets/images/docs/tools/devtools/debug-toggle-slow-animations-enabled.gif)
 
 ### Show guidelines
 
@@ -266,7 +266,7 @@ void showLayoutGuidelines() {
 Widgets that draw to the screen create a [render box][], the 
 building blocks of Flutter layouts. They’re shown with a bright blue border:
 
-![Screenshot of render box guidelines](/assets/images/docs/tools/devtools/debug-toggle-guideline-render-box.png)
+![Screenshot of render box guidelines]({{site.url}}/assets/images/docs/tools/devtools/debug-toggle-guideline-render-box.png)
 
 #### Alignments
 
@@ -274,19 +274,19 @@ Alignments are shown with yellow arrows. These arrows show the vertical
 and horizontal offsets of a widget relative to its parent.
 For example, this button’s icon is shown as being centered by the four arrows:
 
-![Screenshot of alignment guidelines](/assets/images/docs/tools/devtools/debug-toggle-guidelines-alignment.png)
+![Screenshot of alignment guidelines]({{site.url}}/assets/images/docs/tools/devtools/debug-toggle-guidelines-alignment.png)
 
 #### Padding
 
 Padding is shown with a semi-transparent blue background:
 
-![Screenshot of padding guidelines](/assets/images/docs/tools/devtools/debug-toggle-guidelines-padding.png)
+![Screenshot of padding guidelines]({{site.url}}/assets/images/docs/tools/devtools/debug-toggle-guidelines-padding.png)
 
 #### Scroll views
 
 Widgets with scrolling contents (such as list views) are shown with green arrows:
 
-![Screenshot of scroll view guidelines](/assets/images/docs/tools/devtools/debug-toggle-guidelines-scroll.png)
+![Screenshot of scroll view guidelines]({{site.url}}/assets/images/docs/tools/devtools/debug-toggle-guidelines-scroll.png)
 
 #### Clipping
 
@@ -295,14 +295,14 @@ with a dashed pink line with a scissors icon:
 
 [ClipRect widget]: {{site.api}}/flutter/widgets/ClipRect-class.html
 
-![Screenshot of clip guidelines](/assets/images/docs/tools/devtools/debug-toggle-guidelines-clip.png)
+![Screenshot of clip guidelines]({{site.url}}/assets/images/docs/tools/devtools/debug-toggle-guidelines-clip.png)
 
 #### Spacers
 
 Spacer widgets are shown with a grey background,
 such as this `SizedBox` without a child:
 
-![Screenshot of spacer guidelines](/assets/images/docs/tools/devtools/debug-toggle-guidelines-spacer.png)
+![Screenshot of spacer guidelines]({{site.url}}/assets/images/docs/tools/devtools/debug-toggle-guidelines-spacer.png)
 
 ### Show baselines
 
@@ -312,7 +312,7 @@ Baselines are horizontal lines used to position text.
 This can be useful for checking whether text is precisely aligned vertically.
 For example, the text baselines in the following screenshot are slightly misaligned:
 
-![Screenshot with show baselines enabled](/assets/images/docs/tools/devtools/debug-toggle-guidelines-baseline.png)
+![Screenshot with show baselines enabled]({{site.url}}/assets/images/docs/tools/devtools/debug-toggle-guidelines-baseline.png)
 
 The [Baseline][] widget can be used to adjust baselines.
 
@@ -365,7 +365,7 @@ class EverythingRepaintsPage extends StatelessWidget {
 }
 ```
 
-![Screen recording of a whole screen repainting](/assets/images/docs/tools/devtools/debug-toggle-guidelines-repaint-1.gif)
+![Screen recording of a whole screen repainting]({{site.url}}/assets/images/docs/tools/devtools/debug-toggle-guidelines-repaint-1.gif)
 
 Wrapping the progress indicator in a `RepaintBoundary` causes
 only that section of the screen to repaint:
@@ -387,7 +387,7 @@ class AreaRepaintsPage extends StatelessWidget {
 }
 ```
 
-![Screen recording of a just a progress indicator repainting](/assets/images/docs/tools/devtools/debug-toggle-guidelines-repaint-2.gif)
+![Screen recording of a just a progress indicator repainting]({{site.url}}/assets/images/docs/tools/devtools/debug-toggle-guidelines-repaint-2.gif)
 
 `RepaintBoundary` widgets have tradeoffs. They can help with performance,
 but they also have an overhead of creating a new canvas,
@@ -409,7 +409,7 @@ void highlightRepaints() {
 This option highlights images that are too large by both inverting their colors
 and flipping them vertically:
 
-![A highlighted oversized image](/assets/images/docs/tools/devtools/debug-toggle-guidelines-oversized.png)
+![A highlighted oversized image]({{site.url}}/assets/images/docs/tools/devtools/debug-toggle-guidelines-oversized.png)
 
 The highlighted images use more memory than is required;
 for example, a large 5MB image displayed at 100 by 100 pixels.
@@ -478,12 +478,12 @@ You can learn more at the following link:
 Select the **Details Tree** tab to display the details tree for the
 selected widget.
 
-![The Details Tree tab](/assets/images/docs/tools/devtools/details_tree_tab.png)
+![The Details Tree tab]({{site.url}}/assets/images/docs/tools/devtools/details_tree_tab.png)
 
 From the details tree, you can gather useful information about a
 widget's properties, render object, and children.
 
-![The Details Tree view](/assets/images/docs/tools/devtools/details_tree.png)
+![The Details Tree view]({{site.url}}/assets/images/docs/tools/devtools/details_tree.png)
 
 
 ## Track widget creation
@@ -506,11 +506,11 @@ with and without track widget creation enabled.
 
 Track widget creation enabled (default):
 
-![The widget tree with track widget creation enabled](/assets/images/docs/tools/devtools/track_widget_creation_enabled.png){:width="100%"}
+![The widget tree with track widget creation enabled]({{site.url}}/assets/images/docs/tools/devtools/track_widget_creation_enabled.png){:width="100%"}
 
 Track widget creation disabled (not recommended):
 
-![The widget tree with track widget creation disabled](/assets/images/docs/tools/devtools/track_widget_creation_disabled.png){:width="100%"}
+![The widget tree with track widget creation disabled]({{site.url}}/assets/images/docs/tools/devtools/track_widget_creation_disabled.png){:width="100%"}
 
 This feature prevents otherwise-identical `const` Widgets from
 being considered equal in debug builds. For more details, see
@@ -524,22 +524,22 @@ of the Flutter inspector.
 
 
 [`Column`]: {{site.api}}/flutter/widgets/Column-class.html
-[common problems when debugging]: /testing/debugging#common-problems
-[core building block]: /development/ui/widgets-intro
+[common problems when debugging]: {{site.url}}/testing/debugging#common-problems
+[core building block]: {{site.url}}/development/ui/widgets-intro
 [`crossAxisAlignment`]: {{site.api}}/flutter/widgets/Flex/crossAxisAlignment.html
 [DartConf 2018 talk]: {{site.youtube-site}}/watch?v=JIcmJNT9DNI
-[debug mode]: /testing/build-modes#debug
-[Debugging Flutter apps]: /testing/debugging
-[DevTools written in Flutter]: /development/tools/devtools/overview#how-do-i-try-devtools-written-in-flutter
+[debug mode]: {{site.url}}/testing/build-modes#debug
+[Debugging Flutter apps]: {{site.url}}/testing/debugging
+[DevTools written in Flutter]: {{site.url}}/development/tools/devtools/overview#how-do-i-try-devtools-written-in-flutter
 [`Flex`]: {{site.api}}/flutter/widgets/Flex-class.html
 [flex layouts]: {{site.api}}/flutter/widgets/Flex-class.html
 [`FlexFit`]: {{site.api}}/flutter/widgets/FlexFit-class.html
 [`FlexParentData.fit`]: {{site.api}}/flutter/rendering/FlexParentData/fit.html
 [`FlexParentData.flex`]: {{site.api}}/flutter/rendering/FlexParentData/flex.html
-[Flutter performance profiling]: /perf/rendering/ui-performance
+[Flutter performance profiling]: {{site.url}}/perf/rendering/ui-performance
 [`mainAxisAlignment`]: {{site.api}}/flutter/widgets/Flex/mainAxisAlignment.html
 [`mainAxisSize`]: {{site.api}}/flutter/widgets/Flex/mainAxisSize.html
 [`Row`]: {{site.api}}/flutter/widgets/Row-class.html
 [`textDirection`]: {{site.api}}/flutter/widgets/Flex/textDirection.html
-[the performance overlay]: /perf/rendering/ui-performance#the-performance-overlay
-[Understanding constraints]: /development/ui/layout/constraints
+[the performance overlay]: {{site.url}}/perf/rendering/ui-performance#the-performance-overlay
+[Understanding constraints]: {{site.url}}/development/ui/layout/constraints

--- a/src/development/tools/devtools/logging.md
+++ b/src/development/tools/devtools/logging.md
@@ -22,7 +22,7 @@ By default, the logging view shows:
 * `stdout` and `stderr` from applications
 * Custom logging events from applications
 
-![Screenshot of a logging view](/assets/images/docs/tools/devtools/logging_log_entries.png){:width="100%"}
+![Screenshot of a logging view]({{site.url}}/assets/images/docs/tools/devtools/logging_log_entries.png){:width="100%"}
 
 ## Logging from your application
 
@@ -36,5 +36,5 @@ page.
 To clear the log entries in the logging view,
 click the **Clear logs** button.
 
-[Logging]: /testing/code-debugging#logging
-[Debugging Flutter apps programmatically]: /testing/code-debugging
+[Logging]: {{site.url}}/testing/code-debugging#logging
+[Debugging Flutter apps programmatically]: {{site.url}}/testing/code-debugging

--- a/src/development/tools/devtools/memory.md
+++ b/src/development/tools/devtools/memory.md
@@ -87,7 +87,7 @@ corresponds to the timestamp (x-axis) of measured quantities (y-axis)
 of the heap, for example, usage, capacity, external, garbage
 collection, and resident set size.
 
-![Screenshot of a memory anatomy page](/assets/images/docs/tools/devtools/memory_chart_anatomy.png){:width="100%"}
+![Screenshot of a memory anatomy page]({{site.url}}/assets/images/docs/tools/devtools/memory_chart_anatomy.png){:width="100%"}
 
 ### Events Pane
 
@@ -95,7 +95,7 @@ The event timeline displays Dart VM and DevTools events
 on a shared timeline. These events can be snapshots (manual and auto),
 Dart VM GCs, user requested GCs, or monitor and accumulator reset actions.
 
-![Screenshot of DevTools events](/assets/images/docs/tools/devtools/memory_eventtimeline.png)
+![Screenshot of DevTools events]({{site.url}}/assets/images/docs/tools/devtools/memory_eventtimeline.png)
 
 This chart displays DevTools events (such as manual GC, VM GC,
 Snapshot, monitor Allocations **Track** and **Reset** of accumulators button
@@ -104,18 +104,18 @@ markers in the Event timeline displays a hover card of the time when
 the event occurred. This may help identify when a memory leak might have
 occurred in the timeline (x-axis).
 
-![Screenshot of the event timeline legend](/assets/images/docs/tools/devtools/memory_eventtimeline_legend.png)
+![Screenshot of the event timeline legend]({{site.url}}/assets/images/docs/tools/devtools/memory_eventtimeline_legend.png)
 
 This legend shows the symbol for each DevTools event and its meaning
 
 <dl markdown="1">
 <dt markdown="1">**Snapshot**</dt>
-![User Snapshot](/assets/images/docs/tools/devtools/memory_eventtimeline_snapshot.png){:width="17px"}
+![User Snapshot]({{site.url}}/assets/images/docs/tools/devtools/memory_eventtimeline_snapshot.png){:width="17px"}
 <dd markdown="1">User initiated snapshot&mdash;all memory
                 information collected and an analysis performed.
 </dd>
 <dt markdown="1">**Auto-Snapshot**</dt>
-![Auto Snapshot](/assets/images/docs/tools/devtools/memory_eventtimeline_auto_snapshot.png){:width="18px"}
+![Auto Snapshot]({{site.url}}/assets/images/docs/tools/devtools/memory_eventtimeline_auto_snapshot.png){:width="18px"}
 <dd markdown="1">DevTools initiated a snapshot detecting
                  that memory grow by 40% or more from previous
                  size.  This is used to quickly detect memory
@@ -124,25 +124,25 @@ This legend shows the symbol for each DevTools event and its meaning
                  snapshot).
 </dd>
 <dt markdown="1">**Track**</dt>
-![Monitor](/assets/images/docs/tools/devtools/memory_eventtimeline_monitor.png){:width="17px"}
+![Monitor]({{site.url}}/assets/images/docs/tools/devtools/memory_eventtimeline_monitor.png){:width="17px"}
 <dd markdown="1">Collects current state of all active classes
                  number of instances and byte size of all instances.
                  In addition, the deltas are the change in the
                  accumulators since the last "Reset" button pressed.
 </dd>
 <dt markdown="1">**Reset**</dt>
-![Reset](/assets/images/docs/tools/devtools/memory_eventtimeline_reset_monitor.png){:width="18px"}
+![Reset]({{site.url}}/assets/images/docs/tools/devtools/memory_eventtimeline_reset_monitor.png){:width="18px"}
 <dd markdown="1">When both the instance and bytes accumulators
                  were reset to zero.
 </dd>
 <dt markdown="1">**User Initiated GC**</dt>
-![GC](/assets/images/docs/tools/devtools/memory_eventtimeline_gc.png){:width="18px"}
+![GC]({{site.url}}/assets/images/docs/tools/devtools/memory_eventtimeline_gc.png){:width="18px"}
 <dd markdown="1">User initiated request to VM to to perform a
                  garbage collection of memory (only a suggestion
                  to the VM).
 </dd>
 <dt markdown="1">**VM GC**</dt>
-![VM GC](/assets/images/docs/tools/devtools/memory_eventtimeline_vmgc.png){:width="11px"}
+![VM GC]({{site.url}}/assets/images/docs/tools/devtools/memory_eventtimeline_vmgc.png){:width="11px"}
 <dd markdown="1">GC (VM garbage collection) has occurred, frees
                  space no longer used. For more information on
                  how Dart performs garbage collection, see
@@ -152,11 +152,11 @@ This legend shows the symbol for each DevTools event and its meaning
 <dd>Displayed as a triangle in the event pane.  The dark magenta
     triangle "Multiple Flutter or User Events"
 </dd>
-![Aggregate Events](/assets/images/docs/tools/devtools/memory_multi_events.png){:width="25px"}
+![Aggregate Events]({{site.url}}/assets/images/docs/tools/devtools/memory_multi_events.png){:width="25px"}
 <dd>identifies more than one event was received at this timestamp.
     The lighter magenta triangle "One Flutter or User Event" 
 </dd>
-![Single Events](/assets/images/docs/tools/devtools/memory_one_event.png){:width="23px"}
+![Single Events]({{site.url}}/assets/images/docs/tools/devtools/memory_one_event.png){:width="23px"}
 <dd>indicates only one event was received at this timestamp. To
     view the events clicking on the triangle will display a hover
     card and expanding the events at the bottom of the hovercard
@@ -218,11 +218,11 @@ hover card with the details of all events e.g., two custom events at
 the timestamp 04:36:21 with the event name 'MyFirstApp' and the two
 eventData entries method and param are displayed with their values: 
 
-![Hover Card Custom Events](/assets/images/docs/tools/devtools/memory_hover_events.png)
+![Hover Card Custom Events]({{site.url}}/assets/images/docs/tools/devtools/memory_hover_events.png)
 
 Scrolling the events displays:
 
-![Custom Events Details](/assets/images/docs/tools/devtools/memory_events_detail.png)
+![Custom Events Details]({{site.url}}/assets/images/docs/tools/devtools/memory_events_detail.png)
 
 ## Memory overview chart
 
@@ -240,7 +240,7 @@ the state of the memory as the application is running.
 Clicking on the Legend button describes the collected measurements
 and symbols/colors used to display the data.
 
-![Screenshot of a memory anatomy page](/assets/images/docs/tools/devtools/memory_chart_anatomy.png)
+![Screenshot of a memory anatomy page]({{site.url}}/assets/images/docs/tools/devtools/memory_chart_anatomy.png)
 
 The **Memory Size Scale** Y axis scale automatically adjusts to the
 range of data collected in the current visible chart range.
@@ -284,7 +284,7 @@ Clicking in a chart will display a vertical yellow line where the click
 occurred on the X-Axis (Timestamp), a hover card will be displayed with
 the information collected:
 
-![Screenshot of the basic memory chart](/assets/images/docs/tools/devtools/memory_basic_chart.png)
+![Screenshot of the basic memory chart]({{site.url}}/assets/images/docs/tools/devtools/memory_basic_chart.png)
 
 **Memory Events** Memory Events recorded in the Event Pane e.g., VM GC,
 User Initiated GC, User Initiated Snapshot, Auto-Snapshot,
@@ -307,17 +307,17 @@ triangle is displayed with the aggregate list of events. The aggregate
 vents collects all the events nearest a particular timestamp (tick)
 and displays the events to the X-Axis closest tick. Expanding the events
 will display the values for each event:
-![Aggregate Events](/assets/images/docs/tools/devtools/memory_multi_events.png){:width="25px"}
+![Aggregate Events]({{site.url}}/assets/images/docs/tools/devtools/memory_multi_events.png){:width="25px"}
 
 If only one event is collected, a lighter magenta triangle color is
 displayed with the single event values:
-![Single Events](/assets/images/docs/tools/devtools/memory_one_event.png){:width="23px"}
+![Single Events]({{site.url}}/assets/images/docs/tools/devtools/memory_one_event.png){:width="23px"}
 
 If the Android memory chart is displayed then the Android collect data
 will displayed between the "Dart / Flutter Memory" and the "Flutter and
 User Events" e.g.,
 
-![Hovercard of Android chart is visible](/assets/images/docs/tools/devtools/memory_android_hovercard.png)
+![Hovercard of Android chart is visible]({{site.url}}/assets/images/docs/tools/devtools/memory_android_hovercard.png)
 
 ### Android chart
 
@@ -350,7 +350,7 @@ Graphics stack, System size and total).
 Clicking on a timestamp (x-position) will display all data points
 collected for that time period.
 
-![Screenshot of Android Memory Chart](/assets/images/docs/tools/devtools/memory_android.png)
+![Screenshot of Android Memory Chart]({{site.url}}/assets/images/docs/tools/devtools/memory_android.png)
 
 The hover card will display the values of all collected Android memory data.
 
@@ -408,7 +408,7 @@ the CPU—not dedicated GPU memory.
 At the top of the memory page, above the charts, are several buttons and
 dropdowns that control how memory data is displayed.
 
-![Screenshot of a memory controls](/assets/images/docs/tools/devtools/memory_controls.png){:width="100%"}
+![Screenshot of a memory controls]({{site.url}}/assets/images/docs/tools/devtools/memory_controls.png){:width="100%"}
 
 <dl markdown="1">
 <dt markdown="1">**Pause**</dt>
@@ -448,7 +448,7 @@ Below the memory charts (Event Timeline, Memory Overview and Android Overview
 charts) are interactive actions used to collect and analyze information about
 memory usage while using the application DevTools is connected to there are two tabs:
 
-![Two Tabs Memory Actions](/assets/images/docs/tools/devtools/memory_two_tabs.png)
+![Two Tabs Memory Actions]({{site.url}}/assets/images/docs/tools/devtools/memory_two_tabs.png)
 
 ### Analysis tab
 
@@ -460,7 +460,7 @@ Each snapshot is analyzed and an analysis is created too.
 
 The actions available for Analysis are:
 
-![Screenshot of a memory actions](/assets/images/docs/tools/devtools/memory_analysis_actions.png)
+![Screenshot of a memory actions]({{site.url}}/assets/images/docs/tools/devtools/memory_analysis_actions.png)
 
 **Snapshot** Clicking the Snapshot button makes a request to the
 Dart VM to collect the current state of memory.  The
@@ -482,7 +482,7 @@ instance or by class name.
 
 All Analyses and Snapshots are displayed in a Table Tree View:
 
-![Two Tabs Memory Actions](/assets/images/docs/tools/devtools/memory_table_tree_view.png)
+![Two Tabs Memory Actions]({{site.url}}/assets/images/docs/tools/devtools/memory_table_tree_view.png)
 
 The snapshots are grouped by library and within library by class and
 each class will display the list of known instances for that class.
@@ -494,16 +494,16 @@ expanding the class will display all live instances (objects). Clicking on
 an instance, of a class, will bring up the memory inspector to the right-side
 of the table tree.
 
-![Two Tabs Memory Actions](/assets/images/docs/tools/devtools/memory_navigate_inspect.png)
+![Two Tabs Memory Actions]({{site.url}}/assets/images/docs/tools/devtools/memory_navigate_inspect.png)
 
 ## Snapshots
 
-![The Snapshot button](/assets/images/docs/tools/devtools/memory_snapshot.png)
+![The Snapshot button]({{site.url}}/assets/images/docs/tools/devtools/memory_snapshot.png)
 
 Clicking the **Snapshot** button shows the current state of the heap with regard
 to all active classes and their instances. 
 
-![Screenshot of the Snapshot classes](/assets/images/docs/tools/devtools/memory_snapshot_tree.png)
+![Screenshot of the Snapshot classes]({{site.url}}/assets/images/docs/tools/devtools/memory_snapshot_tree.png)
 
 This pane shows classes allocated in the heap, all instances for a class,
 and the ability to inspect a particular instance.
@@ -560,7 +560,7 @@ Expanding a class displays the active instances for that class.
 Clicking on an particular instance displays the type and value of
 the fields for that instance.
 
-![Screenshot of the inspecting an instance](/assets/images/docs/tools/devtools/memory_inspector.png)
+![Screenshot of the inspecting an instance]({{site.url}}/assets/images/docs/tools/devtools/memory_inspector.png)
 
 ## Analysis of a snapshot
 
@@ -568,7 +568,7 @@ Every snapshot creates a corresponding Analyzed entry under the
 Analysis node (the Analyzed date/time corresponds to the matching
 Snapshot date/time).
 
-![Screenshot of a Snapshot Analysis](/assets/images/docs/tools/devtools/memory_analysis.png)
+![Screenshot of a Snapshot Analysis]({{site.url}}/assets/images/docs/tools/devtools/memory_analysis.png)
 
 Currently, Analysis looks for common problems with images e.g.,
 loading large files instead of scaled thumbnails, not using a
@@ -603,7 +603,7 @@ tracking should be used sparingly.
 
 ### Allocation actions
 
-![Screenshot of a memory actions](/assets/images/docs/tools/devtools/memory_allocations_actions.png)
+![Screenshot of a memory actions]({{site.url}}/assets/images/docs/tools/devtools/memory_allocations_actions.png)
 
 <dl markdown="1">
 <dt markdown="1">**Track**</dt>
@@ -636,7 +636,7 @@ tracking should be used sparingly.
 Allocations are displayed in a table view of each class available to
 the connected application:
 
-![Two Tabs Memory Actions](/assets/images/docs/tools/devtools/memory_allocations_overview.png)
+![Two Tabs Memory Actions]({{site.url}}/assets/images/docs/tools/devtools/memory_allocations_overview.png)
 
 Each row displays the class name the number of instances and bytes
 allocated with deltas (accumulators since last reset).
@@ -676,7 +676,7 @@ For more information see [Allocation Tracking](#allocation-tracking).
 
 ### Managing the objects and statistics in the heap (Monitor Allocations)
 
-![The Monitor Allocations button](/assets/images/docs/tools/devtools/memory_monitor_allocations.png)
+![The Monitor Allocations button]({{site.url}}/assets/images/docs/tools/devtools/memory_monitor_allocations.png)
 
 Clicking the allocation **Track** button monitors the total
 number of instances and total number of bytes allocated for a class.
@@ -685,7 +685,7 @@ allocated these accumulators can be reset, to zero, by user action
 (pressing the Reset Accumulators button).  The mechanism is useful
 to find memory leaks.
 
-![Reset Accumulators button](/assets/images/docs/tools/devtools/memory_reset.png)
+![Reset Accumulators button]({{site.url}}/assets/images/docs/tools/devtools/memory_reset.png)
 
 When the **Reset** button is pressed, the accumulators for all classes
 resets to zero. When reset is occurs a "monitor reset" event to the
@@ -718,7 +718,7 @@ for all instances of a class, a stack trace can be recorded when a
 class's constructor is called to help narrow where allocations might
 be astray. To do this enable the Track checkbox for a class e.g.,
 
-![Enable Stack Trace Tracking](/assets/images/docs/tools/devtools/memory_enable_stacktrace.png)
+![Enable Stack Trace Tracking]({{site.url}}/assets/images/docs/tools/devtools/memory_enable_stacktrace.png)
 
 Interact with your application then when you want to view the
 instances allocation press the "Track" button again. This will
@@ -726,12 +726,12 @@ update the count for the instances being tracked e.g., 118 in the
 below figure. Expanding the instances tracked will display all the
 instances and timestamp when each instance was created e.g.,
 
-![Class Tracking](/assets/images/docs/tools/devtools/memory_tracking.png)
+![Class Tracking]({{site.url}}/assets/images/docs/tools/devtools/memory_tracking.png)
 
 Selecting an instance will display the call stack at the time the
 class's constructor (allocated) was called e.g.,
 
-![Call Stack](/assets/images/docs/tools/devtools/memory_tracking_callstack.png)
+![Call Stack]({{site.url}}/assets/images/docs/tools/devtools/memory_tracking_callstack.png)
 
 ## Filtering, Searching and Auto-Complete
 
@@ -757,16 +757,16 @@ Pressing a keystroke when auto-complete is visible:
 </dd>
 </dl>
 
-![Searching](/assets/images/docs/tools/devtools/memory_search_1.png)
+![Searching]({{site.url}}/assets/images/docs/tools/devtools/memory_search_1.png)
 
 Typing more characters would narrow down the possible class names e.g., typing
 **Obje** displays:
 
-![Narrower Search](/assets/images/docs/tools/devtools/memory_search_2.png)
+![Narrower Search]({{site.url}}/assets/images/docs/tools/devtools/memory_search_2.png)
 
 Finally, typing **ObjectW** displays the exact match:
 
-![Narrowed Search](/assets/images/docs/tools/devtools/memory_search_3.png)
+![Narrowed Search]({{site.url}}/assets/images/docs/tools/devtools/memory_search_3.png)
 
 ### Filtering
 
@@ -774,7 +774,7 @@ Filtering is used to move libraries and classes from the main list (tables)
 to a Filter group to help reduce the number of classes visible that are
 less important while profiling memory.
 
-![Filtering](/assets/images/docs/tools/devtools/memory_filtering.png)
+![Filtering]({{site.url}}/assets/images/docs/tools/devtools/memory_filtering.png)
 
 <dl markdown="1">
 <dt markdown="1">**Hide Private Classes**</dt>
@@ -798,7 +798,7 @@ less important while profiling memory.
 
 The Memory profiler has a specific settings dialog:
 
-![Settings](/assets/images/docs/tools/devtools/memory_settings.png)
+![Settings]({{site.url}}/assets/images/docs/tools/devtools/memory_settings.png)
 
 <dl markdown="1">
 <dt markdown="1">**Collect Android Memory Statistics using ADB**</dt>
@@ -874,14 +874,14 @@ understand how your application uses memory.
 </dd>
 </dl>
 
-[architecture]: /resources/architectural-overview
-[performance]: /development/tools/devtools/performance
+[architecture]: {{site.url}}/resources/architectural-overview
+[performance]: {{site.url}}/development/tools/devtools/performance
 [server]: https://dart-lang.github.io/server/server.html
 [embedder]: {{site.repo.flutter}}/wiki/Custom-Flutter-Engine-Embedders
 [vm]: https://mrale.ph/dartvm/
 [event-loop]: {{site.dart-site}}/articles/archive/event-loop
-[profile mode]: /testing/build-modes#profile
-[release mode]: /testing/build-modes#release
-[debug mode]: /testing/build-modes#debug
+[profile mode]: {{site.url}}/testing/build-modes#profile
+[release mode]: {{site.url}}/testing/build-modes#release
+[debug mode]: {{site.url}}/testing/build-modes#debug
 [Don't Fear the Garbage Collector]: {{site.flutter-medium}}/flutter-dont-fear-the-garbage-collector-d69b3ff1ca30
 [case_study]: {{site.repo.organization}}/devtools/tree/master/case_study/memory_leaks/images_1

--- a/src/development/tools/devtools/network.md
+++ b/src/development/tools/devtools/network.md
@@ -12,7 +12,7 @@ description: How to use the DevTools network view.
 The network view allows you to inspect HTTP, HTTPS, and web socket traffic from
 your Dart or Flutter application.
 
-![Screenshot of the network screen](/assets/images/docs/tools/devtools/network-screen.png){:width="100%"}
+![Screenshot of the network screen]({{site.url}}/assets/images/docs/tools/devtools/network-screen.png){:width="100%"}
 
 ## How to use it
 
@@ -29,12 +29,12 @@ of response and request headers and bodies.
 You can use the search and filter controls to find a specific request or filter
 requests out of the request table.
 
-![Screenshot of the network screen](/assets/images/docs/tools/devtools/network-search-and-filter.png)
+![Screenshot of the network screen]({{site.url}}/assets/images/docs/tools/devtools/network-search-and-filter.png)
 
 To apply a filter, press the filter button (right of the search bar). You will
 see a filter dialog pop up:
 
-![Screenshot of the network screen](/assets/images/docs/tools/devtools/network-filter-dialog.png)
+![Screenshot of the network screen]({{site.url}}/assets/images/docs/tools/devtools/network-filter-dialog.png)
 
 The filter query syntax is described in the dialog. You can filter network
 requests by the following keys:
@@ -60,4 +60,4 @@ asynchronous timeline events. Viewing network activity in the timeline can be
 useful if you want to see how HTTP traffic aligns with other events happening
 in your app or in the Flutter framework.
 
-[timeline]: /development/tools/devtools/performance#timeline-events-chart
+[timeline]: {{site.url}}/development/tools/devtools/performance#timeline-events-chart

--- a/src/development/tools/devtools/overview.md
+++ b/src/development/tools/devtools/overview.md
@@ -8,7 +8,7 @@ description: How to use the DevTools with Flutter.
 DevTools is a suite of performance and debugging tools
 for Dart and Flutter.
 
-![Dart DevTools Screens](/assets/images/docs/tools/devtools/dart-devtools.gif){:width="100%"}
+![Dart DevTools Screens]({{site.url}}/assets/images/docs/tools/devtools/dart-devtools.gif){:width="100%"}
 
 ## What can I do with DevTools?
 
@@ -49,9 +49,9 @@ in particular, its list of [other resources][].
 For more information on using DevTools with Dart command-line apps, see the 
 [DevTools documentation on dart.dev]({{site.dart-site}}/tools/dart-devtools).
 
-[Android Studio/IntelliJ]: /development/tools/devtools/android-studio
-[VS Code]: /development/tools/devtools/vscode
-[command line]: /development/tools/devtools/cli
+[Android Studio/IntelliJ]: {{site.url}}/development/tools/devtools/android-studio
+[VS Code]: {{site.url}}/development/tools/devtools/vscode
+[command line]: {{site.url}}/development/tools/devtools/cli
 [DevTools issue tracker]: {{site.github}}/flutter/devtools/issues
-[Debugging]: /testing/debugging
-[Other resources]: /testing/debugging#other-resources
+[Debugging]: {{site.url}}/testing/debugging
+[Other resources]: {{site.url}}/testing/debugging#other-resources

--- a/src/development/tools/devtools/performance.md
+++ b/src/development/tools/devtools/performance.md
@@ -35,13 +35,13 @@ highlight the different portions of work that occur when rendering a Flutter
 frame: work from the UI thread and work from the raster thread (previously known
 as the GPU thread).
 
-![Screenshot from a performance snapshot](/assets/images/docs/tools/devtools/performance-flutter-frames-chart.png){:width="100%"}
+![Screenshot from a performance snapshot]({{site.url}}/assets/images/docs/tools/devtools/performance-flutter-frames-chart.png){:width="100%"}
 
 Selecting a bar from this chart centers the flame chart below on the timeline
 events corresponding to the selected Flutter frame. The events are highlighted
 with blue brackets.
 
-![Screenshot from a timeline recording](/assets/images/docs/tools/devtools/performance-timeline-events-chart-selected-frame.png){:width="100%"}
+![Screenshot from a timeline recording]({{site.url}}/assets/images/docs/tools/devtools/performance-timeline-events-chart-selected-frame.png){:width="100%"}
 
 ### UI
 
@@ -96,7 +96,7 @@ dart:developer
 and [TimelineTask]({{site.api}}/flutter/dart-developer/TimelineTask-class.html)
 APIs.
 
-![Screenshot of timeline events for a frame](/assets/images/docs/tools/devtools/performance-timeline-events-chart.png){:width="100%"}
+![Screenshot of timeline events for a frame]({{site.url}}/assets/images/docs/tools/devtools/performance-timeline-events-chart.png){:width="100%"}
 
 The flame chart supports zooming and panning:
 * To zoom, scroll up and down with the mouse wheel / trackpad
@@ -121,6 +121,6 @@ supports importing files that were originally exported from DevTools.**
 
 
 [generate timeline events]: {{site.developers}}/web/tools/chrome-devtools/evaluate-performance/performance-reference
-[GPU graph]: /perf/rendering/ui-performance#identifying-problems-in-the-gpu-graph
-[Flutter performance profiling]: /perf/rendering/ui-performance
+[GPU graph]: {{site.url}}/perf/rendering/ui-performance#identifying-problems-in-the-gpu-graph
+[Flutter performance profiling]: {{site.url}}/perf/rendering/ui-performance
 [Import and export]: #import-and-export

--- a/src/development/tools/devtools/vscode.md
+++ b/src/development/tools/devtools/vscode.md
@@ -21,25 +21,25 @@ Once the debug session is active and the application has started,
 the **Dart: Open DevTools** command becomes available in the
 VS Code command palette:
 
-![Screenshot showing Open DevTools command](/assets/images/docs/tools/vs-code/vscode_command.png){:width="100%"}
+![Screenshot showing Open DevTools command]({{site.url}}/assets/images/docs/tools/vs-code/vscode_command.png){:width="100%"}
 
 The first time you run this (and subsequently when the DevTools package
 is updated), you are prompted to activate or upgrade DevTools.
 
-![Screenshot showing Active DevTools command](/assets/images/docs/tools/vs-code/vscode_install_prompt.png){:width="100%"}
+![Screenshot showing Active DevTools command]({{site.url}}/assets/images/docs/tools/vs-code/vscode_install_prompt.png){:width="100%"}
 
 Clicking the **Open** button uses `pub global activate` to activate
 the DevTools package for you. Next, DevTools launches in your browser and
 automatically connects to your debug session.
 
-![Screenshot showing DevTools in a browser](/assets/images/docs/tools/vs-code/vscode_show_in_browser.png){:width="100%"}
+![Screenshot showing DevTools in a browser]({{site.url}}/assets/images/docs/tools/vs-code/vscode_show_in_browser.png){:width="100%"}
 
 While DevTools is active, you'll see them in the status bar
 of VS Code. If you've closed the browser tab,
 you can click the status bar to re-launch your browser, so long
 as there's still a suitable Dart/Flutter debugging session available.
 
-![Screenshot showing DevTools in the VS Code status bar](/assets/images/docs/tools/vs-code/vscode_status_bar.png){:width="100%"}
+![Screenshot showing DevTools in the VS Code status bar]({{site.url}}/assets/images/docs/tools/vs-code/vscode_status_bar.png){:width="100%"}
 
 [Dart extension]: https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code
 [Flutter extension]: https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter

--- a/src/development/tools/flutter-fix.md
+++ b/src/development/tools/flutter-fix.md
@@ -28,7 +28,7 @@ Clicking the light bulb displays the suggested fix
 that updates that code to the new API.
 Clicking the suggested fix performs the update.
 
-![Screenshot showing suggested change in IntelliJ](/assets/images/docs/development/tools/flutter-fix-suggestion-intellij.png)<br>
+![Screenshot showing suggested change in IntelliJ]({{site.url}}/assets/images/docs/development/tools/flutter-fix-suggestion-intellij.png)<br>
 A sample quick-fix in IntelliJ
 
 ### VS Code
@@ -51,7 +51,7 @@ You can do any of the following:
   This shows a list of all actions, including
   refactors.
 
-![Screenshot showing suggested change in VS Code](/assets/images/docs/development/tools/flutter-fix-suggestion-vscode.png)<br>
+![Screenshot showing suggested change in VS Code]({{site.url}}/assets/images/docs/development/tools/flutter-fix-suggestion-vscode.png)<br>
 A sample code action in VS Code
 
 ## Applying project-wide fixes

--- a/src/development/tools/formatting.md
+++ b/src/development/tools/formatting.md
@@ -15,7 +15,7 @@ where time might be better spent on code behavior rather than code style.
 
 ## Automatically formatting code in Android Studio and IntelliJ
 
-Install the `Dart` plugin (see [Editor setup](/get-started/editor))
+Install the `Dart` plugin (see [Editor setup]({{site.url}}/get-started/editor))
 to get automatic formatting of code in Android Studio and IntelliJ.
 To automatically format your code in the current source code window,
 use `Cmd+Alt+L` (on Mac) or `Ctrl+Alt+L` (on Windows and Linux).
@@ -25,7 +25,7 @@ which will format the current file automatically when you save it.
 
 ## Automatically formatting code in VS Code
 
-Install the `Flutter` extension (see [Editor setup](/get-started/editor))
+Install the `Flutter` extension (see [Editor setup]({{site.url}}/get-started/editor))
 to get automatic formatting of code in VS Code.
 
 To automatically format the code in the current source code window,
@@ -58,8 +58,8 @@ amount of line breaks for Flutter-style code.
 
 Here is an example of automatically formatted code *with* trailing commas:
 
-![Automatically formatted code with trailing commas](/assets/images/docs/tools/android-studio/trailing-comma-with.png){:width="100%"}
+![Automatically formatted code with trailing commas]({{site.url}}/assets/images/docs/tools/android-studio/trailing-comma-with.png){:width="100%"}
 
 And the same code automatically formatted code *without* trailing commas:
 
-![Automatically formatted code without trailing commas](/assets/images/docs/tools/android-studio/trailing-comma-without.png){:width="100%"}
+![Automatically formatted code without trailing commas]({{site.url}}/assets/images/docs/tools/android-studio/trailing-comma-without.png){:width="100%"}

--- a/src/development/tools/hot-reload.md
+++ b/src/development/tools/hot-reload.md
@@ -65,7 +65,7 @@ the hot reload command. The code updates and execution continues.
   hot reload.
 {{site.alert.end}}
 
-![Android Studio UI](/assets/images/docs/development/tools/android-studio-run-controls.png){:width="100%"}<br>
+![Android Studio UI]({{site.url}}/assets/images/docs/development/tools/android-studio-run-controls.png){:width="100%"}<br>
 Controls for run, run debug, hot reload, and hot restart in Android Studio
 
 A code change has a visible effect only if the modified
@@ -361,6 +361,6 @@ widgets and render objects.
 
 [const-new]: https://news.dartlang.org/2012/06/const-static-final-oh-my.html
 [Dart Virtual Machine (VM)]: {{site.dart-site}}/overview#platform
-[Flutter editor]: /get-started/editor
+[Flutter editor]: {{site.url}}/get-started/editor
 [Issue 43574]: {{site.repo.flutter}}/issues/43574
 [kernel files]: {{site.github}}/dart-lang/sdk/tree/master/pkg/kernel

--- a/src/development/tools/pubspec.md
+++ b/src/development/tools/pubspec.md
@@ -116,9 +116,9 @@ dependencies, see the
 [asset images in package dependencies][]
 section in the same page.
 
-[Assets and images]: /development/ui/assets-and-images
-[asset images in package dependencies]: /development/ui/assets-and-images#from-packages
-[resolution aware]: /development/ui/assets-and-images#resolution-aware
+[Assets and images]: {{site.url}}/development/ui/assets-and-images
+[asset images in package dependencies]: {{site.url}}/development/ui/assets-and-images#from-packages
+[resolution aware]: {{site.url}}/development/ui/assets-and-images#resolution-aware
 
 ## Fonts
 
@@ -133,9 +133,9 @@ see the [Use a custom font][] and
 [Export fonts from a package][] recipes in the
 [Flutter cookbook][].
 
-[Export fonts from a package]: /cookbook/design/package-fonts
-[Flutter cookbook]: /cookbook
-[Use a custom font]: /cookbook/design/fonts
+[Export fonts from a package]: {{site.url}}/cookbook/design/package-fonts
+[Flutter cookbook]: {{site.url}}/cookbook
+[Use a custom font]: {{site.url}}/cookbook/design/fonts
 
 ## More information
 
@@ -149,9 +149,9 @@ and pubspec files, see the following:
 * [What not to commit][] on dart.dev
 
 [Creating packages]: {{site.dart-site}}/guides/libraries/create-library-packages
-[Developing packages and plugins]: /development/packages-and-plugins/developing-packages
-[Federated plugins]: /development/packages-and-plugins/developing-packages#federated-plugins
+[Developing packages and plugins]: {{site.url}}/development/packages-and-plugins/developing-packages
+[Federated plugins]: {{site.url}}/development/packages-and-plugins/developing-packages#federated-plugins
 [Glossary of package terms]: {{site.dart-site}}/tools/pub/glossary
 [Package dependencies]: {{site.dart-site}}/tools/pub/dependencies
-[Using packages]: /development/packages-and-plugins/using-packages
+[Using packages]: {{site.url}}/development/packages-and-plugins/using-packages
 [What not to commit]: {{site.dart-site}}/guides/libraries/private-files#pubspeclock

--- a/src/development/tools/sdk/overview.md
+++ b/src/development/tools/sdk/overview.md
@@ -34,9 +34,9 @@ The [`flutter` CLI tool][] (`flutter/bin/flutter`) is how developers (or IDEs on
 
 The [`dart` CLI tool][] is available with the Flutter SDK at `flutter/bin/dart`.
 
-[Dart DevTools]: /development/tools/devtools
+[Dart DevTools]: {{site.url}}/development/tools/devtools
 [Dart SDK]: {{site.dart-site}}/tools/sdk
 [`dart` CLI tool]: {{site.dart-site}}/tools/dart-tool
-[`flutter` CLI tool]: /reference/flutter-cli
-[Install]: /get-started/install
+[`flutter` CLI tool]: {{site.url}}/reference/flutter-cli
+[Install]: {{site.url}}/get-started/install
 [README file]: {{site.repo.flutter}}/blob/master/README.md

--- a/src/development/tools/sdk/release-notes/index.md
+++ b/src/development/tools/sdk/release-notes/index.md
@@ -37,18 +37,18 @@ releases to the stable channel.
   * [Archived release notes][]
 
 [2.5.0 announcement]: {{site.flutter-medium}}/whats-new-in-flutter-2-5-6f080c3f3dc
-[2.5.0 release notes & change log]: /development/tools/sdk/release-notes/release-notes-2.5.0
+[2.5.0 release notes & change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-2.5.0
 [2.2.0 announcement]: {{site.flutter-medium}}/whats-new-in-flutter-2-2-fd00c65e2039
-[2.2.0 release notes & change log]: /development/tools/sdk/release-notes/release-notes-2.2.0
+[2.2.0 release notes & change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-2.2.0
 [2.0.0 announcement]: {{site.flutter-medium}}/whats-new-in-flutter-2-0-fe8e95ecc65
-[2.0.0 release notes & change log]: /development/tools/sdk/release-notes/release-notes-2.0.0
+[2.0.0 release notes & change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-2.0.0
 [1.22.0 announcement]: {{site.flutter-medium}}/announcing-flutter-1-22-stable-44f146009e5f
-[1.22.0 release notes & change log]: /development/tools/sdk/release-notes/release-notes-1.22.0
+[1.22.0 release notes & change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-1.22.0
 [1.20.0 announcement]: {{site.flutter-medium}}/announcing-flutter-1-20-2aaf68c89c75
-[1.20.0 release notes & change log]: /development/tools/sdk/release-notes/release-notes-1.20.0
+[1.20.0 release notes & change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-1.20.0
 [1.17.0 announcement]: {{site.flutter-medium}}/announcing-flutter-1-17-4182d8af7f8e
-[1.17.0 release notes and change log]: /development/tools/sdk/release-notes/release-notes-1.17.0
+[1.17.0 release notes and change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-1.17.0
 [1.12.13 announcement]: {{site.flutter-medium}}/announcing-flutter-1-12-what-a-year-22c256ba525d
-[1.12.13 release notes and change log]: /development/tools/sdk/release-notes/release-notes-1.12.13
-[Archived release notes]: /development/tools/sdk/release-notes/release-notes-archive
+[1.12.13 release notes and change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-1.12.13
+[Archived release notes]: {{site.url}}/development/tools/sdk/release-notes/release-notes-archive
 [Hotfixes to the Stable Channel]: {{site.repo.flutter}}/wiki/Hotfixes-to-the-Stable-Channel

--- a/src/development/tools/sdk/release-notes/release-notes-1.12.13.md
+++ b/src/development/tools/sdk/release-notes/release-notes-1.12.13.md
@@ -398,7 +398,7 @@ In this release, we’ve merged a list of changes to support Android 10, includi
 
 ## Add to App feature
 
-We’ve made a significant upgrade to Add-to-App, the feature that allows you to integrate a Flutter module into your Android or iOS app. Can’t wait to try it? Check out the [Add-to-App documentation](/development/add-to-app). 
+We’ve made a significant upgrade to Add-to-App, the feature that allows you to integrate a Flutter module into your Android or iOS app. Can’t wait to try it? Check out the [Add-to-App documentation]({{site.url}}/development/add-to-app). 
 
 [41666](https://github.com/flutter/flutter/pull/41666) Generate projects using the new Android embedding
 
@@ -2972,7 +2972,7 @@ In addition to the PRs listed below, please also check out the following release
 
 ## Full PR List
 
- See the [full list](/development/tools/sdk/release-notes/changelogs/changelog-1.12.13) of merged PRs for the 1.12 release.
+ See the [full list]({{site.url}}/development/tools/sdk/release-notes/changelogs/changelog-1.12.13) of merged PRs for the 1.12 release.
 
 
 [breaking change policy on the Flutter wiki]: {{site.github}}/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes

--- a/src/development/tools/sdk/release-notes/release-notes-1.2.1.md
+++ b/src/development/tools/sdk/release-notes/release-notes-1.2.1.md
@@ -286,6 +286,6 @@ In addition to Flutter framework changes in the 1.2 release, we've made a number
 
 ## Full Issue List
 
-You can see [the full list of PRs committed in this release](/development/tools/sdk/release-notes/changelogs/changelog-1.2.1).
+You can see [the full list of PRs committed in this release]({{site.url}}/development/tools/sdk/release-notes/changelogs/changelog-1.2.1).
 
 [Android App Bundles]: https://developer.android.com/guide/app-bundle/

--- a/src/development/tools/sdk/release-notes/release-notes-1.5.4.md
+++ b/src/development/tools/sdk/release-notes/release-notes-1.5.4.md
@@ -253,4 +253,4 @@ As a final note, we’re nearly at the midpoint of the year, when it’s time to
 
 ## Full Issue List
 
-You can see [the full list of PRs committed in this release](/development/tools/sdk/release-notes/changelogs/changelog-1.5.4).
+You can see [the full list of PRs committed in this release]({{site.url}}/development/tools/sdk/release-notes/changelogs/changelog-1.5.4).

--- a/src/development/tools/sdk/release-notes/release-notes-1.7.8.md
+++ b/src/development/tools/sdk/release-notes/release-notes-1.7.8.md
@@ -359,4 +359,4 @@ Last but not least, we continue to polish and simplify our tooling as well, incl
 
 ## Full Issue List
 
-You can see the full list of issues addressed in this release [here](/development/tools/sdk/release-notes/changelogs/changelog-1.7.8).
+You can see the full list of issues addressed in this release [here]({{site.url}}/development/tools/sdk/release-notes/changelogs/changelog-1.7.8).

--- a/src/development/tools/sdk/release-notes/release-notes-1.9.1.md
+++ b/src/development/tools/sdk/release-notes/release-notes-1.9.1.md
@@ -1239,4 +1239,4 @@ In addition, this release also has a lot going on under the hood to provide you 
 
 ## Full PR List
 
-You can see the full list of merged PRs in this release [here](/development/tools/sdk/release-notes/changelogs/changelog-1.9.1).
+You can see the full list of merged PRs in this release [here]({{site.url}}/development/tools/sdk/release-notes/changelogs/changelog-1.9.1).

--- a/src/development/tools/sdk/release-notes/supported-platforms.md
+++ b/src/development/tools/sdk/release-notes/supported-platforms.md
@@ -89,7 +89,7 @@ minimal.
 We have dropped iOS8 support. For more information,
 see [go/rfc-ios8-deprecation] for details.
 
-[go/rfc-ios8-deprecation]: /go/rfc-ios8-deprecation
+[go/rfc-ios8-deprecation]: {{site.url}}/go/rfc-ios8-deprecation
 
 ### Unsupported platforms
 

--- a/src/development/tools/sdk/upgrading.md
+++ b/src/development/tools/sdk/upgrading.md
@@ -84,7 +84,7 @@ You can also ask questions on the [Flutter dev mailing list][flutter-dev].
 Aside from subscribing to receive announcements,
 we'd love to hear from you!
 
-[Flutter SDK releases]: /development/tools/sdk/releases
+[Flutter SDK releases]: {{site.url}}/development/tools/sdk/releases
 [release channels]: {{site.repo.flutter}}/wiki/Flutter-build-release-channels
 [flutter-announce]: {{site.groups}}/forum/#!forum/flutter-announce
 [flutter-dev]: {{site.groups}}/forum/#!forum/flutter-dev

--- a/src/development/tools/vs-code.md
+++ b/src/development/tools/vs-code.md
@@ -72,7 +72,7 @@ enables the following:
   (**View > Problems** or `Ctrl`+`Shift`+`M`
   (`Cmd`+`Shift`+`M` on macOS))
   Any analysis issues are shown in the Problems pane:<br>
-  ![Problems pane](/assets/images/docs/tools/vs-code/problems.png){:.mw-100.pt-1}
+  ![Problems pane]({{site.url}}/assets/images/docs/tools/vs-code/problems.png){:.mw-100.pt-1}
 
 ## Running and debugging
 
@@ -134,7 +134,7 @@ running or debugging.
  1. Click **Run > Start Without Debugging** in the
     main IDE window, or press `Ctrl`+`F5`.
     The status bar turns orange to show you are in a debug session.<br>
-    ![Debug console](/assets/images/docs/tools/vs-code/debug_console.png){:.mw-100.pt-1}
+    ![Debug console]({{site.url}}/assets/images/docs/tools/vs-code/debug_console.png){:.mw-100.pt-1}
 
 ### Run app with breakpoints
 
@@ -196,13 +196,13 @@ When space is limited, the icon is used as the visual
 version of the label.
 
 <dl markdown="1">
-<dt markdown="1"> **Toggle Baseline Painting** ![Baseline painting icon](/assets/images/docs/tools/devtools/paint-baselines-icon.png){:width="20px"}</dt>
+<dt markdown="1"> **Toggle Baseline Painting** ![Baseline painting icon]({{site.url}}/assets/images/docs/tools/devtools/paint-baselines-icon.png){:width="20px"}</dt>
 <dd>Causes each RenderBox to paint a line at each of its baselines.</dd>
-<dt markdown="1"> **Toggle Repaint Rainbow** ![Repaint rainbow icon](/assets/images/docs/tools/devtools/repaint-rainbow-icon.png){:width="20px"}</dt>
+<dt markdown="1"> **Toggle Repaint Rainbow** ![Repaint rainbow icon]({{site.url}}/assets/images/docs/tools/devtools/repaint-rainbow-icon.png){:width="20px"}</dt>
 <dd>Shows rotating colors on layers when repainting.</dd>
-<dt markdown="1">**Toggle Slow Animations** ![Slow animations icon](/assets/images/docs/tools/devtools/slow-animations-icon.png){:width="20px"}</dt>
+<dt markdown="1">**Toggle Slow Animations** ![Slow animations icon]({{site.url}}/assets/images/docs/tools/devtools/slow-animations-icon.png){:width="20px"}</dt>
 <dd>Slows down animations to enable visual inspection.</dd>
-<dt markdown="1">**Toggle Debug Mode Banner** ![Debug mode banner icon](/assets/images/docs/tools/devtools/debug-mode-banner-icon.png){:width="20px"}</dt>
+<dt markdown="1">**Toggle Debug Mode Banner** ![Debug mode banner icon]({{site.url}}/assets/images/docs/tools/devtools/debug-mode-banner-icon.png){:width="20px"}</dt>
 <dd>Hides the debug mode banner even when running a debug build.</dd>
 </dl>
 
@@ -226,7 +226,7 @@ Flutter widget identifier, as indicated by the yellow lightbulb icon.
 The assist can be invoked by clicking the lightbulb, or by using the
 keyboard shortcut `Ctrl`+`.` (`Cmd`+`.` on Mac), as illustrated here:
 
-![Code assists](/assets/images/docs/tools/vs-code/assists.png){:width="467px"}
+![Code assists]({{site.url}}/assets/images/docs/tools/vs-code/assists.png){:width="467px"}
 
 Quick fixes are similar,
 only they are shown with a piece of code has an error and they
@@ -255,7 +255,7 @@ can assist in correcting it.
 Snippets can be used to speed up entering typical code structures.
 They are invoked by typing their prefix,
 and then selecting from the code completion window:
-![Snippets](/assets/images/docs/tools/vs-code/snippets.png){:width="100%"}
+![Snippets]({{site.url}}/assets/images/docs/tools/vs-code/snippets.png){:width="100%"}
 
 The Flutter extension includes the following snippets:
 
@@ -315,12 +315,12 @@ Prior to filing new issues:
 When filing new issues, include [flutter doctor][] output.
 
 [Command Palette]: https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette
-[DevTools]: /development/tools/devtools
-[flutter doctor]: /resources/bug-reports/#provide-some-flutter-diagnostics
-[Flutter inspector]: /development/tools/devtools/inspector
-[Flutter's build modes]: /testing/build-modes
+[DevTools]: {{site.url}}/development/tools/devtools
+[flutter doctor]: {{site.url}}/resources/bug-reports/#provide-some-flutter-diagnostics
+[Flutter inspector]: {{site.url}}/development/tools/devtools/inspector
+[Flutter's build modes]: {{site.url}}/testing/build-modes
 [let us know]: {{site.repo.this}}/issues/new
 [issue tracker]: {{site.github}}/Dart-Code/Dart-Code/issues
-[Running DevTools from VS Code]: /development/tools/devtools/vscode
-[Set up an editor]: /get-started/editor?tab=vscode
-[VS Code status bar]: /assets/images/docs/tools/vs-code/device_status_bar.png
+[Running DevTools from VS Code]: {{site.url}}/development/tools/devtools/vscode
+[Set up an editor]: {{site.url}}/get-started/editor?tab=vscode
+[VS Code status bar]: {{site.url}}/assets/images/docs/tools/vs-code/device_status_bar.png

--- a/src/development/ui/advanced/actions_and_shortcuts.md
+++ b/src/development/ui/advanced/actions_and_shortcuts.md
@@ -618,4 +618,4 @@ void main() => runApp(const MyApp());
 [`CallbackShortcuts`]: {{site.master-api}}/flutter/widgets/CallbackShortcuts-class.html
 [`Intent`]: {{site.api}}/flutter/widgets/Intent-class.html
 [`Shortcuts`]: {{site.api}}/flutter/widgets/Shortcuts-class.html
-[Using Shortcuts Diagram]: /assets/images/docs/using_shortcuts.png
+[Using Shortcuts Diagram]: {{site.url}}/assets/images/docs/using_shortcuts.png

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -204,7 +204,7 @@ instead remove usage of these APIs.
 
 [Android Splash Screens]: {{site.android-dev}}/about/versions/12/features/splash-screen
 [launch screen]: {{site.android-dev}}/topic/performance/vitals/launch-time#themed
-[pre-warming a `FlutterEngine`]: /development/add-to-app/android/add-flutter-fragment#using-a-pre-warmed-flutterengine
+[pre-warming a `FlutterEngine`]: {{site.url}}/development/add-to-app/android/add-flutter-fragment#using-a-pre-warmed-flutterengine
 [`provideSplashScreen`]: {{site.api}}/javadoc/io/flutter/embedding/android/SplashScreenProvider.html#provideSplashScreen--
 [must use an Xcode storyboard]: {{site.apple-dev}}/news/?id=03042020b
 [Human Interface Guidelines]: {{site.apple-dev}}/design/human-interface-guidelines/ios/visual-design/launch-screen/

--- a/src/development/ui/animations/hero-animations.md
+++ b/src/development/ui/animations/hero-animations.md
@@ -652,15 +652,15 @@ Key information:
   The hero's flight path still follows an arc,
   but the image's aspect ratio remains constant.
 
-[Animations in Flutter tutorial]: /development/ui/animations/tutorial
+[Animations in Flutter tutorial]: {{site.url}}/development/ui/animations/tutorial
 [basic_hero_animation]: {{site.repo.this}}/tree/master/examples/_animation/basic_hero_animation/
 [basic_radial_hero_animation]: {{site.repo.this}}/tree/master/examples/_animation/basic_radial_hero_animation
-[Building Layouts in Flutter]: /development/ui/layout
+[Building Layouts in Flutter]: {{site.url}}/development/ui/layout
 [`ClipOval`]: {{site.api}}/flutter/widgets/ClipOval-class.html
 [ClipRect]: {{site.api}}/flutter/widgets/ClipRect-class.html
-[Create a new Flutter example]: /get-started/test-drive
+[Create a new Flutter example]: {{site.url}}/get-started/test-drive
 [`createRectTween`]: {{site.api}}/flutter/widgets/CreateRectTween.html
-[`debugPaintSizeEnabled`]: /testing/code-debugging#debug-flags-layout
+[`debugPaintSizeEnabled`]: {{site.url}}/testing/code-debugging#debug-flags-layout
 [`Hero`]: {{site.api}}/flutter/widgets/Hero-class.html
 [hero_animation]: {{site.repo.this}}/tree/master/examples/_animation/hero_animation/
 [`Inkwell`]: {{site.api}}/flutter/material/InkWell-class.html
@@ -674,7 +674,7 @@ Key information:
 [Radial hero animations]: #radial-hero-animations
 [Radial transformation]: https://web.archive.org/web/20180223140424/https://material.io/guidelines/motion/transforming-material.html
 [`RectTween`]: {{site.api}}/flutter/animation/RectTween-class.html
-[_Route_]: /cookbook/navigation/navigation-basics
+[_Route_]: {{site.url}}/cookbook/navigation/navigation-basics
 [`Route`]: {{site.api}}/flutter/widgets/Route-class.html
 [Standard hero animation code]: #standard-hero-animation-code
 [Tween&lt;Rect&gt;]: {{site.api}}/flutter/animation/Tween-class.html

--- a/src/development/ui/animations/implicit-animations.md
+++ b/src/development/ui/animations/implicit-animations.md
@@ -71,9 +71,9 @@ implicitly animated widgets:
 <iframe width="560" height="315" src="{{site.youtube-site}}/embed/2W7POjFb88g" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
-[`AnimatedContainer` sample]: /cookbook/animation/animated-container
+[`AnimatedContainer` sample]: {{site.url}}/cookbook/animation/animated-container
 [`AnimatedContainer`]: {{site.api}}/flutter/widgets/AnimatedContainer-class.html
 [animation library]: {{site.api}}/flutter/animation/animation-library.html
-[Flutter cookbook]: /cookbook
-[Implicit animations codelab]: /codelabs/implicit-animations
+[Flutter cookbook]: {{site.url}}/cookbook
+[Implicit animations codelab]: {{site.url}}/codelabs/implicit-animations
 [`ImplicitlyAnimatedWidget`]: {{site.api}}/flutter/widgets/ImplicitlyAnimatedWidget-class.html

--- a/src/development/ui/animations/index.md
+++ b/src/development/ui/animations/index.md
@@ -226,19 +226,19 @@ Learn more about Flutter animations at the following links:
   takes you to a technical overview page for the library.
 
 
-[Animate a widget using a physics simulation]: /cookbook/animation/physics-simulation
+[Animate a widget using a physics simulation]: {{site.url}}/cookbook/animation/physics-simulation
 [`AnimatedList` example]: https://flutter.github.io/samples/animations.html
-[Animation and motion widgets]: /development/ui/widgets/animation
+[Animation and motion widgets]: {{site.url}}/development/ui/widgets/animation
 [Animation basics with implicit animations]: {{site.youtube-site}}/watch?v=IVTjpW3W33s&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=1
 [Animation deep dive]: {{site.youtube-site}}/watch?v=PbcILiN8rbo&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=5
 [animation library]: {{site.api}}/flutter/animation/animation-library.html
-[Animation recipes]: /cookbook/animation
+[Animation recipes]: {{site.url}}/cookbook/animation
 [Animation samples]: {{site.github}}/flutter/samples/tree/master/animations#animation-samples
 [Animation videos]: {{site.youtube-site}}/channel/UCwXdFgeE9KYzlDdR7TG9cMw/search?query=animation
 [Animations in Flutter done right]: {{site.youtube-site}}/watch?v=wnARLByOtKA&t=3s
-[Animations: overview]: /development/ui/animations/overview
+[Animations: overview]: {{site.url}}/development/ui/animations/overview
 [animations package]: {{site.pub}}/packages/animations
-[Animations tutorial]: /development/ui/animations/tutorial
+[Animations tutorial]: {{site.url}}/development/ui/animations/tutorial
 [`AnimationController.animateWith`]: {{site.api}}/flutter/animation/AnimationController/animateWith.html
 [article1]: {{site.flutter-medium}}/how-to-choose-which-flutter-animation-widget-is-right-for-you-79ecfb7e72b5
 [article2]: {{site.flutter-medium}}/flutter-animation-basics-with-implicit-animations-95db481c5916
@@ -253,18 +253,18 @@ Learn more about Flutter animations at the following links:
 [Flutter Gallery]: {{site.repo.gallery}}
 [`Grid`]: {{site.repo.gallery}}/blob/master/lib/demos/material/grid_list_demo.dart
 [`Hero`]: {{site.api}}/flutter/widgets/Hero-class.html
-[Hero animations]: /development/ui/animations/hero-animations
+[Hero animations]: {{site.url}}/development/ui/animations/hero-animations
 [How to choose which Flutter Animation Widget is right for you?]: {{site.youtube-site}}/watch?v=GXIJJkq_H8g
-[Implicit animations codelab]: /codelabs/implicit-animations
+[Implicit animations codelab]: {{site.url}}/codelabs/implicit-animations
 [Making your first directional animations with built-in explicit animations]: {{site.youtube-site}}/watch?v=CunyH6unILQ&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=3
-[Material widgets]: /development/ui/widgets/material
+[Material widgets]: {{site.url}}/development/ui/widgets/material
 [`Navigator`]: {{site.api}}/flutter/widgets/Navigator-class.html
 [`PageRoute`]: {{site.api}}/flutter/widgets/PageRoute-class.html
 [part 2]: {{site.medium}}/dartlang/zero-to-one-with-flutter-part-two-5aa2f06655cb
 [Sample app catalog]: https://flutter.github.io/samples
 [Shrine]: {{site.repo.gallery}}/tree/master/lib/studies/shrine
 [`SpringSimulation`]: {{site.api}}/flutter/physics/SpringSimulation-class.html
-[Staggered Animations]: /development/ui/animations/staggered-animations
+[Staggered Animations]: {{site.url}}/development/ui/animations/staggered-animations
 [Step 7 (Animate your app)]: {{site.codelabs}}/codelabs/flutter/#6
-[Write your first Flutter app on the web]: /get-started/codelab-web
+[Write your first Flutter app on the web]: {{site.url}}/get-started/codelab-web
 [Zero to One with Flutter, part 1]: {{site.medium}}/dartlang/zero-to-one-with-flutter-43b13fd7b354

--- a/src/development/ui/animations/staggered-animations.md
+++ b/src/development/ui/animations/staggered-animations.md
@@ -369,9 +369,9 @@ Package not yet vetted.
 [animation controllers]: {{site.api}}/flutter/animation/AnimationController-class.html
 [`AnimationController`]: {{site.api}}/flutter/animation/AnimationController-class.html
 [`AnimatedBuilder`]: {{site.api}}/flutter/widgets/AnimatedBuilder-class.html
-[Animations in Flutter tutorial]: /development/ui/animations/tutorial
+[Animations in Flutter tutorial]: {{site.url}}/development/ui/animations/tutorial
 [basic_staggered_animation]: {{site.repo.this}}/tree/master/examples/_animation/basic_staggered_animation
-[Building Layouts in Flutter]: /development/ui/layout
+[Building Layouts in Flutter]: {{site.url}}/development/ui/layout
 [staggered_pic_selection]: {{site.repo.this}}/tree/master/examples/_animation/staggered_pic_selection
 [`CurvedAnimation`]: {{site.api}}/flutter/animation/CurvedAnimation-class.html
 [`Curves`]: {{site.api}}/flutter/animation/Curves-class.html

--- a/src/development/ui/animations/tutorial.md
+++ b/src/development/ui/animations/tutorial.md
@@ -965,7 +965,7 @@ for the latest available documents and examples.
 [`Animatable`]: {{site.api}}/flutter/animation/Animatable-class.html
 [`Animation`]: {{site.api}}/flutter/animation/Animation-class.html
 [`AnimatedBuilder`]: {{site.api}}/flutter/widgets/AnimatedBuilder-class.html
-[animations landing page]: /development/ui/animations
+[animations landing page]: {{site.url}}/development/ui/animations
 [`AnimationController`]: {{site.api}}/flutter/animation/AnimationController-class.html
 [`AnimationController` section]: #animationcontroller
 [`Curves`]: {{site.api}}/flutter/animation/Curves-class.html

--- a/src/development/ui/assets-and-images.md
+++ b/src/development/ui/assets-and-images.md
@@ -398,7 +398,7 @@ Updating a Flutter application's launch icon works
 the same way as updating launch icons in native
 Android or iOS applications.
 
-![Launch icon](/assets/images/docs/assets-and-images/icon.png)
+![Launch icon]({{site.url}}/assets/images/docs/assets-and-images/icon.png)
 
 #### Android
 
@@ -409,7 +409,7 @@ images named `ic_launcher.png`. Replace them with your
 desired assets respecting the recommended icon size per
 screen density as indicated by the [Android Developer Guide][].
 
-![Android icon location](/assets/images/docs/assets-and-images/android-icon-path.png)
+![Android icon location]({{site.url}}/assets/images/docs/assets-and-images/android-icon-path.png)
 
 {{site.alert.note}}
   If you rename the `.png` files, you must also update the
@@ -427,7 +427,7 @@ sized images as indicated by their filename as dictated by the
 Apple [Human Interface Guidelines][].
 Keep the original file names.
 
-![iOS icon location](/assets/images/docs/assets-and-images/ios-icon-path.png)
+![iOS icon location]({{site.url}}/assets/images/docs/assets-and-images/ios-icon-path.png)
 
 ### Updating the launch screen
 
@@ -479,14 +479,14 @@ drop in images by opening `Assets.xcassets` or do any
 customization using the Interface Builder in
 `LaunchScreen.storyboard`.
 
-![Adding launch icons in Xcode](/assets/images/docs/assets-and-images/ios-launchscreen-xcode.png){:width="100%"}
+![Adding launch icons in Xcode]({{site.url}}/assets/images/docs/assets-and-images/ios-launchscreen-xcode.png){:width="100%"}
 
 For more details, see
 [Adding a splash screen to your mobile app][].
 
 
-[add-to-app]: /development/add-to-app/ios
-[Adding a splash screen to your mobile app]: /development/ui/advanced/splash-screen
+[add-to-app]: {{site.url}}/development/add-to-app/ios
+[Adding a splash screen to your mobile app]: {{site.url}}/development/ui/advanced/splash-screen
 [`AssetBundle`]: {{site.api}}/flutter/services/AssetBundle-class.html
 [`AssetImage`]: {{site.api}}/flutter/painting/AssetImage-class.html
 [`DefaultAssetBundle`]: {{site.api}}/flutter/widgets/DefaultAssetBundle-class.html
@@ -505,7 +505,7 @@ For more details, see
 [layer list drawable]: {{site.android-dev}}/guide/topics/resources/drawable-resource#LayerList
 [`mainBundle`]: {{site.apple-dev}}/documentation/foundation/nsbundle/1410786-mainbundle
 [`openFd`]: {{site.android-dev}}/reference/android/content/res/AssetManager#openFd(java.lang.String
-[package]: /development/packages-and-plugins/using-packages
+[package]: {{site.url}}/development/packages-and-plugins/using-packages
 [`pathForResource:ofType:`]: {{site.apple-dev}}/documentation/foundation/nsbundle/1410989-pathforresource
 [`PluginRegistry.Registrar`]: {{site.api}}/javadoc/io/flutter/plugin/common/PluginRegistry.Registrar.html
 [`pubspec.yaml`]: {{site.dart-site}}/tools/pub/pubspec

--- a/src/development/ui/interactive.md
+++ b/src/development/ui/interactive.md
@@ -779,34 +779,34 @@ Flutter Gallery [running app][], [repo][]
   stateless widgets.  Presented by Google engineer, Ian Hickson.
 
 
-[Android emulator]: /get-started/install/windows#set-up-the-android-emulator
+[Android emulator]: {{site.url}}/get-started/install/windows#set-up-the-android-emulator
 [`Checkbox`]: {{site.api}}/flutter/material/Checkbox-class.html
 [`Cupertino`]: {{site.api}}/flutter/cupertino/cupertino-library.html
 [Dart language tour]: {{site.dart-site}}/guides/language/language-tour
-[Debugging Flutter apps]: /testing/debugging
+[Debugging Flutter apps]: {{site.url}}/testing/debugging
 [`DropdownButton`]: {{site.api}}/flutter/material/DropdownButton-class.html
 [`TextButton`]: {{site.api}}/flutter/material/TextButton-class.html
 [`FloatingActionButton`]: {{site.api}}/flutter/material/FloatingActionButton-class.html
 [Flutter API documentation]: {{site.api}}
-[Flutter cookbook]: /cookbook
+[Flutter cookbook]: {{site.url}}/cookbook
 [Flutter's Layered Design]: {{site.youtube-site}}/watch?v=dkyY9WCGMi0
 [`FormField`]: {{site.api}}/flutter/widgets/FormField-class.html
 [`Form`]: {{site.api}}/flutter/widgets/Form-class.html
 [`foundation` library]: {{site.api}}/flutter/foundation/foundation-library.html
 [`GestureDetector`]: {{site.api}}/flutter/widgets/GestureDetector-class.html
-[Gestures]: /cookbook/gestures
-[Gestures in Flutter]: /development/ui/advanced/gestures
-[Handling gestures]: /development/ui/widgets-intro#handling-gestures
-[hello-world]: /get-started/codelab#step-1-create-the-starter-flutter-app
+[Gestures]: {{site.url}}/cookbook/gestures
+[Gestures in Flutter]: {{site.url}}/development/ui/advanced/gestures
+[Handling gestures]: {{site.url}}/development/ui/widgets-intro#handling-gestures
+[hello-world]: {{site.url}}/get-started/codelab#step-1-create-the-starter-flutter-app
 [`IconButton`]: {{site.api}}/flutter/material/IconButton-class.html
 [`Icon`]: {{site.api}}/flutter/widgets/Icon-class.html
 [`InkWell`]: {{site.api}}/flutter/material/InkWell-class.html
-[Introduction to widgets]: /development/ui/widgets-intro
-[iOS simulator]: /get-started/install/macos#set-up-the-ios-simulator
-[building layouts tutorial]: /development/ui/layout/tutorial
-[building layouts tutorial (step 6)]: /development/ui/layout/tutorial#step-6-final-touch
+[Introduction to widgets]: {{site.url}}/development/ui/widgets-intro
+[iOS simulator]: {{site.url}}/get-started/install/macos#set-up-the-ios-simulator
+[building layouts tutorial]: {{site.url}}/development/ui/layout/tutorial
+[building layouts tutorial (step 6)]: {{site.url}}/development/ui/layout/tutorial#step-6-final-touch
 [community]: {{site.main-url}}/community
-[Handle taps]: /cookbook/gestures/handling-taps
+[Handle taps]: {{site.url}}/cookbook/gestures/handling-taps
 [`lake.jpg`]: {{examples}}/layout/lakes/step6/images/lake.jpg
 [Libraries and visibility]: {{site.dart-site}}/guides/language/language-tour#libraries-and-visibility
 [`ListView`]: {{site.api}}/flutter/widgets/ListView-class.html
@@ -819,7 +819,7 @@ Flutter Gallery [running app][], [repo][]
 [`ElevatedButton`]: {{site.api}}/flutter/material/ElevatedButton-class.html
 [repo]: {{site.repo.gallery}}
 [running app]: {{site.gallery}}
-[set up]: /get-started/install
+[set up]: {{site.url}}/get-started/install
 [`SizedBox`]: {{site.api}}/flutter/widgets/SizedBox-class.html
 [`Slider`]: {{site.api}}/flutter/material/Slider-class.html
 [`State`]: {{site.api}}/flutter/widgets/State-class.html

--- a/src/development/ui/layout/adaptive-responsive.md
+++ b/src/development/ui/layout/adaptive-responsive.md
@@ -157,11 +157,11 @@ in the following resources:
 
 [Adaptive layouts]: {{site.youtube-site}}/watch?v=n6Awpg1MO6M&t=694s
 [Adaptive layouts, part 2]: {{site.youtube-site}}/watch?v=eikOZzfc0l4&t=11s
-[Building adaptive apps]: /development/ui/layout/building-adaptive-apps
+[Building adaptive apps]: {{site.url}}/development/ui/layout/building-adaptive-apps
 
 [Designing truly adaptive user interfaces]: https://aloisdeniel.com/#/posts/adaptative-ui
 [Flutter gallery app]: {{site.gallery}}
 [Folio source code]: {{site.github}}/gskinnerTeam/flutter-folio
 [gskinner blog]: https://blog.gskinner.com/
-[Platform-specific behaviors and adaptations]: /resources/platform-adaptations
+[Platform-specific behaviors and adaptations]: {{site.url}}/resources/platform-adaptations
 [repo]: {{site.repo.gallery}}

--- a/src/development/ui/layout/box-constraints.md
+++ b/src/development/ui/layout/box-constraints.md
@@ -129,5 +129,5 @@ otherwise they would not be able to reasonably align their children.
 [`ScrollView`]: {{site.api}}/flutter/widgets/ScrollView-class.html
 [`Text`]: {{site.api}}/flutter/widgets/Text-class.html
 [`Transform`]: {{site.api}}/flutter/widgets/Transform-class.html
-[Understanding constraints]: /development/ui/layout/constraints
+[Understanding constraints]: {{site.url}}/development/ui/layout/constraints
 [`double.infinity`]: {{site.api}}/flutter/dart-core/double/infinity-constant.html

--- a/src/development/ui/layout/building-adaptive-apps.md
+++ b/src/development/ui/layout/building-adaptive-apps.md
@@ -121,7 +121,7 @@ To see more available widgets and example code, see
 [`Flow`]: {{site.api}}/flutter/widgets/Flow-class.html
 [`FractionallySizedBox`]: {{site.api}}/flutter/widgets/FractionallySizedBox-class.html
 [`GridView`]: {{site.api}}/flutter/widgets/GridView-class.html
-[Layout widgets]: /development/ui/widgets/layout
+[Layout widgets]: {{site.url}}/development/ui/widgets/layout
 [`LayoutBuilder`]: {{site.api}}/flutter/widgets/LayoutBuilder-class.html
 [`ListView`]: {{site.api}}/flutter/widgets/ListView-class.html
 [`Row`]: {{site.api}}/flutter/widgets/Row-class.html
@@ -146,7 +146,7 @@ are set to 0.0, but you can set the densities to any negative
 or positive value that you want. By switching between different
 densities, you can easily adjust your UI:
 
-![Adaptive scaffold](/assets/images/docs/development/ui/layout/adaptive_scaffold.gif){:width="100%"}
+![Adaptive scaffold]({{site.url}}/assets/images/docs/development/ui/layout/adaptive_scaffold.gif){:width="100%"}
 
 To set a custom visual density, inject the density into
 your `MaterialApp` theme:
@@ -446,7 +446,7 @@ while the app is running to preview various screen sizes.
 This, combined with hot reload, can greatly accelerate the
 development of a responsive UI.
 
-![Adaptive scaffold 2](/assets/images/docs/development/ui/layout/adaptive_scaffold2.gif){:width="100%"}
+![Adaptive scaffold 2]({{site.url}}/assets/images/docs/development/ui/layout/adaptive_scaffold2.gif){:width="100%"}
 
 ### Solve touch first
 
@@ -940,7 +940,7 @@ the title bar of your app window, adding a logo for
 stronger branding or contextual controls to help save
 vertical space in your main UI. 
  
-![Samples of title bars](/assets/images/docs/development/ui/layout/titlebar.png)
+![Samples of title bars]({{site.url}}/assets/images/docs/development/ui/layout/titlebar.png)
 
 This isn't supported directly in Flutter, but you can use the
 [`bits_dojo`][] package to disable the native title bars,
@@ -1051,9 +1051,9 @@ return Row(
 );
 ```
 
-![Sample of embedded image](/assets/images/docs/development/ui/layout/embed_image1.png)
+![Sample of embedded image]({{site.url}}/assets/images/docs/development/ui/layout/embed_image1.png)
 
-![Sample of embedded image](/assets/images/docs/development/ui/layout/embed_image2.png)
+![Sample of embedded image]({{site.url}}/assets/images/docs/development/ui/layout/embed_image2.png)
 
 #### Menu bar
 

--- a/src/development/ui/layout/index.md
+++ b/src/development/ui/layout/index.md
@@ -1227,7 +1227,7 @@ The following resources might help when writing layout code.
 : One person's experience writing his first Flutter app.
 
 
-[Adding assets and images]: /development/ui/assets-and-images
+[Adding assets and images]: {{site.url}}/development/ui/assets-and-images
 [API reference docs]: {{api}}
 [`build()`]: {{api}}/widgets/StatelessWidget/build.html
 [`Card`]: {{api}}/material/Card-class.html
@@ -1238,17 +1238,17 @@ The following resources might help when writing layout code.
 [`Container`]: {{api}}/widgets/Container-class.html
 [`CrossAxisAlignment`]: {{api}}/rendering/CrossAxisAlignment-class.html
 [`DataTable`]: {{api}}/material/DataTable-class.html
-[Dealing with Box Constraints in Flutter]: /development/ui/layout/box-constraints
+[Dealing with Box Constraints in Flutter]: {{site.url}}/development/ui/layout/box-constraints
 [Elevation]: {{site.material}}/design/environment/elevation.html
 [`Expanded`]: {{api}}/widgets/Expanded-class.html
 [Flutter in Focus]: {{site.youtube-site}}/watch?v=wgTBLj7rMPM&list=PLjxrf2q8roU2HdJQDjJzOeO6J3FoFLWr2
 [`GridView`]: {{api}}/widgets/GridView-class.html
 [`GridTile`]: {{api}}/material/GridTile-class.html
-[HTML/CSS Analogs in Flutter]: /get-started/flutter-for/web-devs
+[HTML/CSS Analogs in Flutter]: {{site.url}}/get-started/flutter-for/web-devs
 [`Icon`]: {{api}}/material/Icons-class.html
 [`Image`]: {{api}}/widgets/Image-class.html
-[Layout tutorial]: /development/ui/layout/tutorial
-[layout widgets]: /development/ui/widgets/layout
+[Layout tutorial]: {{site.url}}/development/ui/layout/tutorial
+[layout widgets]: {{site.url}}/development/ui/widgets/layout
 [`ListTile`]: {{api}}/material/ListTile-class.html
 [`ListView`]: {{api}}/widgets/ListView-class.html
 [`MainAxisAlignment`]: {{api}}/rendering/MainAxisAlignment-class.html
@@ -1266,11 +1266,11 @@ The following resources might help when writing layout code.
 [`Stack`]: {{api}}/widgets/Stack-class.html
 [`Table`]: {{api}}/widgets/Table-class.html
 [`Text`]: {{api}}/widgets/Text-class.html
-[tutorial]: /development/ui/layout/tutorial
+[tutorial]: {{site.url}}/development/ui/layout/tutorial
 [widgets library]: {{api}}/widgets/widgets-library.html
-[Widget catalog]: /development/ui/widgets
-[Debugging layout issues visually]: /development/tools/devtools/inspector#debugging-layout-issues-visually
-[Understanding constraints]: /development/ui/layout/constraints
-[Using the Flutter inspector]: /development/tools/devtools/inspector
+[Widget catalog]: {{site.url}}/development/ui/widgets
+[Debugging layout issues visually]: {{site.url}}/development/tools/devtools/inspector#debugging-layout-issues-visually
+[Understanding constraints]: {{site.url}}/development/ui/layout/constraints
+[Using the Flutter inspector]: {{site.url}}/development/tools/devtools/inspector
 [Widget of the Week series]: {{site.youtube-site}}/playlist?list=PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG
 [Zero to One with Flutter]: {{site.medium}}/@mravn/zero-to-one-with-flutter-43b13fd7b354

--- a/src/development/ui/layout/tutorial.md
+++ b/src/development/ui/layout/tutorial.md
@@ -439,15 +439,15 @@ You can add interactivity to this layout by following
 [Adding Interactivity to Your Flutter App][].
 
 
-[Adding Interactivity to Your Flutter App]: /development/ui/interactive
-[automatic reformatting support]: /development/tools/formatting
+[Adding Interactivity to Your Flutter App]: {{site.url}}/development/ui/interactive
+[automatic reformatting support]: {{site.url}}/development/tools/formatting
 [available online]: https://images.unsplash.com/photo-1471115853179-bb1d604434e0?dpr=1&amp;auto=format&amp;fit=crop&amp;w=767&amp;h=583&amp;q=80&amp;cs=tinysrgb&amp;crop=
-[Flutter's approach to layout]: /development/ui/layout
-[hello-world]: /get-started/codelab#step-1-create-the-starter-flutter-app
+[Flutter's approach to layout]: {{site.url}}/development/ui/layout
+[hello-world]: {{site.url}}/get-started/codelab#step-1-create-the-starter-flutter-app
 [images]: {{examples}}/layout/lakes/step6/images
 [`lake.jpg`]: {{rawExFile}}/layout/lakes/step5/images/lake.jpg
 [`lib/main.dart`]: {{examples}}/layout/lakes/step2/lib/main.dart
-[hot reload]: /development/tools/hot-reload
+[hot reload]: {{site.url}}/development/tools/hot-reload
 [`main.dart`]: {{examples}}/layout/lakes/step6/lib/main.dart
 [`pubspec.yaml`]: {{examples}}/layout/lakes/step6/pubspec.yaml
-[set up]: /get-started/install
+[set up]: {{site.url}}/get-started/install

--- a/src/development/ui/navigation/deep-linking.md
+++ b/src/development/ui/navigation/deep-linking.md
@@ -113,7 +113,7 @@ current set of pages when a new deep link is opened while the app is running.
 [Learning Flutter’s new navigation and routing system][] provides an introduction to the Router system.
 
 [Learning Flutter’s new navigation and routing system]: https://medium.com/flutter/learning-flutters-new-navigation-and-routing-system-7c9068155ade
-[switching-channels]: /development/tools/sdk/upgrading#switching-flutter-channels
+[switching-channels]: {{site.url}}/development/tools/sdk/upgrading#switching-flutter-channels
 [routes]: {{site.api}}/flutter/material/MaterialApp/routes.html
 [onGenerateRoute]: {{site.api}}/flutter/material/MaterialApp/onGenerateRoute.html
 [Router]: {{site.api}}/flutter/widgets/Router-class.html
@@ -123,4 +123,4 @@ current set of pages when a new deep link is opened while the app is running.
 [verify-android-links]: {{site.android-dev}}/training/app-links/verify-site-associations
 [router-sample]: {{site.repo.samples}}/tree/master/navigation_and_routing
 
-[configuring the URL strategy]: /development/ui/navigation/url-strategies
+[configuring the URL strategy]: {{site.url}}/development/ui/navigation/url-strategies

--- a/src/development/ui/navigation/index.md
+++ b/src/development/ui/navigation/index.md
@@ -28,9 +28,9 @@ To learn about `Router` and the declarative approach, see [Learning
 Flutter’s new navigation and routing system][], and the [`Router`][]
 API docs.
 
-[Flutter cookbook]: /cookbook
+[Flutter cookbook]: {{site.url}}/cookbook
 [Learning Flutter’s new navigation and routing system]: {{site.flutter-medium}}/learning-flutters-new-navigation-and-routing-system-7c9068155ade
-[Navigation recipes]: /cookbook/navigation
+[Navigation recipes]: {{site.url}}/cookbook/navigation
 [`Navigator`]: {{site.api}}/flutter/widgets/Navigator-class.html
 [`Router`]: {{site.api}}/flutter/widgets/Router-class.html
 [`MaterialApp.routes`]: {{site.api}}/flutter/material/MaterialApp/routes.html

--- a/src/development/ui/widgets-intro.md
+++ b/src/development/ui/widgets-intro.md
@@ -902,17 +902,17 @@ For more information, see the [`GlobalKey`][] API.
 
 
 [`actions`]: {{api}}/material/AppBar-class.html#actions
-[adding interactivity to your Flutter app]: /development/ui/interactive
+[adding interactivity to your Flutter app]: {{site.url}}/development/ui/interactive
 [`AppBar`]: {{api}}/material/AppBar-class.html
-[basic layout codelab]: /codelabs/layout-basics
+[basic layout codelab]: {{site.url}}/codelabs/layout-basics
 [`BoxDecoration`]: {{api}}/painting/BoxDecoration-class.html
 [`build()`]: {{api}}/widgets/StatelessWidget/build.html
-[building layouts]: /development/ui/layout
+[building layouts]: {{site.url}}/development/ui/layout
 [`Center`]: {{api}}/widgets/Center-class.html
 [`Column`]: {{api}}/widgets/Column-class.html
 [`Container`]: {{api}}/widgets/Container-class.html
 [`createState()`]: {{api}}/widgets/StatefulWidget-class.html#createState
-[Cupertino components]: /development/ui/widgets/cupertino
+[Cupertino components]: {{site.url}}/development/ui/widgets/cupertino
 [`CupertinoApp`]: {{api}}/cupertino/CupertinoApp-class.html
 [`CupertinoNavigationBar`]: {{api}}/cupertino/CupertinoNavigationBar-class.html
 [`didUpdateWidget()`]: {{api}}/widgets/State-class.html#didUpdateWidget
@@ -921,16 +921,16 @@ For more information, see the [`GlobalKey`][] API.
 [`final`]: {{site.dart-site}}/guides/language/language-tour#final-and-const
 [`flex`]: {{api}}/widgets/Expanded-class.html#flex
 [`FloatingActionButton`]: {{api}}/material/FloatingActionButton-class.html
-[Gestures in Flutter]: /development/ui/advanced/gestures
+[Gestures in Flutter]: {{site.url}}/development/ui/advanced/gestures
 [`GestureDetector`]: {{api}}/widgets/GestureDetector-class.html
 [`GlobalKey`]: {{api}}/widgets/GlobalKey-class.html
 [`IconButton`]: {{api}}/material/IconButton-class.html
 [`initState()`]: {{api}}/widgets/State-class.html#initState
 [`key`]: {{api}}/widgets/Widget-class.html#key
 [`Key`]: {{api}}/foundation/Key-class.html
-[Layouts]: /development/ui/widgets/layout
+[Layouts]: {{site.url}}/development/ui/widgets/layout
 [`leading`]: {{api}}/material/AppBar-class.html#leading
-[Material Components widgets]: /development/ui/widgets/material
+[Material Components widgets]: {{site.url}}/development/ui/widgets/material
 [Material icons]: https://design.google.com/icons/
 [`MaterialApp`]: {{api}}/material/MaterialApp-class.html
 [`Navigator`]: {{api}}/widgets/Navigator-class.html

--- a/src/development/ui/widgets/index.md
+++ b/src/development/ui/widgets/index.md
@@ -24,4 +24,4 @@ you can also see all the widgets in the [widget index][].
 </div>
 
 
-[widget index]: /reference/widgets
+[widget index]: {{site.url}}/reference/widgets

--- a/src/embedded/index.md
+++ b/src/embedded/index.md
@@ -36,7 +36,7 @@ resources.
 [community]: {{site.main-url}}/community
 [Discord]: https://discord.com/invite/N7Yshp4
 [Custom Flutter Engine Embedders]: {{site.repo.flutter}}/wiki/Custom-Flutter-Engine-Embedders
-[Flutter architectural overview]: /resources/architectural-overview
+[Flutter architectural overview]: {{site.url}}/resources/architectural-overview
 [Flutter engine `engine.h` file]: {{site.github}}/flutter/engine/blob/master/shell/platform/embedder/embedder.h
 [Flutter Embedder Engine GLFW example]: {{site.github}}/flutter/engine/tree/master/examples/glfw#flutter-embedder-engine-glfw-example
 [Issue 31043]: {{site.repo.flutter}}/issues/31043

--- a/src/get-started/codelab-web.md
+++ b/src/get-started/codelab-web.md
@@ -598,7 +598,7 @@ Go to this URL in a Chrome browser. You should see the DevTools
 launch screen. It should look like the following:
 
 {% indent %}
-  ![Screenshot of the DevTools launch screen](/assets/images/docs/get-started/devtools-launch-screen.png){:width="100%"}
+  ![Screenshot of the DevTools launch screen]({{site.url}}/assets/images/docs/get-started/devtools-launch-screen.png){:width="100%"}
 {% endindent %}
 </li>
 
@@ -609,7 +609,7 @@ and click Connect. You should now see Dart DevTools
 running successfully in your Chrome browser:
 
 {% indent %}
-  ![Screenshot of DevTools running screen](/assets/images/docs/get-started/devtools-running.png){:width="100%"}
+  ![Screenshot of DevTools running screen]({{site.url}}/assets/images/docs/get-started/devtools-running.png){:width="100%"}
 {% endindent %}
 
 Congratulations, you are now running Dart DevTools!
@@ -623,7 +623,7 @@ Congratulations, you are now running Dart DevTools!
   **Flutter Inspector** -> **More Actions** -> **Open DevTools**:
 
   {% indent %}
-  ![Screenshot of Flutter inspector with DevTools menu](/assets/images/docs/get-started/intellij-devtools.png){:width="100%"}
+  ![Screenshot of Flutter inspector with DevTools menu]({{site.url}}/assets/images/docs/get-started/intellij-devtools.png){:width="100%"}
   {% endindent %}
 {{site.alert.end}}
 
@@ -637,7 +637,7 @@ Select `signin/main.dart` to display your Dart code
 in the center pane.
 
 {% indent %}
-  ![Screenshot of the DevTools debugger](/assets/images/docs/get-started/devtools-debugging.png){:width="100%"}
+  ![Screenshot of the DevTools debugger]({{site.url}}/assets/images/docs/get-started/devtools-debugging.png){:width="100%"}
 {% endindent %}
 </li>
 
@@ -1026,28 +1026,28 @@ Dart DevTools, or Flutter animations, see the following:
 * [Web samples][]
 
 
-[Android Studio and IntelliJ]: /development/tools/devtools/android-studio
-[Animation docs]: /development/ui/animations
-[Building a form with validation]: /cookbook/forms/validation
-[Building a web application with Flutter]: /get-started/web
+[Android Studio and IntelliJ]: {{site.url}}/development/tools/devtools/android-studio
+[Animation docs]: {{site.url}}/development/ui/animations
+[Building a form with validation]: {{site.url}}/cookbook/forms/validation
+[Building a web application with Flutter]: {{site.url}}/get-started/web
 [Chrome browser]: https://www.google.com/chrome/?brand=CHBD&gclid=CjwKCAiAws7uBRAkEiwAMlbZjlVMZCxJDGAHjoSpoI_3z_HczSbgbMka5c9Z521R89cDoBM3zAluJRoCdCEQAvD_BwE&gclsrc=aw.ds
-[create a new Flutter project]: /get-started/test-drive
-[Dart DevTools]: /development/tools/devtools/overview
+[create a new Flutter project]: {{site.url}}/get-started/test-drive
+[Dart DevTools]: {{site.url}}/development/tools/devtools/overview
 [DartPad]: {{site.dartpad}}
-[DevTools command line]: /development/tools/devtools/cli
-[DevTools documentation]: /development/tools/devtools
-[DevTools installed]: /development/tools/devtools/overview#how-do-i-install-devtools
+[DevTools command line]: {{site.url}}/development/tools/devtools/cli
+[DevTools documentation]: {{site.url}}/development/tools/devtools
+[DevTools installed]: {{site.url}}/development/tools/devtools/overview#how-do-i-install-devtools
 [DartPad troubleshooting page]: {{site.dart-site}}/tools/dartpad/troubleshoot
 [`didUpdateWidget`]: {{site.api}}/flutter/widgets/State/didUpdateWidget.html
-[editor]: /get-started/editor
+[editor]: {{site.url}}/get-started/editor
 [Effective Dart Style Guide]: {{site.dart-site}}/guides/language/effective-dart/style#dont-use-a-leading-underscore-for-identifiers-that-arent-private
-[Flutter cookbook]: /cookbook
-[Flutter SDK]: /get-started/install
-[Implicit animations]: /codelabs/implicit-animations
-[Introduction to declarative UI]: /get-started/flutter-for/declarative
+[Flutter cookbook]: {{site.url}}/cookbook
+[Flutter SDK]: {{site.url}}/get-started/install
+[Implicit animations]: {{site.url}}/codelabs/implicit-animations
+[Introduction to declarative UI]: {{site.url}}/get-started/flutter-for/declarative
 [Material Design]: {{site.material}}/design/introduction/#
 [TextButton]: {{site.api}}/flutter/material/TextButton-class.html
-[VS Code]: /development/tools/devtools/vscode
+[VS Code]: {{site.url}}/development/tools/devtools/vscode
 [Web samples]: {{site.github}}/flutter/samples/tree/master/web
 [Widget]: {{site.api}}/flutter/widgets/Widget-class.html
-[writing your first Flutter app on mobile]: /get-started/codelab
+[writing your first Flutter app on mobile]: {{site.url}}/get-started/codelab

--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -630,27 +630,27 @@ where you add the following functionality:
 * Modify the theme color, making an all-white app.
 
 
-[an editor]: /get-started/editor
+[an editor]: {{site.url}}/get-started/editor
 [Android]: install/macos#set-up-your-android-device
 [Android emulator]: install/macos#set-up-the-android-emulator
-[Building a web application with Flutter]: /web
-[DevTools]: /development/tools/devtools
-[enabled web]: /get-started/web
+[Building a web application with Flutter]: {{site.url}}/web
+[DevTools]: {{site.url}}/development/tools/devtools
+[enabled web]: {{site.url}}/get-started/web
 [enforces privacy]: {{site.dart-site}}/guides/language/language-tour#libraries-and-visibility
 [english_words]: {{site.pub}}/packages/english_words
-[Flutter SDK]: /get-started/install
-[Getting Started with your first Flutter app]: /get-started/test-drive#create-app
+[Flutter SDK]: {{site.url}}/get-started/install
+[Getting Started with your first Flutter app]: {{site.url}}/get-started/test-drive#create-app
 [Google Developers Codelabs]: {{site.codelabs}}
-[hot reload]: /get-started/test-drive
-[in the way your IDE describes]: /get-started/test-drive
+[hot reload]: {{site.url}}/get-started/test-drive
+[in the way your IDE describes]: {{site.url}}/get-started/test-drive
 [Icons]: https://fonts.google.com/icons
 [iOS]: install/macos#deploy-to-ios-devices
 [iOS simulator]: install/macos#set-up-the-ios-simulator
 [Material]: {{site.material}}/guidelines
 [Part 1]: {{site.codelabs}}/codelabs/first-flutter-app-pt1
 [part 2]: {{site.codelabs}}/codelabs/first-flutter-app-pt2
-[plugins installed for Flutter and Dart]: /get-started/editor
+[plugins installed for Flutter and Dart]: {{site.url}}/get-started/editor
 [pub.dev]: {{site.pub}}
 [`Scaffold`]: {{site.api}}/flutter/material/Scaffold-class.html
 [`State`]: {{site.api}}/flutter/widgets/State-class.html
-[codelab-web]: /get-started/codelab-web
+[codelab-web]: {{site.url}}/get-started/codelab-web

--- a/src/get-started/editor.md
+++ b/src/get-started/editor.md
@@ -117,7 +117,7 @@ For information on how to install and use the package, see the [lsp-dart documen
 [Android Studio]: {{site.android-dev}}/studio
 [IntelliJ IDEA Community]: https://www.jetbrains.com/idea/download/
 [IntelliJ IDEA Ultimate]: https://www.jetbrains.com/idea/download/
-[next step: Test drive]: /get-started/test-drive
+[next step: Test drive]: {{site.url}}/get-started/test-drive
 [VS Code]: https://code.visualstudio.com/
 [Emacs]: https://www.gnu.org/software/emacs/download.html
 [lsp-dart documentation]: https://emacs-lsp.github.io/lsp-dart/

--- a/src/get-started/flutter-for/android-devs.md
+++ b/src/get-started/flutter-for/android-devs.md
@@ -2313,19 +2313,19 @@ For more information on using the Firebase Cloud Messaging API,
 see the [`firebase_messaging`][] plugin documentation.
 
 
-[Add Flutter to existing app]: /development/add-to-app
-[Animation & Motion widgets]: /development/ui/widgets/animation
-[Animations tutorial]: /development/ui/animations/tutorial
-[Animations overview]: /development/ui/animations
+[Add Flutter to existing app]: {{site.url}}/development/add-to-app
+[Animation & Motion widgets]: {{site.url}}/development/ui/widgets/animation
+[Animations tutorial]: {{site.url}}/development/ui/animations/tutorial
+[Animations overview]: {{site.url}}/development/ui/animations
 [`AppLifecycleStatus` documentation]: {{site.api}}/flutter/dart-ui/AppLifecycleState-class.html
 [Apple's iOS design language]: {{site.apple-dev}}/design/resources/
 [`cloud_firestore`]: {{site.pub}}/packages/cloud_firestore
-[composing]: /resources/architectural-overview#composition
-[Cupertino widgets]: /development/ui/widgets/cupertino
+[composing]: {{site.url}}/resources/architectural-overview#composition
+[Cupertino widgets]: {{site.url}}/development/ui/widgets/cupertino
 [Custom Paint]: {{site.so}}/questions/46241071/create-signature-area-for-mobile-app-in-dart-flutter
-[developing packages and plugins]: /development/packages-and-plugins/developing-packages
+[developing packages and plugins]: {{site.url}}/development/packages-and-plugins/developing-packages
 [`devicePixelRatio`]: {{site.api}}/flutter/dart-ui/FlutterView/devicePixelRatio.html
-[DevTools]: /development/tools/devtools
+[DevTools]: {{site.url}}/development/tools/devtools
 [existing plugin]: {{site.pub}}/flutter/
 [`flutter_facebook_login`]: {{site.pub}}/packages/flutter_facebook_login
 [`firebase_admob`]: {{site.pub}}/packages/firebase_admob
@@ -2337,7 +2337,7 @@ see the [`firebase_messaging`][] plugin documentation.
 [`flutter_firebase_ui`]: {{site.pub}}/packages/flutter_firebase_ui
 [Firebase Messaging]: {{site.github}}/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging
 [first party plugins]: {{site.pub}}/flutter/packages?q=firebase
-[Flutter cookbook]: /cookbook
+[Flutter cookbook]: {{site.url}}/cookbook
 [Flutter for Android Developers: How to design LinearLayout in Flutter]: https://proandroiddev.com/flutter-for-android-developers-how-to-design-linearlayout-in-flutter-5d819c0ddf1a
 [Flutter for Android Developers: How to design Activity UI in Flutter]: https://blog.usejournal.com/flutter-for-android-developers-how-to-design-activity-ui-in-flutter-4bf7b0de1e48
 [`geolocator`]: {{site.pub}}/packages/geolocator
@@ -2345,14 +2345,14 @@ see the [`firebase_messaging`][] plugin documentation.
 [`image_picker`]: {{site.pub}}/packages/image_picker
 [Intents]: #what-is-the-equivalent-of-an-intent-in-flutter
 [intl package]: {{site.pub}}/packages/intl
-[Introduction to declarative UI]: /get-started/flutter-for/declarative
+[Introduction to declarative UI]: {{site.url}}/get-started/flutter-for/declarative
 [Material Components]: {{site.material}}/develop/flutter
 [Material Design guidelines]: {{site.material}}/design
 [optimized for all platforms]: {{site.material}}/design/platform-guidance/cross-platform-adaptation.html#cross-platform-guidelines
 [a plugin]: {{site.pub}}/packages/android_intent
 [pub.dev]: {{site.pub}}/flutter/packages/
-[Retrieve the value of a text field]: /cookbook/forms/retrieve-input
+[Retrieve the value of a text field]: {{site.url}}/cookbook/forms/retrieve-input
 [Shared_Preferences plugin]: {{site.pub}}/packages/shared_preferences
 [SQFlite]: {{site.pub}}/packages/sqflite
 [StackOverflow]: {{site.so}}/questions/44396075/equivalent-of-relativelayout-in-flutter
-[widget catalog]: /development/ui/widgets/layout
+[widget catalog]: {{site.url}}/development/ui/widgets/layout

--- a/src/get-started/flutter-for/ios-devs.md
+++ b/src/get-started/flutter-for/ios-devs.md
@@ -2192,22 +2192,22 @@ Messaging API, see the [`firebase_messaging`][]
 plugin documentation.
 
 
-[Add Flutter to existing app]: /development/add-to-app
-[Adding Assets and Images in Flutter]: /development/ui/assets-and-images
-[Animation & Motion widgets]: /development/ui/widgets/animation
-[Animations overview]: /development/ui/animations
-[Animations tutorial]: /development/ui/animations/tutorial
+[Add Flutter to existing app]: {{site.url}}/development/add-to-app
+[Adding Assets and Images in Flutter]: {{site.url}}/development/ui/assets-and-images
+[Animation & Motion widgets]: {{site.url}}/development/ui/widgets/animation
+[Animations overview]: {{site.url}}/development/ui/animations
+[Animations tutorial]: {{site.url}}/development/ui/animations/tutorial
 [Apple's iOS design language]: {{site.apple-dev}}/design/resources
 [`AppLifecycleState` documentation]: {{site.api}}/flutter/dart-ui/AppLifecycleState-class.html
 [arb]: {{site.github}}/googlei18n/app-resource-bundle
 [`AssetBundle`]: {{site.api}}/flutter/services/AssetBundle-class.html
 [`cloud_firestore`]: {{site.pub-pkg}}/cloud_firestore
-[composing]: /resources/architectural-overview#composition
+[composing]: {{site.url}}/resources/architectural-overview#composition
 [Cupertino library]: {{site.api}}/flutter/cupertino/cupertino-library.html
-[Cupertino widgets]: /development/ui/widgets/cupertino
-[developing packages and plugins]: /development/packages-and-plugins/developing-packages
+[Cupertino widgets]: {{site.url}}/development/ui/widgets/cupertino
+[developing packages and plugins]: {{site.url}}/development/packages-and-plugins/developing-packages
 [`devicePixelRatio`]: {{site.api}}/flutter/dart-ui/FlutterView/devicePixelRatio.html
-[DevTools]: /development/tools/devtools
+[DevTools]: {{site.url}}/development/tools/devtools
 [existing plugin]: {{site.pub}}/flutter
 [`firebase_admob`]: {{site.pub-pkg}}/firebase_admob
 [`firebase_analytics`]: {{site.pub-pkg}}/firebase_analytics
@@ -2218,32 +2218,32 @@ plugin documentation.
 [`firebase_storage`]: {{site.pub-pkg}}/firebase_storage
 [first party plugins]: {{site.pub}}/flutter/packages?q=firebase
 [`flutter_facebook_login`]: {{site.pub-pkg}}/flutter_facebook_login
-[Flutter cookbook]: /cookbook
+[Flutter cookbook]: {{site.url}}/cookbook
 [Flutter Youtube channel]: {{site.youtube-site}}/flutterdev
 [`geolocator`]: {{site.pub-pkg}}/geolocator
 [`http` package]: {{site.pub-pkg}}/http
 [Human Interface Guidelines]: {{site.apple-dev}}/ios/human-interface-guidelines/overview/themes/
 [`image_picker`]: {{site.pub-pkg}}/image_picker
-[internationalization guide]: /development/accessibility-and-localization/internationalization
+[internationalization guide]: {{site.url}}/development/accessibility-and-localization/internationalization
 [`intl`]: {{site.pub-pkg}}/intl
 [`intl_translation`]: {{site.pub-pkg}}/intl_translation
-[Introduction to declarative UI]: /get-started/flutter-for/declarative
-[layout tutorial]: /development/ui/widgets/layout
+[Introduction to declarative UI]: {{site.url}}/get-started/flutter-for/declarative
+[layout tutorial]: {{site.url}}/development/ui/widgets/layout
 [`Localizations`]: {{site.api}}/flutter/widgets/Localizations-class.html
 [Material Components]: {{site.material}}/develop/flutter/
 [Material Design guidelines]: {{site.material}}/design/
 [optimized for all platforms]: {{site.material}}/design/platform-guidance/cross-platform-adaptation.html#cross-platform-guidelines
-[Platform adaptations]: /resources/platform-adaptations
-[platform channel]: /development/platform-integration/platform-channels
-[plugins]: /development/packages-and-plugins/using-packages
+[Platform adaptations]: {{site.url}}/resources/platform-adaptations
+[platform channel]: {{site.url}}/development/platform-integration/platform-channels
+[plugins]: {{site.url}}/development/packages-and-plugins/using-packages
 [pub.dev]: {{site.pub}}/flutter/packages
-[publish it on pub.dev]: /development/packages-and-plugins/developing-packages#publish
-[Retrieve the value of a text field]: /cookbook/forms/retrieve-input
+[publish it on pub.dev]: {{site.url}}/development/packages-and-plugins/developing-packages#publish
+[Retrieve the value of a text field]: {{site.url}}/cookbook/forms/retrieve-input
 [Shared Preferences plugin]: {{site.pub-pkg}}/shared_preferences
 [SQFlite]: {{site.pub-pkg}}/sqflite
 [`TextEditingController`]: {{site.api}}/flutter/widgets/TextEditingController-class.html
 [`url_launcher`]: {{site.pub-pkg}}/url_launcher
-[widget]: /resources/architectural-overview#widgets
-[widget catalog]: /development/ui/widgets/layout
+[widget]: {{site.url}}/resources/architectural-overview#widgets
+[widget catalog]: {{site.url}}/development/ui/widgets/layout
 [`Window.locale`]: {{site.api}}/flutter/dart-ui/Window/locale.html
-[write your own]: /development/packages-and-plugins/developing-packages
+[write your own]: {{site.url}}/development/packages-and-plugins/developing-packages

--- a/src/get-started/flutter-for/react-native-devs.md
+++ b/src/get-started/flutter-for/react-native-devs.md
@@ -2482,7 +2482,7 @@ and common widget properties.
 
 
 [`AboutDialog`]: {{site.api}}/flutter/material/AboutDialog-class.html
-[Adding Assets and Images in Flutter]: /development/ui/assets-and-images
+[Adding Assets and Images in Flutter]: {{site.url}}/development/ui/assets-and-images
 [`alertDialog`]: {{site.api}}/flutter/material/AlertDialog-class.html
 [`Align`]: {{site.api}}/flutter/widgets/Align-class.html
 [`Animation`]: {{site.api}}/flutter/animation/Animation-class.html
@@ -2499,7 +2499,7 @@ and common widget properties.
 [`Checkbox`]: {{site.api}}/flutter/material/Checkbox-class.html
 [`CircleAvatar`]: {{site.api}}/flutter/material/CircleAvatar-class.html
 [`CircularProgressIndicator`]: {{site.api}}/flutter/material/CircularProgressIndicator-class.html
-[Cupertino (iOS-style)]: /development/ui/widgets/cupertino
+[Cupertino (iOS-style)]: {{site.url}}/development/ui/widgets/cupertino
 [`CustomPaint`]: {{site.api}}/flutter/widgets/CustomPaint-class.html
 [`CustomPainter`]: {{site.api}}/flutter/rendering/CustomPainter-class.html
 [Dart]: {{site.dart-site}}/dart-2
@@ -2511,28 +2511,28 @@ and common widget properties.
 [DartPadD]: {{site.dartpad}}/57ec21faa8b6fe2326ffd74e9781a2c7
 [DartPadE]: {{site.dartpad}}/c85038ad677963cb6dc943eb1a0b72e6
 [DartPadF]: {{site.dartpad}}/5454e8bfadf3000179d19b9bc6be9918
-[Developing Packages & Plugins]: /development/packages-and-plugins/developing-packages
-[DevTools]: /development/tools/devtools
+[Developing Packages & Plugins]: {{site.url}}/development/packages-and-plugins/developing-packages
+[DevTools]: {{site.url}}/development/tools/devtools
 [`Dismissible`]: {{site.api}}/flutter/widgets/Dismissible-class.html
 [`FadeTransition`]: {{site.api}}/flutter/widgets/FadeTransition-class.html
 [Flutter packages]: {{site.pub}}/flutter/
-[Flutter Architectural Overview]: /resources/architectural-overview
-[Flutter Basic Widgets]: /development/ui/widgets/basics
-[Flutter Technical Overview]: /resources/architectural-overview
-[Flutter Widget Catalog]: /development/ui/widgets
-[Flutter Widget Index]: /reference/widgets
+[Flutter Architectural Overview]: {{site.url}}/resources/architectural-overview
+[Flutter Basic Widgets]: {{site.url}}/development/ui/widgets/basics
+[Flutter Technical Overview]: {{site.url}}/resources/architectural-overview
+[Flutter Widget Catalog]: {{site.url}}/development/ui/widgets
+[Flutter Widget Index]: {{site.url}}/reference/widgets
 [`FlutterLogo`]: {{site.api}}/flutter/material/FlutterLogo-class.html
 [`Form`]: {{site.api}}/flutter/widgets/Form-class.html
 [`TextButton`]: {{site.api}}/flutter/material/TextButton-class.html
 [functions]: {{site.dart-site}}/guides/language/language-tour#functions
 [`Future`]: {{site.dart-site}}/tutorials/language/futures
 [`GestureDetector`]: {{site.api}}/flutter/widgets/GestureDetector-class.html
-[Getting started]: /get-started
+[Getting started]: {{site.url}}/get-started
 [`Image`]: {{site.api}}/flutter/widgets/Image-class.html
 [`IndexedWidgetBuilder`]: {{site.api}}/flutter/widgets/IndexedWidgetBuilder.html
 [`InheritedWidget`]: {{site.api}}/flutter/widgets/InheritedWidget-class.html
 [`InkWell`]: {{site.api}}/flutter/material/InkWell-class.html
-[Layout Widgets]: /development/ui/widgets/layout
+[Layout Widgets]: {{site.url}}/development/ui/widgets/layout
 [`LinearProgressIndicator`]: {{site.api}}/flutter/material/LinearProgressIndicator-class.html
 [`ListTile`]: {{site.api}}/flutter/material/ListTile-class.html
 [`ListView`]: {{site.api}}/flutter/widgets/ListView-class.html
@@ -2562,7 +2562,7 @@ and common widget properties.
 [`SingleTickerProviderStateMixin`]: {{site.api}}/flutter/widgets/SingleTickerProviderStateMixin-mixin.html
 [`Slider`]: {{site.api}}/flutter/material/Slider-class.html
 [`Stack`]: {{site.api}}/flutter/widgets/Stack-class.html
-[State management]: /development/data-and-backend/state-mgmt
+[State management]: {{site.url}}/development/data-and-backend/state-mgmt
 [`StatefulWidget`]: {{site.api}}/flutter/widgets/StatefulWidget-class.html
 [`StatelessWidget`]: {{site.api}}/flutter/widgets/StatelessWidget-class.html
 [`Switch`]: {{site.api}}/flutter/material/Switch-class.html
@@ -2583,7 +2583,7 @@ and common widget properties.
 [`TickerProvider`]: {{site.api}}/flutter/scheduler/TickerProvider-class.html
 [`TickerProviderStateMixin`]: {{site.api}}/flutter/widgets/TickerProviderStateMixin-mixin.html
 [`Tween`]: {{site.api}}/flutter/animation/Tween-class.html
-[Using Packages]: /development/packages-and-plugins/using-packages
+[Using Packages]: {{site.url}}/development/packages-and-plugins/using-packages
 [variables]: {{site.dart-site}}/guides/language/language-tour#variables
 [`WidgetBuilder`]: {{site.api}}/flutter/widgets/WidgetBuilder.html
 [Write Your First Flutter App, Part 1]: {{site.codelabs}}/codelabs/first-flutter-app-pt1

--- a/src/get-started/flutter-for/web-devs.md
+++ b/src/get-started/flutter-for/web-devs.md
@@ -995,7 +995,7 @@ var container = Container( // grey box
 [`BoxShadow`]: {{site.api}}/flutter/painting/BoxShadow-class.html
 [`Center`]: {{site.api}}/flutter/widgets/Center-class.html
 [`Container`]: {{site.api}}/flutter/widgets/Container-class.html
-[Introduction to declarative UI]: /get-started/flutter-for/declarative
+[Introduction to declarative UI]: {{site.url}}/get-started/flutter-for/declarative
 [`Matrix4`]: {{site.api}}/flutter/vector_math_64/Matrix4-class.html
 [`Positioned`]: {{site.api}}/flutter/widgets/Positioned-class.html
 [`RichText`]: {{site.api}}/flutter/widgets/RichText-class.html
@@ -1004,5 +1004,5 @@ var container = Container( // grey box
 [`TextSpan`]: {{site.api}}/flutter/painting/TextSpan-class.html
 [`TextStyle`]: {{site.api}}/flutter/painting/TextStyle-class.html
 [`Transform`]: {{site.api}}/flutter/widgets/Transform-class.html
-[Understanding constraints]: /development/ui/layout/constraints
+[Understanding constraints]: {{site.url}}/development/ui/layout/constraints
 

--- a/src/get-started/flutter-for/xamarin-forms-devs.md
+++ b/src/get-started/flutter-for/xamarin-forms-devs.md
@@ -2471,19 +2471,19 @@ For more information on using the Firebase Cloud Messaging API, see the
 [`firebase_messaging`][] plugin documentation.
 
 
-[Adding assets and images]: /development/ui/assets-and-images
-[Animation & Motion widgets]: /development/ui/widgets/animation
-[Animations overview]: /development/ui/animations
-[Animations tutorial]: /development/ui/animations/tutorial
+[Adding assets and images]: {{site.url}}/development/ui/assets-and-images
+[Animation & Motion widgets]: {{site.url}}/development/ui/widgets/animation
+[Animations overview]: {{site.url}}/development/ui/animations
+[Animations tutorial]: {{site.url}}/development/ui/animations/tutorial
 [Apple's iOS design language]: {{site.apple-dev}}/design/resources/
 [arb]: {{site.github}}/google/app-resource-bundle
 [Async UI]: #async-ui
 [`cloud_firestore`]: {{site.pub}}/packages/cloud_firestore
-[composing]: /resources/architectural-overview#composition
-[Cupertino widgets]: /development/ui/widgets/cupertino
+[composing]: {{site.url}}/resources/architectural-overview#composition
+[Cupertino widgets]: {{site.url}}/development/ui/widgets/cupertino
 [`devicePixelRatio`]: {{site.api}}/flutter/dart-ui/FlutterView/devicePixelRatio.html
-[developing packages and plugins]: /development/packages-and-plugins/developing-packages
-[DevTools]: /development/tools/devtools/overview
+[developing packages and plugins]: {{site.url}}/development/packages-and-plugins/developing-packages
+[DevTools]: {{site.url}}/development/tools/devtools/overview
 [existing plugin]: {{site.pub}}/flutter
 [`firebase_admob`]: {{site.pub}}/packages/firebase_admob
 [`firebase_analytics`]: {{site.pub}}/packages/firebase_analytics
@@ -2493,34 +2493,34 @@ For more information on using the Firebase Cloud Messaging API, see the
 [`firebase_storage`]: {{site.pub}}/packages/firebase_storage
 [Firebase_Messaging]: {{site.pub}}/packages/firebase_messaging
 [first party plugins]: {{site.pub}}/flutter/packages?q=firebase
-[Flutter cookbook]: /cookbook
+[Flutter cookbook]: {{site.url}}/cookbook
 [`flutter_facebook_login`]: {{site.pub}}/packages/flutter_facebook_login
 [`flutter_firebase_ui`]: {{site.pub}}/packages/flutter_firebase_ui
 [`geolocator`]: {{site.pub}}/packages/geolocator
 [`http` package]: {{site.pub}}/packages/http
 [`image_picker`]: {{site.pub}}/packages/image_picker
-[internationalization guide]: /development/accessibility-and-localization/internationalization
+[internationalization guide]: {{site.url}}/development/accessibility-and-localization/internationalization
 [`intl`]: {{site.pub}}/packages/intl
 [`intl_translation`]: {{site.pub}}/packages/intl_translation
-[Introduction to declarative UI]: /get-started/flutter-for/declarative
+[Introduction to declarative UI]: {{site.url}}/get-started/flutter-for/declarative
 [`Localizations`]: {{site.api}}/flutter/widgets/Localizations-class.html
-[Material Components]: /development/ui/widgets/material
+[Material Components]: {{site.url}}/development/ui/widgets/material
 [Material Design]: {{site.material}}/design
 [Material Design guidelines]: {{site.material}}/design
 [`Opacity` widget]: {{site.api}}/flutter/widgets/Opacity-class.html
 [optimized for all platforms]: {{site.material}}/design/platform-guidance/cross-platform-adaptation.html#cross-platform-guidelines
-[platform channels]: /development/platform-integration/platform-channels
-[plugins]: /development/packages-and-plugins/using-packages
+[platform channels]: {{site.url}}/development/platform-integration/platform-channels
+[plugins]: {{site.url}}/development/packages-and-plugins/using-packages
 [pub.dev]: {{site.pub}}
-[publish it on pub.dev]: /development/packages-and-plugins/developing-packages#publish
-[Retrieve the value of a text field]: /cookbook/forms/retrieve-input
+[publish it on pub.dev]: {{site.url}}/development/packages-and-plugins/developing-packages#publish
+[Retrieve the value of a text field]: {{site.url}}/cookbook/forms/retrieve-input
 [`shared_preferences`]: {{site.pub}}/packages/shared_preferences
 [`sqflite`]: {{site.pub}}/packages/sqflite
 [`TextEditingController`]: {{site.api}}/flutter/widgets/TextEditingController-class.html
 [`url_launcher`]: {{site.pub}}/packages/url_launcher
-[widget]: /resources/architectural-overview#widgets
-[widget catalog]: /development/ui/widgets/layout
+[widget]: {{site.url}}/resources/architectural-overview#widgets
+[widget catalog]: {{site.url}}/development/ui/widgets/layout
 [`Window.locale`]: {{site.api}}/flutter/dart-ui/Window/locale.html
 [Write your first Flutter app, part 1]: {{site.codelabs}}/codelabs/first-flutter-app-pt1
 [Write your first Flutter app, part 2]: {{site.codelabs}}/codelabs/first-flutter-app-pt2
-[write your own]: /development/packages-and-plugins/developing-packages
+[write your own]: {{site.url}}/development/packages-and-plugins/developing-packages

--- a/src/get-started/install/_get-sdk-chromeos.md
+++ b/src/get-started/install/_get-sdk-chromeos.md
@@ -118,8 +118,8 @@ command again to verify that you’ve set everything up correctly.
 
 [Flutter repo]: {{site.repo.flutter}}
 [Installing snapd]: https://snapcraft.io/docs/installing-snapd
-[SDK releases]: /development/tools/sdk/releases
+[SDK releases]: {{site.url}}/development/tools/sdk/releases
 [Snap Store]: https://snapcraft.io/store
 [snapd]: https://snapcraft.io/flutter
 [Update your path]: #update-your-path
-[Upgrading Flutter]: /development/tools/sdk/upgrading
+[Upgrading Flutter]: {{site.url}}/development/tools/sdk/upgrading

--- a/src/get-started/install/_get-sdk-linux.md
+++ b/src/get-started/install/_get-sdk-linux.md
@@ -137,6 +137,6 @@ command again to verify that you’ve set everything up correctly.
 [Flutter repo]: {{site.repo.flutter}}
 [install Flutter using the Snap Store]: https://snapcraft.io/flutter
 [Installing snapd]: https://snapcraft.io/docs/installing-snapd
-[SDK releases]: /development/tools/sdk/releases
+[SDK releases]: {{site.url}}/development/tools/sdk/releases
 [Update your path]: #update-your-path
-[Upgrading Flutter]: /development/tools/sdk/upgrading
+[Upgrading Flutter]: {{site.url}}/development/tools/sdk/upgrading

--- a/src/get-started/install/_get-sdk-mac.md
+++ b/src/get-started/install/_get-sdk-mac.md
@@ -103,8 +103,8 @@ For additional download options, see `flutter help precache`.
 
 [Flutter repo]: {{site.repo.flutter}}
 [Installing snapd]: https://snapcraft.io/docs/installing-snapd
-[SDK releases]: /development/tools/sdk/releases
+[SDK releases]: {{site.url}}/development/tools/sdk/releases
 [Snap Store]: https://snapcraft.io/store
 [snapd]: https://snapcraft.io/flutter
 [Update your path]: #update-your-path
-[Upgrading Flutter]: /development/tools/sdk/upgrading
+[Upgrading Flutter]: {{site.url}}/development/tools/sdk/upgrading

--- a/src/get-started/install/_get-sdk-win.md
+++ b/src/get-started/install/_get-sdk-win.md
@@ -88,5 +88,5 @@ verify that you’ve set everything up correctly.
 
 
 [Flutter repo]: {{site.repo.flutter}}
-[SDK releases]: /development/tools/sdk/releases
-[Set up an editor]: /get-started/editor?tab=androidstudio
+[SDK releases]: {{site.url}}/development/tools/sdk/releases
+[Set up an editor]: {{site.url}}/get-started/editor?tab=androidstudio

--- a/src/get-started/install/_ios-setup.md
+++ b/src/get-started/install/_ios-setup.md
@@ -165,11 +165,11 @@ or clicking the Run button in Xcode.
 </li>
 </ol>
 
-[Check the app's Bundle ID]: /assets/images/docs/setup/xcode-unique-bundle-id.png
+[Check the app's Bundle ID]: {{site.url}}/assets/images/docs/setup/xcode-unique-bundle-id.png
 [Choosing a Membership]: {{site.apple-dev}}/support/compare-memberships
 [Mac App Store]: https://itunes.apple.com/us/app/xcode/id497799835
-[Flutter plugins]: /development/packages-and-plugins/developing-packages#types
+[Flutter plugins]: {{site.url}}/development/packages-and-plugins/developing-packages#types
 [Install and set up CocoaPods]: https://guides.cocoapods.org/using/getting-started.html#installation
-[Trust Mac]: /assets/images/docs/setup/trust-computer.png
+[Trust Mac]: {{site.url}}/assets/images/docs/setup/trust-computer.png
 [web download]: {{site.apple-dev}}/xcode/
-[Xcode account add]: /assets/images/docs/setup/xcode-account.png
+[Xcode account add]: {{site.url}}/assets/images/docs/setup/xcode-account.png

--- a/src/get-started/install/_linux-desktop-setup.md
+++ b/src/get-started/install/_linux-desktop-setup.md
@@ -51,4 +51,4 @@ $ flutter config --enable-linux-desktop
 
 For more information, see [Desktop support for Flutter][]
 
-[Desktop support for Flutter]: /desktop
+[Desktop support for Flutter]: {{site.url}}/desktop

--- a/src/get-started/install/_macos-desktop-setup.md
+++ b/src/get-started/install/_macos-desktop-setup.md
@@ -38,4 +38,4 @@ $ flutter config --enable-macos-desktop
 
 For more information, see [Desktop support for Flutter][]
 
-[Desktop support for Flutter]: /desktop
+[Desktop support for Flutter]: {{site.url}}/desktop

--- a/src/get-started/install/_web-setup.md
+++ b/src/get-started/install/_web-setup.md
@@ -6,4 +6,4 @@ builds for the web. To add web support to an existing app, follow
 the instructions on [Building a web application with Flutter][] 
 when you've completed the setup above.
 
-[Building a web application with Flutter]: /get-started/web
+[Building a web application with Flutter]: {{site.url}}/get-started/web

--- a/src/get-started/install/_windows-desktop-setup.md
+++ b/src/get-started/install/_windows-desktop-setup.md
@@ -57,4 +57,4 @@ $ flutter config --enable-windows-uwp-desktop
 
 For more information, see [Desktop support for Flutter][]
 
-[Desktop support for Flutter]: /desktop
+[Desktop support for Flutter]: {{site.url}}/desktop

--- a/src/get-started/install/index.md
+++ b/src/get-started/install/index.md
@@ -33,4 +33,4 @@ Select the operating system on which you are installing Flutter:
   If you're in China, first read [Using Flutter in China][].
 {{site.alert.end}}
 
-[Using Flutter in China]: /community/china
+[Using Flutter in China]: {{site.url}}/community/china

--- a/src/get-started/learn-more.md
+++ b/src/get-started/learn-more.md
@@ -36,19 +36,19 @@ Reach out to us at our [mailing list][]. We'd love to hear from you!
 
 Happy Fluttering!
 
-[Add interactivity]: /development/ui/interactive
-[Bootstrap into Dart: learn more about the language]: /resources/bootstrap-into-dart
-[Building layouts]: /development/ui/layout/tutorial
+[Add interactivity]: {{site.url}}/development/ui/interactive
+[Bootstrap into Dart: learn more about the language]: {{site.url}}/resources/bootstrap-into-dart
+[Building layouts]: {{site.url}}/development/ui/layout/tutorial
 [The Complete Flutter Developer Bootcamp Using Dart]: https://www.appbrewery.co/p/flutter-development-bootcamp-with-dart
 [Flutter API Docs]: {{site.api}}
-[Flutter cookbook]: /cookbook
-[Flutter for Android developers]: /get-started/flutter-for/android-devs
-[Flutter for iOS developers]: /get-started/flutter-for/ios-devs
-[Flutter for React Native developers]: /get-started/flutter-for/react-native-devs
+[Flutter cookbook]: {{site.url}}/cookbook
+[Flutter for Android developers]: {{site.url}}/get-started/flutter-for/android-devs
+[Flutter for iOS developers]: {{site.url}}/get-started/flutter-for/ios-devs
+[Flutter for React Native developers]: {{site.url}}/get-started/flutter-for/react-native-devs
 [Flutter samples]: https://flutter.github.io/samples
-[Flutter for web developers]: /get-started/flutter-for/web-devs
-[Flutter for Xamarin.Forms developers]: /get-started/flutter-for/xamarin-forms-devs
+[Flutter for web developers]: {{site.url}}/get-started/flutter-for/web-devs
+[Flutter for Xamarin.Forms developers]: {{site.url}}/get-started/flutter-for/xamarin-forms-devs
 [From Java to Dart]: {{site.codelabs}}/codelabs/from-java-to-dart
-[Introduction to widgets]: /development/ui/widgets-intro
+[Introduction to widgets]: {{site.url}}/development/ui/widgets-intro
 [mailing list]: mailto:{{site.email}}
 [Udacity online Flutter training]: https://www.udacity.com/course/build-native-mobile-apps-with-flutter--ud905

--- a/src/get-started/test-drive/_androidstudio.md
+++ b/src/get-started/test-drive/_androidstudio.md
@@ -39,7 +39,7 @@ contains a simple demo app that uses [Material Components][].
 {% include_relative _try-hot-reload.md save_changes=save_changes %}
 {% include docs/run-profile.md ide_profile=ide_profile %}
 
-[trusted your computer]: /get-started/install/macos#trust
+[trusted your computer]: {{site.url}}/get-started/install/macos#trust
 </div>
 
 

--- a/src/get-started/test-drive/_terminal.md
+++ b/src/get-started/test-drive/_terminal.md
@@ -46,7 +46,7 @@ contains a simple demo app that uses [Material Components][].
 {% include_relative _try-hot-reload.md save_changes=save_changes %}
 {% include docs/run-profile.md %}
 
-[trusted your computer]: /get-started/install/macos#trust
+[trusted your computer]: {{site.url}}/get-started/install/macos#trust
 
 </div>
 

--- a/src/get-started/test-drive/_vscode.md
+++ b/src/get-started/test-drive/_vscode.md
@@ -51,10 +51,10 @@ contains a simple demo app that uses [Material Components][].
 {% include_relative _try-hot-reload.md save_changes=save_changes %}
 {% include docs/run-profile.md %}
 
-[Install]: /get-started/install
+[Install]: {{site.url}}/get-started/install
 [Material Components]: {{site.material}}/guidelines
 [Quickly switching between Flutter devices]: https://dartcode.org/docs/quickly-switching-between-flutter-devices
-[status bar]: /assets/images/docs/tools/vs-code/device_status_bar.png
-[trusted your computer]: /get-started/install/macos#trust
+[status bar]: {{site.url}}/assets/images/docs/tools/vs-code/device_status_bar.png
+[trusted your computer]: {{site.url}}/get-started/install/macos#trust
 
 </div>

--- a/src/get-started/test-drive/index.md
+++ b/src/get-started/test-drive/index.md
@@ -38,7 +38,7 @@ Flutter apps.
 
 
 
-[Install]: /get-started/install
-[Main IntelliJ toolbar]: /assets/images/docs/tools/android-studio/main-toolbar.png
+[Install]: {{site.url}}/get-started/install
+[Main IntelliJ toolbar]: {{site.url}}/assets/images/docs/tools/android-studio/main-toolbar.png
 [Managing AVDs]: {{site.android-dev}}/studio/run/managing-avds
 [Material Components]: {{site.material}}/guidelines

--- a/src/get-started/web.md
+++ b/src/get-started/web.md
@@ -151,15 +151,15 @@ from your project's directory:
 $ flutter create .
 ```
 
-[Build and release a web app]: /deployment/web
-[creating a new Flutter project]: /get-started/test-drive
+[Build and release a web app]: {{site.url}}/deployment/web
+[creating a new Flutter project]: {{site.url}}/get-started/test-drive
 [dart2js]: {{site.dart-site}}/tools/dart2js
-[desktop support]: /desktop
+[desktop support]: {{site.url}}/desktop
 [development compiler]: {{site.dart-site}}/tools/dartdevc
 [file an issue]: {{site.repo.flutter}}/issues/new?title=[web]:+%3Cdescribe+issue+here%3E&labels=%E2%98%B8+platform-web&body=Describe+your+issue+and+include+the+command+you%27re+running,+flutter_web%20version,+browser+version
-[install the Flutter and Dart plugins]: /get-started/editor
-[setting up an editor]: /get-started/editor
-[web FAQ]: /development/platform-integration/web
+[install the Flutter and Dart plugins]: {{site.url}}/get-started/editor
+[setting up an editor]: {{site.url}}/get-started/editor
+[web FAQ]: {{site.url}}/development/platform-integration/web
 [Chrome]: https://www.google.com/chrome/
-[Flutter SDK]: /get-started/install
-[Web renderers]: /development/tools/web-renderers
+[Flutter SDK]: {{site.url}}/get-started/install
+[Web renderers]: {{site.url}}/development/tools/web-renderers

--- a/src/index.md
+++ b/src/index.md
@@ -94,28 +94,28 @@ You might also find these docs useful:
 
 The documentation on this site reflects the latest stable release of Flutter.
 
-[A tour of the Flutter widget framework]: /development/ui/widgets-intro
-[Adding assets and images]: /development/ui/assets-and-images
-[Adding interactivity to your Flutter app]: /development/ui/interactive
-[Android]: /get-started/flutter-for/android-devs
-[Animations]: /development/ui/animations
+[A tour of the Flutter widget framework]: {{site.url}}/development/ui/widgets-intro
+[Adding assets and images]: {{site.url}}/development/ui/assets-and-images
+[Adding interactivity to your Flutter app]: {{site.url}}/development/ui/interactive
+[Android]: {{site.url}}/get-started/flutter-for/android-devs
+[Animations]: {{site.url}}/development/ui/animations
 [Boring Flutter Show]: {{site.youtube-site}}/watch?v=vqPG1tU6-c0&list=PLjxrf2q8roU28W3pXbISJbVA5REsA41Sx&index=3&t=9s
 [Boring Flutter Show playlist]: {{site.youtube-site}}/watch?v=vqPG1tU6-c0&list=PLjxrf2q8roU28W3pXbISJbVA5REsA41Sx&index=3&t=9s
-[Building layouts]: /development/ui/layout
-[FAQ]: /resources/faq
+[Building layouts]: {{site.url}}/development/ui/layout
+[FAQ]: {{site.url}}/resources/faq
 [flutter-announce]: {{site.groups}}/forum/#!forum/flutter-announce
 [Flutter in Focus]: {{site.youtube-site}}/playlist?list=PLjxrf2q8roU2HdJQDjJzOeO6J3FoFLWr2
 [Flutter in Focus series]: {{site.youtube-site}}/playlist?list=PLjxrf2q8roU2HdJQDjJzOeO6J3FoFLWr2
 [Flutter YouTube channel]: {{site.social.youtube}}
-[Get started]: /get-started/install
-[iOS]: /get-started/flutter-for/ios-devs
-[Navigation and routing]: /development/ui/navigation
-[React Native]: /get-started/flutter-for/react-native-devs
-[State management]: /development/data-and-backend/state-mgmt/intro
-[Understanding constraints]: /development/ui/layout/constraints
-[Using packages]: /development/packages-and-plugins/using-packages
-[videos]: /resources/videos
-[Web]: /get-started/flutter-for/web-devs
-[What's new]: /whats-new
-[Write your first Flutter app]: /get-started/codelab
-[Xamarin.Forms]: /get-started/flutter-for/xamarin-forms-devs
+[Get started]: {{site.url}}/get-started/install
+[iOS]: {{site.url}}/get-started/flutter-for/ios-devs
+[Navigation and routing]: {{site.url}}/development/ui/navigation
+[React Native]: {{site.url}}/get-started/flutter-for/react-native-devs
+[State management]: {{site.url}}/development/data-and-backend/state-mgmt/intro
+[Understanding constraints]: {{site.url}}/development/ui/layout/constraints
+[Using packages]: {{site.url}}/development/packages-and-plugins/using-packages
+[videos]: {{site.url}}/resources/videos
+[Web]: {{site.url}}/get-started/flutter-for/web-devs
+[What's new]: {{site.url}}/whats-new
+[Write your first Flutter app]: {{site.url}}/get-started/codelab
+[Xamarin.Forms]: {{site.url}}/get-started/flutter-for/xamarin-forms-devs

--- a/src/jobs/index.md
+++ b/src/jobs/index.md
@@ -5,10 +5,10 @@ description: Open job listings for the Flutter and Dart teams.
 
 We currently have the following job openings on the Flutter and Dart teams:
 
-* [Android Engineer](/jobs/android)
-* [Senior Technical Program Manager](/jobs/tpm)
-* [Developer Relations Engineer](/jobs/dre)
-* [Dart Platform Engineer](/jobs/dart_platform)
-* [Flutter Engineering Productivity](/jobs/infrastructure)
-* [Flutter CLI and Tools](/jobs/tools)
-* [Flutter & Dart Developer Experience SWE](/jobs/devexp)
+* [Android Engineer]({{site.url}}/jobs/android)
+* [Senior Technical Program Manager]({{site.url}}/jobs/tpm)
+* [Developer Relations Engineer]({{site.url}}/jobs/dre)
+* [Dart Platform Engineer]({{site.url}}/jobs/dart_platform)
+* [Flutter Engineering Productivity]({{site.url}}/jobs/infrastructure)
+* [Flutter CLI and Tools]({{site.url}}/jobs/tools)
+* [Flutter & Dart Developer Experience SWE]({{site.url}}/jobs/devexp)

--- a/src/null-safety.md
+++ b/src/null-safety.md
@@ -82,7 +82,7 @@ We're currently aware of the following issues:
     which might take longer to be migrated.
 
   * Integration testing with
-    [`flutter_driver`](/cookbook/testing/integration/introduction) and 
+    [`flutter_driver`]({{site.url}}/cookbook/testing/integration/introduction) and 
     the version of `integration_test` in the Flutter SDK.
     
       * Currently, these methods do not support null safety on the host

--- a/src/perf/app-size.md
+++ b/src/perf/app-size.md
@@ -187,15 +187,15 @@ Some other things you can do to make your app smaller are:
 * Minimize resource imported from libraries
 * Compress PNG and JPEG files
 
-[FAQ]: /resources/faq
-[How big is the Flutter engine?]: /resources/faq#how-big-is-the-flutter-engine
-[instructions]: /deployment/ios
+[FAQ]: {{site.url}}/resources/faq
+[How big is the Flutter engine?]: {{site.url}}/resources/faq#how-big-is-the-flutter-engine
+[instructions]: {{site.url}}/deployment/ios
 [Xcode App Size Report]: {{site.apple-dev}}/documentation/xcode/reducing_your_app_s_size#3458589
-[iOS create build archive instructions]: /deployment/ios#create-a-build-archive-with-xcode
+[iOS create build archive instructions]: {{site.url}}/deployment/ios#create-a-build-archive-with-xcode
 [Model ID / Hardware number]: https://en.wikipedia.org/wiki/List_of_iOS_devices#Models
-[Obfuscating Dart code]: /deployment/obfuscate
-[Test drive]: /get-started/test-drive
-[Write your first Flutter app]: /get-started/codelab
+[Obfuscating Dart code]: {{site.url}}/deployment/obfuscate
+[Test drive]: {{site.url}}/get-started/test-drive
+[Write your first Flutter app]: {{site.url}}/get-started/codelab
 [Play Console's instructions]: https://support.google.com/googleplay/android-developer/answer/9302563?hl=en
 [Google Play Console]: https://play.google.com/apps/publish/
-[DevTools documentation]: /development/tools/devtools/app-size
+[DevTools documentation]: {{site.url}}/development/tools/devtools/app-size

--- a/src/perf/deferred-components.md
+++ b/src/perf/deferred-components.md
@@ -604,5 +604,5 @@ Play store's delivery feature.
 [Flutter wiki]: {{site.repo.flutter}}/wiki
 [github.com/google/bundletool/releases]: {{site.github}}/google/bundletool/releases
 [lazily loading a library]: {{site.dart-site}}/guides/language/language-tour#lazily-loading-a-library
-[release or profile mode]: /testing/build-modes
+[release or profile mode]: {{site.url}}/testing/build-modes
 [step 3.3]: #step-3.3

--- a/src/perf/faq.md
+++ b/src/perf/faq.md
@@ -24,7 +24,7 @@ about evaluating and debugging Flutter's performance.
 
 * What are some tools for capturing and analyzing performance
   metrics?
-  * [Dart DevTools](/development/tools/devtools)
+  * [Dart DevTools]({{site.url}}/development/tools/devtools)
   * [Apple instruments](https://en.wikipedia.org/wiki/Instruments_(software))
   * [Linux perf](https://en.wikipedia.org/wiki/Perf_(Linux))
   * [Chrome tracing (enter `about:tracing` in your
@@ -41,7 +41,7 @@ about evaluating and debugging Flutter's performance.
 * My Flutter app looks janky or stutters. How do I fix it?
   * [Improving rendering performance][]
 
-[Improving rendering performance]: /perf/rendering
+[Improving rendering performance]: {{site.url}}/perf/rendering
 
 * What are some costly performance operations that I need
   to be careful with?
@@ -52,9 +52,9 @@ about evaluating and debugging Flutter's performance.
 
 [`Clip.antiAliasWithSaveLayer`]: {{site.api}}/flutter/dart-ui/Clip-class.html
 [`ImageFilter`]: {{site.api}}/flutter/dart-ui/ImageFilter-class.html
-[Performance best practices]: /flutter/dart-ui/ImageFilter-class.html
+[Performance best practices]: {{site.url}}/flutter/dart-ui/ImageFilter-class.html
 [`Opacity`]: {{site.api}}/flutter/widgets/Opacity-class.html
-[Performance best practices]: /perf/rendering/best-practices
+[Performance best practices]: {{site.url}}/perf/rendering/best-practices
 [`savelayer`]: {{site.api}}/flutter/dart-ui/Canvas/saveLayer.html
 
 * How do I tell which widgets in my Flutter app are rebuilt
@@ -85,13 +85,13 @@ about evaluating and debugging Flutter's performance.
     as demonstrated in [Parse JSON in the background][] cookbook.
 
 [`compute()`]: {{site.api}}/flutter/foundation/compute-constant.html
-[Parse JSON in the background]: /cookbook/networking/background-parsing
+[Parse JSON in the background]: {{site.url}}/cookbook/networking/background-parsing
 
 * How do I determine my Flutter app’s package size that a
   user will download?
   * See [Measuring your app's size][]
 
-[Measuring your app's size]: /perf/app-size
+[Measuring your app's size]: {{site.url}}/perf/app-size
 
 * How do I see the breakdown of the Flutter engine size?
   * Visit the [binary size dashboard][], and replace the git

--- a/src/perf/index.md
+++ b/src/perf/index.md
@@ -18,14 +18,14 @@ that you have about performance.
 The answers to the first two questions are mostly philosophical, and not as 
 helpful to many developers who visit this page with specific
 performance issues that need to be solved. Therefore, the answers to those 
-questions are in the [appendix](/perf/appendix).
+questions are in the [appendix]({{site.url}}/perf/appendix).
 
 To improve performance, you first need metrics: some measurable numbers to
-verify the problems and improvements. In the [metrics](/perf/metrics) 
+verify the problems and improvements. In the [metrics]({{site.url}}/perf/metrics) 
 page, you'll see which metrics are currently used, and which tools and APIs 
 are available to get the metrics.
 
-There is a list of [Frequently asked questions](/perf/faq), 
+There is a list of [Frequently asked questions]({{site.url}}/perf/faq), 
 so you can find out if the questions you have or the problems you're having 
 were already answered or encountered, and whether there are existing solutions. 
 (Alternatively, you can check the Flutter GitHub issue database using the
@@ -48,7 +48,7 @@ category.
 Are your animations janky (not smooth)? Learn how to 
 evaluate and fix rendering issues.
 
-[Improving rendering performance](/perf/rendering)
+[Improving rendering performance]({{site.url}}/perf/rendering)
 
 {% comment %}
 Do your apps take a long time to open? We'll also cover the startup speed issue
@@ -58,7 +58,7 @@ in some future pages.
 
 ## Memory
 
-[Using memory wisely](/perf/memory)
+[Using memory wisely]({{site.url}}/perf/memory)
 
 
 ## App size
@@ -75,11 +75,11 @@ download.
 
 How to ensure a longer battery life when running your app.
 
-[Preserving your battery](/perf/power)
+[Preserving your battery]({{site.url}}/perf/power)
 
 {% endcomment %}
 
-[Measuring your app's size]: /perf/app-size
+[Measuring your app's size]: {{site.url}}/perf/app-size
 
 [speed]: {{site.repo.flutter}}/issues?q=is%3Aopen+label%3A%22perf%3A+speed%22+sort%3Aupdated-asc+
 [energy]: {{site.repo.flutter}}/issues?q=is%3Aopen+label%3A%22perf%3A+energy%22+sort%3Aupdated-asc+

--- a/src/perf/metrics.md
+++ b/src/perf/metrics.md
@@ -37,7 +37,7 @@ description: Flutter metrics, and which tools and APIs are used to get them
     and [flutter_gallery_ios][] tests.
   * See [metrics][size_perf] in the dashboard.
   * For info on how to measure the size more accurately,
-    see the [app size](/perf/app-size) page.
+    see the [app size]({{site.url}}/perf/app-size) page.
 
 For a complete list of performance metrics Flutter measures per commit, visit 
 the following sites, click **Query**, and filter the **test** and 

--- a/src/perf/rendering/best-practices.md
+++ b/src/perf/rendering/best-practices.md
@@ -139,10 +139,10 @@ Also see:
   a community article by AbdulRahman AlHamali
 * [`Listview.builder`][] API
 
-[Cookbook]: /cookbook
+[Cookbook]: {{site.url}}/cookbook
 [Creating a ListView that loads one page at a time]: {{site.medium}}/saugo360/flutter-creating-a-listview-that-loads-one-page-at-a-time-c5c91b6fabd3
 [`Listview.builder`]: {{site.api}}/flutter/widgets/ListView/ListView.builder.html
-[Working with long lists]: /cookbook/lists/long-lists
+[Working with long lists]: {{site.url}}/cookbook/lists/long-lists
 
 ###  Build and display frames in 16ms
 
@@ -176,7 +176,7 @@ render a frame as fast as possible. Why?
 If you are wondering why 60fps leads to a smooth visual experience,
 see the video [Why 60fps?][]
 
-[profile mode]: /testing/build-modes#profile
+[profile mode]: {{site.url}}/testing/build-modes#profile
 [Why 60fps?]: {{site.youtube-site}}/watch?v=CaMTIgxCSqU
 
 ## Pitfalls

--- a/src/perf/rendering/index.md
+++ b/src/perf/rendering/index.md
@@ -43,7 +43,7 @@ Do you see noticeable jank on your mobile app, but only on
 the first run of an animation? If so, see
 [Reduce shader animation jank on mobile][].
 
-[Reduce shader animation jank on mobile]: /perf/rendering/shader
+[Reduce shader animation jank on mobile]: {{site.url}}/perf/rendering/shader
 
 ## Web-only advice
 
@@ -57,9 +57,9 @@ app on the web:
 
 
 [Building performant Flutter widgets]: {{site.flutter-medium}}/building-performant-flutter-widgets-3b2558aa08fa
-[Flutter's build modes]: /testing/build-modes
-[Flutter performance profiling]: /perf/rendering/ui-performance
+[Flutter's build modes]: {{site.url}}/testing/build-modes
+[Flutter performance profiling]: {{site.url}}/perf/rendering/ui-performance
 [images]: {{site.flutter-medium}}/improving-perceived-performance-with-image-placeholders-precaching-and-disabled-navigation-6b3601087a2b
-[Performance best practices]: /perf/rendering/best-practices
+[Performance best practices]: {{site.url}}/perf/rendering/best-practices
 [shaking]: {{site.flutter-medium}}/optimizing-performance-in-flutter-web-apps-with-tree-shaking-and-deferred-loading-535fbe3cd674
-[Show performance data]: /development/tools/android-studio#show-performance-data
+[Show performance data]: {{site.url}}/development/tools/android-studio#show-performance-data

--- a/src/perf/rendering/shader.md
+++ b/src/perf/rendering/shader.md
@@ -11,7 +11,7 @@ but only on the first run, you can _warm up_ the
 shader captured in the Skia Shader Language (SkSL) for a
 significant improvement.
 
-![Side-by-side screenshots of janky mobile app next to non-janky app](/assets/images/docs/perf/render/shader-jank.gif)
+![Side-by-side screenshots of janky mobile app next to non-janky app]({{site.url}}/assets/images/docs/perf/render/shader-jank.gif)
 
 ## What is shader compilation jank?
 
@@ -33,7 +33,7 @@ Definitive evidence for the presence of shader compilation jank is to see
 `GrGLProgramBuilder::finalize` in the tracing with `--trace-skia` enabled. See
 the following screenshot for an example timeline tracing.
 
-![A tracing screenshot verifying jank](/assets/images/docs/perf/render/tracing.png){:width="100%"}
+![A tracing screenshot verifying jank]({{site.url}}/assets/images/docs/perf/render/tracing.png){:width="100%"}
 
 ## What do we mean by "first run"?
 
@@ -127,7 +127,7 @@ SkSLs are generated and tested automatically over the lifetime of an app.
 
 {{site.alert.note}}
   The integration_test package is now the recommended way to write integration
-  tests. See the [Integration testing](/testing/integration-tests/) page
+  tests. See the [Integration testing]({{site.url}}/testing/integration-tests/) page
   for details.
 {{site.alert.end}}
 
@@ -149,9 +149,9 @@ difference as illustrated in the beginning of this article.
 [Flutter Gallery]: {{site.repo.flutter}}/tree/master/dev/integration_tests/flutter_gallery
 [`flutter_gallery_sksl_warmup__transition_perf`]: {{site.repo.flutter}}/blob/master/dev/devicelab/bin/tasks/flutter_gallery_sksl_warmup__transition_perf.dart
 [`flutter_gallery_sksl_warmup__transition_perf_e2e_ios32`]: {{site.repo.flutter}}/blob/master/dev/devicelab/bin/tasks/flutter_gallery_sksl_warmup__transition_perf_e2e_ios32.dart
-[integration tests]: /cookbook/testing/integration/introduction
+[integration tests]: {{site.url}}/cookbook/testing/integration/introduction
 [`transitions_perf_test.dart`]: {{site.repo.flutter}}/blob/master/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_test.dart
-[limitations and considerations]: /perf/rendering/shader#limitations-and-considerations
+[limitations and considerations]: {{site.url}}/perf/rendering/shader#limitations-and-considerations
 
 ## Frequently asked questions
 

--- a/src/perf/rendering/ui-performance.md
+++ b/src/perf/rendering/ui-performance.md
@@ -35,8 +35,8 @@ steps to take, and tools that can help.
     in the [Debugging][] page.
 {{site.alert.end}}
 
-[Debugging]: /testing/debugging
-[Tracing Dart code]: /testing/debugging#tracing-dart-code
+[Debugging]: {{site.url}}/testing/debugging
+[Tracing Dart code]: {{site.url}}/testing/debugging#tracing-dart-code
 
 ## Diagnosing performance problems
 
@@ -48,7 +48,7 @@ Before you begin, you want to make sure that you're running in
 For best results, you might choose the slowest device that
 your users might use.
 
-[profile mode]: /testing/build-modes#profile
+[profile mode]: {{site.url}}/testing/build-modes#profile
 
 ### Connect to a physical device
 
@@ -115,7 +115,7 @@ see [Flutter's build modes][].
 You'll begin by opening DevTools and viewing
 the performance overlay, as discussed in the next section.
 
-[Flutter's build modes]: /testing/build-modes
+[Flutter's build modes]: {{site.url}}/testing/build-modes
 
 ## Launch DevTools
 
@@ -128,8 +128,8 @@ UI performance of your application on a frame-by-frame basis.
 Once your app is running in profile mode,
 [launch DevTools][].
 
-[launch DevTools]: /development/tools/devtools
-[Timeline view]: /development/tools/devtools/performance
+[launch DevTools]: {{site.url}}/development/tools/devtools
+[Timeline view]: {{site.url}}/development/tools/devtools/performance
 
 ## The performance overlay
 
@@ -146,7 +146,7 @@ and use it to diagnose the cause of jank in your application.
 The following screenshot shows the performance overlay running
 on the Flutter Gallery example:
 
-![Screenshot of overlay showing zero jank](/assets/images/docs/tools/devtools/performance-overlay-green.png)
+![Screenshot of overlay showing zero jank]({{site.url}}/assets/images/docs/tools/devtools/performance-overlay-green.png)
 <br>Performance overlay showing the raster thread (top),
 and UI thread (bottom).<br>The vertical green bars
 represent the current frame.
@@ -176,12 +176,12 @@ If a red bar appears in the UI graph, the Dart code is too
 expensive. If a red vertical bar appears in the GPU graph,
 the scene is too complicated to render quickly.
 
-![Screenshot of performance overlay showing jank with red bars](/assets/images/docs/tools/devtools/performance-overlay-jank.png)
+![Screenshot of performance overlay showing jank with red bars]({{site.url}}/assets/images/docs/tools/devtools/performance-overlay-jank.png)
 <br>The vertical red bars indicate that the current frame is
 expensive to both render and paint.<br>When both graphs
 display red, start by diagnosing the UI thread.
 
-[debug mode]: /testing/build-modes#debug
+[debug mode]: {{site.url}}/testing/build-modes#debug
 
 ## Flutter's threads
 
@@ -255,7 +255,7 @@ from the Flutter inspector, which is available in the
 **Performance Overlay** button to toggle the overlay
 on your running app.
 
-[Inspector view]: /development/tools/devtools/inspector
+[Inspector view]: {{site.url}}/development/tools/devtools/inspector
 
 #### From the command line
 
@@ -268,8 +268,8 @@ To enable the overlay programmatically, see
 [Performance overlay][], a section in the
 [Debugging Flutter apps programmatically][] page.
 
-[Debugging Flutter apps programmatically]: /testing/code-debugging
-[Performance overlay]: /testing/code-debugging#performance-overlay
+[Debugging Flutter apps programmatically]: {{site.url}}/testing/code-debugging
+[Performance overlay]: {{site.url}}/testing/code-debugging#performance-overlay
 
 ## Identifying problems in the UI graph
 
@@ -302,7 +302,7 @@ instead of clipping to a rounded rectangle.
 If it's a static scene that's being faded, rotated, or otherwise
 manipulated, a [`RepaintBoundary`][] might help.
 
-[programmatically]: /testing/code-debugging#debugging-animations
+[programmatically]: {{site.url}}/testing/code-debugging#debugging-animations
 [`RepaintBoundary`]: {{site.api}}/flutter/widgets/RepaintBoundary-class.html
 [`saveLayer`]: {{site.api}}/flutter/dart-ui/Canvas/saveLayer.html
 
@@ -401,7 +401,7 @@ You can view the widget rebuilt counts for the current screen and
 frame in the Flutter plugin for Android Studio and IntelliJ.
 For details on how to do this, see [Show performance data][]
 
-[Show performance data]: /development/tools/android-studio#show-performance-data
+[Show performance data]: {{site.url}}/development/tools/android-studio#show-performance-data
 
 ## Benchmarking
 
@@ -421,8 +421,8 @@ regression is introduced that adversely affects performance.
 For more information, see [Integration testing][],
 a section in [Testing Flutter apps][].
 
-[Integration testing]: /testing#integration-tests
-[Testing Flutter apps]: /testing
+[Integration testing]: {{site.url}}/testing#integration-tests
+[Testing Flutter apps]: {{site.url}}/testing
 
 ## Other resources
 
@@ -439,9 +439,9 @@ Flutter's tools and debugging in Flutter:
   and the [dart:developer][] package
 
 [dart:developer]: {{site.api}}/flutter/dart-developer/dart-developer-library.html
-[devtools]: /development/tools/devtools
+[devtools]: {{site.url}}/development/tools/devtools
 [Flutter API]: {{site.api}}
-[Flutter inspector]: /development/tools/devtools/inspector
+[Flutter inspector]: {{site.url}}/development/tools/devtools/inspector
 [Flutter inspector talk]: {{site.youtube-site}}/watch?v=JIcmJNT9DNI
 [`PerformanceOverlay`]: {{site.api}}/flutter/widgets/PerformanceOverlay-class.html
 [video]: {{site.youtube-site}}/watch?v=5F-6n_2XWR8

--- a/src/reference/tutorials.md
+++ b/src/reference/tutorials.md
@@ -8,22 +8,22 @@ build mobile applications for iOS and Android.
 
 Choose from the following:
 
-* [Building layouts](/development/ui/layout/tutorial)
+* [Building layouts]({{site.url}}/development/ui/layout/tutorial)
 : How to build layouts using Flutter's layout mechanism. Once you've learned
   basic principles, you'll build the layout for a sample screenshot.
 
-* [Adding interactivity to your Flutter app](/development/ui/interactive)
+* [Adding interactivity to your Flutter app]({{site.url}}/development/ui/interactive)
 : You'll extend the simple layout app created in
   "Building Layouts in Flutter" to make an icon tappable.
   Different ways of managing a widget's state are also discussed.
 
-* [Animations in Flutter](/development/ui/animations/tutorial)
+* [Animations in Flutter]({{site.url}}/development/ui/animations/tutorial)
 : Explains the fundamental classes in the Flutter animation package
   (controllers, Animatable, curves, listeners, builders),
   as it guides you through a progression of tween animations using
   different aspects of the animation APIs.
 
-* [Internationalizing Flutter apps](/development/accessibility-and-localization/internationalization)
+* [Internationalizing Flutter apps]({{site.url}}/development/accessibility-and-localization/internationalization)
 : Learn how to internationalize your Flutter application. A guide through
   the widgets and classes that enable apps to display their
   content using the user's language and formatting conventions.

--- a/src/reference/widgets.md
+++ b/src/reference/widgets.md
@@ -13,7 +13,7 @@ Flutter. You can also [browse widgets by category][catalog].
 You might also want to check out our Widget of the Week video series
 on the [Flutter YouTube channel]({{site.social.youtube}}). Each short
 episode features a different Flutter widget. For more video series, see
-our [videos](/resources/videos) page.
+our [videos]({{site.url}}/resources/videos) page.
 
 <iframe width="560" height="315" src="{{site.youtube-site}}/embed/b_sQ9bMltGU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 [Widget of the Week playlist]({{site.youtube-site}}/playlist?list=PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG)
@@ -34,4 +34,4 @@ our [videos](/resources/videos) page.
 {% endfor %}
 </div>
 
-[catalog]: /development/ui/widgets
+[catalog]: {{site.url}}/development/ui/widgets

--- a/src/release/breaking-changes/1-22-deprecations.md
+++ b/src/release/breaking-changes/1-22-deprecations.md
@@ -21,8 +21,8 @@ A [design document][] and [article][] are available
 for more context on Flutter's deprecation policy.
 
 [Deprecation Policy]: {{site.repo.flutter}}/wiki/Tree-hygiene#deprecation
-[quick reference sheet]: /go/deprecations-removed-after-1-22
-[design document]: /go/deprecation-lifetime
+[quick reference sheet]: {{site.url}}/go/deprecations-removed-after-1-22
+[design document]: {{site.url}}/go/deprecation-lifetime
 [article]: {{site.flutter-medium}}/deprecation-lifetime-in-flutter-e4d76ee738ad
 
 ## Changes

--- a/src/release/breaking-changes/2-2-deprecations.md
+++ b/src/release/breaking-changes/2-2-deprecations.md
@@ -15,7 +15,7 @@ primary source to aid in migration. A
 
 
 [Deprecation Policy]: {{site.repo.flutter}}/wiki/Tree-hygiene#deprecation
-[quick reference sheet]: /go/deprecations-removed-after-2-2
+[quick reference sheet]: {{site.url}}/go/deprecations-removed-after-2-2
 
 ## Changes
 
@@ -259,7 +259,7 @@ Relevant PRs:
 * Deprecated in [#48547][]
 * Removed in [#83924][]
 
-[Update the TextTheme API]: /go/update-text-theme-api
+[Update the TextTheme API]: {{site.url}}/go/update-text-theme-api
 [`TextTheme`]: {{site.api}}/flutter/material/TextTheme-class.html
 [Migrate TextTheme to 2018 APIs]: {{site.repo.flutter}}/issues/45745
 [#48547]: {{site.repo.flutter}}/pull/48547
@@ -311,7 +311,7 @@ Relevant PRs:
 * Deprecated in [#48547][]
 * Removed in [#83924][]
 
-[Update the TextTheme API]: /go/update-text-theme-api
+[Update the TextTheme API]: {{site.url}}/go/update-text-theme-api
 [`Typography`]: {{site.api}}/flutter/material/Typography-class.html
 [Migrate TextTheme to 2018 APIs]: {{site.repo.flutter}}/issues/45745
 [#48547]: {{site.repo.flutter}}/pull/48547

--- a/src/release/breaking-changes/2-5-deprecations.md
+++ b/src/release/breaking-changes/2-5-deprecations.md
@@ -15,7 +15,7 @@ primary source to aid in migration. A
 
 
 [Deprecation Policy]: {{site.repo.flutter}}/wiki/Tree-hygiene#deprecation
-[quick reference sheet]: /go/deprecations-removed-after-2-5
+[quick reference sheet]: {{site.url}}/go/deprecations-removed-after-2-5
 
 ## Changes
 
@@ -82,7 +82,7 @@ const DropdownButtonFormField dropDownButtonFormField = DropdownButtonFormField(
 const DropdownButtonFormField dropdownButtonFormField = DropdownButtonFormField(autovalidateMode: AutovalidateMode.disabled);
 ```
 
-[In-depth migration guide available]: /release/breaking-changes/form-field-autovalidation-api
+[In-depth migration guide available]: {{site.url}}/release/breaking-changes/form-field-autovalidation-api
 
 **References**
 
@@ -337,8 +337,8 @@ Relevant PRs:
 * Deprecated in [#59127]({{site.repo.flutter}}/issues/59127)
 * Removed in [#90295]({{site.repo.flutter}}/issues/90295)
 
-[In-depth migration guide available]: /release/breaking-changes/bottom-navigation-title-to-label
-[BottomNavigationBarItem title]: /go/bottom-navigation-bar-title-deprecation
+[In-depth migration guide available]: {{site.url}}/release/breaking-changes/bottom-navigation-title-to-label
+[BottomNavigationBarItem title]: {{site.url}}/go/bottom-navigation-bar-title-deprecation
 [`BottomNavigationBarItem`]: {{site.api}}/flutter/widgets/BottomNavigationBarItem-class.html
 [`BottomNavigationBar`]: {{site.api}}/flutter/material/BottomNavigationBar-class.html
 [`Tooltip`]: {{site.api}}/flutter/material/Tooltip-class.html

--- a/src/release/breaking-changes/actions-api-revision.md
+++ b/src/release/breaking-changes/actions-api-revision.md
@@ -58,7 +58,7 @@ The majority of these changes were made in the PRs for
 [Revise Action API][] and [Make Action.enabled be
 isEnabled(Intent intent) instead][], and are
 described in detail in [the design
-doc](/go/actions-and-shortcuts-design-revision).
+doc]({{site.url}}/go/actions-and-shortcuts-design-revision).
 
 ## Description of change
 

--- a/src/release/breaking-changes/android-v1-embedding-create-deprecation.md
+++ b/src/release/breaking-changes/android-v1-embedding-create-deprecation.md
@@ -19,9 +19,9 @@ Plugins targeting the v1 Android embedding are encouraged
 to migrate following the instructions in
 [Supporting the new Android plugins APIs][].
 
-[Android Migration Summary]: /go/android-migration-summary
-[Upgrading pre 1.12 Android projects]: /go/android-project-migration
-[Supporting the new Android plugins APIs]: /development/packages-and-plugins/plugin-api-migration
+[Android Migration Summary]: {{site.url}}/go/android-migration-summary
+[Upgrading pre 1.12 Android projects]: {{site.url}}/go/android-project-migration
+[Supporting the new Android plugins APIs]: {{site.url}}/development/packages-and-plugins/plugin-api-migration
 
 ## Context
 
@@ -41,7 +41,7 @@ the 7 months since the launch of Flutter v1.12,
 we disabled the creation of new app and plugin
 projects using the v1 embeddings.
 
-[add-to-app]: /development/add-to-app
+[add-to-app]: {{site.url}}/development/add-to-app
 [`io.flutter.embedding`]: https://cs.opensource.google/flutter/engine/+/master:shell/platform/android/io/flutter/embedding/
 [`io.flutter.app`]: https://cs.opensource.google/flutter/engine/+/master:shell/platform/android/io/flutter/app/.
 
@@ -77,7 +77,7 @@ as plugin developers create and publish v2 plugins.
 
 See the [migration guide][].
 
-[migration guide]: /go/android-project-migration
+[migration guide]: {{site.url}}/go/android-project-migration
 
 ## Timeline
 

--- a/src/release/breaking-changes/bottom-navigation-title-to-label.md
+++ b/src/release/breaking-changes/bottom-navigation-title-to-label.md
@@ -69,6 +69,6 @@ Breaking change proposal:
 
 
 [`BottomNavigationBarItem`]: {{site.api}}/flutter/widgets/BottomNavigationBarItem-class.html
-[Breaking Change: Bottom Navigation Item Title]: /go/bottom-navigation-bar-title-deprecation
+[Breaking Change: Bottom Navigation Item Title]: {{site.url}}/go/bottom-navigation-bar-title-deprecation
 [PR 59127]: {{site.repo.flutter}}/pull/59127
 [PR 60655]: {{site.repo.flutter}}/pull/60655

--- a/src/release/breaking-changes/cupertino-tab-bar-localizations.md
+++ b/src/release/breaking-changes/cupertino-tab-bar-localizations.md
@@ -166,6 +166,6 @@ Relevant PR:
 [`DefaultCupertinoLocalizations`]: {{site.api}}/flutter/cupertino/DefaultCupertinoLocalizations-class.html
 [`Semantics`]: {{site.api}}/flutter/widgets/Semantics-class.html
 [`CupertinoApp`]: {{site.api}}/flutter/cupertino/CupertinoApp-class.html
-[Internationalizing Flutter Apps]: /development/accessibility-and-localization/internationalization
+[Internationalizing Flutter Apps]: {{site.url}}/development/accessibility-and-localization/internationalization
 [PR 55336: Adding tabSemanticsLabel to CupertinoLocalizations]: {{site.repo.flutter}}/pull/55336
 [PR 56582: Update Tab semantics in Cupertino to be the same as Material]: {{site.repo.flutter}}/pull/56582#issuecomment-625497951

--- a/src/release/breaking-changes/eliminating-nullok-parameters.md
+++ b/src/release/breaking-changes/eliminating-nullok-parameters.md
@@ -37,7 +37,7 @@ the widget was not present.
 
 The design document for this change is [Eliminating nullOk parameters][].
 
-[Eliminating nullOk parameters]: /go/eliminating-nullok-parameters
+[Eliminating nullOk parameters]: {{site.url}}/go/eliminating-nullok-parameters
 
 
 ## Description of change

--- a/src/release/breaking-changes/fab-theme-data-accent-properties.md
+++ b/src/release/breaking-changes/fab-theme-data-accent-properties.md
@@ -149,8 +149,8 @@ Other:
 [`FloatingActionButton`]: {{site.api}}/flutter/material/FloatingActionButton/foregroundColor.html
 [`FloatingActionButtonThemeData`]: {{site.api}}/flutter/material/FloatingActionButtonThemeData-class.html
 [Material Design spec]: {{site.material}}/design/color
-[Material Theme System Updates]: /go/material-theme-system-updates
-[Remove FAB Accent Theme Dependency]: /go/remove-fab-accent-theme-dependency
+[Material Theme System Updates]: {{site.url}}/go/material-theme-system-updates
+[Remove FAB Accent Theme Dependency]: {{site.url}}/go/remove-fab-accent-theme-dependency
 [secondary color]: {{site.material}}/design/color/the-color-system.html#color-theme-creation
 [Step 1 of 2]: {{site.repo.flutter}}/pull/48435
 [Step 2 of 2]: {{site.repo.flutter}}/pull/46923

--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -14,7 +14,7 @@ release, and listed in alphabetical order:
 
 * [Deprecated API removed after v2.5][]
 
-[Deprecated API removed after v2.5]: /release/breaking-changes/2-5-deprecations
+[Deprecated API removed after v2.5]: {{site.url}}/release/breaking-changes/2-5-deprecations
 
 ### Released in Flutter 2.5
 
@@ -28,15 +28,15 @@ release, and listed in alphabetical order:
 * [Transition of platform channel test interfaces to flutter_test package][]
 * [Using HTML slots to render platform views in the web][]
 
-[Change the enterText method to move the caret to the end of the input text]: /release/breaking-changes/enterText-trailing-caret
-[Default drag scrolling devices]: /release/breaking-changes/default-scroll-behavior-drag
-[Deprecated API removed after v2.2]: /release/breaking-changes/2-2-deprecations
-[GestureRecognizer cleanup]: /release/breaking-changes/gesture-recognizer-add-allowed-pointer
-[Introducing package:flutter_lints]: /release/breaking-changes/flutter-lints-package
-[Replace AnimationSheetBuilder.display with collate]: /release/breaking-changes/animation-sheet-builder-display
-[ThemeData's accent properties have been deprecated]: /release/breaking-changes/theme-data-accent-properties
-[Transition of platform channel test interfaces to flutter_test package]: /release/breaking-changes/mock-platform-channels
-[Using HTML slots to render platform views in the web]: /release/breaking-changes/platform-views-using-html-slots-web
+[Change the enterText method to move the caret to the end of the input text]: {{site.url}}/release/breaking-changes/enterText-trailing-caret
+[Default drag scrolling devices]: {{site.url}}/release/breaking-changes/default-scroll-behavior-drag
+[Deprecated API removed after v2.2]: {{site.url}}/release/breaking-changes/2-2-deprecations
+[GestureRecognizer cleanup]: {{site.url}}/release/breaking-changes/gesture-recognizer-add-allowed-pointer
+[Introducing package:flutter_lints]: {{site.url}}/release/breaking-changes/flutter-lints-package
+[Replace AnimationSheetBuilder.display with collate]: {{site.url}}/release/breaking-changes/animation-sheet-builder-display
+[ThemeData's accent properties have been deprecated]: {{site.url}}/release/breaking-changes/theme-data-accent-properties
+[Transition of platform channel test interfaces to flutter_test package]: {{site.url}}/release/breaking-changes/mock-platform-channels
+[Using HTML slots to render platform views in the web]: {{site.url}}/release/breaking-changes/platform-views-using-html-slots-web
 
 ### Reverted change in 2.2
 
@@ -46,13 +46,13 @@ The following breaking change was reverted in release 2.2:
 :  Introduced in version: 2.0.0<br>
    Reverted in version:   2.2.0 (proposed)
 
-[Network Policy on iOS and Android]: /release/breaking-changes/network-policy-ios-android
+[Network Policy on iOS and Android]: {{site.url}}/release/breaking-changes/network-policy-ios-android
 
 ### Released in Flutter 2.2
 
 * [Default Scrollbars on Desktop][]
 
-[Default Scrollbars on Desktop]: /release/breaking-changes/default-desktop-scrollbars
+[Default Scrollbars on Desktop]: {{site.url}}/release/breaking-changes/default-desktop-scrollbars
 
 ### Released in Flutter 2
 
@@ -69,18 +69,18 @@ The following breaking change was reverted in release 2.2:
 * [Use maxLengthEnforcement instead of maxLengthEnforced][]
 * [Transition of platform channel test interfaces to flutter_test package][]
 
-[Added BuildContext parameter to TextEditingController.buildTextSpan]: /release/breaking-changes/buildtextspan-buildcontext
-[Android ActivityControlSurface attachToActivity signature change]: /release/breaking-changes/android-activity-control-surface-attach
-[Android FlutterMain.setIsRunningInRobolectricTest testing API removed]: /release/breaking-changes/android-setIsRunningInRobolectricTest-removed
-[Clip behavior]: /release/breaking-changes/clip-behavior
-[Deprecated API removed after v1.22]: /release/breaking-changes/1-22-deprecations
-[Dry layout support for RenderBox]: /release/breaking-changes/renderbox-dry-layout
-[Eliminating nullOk Parameters]: /release/breaking-changes/eliminating-nullok-parameters
-[Material Chip button semantics]: /release/breaking-changes/material-chip-button-semantics
-[SnackBars managed by the ScaffoldMessenger]: /release/breaking-changes/scaffold-messenger
-[TextSelectionTheme migration]: /release/breaking-changes/text-selection-theme
-[Use maxLengthEnforcement instead of maxLengthEnforced]: /release/breaking-changes/use-maxLengthEnforcement-instead-of-maxLengthEnforced
-[Transition of platform channel test interfaces to flutter_test package]: /release/breaking-changes/mock-platform-channels
+[Added BuildContext parameter to TextEditingController.buildTextSpan]: {{site.url}}/release/breaking-changes/buildtextspan-buildcontext
+[Android ActivityControlSurface attachToActivity signature change]: {{site.url}}/release/breaking-changes/android-activity-control-surface-attach
+[Android FlutterMain.setIsRunningInRobolectricTest testing API removed]: {{site.url}}/release/breaking-changes/android-setIsRunningInRobolectricTest-removed
+[Clip behavior]: {{site.url}}/release/breaking-changes/clip-behavior
+[Deprecated API removed after v1.22]: {{site.url}}/release/breaking-changes/1-22-deprecations
+[Dry layout support for RenderBox]: {{site.url}}/release/breaking-changes/renderbox-dry-layout
+[Eliminating nullOk Parameters]: {{site.url}}/release/breaking-changes/eliminating-nullok-parameters
+[Material Chip button semantics]: {{site.url}}/release/breaking-changes/material-chip-button-semantics
+[SnackBars managed by the ScaffoldMessenger]: {{site.url}}/release/breaking-changes/scaffold-messenger
+[TextSelectionTheme migration]: {{site.url}}/release/breaking-changes/text-selection-theme
+[Use maxLengthEnforcement instead of maxLengthEnforced]: {{site.url}}/release/breaking-changes/use-maxLengthEnforcement-instead-of-maxLengthEnforced
+[Transition of platform channel test interfaces to flutter_test package]: {{site.url}}/release/breaking-changes/mock-platform-channels
 
 ### Released in Flutter 1.22
 
@@ -89,9 +89,9 @@ The following breaking change was reverted in release 2.2:
 * [The new Form, FormField auto-validation API][]
 
 
-[Android v1 embedding app and plugin creation deprecation]: /release/breaking-changes/android-v1-embedding-create-deprecation
-[Cupertino icons 1.0.0]: /release/breaking-changes/cupertino-icons-1.0.0
-[The new Form, FormField auto-validation API]: /release/breaking-changes/form-field-autovalidation-api
+[Android v1 embedding app and plugin creation deprecation]: {{site.url}}/release/breaking-changes/android-v1-embedding-create-deprecation
+[Cupertino icons 1.0.0]: {{site.url}}/release/breaking-changes/cupertino-icons-1.0.0
+[The new Form, FormField auto-validation API]: {{site.url}}/release/breaking-changes/form-field-autovalidation-api
 
 ### Released in Flutter 1.20
 
@@ -108,18 +108,18 @@ The following breaking change was reverted in release 2.2:
 * [TestWidgetsFlutterBinding.clock][]
 * [TextField requires MaterialLocalizations][]
 
-[Actions API revision]: /release/breaking-changes/actions-api-revision
-[Adding TextInputClient.currentAutofillScope property]: /release/breaking-changes/add-currentAutofillScope-to-TextInputClient
-[New Buttons and Button Themes]: /release/breaking-changes/buttons
-[Dialogs' Default BorderRadius]: /release/breaking-changes/dialog-border-radius
-[More Strict Assertions in the Navigator and the Hero Controller Scope]: /release/breaking-changes/hero-controller-scope
-[Reversing the dependency between the scheduler and services layer]: /release/breaking-changes/services-scheduler-dependency-reversed
-[The RenderEditable needs to be laid out before hit testing]: /release/breaking-changes/rendereditable-layout-before-hit-test
-[Semantics Order of the Overlay Entries in Modal Routes]: /release/breaking-changes/modal-router-semantics-order
-[showAutocorrectionPromptRect method added to TextInputClient]: /release/breaking-changes/add-showAutocorrectionPromptRect
-[TestWidgetsFlutterBinding.clock]: /release/breaking-changes/test-widgets-flutter-binding-clock
-[TextField requires MaterialLocalizations]: /release/breaking-changes/text-field-material-localizations
-[The Route Transition record and Transition delegate updates]: /release/breaking-changes/route-transition-record-and-transition-delegate
+[Actions API revision]: {{site.url}}/release/breaking-changes/actions-api-revision
+[Adding TextInputClient.currentAutofillScope property]: {{site.url}}/release/breaking-changes/add-currentAutofillScope-to-TextInputClient
+[New Buttons and Button Themes]: {{site.url}}/release/breaking-changes/buttons
+[Dialogs' Default BorderRadius]: {{site.url}}/release/breaking-changes/dialog-border-radius
+[More Strict Assertions in the Navigator and the Hero Controller Scope]: {{site.url}}/release/breaking-changes/hero-controller-scope
+[Reversing the dependency between the scheduler and services layer]: {{site.url}}/release/breaking-changes/services-scheduler-dependency-reversed
+[The RenderEditable needs to be laid out before hit testing]: {{site.url}}/release/breaking-changes/rendereditable-layout-before-hit-test
+[Semantics Order of the Overlay Entries in Modal Routes]: {{site.url}}/release/breaking-changes/modal-router-semantics-order
+[showAutocorrectionPromptRect method added to TextInputClient]: {{site.url}}/release/breaking-changes/add-showAutocorrectionPromptRect
+[TestWidgetsFlutterBinding.clock]: {{site.url}}/release/breaking-changes/test-widgets-flutter-binding-clock
+[TextField requires MaterialLocalizations]: {{site.url}}/release/breaking-changes/text-field-material-localizations
+[The Route Transition record and Transition delegate updates]: {{site.url}}/release/breaking-changes/route-transition-record-and-transition-delegate
 
 ### Released in Flutter 1.17
 
@@ -141,22 +141,22 @@ The following breaking change was reverted in release 2.2:
 * [The Route and Navigator refactoring][]
 * [FloatingActionButton and ThemeData's accent properties][]
 
-[Adding 'linux' and 'windows' to TargetPlatform enum]: /release/breaking-changes/target-platform-linux-windows
-[Annotations return local position relative to object]: /release/breaking-changes/annotations-return-local-position-relative-to-object
-[breaking change policy]: /resources/compatibility
-[Container color optimization]: /release/breaking-changes/container-color
-[CupertinoTabBar requires Localizations parent]: /release/breaking-changes/cupertino-tab-bar-localizations
-[Generic type of ParentDataWidget changed to ParentData]: /release/breaking-changes/parent-data-widget-generic-type
-[ImageCache and ImageProvider changes]: /release/breaking-changes/image-cache-and-provider
-[ImageCache large images]: /release/breaking-changes/imagecache-large-images
-[MouseTracker moved to rendering]: /release/breaking-changes/mouse-tracker-moved-to-rendering
-[MouseTracker no longer attaches annotations]: /release/breaking-changes/mouse-tracker-no-longer-attaches-annotations
-[Nullable CupertinoTheme.brightness]: /release/breaking-changes/nullable-cupertinothemedata-brightness
-[Rebuild optimization for OverlayEntries and Routes]: /release/breaking-changes/overlay-entry-rebuilds
-[Replace AnimationSheetBuilder.display with collate]: /release/breaking-changes/animation-sheet-builder-display
-[Scrollable AlertDialog]: /release/breaking-changes/scrollable-alert-dialog
-[TestTextInput state reset]: /release/breaking-changes/test-text-input
-[TextInputClient currentTextEditingValue]: /release/breaking-changes/text-input-client-current-value
-[The forgetChild() method must call super]: /release/breaking-changes/forgetchild-call-super
-[The Route and Navigator refactoring]: /release/breaking-changes/route-navigator-refactoring
-[FloatingActionButton and ThemeData's accent properties]: /release/breaking-changes/fab-theme-data-accent-properties
+[Adding 'linux' and 'windows' to TargetPlatform enum]: {{site.url}}/release/breaking-changes/target-platform-linux-windows
+[Annotations return local position relative to object]: {{site.url}}/release/breaking-changes/annotations-return-local-position-relative-to-object
+[breaking change policy]: {{site.url}}/resources/compatibility
+[Container color optimization]: {{site.url}}/release/breaking-changes/container-color
+[CupertinoTabBar requires Localizations parent]: {{site.url}}/release/breaking-changes/cupertino-tab-bar-localizations
+[Generic type of ParentDataWidget changed to ParentData]: {{site.url}}/release/breaking-changes/parent-data-widget-generic-type
+[ImageCache and ImageProvider changes]: {{site.url}}/release/breaking-changes/image-cache-and-provider
+[ImageCache large images]: {{site.url}}/release/breaking-changes/imagecache-large-images
+[MouseTracker moved to rendering]: {{site.url}}/release/breaking-changes/mouse-tracker-moved-to-rendering
+[MouseTracker no longer attaches annotations]: {{site.url}}/release/breaking-changes/mouse-tracker-no-longer-attaches-annotations
+[Nullable CupertinoTheme.brightness]: {{site.url}}/release/breaking-changes/nullable-cupertinothemedata-brightness
+[Rebuild optimization for OverlayEntries and Routes]: {{site.url}}/release/breaking-changes/overlay-entry-rebuilds
+[Replace AnimationSheetBuilder.display with collate]: {{site.url}}/release/breaking-changes/animation-sheet-builder-display
+[Scrollable AlertDialog]: {{site.url}}/release/breaking-changes/scrollable-alert-dialog
+[TestTextInput state reset]: {{site.url}}/release/breaking-changes/test-text-input
+[TextInputClient currentTextEditingValue]: {{site.url}}/release/breaking-changes/text-input-client-current-value
+[The forgetChild() method must call super]: {{site.url}}/release/breaking-changes/forgetchild-call-super
+[The Route and Navigator refactoring]: {{site.url}}/release/breaking-changes/route-navigator-refactoring
+[FloatingActionButton and ThemeData's accent properties]: {{site.url}}/release/breaking-changes/fab-theme-data-accent-properties

--- a/src/release/breaking-changes/layout-builder-optimization.md
+++ b/src/release/breaking-changes/layout-builder-optimization.md
@@ -291,7 +291,7 @@ Relevant issues:
 Relevant PRs:
 * [LayoutBuilder: skip calling builder when constraints are the same][6]
 
-[1]: /go/layout-builder-optimization
+[1]: {{site.url}}/go/layout-builder-optimization
 [2]: {{site.api}}/flutter/widgets/LayoutBuilder-class.html
 [3]: {{site.api}}/flutter/widgets/SliverLayoutBuilder-class.html
 [4]: {{site.api}}/flutter/widgets/LayoutBuilder/builder.html

--- a/src/release/breaking-changes/network-policy-ios-android.md
+++ b/src/release/breaking-changes/network-policy-ios-android.md
@@ -76,7 +76,7 @@ builds, you can add the following snippet to your $project_path\android\app\src\
 <application android:usesCleartextTraffic="true"/>
 ```
 
-For iOS, you can follow [these instructions](/development/add-to-app/ios/project-setup#local-network-privacy-permissions) to create a `Info-debug.plist` and put this in:
+For iOS, you can follow [these instructions]({{site.url}}/development/add-to-app/ios/project-setup#local-network-privacy-permissions) to create a `Info-debug.plist` and put this in:
 
 ```
 <key>NSAppTransportSecurity</key>

--- a/src/release/breaking-changes/nullable-cupertinothemedata-brightness.md
+++ b/src/release/breaking-changes/nullable-cupertinothemedata-brightness.md
@@ -78,4 +78,4 @@ Relevant PR:
 [`CupertinoThemeData.brightness`]: {{site.api}}/flutter/cupertino/NoDefaultCupertinoThemeData/brightness.html
 [Issue 47255]: {{site.repo.flutter}}/issues/47255
 [Let material `ThemeData` dictate brightness if `cupertinoOverrideTheme.brightness` is null]: {{site.repo.flutter}}/pull/47249
-[Make `CupertinoThemeData.brightness nullable`]: /go/nullable-cupertinothemedata-brightness
+[Make `CupertinoThemeData.brightness nullable`]: {{site.url}}/go/nullable-cupertinothemedata-brightness

--- a/src/release/breaking-changes/platform-views-using-html-slots-web.md
+++ b/src/release/breaking-changes/platform-views-using-html-slots-web.md
@@ -189,7 +189,7 @@ Relevant PRs:
 [`CSS width`]: https://developer.mozilla.org/en-US/docs/Web/CSS/width
 [`HtmlElementView` widgets]: {{site.api}}/flutter/widgets/HtmlElementView-class.html
 [`PlatformViewFactory` functions]: {{site.github}}/flutter/engine/blob/58459a5e342f84c755919f2ad5029b22bcddd548/lib/web_ui/lib/src/engine/platform_views/content_manager.dart#L15-L18
-[design doc]: /go/web-slot-content
+[design doc]: {{site.url}}/go/web-slot-content
 [issue-80524]: {{site.repo.flutter}}/issues/80524
 [pull-25747]: {{site.github}}/flutter/engine/pull/25747
 [pull-364]: {{site.github}}/flutter/packages/pull/364

--- a/src/release/breaking-changes/route-navigator-refactoring.md
+++ b/src/release/breaking-changes/route-navigator-refactoring.md
@@ -154,7 +154,7 @@ Relevant PR:
 [`Navigator`]: {{site.api}}/flutter/widgets/Navigator-class.html
 [`Navigator.pop`]: {{site.api}}/flutter/widgets/Navigator/pop.html
 [`Navigator.canPop`]: {{site.api}}/flutter/widgets/Navigator/canPop.html
-[Router]: /go/navigator-with-router
+[Router]: {{site.url}}/go/navigator-with-router
 [PR 44930]: {{site.repo.flutter}}/pull/44930
 [`Route`]: {{site.api}}/flutter/widgets/Route-class.html
 [`Route.install`]: {{site.api}}/flutter/widgets/Route/install.html

--- a/src/release/breaking-changes/scrollable-alert-dialog.md
+++ b/src/release/breaking-changes/scrollable-alert-dialog.md
@@ -198,5 +198,5 @@ Relevant PRs:
 [Original attempt to implement scrollable `AlertDialog`]: {{site.repo.flutter}}/pull/43226
 [Overflow exceptions with maximum accessibility font size]: {{site.repo.flutter}}/issues/42696
 [Revert of original attempt to implement scrollable `AlertDialog`]: {{site.repo.flutter}}/pull/44003
-[Scrollable `AlertDialog`]: /go/scrollable-alert-dialog
+[Scrollable `AlertDialog`]: {{site.url}}/go/scrollable-alert-dialog
 [Update to `AlertDialog.scrollable`]: {{site.repo.flutter}}/pull/45079

--- a/src/release/breaking-changes/text-field-material-localizations.md
+++ b/src/release/breaking-changes/text-field-material-localizations.md
@@ -125,5 +125,5 @@ Relevant PR:
 [`MaterialLocalizations`]: {{site.api}}/flutter/material/MaterialLocalizations-class.html
 [`DefaultMaterialLocalizations`]: {{site.api}}/flutter/material/DefaultMaterialLocalizations-class.html
 [`MaterialApp`]: {{site.api}}/flutter/material/MaterialApp-class.html
-[Internationalizing Flutter apps]: /development/accessibility-and-localization/internationalization
+[Internationalizing Flutter apps]: {{site.url}}/development/accessibility-and-localization/internationalization
 [PR 58831: Assert debugCheckHasMaterialLocalizations on TextField]: {{site.repo.flutter}}/pull/58831

--- a/src/release/breaking-changes/text-selection-theme.md
+++ b/src/release/breaking-changes/text-selection-theme.md
@@ -117,8 +117,8 @@ API documentation:
 Relevant PRs:
 * [PR 62014: TextSelectionTheme support][]
 
-[Material Theme Updates]: /go/material-theme-system-updates
+[Material Theme Updates]: {{site.url}}/go/material-theme-system-updates
 [PR 62014: TextSelectionTheme support]: {{site.repo.flutter}}/pull/62014
-[Text Selection Theme]: /go/text-selection-theme
+[Text Selection Theme]: {{site.url}}/go/text-selection-theme
 [`TextSelectionThemeData`]: {{site.api}}/flutter/material/TextSelectionThemeData-class.html
 [`ThemeData`]: {{site.api}}/flutter/material/ThemeData-class.html

--- a/src/release/breaking-changes/theme-data-accent-properties.md
+++ b/src/release/breaking-changes/theme-data-accent-properties.md
@@ -178,12 +178,12 @@ Other:
 [`colorScheme.secondary`]: {{site.api}}/flutter/material/ColorScheme/secondary.html
 [`ColorScheme`]: {{site.api}}/flutter/material/ColorScheme-class.html
 [Issue #56918]: {{site.repo.flutter}}/issues/56918
-[FloatingActionButton and ThemeData's accent properties]: /release/breaking-changes/fab-theme-data-accent-properties
+[FloatingActionButton and ThemeData's accent properties]: {{site.url}}/release/breaking-changes/fab-theme-data-accent-properties
 [`FloatingActionButton`]: {{site.api}}/flutter/material/FloatingActionButton-class.html
 [`FloatingActionButtonTheme`]: {{site.api}}/flutter/material/FloatingActionButtonTheme-class.html
 [`FloatingActionButtonThemeData`]: {{site.api}}/flutter/material/FloatingActionButtonThemeData-class.html
 [Material Design spec]: {{site.material}}/design/color
-[Material Theme System Updates]: /go/material-theme-system-updates
+[Material Theme System Updates]: {{site.url}}/go/material-theme-system-updates
 [secondary color]: {{site.api}}/flutter/material/ColorScheme/secondary.html
 [onSecondary color]: {{site.api}}/flutter/material/ColorScheme/onSecondary.html
 [PR #81336]: {{site.repo.flutter}}/pull/81336

--- a/src/release/breaking-changes/use-maxLengthEnforcement-instead-of-maxLengthEnforced.md
+++ b/src/release/breaking-changes/use-maxLengthEnforcement-instead-of-maxLengthEnforced.md
@@ -247,7 +247,7 @@ Relevant PR:
 * [PR 63754][]: Fix TextField crashed with composing and maxLength set
 * [PR 68086][]: Introduce `MaxLengthEnforcement`
 
-[`MaxLengthEnforcement` design doc]: /go/max-length-enforcement
+[`MaxLengthEnforcement` design doc]: {{site.url}}/go/max-length-enforcement
 
 [`MaxLengthEnforcement`]: {{site.api}}/flutter/services/MaxLengthEnforcement-class.html
 

--- a/src/resources/architectural-overview.md
+++ b/src/resources/architectural-overview.md
@@ -60,7 +60,7 @@ The following settings were used:
 {% endcomment %}
 
 ![Architectural
-diagram](/assets/images/docs/arch-overview/archdiagram.png){:width="100%"}
+diagram]({{site.url}}/assets/images/docs/arch-overview/archdiagram.png){:width="100%"}
 
 To the underlying operating system, Flutter applications are packaged in the
 same way as any other native application. A platform-specific embedder provides
@@ -139,7 +139,7 @@ other targets.
 ## Reactive user interfaces
 
 On the surface, Flutter is [a reactive, pseudo-declarative UI
-framework](/resources/faq#what-programming-paradigm-does-flutters-framework-use),
+framework]({{site.url}}/resources/faq#what-programming-paradigm-does-flutters-framework-use),
 in which the developer provides a mapping from application state to interface
 state, and the framework takes on the task of updating the interface at runtime
 when the application state changes. This model is inspired by [work that came
@@ -153,7 +153,7 @@ to events. One challenge of this approach is that, as the application grows in
 complexity, the developer needs to be aware of how state changes cascade
 throughout the entire UI. For example, consider the following UI:
 
-![Color picker dialog](/assets/images/docs/arch-overview/color-picker.png){:width="66%"}
+![Color picker dialog]({{site.url}}/assets/images/docs/arch-overview/color-picker.png){:width="66%"}
 
 There are many places where the state can be changed: the color box, the hue
 slider, the radio buttons. As the user interacts with the UI, changes must be
@@ -344,7 +344,7 @@ href="#a1">1</a></sup>, regardless of what the widget previously returned. The
 framework does the heavy lifting work to determine which build methods need to
 be called based on the render object tree (described in more detail later). More
 information about this process can be found in the [Inside Flutter
-topic](/resources/inside-flutter#linear-reconciliation).
+topic]({{site.url}}/resources/inside-flutter#linear-reconciliation).
 
 On each rendered frame, Flutter can recreate just the parts of the UI where the
 state has changed by calling that widget’s `build()` method. Therefore it is
@@ -414,7 +414,7 @@ provides an easy way to grab data from a shared ancestor. You can use
 `InheritedWidget` to create a state widget that wraps a common ancestor in the
 widget tree, as shown in this example:
 
-![Inherited widgets](/assets/images/docs/arch-overview/inherited-widget.png){:width="50%"}
+![Inherited widgets]({{site.url}}/assets/images/docs/arch-overview/inherited-widget.png){:width="50%"}
 
 Whenever one of the `ExamWidget` or `GradeWidget` objects needs data from
 `StudentState`, it can now access it with a command such as:
@@ -506,7 +506,7 @@ The overriding principle that Flutter applies to its rendering pipeline is that
 the system, as shown in the following sequencing diagram:
 
 ![Render pipeline sequencing
-diagram](/assets/images/docs/arch-overview/render-pipeline.png){:width="100%"}
+diagram]({{site.url}}/assets/images/docs/arch-overview/render-pipeline.png){:width="100%"}
 
 Let’s take a look at some of these phases in greater detail.
 
@@ -549,10 +549,10 @@ hierarchy may therefore be deeper than what the code represents, as in this
 case<sup><a href="#a2">2</a></sup>:
 
 ![Render pipeline sequencing
-diagram](/assets/images/docs/arch-overview/widgets.png){:width="35%"}
+diagram]({{site.url}}/assets/images/docs/arch-overview/widgets.png){:width="35%"}
 
 This explains why, when you examine the tree through a debug tool such as the
-[Flutter inspector](/development/tools/devtools/inspector), part of the
+[Flutter inspector]({{site.url}}/development/tools/devtools/inspector), part of the
 Dart DevTools, you might see a structure that is considerably deeper than what
 is in your original code.
 
@@ -566,7 +566,7 @@ hierarchy. There are two basic types of elements:
   phases.
 
 ![Render pipeline sequencing
-diagram](/assets/images/docs/arch-overview/widget-element.png){:width="85%"}
+diagram]({{site.url}}/assets/images/docs/arch-overview/widget-element.png){:width="85%"}
 
 `RenderObjectElement`s are an intermediary between their widget analog and the
 underlying `RenderObject`, which we’ll come to later.
@@ -614,7 +614,7 @@ an image, and
 applies a transformation before painting its child.
 
 ![Differences between the widgets hierarchy and the element and render
-trees](/assets/images/docs/arch-overview/trees.png){:width="100%"}
+trees]({{site.url}}/assets/images/docs/arch-overview/trees.png){:width="100%"}
 
 Most Flutter widgets are rendered by an object that inherits from the
 `RenderBox` subclass, which represents a `RenderObject` of fixed size in a 2D
@@ -629,7 +629,7 @@ respond by **passing up a size** to their parent object within the constraints
 the parent established.
 
 ![Constraints go down, sizes go
-up](/assets/images/docs/arch-overview/constraints-sizes.png){:width="80%"}
+up]({{site.url}}/assets/images/docs/arch-overview/constraints-sizes.png){:width="80%"}
 
 At the end of this single walk through the tree, every object has a defined size
 within its parent’s constraints and is ready to be painted by calling the
@@ -672,7 +672,7 @@ Widget build(BuildContext context) {
 
 More information about the constraint and layout system, along with worked
 examples, can be found in the [Understanding
-constraints](/development/ui/layout/constraints) topic.
+constraints]({{site.url}}/development/ui/layout/constraints) topic.
 
 The root of all `RenderObject`s is the `RenderView`, which represents the total
 output of the render tree. When the platform demands a new frame to be rendered
@@ -755,7 +755,7 @@ and then deserialized into an equivalent representation in Kotlin (such as
 `HashMap`) or Swift (such as `Dictionary`).
 
 ![How platform channels allow Flutter to communicate with host
-code](/assets/images/docs/arch-overview/platform-channels.png){:width="70%"}
+code]({{site.url}}/assets/images/docs/arch-overview/platform-channels.png){:width="70%"}
 
 The following is a simple platform channel example of a Dart call to a receiving
 event handler in Kotlin (Android) or Swift (iOS):
@@ -930,7 +930,7 @@ with loading the necessary libraries.
 
 More information about how Flutter is loaded into an existing Android or iOS app
 can be found at the [Load sequence, performance and memory
-topic](/development/add-to-app/performance).
+topic]({{site.url}}/development/add-to-app/performance).
 
 ## Flutter web support
 
@@ -960,7 +960,7 @@ native mobile targets<sup><a href="#a5">5</a></sup>.
 The web version of the architectural layer diagram is as follows:
 
 ![Flutter web
-architecture](/assets/images/docs/arch-overview/web-arch.png){:width="100%"}
+architecture]({{site.url}}/assets/images/docs/arch-overview/web-arch.png){:width="100%"}
 
 Perhaps the most notable difference compared to other platforms on which Flutter
 runs is that there is no need for Flutter to provide a Dart runtime. Instead,
@@ -983,7 +983,7 @@ imports]({{site.dart-site}}/guides/language/language-tour#lazily-loading-a-libra
 ## Further information
 
 For those interested in more information about the internals of Flutter, the
-[Inside Flutter](/resources/inside-flutter) whitepaper
+[Inside Flutter]({{site.url}}/resources/inside-flutter) whitepaper
 provides a useful guide to the framework’s design philosophy.
 
 ---

--- a/src/resources/bootstrap-into-dart.md
+++ b/src/resources/bootstrap-into-dart.md
@@ -49,7 +49,7 @@ Check out the [Dart community][].
 [Asynchronous programming: streams]: {{site.dart-site}}/tutorials/streams
 [Dart]: {{site.dart-site}}
 [Dart community]: {{site.dart-site}}/community
-[Dart is easy and fun to learn]: /resources/faq#why-did-flutter-choose-to-use-dart
+[Dart is easy and fun to learn]: {{site.url}}/resources/faq#why-did-flutter-choose-to-use-dart
 [Effective Dart]: {{site.dart-site}}/guides/language/effective-dart
 [`File`]: {{site.api}}/flutter/dart-io/File-class.html
 [Intro to Dart for Java Developers]: {{site.codelabs}}/codelabs/from-java-to-dart

--- a/src/resources/bug-reports.md
+++ b/src/resources/bug-reports.md
@@ -78,7 +78,7 @@ Follow these steps only if your issue is related to the
   If attached to the issue, the output from this command
   might aid in diagnosing the problem.
 * Attach the results of the command to the GitHub issue.
-![flutter verbose](/assets/images/docs/verbose_flag.png){:width="100%"}
+![flutter verbose]({{site.url}}/assets/images/docs/verbose_flag.png){:width="100%"}
 
 ## Provide the most recent logs
 
@@ -90,7 +90,7 @@ Follow these steps only if your issue is related to the
 * If you are getting exceptions thrown by the framework,
   include all the output between and including the dashed
   lines of the first such exception.
-![flutter logs](/assets/images/docs/logs.png){:width="100%"}
+![flutter logs]({{site.url}}/assets/images/docs/logs.png){:width="100%"}
 
 ## Provide the crash report
 
@@ -100,7 +100,7 @@ Follow these steps only if your issue is related to the
   a crash report is generated in `~/Library/Logs/CrashReporter/MobileDevice`.
 * Find the report corresponding to the crash (usually the latest)
   and attach it to the GitHub issue.
-![crash report](/assets/images/docs/crash_reports.png){:width="100%"}
+![crash report]({{site.url}}/assets/images/docs/crash_reports.png){:width="100%"}
 
 
 [DartPad]: {{site.dartpad}}

--- a/src/resources/compatibility.md
+++ b/src/resources/compatibility.md
@@ -63,4 +63,4 @@ migration guide.
 [documented on the Dart wiki]: {{site.github}}/dart-lang/sdk/blob/master/docs/process/breaking-changes.md
 [flutter/tests repository]: {{site.github}}/flutter/tests
 [flutter-announce]: {{site.groups}}/forum/#!forum/flutter-announce
-[guides for migrating code]: /release/breaking-changes
+[guides for migrating code]: {{site.url}}/release/breaking-changes

--- a/src/resources/design-docs.md
+++ b/src/resources/design-docs.md
@@ -10,7 +10,7 @@ This is a collection of design documents written by engineers working on
 Flutter. New design documents can be added by following the instructions in the
 [template].
 
-[template]: /go/template
+[template]: {{site.url}}/go/template
 
 <ul id="go-links">
 </ul>

--- a/src/resources/faq.md
+++ b/src/resources/faq.md
@@ -12,8 +12,8 @@ specialized FAQs:
 * [Web FAQ][]
 * [Performance FAQ][]
 
-[Web FAQ]: /development/platform-integration/web
-[Performance FAQ]: /perf/faq
+[Web FAQ]: {{site.url}}/development/platform-integration/web
+[Performance FAQ]: {{site.url}}/perf/faq
 
 ### What is Flutter?
 
@@ -993,21 +993,21 @@ apps built with Flutter should follow Apple's
 [guidelines][] for App Store submission.
 
 [`AboutListTile`]: {{site.api}}/flutter/material/AboutListTile-class.html
-[accessibility documentation]: /development/accessibility-and-localization/accessibility
-[add-to-app]: /development/add-to-app
-[ads]: /ads
+[accessibility documentation]: {{site.url}}/development/accessibility-and-localization/accessibility
+[add-to-app]: {{site.url}}/development/add-to-app
+[ads]: {{site.url}}/ads
 [Android]: #run-android
 [Android Studio]: {{site.android-dev}}/studio
 [Android Studio instructions]: {{site.android-dev}}/studio/build/apk-analyzer
-[Android Studio/IntelliJ]: /development/tools/android-studio
+[Android Studio/IntelliJ]: {{site.url}}/development/tools/android-studio
 [`AnimatedDefaultTextStyle`]: {{site.api}}/flutter/widgets/AnimatedDefaultTextStyle-class.html
 [`AnimatedPhysicalModel`]: {{site.api}}/flutter/widgets/AnimatedPhysicalModel-class.html
 [apkanalyzer]: {{site.android-dev}}/studio/command-line/apkanalyzer
 [architecture diagram]: https://docs.google.com/presentation/d/1cw7A4HbvM_Abv320rVgPVGiUP2msVs7tfGbkgdrTy0I/edit#slide=id.gbb3c3233b_0_162
-[architectural overview]: /resources/architectural-overview
+[architectural overview]: {{site.url}}/resources/architectural-overview
 [`BasicMessageChannel`]: {{site.api}}/flutter/services/BasicMessageChannel-class.html
 [built into Android Studio]: {{site.android-dev}}/studio/build/apk-analyzer
-[catalog of Flutter's widgets]: /development/ui/widgets
+[catalog of Flutter's widgets]: {{site.url}}/development/ui/widgets
 [`Center`]: {{site.api}}/flutter/widgets/Center-class.html
 [`Chip`]: {{site.api}}/flutter/material/Chip-class.html
 [`color`]: {{site.api}}/flutter/widgets/Icon/color.html
@@ -1017,27 +1017,27 @@ apps built with Flutter should follow Apple's
 [Contributing Guide]: {{site.repo.flutter}}/blob/master/CONTRIBUTING.md
 [CodePen]: https://codepen.io/topic/flutter
 [Dart]: {{site.dart-site}}/
-[Dart DevTools]: /development/tools/devtools
-[Debugging with Flutter]: /testing/debugging
-[desktop]: /desktop
+[Dart DevTools]: {{site.url}}/development/tools/devtools
+[Debugging with Flutter]: {{site.url}}/testing/debugging
+[desktop]: {{site.url}}/desktop
 [detailed discussion on the API docs for `State.build`]: {{site.api}}/flutter/widgets/State/build.html
 [Discord]: https://discord.gg/N7Yshp4
 [`Divider`]: {{site.api}}/flutter/material/Divider-class.html
 [`Drawer`]: {{site.api}}/flutter/material/Drawer-class.html
 [easy starter issues]: {{site.repo.flutter}}/issues?q=is%3Aopen+is%3Aissue+label%3A%22easy+fix%22
 [editing Dart]: {{site.dart-site}}/tools
-[editor configuration]: /get-started/editor
+[editor configuration]: {{site.url}}/get-started/editor
 [example of using isolates with Flutter]: {{site.repo.flutter}}/blob/master/examples/layers/services/isolate.dart
 [example project]: {{site.repo.flutter}}/tree/master/examples/platform_channel
 [Executing Dart in the Background with Flutter Plugins and Geofencing]: {{site.flutter-medium}}/executing-dart-in-the-background-with-flutter-plugins-and-geofencing-2b3e40a1a124
-[Flutter DevTools]: /development/tools/devtools/overview
+[Flutter DevTools]: {{site.url}}/development/tools/devtools/overview
 [`TextButton`]: {{site.api}}/flutter/material/TextButton-class.html
 [Flutter 1.0]: {{site.google-blog}}/2018/12/flutter-10-googles-portable-ui-toolkit.html
 [Flutter 2]: {{site.google-blog}}/2021/03/announcing-flutter-2.html
 [flutter_view]: {{site.repo.flutter}}/tree/master/examples/flutter_view
 [`Future`]: {{site.api}}/flutter/dart-async/Future-class.html
 [Get $75 app advertising credit when you spend $25.]: https://ads.google.com/lp/appcampaigns/#?modal_active=none&subid=ww-ww-et-aw-a-flutter1!o3
-[gesture system]: /development/ui/advanced/gestures
+[gesture system]: {{site.url}}/development/ui/advanced/gestures
 [`GestureDetector`]: {{site.api}}/flutter/widgets/GestureDetector-class.html
 [get_it]: {{site.pub}}/packages/get_it
 [GitHub]: {{site.repo.flutter}}
@@ -1046,7 +1046,7 @@ apps built with Flutter should follow Apple's
 [Hamilton for Android]: https://play.google.com/store/apps/details?id=com.hamilton.app
 [Hamilton for iOS]: https://itunes.apple.com/us/app/hamilton-the-official-app/id1255231054?mt=8
 [hot reload]: #hot-reload
-[Hot reload]: /development/tools/hot-reload
+[Hot reload]: {{site.url}}/development/tools/hot-reload
 [`icon`]: {{site.api}}/flutter/widgets/Icon/icon.html
 [`Icon`]: {{site.api}}/flutter/widgets/Icon-class.html
 [`IconTheme`]: {{site.api}}/flutter/widgets/IconTheme-class.html
@@ -1054,17 +1054,17 @@ apps built with Flutter should follow Apple's
 [`InkWell`]: {{site.api}}/flutter/material/InkWell-class.html
 [iOS]: #run-ios
 [iOS App Store Specific Considerations]: {{site.apple-dev}}/library/archive/qa/qa1795/_index.html#//apple_ref/doc/uid/DTS40014195-CH1-APP_STORE_CONSIDERATIONS
-[iOS instructions]: /deployment/ios
-[install]: /get-started/install
+[iOS instructions]: {{site.url}}/deployment/ios
+[install]: {{site.url}}/get-started/install
 [IntelliJ IDEA]: https://www.jetbrains.com/idea/
-[internationalization tutorial]: /development/accessibility-and-localization/internationalization
-[is easy]: /development/packages-and-plugins/using-packages
+[internationalization tutorial]: {{site.url}}/development/accessibility-and-localization/internationalization
+[is easy]: {{site.url}}/development/packages-and-plugins/using-packages
 [issue #9253]: {{site.repo.flutter}}/issues/9253
 [issue #14821]: {{site.repo.flutter}}/issues/14821
 [issue tracker]: {{site.repo.flutter}}/issues
 [issues related to running Flutter on Chromebooks]: {{site.repo.flutter}}/labels/platform-arc
 [`Iterable`]: {{site.api}}/flutter/dart-core/Iterable-class.html
-[JSON tutorial]: /development/data-and-backend/json
+[JSON tutorial]: {{site.url}}/development/data-and-backend/json
 [kiwi]: {{site.pub}}/packages/kiwi
 [license file]: https://raw.githubusercontent.com/flutter/engine/master/sky/packages/sky_engine/LICENSE
 [`LicenseRegistry`]: {{site.api}}/flutter/foundation/LicenseRegistry-class.html
@@ -1074,16 +1074,16 @@ apps built with Flutter should follow Apple's
 [`Material`]: {{site.api}}/flutter/material/Material-class.html
 [`MaterialButton`]: {{site.api}}/flutter/material/MaterialButton-class.html
 [MDC-103 Flutter: Material Theming]: {{site.codelabs}}/codelabs/mdc-103-flutter/index.html?index=..%2F..index#0
-[Measuring your app's size]: /perf/app-size
+[Measuring your app's size]: {{site.url}}/perf/app-size
 [minimal Flutter app]: {{site.repo.flutter}}/tree/75228a59dacc24f617272f7759677e242bbf74ec/examples/hello_world
-[multiple Flutter screens or views]: /development/add-to-app/multiple-flutters
+[multiple Flutter screens or views]: {{site.url}}/development/add-to-app/multiple-flutters
 [`NotificationListener`]: {{site.api}}/flutter/widgets/NotificationListener-class.html
 [one of the top design ideas of the decade]: https://www.fastcompany.com/90442092/the-14-most-important-design-ideas-of-the-decade-according-to-the-experts
 [only one license]: {{site.repo.flutter}}/blob/master/LICENSE
 [package ecosystem]: {{site.pub}}/flutter
 [`Padding`]: {{site.api}}/flutter/widgets/Padding-class.html
-[platform and third-party APIs]: /development/platform-integration/platform-channels
-[platform channels]: /development/platform-integration/platform-channels
+[platform and third-party APIs]: {{site.url}}/development/platform-integration/platform-channels
+[platform channels]: {{site.url}}/development/platform-integration/platform-channels
 [platform_view]: {{site.repo.flutter}}/tree/master/examples/platform_view
 [popped]: {{site.api}}/flutter/widgets/Navigator/pop.html
 [pub.dev]: {{site.pub}}
@@ -1091,8 +1091,8 @@ apps built with Flutter should follow Apple's
 [ready-made packages]: {{site.pub}}/flutter/
 [`Rect`]: {{site.api}}/flutter/dart-ui/Rect-class.html
 [Reflectly]: https://apps.apple.com/us/app/reflectly-journal-ai-diary/id1241229134
-[release build of your Android app]: /deployment/android
-[release build of your iOS app]: /deployment/ios
+[release build of your Android app]: {{site.url}}/deployment/android
+[release build of your iOS app]: {{site.url}}/deployment/ios
 [`RenderObject`]: {{site.api}}/flutter/rendering/RenderObject-class.html
 [`RenderBox`]: {{site.api}}/flutter/rendering/RenderBox-class.html
 [`Route`]: {{site.api}}/flutter/widgets/Route-class.html
@@ -1107,12 +1107,12 @@ apps built with Flutter should follow Apple's
 [`State`]: {{site.api}}/flutter/widgets/State-class.html
 [`StatelessWidget`]: {{site.api}}/flutter/widgets/StatelessWidget-class.html
 [test coverage]: https://coveralls.io/github/flutter/flutter?branch=master
-[testing with Flutter]: /testing
+[testing with Flutter]: {{site.url}}/testing
 [`TextStyle`]: {{site.api}}/flutter/painting/TextStyle-class.html
 [`UserAccountsDrawerHeader`]: {{site.api}}/flutter/material/UserAccountsDrawerHeader-class.html
 [VS Code]: https://code.visualstudio.com/
-[web]: /web
-[web instructions]: /get-started/web
+[web]: {{site.url}}/web
+[web instructions]: {{site.url}}/get-started/web
 [`Widget`]: {{site.api}}/flutter/widgets/Widget-class.html
-[widgets]: /development/ui/widgets
-[supported platforms]: /development/tools/sdk/release-notes/supported-platforms
+[widgets]: {{site.url}}/development/ui/widgets
+[supported platforms]: {{site.url}}/development/tools/sdk/release-notes/supported-platforms

--- a/src/security/index.md
+++ b/src/security/index.md
@@ -34,7 +34,7 @@ For more details on how we handle security vulnerabilities, please see our [inte
 
 * **Keep your application’s dependencies up to date.**
   Make sure you [upgrade your package
-  dependencies](/development/tools/sdk/upgrading)
+  dependencies]({{site.url}}/development/tools/sdk/upgrading)
   to keep the dependencies up to date. Avoid pinning to specific versions
   for your dependencies and, if you do, make sure you check
   periodically to see if your dependencies have had security updates,

--- a/src/testing/build-modes.md
+++ b/src/testing/build-modes.md
@@ -116,12 +116,12 @@ For more information on the build modes, see
 [Flutter's build modes][].
 
 
-[Android]: /deployment/android
+[Android]: {{site.url}}/deployment/android
 [Assertions]: {{site.dart-site}}/guides/language/language-tour#assert
 [dart2js]: {{site.dart-site}}/tools/dart2js
 [dartdevc]: {{site.dart-site}}/tools/dartdevc
-[DevTools]: /development/tools/devtools
+[DevTools]: {{site.url}}/development/tools/devtools
 [Flutter wiki]: {{site.repo.flutter}}/wiki/Flutter's-modes
 [Flutter's build modes]: {{site.repo.flutter}}/wiki/Flutter%27s-modes
-[hot reload]: /development/tools/hot-reload
-[iOS]: /deployment/ios
+[hot reload]: {{site.url}}/development/tools/hot-reload
+[iOS]: {{site.url}}/deployment/ios

--- a/src/testing/code-debugging.md
+++ b/src/testing/code-debugging.md
@@ -953,20 +953,20 @@ effect by using a [`GridPaper`][] widget directly.
 [`setState()`]: {{site.api}}/flutter/widgets/State/setState.html
 [`InkFeature`]: {{site.api}}/flutter/material/InkFeature-class.html
 [`Material`]: {{site.api}}/flutter/material/Material-class.html
-[Flutter's modes]: /testing/build-modes
-[profile mode]: /testing/build-modes#profile
-[debug mode]: /testing/build-modes#debug
-[release mode]: /testing/build-modes#release
-[DevTools]: /development/tools/devtools
-[Flutter inspector]: /development/tools/devtools/inspector
-[Logging view]: /development/tools/devtools/logging
-[Flutter enabled IDE/editor]: /get-started/editor
+[Flutter's modes]: {{site.url}}/testing/build-modes
+[profile mode]: {{site.url}}/testing/build-modes#profile
+[debug mode]: {{site.url}}/testing/build-modes#debug
+[release mode]: {{site.url}}/testing/build-modes#release
+[DevTools]: {{site.url}}/development/tools/devtools
+[Flutter inspector]: {{site.url}}/development/tools/devtools/inspector
+[Logging view]: {{site.url}}/development/tools/devtools/logging
+[Flutter enabled IDE/editor]: {{site.url}}/get-started/editor
 [`log()`]: {{site.api}}/flutter/dart-developer/log.html
-[Timeline view]: /development/tools/devtools/performance
-[Debugger]: /development/tools/devtools/debugger
-[Inspector view]: /development/tools/devtools/inspector
-[The performance overlay]: /perf/rendering/ui-performance#the-performance-overlay
-[Profiling Flutter performance]: /perf/rendering/ui-performance
-[Debugging]: /testing/debugging
+[Timeline view]: {{site.url}}/development/tools/devtools/performance
+[Debugger]: {{site.url}}/development/tools/devtools/debugger
+[Inspector view]: {{site.url}}/development/tools/devtools/inspector
+[The performance overlay]: {{site.url}}/perf/rendering/ui-performance#the-performance-overlay
+[Profiling Flutter performance]: {{site.url}}/perf/rendering/ui-performance
+[Debugging]: {{site.url}}/testing/debugging
 [file an issue]: {{site.github}}/flutter/devtools/issues
 [rendering library]: {{site.api}}/flutter/rendering/rendering-library.html

--- a/src/testing/common-errors.md
+++ b/src/testing/common-errors.md
@@ -74,7 +74,7 @@ how Flutter framework performs layout:
 "_To perform layout, Flutter walks the render tree in a depth-first traversal
 and **passes down size constraints** from parent to child… Children respond by
 **passing up a size** to their parent object within the constraints the parent
-established._"  – [Flutter architectural overview](/resources/architectural-overview#layout-and-rendering)
+established._"  – [Flutter architectural overview]({{site.url}}/resources/architectural-overview#layout-and-rendering)
 
 In this case, the `Row` widget doesn’t constrain the size of its children, nor
 does the `Column` widget. Lacking constraints from its parent widget, the second
@@ -117,7 +117,7 @@ The resources linked below provide further information about this error.
 
 *   [Flexible (Flutter Widget of the Week)]({{site.youtube-site}}/watch?v=CI7x0mAZiY0)
 *   [How to debug layout issues with the Flutter Inspector]({{site.flutter-medium}}/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db#738b)
-*   [Understanding constraints](/development/ui/layout/constraints)
+*   [Understanding constraints]({{site.url}}/development/ui/layout/constraints)
 
 
 ## ‘RenderBox was not laid out’
@@ -141,7 +141,7 @@ be solved by providing more information to Flutter about how you’d like to
 constrain the widgets in question. You can learn more about how constraints work
 in Flutter on the page [Understanding constraints][]. 
 
-[Understanding constraints]: /development/ui/layout/constraints
+[Understanding constraints]: {{site.url}}/development/ui/layout/constraints
 
 The `RenderBox was not laid out` error is often caused by one of two other errors:
 
@@ -241,7 +241,7 @@ Widget build(BuildContext context) {
 The resources linked below provide further information about this error.
 
 *   [How to debug layout issues with the Flutter Inspector]({{site.flutter-medium}}/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db#1de2)
-*   [Understanding constraints](/development/ui/layout/constraints)
+*   [Understanding constraints]({{site.url}}/development/ui/layout/constraints)
 
 
 ## ‘An InputDecorator...cannot have an unbounded width’
@@ -459,6 +459,6 @@ To learn more about how to debug errors, especially layout errors in Flutter,
 check out the following resources: 
 
 *   [How to debug layout issues with the Flutter Inspector]({{site.flutter-medium}}/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db)
-*   [Understanding constraints](/development/ui/layout/constraints)
-*   [Dealing with box constraints](/development/ui/layout/box-constraints)
-*   [Flutter architectural overview](/resources/architectural-overview#layout-and-rendering)
+*   [Understanding constraints]({{site.url}}/development/ui/layout/constraints)
+*   [Dealing with box constraints]({{site.url}}/development/ui/layout/box-constraints)
+*   [Flutter architectural overview]({{site.url}}/resources/architectural-overview#layout-and-rendering)

--- a/src/testing/debugging.md
+++ b/src/testing/debugging.md
@@ -50,7 +50,7 @@ the main output that appears on your profile are the
 debug asserts verifying the framework's various invariants
 (see [Debug mode assertions](#debug-mode-assertions)).
 
-![GIF showing DevTools features](/assets/images/docs/tools/devtools/inspector.gif){:width="100%"}
+![GIF showing DevTools features]({{site.url}}/assets/images/docs/tools/devtools/inspector.gif){:width="100%"}
 
 For more information, see the
 [DevTools][] documentation.
@@ -284,19 +284,19 @@ You might find the following docs useful:
 * [VS Code][]
 
 
-[Flutter enabled IDE/editor]: /get-started/editor
+[Flutter enabled IDE/editor]: {{site.url}}/get-started/editor
 
-[Debugging Flutter apps programmatically]: /testing/code-debugging
-[perform traces programmatically]: /testing/code-debugging#tracing-dart-code-performance
-[Debug flags: application layers]: /testing/code-debugging#debug-flags-application-layers
-[Debug flags: performance]: /testing/code-debugging#debug-flags-performance
-[slow the animations programmatically]: /testing/code-debugging#debugging-animations
-[breakpoints]: /testing/code-debugging#setting-breakpoints
-[logging]: /testing/code-debugging#logging
-[Flutter's modes]: /testing/build-modes
-[Flutter performance profiling]: /perf/rendering/ui-performance
-[Performance best practices]: /perf/rendering/best-practices
-[Using an OEM debugger]: /testing/oem-debuggers
+[Debugging Flutter apps programmatically]: {{site.url}}/testing/code-debugging
+[perform traces programmatically]: {{site.url}}/testing/code-debugging#tracing-dart-code-performance
+[Debug flags: application layers]: {{site.url}}/testing/code-debugging#debug-flags-application-layers
+[Debug flags: performance]: {{site.url}}/testing/code-debugging#debug-flags-performance
+[slow the animations programmatically]: {{site.url}}/testing/code-debugging#debugging-animations
+[breakpoints]: {{site.url}}/testing/code-debugging#setting-breakpoints
+[logging]: {{site.url}}/testing/code-debugging#logging
+[Flutter's modes]: {{site.url}}/testing/build-modes
+[Flutter performance profiling]: {{site.url}}/perf/rendering/ui-performance
+[Performance best practices]: {{site.url}}/perf/rendering/best-practices
+[Using an OEM debugger]: {{site.url}}/testing/oem-debuggers
 
 [The Layer Cake]: {{site.medium}}/flutter-community/the-layer-cake-widgets-elements-renderobjects-7644c3142401
 
@@ -304,20 +304,20 @@ You might find the following docs useful:
 [Using the Dart analyzer]: {{site.repo.flutter}}/wiki/Using-the-Dart-analyzer
 [The Framework architecture]: {{site.repo.flutter}}/wiki/The-Framework-architecture
 
-[Android Studio/IntelliJ]: /development/tools/android-studio#run-app-with-breakpoints
-[VS Code]: /development/tools/vs-code#run-app-with-breakpoints
-[DevTools]: /development/tools/devtools
-[Flutter inspector]: /development/tools/devtools/inspector
-[DevTools debugger]: /development/tools/devtools/debugger
-[logging view]: /development/tools/devtools/logging
-[Timeline view]: /development/tools/devtools/performance
-[The performance overlay]: /perf/rendering/ui-performance#the-performance-overlay
-[Flutter performance profiling]: /perf/rendering/ui-performance
-[overlay]: /testing/code-debugging#performance-overlay
-[debug mode]: /testing/build-modes#debug
-[profile mode]: /testing/build-modes#profile
-[release mode]: /testing/build-modes#release
-[how the Widget Inspector uses widget creation tracking]: /development/tools/devtools/inspector#track-widget-creation
+[Android Studio/IntelliJ]: {{site.url}}/development/tools/android-studio#run-app-with-breakpoints
+[VS Code]: {{site.url}}/development/tools/vs-code#run-app-with-breakpoints
+[DevTools]: {{site.url}}/development/tools/devtools
+[Flutter inspector]: {{site.url}}/development/tools/devtools/inspector
+[DevTools debugger]: {{site.url}}/development/tools/devtools/debugger
+[logging view]: {{site.url}}/development/tools/devtools/logging
+[Timeline view]: {{site.url}}/development/tools/devtools/performance
+[The performance overlay]: {{site.url}}/perf/rendering/ui-performance#the-performance-overlay
+[Flutter performance profiling]: {{site.url}}/perf/rendering/ui-performance
+[overlay]: {{site.url}}/testing/code-debugging#performance-overlay
+[debug mode]: {{site.url}}/testing/build-modes#debug
+[profile mode]: {{site.url}}/testing/build-modes#profile
+[release mode]: {{site.url}}/testing/build-modes#release
+[how the Widget Inspector uses widget creation tracking]: {{site.url}}/development/tools/devtools/inspector#track-widget-creation
 
 [`Assert`]: {{site.dart-site}}/guides/language/language-tour#assert
 [Dart language tour]: {{site.dart-site}}/guides/language/language-tour

--- a/src/testing/errors.md
+++ b/src/testing/errors.md
@@ -206,6 +206,6 @@ class MyApp extends StatelessWidget {
 [`FlutterError.presentError`]: {{site.api}}/flutter/foundation/FlutterError/presentError.html
 [`kReleaseMode`]:  {{site.api}}/flutter/foundation/kReleaseMode-constant.html
 [`MaterialApp.builder`]: {{site.api}}/flutter/material/MaterialApp/builder.html
-[reporting errors to a service]: /cookbook/maintenance/error-reporting
+[reporting errors to a service]: {{site.url}}/cookbook/maintenance/error-reporting
 [`runZonedGuarded`]: {{site.api}}/flutter/dart-async/runZonedGuarded.html
 [`Zone`]: {{site.api}}/flutter/dart-async/Zone-class.html

--- a/src/testing/index.md
+++ b/src/testing/index.md
@@ -41,7 +41,7 @@ A _unit test_ tests a single function, method, or class.
 The goal of a unit test is to verify the correctness of a
 unit of logic under a variety of conditions.
 External dependencies of the unit under test are generally
-[mocked out](/cookbook/testing/unit/mocking).
+[mocked out]({{site.url}}/cookbook/testing/unit/mocking).
 Unit tests generally don't read from or write
 to disk, render to screen, or receive user actions from
 outside the process running the test.
@@ -111,11 +111,11 @@ integration services, see the following:
 
 [code coverage]: https://en.wikipedia.org/wiki/Code_coverage
 [Codemagic CI/CD for Flutter]: https://blog.codemagic.io/getting-started-with-codemagic/
-[Continuous delivery using fastlane with Flutter]: /deployment/cd#fastlane
+[Continuous delivery using fastlane with Flutter]: {{site.url}}/deployment/cd#fastlane
 [Flutter CI/CD with Bitrise]: https://devcenter.bitrise.io/getting-started/getting-started-with-flutter-apps/
 [How to test a Flutter app]: {{site.codelabs}}/codelabs/flutter-app-testing
-[mocked out]: /cookbook/testing/unit/mocking
+[mocked out]: {{site.url}}/cookbook/testing/unit/mocking
 [Test Flutter apps on Appcircle]: https://appcircle.io/blog/guide-to-automated-mobile-ci-cd-for-flutter-projects-with-appcircle/#testing-the-flutter-app
 [Test Flutter apps on Cirrus]: https://cirrus-ci.org/examples/#flutter
 [Test Flutter apps on Travis]: {{site.flutter-medium}}/test-flutter-apps-on-travis-3fd5142ecd8c
-[integration testing page]: /testing/integration-tests
+[integration testing page]: {{site.url}}/testing/integration-tests

--- a/src/testing/integration-tests/index.md
+++ b/src/testing/integration-tests/index.md
@@ -338,4 +338,4 @@ equivalent methods.
 [integration_test usage]: {{site.repo.flutter}}/tree/master/packages/integration_test#usage
 [iOS Device Testing]: {{site.repo.flutter}}/tree/master/packages/integration_test#ios-device-testing
 [Running Flutter driver tests with web]: {{site.repo.flutter}}/wiki/Running-Flutter-Driver-tests-with-Web
-[widget tests]: /testing#widget-tests
+[widget tests]: {{site.url}}/testing#widget-tests

--- a/src/testing/oem-debuggers.md
+++ b/src/testing/oem-debuggers.md
@@ -31,7 +31,7 @@ plugins installed and configured.
 ### Dart debugger
 
 * Open your project in Android Studio. If you don't have a project yet,
-  create one using the instructions in [Test drive](/get-started/test-drive).
+  create one using the instructions in [Test drive]({{site.url}}/get-started/test-drive).
 
 * Simultaneously bring up the Debug pane and run the app in the Console
   view by clicking the bug icon
@@ -339,10 +339,10 @@ iOS, and Android:
 
 ### Flutter
 
-* [Debugging Flutter apps](/testing/debugging)
+* [Debugging Flutter apps]({{site.url}}/testing/debugging)
 * [Flutter inspector][], as well as the general
   [DevTools][] docs.
-* [Performance Profiling](/perf/rendering/ui-performance)
+* [Performance Profiling]({{site.url}}/perf/rendering/ui-performance)
 
 ### Android
 
@@ -366,7 +366,7 @@ You can find the following debugging resources on
 [Debugging]: {{site.apple-dev}}/support/debugging/
 [developer.android.com]: {{site.android-dev}}
 [developer.apple.com]: {{site.apple-dev}}
-[DevTools]: /development/tools/devtools
-[Flutter inspector]: /development/tools/devtools/inspector
-[Flutter's modes]: /testing/build-modes
+[DevTools]: {{site.url}}/development/tools/devtools
+[Flutter inspector]: {{site.url}}/development/tools/devtools/inspector
+[Flutter's modes]: {{site.url}}/testing/build-modes
 [Instruments Help]: https://help.apple.com/instruments/mac/current/

--- a/src/tos/index.md
+++ b/src/tos/index.md
@@ -12,7 +12,7 @@ The "Flutter" name and the Flutter logo
 within the assets licensed under the Creative Commons Attribution 4.0
 International License.  Google grants you a non-transferable,
 non-exclusive, royalty-free limited license to use the Flutter Marks
-subject to your compliance with the [Flutter Brand Guidelines](/brand).
+subject to your compliance with the [Flutter Brand Guidelines]({{site.url}}/brand).
 Except as set forth above, nothing herein grants or should be deemed
 to grant to you any right, title or interest in or to the Flutter Marks.
 
@@ -22,7 +22,7 @@ SDK, including through training materials and other community content.
 
 At the same time, it's important to make sure that people don't
 use the marks in ways that could cause confusion or otherwise misuse
-the marks, so we have prepared [brand guidelines](/brand) that describe the
+the marks, so we have prepared [brand guidelines]({{site.url}}/brand) that describe the
 allowed uses of the marks. Our goal in protecting the Flutter trademarks
 is to benefit the entire community by ensuring that the marks are only used
 in ways that are consistent with Google's mission to provide a free and open

--- a/src/web/index.md
+++ b/src/web/index.md
@@ -80,14 +80,14 @@ The following resources can help you get started:
 ---
 
 
-[Building a web application with Flutter]: /get-started/web
-[Creating responsive apps]: /development/ui/layout/adaptive-responsive
+[Building a web application with Flutter]: {{site.url}}/get-started/web
+[Creating responsive apps]: {{site.url}}/development/ui/layout/adaptive-responsive
 [Discord]: https://discordapp.com/invite/yeZ6s7k
 [file an issue]: https://goo.gle/flutter_web_issue
 [Flutter Gallery]: {{site.gallery}}
 [main Flutter repo]: {{site.repo.flutter}}
-[Preparing an app for web release]: /deployment/web
+[Preparing an app for web release]: {{site.url}}/deployment/web
 [Progressive Web Application]: {{site.developers}}/web/progressive-web-apps/
-[web FAQ]: /development/platform-integration/web
+[web FAQ]: {{site.url}}/development/platform-integration/web
 [web samples for Flutter]: https://flutter.github.io/samples/
-[Web renderers]: /development/tools/web-renderers
+[Web renderers]: {{site.url}}/development/tools/web-renderers

--- a/src/whats-new.md
+++ b/src/whats-new.md
@@ -49,7 +49,7 @@ publication since the last stable release:
 [Improving Platform Channel Performance in Flutter]: {{site.flutter-medium}}/improving-platform-channel-performance-in-flutter-e5b4e5df04af
 [Raster thread performance optimization tips]: {{site.flutter-medium}}/raster-thread-performance-optimization-tips-e949b9dbcf06
 [README]: {{site.repo.this}}/#flutter-website
-[Using Actions and Shortcuts]: /development/ui/advanced/actions_and_shortcuts
+[Using Actions and Shortcuts]: {{site.url}}/development/ui/advanced/actions_and_shortcuts
 [What can we do to better improve Flutter?]: {{site.flutter-medium}}/what-can-we-do-better-to-improve-flutter-q2-2021-user-survey-results-1037fb8f057b
 [Writing a good code sample]: {{site.flutter-medium}}/writing-a-good-code-sample-323358edd9f3
 
@@ -127,24 +127,24 @@ publication since the last stable release:
 
 [Adding in-app purchases to your Flutter app]: {{site.codelabs}}/codelabs/flutter-in-app-purchases
 [Announcing Flutter 2.2]: {{site.flutter-medium}}/announcing-flutter-2-2-at-google-i-o-2021-92f0fcbd7ef9
-[Building adaptive apps]: /development/ui/layout/building-adaptive-apps
+[Building adaptive apps]: {{site.url}}/development/ui/layout/building-adaptive-apps
 [Build Voice Bots for Android with Dialogflow Essentials & Flutter]: {{site.codelabs}}/codelabs/dialogflow-flutter?hl=en&continue=https%3A%2F%2Fcodelabs.developers.google.com%2F#0
 [Building your first Flutter app]: {{site.youtube-site}}/watch?v=Z6KZ3cTGBWw
 [DartPad Sharing Guide (using a Gist file)]: {{site.github}}/dart-lang/dart-pad/wiki/Sharing-Guide
 [DartPad Workshop Authoring Guide]: {{site.github}}/dart-lang/dart-pad/wiki/Workshop-Authoring-Guide
-[Deferred components]: /perf/deferred-components
-[desktop]: /desktop
-[Embedded Support for Flutter]: /embedded
+[Deferred components]: {{site.url}}/perf/deferred-components
+[desktop]: {{site.url}}/desktop
+[Embedded Support for Flutter]: {{site.url}}/embedded
 [Embedding DartPad in your web page]: {{site.github}}/dart-lang/dart-pad/wiki/Embedding-Guide
 [Firebase for Flutter]: {{site.youtube-site}}/watch?v=4wunbF29Kkg
 [Flutter and Dialogflow voice bots]: {{site.youtube-site}}/watch?v=O7JfSF3CJ84
 [Get to know Firebase for Flutter]: {{site.firebase}}/codelabs/firebase-get-to-know-flutter#0
-[Google APIs]: /development/data-and-backend/google-apis
+[Google APIs]: {{site.url}}/development/data-and-backend/google-apis
 [Google I/O workshops page]: https://events.google.com/io/program/content?4=topic_flutter&5=type_workshop&lng=en
 [How It's Made: I/O Photo Booth]: {{site.flutter-medium}}/how-its-made-i-o-photo-booth-3b8355d35883
 [Inherited widgets]: {{site.youtube-site}}/watch?v=LFcGPS6cGrY
-[Inherited widgets DartPad]: /go/inheritedwidget-workshop
-[Memory view page]: /development/tools/devtools/memory
+[Inherited widgets DartPad]: {{site.url}}/go/inheritedwidget-workshop
+[Memory view page]: {{site.url}}/development/tools/devtools/memory
 [Null safety]: {{site.youtube-site}}/watch?v=HdKwuHQvArY
 [Slivers]: {{site.youtube-site}}/watch?v=YY-_yrZdjGc
 [Q1 2021 survey]: {{site.flutter-medium}}/which-factors-affected-users-decisions-to-adopt-flutter-q1-2021-user-survey-results-563e61fc68c9
@@ -226,42 +226,42 @@ publication since the last stable release:
 
 [Accessible expression with Material Icons and Flutter]: {{site.flutter-medium}}/accessible-expression-with-material-icons-and-flutter-e3f3f622200b
 [Adding AdMob banner and native inline ads to a Flutter app]: {{site.codelabs}}/codelabs/admob-inline-ads-in-flutter
-[Adding a Flutter view to an Android app]: /development/add-to-app/android/add-flutter-view
+[Adding a Flutter view to an Android app]: {{site.url}}/development/add-to-app/android/add-flutter-view
 [Announcing Dart null safety beta]: {{site.flutter-medium}}/announcing-dart-null-safety-beta-4491da22077a
 [Announcing Dart 2.12]: {{site.medium}}/dartlang/announcing-dart-2-12-499a6e689c87
 [Announcing Flutter 2]: {{site.google-blog}}/2021/03/announcing-flutter-2.html
 [comp]: {{site.flutter-medium}}/providing-operating-system-compatibility-on-a-large-scale-374cc2fb0dad
-[Configuring the URL strategy on the web]: /development/ui/navigation/url-strategies
-[Creating responsive and adaptive apps]: /development/ui/layout/adaptive-responsive
+[Configuring the URL strategy on the web]: {{site.url}}/development/ui/navigation/url-strategies
+[Creating responsive and adaptive apps]: {{site.url}}/development/ui/layout/adaptive-responsive
 [Dart sound null safety: technical preview 2]: {{site.flutter-medium}}/null-safety-flutter-tech-preview-cb5c98aba187
 [Deprecation Lifetime in Flutter]: {{site.flutter-medium}}/deprecation-lifetime-in-flutter-e4d76ee738ad
-[Desktop support for Flutter]: /desktop
-[Devtools]: /development/tools/devtools/overview
-[Flutter Ads]: /ads
-[Flutter 2 release notes]: /development/tools/sdk/release-notes/release-notes-2.0.0
-[Flutter Fix]: /development/tools/flutter-fix
-[Flutter inspector]: /development/tools/devtools/inspector
+[Desktop support for Flutter]: {{site.url}}/desktop
+[Devtools]: {{site.url}}/development/tools/devtools/overview
+[Flutter Ads]: {{site.url}}/ads
+[Flutter 2 release notes]: {{site.url}}/development/tools/sdk/release-notes/release-notes-2.0.0
+[Flutter Fix]: {{site.url}}/development/tools/flutter-fix
+[Flutter inspector]: {{site.url}}/development/tools/devtools/inspector
 [Flutter web support hits the stable milestone]: {{site.flutter-medium}}/flutter-web-support-hits-the-stable-milestone-d6b84e83b425
-[implement deep linking]: /development/ui/navigation/deep-linking
-[internationalization]: /development/accessibility-and-localization/internationalization
+[implement deep linking]: {{site.url}}/development/ui/navigation/deep-linking
+[internationalization]: {{site.url}}/development/accessibility-and-localization/internationalization
 [Join us for #30DaysOfFlutter]: {{site.flutter-medium}}/join-us-for-30daysofflutter-9993e3ec847b
-[More thoughts about performance]: /perf/appendix
+[More thoughts about performance]: {{site.url}}/perf/appendix
 [New ad formats for Flutter]: {{site.flutter-medium}}/new-ads-beta-inline-banner-and-native-support-for-the-flutter-mobile-ads-plugin-e48a7e9a0e64
 [perf-H1-2020]: {{site.flutter-medium}}/flutter-performance-updates-in-the-first-half-of-2020-5c597168b6bb
-[performance]: /perf
-[Performance faq]: /perf/faq
-[Performance metrics]: /perf/metrics
+[performance]: {{site.url}}/perf
+[Performance faq]: {{site.url}}/perf/faq
+[Performance metrics]: {{site.url}}/perf/metrics
 [Performance testing on the web]: {{site.flutter-medium}}/performance-testing-on-the-web-25323252de69
 [Q3]: {{site.flutter-medium}}/flutter-on-the-web-slivers-and-platform-specific-issues-user-survey-results-from-q3-2020-f8034236b2a8
 [Q4]: {{site.flutter-medium}}/are-you-happy-with-flutter-q4-2020-user-survey-results-41cdd90aaa48
 [Testable Flutter and Cloud Firestore]: {{site.flutter-medium}}/flutter/testable-flutter-and-cloud-firestore-1cf2fbbce97b
 [Updates on Flutter Testing]: {{site.flutter-medium}}/updates-on-flutter-testing-f54aa9f74c7e
-[Using multiple Flutter instances]: /development/add-to-app/multiple-flutters
-[Web FAQ]: /development/platform-integration/web
-[Web support for Flutter]: /web
+[Using multiple Flutter instances]: {{site.url}}/development/add-to-app/multiple-flutters
+[Web FAQ]: {{site.url}}/development/platform-integration/web
+[Web support for Flutter]: {{site.url}}/web
 [What's new in Flutter 2]: {{site.flutter-medium}}/whats-new-in-flutter-2-0-fe8e95ecc65
-[Who is Dash?]: /dash
-[write integration tests using the integration_test package]: /testing/integration-tests
+[Who is Dash?]: {{site.url}}/dash
+[write integration tests using the integration_test package]: {{site.url}}/testing/integration-tests
 
 ---
 
@@ -317,21 +317,21 @@ publication since the last stable release:
 * [Updates on Flutter and Firebase][]
 
 
-[add an iOS App Clip]: /development/platform-integration/ios-app-clip
+[add an iOS App Clip]: {{site.url}}/development/platform-integration/ios-app-clip
 [animations]: {{site.pub}}/packages/animations
 [Announcing Flutter 1.22]: {{site.flutter-medium}}/announcing-flutter-1-22-44f146009e5f
 [Announcing Flutter Windows Alpha]: {{site.flutter-medium}}/announcing-flutter-windows-alpha-33982cd0f433
-[App Size tool]: /development/tools/devtools/app-size
+[App Size tool]: {{site.url}}/development/tools/devtools/app-size
 [Building Beautiful Transitions with Material Motion for Flutter]: {{site.codelabs}}/codelabs/material-motion-flutter
-[cupertino-icons]: /release/breaking-changes/cupertino-icons-1.0.0
-[Developing for iOS 14]: /development/ios-14
+[cupertino-icons]: {{site.url}}/release/breaking-changes/cupertino-icons-1.0.0
+[Developing for iOS 14]: {{site.url}}/development/ios-14
 [google_maps_flutter]: {{site.pub}}/packages/google_maps_flutter
 [Handling web gestures in Flutter]: {{site.flutter-medium}}/handling-web-gestures-in-flutter-e16946a04745
 [Integration testing with flutter_driver]: {{site.flutter-medium}}/integration-testing-with-flutter-driver-36f66ede5cf2
 [Learn testing with the new Flutter sample]: {{site.flutter-medium}}/learn-testing-with-the-new-flutter-sample-gsoc20-work-product-e872c7f6492a
 [Learning Flutter's new navigation and routing]: {{site.flutter-medium}}/learning-flutters-new-navigation-and-routing-system-7c9068155ade
 [Platform channel examples]: {{site.flutter-medium}}/platform-channel-examples-7edeaeba4a66
-[platform-views]: /development/platform-integration/platform-views
+[platform-views]: {{site.url}}/development/platform-integration/platform-views
 [Supporting iOS 14 and Xcode 12 with Flutter]: {{site.flutter-medium}}/supporting-ios-14-and-xcode-12-with-flutter-15fe0062e98b
 [Updates on Flutter and Firebase]: {{site.flutter-medium}}/updates-on-flutter-and-firebase-8076f70bc90e
 [webview_flutter]: {{site.pub}}/packages/webview_flutter
@@ -411,27 +411,27 @@ publication since the last stable release:
 [Announcing Adobe XD Support for Flutter]: {{site.flutter-medium}}/announcing-adobe-xd-support-for-flutter-4b3dd55ff40e
 [Announcing Flutter 1.20]: {{site.flutter-medium}}/announcing-flutter-1-20-2aaf68c89c75
 [Building performant Flutter widgets]: {{site.flutter-medium}}/building-performant-flutter-widgets-3b2558aa08fa
-[codelabs landing]: /codelabs
-[Desktop support]: /desktop
+[codelabs landing]: {{site.url}}/codelabs
+[Desktop support]: {{site.url}}/desktop
 [dev-tools]: {{site.flutter-medium}}/new-tools-for-flutter-developers-built-in-flutter-a122cb4eec86
-[Developing for iOS 14 beta]: /development/ios-14
+[Developing for iOS 14 beta]: {{site.url}}/development/ios-14
 [Enums with Extensions in Dart]: {{site.flutter-medium}}/enums-with-extensions-dart-460c42ea51f7
 [Flutter and Desktop apps]: {{site.flutter-medium}}/flutter-and-desktop-3a0dd0f8353e
-[Flutter architectural overview]: /resources/architectural-overview
-[Flutter books]: /resources/books
-[Flutter codelabs]: /codelabs
+[Flutter architectural overview]: {{site.url}}/resources/architectural-overview
+[Flutter books]: {{site.url}}/resources/books
+[Flutter codelabs]: {{site.url}}/codelabs
 [Flutter Day]: https://events.withgoogle.com/flutter-day/
 [Flutter Package Ecosystem Update]: {{site.flutter-medium}}/flutter-package-ecosystem-update-d50645f2d7bc
 [Flutter Performance Updates in 2019]: {{site.flutter-medium}}/going-deeper-with-flutters-web-support-66d7ad95eb5224
 [Going deeper with Flutter's web support]: {{site.flutter-medium}}/going-deeper-with-flutters-web-support-66d7ad95eb52
 [Handling 404: Page not found error in Flutter]: {{site.flutter-medium}}/handling-404-page-not-found-error-in-flutter-731f5a9fba29
 [How to write a Flutter plugin]: {{site.codelabs}}/codelabs/write-flutter-plugin
-[installing Flutter on Linux using snapd.]: /get-started/install/linux
+[installing Flutter on Linux using snapd.]: {{site.url}}/get-started/install/linux
 [Managing issues in a large-scale open source project]: {{site.flutter-medium}}/managing-issues-in-a-large-scale-open-source-project-b3be6eecae2b
 [How to debug layout issues with the Flutter Inspector]: {{site.flutter-medium}}/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db
 [Multi-platform Firestore Flutter]: {{site.codelabs}}/codelabs/friendlyeats-flutter/
 [q1-2020]: {{site.flutter-medium}}/what-are-the-important-difficult-tasks-for-flutter-devs-q1-2020-survey-results-a5ef2305429b
-[Reducing shader compilation jank on mobile]: /perf/rendering/shader
+[Reducing shader compilation jank on mobile]: {{site.url}}/perf/rendering/shader
 [shaking]: {{site.flutter-medium}}/optimizing-performance-in-flutter-web-apps-with-tree-shaking-and-deferred-loading-535fbe3cd674
 [Two Months of #FlutterGoodNewsWednesday]: {{site.flutter-medium}}/two-months-of-fluttergoodnewswednesday-a12e60bab782
 [ubuntu]: {{site.flutter-medium}}/announcing-flutter-linux-alpha-with-canonical-19eb824590a9
@@ -500,22 +500,22 @@ Other newness:
   * [Flutter web support updates][]
   * [Modern Flutter plugin development][]
 
-[add2app]: /development/add-to-app/android/plugin-setup
+[add2app]: {{site.url}}/development/add-to-app/android/plugin-setup
 [Animation deep dive]: {{site.flutter-medium}}/animation-deep-dive-39d3ffea111f
-[animations landing page]: /development/ui/animations
+[animations landing page]: {{site.url}}/development/ui/animations
 [Announcing a free Flutter introductory course]: {{site.flutter-medium}}/learn-flutter-for-free-c9bc3b898c4d
 [Announcing CodePen support for Flutter]: {{site.flutter-medium}}/announcing-codepen-support-for-flutter-bb346406fe50
 [Announcing Flutter 1.17]: {{site.flutter-medium}}/announcing-flutter-1-17-4182d8af7f8e
 [Custom implicit animations in Flutter…with TweenAnimationBuilder]: {{site.flutter-medium}}/custom-implicit-animations-in-flutter-with-tweenanimationbuilder-c76540b47185
-[Desktop]: /desktop
-[Developing packages and plugins]: /development/packages-and-plugins/developing-packages
-[Developing plugin packages]: /development/packages-and-plugins/developing-packages#federated-plugins
+[Desktop]: {{site.url}}/desktop
+[Developing packages and plugins]: {{site.url}}/development/packages-and-plugins/developing-packages
+[Developing plugin packages]: {{site.url}}/development/packages-and-plugins/developing-packages#federated-plugins
 [Directional animations with build-in explicit animations]: {{site.flutter-medium}}/directional-animations-with-built-in-explicit-animations-3e7c5e6fbbd7
 [Flutter Medium]: {{site.medium}}/flutter
 [Flutter Spring 2020 update]: {{site.flutter-medium}}/spring-2020-update-f723d898d7af
 [Flutter web: Navigating URLs using named routes]: {{site.flutter-medium}}/web-navigating-urls-using-named-routes-307e1b1e2050
 [Flutter web support updates]: {{site.flutter-medium}}/web-support-updates-8b14bfe6a908
-[hot reload]: /development/tools/hot-reload
+[hot reload]: {{site.url}}/development/tools/hot-reload
 [How to choose which Flutter animation widget is right for you?]: {{site.flutter-medium}}/how-to-choose-which-flutter-animation-widget-is-right-for-you-79ecfb7e72b5
 [How to embed a Flutter application in a website using DartPad]: {{site.flutter-medium}}/how-to-embed-a-flutter-application-in-a-website-using-dartpad-b8fd0ee8c4b9
 [How to float an overlay widget over a (possibly transformed) UI widget]: {{site.flutter-medium}}/how-to-float-an-overlay-widget-over-a-possibly-transformed-ui-widget-1d15ca7667b6
@@ -523,14 +523,14 @@ Other newness:
 [Improving Flutter with your opinion - Q4 2019 survey results]: {{site.flutter-medium}}/improving-flutter-with-your-opinion-q4-2019-survey-results-ba0e6721bf23
 [Introducing Google Fonts for Flutter v 1.0.0!]: {{site.flutter-medium}}/introducing-google-fonts-for-flutter-v-1-0-0-c0e993617118
 [It’s Time: The Flutter Clock contest results]: {{site.flutter-medium}}/its-time-the-flutter-clock-contest-results-dcebe2eb3957
-[Obfuscating Dart code]: /deployment/obfuscate
+[Obfuscating Dart code]: {{site.url}}/deployment/obfuscate
 [package for pre-canned Material widget animations]: {{site.pub}}/packages/animations
 [Modern Flutter plugin development]: {{site.flutter-medium}}/modern-flutter-plugin-development-4c3ee015cf5a
-[Supporting the new Android plugin APIs]: /development/packages-and-plugins/plugin-api-migration
-[Understanding constraints]: /development/ui/layout/constraints
+[Supporting the new Android plugin APIs]: {{site.url}}/development/packages-and-plugins/plugin-api-migration
+[Understanding constraints]: {{site.url}}/development/ui/layout/constraints
 [When should I use AnimatedBuilder or AnimatedWidget?]: {{site.flutter-medium}}/when-should-i-useanimatedbuilder-or-animatedwidget-57ecae0959e8
-[Writing custom platform-specific code]: /development/platform-integration/platform-channels
-[Xcode 11.4]: /development/ios-project-migration
+[Writing custom platform-specific code]: {{site.url}}/development/platform-integration/platform-channels
+[Xcode 11.4]: {{site.url}}/development/ios-project-migration
 
 ## Dec 11, 2019, Flutter Interact Edition: 1.12 release
 
@@ -580,23 +580,23 @@ Other newness:
 
 Happy Fluttering!
 
-[add Flutter to an existing app]: /development/add-to-app
+[add Flutter to an existing app]: {{site.url}}/development/add-to-app
 [Announcing Flutter 1.12: What a year!]: {{site.flutter-medium}}/announcing-flutter-1-12-what-a-year-22c256ba525d
-[app size]: /perf/app-size#ios
-[building a web app with Flutter]: /get-started/web
-[Desktop support for Flutter]: /desktop
+[app size]: {{site.url}}/perf/app-size#ios
+[building a web app with Flutter]: {{site.url}}/get-started/web
+[Desktop support for Flutter]: {{site.url}}/desktop
 [Flutter: the first UI platform designed for ambient computing]: {{site.google-blog}}/2019/12/flutter-ui-ambient-computing.html?m=1
-[Flutter Favorite program]: /development/packages-and-plugins/favorites
-[Flutter 1.12.13]: /development/tools/sdk/release-notes/release-notes-1.12.13
+[Flutter Favorite program]: {{site.url}}/development/packages-and-plugins/favorites
+[Flutter 1.12.13]: {{site.url}}/development/tools/sdk/release-notes/release-notes-1.12.13
 [Flutter Gallery]: https://flutter.github.io/samples/#/
-[Flutter Layout Explorer]: /development/tools/devtools/inspector#flutter-layout-explorer
+[Flutter Layout Explorer]: {{site.url}}/development/tools/devtools/inspector#flutter-layout-explorer
 [Flutter Medium publication]: {{site.medium}}/flutter
-[Migrating your plugin to the new Android APIs]: /development/packages-and-plugins/plugin-api-migration
-[implicit animations]: /codelabs/implicit-animations
-[Web support for Flutter]: /web
+[Migrating your plugin to the new Android APIs]: {{site.url}}/development/packages-and-plugins/plugin-api-migration
+[implicit animations]: {{site.url}}/codelabs/implicit-animations
+[Web support for Flutter]: {{site.url}}/web
 [Web support for Flutter goes beta]: {{site.flutter-medium}}/web-support-for-flutter-goes-beta-35b64a1217c0
-[write your first Flutter app on the web]: /get-started/codelab-web
-[Get started]: /get-started/install
+[write your first Flutter app on the web]: {{site.url}}/get-started/codelab-web
+[Get started]: {{site.url}}/get-started/install
 
 ## Sept 10, 2019: 1.9 release
 
@@ -655,25 +655,25 @@ Other relevant docs:
 
 Happy Fluttering!
 
-[1.9.1 release notes]: /development/tools/sdk/release-notes/release-notes-1.9.1
-[building a web application]: /get-started/web
+[1.9.1 release notes]: {{site.url}}/development/tools/sdk/release-notes/release-notes-1.9.1
+[building a web application]: {{site.url}}/get-started/web
 [`ColorFiltered`]: {{site.api}}/flutter/widgets/ColorFiltered-class.html
 [ColorFiltered demo]: {{site.github}}/csells/flutter_color_filter
-[creating responsive apps]: /development/ui/layout/adaptive-responsive
+[creating responsive apps]: {{site.url}}/development/ui/layout/adaptive-responsive
 [Flutter Medium publication]: {{site.medium}}/flutter
-[Flutter for web]: /web
+[Flutter for web]: {{site.url}}/web
 [Flutter news from GDD China: uniting Flutter on web and mobile, and introducing Flutter 1.9]: {{site.google-blog}}/2019/09/flutter-news-from-gdd-china-flutter1.9.html?m=1
 [Improving Flutter's Error Messages]: {{site.flutter-medium}}/improving-flutters-error-messages-e098513cecf9
-[Performance view]: /development/tools/devtools/performance
-[preparing a web app for release]: /deployment/web
+[Performance view]: {{site.url}}/development/tools/devtools/performance
+[preparing a web app for release]: {{site.url}}/deployment/web
 [`SelectableText`]: {{site.api}}/flutter/material/SelectableText-class.html
 [Showcase]: {{site.main-url}}/showcase
 [`ToggleButtons`]: {{site.api}}/flutter/material/ToggleButtons-class.html
 [ToggleButtons demo]: {{site.github}}/csells/flutter_toggle_buttons
-[Try it out]: /codelabs/layout-basics
+[Try it out]: {{site.url}}/codelabs/layout-basics
 [Upgrading from package:flutter_web to the Flutter SDK]: {{site.repo.flutter}}/wiki/Upgrading-from-package:flutter_web-to-the-Flutter-SDK
-[using the dart:ffi library]: /development/platform-integration/c-interop
-[web FAQ]: /development/platform-integration/web
+[using the dart:ffi library]: {{site.url}}/development/platform-integration/c-interop
+[web FAQ]: {{site.url}}/development/platform-integration/web
 
 ## July 9, 2019: 1.7 release
 
@@ -710,21 +710,21 @@ endpoints in a range of values. For information about this
 component and how to customize it, see
 [Material RangeSlider in Flutter].
 
-[1.7.8 release notes]: /development/tools/sdk/release-notes/release-notes-1.7.8
-[Animate a page route transition]: /cookbook/animation/page-route-animation
+[1.7.8 release notes]: {{site.url}}/development/tools/sdk/release-notes/release-notes-1.7.8
+[Animate a page route transition]: {{site.url}}/cookbook/animation/page-route-animation
 [Announcing Flutter 1.7]: {{site.flutter-medium}}/announcing-flutter-1-7-9cab4f34eacf
-[Cookbook]: /cookbook
-[Debugging]: /testing/debugging
-[Debugging apps programmatically]: /testing/code-debugging
-[DevTools]: /development/tools/devtools
+[Cookbook]: {{site.url}}/cookbook
+[Debugging]: {{site.url}}/testing/debugging
+[Debugging apps programmatically]: {{site.url}}/testing/code-debugging
+[DevTools]: {{site.url}}/development/tools/devtools
 [Flutter Medium Publication]: {{site.flutter-medium}}
-[Flutter's build modes]: /testing/build-modes
+[Flutter's build modes]: {{site.url}}/testing/build-modes
 [Material RangeSlider in Flutter]: {{site.flutter-medium}}/material-range-slider-in-flutter-a285c6e3447d
-[Performance best practices]: /perf/rendering/best-practices
-[Performance profiling]: /perf/rendering/ui-performance
-[Preparing an Android app for release]: /deployment/android
+[Performance best practices]: {{site.url}}/perf/rendering/best-practices
+[Performance profiling]: {{site.url}}/perf/rendering/ui-performance
+[Preparing an Android app for release]: {{site.url}}/deployment/android
 [`RangeSlider`]: {{site.api}}/flutter/material/RangeSlider-class.html
-[Simple app state management]: /development/data-and-backend/state-mgmt/simple
+[Simple app state management]: {{site.url}}/development/data-and-backend/state-mgmt/simple
 
 ## May 7, 2019, Google I/O Edition: 1.5 release
 
@@ -736,10 +736,10 @@ or [download the release][].
 We are updating DartPad to work with Flutter. Try our new
 [Basic Flutter layout codelab][] and tell us what you think!
 
-[Basic Flutter layout codelab]: /codelabs/layout-basics
-[download the release]: /development/tools/sdk/releases
+[Basic Flutter layout codelab]: {{site.url}}/codelabs/layout-basics
+[download the release]: {{site.url}}/development/tools/sdk/releases
 [Flutter 1.5]: {{site.google-blog}}/2019/05/Flutter-io19.html
-[1.5.4 release notes]: /development/tools/sdk/release-notes/release-notes-1.5.4
+[1.5.4 release notes]: {{site.url}}/development/tools/sdk/release-notes/release-notes-1.5.4
 
 ## February 26, 2019: 1.2 release
 
@@ -773,21 +773,21 @@ In addition, here are some recent new and updated docs:
 If you have questions or comments about any of these docs,
 [file an issue][].
 
-[Android Studio/IntelliJ]: /development/tools/android-studio
-[different state management options]: /development/data-and-backend/state-mgmt/options
-[download the release]: /development/tools/sdk/releases
-[ephemeral vs app state]: /development/data-and-backend/state-mgmt/ephemeral-vs-app
+[Android Studio/IntelliJ]: {{site.url}}/development/tools/android-studio
+[different state management options]: {{site.url}}/development/data-and-backend/state-mgmt/options
+[download the release]: {{site.url}}/development/tools/sdk/releases
+[ephemeral vs app state]: {{site.url}}/development/data-and-backend/state-mgmt/ephemeral-vs-app
 [file an issue]: {{site.repo.this}}/issues
-[introduction]: /development/data-and-backend/state-mgmt/intro
-[Performance profiling]: /perf/rendering/ui-performance
-[1.2.1 release notes]: /development/tools/sdk/release-notes/release-notes-1.2.1
-[simple app state management]: /development/data-and-backend/state-mgmt/simple
-[state management advice]: /development/data-and-backend/state-mgmt/intro
-[thinking declaratively]: /development/data-and-backend/state-mgmt/declarative
-[this site]: /development/tools/devtools
-[timeline view]: /development/tools/devtools/performance
-[VS Code]: /development/tools/vs-code
-[widget inspector]: /development/tools/devtools/inspector
+[introduction]: {{site.url}}/development/data-and-backend/state-mgmt/intro
+[Performance profiling]: {{site.url}}/perf/rendering/ui-performance
+[1.2.1 release notes]: {{site.url}}/development/tools/sdk/release-notes/release-notes-1.2.1
+[simple app state management]: {{site.url}}/development/data-and-backend/state-mgmt/simple
+[state management advice]: {{site.url}}/development/data-and-backend/state-mgmt/intro
+[thinking declaratively]: {{site.url}}/development/data-and-backend/state-mgmt/declarative
+[this site]: {{site.url}}/development/tools/devtools
+[timeline view]: {{site.url}}/development/tools/devtools/performance
+[VS Code]: {{site.url}}/development/tools/vs-code
+[widget inspector]: {{site.url}}/development/tools/devtools/inspector
 
 
 [version 1.2]: {{site.google-blog}}/2019/02/launching-flutter-12-at-mobile-world.html
@@ -822,13 +822,13 @@ Some of the new content includes:
 If you have questions or comments about the revamped site,
 [file an issue][].
 
-[a native debugger _and_ a Dart debugger to your app]: /testing/oem-debuggers
-[Background Dart processes]: /development/packages-and-plugins/background-processes
+[a native debugger _and_ a Dart debugger to your app]: {{site.url}}/testing/oem-debuggers
+[Background Dart processes]: {{site.url}}/development/packages-and-plugins/background-processes
 [community]: {{site.main-url}}/community
 [file an issue]: {{site.repo.this}}/issues
-[Flutter's build modes]: /testing/build-modes
-[front]: /
-[Inside Flutter]: /resources/inside-flutter
+[Flutter's build modes]: {{site.url}}/testing/build-modes
+[front]: {{site.url}}/
+[Inside Flutter]: {{site.url}}/resources/inside-flutter
 [showcase]: {{site.main-url}}/showcase
-[State management]: /development/data-and-backend/state-mgmt
-[Technical videos]: /resources/videos
+[State management]: {{site.url}}/development/data-and-backend/state-mgmt
+[Technical videos]: {{site.url}}/resources/videos


### PR DESCRIPTION
Hello team:

Congratulations on the launch of flutter's newly designed site, we've also launched the CN site, thanks to the team!

For the documentation site, we currently plan to keep it at flutter.cn/docs, so the proposal in this PR is to replace all relative links in the documentation site with full links by adding {{site.url}}.
This change will allow us to handle the .CN sites more easily, and hopefully this proposal will be reviewed and approved!

We did this by globally searching for `]: /` and `](/`, replacing them with `]: {{site.url}}/` and `]({{site.url}}/`.

Thanks!
Luke