### PR TITLE
Update ios-devs.md

### DIFF
--- a/src/get-started/flutter-for/ios-devs.md
+++ b/src/get-started/flutter-for/ios-devs.md
@@ -1241,13 +1241,6 @@ For further details on internationalization and localization in Flutter,
 see the [internationalization guide][],
 which has sample code with and without the `intl` package.
 
-Note that before Flutter 1.0 beta 2,
-assets defined in Flutter were not
-accessible from the native side, and vice versa,
-native assets and resources
-weren’t available to Flutter,
-as they lived in separate folders.
-
 ### What is the equivalent of CocoaPods? How do I add dependencies?
 
 In iOS, you add dependencies by adding to your `Podfile`.


### PR DESCRIPTION
Remove comment about Flutter 1.0 beta 2 -- it's irrelevant at this stage (0.0% of users are on this build).

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
