### PR TITLE
Add Dart writer job post

### DIFF
--- a/src/jobs/index.md
+++ b/src/jobs/index.md
@@ -9,3 +9,4 @@ We currently have the following job openings on the Flutter and Dart teams:
 * [Flutter Engineering Productivity]({{site.url}}/jobs/infrastructure)
 * [Flutter CLI and Tools]({{site.url}}/jobs/tools)
 * [Flutter & Dart Developer Experience SWE]({{site.url}}/jobs/devexp)
+* [Dart writer]({{site.url}}/jobs/writer)

--- a/src/jobs/writer.html
+++ b/src/jobs/writer.html
@@ -52,7 +52,7 @@ toc: false
 <p><i>You must meet these minimum qualifications to apply for this job:</i></p>
 
 <ul>
-  <li> Bachelor's degree or equivalent practical experience </li>
+  <li> Ability to work in the U.S. </li>
   <li> 5 years of experience in technical writing, product documentation, or
     online publishing </li>
   <li> Experience working with software engineers </li>

--- a/src/jobs/writer.html
+++ b/src/jobs/writer.html
@@ -1,0 +1,87 @@
+---
+title: Dart Writer
+toc: false
+---
+
+<p>
+  Dart and Flutter Developer Relations (DevRel)
+  grows and supports the Dart and Flutter developer communities.
+  We onboard and retain developers by
+  building a fun, smart, and approachable culture,
+  providing resources to help them succeed,
+  and advocating on their behalf.
+</p>
+
+<p>
+  As a Senior Technical Writer for Dart,
+  you'll join a community of developers using Dart and Flutter to
+  build apps for mobile, web, and desktop.
+</p>
+
+<aside class="alert alert-info" role="alert">
+  <strong>Important:</strong>
+  This job requires work authorization in the United States.
+</aside>
+
+
+<h2>Job responsibilities</h2>
+
+<ul>
+  <li> Write great docs, blog posts, and technical guides for Dart. </li>
+  <li> Be editor for <a href="https://dart.dev">dart.dev</a> and the
+    <a href="https://medium.com/dartlang">Dart blog</a>. </li>
+  <li> Interview engineers, product managers, and others to
+    gather technical details for documents. </li>
+  <li> Edit writing from internal and external contributors
+    at a variety of proficiency levels and
+    provide constructive feedback. </li>
+  <li> Publish content using a variety of media and tools. </li>
+</ul>
+
+<h2>Job location</h2>
+
+<ul>
+  <li> Seattle, WA </li>
+  <li> Portland, OR </li>
+  <li> San Francisco, CA </li>
+  <li> Mountain View, CA </li>
+</ul>
+
+<h2>Minimum qualifications</h2>
+
+<p><i>You must meet these minimum qualifications to apply for this job:</i></p>
+
+<ul>
+  <li> Bachelor's degree or equivalent practical experience </li>
+  <li> 5 years of experience in technical writing, product documentation, or
+    online publishing </li>
+  <li> Experience working with software engineers </li>
+</ul>
+
+<h2>Preferred qualifications</h2>
+
+<p><i>Having these qualifications is a plus, but transferable
+  skills/experiences may be equally valuable:</i></p>
+
+<ul>
+  <li> Experience contributing to open source documentation. </li>
+  <li> Ability to read and understand simple to complex code examples in
+    Java, C++, Python and/or JavaScript. </li>
+</ul>
+
+<h2>To apply</h2>
+
+<p>
+Please apply to
+<a href="https://careers.google.com/jobs/results/117755653033730758/">the
+  Google job post</a>
+or send the following to
+<a href="mailto:flutter-jobs@google.com">flutter-jobs@google.com</a>:
+</p>
+
+<ul>
+  <li> A resume outlining your relevant experience </li>
+  <li> A short introduction describing why you think
+    you’d be a good fit for this position </li>
+  <li> The preferred method by which you’d like Google to contact you </li>
+</ul>


### PR DESCRIPTION
This PR adds a page for the open Dart writer job.

I used https://docs.flutter.dev/jobs/devexp as a template, with some twists:

* Turned off the TOC, since its links aren't working
* Minor formatting tweaks, mostly to whitespace
* Took the colon out of the last heading (I feel better now)

I looked at it locally (in my dart.dev space) but don't have a docs.flutter.dev preview server set up.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
