### PR TITLE
Remove old version references

### DIFF
--- a/src/deployment/obfuscate.md
+++ b/src/deployment/obfuscate.md
@@ -13,14 +13,8 @@ The following list describes which platforms
 support the obfuscation process described in
 this page:
 
-**Android**/**iOS**
-: Supported as of Flutter 1.16.2.  To obfuscate
-  an app built against an earlier version of Flutter,
-  use the [obfuscation instructions][] on the Flutter wiki.
-
-**macOS**
-: macOS ([in alpha][] as of Flutter 1.13),
-  supports obfuscation as of Flutter 1.16.2.
+**Android**/**iOS**/**macOS**
+: Supported. 
 
 **Linux**/**Windows**
 : Not yet supported.

--- a/src/development/packages-and-plugins/developing-packages.md
+++ b/src/development/packages-and-plugins/developing-packages.md
@@ -297,9 +297,10 @@ endorsed federated implementations.
 To create a plugin package, use the `--template=plugin`
 flag with `flutter create`.
 
-As of Flutter 1.20.0, Use the `--platforms=` option followed by a comma separated list to
-specify the platforms that the plugin supports. Available platforms are: `android`, `ios`, `web`, `linux`, `macos`, and `windows`.
-If no platforms are specified, the resulting project doesn't support any platforms.
+Use the `--platforms=` option followed by a comma separated list to specify the
+platforms that the plugin supports. Available platforms are: `android`, `ios`,
+`web`, `linux`, `macos`, and `windows`. If no platforms are specified, the
+resulting project doesn't support any platforms.
 
 Use the `--org` option to specify your organization,
 using reverse domain name notation. This value is used

--- a/src/development/platform-integration/c-interop.md
+++ b/src/development/platform-integration/c-interop.md
@@ -24,11 +24,6 @@ In this walkthrough, you'll create a C function
 that implements 32-bit addition and then
 exposes it through a Dart plugin named "native_add".
 
-{{ site.alert.version-note }}
-  As of Dart 2.12.0 (included in Flutter 2.0 or later),
-  FFI has been marked as stable.
-{{ site.alert.end }}
-
 ### Dynamic vs static linking
 
 A native library can be linked into an app either

--- a/src/development/platform-integration/platform-views.md
+++ b/src/development/platform-integration/platform-views.md
@@ -28,9 +28,7 @@ Which one to use depends on the use case. Let's take a look:
   Certain platform interactions such as keyboard handling, and accessibility
   features might not work.
 
-* Hybrid composition requires Flutter 1.22
-  ([version 1.22.2][] or higher is recommended).
-  This mode appends the native `android.view.View`
+* Hybrid composition appends the native `android.view.View`
   to the view hierarchy. Therefore, keyboard
   handling, and accessibility work out of the box.
   Prior to Android 10, this mode might significantly
@@ -411,10 +409,6 @@ android {
 iOS only uses Hybrid composition,
 which means that the native
 `UIView` is appended to view hierarchy.
-
-Prior to Flutter 1.22, platform views were in developers preview.
-In 1.22 or above, this is no longer the case, so there's no need to
-set the `io.flutter.embedded_views_preview` flag in `Info.plist`.
 
 To create a platform view on iOS, follow these steps:
 

--- a/src/development/tools/flutter-fix.md
+++ b/src/development/tools/flutter-fix.md
@@ -3,17 +3,17 @@ title: Flutter Fix
 description: Keep your code up to date with the help of the Flutter Fix feature.
 ---
 
-The _Flutter Fix_ feature, introduced in Flutter 2,
-combines a Dart command-line tool with
-changes suggested by the Dart analyzer
-to automatically clean up deprecated APIs
-in your codebase.
+As Flutter continues to evolve, we provide a tool to help you clean up
+deprecated APIs from your codebase. The tool ships as part of Flutter, and
+suggests changes that you might want to make to your code. The tool is available
+from the command line, and is also integrated into the IDE plugins for Android
+Studio and Visual Studio Code. 
 
-This feature has also been added to IDE
-plugins for Flutter (2.0) and Dart (2.12).
-Depending on the IDE, these automated
-updates are called _quick-fixes_ (IntelliJ,
-Android Studio, Eclipse) or _code actions_ (VS Code).
+{{site.alert.tip}}
+  These automated updates are called _quick-fixes_ in IntelliJ and Android
+  Studio, and _code actions_ in VS Code).
+{{site.alert.end}}
+
 
 ## Applying individual fixes
 

--- a/src/development/tools/hot-reload.md
+++ b/src/development/tools/hot-reload.md
@@ -192,12 +192,6 @@ the data it would have if it executed from scratch.
 The result might be different behavior after hot reload
 versus a hot restart.
 
-{{site.alert.note}}
-  As of Flutter 1.17, you can switch a widget
-  from a `StatefulWidget` to a `StatelessWidget`
-  (or the reverse), without requiring a hot restart.
-{{site.alert.end}}
-
 ### Recent code change is included but app state is excluded
 
 In Dart, [static fields are lazily initialized][const-new].

