### PR TITLE
Add iOS 15 to supported platforms list

### DIFF
--- a/src/development/tools/sdk/release-notes/supported-platforms.md
+++ b/src/development/tools/sdk/release-notes/supported-platforms.md
@@ -51,10 +51,7 @@ platforms on which Flutter runs:
 |Android|Android SDK 22        |
 |Android|Android SDK 21        |
 |Android|Android SDK 19        |
-|iOS    | 14 (all)             |
-|iOS    | 13.3-13.7            |
-|iOS    | 13.0                 |
-|iOS    | 12.4 & 12.4.1        |
+|iOS    | 14-15                |
 |iOS    | 9.3.6                |
 |Web    | Chrome 84            |
 |Web    | Firefox 72.0         |
@@ -78,10 +75,7 @@ minimal.
 |Android |Android SDK 18 |
 |Android |Android SDK 17 |
 |Android |Android SDK 16 |
-|iOS     |iOS 13.1       |
-|iOS     |iOS 12.1-12.3  |
-|iOS     |iOS 10 (all)   |
-|iOS     |iOS 9.0        |
+|iOS     |iOS 9-13       |
 |Windows |Windows 8      |
 |Windows |Windows 7      |
 |Linux   |Debian & below |


### PR DESCRIPTION
**Description of what this PR is changing or adding, and why:**
Add iOS 15 to "Supported Google-tested platforms" list.  Remove iOS 12 and 13 since we have no coverage on iOS 12 and almost no coverage on iOS 13 (a few engine and safari web tests).  Get rid of all the dot release ranges since we generally only test one 14.* or 15.* version at time, not iOS 14.0, iOS 14.1, iOS 14.2, etc.  Keep iOS 9.3.6 as a line item since we have a iPhone 4S running a few tests in the devicelab.

**Issues fixed by this PR (if any):** https://github.com/flutter/website/issues/6594

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
