### PR TITLE
Fix mistake in example plugin pubspec

### DIFF
--- a/src/development/packages-and-plugins/developing-packages.md
+++ b/src/development/packages-and-plugins/developing-packages.md
@@ -260,7 +260,7 @@ flutter:
   plugin:
     implements: hello
     platforms:
-      ios:
+      windows:
         pluginClass: HelloPlugin
 ```
 


### PR DESCRIPTION
Fixes a mistake in my recent PR; the plugin is described as implementing Windows, but showed iOS as the implemented platform.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