--- a/src/development/tools/sdk/release-notes/supported-platforms.md
+++ b/src/development/tools/sdk/release-notes/supported-platforms.md
@@ -6,7 +6,7 @@ description: The platforms that Flutter supports by platform version.
 
 ## Supported platforms
 
-As of release 2.5, Flutter supports the following platforms:
+As of the current release, Flutter supports the following platforms:
 
 |Platform|Version                       |Channels |
 |--------|------------------------------|---------|
@@ -26,8 +26,7 @@ All channels include master, beta and stable channels.
 
 ## How we define a supported platform
 
-As of Flutter 1.20, we define three tiers of support for the 
-platforms on which Flutter runs:
+We define three tiers of support for the platforms on which Flutter runs:
 1. Supported Google-tested platforms,
    which are platforms the Flutter team at 
    Google tests in continuous integration at every commit. 

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -189,18 +189,14 @@ Android splash screen in the same positions on screen.
 
 ### Migrating from Manifest / Activity defined custom splash screens
 
-{{site.alert.note}}
-  This is an upcoming change for Flutter 2.5.
-{{site.alert.end}}
-
 Previously, Android Flutter apps would either set
 `io.flutter.embedding.android.SplashScreenDrawable` in their application
 manifest, or implement [`provideSplashScreen`][] within their Flutter Activity.
 This would be shown momentarily in between the time after the Android launch
 screen is shown and when Flutter has drawn the first frame. This is no longer
-needed and is deprecated – Flutter now automatically keeps the Android launch
-screen displayed until Flutter has drawn the first frame. Developers should
-instead remove usage of these APIs.
+needed and is deprecated – in Flutter 2.5 and later, Flutter automatically keeps 
+the Android launch screen displayed until Flutter has drawn the first frame. 
+Developers should instead remove usage of these APIs.
 
 [Android Splash Screens]: {{site.android-dev}}/about/versions/12/features/splash-screen
 [launch screen]: {{site.android-dev}}/topic/performance/vitals/launch-time#themed

--- a/src/get-started/flutter-for/xamarin-forms-devs.md
+++ b/src/get-started/flutter-for/xamarin-forms-devs.md
@@ -1259,15 +1259,6 @@ Assets are located in any arbitrary folder&mdash;Flutter has no
 predefined folder structure. You declare the assets (with location) in
 the `pubspec.yaml` file, and Flutter picks them up.
 
-Note that before Flutter 1.0 beta 2, assets defined in Flutter were not
-accessible from the native side, and vice versa, native assets and resources
-weren’t available to Flutter, as they lived in separate folders.
-
-As of Flutter beta 2, assets are stored in the native asset folder,
-and are accessed on the native side using Android's `AssetManager`:
-
-As of Flutter beta 2, Flutter still cannot access native resources,
-nor it can access native assets.
 
 To add a new image asset called `my_icon.png` to our Flutter project,
 for example, and deciding that it should live in a folder we

--- a/src/resources/faq.md
+++ b/src/resources/faq.md
@@ -112,7 +112,7 @@ for the majority of the system.
 
 [Flutter 1.0][] was launched on Dec 4th, 2018 and
 [Flutter 2][] on March 3rd, 2021.
-Since then, over 100,000 apps have shipped using
+Since its launch, over 400,000 apps have shipped using
 Flutter to many hundreds of millions of devices.
 See some sample apps in the [showcase][].
 

--- a/src/testing/integration-tests/index.md
+++ b/src/testing/integration-tests/index.md
@@ -3,7 +3,7 @@ title: Integration testing
 description: Learn how to write integration tests
 ---
 
-This page describes how to use the `integration_test` package to run
+This page describes how to use the [`integration_test`][] package to run
 integration tests. Tests written using this package have the following
 properties:
  
@@ -15,14 +15,10 @@ properties:
   enabling tests to be written in a similar style as [widget tests][]
 
 {{site.alert.note}}
-  As of Flutter 2, the `integration_test` package
-  was moved into the Flutter SDK. Going forward,
-  use the [`integration_test`][] package docs,
-  rather than the docs on pub.dev. **Also,
-  make sure that you update your app's pubspec file
-  to include this package as one of your
-  `dev_dependencies`.** For an example,
-  see the [Project setup](#project-setup) section below.
+  The `integration_test` package is part of the Flutter SDK itself. 
+  To use it, make sure that you update your app's pubspec file
+  to include this package as one of your `dev_dependencies`. 
+  For an example, see the [Project setup](#project-setup) section below.
 {{site.alert.end}}
 
 ## Overview


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Removing mentions to older versions where it no longer makes sense. It's good to have version notes when a feature is first introduced, but when that version has 99%+ share (e.g. Flutter 2.0 and later), we should remove references to older versions so that they don't clutter up the article with unnecessary caveats.

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
