### PR TITLE
Remove duplicate entries from Best Effort list

### DIFF
--- a/src/development/tools/sdk/release-notes/supported-platforms.md
+++ b/src/development/tools/sdk/release-notes/supported-platforms.md
@@ -70,9 +70,7 @@ minimal.
 
 |Platform|Version       |
 |--------|---------------|
-|Android |Android SDK 22 |
 |Android |Android SDK 20 |
-|Android |Android SDK 19 |
 |Android |Android SDK 18 |
 |Android |Android SDK 17 |
 |Android |Android SDK 16 |


### PR DESCRIPTION
Android SDKs 19 and 22 are tested in FTL and were duplicated across the Best Effort and Supported lists, so remove them from the Best Effort list.

/cc @godofredoc @timsneath 