### PR TITLE
Improve /jobs pages a bit

### DIFF
--- a/src/jobs/android.html
+++ b/src/jobs/android.html
@@ -1,5 +1,6 @@
 ---
 title: Android Engineer
+toc: false
 ---
 
 <p>The Flutter team is constantly looking to improve our fidelity on
@@ -62,7 +63,7 @@ title: Android Engineer
 </ul>
 </p>
 
-<h2>Preferred qualifications:</h2>
+<h2>Preferred qualifications</h2>
 
 <p><i>Having these qualifications is a plus, but transferable
   skills/experiences may be equally valuable</i></p>

--- a/src/jobs/android.html
+++ b/src/jobs/android.html
@@ -82,6 +82,9 @@ toc: false
 
 <h2>To apply</h2>
 
-<p>Please apply at
-  <a href="https://careers.google.com/jobs/results/122913957812806342-senior-software-engineer-platforms-and-ecosystem-flutter/">Google's careers site</a>
-  and mention this page / URL in the "Cover letter/other notes" section.</p>
+<p>
+  Please apply at the
+  <a href="https://careers.google.com/jobs/results/122913957812806342-senior-software-engineer-platforms-and-ecosystem-flutter/">Google Careers site</a>
+  and mention this page/URL in the <b>Cover letter/other notes</b> section.
+</p>
+

--- a/src/jobs/devexp.html
+++ b/src/jobs/devexp.html
@@ -1,5 +1,6 @@
 ---
 title: Flutter and Dart Developer Experience SWE
+toc: false
 ---
 
 <p>The Flutter team is constantly looking to improve our developer experience story,
@@ -54,7 +55,7 @@ deep understanding of Dart and Flutter.</p>
 </ul>
 </p>
 
-<h2>Preferred qualifications:</h2>
+<h2>Preferred qualifications</h2>
 
 <p><i>Having these qualifications is a plus, but transferable
   skills/experiences may be equally valuable:</i></p>

--- a/src/jobs/engine_web.html
+++ b/src/jobs/engine_web.html
@@ -100,6 +100,8 @@ toc: false
 
 <h2>To apply</h2>
 
-<p>Please apply at
-  <a href="https://careers.google.com/jobs/results/122913957812806342-senior-software-engineer-platforms-and-ecosystem-flutter/">Google's careers site</a>
-  and mention this page / URL in the "Cover letter/other notes" section.</p>
+<p>
+  Please apply at the
+  <a href="https://careers.google.com/jobs/results/122913957812806342-senior-software-engineer-platforms-and-ecosystem-flutter/">Google Careers site</a>
+  and mention this page/URL in the <b>Cover letter/other notes</b> section.
+</p>

--- a/src/jobs/engine_web.html
+++ b/src/jobs/engine_web.html
@@ -1,10 +1,11 @@
 ---
 title: Flutter Web Engineer
+toc: false
 ---
 
 <p>Flutter is Google’s UI toolkit for building beautiful, natively 
    compiled applications for mobile, web, and desktop from a single 
