### PR TITLE
Update cookbook performance profiling to use integration_test

### DIFF
--- a/examples/cookbook/testing/integration/profiling/analysis_options.yaml
+++ b/examples/cookbook/testing/integration/profiling/analysis_options.yaml
@@ -1,0 +1,9 @@
+# Take our settings from the example directory's main analysis_options.yaml
+# file. If necessary for a particular example, this file can also include
+# overrides for individual lints.
+
+include: ../../../../analysis_options.yaml
+
+linter:
+  rules:
+    avoid_print: false

--- a/examples/cookbook/testing/integration/profiling/analysis_options.yaml
+++ b/examples/cookbook/testing/integration/profiling/analysis_options.yaml
@@ -1,9 +1,1 @@
-# Take our settings from the example directory's main analysis_options.yaml
-# file. If necessary for a particular example, this file can also include
-# overrides for individual lints.
-
 include: ../../../../analysis_options.yaml
-
-linter:
-  rules:
-    avoid_print: false

--- a/examples/cookbook/testing/integration/profiling/integration_test/scrolling_test.dart
+++ b/examples/cookbook/testing/integration/profiling/integration_test/scrolling_test.dart
@@ -1,10 +1,17 @@
 // #docregion ScrollWidgetTest
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_driver/flutter_driver.dart' as driver;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
 
 import 'package:scrolling/main.dart';
 
 void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized()
+      as IntegrationTestWidgetsFlutterBinding;
+
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(MyApp(
@@ -14,15 +21,36 @@ void main() {
     final listFinder = find.byType(Scrollable);
     final itemFinder = find.byKey(const ValueKey('item_50_text'));
 
-    // Scroll until the item to be found appears.
-    await tester.scrollUntilVisible(
-      itemFinder,
-      500.0,
-      scrollable: listFinder,
-    );
+    // #docregion traceAction
+    await binding.traceAction(() async {
+      // Scroll until the item to be found appears.
+      await tester.scrollUntilVisible(
+        itemFinder,
+        500.0,
+        scrollable: listFinder,
+      );
 
-    // Verify that the item contains the correct text.
-    expect(itemFinder, findsOneWidget);
+      // Verify that the item contains the correct text.
+      expect(itemFinder, findsOneWidget);
+    });
+    // #enddocregion traceAction
+
+    final timeline = driver.Timeline.fromJson(binding.reportData?['timeline']);
+    print(timeline);
+
+    // Convert the Timeline into a TimelineSummary that's easier to
+    // read and understand.
+    final summary = driver.TimelineSummary.summarize(timeline);
+
+    // Then, write the entire timeline to disk in a json format.
+    // This file can be opened in the Chrome browser's tracing tools
+    // found by navigating to chrome://tracing.
+    // Optionally, save the summary to disk by setting includeSummary to true
+    await summary.writeTimelineToFile(
+      'scrolling_timeline',
+      pretty: true,
+      includeSummary: true,
+    );
   });
 }
 // #enddocregion ScrollWidgetTest

--- a/examples/cookbook/testing/integration/profiling/integration_test/scrolling_test.dart
+++ b/examples/cookbook/testing/integration/profiling/integration_test/scrolling_test.dart
@@ -1,12 +1,4 @@
 // #docregion ScrollWidgetTest
-
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility that Flutter provides. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/examples/cookbook/testing/integration/profiling/integration_test/scrolling_test.dart
+++ b/examples/cookbook/testing/integration/profiling/integration_test/scrolling_test.dart
@@ -27,8 +27,6 @@ void main() {
           500.0,
           scrollable: listFinder,
         );
-
-        // Verify that the item contains the correct text.
       },
       reportKey: 'scrolling_timeline',
     );

