### PR TITLE
Add ios-scribble go redirect

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -243,6 +243,7 @@
       { "source": "/go/input-field-autofill", "destination": "https://docs.google.com/document/d/1wYLsoc7NiHl2jFueB4Ros09E3nDCotdWVovDCFSMcAk/edit", "type": 301 },
       { "source": "/go/ios-autocorrection-highlight-support", "destination": "https://docs.google.com/document/d/18ZO7ThKu2wwCofGOKZSInPsq93IzkQTRn9eiyskeh7I/edit", "type": 301 },
       { "source": "/go/ios-pull-to-refresh", "destination": "https://docs.google.com/document/d/1oUgNd3fsJ1QVuEmA6ENBT8vq3o6QKCRUPGCB6q91VgI/edit", "type": 301 },
+      { "source": "/go/ios-scribble", "destination": "https://docs.google.com/document/d/1mjQbsSRQnHuAgMNdouaSgTS-Xv-w57fdKfOUUafWpRo", "type": 301 },
       { "source": "/go/ios-switch-controll-scrolling", "destination": "https://docs.google.com/document/d/1CZ2CRXihPQ1hBUXWODpyPVJ_2Yc0es6tkXrJSnpDajA", "type": 301 },
       { "source": "/go/issue-triage-changes", "destination": "https://docs.google.com/document/d/1KJVPMxzfFaL_gIB6Z3oNRTBKA-NP25YpM8xi3xUKbBY", "type": 301 },
       { "source": "/go/key-based-mouse-tracker-annotation", "destination": "https://docs.google.com/document/d/18DCRSX4-KjJIrnru_Cv9cJjzQmUWM95r8n6uvbS45-E/edit", "type": 301 },


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Add redirect link to https://docs.google.com/document/d/1mjQbsSRQnHuAgMNdouaSgTS-Xv-w57fdKfOUUafWpRo

Realized the go link in that doc never worked.

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
