### PR TITLE
Add flutter.dev/go/android-ndk-version link

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -148,6 +148,7 @@
       { "source": "/go/android-embedding-dependencies", "destination": "https://docs.google.com/document/d/1vITp2mUZRa-cmll0sPH0zjNgPlyvOMx7awxPNRAPyic/edit", "type": 301 },
       { "source": "/go/android-embedding-move", "destination": "https://docs.google.com/document/d/1nQujwZfEe3QOHTyZn160eImpoJOYioADP09DtumcLcc/edit?ts=5d8041db#", "type": 301 },
       { "source": "/go/android-migration-summary", "destination": "https://docs.google.com/document/d/1wKspwf6LQu6uo32uQ9NcukfiKhLL4ButV9cwpjeb8QI", "type": 301 },
+      { "source": "/go/android-ndk-version", "destination": "https://docs.google.com/document/d/1sljfqHpI5m4uxsL7B89yhYluO97Mz1YKyA0VgzzXyZ4/edit?usp=sharing&resourcekey=0-Ts9Rk8jbJor7WBMMiehKWg", "type": 301 },
       { "source": "/go/android-plugin-migration.", "destination": "/development/packages-and-plugins/plugin-api-migration", "type": 301 },
       { "source": "/go/android-plugin-migration", "destination": "/development/packages-and-plugins/plugin-api-migration", "type": 301 },
       { "source": "/go/android-project-migration", "destination": "https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects", "type": 301 },


### PR DESCRIPTION
Add a go link to the doc describing NDK versioning in Flutter.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
