### PR TITLE
Point directly to dev channel deprecation section of blog

### DIFF
--- a/src/development/tools/sdk/releases.md
+++ b/src/development/tools/sdk/releases.md
@@ -17,7 +17,7 @@ js:
 The {{site.sdk.channel | capitalize }} channel contains the
 most stable Flutter builds. See [Flutter’s channels][] for details.
 
-**Please note - dev channel has been deprecated. Refer to this [blog](https://medium.com/flutter/whats-new-in-flutter-2-8-d085b763d181) for more information.**
+**Please note - dev channel has been deprecated. Refer to this [blog](https://medium.com/flutter/whats-new-in-flutter-2-8-d085b763d181#34c4) for more information.**
 
 {% comment %} Nav tabs {% endcomment -%}
 <ul class="nav nav-tabs" id="editor-setup" role="tablist">


### PR DESCRIPTION
Link to specific section of Flutter 2.8 blog for deprecation of `dev` channel.

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
