### PR TITLE
Remove the alpha warning for Linux deployment.

### DIFF
--- a/src/deployment/linux.md
+++ b/src/deployment/linux.md
@@ -14,18 +14,6 @@ When you're ready to prepare a _release_ version of your app,
 for example to [publish to the Snap Store][snap],
 this page can help.
 
-{{site.alert.warning}}
-  **Work in progress!**
-  This page covers desktop support for Linux,
-  which is available as an alpha-quality feature in the Flutter dev channel.
-  There are still notable feature gaps,
-  including accessibility support.
-  We strongly recommend that you examine the
-  [Desktop shells][] page in the [Flutter wiki][]
-  to understand known limitations and ongoing work.
-{{site.alert.end}}
-
-
 ## Prerequisites
 
 To build and publish to the Snap Store, you need the


### PR DESCRIPTION
Linux is currently in beta and doesn't have any notable feature gaps.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
