### PR TITLE
Fix lint warnings

### DIFF
--- a/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-1.md
+++ b/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-1.md
@@ -29,7 +29,7 @@ class _BouncingBallDemoState extends State<BouncingBallDemo> {
     return Container(
       margin: EdgeInsets.only(top: marginTop),
       child: Container(
-        decoration: BoxDecoration(
+        decoration: const BoxDecoration(
           shape: BoxShape.circle,
           color: Colors.green,
         ),

--- a/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-2.md
+++ b/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-2.md
@@ -24,7 +24,7 @@ class _BouncingBallDemoState extends State<BouncingBallDemo> {
     increment = 25;
     start = 0;
     end = 100;
-    duration = Duration(milliseconds: 250);
+    duration = const Duration(milliseconds: 250);
 
     Timer.periodic(duration, bounce);
   }
@@ -59,7 +59,7 @@ class _BouncingBallDemoState extends State<BouncingBallDemo> {
     return Container(
       margin: EdgeInsets.only(top: marginTop),
       child: Container(
-        decoration: BoxDecoration(
+        decoration: const BoxDecoration(
           shape: BoxShape.circle,
           color: Colors.green,
         ),

--- a/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-3.md
+++ b/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-3.md
@@ -45,7 +45,7 @@ class _BouncingBallDemoState extends State<BouncingBallDemo> {
     return Container(
       margin: EdgeInsets.only(top: marginTop),
       child: Container(
-        decoration: BoxDecoration(
+        decoration: const BoxDecoration(
           shape: BoxShape.circle,
           color: Colors.green,
         ),

--- a/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-4.md
+++ b/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-4.md
@@ -17,7 +17,7 @@ class _BouncingBallDemoState extends State<BouncingBallDemo>
     super.initState();
     controller = AnimationController(
       vsync: this,
-      duration: Duration(seconds: 1),
+      duration: const Duration(seconds: 1),
       lowerBound: 0,
       upperBound: 100,
     );
@@ -34,7 +34,7 @@ class _BouncingBallDemoState extends State<BouncingBallDemo>
     return Container(
       margin: EdgeInsets.only(top: controller.value),
       child: Container(
-        decoration: BoxDecoration(
+        decoration: const BoxDecoration(
           shape: BoxShape.circle,
           color: Colors.green,
         ),


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Linting the bouncing ball DartPad includes

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
