### PR TITLE
Fix #5356: the dollar sign won't be copied

### DIFF
--- a/src/get-started/install/_get-sdk-linux.md
+++ b/src/get-started/install/_get-sdk-linux.md
@@ -12,14 +12,14 @@ Once you have snapd, you can
 [install Flutter using the Snap Store][],
 or at the command line:
 
-```sh
+```terminal
 $ sudo snap install flutter --classic
 ```
 
 {{site.alert.note}}
   Once the snap is installed, you can use the following command to display your Flutter SDK path:
 
-  ```sh
+  ```terminal
   $ flutter sdk-path
   ```
 {{site.alert.end}}

--- a/src/perf/deferred-components.md
+++ b/src/perf/deferred-components.md
@@ -293,7 +293,7 @@ You can find another example of deferred import loading in
 Use the following `flutter` command to build a deferred
 components app:
 
-```sh
+```terminal
 $ flutter build appbundle
 ```
 
@@ -559,7 +559,7 @@ To run the `.aab` file on a test device,
 download the bundletool jar executable from
 [github.com/google/bundletool/releases][] and run:
 
-```sh
+```terminal
 $ java -jar bundletool.jar build-apks --bundle=<your_app_project_dir>/build/app/outputs/bundle/release/app-release.aab --output=<your_temp_dir>/app.apks --local-testing
 
 $ java -jar bundletool.jar install-apks --apks=<your_temp_dir>/app.apks
@@ -576,7 +576,7 @@ installation of deferred components is emulated.
 Before running `build-apks` again,
 remove the existing app .apks file:
 
-```sh
+```terminal
 $ rm <your_temp_dir>/app.apks
 ```
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Although #5356 is closed the Linux install page has two types of shell command sections: majority are green on black and the dollar sign is not selectable / not copiable. However there are two blocks which are light themed and the dollar sign is copiable and selectable. The #5356 could have been about those. Upon inspection it looks like the `sh` source code type lets everything to be copied while the `terminal` source code type is intelligent enough to not let the shell dollar sign selected or copied. The `sh`'s look is light while the terminal is the dark themed.

The `sh` is used at a dozen more places though, although most of the time the dollar sign is not used along with it so that doesn't create copy problem. In my opinion it would be great if all `sh`s would be replaced with the `terminal` just in case someone in the future may introduce the dollar signs.

I don't want to churn too much code though so I'll only correct those additional sets of shell code sections which use a dollar sign. The only possible downside of this is that the theme of the code changes from light do dark. In my opinion that sets apart the regular source code from the shell code which can even help a little when skimming through pages.

_Issues fixed by this PR (if any):_ #5356

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
