### PR TITLE
Fixed broken link on 'Update the UI based on orientation'

### DIFF
--- a/src/cookbook/design/orientation.md
+++ b/src/cookbook/design/orientation.md
@@ -143,5 +143,5 @@ class OrientationList extends StatelessWidget {
 
 
 [Creating a grid list]: {{site.url}}/cookbook/lists/grid-lists
-[`Orientation`]: {{site.api}}/flutter/widgets/Orientation-class.html
+[`Orientation`]: {{site.api}}/flutter/widgets/Orientation.html
 [`OrientationBuilder`]: {{site.api}}/flutter/widgets/OrientationBuilder-class.html


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ 
Changes the broken link for Orientation (https://api.flutter.dev/flutter/widgets/Orientation-class.html) to the correct link (https://api.flutter.dev/flutter/widgets/Orientation.html) on the cookbook doc for [orientation](https://docs.flutter.dev/cookbook/design/orientation)

_Issues fixed by this PR (if any):_
- https://github.com/flutter/website/issues/6666

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
