### PR TITLE
Breaking changes: Raw images on Web uses correct origin and colors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,7 @@ repo:
   samples: https://github.com/flutter/samples
   plugins: https://github.com/flutter/plugins
   gallery: https://github.com/flutter/gallery
+  engine: https://github.com/flutter/engine
 dart:
   api: https://api.dart.dev
   sdk:

--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -14,7 +14,7 @@ release, and listed in alphabetical order:
 
 * [Required Kotlin version][]
 * [Deprecated API removed after v2.5][]
-* [Correct origin and colors of raw images on Web][]
+* [Raw images on Web uses correct origin and colors][]
 
 [Required Kotlin version]: {{site.url}}/release/breaking-changes/kotlin-version
 [Deprecated API removed after v2.5]: {{site.url}}/release/breaking-changes/2-5-deprecations

--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -14,14 +14,16 @@ release, and listed in alphabetical order:
 
 * [Required Kotlin version][]
 * [Deprecated API removed after v2.5][]
+* [Correct origin and colors of raw images on Web][]
 
 [Required Kotlin version]: {{site.url}}/release/breaking-changes/kotlin-version
 [Deprecated API removed after v2.5]: {{site.url}}/release/breaking-changes/2-5-deprecations
+[Raw images on Web uses correct origin and colors]: {{site.url}}/release/breaking-changes/raw-images-on-web-uses-correct-origin-and-colors
 
 ### Released in Flutter 2.5
 
 * [Default drag scrolling devices][]
-* [Deprecated API removed after v2.2][]  
+* [Deprecated API removed after v2.2][]
 * [Change the enterText method to move the caret to the end of the input text][]
 * [GestureRecognizer cleanup][]
 * [Introducing package:flutter_lints][]