--- a/examples/cookbook/testing/integration/profiling/integration_test/scrolling_test.dart
+++ b/examples/cookbook/testing/integration/profiling/integration_test/scrolling_test.dart
@@ -19,17 +19,19 @@ void main() {
     final itemFinder = find.byKey(const ValueKey('item_50_text'));
 
     // #docregion traceAction
-    await binding.traceAction(() async {
-      // Scroll until the item to be found appears.
-      await tester.scrollUntilVisible(
-        itemFinder,
-        500.0,
-        scrollable: listFinder,
-      );
+    await binding.traceAction(
+      () async {
+        // Scroll until the item to be found appears.
+        await tester.scrollUntilVisible(
+          itemFinder,
+          500.0,
+          scrollable: listFinder,
+        );
 
-      // Verify that the item contains the correct text.
-      expect(itemFinder, findsOneWidget);
-    });
+        // Verify that the item contains the correct text.
+      },
+      reportKey: 'scrolling_timeline',
+    );
     // #enddocregion traceAction
   });
 }

--- a/examples/cookbook/testing/integration/profiling/integration_test/scrolling_test.dart
+++ b/examples/cookbook/testing/integration/profiling/integration_test/scrolling_test.dart
@@ -1,8 +1,5 @@
 // #docregion ScrollWidgetTest
-import 'dart:developer';
-
 import 'package:flutter/material.dart';
-import 'package:flutter_driver/flutter_driver.dart' as driver;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -34,24 +31,6 @@ void main() {
       expect(itemFinder, findsOneWidget);
     });
     // #enddocregion traceAction
-
-    // #docregion Timeline
-    final timeline = driver.Timeline.fromJson(binding.reportData?['timeline']);
-
-    // Convert the Timeline into a TimelineSummary that's easier to
-    // read and understand.
-    final summary = driver.TimelineSummary.summarize(timeline);
-
-    // Then, write the entire timeline to disk in a json format.
-    // This file can be opened in the Chrome browser's tracing tools
-    // found by navigating to chrome://tracing.
-    // Optionally, save the summary to disk by setting includeSummary to true
-    await summary.writeTimelineToFile(
-      'scrolling_timeline',
-      pretty: true,
-      includeSummary: true,
-    );
-    // #enddocregion Timeline
   });
 }
 // #enddocregion ScrollWidgetTest

--- a/examples/cookbook/testing/integration/profiling/integration_test/scrolling_test.dart
+++ b/examples/cookbook/testing/integration/profiling/integration_test/scrolling_test.dart
@@ -35,8 +35,8 @@ void main() {
     });
     // #enddocregion traceAction
 
+    // #docregion Timeline
     final timeline = driver.Timeline.fromJson(binding.reportData?['timeline']);
-    print(timeline);
 
     // Convert the Timeline into a TimelineSummary that's easier to
     // read and understand.
@@ -51,6 +51,7 @@ void main() {
       pretty: true,
       includeSummary: true,
     );
+    // #enddocregion Timeline
   });
 }
 // #enddocregion ScrollWidgetTest

