### PR TITLE
Fix documentation about dartPluginClass

### DIFF
--- a/src/development/packages-and-plugins/developing-packages.md
+++ b/src/development/packages-and-plugins/developing-packages.md
@@ -459,8 +459,10 @@ class HelloPluginWindows extends HelloPluginPlatform {
   }
 ```
 
-This is supported for Windows, macOS, and Linux starting in Flutter 2.5, and
-for Android and iOS starting in Flutter 2.8.
+This is supported for Windows, macOS, and Linux starting in Flutter 2.5.
+`dartPluginClass` is supported for Android and iOS starting in Flutter 2.8,
+but currently a `pluginClass` is still required for those platforms. That
+requirement will be removed in a future version of Flutter.
 
 ### Testing your plugin
 


### PR DESCRIPTION
The current docs say that Dart-only plugin implementations are supported for mobile in 2.8+, but it turns out that there is a bug that wasn't caught until after 2.8 reached stable, and that's not the case. This corrects the docs to reflect the actual state, which is that while `dartPluginClass` works to register Dart code for those platforms as of 2.8, native code is currently still required.

See https://github.com/flutter/flutter/issues/95012

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
