### PR TITLE
Support "C++" as a language in samplecode

### DIFF
--- a/src/_plugins/code_tabs.rb
+++ b/src/_plugins/code_tabs.rb
@@ -89,6 +89,11 @@
 # - lib/liquid/block.rb
 # - lib/liquid/block_body.rb
 module Jekyll
+    
+    def language_as_id(language)
+        language_sanitized = language.downcase
+        language_sanitized.gsub(/\+/, "-plus")
+    end
 
     class SampleCode < Liquid::Block
 
@@ -183,10 +188,10 @@ module Jekyll
 
             is_active = true
             for language in @languages
-                languageLower = language.downcase
+                language_id = language_as_id(language)
                 output += %Q(
 <li class="nav-item">
-  <a class="nav-link #{is_active ? "active" : ""}" id="#{@title}-#{languageLower}" href="\##{@title}-#{languageLower}-tab" role="tab" aria-controls="#{@title}-#{languageLower}" aria-selected="true">#{language}</a>
+  <a class="nav-link #{is_active ? "active" : ""}" id="#{@title}-#{language_id}" href="\##{@title}-#{language_id}-tab" role="tab" aria-controls="#{@title}-#{language_id}" aria-selected="true">#{language}</a>
 </li>
 )
                 is_active = false
@@ -210,9 +215,9 @@ module Jekyll
 
         def render(context)
             code = super
-            language_name_lower = @language_name.downcase
+            language_id = language_as_id(@language_name)
             %Q(
-<div class="tab-pane #{@is_active ? "active" : ""}" id="#{@title}-#{language_name_lower}-tab" role="tabpanel" aria-labelledby="#{@title}-#{language_name_lower}-tab" markdown="1">
+<div class="tab-pane #{@is_active ? "active" : ""}" id="#{@title}-#{language_id}-tab" role="tabpanel" aria-labelledby="#{@title}-#{language_id}-tab" markdown="1">
 #{code}
 </div>
 )


### PR DESCRIPTION
Since `+` is not a valid character in an HTML ID, replace it with `-plus`.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
