### PR TITLE
Fix links to Visual Studio 2019

### DIFF
--- a/src/desktop/index.md
+++ b/src/desktop/index.md
@@ -93,7 +93,7 @@ you need the following in addition to the Flutter SDK:
   you need the "Universal Windows Platform development"
   workload installed, with the optional UWP C++ tools.
 
-[Visual Studio 2019]: https://visualstudio.microsoft.com/downloads/
+[Visual Studio 2019]: https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=community&rel=16
 
 ### Additional macOS requirements
 

--- a/src/get-started/install/_windows-desktop-setup.md
+++ b/src/get-started/install/_windows-desktop-setup.md
@@ -35,7 +35,7 @@ you need the following in addition to the Flutter SDK:
   you need the "Universal Windows Platform development"
   workload installed, with the optional UWP C++ tools.
 
-[Visual Studio 2019]: https://visualstudio.microsoft.com/downloads/
+[Visual Studio 2019]: https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=community&rel=16
 
 ### Enable desktop support
 


### PR DESCRIPTION
Existing links lead to Visual Studio 2022

## Presubmit checklist
- [x ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