--- a/src/release/breaking-changes/raw-images-on-web-uses-correct-origin-and-colors.md
+++ b/src/release/breaking-changes/raw-images-on-web-uses-correct-origin-and-colors.md
@@ -150,7 +150,7 @@ ui.Image parseMyImage(Uint8List image, int width, int height) async {
 
 ## Timeline
 
-Landed in version: not yet<br>
+Landed in version: 2.9.0-0.0.pre<br>
 In stable release: not yet
 
 ## References

--- a/src/release/breaking-changes/raw-images-on-web-uses-correct-origin-and-colors.md
+++ b/src/release/breaking-changes/raw-images-on-web-uses-correct-origin-and-colors.md
@@ -128,7 +128,7 @@ late Future<bool> imageRawUsesCorrectBehavior = (() async {
   final ui.ImageDescriptor descriptor = ui.ImageDescriptor.raw(
     await ui.ImmutableBuffer.fromUint8List(Uint8List.fromList(<int>[0xED, 0, 0, 0])),
     width: 1, height: 1, pixelFormat: ui.PixelFormat.rgba8888);
-  final Image image = (await (await descriptor.instantiateCodec()).getNextFrame()).image;
+  final ui.Image image = (await (await descriptor.instantiateCodec()).getNextFrame()).image;
   final Uint8List resultPixels = Uint8List.sublistView(
     (await image.toByteData(format: ui.ImageByteFormat.rawStraightRgba))!);
   return resultPixels[0] == 0xED;
@@ -136,14 +136,14 @@ late Future<bool> imageRawUsesCorrectBehavior = (() async {
 
 Future<ui.Image> parseMyImage(Uint8List image, int width, int height) async {
   final Uint8List correctedImage = (await imageRawUsesCorrectBehavior) ?
-    verticallyFlipImage(image) : image;
+    verticallyFlipImage(image, width, height) : image;
   final ui.ImageDescriptor descriptor = ui.ImageDescriptor.raw(
     await ui.ImmutableBuffer.fromUint8List(correctedImage), // Use the corrected image
     width: width,
     height: height,
     pixelFormat: ui.PixelFormat.bgra8888, // Use the alternate format
   );
-  return await (await descriptor.instantiateCodec()).getNextFrame()).image;
+  return (await (await descriptor.instantiateCodec()).getNextFrame()).image;
 }
 ```
 

--- a/src/release/breaking-changes/raw-images-on-web-uses-correct-origin-and-colors.md
+++ b/src/release/breaking-changes/raw-images-on-web-uses-correct-origin-and-colors.md
@@ -1,9 +1,7 @@
 ---
 title: Raw images on Web uses correct origin and colors
-description:
+description: Raw images directly decoded by calling the Web engine functions now uses the correct pixel format and starts from the top left corner.
 
-
-Brief description similar to the "context" section below. The description shouldn't have any linebreaks - let it go long and wrap. Text below should break at 80 chars or less.
 ---
 
 ## Summary
@@ -152,23 +150,8 @@ ui.Image parseMyImage(Uint8List image, int width, int height) async {
 
 ## Timeline
 
-{% comment %}
-  The version # of the SDK where this change was
-  introduced.  If there is a deprecation window,
-  the version # to which we guarantee to maintain
-  the old API. Use the following template:
-
-  If a breaking change has been reverted in a
-  subsequent release, move that item to the
-  "Reverted" section of the index.md file.
-  Also add the "Reverted in version" line,
-  shown as optional below. Otherwise, delete
-  that line.
-{% endcomment %}
-
-Landed in version: xxx<br>
+Landed in version: not yet<br>
 In stable release: not yet
-Reverted in version: xxx  (OPTIONAL, delete if not used)
 
 ## References
 

--- a/src/release/breaking-changes/raw-images-on-web-uses-correct-origin-and-colors.md
+++ b/src/release/breaking-changes/raw-images-on-web-uses-correct-origin-and-colors.md
@@ -1,0 +1,197 @@
+---
+title: Raw images on Web uses correct origin and colors
+description:
+
+
+Brief description similar to the "context" section below. The description shouldn't have any linebreaks - let it go long and wrap. Text below should break at 80 chars or less.
+---
+
+## Summary
+
+How raw images are rendered on Web has been corrected
+and is now consistent with that on other platforms.
+This breaks legacy apps that had to feed incorrect data
+to `ui.ImageDescriptor.raw` or `ui.decodeImageFromPixels`,
+causing the resulting images to be upside-down
+and incorrectly colored
+(whose red and blue channels are swapped.)
+
+## Context
+
+The "pixel stream" that Flutter uses internally
+has always been defined as the same format:
+for each pixel, four 8-bit channels are packed in the order defined
+by a `format` argument, then grouped in a row,
+from left to right, then rows from top to bottom.
+
+However, Flutter for Web, or more specifically, the HTML renderer,
+used to implement it in a wrong way
+due to incorrect understanding of the BMP format specification.
+As a result, if the app or library uses
+`ui.ImageDescriptor.raw` or `ui.decodeImageFromPixels`,
+it had to feed pixels from bottom to top and swap their red and blue channels
+(for example, with the `ui.PixelFormat.rgba8888` format,
+the first 4 bytes of the data were considered the blue, green, red, and alpha channels
+of the first pixel instead.)
+
+This bug has been fixed by [engine#29593][].
+But apps and libraries will have to correct how their data are generated.
+
+## Description of change
+
+The `pixels` argument of `ui.ImageDescriptor.raw` or `ui.decodeImageFromPixels`
+now uses the correct pixel order described by `format`,
+and originates from the top left corner.
+
+Images rendered by directly calling these two functions
+Legacy code that invokes these functions directly might
+find their images upside down and colored incorrectly.
+
+## Migration guide
+
+If the app uses the latest version of Flutter and experiences this situation,
+the most direct solution is to manually flip the image, and use the alternate
+pixel format:
+
+Code before migration:
+
+<!-- skip -->
+```dart
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+// Parse `image` as a displayable image.
+//
+// Each byte in `image` is a pixel channel, in the order of blue, green, red,
+// and alpha, starting from the bottom left corner and going row first.
+ui.Image parseMyImage(Uint8List image, int width, int height) async {
+  final ImageDescriptor descriptor = ImageDescriptor.raw(
+    await ui.ImmutableBuffer.fromUint8List(image),
+    width: width,
+    height: height,
+    pixelFormat: ui.PixelFormat.rgba8888,
+  );
+  return await (await descriptor.instantiateCodec()).getNextFrame()).image;
+}
+```
+
+Code after migration:
+
+<!-- skip -->
+```dart
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+Uint8List verticallyFlipImage(Uint8List sourceBytes, int width, int height) {
+  final Uint32List source = Uint32List.sublistView(ByteData.sublistView(sourceBytes));
+  final Uint32List result = Uint32List(source.length);
+  int sourceOffset = 0;
+  int resultOffset = 0;
+  for (final int row = height - 1; row >= 0; row -= 1) {
+    sourceOffset = width * row;
+    for (final int col = 0; col < width; col += 1) {
+      result[resultOffset] = source[sourceOffset];
+      resultOffset += 1;
+      sourceOffset += 1;
+    }
+  }
+  return Uint8List.sublistView(ByteData.sublistView(sourceBytes))
+}
+
+ui.Image parseMyImage(Uint8List image, int width, int height) async {
+  final Uint8List correctedImage = verticallyFlipImage(image);
+  final ui.ImageDescriptor descriptor = ui.ImageDescriptor.raw(
+    await ui.ImmutableBuffer.fromUint8List(correctedImage), // Use the corrected image
+    width: width,
+    height: height,
+    pixelFormat: ui.PixelFormat.bgra8888, // Use the alternate format
+  );
+  return await (await descriptor.instantiateCodec()).getNextFrame()).image;
+}
+```
+
+Since such pixel data are usually constructed from other sources,
+the better way would be to flip it during the construction process.
+
+A trickier situation is when you're writing a library,
+and you want this library to work on both the most recent Flutter
+and a pre-patch one.
+In that case, you can decide whether the behavior has been changed
+by letting it decode a single pixel first.
+
+Code after migration:
+
+<!-- skip -->
+```dart
+Uint8List verticallyFlipImage(Uint8List sourceBytes, int width, int height) {
+  // Same as the example above.
+}
+
+late Future<bool> imageRawUsesCorrectBehavior = (() async {
+  final ui.ImageDescriptor descriptor = ui.ImageDescriptor.raw(
+    await ui.ImmutableBuffer.fromUint8List(Uint8List.fromList(<int>[0xED, 0, 0, 0])),
+    width: 1, height: 1, pixelFormat: ui.PixelFormat.rgba8888);
+  final Image image = (await (await descriptor.instantiateCodec()).getNextFrame()).image;
+  final Uint8List resultPixels = Uint8List.sublistView(
+    (await image.toByteData(format: ui.ImageByteFormat.rawStraightRgba))!);
+  return resultPixels[0] == 0xED;
+})();
+
+ui.Image parseMyImage(Uint8List image, int width, int height) async {
+  final Uint8List correctedImage = (await imageRawUsesCorrectBehavior) ?
+    verticallyFlipImage(image) : image;
+  final ui.ImageDescriptor descriptor = ui.ImageDescriptor.raw(
+    await ui.ImmutableBuffer.fromUint8List(correctedImage), // Use the corrected image
+    width: width,
+    height: height,
+    pixelFormat: ui.PixelFormat.bgra8888, // Use the alternate format
+  );
+  return await (await descriptor.instantiateCodec()).getNextFrame()).image;
+}
+```
+
+## Timeline
+
+{% comment %}
+  The version # of the SDK where this change was
+  introduced.  If there is a deprecation window,
+  the version # to which we guarantee to maintain
+  the old API. Use the following template:
+
+  If a breaking change has been reverted in a
+  subsequent release, move that item to the
+  "Reverted" section of the index.md file.
+  Also add the "Reverted in version" line,
+  shown as optional below. Otherwise, delete
+  that line.
+{% endcomment %}
+
+Landed in version: xxx<br>
+In stable release: not yet
+Reverted in version: xxx  (OPTIONAL, delete if not used)
+
+## References
+
+API documentation:
+
+* [`decodeImageFromPixels`][]
+* [`ImageDescriptor.raw`][]
+
+Relevant issues:
+
+* [[Web] Regression in Master - PDF display distorted due to change in BMP Encoder][]
+* [[web] ImageDescriptor.raw flips and inverts images (partial reason included)][]
+
+Relevant PRs:
+
+* [[Web] Reland: Fix BMP encoder][]
+
+<!-- Stable channel link: -->
+[`decodeImageFromPixels`]: {{site.api}}/flutter/dart-ui/decodeImageFromPixels.html
+[`ImageDescriptor.raw`]: {{site.api}}/flutter/dart-ui/ImageDescriptor/ImageDescriptor.raw.html
+
+[[Web] Regression in Master - PDF display distorted due to change in BMP Encoder]: {{site.repo.flutter}}/issues/93615
+[[web] ImageDescriptor.raw flips and inverts images (partial reason included)]: {{site.repo.flutter}}/issues/89610
+
+[engine#29593]: {{site.repo.engine}}/pull/29593
+[[Web] Reland: Fix BMP encoder]: {{site.repo.engine}}/pull/29593


### PR DESCRIPTION
Add migration guide: Raw images on Web uses correct origin and colors

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
