### PR TITLE
Fix analyzer warning in Flutter 2.8 by removing unnecessary imports

### DIFF
--- a/examples/animation/animate1/lib/main.dart
+++ b/examples/animation/animate1/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 
 void main() => runApp(const LogoApp());

--- a/examples/animation/animate2/lib/main.dart
+++ b/examples/animation/animate2/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 
 void main() => runApp(const LogoApp());

--- a/examples/animation/animate3/lib/main.dart
+++ b/examples/animation/animate3/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 
 void main() => runApp(const LogoApp());

--- a/examples/animation/animate4/lib/main.dart
+++ b/examples/animation/animate4/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 
 void main() => runApp(const LogoApp());

--- a/examples/animation/animate5/lib/main.dart
+++ b/examples/animation/animate5/lib/main.dart
@@ -2,7 +2,6 @@
 import 'dart:math';
 
 // #enddocregion ShakeCurve
-import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 
 void main() => runApp(const LogoApp());

--- a/examples/cookbook/design/themes/lib/main.dart
+++ b/examples/cookbook/design/themes/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() {

--- a/examples/cookbook/gestures/dismissible/lib/main.dart
+++ b/examples/cookbook/gestures/dismissible/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() {

--- a/examples/cookbook/gestures/dismissible/lib/step1.dart
+++ b/examples/cookbook/gestures/dismissible/lib/step1.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() {

--- a/examples/cookbook/gestures/dismissible/lib/step2.dart
+++ b/examples/cookbook/gestures/dismissible/lib/step2.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() {

--- a/examples/cookbook/lists/floating_app_bar/lib/main.dart
+++ b/examples/cookbook/lists/floating_app_bar/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/examples/cookbook/lists/floating_app_bar/lib/step2.dart
+++ b/examples/cookbook/lists/floating_app_bar/lib/step2.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/examples/cookbook/lists/long_lists/lib/main.dart
+++ b/examples/cookbook/lists/long_lists/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() {

--- a/examples/cookbook/navigation/passing_data/lib/main.dart
+++ b/examples/cookbook/navigation/passing_data/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 // #docregion Todo

--- a/examples/cookbook/navigation/passing_data/lib/main_routesettings.dart
+++ b/examples/cookbook/navigation/passing_data/lib/main_routesettings.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 class Todo {

--- a/examples/cookbook/networking/web_sockets/lib/main.dart
+++ b/examples/cookbook/networking/web_sockets/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:flutter/material.dart';
 

--- a/examples/cookbook/persistence/reading_writing_files/lib/main.dart
+++ b/examples/cookbook/persistence/reading_writing_files/lib/main.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 

--- a/examples/cookbook/testing/widget/scrolling/lib/main.dart
+++ b/examples/cookbook/testing/widget/scrolling/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() {

--- a/examples/ui/advanced/actions_and_shortcuts/lib/samples.dart
+++ b/examples/ui/advanced/actions_and_shortcuts/lib/samples.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 
 class ShortcutsExample extends StatelessWidget {
 // #docregion ShortcutsExample

--- a/examples/ui/layout/adaptive_app_demos/lib/pages/focus_examples_page.dart
+++ b/examples/ui/layout/adaptive_app_demos/lib/pages/focus_examples_page.dart
@@ -1,7 +1,6 @@
 import 'package:adaptive_app_demos/global/device_type.dart';
 import 'package:flextras/flextras.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/gestures.dart';
 

--- a/examples/ui/layout/adaptive_app_demos/lib/widgets/extra_widget_excerpts.dart
+++ b/examples/ui/layout/adaptive_app_demos/lib/widgets/extra_widget_excerpts.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';

--- a/src/cookbook/design/themes.md
+++ b/src/cookbook/design/themes.md
@@ -135,7 +135,6 @@ Container(
 
 <?code-excerpt "lib/main.dart"?>
 ```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/cookbook/gestures/dismissible.md
+++ b/src/cookbook/gestures/dismissible.md
@@ -134,7 +134,6 @@ provide a `background` parameter to the `Dismissible`.
 
 <?code-excerpt "lib/main.dart"?>
 ```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/cookbook/lists/floating-app-bar.md
+++ b/src/cookbook/lists/floating-app-bar.md
@@ -151,7 +151,6 @@ SliverList(
 
 <?code-excerpt "lib/main.dart"?>
 ```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/cookbook/lists/long-lists.md
+++ b/src/cookbook/lists/long-lists.md
@@ -59,7 +59,6 @@ ListView.builder(
 
 <?code-excerpt "lib/main.dart"?>
 ```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/cookbook/navigation/passing-data.md
+++ b/src/cookbook/navigation/passing-data.md
@@ -195,7 +195,6 @@ body: ListView.builder(
 
 <?code-excerpt "lib/main.dart"?>
 ```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 class Todo {
@@ -349,7 +348,6 @@ ListView.builder(
 
 <?code-excerpt "lib/main_routesettings.dart"?>
 ```dart
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 class Todo {

--- a/src/cookbook/networking/web-sockets.md
+++ b/src/cookbook/networking/web-sockets.md
@@ -113,7 +113,6 @@ channel.sink.close();
 
 <?code-excerpt "lib/main.dart"?>
 ```dart
-import 'package:flutter/foundation.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:flutter/material.dart';
 

--- a/src/cookbook/persistence/reading-writing-files.md
+++ b/src/cookbook/persistence/reading-writing-files.md
@@ -122,7 +122,6 @@ Future<int> readCounter() async {
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 

--- a/src/cookbook/testing/widget/scrolling.md
+++ b/src/cookbook/testing/widget/scrolling.md
@@ -44,7 +44,6 @@ inside the integration tests.
 
 <?code-excerpt "lib/main.dart"?>
 ```dart
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/development/ui/animations/tutorial.md
+++ b/src/development/ui/animations/tutorial.md
@@ -325,12 +325,7 @@ The changes from the non-animated example are highlighted:
 ```diff
 --- animate0/lib/main.dart
 +++ animate1/lib/main.dart
-@@ -1,3 +1,4 @@
-+import 'package:flutter/animation.dart';
- import 'package:flutter/material.dart';
-
- void main() => runApp(const LogoApp());
-@@ -9,16 +10,39 @@
+@@ -9,16 +9,39 @@
    _LogoAppState createState() => _LogoAppState();
  }
 
@@ -477,8 +472,7 @@ and it passes the `Animation` object to `AnimatedLogo`:
 ```diff
 --- animate1/lib/main.dart
 +++ animate2/lib/main.dart
-@@ -1,11 +1,29 @@
- import 'package:flutter/animation.dart';
+@@ -1,10 +1,28 @@
  import 'package:flutter/material.dart';
 
  void main() => runApp(const LogoApp());
@@ -507,7 +501,7 @@ and it passes the `Animation` object to `AnimatedLogo`:
    @override
    _LogoAppState createState() => _LogoAppState();
  }
-@@ -16,32 +34,18 @@
+@@ -15,32 +33,18 @@
 
    @override
    void initState() {
@@ -599,7 +593,7 @@ at the beginning or the end. This creates a "breathing" effect:
 ```diff
 --- animate2/lib/main.dart
 +++ animate3/lib/main.dart
-@@ -36,7 +36,15 @@
+@@ -35,7 +35,15 @@
    void initState() {
      super.initState();
      controller =
@@ -740,8 +734,7 @@ in the bullet points above.
 ```diff
 --- animate2/lib/main.dart
 +++ animate4/lib/main.dart
-@@ -1,28 +1,48 @@
- import 'package:flutter/animation.dart';
+@@ -1,27 +1,47 @@
  import 'package:flutter/material.dart';
 
  void main() => runApp(const LogoApp());
@@ -798,7 +791,7 @@ in the bullet points above.
 
    @override
    _LogoAppState createState() => _LogoAppState();
-@@ -35,18 +55,23 @@
+@@ -34,18 +54,23 @@
    @override
    void initState() {
      super.initState();


### PR DESCRIPTION
The build is failing because of a new analyzer feature, `unnecessary_import`.

```
The import of 'package:flutter/animation.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/material.dart'
```

I was unable to refresh the code excerpts due to https://github.com/flutter/website/issues/6551

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
