### PR TITLE
Fix various font page links

### DIFF
--- a/src/cookbook/design/fonts.md
+++ b/src/cookbook/design/fonts.md
@@ -100,11 +100,10 @@ outline weights and styles:
 
   * The `weight` property specifies the weight of the outlines in
     the file as an integer multiple of 100, between 100 and 900.
-    These values correspond to the [`FontWeight`][]
-    and can be used in the [`fontWeight`][] property of a
-    [`TextStyle`][] object. For example, if you want to use
-    the `RobotoMono-Bold` font defined above, you would set `fontWeight`
-    to `FontWeight.w700` in your `TextStyle`.
+    These values correspond to the [`FontWeight`][] and can be used in the
+    [`fontWeight`][fontWeight property] property of a [`TextStyle`][] object. 
+    For example, if you want to use the `RobotoMono-Bold` font defined above, 
+    you would set `fontWeight` to `FontWeight.w700` in your `TextStyle`.
     
     Note that defining the `weight` property does not
     override the actual weight of the font. You would not be able to
@@ -112,11 +111,11 @@ outline weights and styles:
     was set to 100.
 
   * The `style` property specifies whether the outlines in the file are
-    `italic` or `normal`. These values correspond to the
-    [`FontStyle`][] and can be used in the [`fontStyle`][] property of a
-    [`TextStyle`][] object. For example, if you want to use
-    the `Raleway-Italic` font defined above, you would set `fontStyle`
-    to `FontStyle.italic` in your `TextStyle`.
+    `italic` or `normal`. 
+    These values correspond to the [`FontStyle`][] and can be used in the
+    [`fontStyle`][fontStyle property] property of a [`TextStyle`][] object. 
+    For example, if you want to use the `Raleway-Italic` font defined above, 
+    you would set `fontStyle` to `FontStyle.italic` in your `TextStyle`.
     
     Note that defining the `style` property does not
     override the actual style of the font; You would not be able to
@@ -255,9 +254,9 @@ class MyHomePage extends StatelessWidget {
 
 [Export fonts from a package]: {{site.url}}/cookbook/design/package-fonts
 [`fontFamily`]: {{site.api}}/flutter/painting/TextStyle/fontFamily.html
-[`fontStyle`]: {{site.api}}/flutter/painting/TextStyle/fontStyle.html
-[`FontStyle`]: {{site.api}}/flutter/dart-ui/FontStyle-class.html
-[`fontWeight`]: {{site.api}}/flutter/painting/TextStyle/fontWeight.html
+[fontStyle property]: {{site.api}}/flutter/painting/TextStyle/fontStyle.html
+[`FontStyle`]: {{site.api}}/flutter/dart-ui/FontStyle.html
+[fontWeight property]: {{site.api}}/flutter/painting/TextStyle/fontWeight.html
 [`FontWeight`]: {{site.api}}/flutter/dart-ui/FontWeight-class.html
 [Google Fonts]: https://fonts.google.com
 [google_fonts]: {{site.pub-pkg}}/google_fonts


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Fixes various broken links on fonts page. Some due to wrong link and others due to the link resolution ignoring capitalization. 

_Issues fixed by this PR (if any):_ Fixes #6610

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
