### PR TITLE
iOS simulator: not possible to start on Windows or Linux

### DIFF
--- a/src/get-started/test-drive/_vscode.md
+++ b/src/get-started/test-drive/_vscode.md
@@ -34,7 +34,7 @@ contains a simple demo app that uses [Material Components][].
       open -a simulator
       ```
 
-      In Android it is not possible to launch iOS simulator.
+      On Windows or Linux it is not possible to launch iOS simulator.
       {{site.alert.end}}
 
     - To setup a real device, follow the device-specific instructions on the


### PR DESCRIPTION
Fixing presumed typo.

_Description of what this PR is changing or adding, and why:_
The alert says: on Android it is not possible to start iOS simulator. I presume the doc should say on development platforms instead of Android, correcting Android to Windows or Linux

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [ x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
