### PR TITLE
fix(play-video): Fixed a bug in the play-video example

### DIFF
--- a/examples/cookbook/networking/fetch_data/lib/main.dart
+++ b/examples/cookbook/networking/fetch_data/lib/main.dart
@@ -27,7 +27,7 @@ class Album {
   final int id;
   final String title;
 
-  const Album({
+  Album({
     required this.userId,
     required this.id,
     required this.title,

--- a/examples/cookbook/networking/fetch_data/lib/main.dart
+++ b/examples/cookbook/networking/fetch_data/lib/main.dart
@@ -27,7 +27,7 @@ class Album {
   final int id;
   final String title;
 
-  Album({
+  const Album({
     required this.userId,
     required this.id,
     required this.title,

--- a/examples/cookbook/plugins/play_video/lib/main.dart
+++ b/examples/cookbook/plugins/play_video/lib/main.dart
@@ -31,7 +31,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
   @override
   void initState() {
     super.initState();
-    
+
     // Create and store the VideoPlayerController. The VideoPlayerController
     // offers several different constructors to play videos from assets, files,
     // or the internet.

--- a/examples/cookbook/plugins/play_video/lib/main.dart
+++ b/examples/cookbook/plugins/play_video/lib/main.dart
@@ -30,6 +30,8 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
 
   @override
   void initState() {
+    super.initState();
+    
     // Create and store the VideoPlayerController. The VideoPlayerController
     // offers several different constructors to play videos from assets, files,
     // or the internet.
@@ -41,9 +43,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
     _initializeVideoPlayerFuture = _controller.initialize();
 
     // Use the controller to loop the video.
-    _controller.setLooping(true);
-
-    super.initState();
+    _controller.setLooping(true);    
   }
 
   @override

--- a/examples/cookbook/plugins/play_video/lib/main_step3.dart
+++ b/examples/cookbook/plugins/play_video/lib/main_step3.dart
@@ -17,6 +17,8 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
 
   @override
   void initState() {
+    super.initState();
+    
     // Create and store the VideoPlayerController. The VideoPlayerController
     // offers several different constructors to play videos from assets, files,
     // or the internet.
@@ -24,9 +26,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
       'https://flutter.github.io/assets-for-api-docs/assets/videos/butterfly.mp4',
     );
 
-    _initializeVideoPlayerFuture = _controller.initialize();
-
-    super.initState();
+    _initializeVideoPlayerFuture = _controller.initialize();    
   }
 
   @override

--- a/examples/cookbook/plugins/play_video/lib/main_step3.dart
+++ b/examples/cookbook/plugins/play_video/lib/main_step3.dart
@@ -18,7 +18,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
   @override
   void initState() {
     super.initState();
-    
+
     // Create and store the VideoPlayerController. The VideoPlayerController
     // offers several different constructors to play videos from assets, files,
     // or the internet.
@@ -26,7 +26,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
       'https://flutter.github.io/assets-for-api-docs/assets/videos/butterfly.mp4',
     );
 
-    _initializeVideoPlayerFuture = _controller.initialize();    
+    _initializeVideoPlayerFuture = _controller.initialize();
   }
 
   @override

--- a/src/cookbook/plugins/play-video.md
+++ b/src/cookbook/plugins/play-video.md
@@ -120,6 +120,8 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
 
   @override
   void initState() {
+    super.initState();
+    
     // Create and store the VideoPlayerController. The VideoPlayerController
     // offers several different constructors to play videos from assets, files,
     // or the internet.
@@ -127,9 +129,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
       'https://flutter.github.io/assets-for-api-docs/assets/videos/butterfly.mp4',
     );
 
-    _initializeVideoPlayerFuture = _controller.initialize();
-
-    super.initState();
+    _initializeVideoPlayerFuture = _controller.initialize();    
   }
 
   @override

--- a/src/cookbook/plugins/play-video.md
+++ b/src/cookbook/plugins/play-video.md
@@ -121,7 +121,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
   @override
   void initState() {
     super.initState();
-    
+
     // Create and store the VideoPlayerController. The VideoPlayerController
     // offers several different constructors to play videos from assets, files,
     // or the internet.
@@ -129,7 +129,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
       'https://flutter.github.io/assets-for-api-docs/assets/videos/butterfly.mp4',
     );
 
-    _initializeVideoPlayerFuture = _controller.initialize();    
+    _initializeVideoPlayerFuture = _controller.initialize();
   }
 
   @override
@@ -263,6 +263,8 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
 
   @override
   void initState() {
+    super.initState();
+
     // Create and store the VideoPlayerController. The VideoPlayerController
     // offers several different constructors to play videos from assets, files,
     // or the internet.
@@ -275,8 +277,6 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
 
     // Use the controller to loop the video.
     _controller.setLooping(true);
-
-    super.initState();
   }
 
   @override


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

There is an issue in the code where `super.initState()` is **not** called first

_Issues fixed by this PR (if any):_

n/a

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