--- a/examples/cookbook/testing/integration/profiling/lib/main.dart
+++ b/examples/cookbook/testing/integration/profiling/lib/main.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(MyApp(
+    items: List<String>.generate(10000, (i) => "Item $i"),
+  ));
+}
+
+class MyApp extends StatelessWidget {
+  final List<String> items;
+
+  const MyApp({Key? key, required this.items}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    const title = 'Long List';
+
+    return MaterialApp(
+      title: title,
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text(title),
+        ),
+        body: ListView.builder(
+          // Add a key to the ListView. This makes it possible to
+          // find the list and scroll through it in the tests.
+          key: const Key('long_list'),
+          itemCount: items.length,
+          itemBuilder: (context, index) {
+            return ListTile(
+              title: Text(
+                items[index],
+                // Add a key to the Text widget for each item. This makes
+                // it possible to look for a particular item in the list
+                // and verify that the text is correct
+                key: Key('item_${index}_text'),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/examples/cookbook/testing/integration/profiling/pubspec.yaml
+++ b/examples/cookbook/testing/integration/profiling/pubspec.yaml
@@ -16,8 +16,8 @@ dev_dependencies:
   flutter_lints: ^1.0.3
   integration_test:
     sdk: flutter
-  flutter_driver:
-    sdk: flutter
+  # flutter_driver:
+  #   sdk: flutter
 
 flutter:
   uses-material-design: true

--- a/examples/cookbook/testing/integration/profiling/pubspec.yaml
+++ b/examples/cookbook/testing/integration/profiling/pubspec.yaml
@@ -1,0 +1,19 @@
+name: scrolling
+description: A new Flutter project.
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  path_provider: ^2.0.1
+  path: ^1.8.0
+  flutter_test:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_lints: ^1.0.3
+
+flutter:
+  uses-material-design: true

--- a/examples/cookbook/testing/integration/profiling/pubspec.yaml
+++ b/examples/cookbook/testing/integration/profiling/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^1.0.3
+  integration_test:
+    sdk: flutter
 
 flutter:
   uses-material-design: true

--- a/examples/cookbook/testing/integration/profiling/pubspec.yaml
+++ b/examples/cookbook/testing/integration/profiling/pubspec.yaml
@@ -16,6 +16,8 @@ dev_dependencies:
   flutter_lints: ^1.0.3
   integration_test:
     sdk: flutter
+  flutter_driver:
+    sdk: flutter
 
 flutter:
   uses-material-design: true

--- a/examples/cookbook/testing/integration/profiling/test/widget_test.dart
+++ b/examples/cookbook/testing/integration/profiling/test/widget_test.dart
@@ -1,0 +1,36 @@
+// #docregion ScrollWidgetTest
+
+// This is a basic Flutter widget test.
+//
+// To perform an interaction with a widget in your test, use the WidgetTester
+// utility that Flutter provides. For example, you can send tap and scroll
+// gestures. You can also use WidgetTester to find child widgets in the widget
+// tree, read text, and verify that the values of widget properties are correct.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:scrolling/main.dart';
+
+void main() {
+  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    await tester.pumpWidget(MyApp(
+      items: List<String>.generate(10000, (i) => "Item $i"),
+    ));
+
+    final listFinder = find.byType(Scrollable);
+    final itemFinder = find.byKey(const ValueKey('item_50_text'));
+
+    // Scroll until the item to be found appears.
+    await tester.scrollUntilVisible(
+      itemFinder,
+      500.0,
+      scrollable: listFinder,
+    );
+
+    // Verify that the item contains the correct text.
+    expect(itemFinder, findsOneWidget);
+  });
+}
+// #enddocregion ScrollWidgetTest

--- a/examples/cookbook/testing/integration/profiling/test_driver/perf_driver.dart
+++ b/examples/cookbook/testing/integration/profiling/test_driver/perf_driver.dart
@@ -6,7 +6,7 @@ Future<void> main() {
   return integrationDriver(
     responseDataCallback: (data) async {
       if (data != null) {
-        final timeline = driver.Timeline.fromJson(data['timeline']);
+        final timeline = driver.Timeline.fromJson(data['scrolling_timeline']);
 
         // Convert the Timeline into a TimelineSummary that's easier to
         // read and understand.

--- a/examples/cookbook/testing/integration/profiling/test_driver/perf_driver.dart
+++ b/examples/cookbook/testing/integration/profiling/test_driver/perf_driver.dart
@@ -1,0 +1,29 @@
+// #docregion Timeline
+import 'package:integration_test/integration_test_driver.dart';
+import 'package:flutter_driver/flutter_driver.dart' as driver;
+
+Future<void> main() {
+  return integrationDriver(
+    responseDataCallback: (data) async {
+      if (data != null) {
+        final timeline = driver.Timeline.fromJson(data['timeline']);
+
+        // Convert the Timeline into a TimelineSummary that's easier to
+        // read and understand.
+        final summary = driver.TimelineSummary.summarize(timeline);
+
+        // Then, write the entire timeline to disk in a json format.
+        // This file can be opened in the Chrome browser's tracing tools
+        // found by navigating to chrome://tracing.
+        // Optionally, save the summary to disk by setting includeSummary
+        // to true
+        await summary.writeTimelineToFile(
+          'scrolling_timeline',
+          pretty: true,
+          includeSummary: true,
+        );
+      }
+    },
+  );
+}
+// #enddocregion Timeline

--- a/src/cookbook/testing/integration/profiling.md
+++ b/src/cookbook/testing/integration/profiling.md
@@ -122,6 +122,11 @@ Future<void> main() {
 }
 ```
 
+The `integrationDriver` function has a `responseDataCallback` 
+which you can customize. 
+By default, it writes the results to the `integration_response_data.json` file,
+but you can customize it to generate a summary like in this example.
+
 ### 4. Run the test
 
 After configuring the test to capture a performance `Timeline` and save a

--- a/src/cookbook/testing/integration/profiling.md
+++ b/src/cookbook/testing/integration/profiling.md
@@ -109,7 +109,8 @@ Future<void> main() {
         // Then, write the entire timeline to disk in a json format.
         // This file can be opened in the Chrome browser's tracing tools
         // found by navigating to chrome://tracing.
-        // Optionally, save the summary to disk by setting includeSummary to true
+        // Optionally, save the summary to disk by setting includeSummary
+        // to true
         await summary.writeTimelineToFile(
           'scrolling_timeline',
           pretty: true,
@@ -142,7 +143,6 @@ what will be experienced by end users.
   This option disables the Dart Development Service (DDS), which won't
   be accessible from your computer.
 {{site.alert.end}}
-
 
 ### 5. Review the results
 
@@ -185,6 +185,8 @@ the project contains two files:
 
 ### Complete example
 
+**integration_test/scrolling_test.dart**
+
 <?code-excerpt "integration_test/scrolling_test.dart"?>
 ```dart
 import 'package:flutter/material.dart';
@@ -221,11 +223,43 @@ void main() {
 }
 ```
 
+**test_driver/perf_driver.dart**
+
+<?code-excerpt "test_driver/perf_driver.dart"?>
+```dart
+import 'package:integration_test/integration_test_driver.dart';
+import 'package:flutter_driver/flutter_driver.dart' as driver;
+
+Future<void> main() {
+  return integrationDriver(
+    responseDataCallback: (data) async {
+      if (data != null) {
+        final timeline = driver.Timeline.fromJson(data['timeline']);
+
+        // Convert the Timeline into a TimelineSummary that's easier to
+        // read and understand.
+        final summary = driver.TimelineSummary.summarize(timeline);
+
+        // Then, write the entire timeline to disk in a json format.
+        // This file can be opened in the Chrome browser's tracing tools
+        // found by navigating to chrome://tracing.
+        // Optionally, save the summary to disk by setting includeSummary
+        // to true
+        await summary.writeTimelineToFile(
+          'scrolling_timeline',
+          pretty: true,
+          includeSummary: true,
+        );
+      }
+    },
+  );
+}
+```
+
 
 [chrome://tracing]: chrome://tracing
 [`IntegrationTestWidgetsFlutterBinding`]: {{site.api}}/flutter/package-integration_test_integration_test/IntegrationTestWidgetsFlutterBinding-class.html
 [Scrolling]: {{site.url}}/cookbook/testing/widget/scrolling
-[`flutter_driver`]: {{site.api}}/flutter/flutter_driver/flutter_driver-library.html
 [`Timeline`]: {{site.api}}/flutter/flutter_driver/Timeline-class.html
 [`TimelineSummary`]: {{site.api}}/flutter/flutter_driver/TimelineSummary-class.html
 [`traceAction()`]: {{site.api}}/flutter/flutter_driver/FlutterDriver/traceAction.html

--- a/src/cookbook/testing/integration/profiling.md
+++ b/src/cookbook/testing/integration/profiling.md
@@ -88,25 +88,37 @@ to review the results:
      This file can be opened with the Chrome browser's
      tracing tools found at [chrome://tracing][].
 
-<!-- TODO: this TimelineSummary only exists in flutter_driver, explain that -->
+To capture the results, create a file named `perf_driver.dart`
+in the `test_driver` folder and add the following code:
 
-<?code-excerpt "integration_test/scrolling_test.dart (Timeline)"?>
+<?code-excerpt "test_driver/perf_driver.dart"?>
 ```dart
-final timeline = driver.Timeline.fromJson(binding.reportData?['timeline']);
+import 'package:integration_test/integration_test_driver.dart';
+import 'package:flutter_driver/flutter_driver.dart' as driver;
 
-// Convert the Timeline into a TimelineSummary that's easier to
-// read and understand.
-final summary = driver.TimelineSummary.summarize(timeline);
+Future<void> main() {
+  return integrationDriver(
+    responseDataCallback: (data) async {
+      if (data != null) {
+        final timeline = driver.Timeline.fromJson(data['timeline']);
 
-// Then, write the entire timeline to disk in a json format.
-// This file can be opened in the Chrome browser's tracing tools
-// found by navigating to chrome://tracing.
-// Optionally, save the summary to disk by setting includeSummary to true
-await summary.writeTimelineToFile(
-  'scrolling_timeline',
-  pretty: true,
-  includeSummary: true,
-);
+        // Convert the Timeline into a TimelineSummary that's easier to
+        // read and understand.
+        final summary = driver.TimelineSummary.summarize(timeline);
+
+        // Then, write the entire timeline to disk in a json format.
+        // This file can be opened in the Chrome browser's tracing tools
+        // found by navigating to chrome://tracing.
+        // Optionally, save the summary to disk by setting includeSummary to true
+        await summary.writeTimelineToFile(
+          'scrolling_timeline',
+          pretty: true,
+          includeSummary: true,
+        );
+      }
+    },
+  );
+}
 ```
 
 ### 4. Run the test
@@ -114,15 +126,23 @@ await summary.writeTimelineToFile(
 After configuring the test to capture a performance `Timeline` and save a
 summary of the results to disk, run the test with the following command:
 
-<!-- TODO: Add the --no-dds option and explain why it is needed -->
-
 ```
-flutter drive --target=test_driver/app.dart --profile
+flutter drive \
+  --driver=test_driver/perf_driver.dart \
+  --target=integration_test/scrolling_test.dart \
+  --profile
 ```
 
 The `--profile` option means to compile the app for the "profile mode" 
 rather than the "debug mode", so that the benchmark result is closer to 
 what will be experienced by end users. 
+
+{{site.alert.note}}
+  Run the command with `--no-dds` when running on a mobile device or emulator.
+  This option disables the Dart Development Service (DDS), which won't
+  be accessible from your computer.
+{{site.alert.end}}
+
 
 ### 5. Review the results
 
@@ -167,10 +187,7 @@ the project contains two files:
 
 <?code-excerpt "integration_test/scrolling_test.dart"?>
 ```dart
-import 'dart:developer';
-
 import 'package:flutter/material.dart';
-import 'package:flutter_driver/flutter_driver.dart' as driver;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -200,22 +217,6 @@ void main() {
       // Verify that the item contains the correct text.
       expect(itemFinder, findsOneWidget);
     });
-
-    final timeline = driver.Timeline.fromJson(binding.reportData?['timeline']);
-
-    // Convert the Timeline into a TimelineSummary that's easier to
-    // read and understand.
-    final summary = driver.TimelineSummary.summarize(timeline);
-
-    // Then, write the entire timeline to disk in a json format.
-    // This file can be opened in the Chrome browser's tracing tools
-    // found by navigating to chrome://tracing.
-    // Optionally, save the summary to disk by setting includeSummary to true
-    await summary.writeTimelineToFile(
-      'scrolling_timeline',
-      pretty: true,
-      includeSummary: true,
-    );
   });
 }
 ```
@@ -224,6 +225,7 @@ void main() {
 [chrome://tracing]: chrome://tracing
 [`IntegrationTestWidgetsFlutterBinding`]: {{site.api}}/flutter/package-integration_test_integration_test/IntegrationTestWidgetsFlutterBinding-class.html
 [Scrolling]: {{site.url}}/cookbook/testing/widget/scrolling
+[`flutter_driver`]: {{site.api}}/flutter/flutter_driver/flutter_driver-library.html
 [`Timeline`]: {{site.api}}/flutter/flutter_driver/Timeline-class.html
 [`TimelineSummary`]: {{site.api}}/flutter/flutter_driver/TimelineSummary-class.html
 [`traceAction()`]: {{site.api}}/flutter/flutter_driver/FlutterDriver/traceAction.html

--- a/src/cookbook/testing/integration/profiling.md
+++ b/src/cookbook/testing/integration/profiling.md
@@ -48,13 +48,13 @@ verify that everything works as expected.
 
 Next, record the performance of the app as it scrolls through the
 list. Perform this task using the [`traceAction()`][]
-method provided by the [`FlutterDriver`][] class.
+method provided by the [`IntegrationTestWidgetsFlutterBinding`][] class.
 
 This method runs the provided function and records a [`Timeline`][]
 with detailed information about the performance of the app. This example
 provides a function that scrolls through the list of items,
 ensuring that a specific item is displayed. When the function completes,
-the `traceAction()` method returns a `Timeline`.
+the `traceAction()` creates a report data `Map` that contains the `Timeline`.
 
 <?code-excerpt "integration_test/scrolling_test.dart (traceAction)"?>
 ```dart
@@ -88,21 +88,25 @@ to review the results:
      This file can be opened with the Chrome browser's
      tracing tools found at [chrome://tracing][].
 
-<!-- TODO: should we use TimelineSummary here? -->
+<!-- TODO: this TimelineSummary only exists in flutter_driver, explain that -->
 
-<!-- skip -->
+<?code-excerpt "integration_test/scrolling_test.dart (Timeline)"?>
 ```dart
-// Convert the Timeline into a TimelineSummary that's easier to read and
-// understand.
-final summary = new TimelineSummary.summarize(timeline);
+final timeline = driver.Timeline.fromJson(binding.reportData?['timeline']);
 
-// Then, save the summary to disk.
-await summary.writeSummaryToFile('scrolling_summary', pretty: true);
+// Convert the Timeline into a TimelineSummary that's easier to
+// read and understand.
+final summary = driver.TimelineSummary.summarize(timeline);
 
-// Optionally, write the entire timeline to disk in a json format. This
-// file can be opened in the Chrome browser's tracing tools found by
-// navigating to chrome://tracing.
-await summary.writeTimelineToFile('scrolling_timeline', pretty: true);
+// Then, write the entire timeline to disk in a json format.
+// This file can be opened in the Chrome browser's tracing tools
+// found by navigating to chrome://tracing.
+// Optionally, save the summary to disk by setting includeSummary to true
+await summary.writeTimelineToFile(
+  'scrolling_timeline',
+  pretty: true,
+  includeSummary: true,
+);
 ```
 
 ### 4. Run the test
@@ -166,6 +170,7 @@ the project contains two files:
 import 'dart:developer';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_driver/flutter_driver.dart' as driver;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -196,27 +201,28 @@ void main() {
       expect(itemFinder, findsOneWidget);
     });
 
-    final timeline = binding.reportData?['timeline'];
-    print(timeline);
+    final timeline = driver.Timeline.fromJson(binding.reportData?['timeline']);
 
-    // // Convert the Timeline into a TimelineSummary that's easier to
-    // // read and understand.
-    // final summary = TimelineSummary.summarize(timeline);
+    // Convert the Timeline into a TimelineSummary that's easier to
+    // read and understand.
+    final summary = driver.TimelineSummary.summarize(timeline);
 
-    // // Then, save the summary to disk.
-    // await summary.writeSummaryToFile('scrolling_summary', pretty: true);
-
-    // // Optionally, write the entire timeline to disk in a json format.
-    // // This file can be opened in the Chrome browser's tracing tools
-    // // found by navigating to chrome://tracing.
-    // await summary.writeTimelineToFile('scrolling_timeline', pretty: true);
+    // Then, write the entire timeline to disk in a json format.
+    // This file can be opened in the Chrome browser's tracing tools
+    // found by navigating to chrome://tracing.
+    // Optionally, save the summary to disk by setting includeSummary to true
+    await summary.writeTimelineToFile(
+      'scrolling_timeline',
+      pretty: true,
+      includeSummary: true,
+    );
   });
 }
 ```
 
 
 [chrome://tracing]: chrome://tracing
-[`FlutterDriver`]: {{site.api}}/flutter/flutter_driver/FlutterDriver-class.html
+[`IntegrationTestWidgetsFlutterBinding`]: {{site.api}}/flutter/package-integration_test_integration_test/IntegrationTestWidgetsFlutterBinding-class.html
 [Scrolling]: {{site.url}}/cookbook/testing/widget/scrolling
 [`Timeline`]: {{site.api}}/flutter/flutter_driver/Timeline-class.html
 [`TimelineSummary`]: {{site.api}}/flutter/flutter_driver/TimelineSummary-class.html

--- a/src/cookbook/testing/integration/profiling.md
+++ b/src/cookbook/testing/integration/profiling.md
@@ -58,17 +58,19 @@ the `traceAction()` creates a report data `Map` that contains the `Timeline`.
 
 <?code-excerpt "integration_test/scrolling_test.dart (traceAction)"?>
 ```dart
