### PR TITLE
Add breaking change that requires a greater Kotlin version

### DIFF
--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -12,9 +12,11 @@ release, and listed in alphabetical order:
 
 ### Not yet released to stable
 
+* [Required Kotlin version][]
 * [Deprecated API removed after v2.5][]
 
 [Deprecated API removed after v2.5]: {{site.url}}/release/breaking-changes/2-5-deprecations
+[Required Kotlin version]: {{site.url}}/release/breaking-changes/kotlin-version
 
 ### Released in Flutter 2.5
 

--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -15,8 +15,8 @@ release, and listed in alphabetical order:
 * [Required Kotlin version][]
 * [Deprecated API removed after v2.5][]
 
-[Deprecated API removed after v2.5]: {{site.url}}/release/breaking-changes/2-5-deprecations
 [Required Kotlin version]: {{site.url}}/release/breaking-changes/kotlin-version
+[Deprecated API removed after v2.5]: {{site.url}}/release/breaking-changes/2-5-deprecations
 
 ### Released in Flutter 2.5
 

--- a/src/release/breaking-changes/kotlin-version.md
+++ b/src/release/breaking-changes/kotlin-version.md
@@ -1,0 +1,58 @@
+---
+title: Kotlin version 
+description: Flutter apps built for the Android platform require Kotlin 1.5.31 or greater.
+---
+
+## Summary
+
+To build a Flutter app for Android, Kotlin 1.5.31 or greater is required.
+
+If your app uses a lower version, you will receive the following error message:
+
+```
+┌─ Flutter Fix ────────────────────────────────────────────────────────────┐
+│                                                                          │
+│ [!] Your project requires a newer version of the Kotlin Gradle plugin.   │
+│ Find the latest version on                                               │
+│ https://kotlinlang.org/docs/gradle.html#plugin-and-versions, then update │
+│ <path-to-app>/android/build.gradle:                                      │
+│ ext.kotlin_version = '<latest-version>'                                  │
+│                                                                          │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## Context
+
+Flutter added support for [foldable devices][1] on Android.
+This required to add an AndroidX dependency to the Flutter embedding that
+requires apps to use Kotlin 1.5.31 or greater.
+
+## Description of change
+
+A Flutter app compiled for Android now includes the Gradle dependency 
+`androidx.window:window-java`.
+
+## Migration guide
+
+Open `<app-src>/android/build.gradle`, and change `ext.kotlin_version`:
+
+```diff
+buildscript {
+-    ext.kotlin_version = '1.3.50'
++    ext.kotlin_version = '1.5.31'
+```
+
+## Timeline
+
+This change will be released in v2.9.0.
+
+## References
+
+Relevant PRs:
+
+* [Display Features support][]
+
+
+[Display Features support]: https://github.com/flutter/engine/pull/29585
+
+[1]: https://developer.android.com/guide/topics/large-screens/learn-about-foldables

--- a/src/release/breaking-changes/kotlin-version.md
+++ b/src/release/breaking-changes/kotlin-version.md
@@ -44,7 +44,7 @@ buildscript {
 
 ## Timeline
 
-This change will be released in v2.9.0.
+This change will be released in v2.9.0 beta.
 
 ## References
 

--- a/src/release/breaking-changes/kotlin-version.md
+++ b/src/release/breaking-changes/kotlin-version.md
@@ -1,5 +1,5 @@
 ---
-title: Kotlin version 
+title: Required Kotlin version 
 description: Flutter apps built for the Android platform require Kotlin 1.5.31 or greater.
 ---
 


### PR DESCRIPTION
This is required after https://github.com/flutter/engine/pull/29585

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
