### PR TITLE
Update react-native-devs.md Futures example

### DIFF
--- a/src/get-started/flutter-for/react-native-devs.md
+++ b/src/get-started/flutter-for/react-native-devs.md
@@ -233,7 +233,7 @@ import 'package:http/http.dart' as http;
 
 class Example {
   Future<String> _getIPAddress() {
-    final url = 'https://httpbin.org/ip';
+    final url = new Uri.https('httpbin.org', '/ip');
     return http.get(url).then((response) {
       String ip = jsonDecode(response.body)['origin'];
       return ip;
@@ -297,7 +297,7 @@ import 'package:http/http.dart' as http;
 
 class Example {
   Future<String> _getIPAddress() async {
-    final url = 'https://httpbin.org/ip';
+    final url = new Uri.https('httpbin.org', '/ip');
     final response = await http.get(url);
     String ip = jsonDecode(response.body)['origin'];
     return ip;


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

In *Asynchronous programming* -> *Futures* section the example provided is not working and returns the following error in DartPad:

```
Error compiling to JavaScript:
Info: Compiling with sound null safety
Warning: Interpreting this as package URI, 'package:dartpad_sample/main.dart'.
lib/main.dart:7:21:
Error: The argument type 'String' can't be assigned to the parameter type 'Uri'.
 - 'Uri' is from 'dart:core'.
    return http.get(url).then((response) {
                    ^
Error: Compilation failed.
```

An update is needed for *url* variable as follows:

```Dart
 final url = new Uri.https('httpbin.org', '/ip');
```

This is related to an update to Dart http package that requires an argument of type _Uri_ instead of _String_.

* https://api.dart.dev/stable/2.14.4/dart-core/Uri-class.html
* https://pub.dev/packages/http

_Issues fixed by this PR (if any):
N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
