### PR TITLE
Add link to adaptive icons

### DIFF
--- a/src/resources/platform-adaptations.md
+++ b/src/resources/platform-adaptations.md
@@ -342,6 +342,8 @@ has a stem/shaft on Android.
   </div>
 </div>
 
+The material library also provides a set of platform-adaptive icons through [`Icons.adaptive`].
+
 ## Haptic feedback
 
 The Material and Cupertino packages automatically
@@ -558,6 +560,7 @@ double tap and shows the selection toolbar.
 [overscrolls]: {{site.api}}/flutter/widgets/BouncingScrollPhysics-class.html
 [`PageRoute.fullscreenDialog`]: {{site.api}}/flutter/widgets/PageRoute-class.html
 [platform_design code samples]: {{site.github}}/flutter/samples/tree/master/platform_design
+[`Icons.adaptive`]: {{site.api}}/flutter/material/PlatformAdaptiveIcons-class.html
 [slides and clip-reveals up]: {{site.api}}/flutter/material/OpenUpwardsPageTransitionsBuilder-class.html
 [slides up and fades in]: {{site.api}}/flutter/material/FadeUpwardsPageTransitionsBuilder-class.html
 [`startActivity()`]: {{site.android-dev}}/reference/android/app/Activity.html#startActivity(android.content.Intent


### PR DESCRIPTION
Adds a links to all platform-adaptive icons

_Issues fixed by this PR (if any): https://github.com/flutter/flutter/issues/68016

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
