### PR TITLE
Drop empty page

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -102,7 +102,6 @@
             - title: Staggered animations
               permalink: /development/ui/animations/staggered-animations
         - title: Advanced UI
-          permalink: /development/ui/advanced
           children:
             - title: Actions & shortcuts [NEW]
               permalink: /development/ui/advanced/actions_and_shortcuts

--- a/src/development/ui/advanced/index.md
+++ b/src/development/ui/advanced/index.md
@@ -1,5 +1,0 @@
----
-layout: toc
-title: Advanced UI
-short-title: Advanced
----


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Empty Advanced UI renders as empty page. Deleting the page should, in theory, fix the issue. I think.

_Issues fixed by this PR (if any):_ https://github.com/flutter/website/issues/6565

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