-await binding.traceAction(() async {
-  // Scroll until the item to be found appears.
-  await tester.scrollUntilVisible(
-    itemFinder,
-    500.0,
-    scrollable: listFinder,
-  );
+await binding.traceAction(
+  () async {
+    // Scroll until the item to be found appears.
+    await tester.scrollUntilVisible(
+      itemFinder,
+      500.0,
+      scrollable: listFinder,
+    );
 
-  // Verify that the item contains the correct text.
-  expect(itemFinder, findsOneWidget);
-});
+    // Verify that the item contains the correct text.
+  },
+  reportKey: 'scrolling_timeline',
+);
 ```
 
 ### 3. Save the results to disk
@@ -100,7 +102,7 @@ Future<void> main() {
   return integrationDriver(
     responseDataCallback: (data) async {
       if (data != null) {
-        final timeline = driver.Timeline.fromJson(data['timeline']);
+        final timeline = driver.Timeline.fromJson(data['scrolling_timeline']);
 
         // Convert the Timeline into a TimelineSummary that's easier to
         // read and understand.
@@ -213,17 +215,19 @@ void main() {
     final listFinder = find.byType(Scrollable);
     final itemFinder = find.byKey(const ValueKey('item_50_text'));
 
-    await binding.traceAction(() async {
-      // Scroll until the item to be found appears.
-      await tester.scrollUntilVisible(
-        itemFinder,
-        500.0,
-        scrollable: listFinder,
-      );
+    await binding.traceAction(
+      () async {
+        // Scroll until the item to be found appears.
+        await tester.scrollUntilVisible(
+          itemFinder,
+          500.0,
+          scrollable: listFinder,
+        );
 
-      // Verify that the item contains the correct text.
-      expect(itemFinder, findsOneWidget);
-    });
+        // Verify that the item contains the correct text.
+      },
+      reportKey: 'scrolling_timeline',
+    );
   });
 }
 ```