-   codebase (http://flutter.dev, go/flutter). Flutter Web is an 
+   codebase (https://flutter.dev). Flutter Web is an 
    API-compatible Flutter runtime for web.</p>
 
 <p>The Flutter team is looking to improve the performance,
@@ -77,7 +78,7 @@ title: Flutter Web Engineer
 </ul>
 </p>
 
-<h2>Preferred qualifications:</h2>
+<h2>Preferred qualifications</h2>
 
 <p><i>Having these qualifications is a plus, but transferable
   skills/experiences may be equally valuable</i></p>

--- a/src/jobs/framework.html
+++ b/src/jobs/framework.html
@@ -1,5 +1,6 @@
 ---
 title: Framework Engineer
+toc: false
 ---
 
 <p>Flutter's Framework Team develops most of Flutter's
@@ -57,7 +58,7 @@ title: Framework Engineer
 </ul>
 </p>
 
-<h2>Preferred qualifications:</h2>
+<h2>Preferred qualifications</h2>
 
 <p><i>Having these qualifications is a plus, but transferable
   skills/experiences may be equally valuable</i></p>

--- a/src/jobs/framework.html
+++ b/src/jobs/framework.html
@@ -76,6 +76,9 @@ toc: false
 
 <h2>To apply</h2>
 
-<p>Please apply at
-  <a href="https://careers.google.com/jobs/results/122913957812806342-senior-software-engineer-platforms-and-ecosystem-flutter/">Google's careers site</a>
-  and mention this page / URL in the "Cover letter/other notes" section.</p>
+<p>
+  Please apply at the
+  <a href="https://careers.google.com/jobs/results/122913957812806342-senior-software-engineer-platforms-and-ecosystem-flutter/">Google Careers site</a>
+  and mention this page/URL in the <b>Cover letter/other notes</b> section.
+</p>
+

--- a/src/jobs/index.md
+++ b/src/jobs/index.md
@@ -3,8 +3,8 @@ title: Flutter and Dart team job openings
 description: Open job listings for the Flutter and Dart teams.
 ---
 
-We are hiring on the Flutter and Dart teama! Below is a listing of our various
-openings:
+We are hiring on the Flutter and Dart teams!
+The following jobs are open:
 
 * [Windows Engineer]({{site.url}}/jobs/windows)
 * [Android Engineer]({{site.url}}/jobs/android)

--- a/src/jobs/infrastructure.html
+++ b/src/jobs/infrastructure.html
@@ -1,5 +1,6 @@
 ---
 title: Flutter Infrastructure Engineer
+toc: false
 ---
 
 <p>The Flutter team is in need of robust infrastructure to facilitate

--- a/src/jobs/infrastructure.html
+++ b/src/jobs/infrastructure.html
@@ -110,6 +110,8 @@ you may be tasked with are:</p>
 
 <h2>To apply</h2>
 
-<p>Please apply at
-  <a href="https://careers.google.com/jobs/results/122913957812806342-senior-software-engineer-platforms-and-ecosystem-flutter/">Google's careers site</a>
-  and mention this page / URL in the "Cover letter/other notes" section.</p>
+<p>
+  Please apply at the
+  <a href="https://careers.google.com/jobs/results/122913957812806342-senior-software-engineer-platforms-and-ecosystem-flutter/">Google Careers site</a>
+  and mention this page/URL in the <b>Cover letter/other notes</b> section.
+</p>

--- a/src/jobs/ios.html
+++ b/src/jobs/ios.html
@@ -1,5 +1,6 @@
 ---
 title: iOS Engineer
+toc: false
 ---
 
 <p>The Flutter team is constantly looking to improve our fidelity on
@@ -60,7 +61,7 @@ title: iOS Engineer
 </ul>
 </p>
 
-<h2>Preferred qualifications:</h2>
+<h2>Preferred qualifications</h2>
 
 <p><i>Having these qualifications is a plus, but transferable
   skills/experiences may be equally valuable</i></p>

--- a/src/jobs/ios.html
+++ b/src/jobs/ios.html
@@ -80,6 +80,8 @@ toc: false
 
 <h2>To apply</h2>
 
-<p>Please apply at
-  <a href="https://careers.google.com/jobs/results/122913957812806342-senior-software-engineer-platforms-and-ecosystem-flutter/">Google's careers site</a>
-  and mention this page / URL in the "Cover letter/other notes" section.</p>
+<p>
+  Please apply at the
+  <a href="https://careers.google.com/jobs/results/122913957812806342-senior-software-engineer-platforms-and-ecosystem-flutter/">Google Careers site</a>
+  and mention this page/URL in the <b>Cover letter/other notes</b> section.
+</p>

--- a/src/jobs/tools.html
+++ b/src/jobs/tools.html
@@ -92,6 +92,8 @@ for both command-line and IDE users of Flutter.</p>
 
 <h2>To apply</h2>
 
-<p>Please apply at
-  <a href="https://careers.google.com/jobs/results/122913957812806342-senior-software-engineer-platforms-and-ecosystem-flutter/">Google's careers site</a>
-  and mention this page / URL in the "Cover letter/other notes" section.</p>
+<p>
+  Please apply at the
+  <a href="https://careers.google.com/jobs/results/122913957812806342-senior-software-engineer-platforms-and-ecosystem-flutter/">Google Careers site</a>
+  and mention this page/URL in the <b>Cover letter/other notes</b> section.
+</p>

--- a/src/jobs/tools.html
+++ b/src/jobs/tools.html
@@ -1,5 +1,6 @@
 ---
 title: Flutter Tools Engineer
+toc: false
 ---
 
 <p>The Flutter command line tool is the main entrypoint to Flutter for hundreds
@@ -66,7 +67,7 @@ for both command-line and IDE users of Flutter.</p>
 </ul>
 </p>
 
-<h2>Preferred qualifications:</h2>
+<h2>Preferred qualifications</h2>
 
 <p><i>Having these qualifications is a plus, but transferable
   skills/experiences may be equally valuable</i></p>

--- a/src/jobs/windows.html
+++ b/src/jobs/windows.html
@@ -1,5 +1,6 @@
 ---
 title: Windows Engineer
+toc: false
 ---
 
 <p>Flutter is the most popular multi-platform UI toolkit, with shipped support
@@ -58,7 +59,7 @@ title: Windows Engineer
 </ul>
 </p>
 
-<h2>Preferred qualifications:</h2>
+<h2>Preferred qualifications</h2>
 
 <p><i>Having these qualifications is a plus, but transferable
   skills/experiences may be equally valuable</i></p>

--- a/src/jobs/windows.html
+++ b/src/jobs/windows.html
@@ -78,6 +78,8 @@ toc: false
 
 <h2>To apply</h2>
 
-<p>Please apply at
-  <a href="https://careers.google.com/jobs/results/122913957812806342-senior-software-engineer-platforms-and-ecosystem-flutter/">Google's careers site</a>
-  and mention this page / URL in the "Cover letter/other notes" section.</p>
+<p>
+  Please apply at the
+  <a href="https://careers.google.com/jobs/results/122913957812806342-senior-software-engineer-platforms-and-ecosystem-flutter/">Google Careers site</a>
+  and mention this page/URL in the <b>Cover letter/other notes</b> section.
+</p>

--- a/src/jobs/writer.html
+++ b/src/jobs/writer.html
@@ -72,16 +72,7 @@ toc: false
 <h2>To apply</h2>
 
 <p>
-Please apply to
-<a href="https://careers.google.com/jobs/results/117755653033730758/">the
-  Google job post</a>
-or send the following to
-<a href="mailto:flutter-jobs@google.com">flutter-jobs@google.com</a>:
+  Please apply at the
+  <a href="https://careers.google.com/jobs/results/117755653033730758/">Google Careers site</a>
+  and mention this page/URL in the <b>Cover letter/other notes</b> section.
 </p>
-
-<ul>
-  <li> A resume outlining your relevant experience </li>
-  <li> A short introduction describing why you think
-    you’d be a good fit for this position </li>
-  <li> The preferred method by which you’d like Google to contact you </li>
-</ul>


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

* Updated application instructions in /jobs/writer
* Fixed a typo in /jobs
* Fixed a few other things in other job pages

Note that /jobs/devexp still has the old application instructions. (I couldn't find an external job posting for it.)

_Issues fixed by this PR (if any):_

None I could find.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
