### PR TITLE
Scribble text input client breaking change

### DIFF
--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -15,10 +15,12 @@ release, and listed in alphabetical order:
 * [Required Kotlin version][]
 * [Deprecated API removed after v2.5][]
 * [Raw images on Web uses correct origin and colors][]
+* [Scribble Text Input Client][]
 
 [Required Kotlin version]: {{site.url}}/release/breaking-changes/kotlin-version
 [Deprecated API removed after v2.5]: {{site.url}}/release/breaking-changes/2-5-deprecations
 [Raw images on Web uses correct origin and colors]: {{site.url}}/release/breaking-changes/raw-images-on-web-uses-correct-origin-and-colors
+[Scribble Text Input Client]: {{site.url}}/release/breaking-changes/scribble-text-input-client
 
 ### Released in Flutter 2.5
 

--- a/src/release/breaking-changes/scribble-text-input-client.md
+++ b/src/release/breaking-changes/scribble-text-input-client.md
@@ -1,0 +1,94 @@
+---
+title: Scribble Text Input Client
+description: Add new methods to the TextInputClient interface to allow Scribble to insert or remove text placeholders and show the toolbar.
+---
+
+## Summary
+
+Adds three methods, `showToolbar`, `insertTextPlaceholder`, and
+`removeTextPlaceholder` to the `TextInputClient` interface to allow the iOS 14
+Scribble feature to insert and remove text placeholders and show the toolbar.
+
+
+## Context
+
+As of iOS 14, iPads support the Scribble feature when using the Apple Pencil.
+This feature allows users to use the pencil to interact with text fields to
+add, delete, select, and modify text.
+
+
+## Description of change
+
+In native text widgets, the text toolbar is shown when a user uses the pencil
+to select text on an iPad running iOS 14 or higher. To replicate this behavior,
+the platform sends a `textInput` channel message called
+`TextInputClient.showToolbar`. This notifies the Dart code that the toolbar
+should be shown.
+
+When a user holds the pencil down, a visual gap in the text is shown to allow
+the user extra space to write. To replicate this behavior, the platform sends
+`textInput` channel messages called `TextInputClient.insertTextPlaceholder`
+and `TextInputClient.removeTextPlaceholder`. Multiline text inputs should have
+placeholders that provide vertical space, while single line inputs should
+provide horizontal space.
+
+
+## Migration guide
+
+If you previously implemented or extended `TextEditingClient`, you may override
+`showToolbar`, `insertTextPlaceholder`, and `removeTextPlaceholder` in order to
+support these Scribble features.
+
+To migrate, implement `showToolbar`, `insertTextPlaceholder`, and
+`removeTextPlaceholder`.
+
+Code before migration:
+
+<!-- skip -->
+```dart
+class MyCustomTextInputClient implements TextInputClient {
+  ...
+}
+```
+
+Code after migration:
+
+<!-- skip -->
+```dart
+class MyCustomTextInputClient implements TextInputClient {
+  ...
+  @override
+  void showToolbar() {
+    ...
+  }
+  
+  @override
+  void insertTextPlaceholder(Size size) {
+    ...
+  }
+  
+  @override
+  void removeTextPlaceholder() {
+    ...
+  }
+}
+```
+
+## Timeline
+
+Landed in version: 2.9.0-1.0.pre<br>
+In stable release: not yet
+
+## References
+
+API documentation:
+
+* [`TextInputClient`][{{site.master-api}}/flutter/services/TextInputClient-class.html]
+
+Relevant issues:
+
+* [Issue 61278][{{site.repo.flutter}}/issues/61278]
+
+Relevant PRs:
+
+* [Support Scribble Handwriting][{{site.repo.flutter}}/pull/75472]

--- a/src/release/breaking-changes/scribble-text-input-client.md
+++ b/src/release/breaking-changes/scribble-text-input-client.md
@@ -37,7 +37,7 @@ while single line inputs should provide horizontal space.
 ## Migration guide
 
 If you previously implemented `TextEditingClient`, you must override
-`showToolbar`, `insertTextPlaceholder`, and `removeTextPlaceholder` and either
+`showToolbar`, `insertTextPlaceholder`, and `removeTextPlaceholder` to either
 support these Scribble features or provide an empty implementation.
 
 To migrate, implement `showToolbar`, `insertTextPlaceholder`, and
@@ -84,12 +84,12 @@ In stable release: not yet
 
 API documentation:
 
-* [`TextInputClient`][{{site.master-api}}/flutter/services/TextInputClient-class.html]
+* [`TextInputClient`](https://master-api.flutter.dev/flutter/services/TextInputClient-class.html)
 
 Relevant issues:
 
-* [Issue 61278][{{site.repo.flutter}}/issues/61278]
+* [Issue 61278](https://github.com/flutter/flutter/issues/61278)
 
 Relevant PRs:
 
-* [Support Scribble Handwriting][{{site.repo.flutter}}/pull/75472]
+* [Support Scribble Handwriting](https://github.com/flutter/flutter/pull/75472)

--- a/src/release/breaking-changes/scribble-text-input-client.md
+++ b/src/release/breaking-changes/scribble-text-input-client.md
@@ -36,9 +36,9 @@ while single line inputs should provide horizontal space.
 
 ## Migration guide
 
-If you previously implemented or extended `TextEditingClient`, you may override
-`showToolbar`, `insertTextPlaceholder`, and `removeTextPlaceholder` in order to
-support these Scribble features.
+If you previously implemented `TextEditingClient`, you must override
+`showToolbar`, `insertTextPlaceholder`, and `removeTextPlaceholder` and either
+support these Scribble features or provide an empty implementation.
 
 To migrate, implement `showToolbar`, `insertTextPlaceholder`, and
 `removeTextPlaceholder`.

--- a/src/release/breaking-changes/scribble-text-input-client.md
+++ b/src/release/breaking-changes/scribble-text-input-client.md
@@ -20,17 +20,18 @@ add, delete, select, and modify text.
 ## Description of change
 
 In native text widgets, the text toolbar is shown when a user uses the pencil
-to select text on an iPad running iOS 14 or higher. To replicate this behavior,
-the platform sends a `textInput` channel message called
-`TextInputClient.showToolbar`. This notifies the Dart code that the toolbar
-should be shown.
+to select text on an iPad running iOS 14 or higher.
+To replicate this behavior, the platform sends a `textInput` channel message
+called `TextInputClient.showToolbar`.
+This notifies the Dart code that the toolbar should be shown.
 
 When a user holds the pencil down, a visual gap in the text is shown to allow
-the user extra space to write. To replicate this behavior, the platform sends
-`textInput` channel messages called `TextInputClient.insertTextPlaceholder`
-and `TextInputClient.removeTextPlaceholder`. Multiline text inputs should have
-placeholders that provide vertical space, while single line inputs should
-provide horizontal space.
+the user extra space to write.
+To replicate this behavior, the platform sends `textInput` channel messages
+called `TextInputClient.insertTextPlaceholder` and
+`TextInputClient.removeTextPlaceholder`.
+Multiline text inputs should have placeholders that provide vertical space,
+while single line inputs should provide horizontal space.
 
 
 ## Migration guide


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

This adds a migration guide for the new members of `TextInputClient` added by https://github.com/flutter/flutter/pull/75472

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