@@ -239,7 +243,7 @@ Future<void> main() {
   return integrationDriver(
     responseDataCallback: (data) async {
       if (data != null) {
-        final timeline = driver.Timeline.fromJson(data['timeline']);
+        final timeline = driver.Timeline.fromJson(data['scrolling_timeline']);
 
         // Convert the Timeline into a TimelineSummary that's easier to
         // read and understand.

--- a/src/cookbook/testing/integration/profiling.md
+++ b/src/cookbook/testing/integration/profiling.md
@@ -56,6 +56,10 @@ provides a function that scrolls through the list of items,
 ensuring that a specific item is displayed. When the function completes,
 the `traceAction()` creates a report data `Map` that contains the `Timeline`.
 
+Specify the `reportKey` when running more than one `traceAction`.
+By default all `Timelines` are stored with the key `timeline`,
+in this example the `reportKey` is changed to `scrolling_timeline`.
+
 <?code-excerpt "integration_test/scrolling_test.dart (traceAction)"?>
 ```dart
 await binding.traceAction(
@@ -66,8 +70,6 @@ await binding.traceAction(
       500.0,
       scrollable: listFinder,
     );
-
-    // Verify that the item contains the correct text.
   },
   reportKey: 'scrolling_timeline',
 );
@@ -223,8 +225,6 @@ void main() {
           500.0,
           scrollable: listFinder,
         );
-
-        // Verify that the item contains the correct text.
       },
       reportKey: 'scrolling_timeline',
     );


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

In this PR I update the performance profiling guide to show package:integration_test instead of Flutter driver.

(original page: https://docs.flutter.dev/cookbook/testing/integration/profiling)

In my code I have moved the traceAction method from the flutter_driver implementation to the integration_test one, and it works.

I have also added a short explanation about the `integrationDriver` method, which already captures the performance, but that can be customized like in the example.

I have also added an alert note explaining that if you run the profiling command on a mobile device or emulator, you need to add the `--no-dds` parameter.

_Issues fixed by this PR (if any):_
none

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
