### PR TITLE
Add go/chip-usedeletebuttontooltip-deprecation

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -171,6 +171,7 @@
       { "source": "/go/cascading-menus", "destination": "https://docs.google.com/document/d/17XOSGzLzqbpNcCUwakM_WQ2ZOMcUOXcPC__7nPORwms/edit?usp=sharing&resourcekey=0-hg74S2vAAqwJFN984ZXQHg", "type": 301 },
       { "source": "/go/center-floating-label-inputdecoration", "destination": "https://docs.google.com/document/d/1sxP91vZiY7McmSMmzrboklIJWQ_6pSS9MBSCrQq016M/edit#", "type": 301 },
       { "source": "/go/change-default-textselectionhandlecolor-to-accentcolor", "destination": "https://docs.google.com/document/d/1RJQd5ABWJ_7DZN19aTZBCE7xHzlC4MYBP1bWE2FWcvc/edit", "type": 301 },
+      { "source": "/go/chip-usedeletebuttontooltip-deprecation", "destination": "https://docs.google.com/document/d/1wc9ot7T2E7hJubYxEWMX230a79wYSiFey4BHxnEzHtw/edit?usp=sharing&resourcekey=0-Bo7KPqEtkWgZcSuRCqwQ5w", "type": 301 },
       { "source": "/go/clip-behavior", "destination": "https://docs.google.com/document/d/1gC5Di4ykTCqupD77PWpy9D8xXo0Ide5CnrH0zzVIhKo/edit", "type": 301 },
       { "source": "/go/colorscheme-generation", "destination": "https://docs.google.com/document/d/1P7f-DGPWz6HCbwLoAruRuWtakPx4VY-e8nT_yuQ71sc/edit?usp=sharing&resourcekey=0-qxeub7yCKa_No0HlrzEk-g", "type": 301 },
       { "source": "/go/colorscheme-m3", "destination": "https://docs.google.com/document/d/1mY1ahBQEMAfsawGJMX5S34pXb7c8dHGatyotClReeas/edit#heading=h.cnnhzna3pz6d", "type": 301 },


### PR DESCRIPTION
Add design doc go link for deprecating useDeleteButtonTooltip for Chips
Context: https://github.com/flutter/flutter/pull/96174

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
