### PR TITLE
Update `examples/visual_debugging`

### DIFF
--- a/examples/visual_debugging/lib/highlight_repaints.dart
+++ b/examples/visual_debugging/lib/highlight_repaints.dart
@@ -10,11 +10,13 @@ void highlightRepaints() {
 
 // #docregion EverythingRepaints
 class EverythingRepaintsPage extends StatelessWidget {
+  const EverythingRepaintsPage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Repaint Example')),
-      body: Center(
+      appBar: AppBar(title: const Text('Repaint Example')),
+      body: const Center(
         child: CircularProgressIndicator(),
       ),
     );
@@ -24,11 +26,13 @@ class EverythingRepaintsPage extends StatelessWidget {
 
 // #docregion AreaRepaints
 class AreaRepaintsPage extends StatelessWidget {
+  const AreaRepaintsPage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Repaint Example')),
-      body: Center(
+      appBar: AppBar(title: const Text('Repaint Example')),
+      body: const Center(
         child: RepaintBoundary(
           child: CircularProgressIndicator(),
         ),

--- a/examples/visual_debugging/lib/oversized_images.dart
+++ b/examples/visual_debugging/lib/oversized_images.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 
 // #docregion Toggle
-import 'package:flutter/painting.dart';
-
 void showOversizedImages() {
   debugInvertOversizedImages = true;
 }
@@ -10,6 +8,8 @@ void showOversizedImages() {
 
 // #docregion ResizedImage
 class ResizedImage extends StatelessWidget {
+  const ResizedImage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Image.asset(

--- a/examples/visual_debugging/pubspec.yaml
+++ b/examples/visual_debugging/pubspec.yaml
@@ -4,7 +4,7 @@ description: Examples of visual debugging
 version: 1.0.0
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/src/development/tools/devtools/inspector.md
+++ b/src/development/tools/devtools/inspector.md
@@ -353,11 +353,13 @@ Here the progress indicator causes its container to repaint:
 <?code-excerpt "lib/highlight_repaints.dart (EverythingRepaints)"?>
 ```dart
 class EverythingRepaintsPage extends StatelessWidget {
+  const EverythingRepaintsPage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Repaint Example')),
-      body: Center(
+      appBar: AppBar(title: const Text('Repaint Example')),
+      body: const Center(
         child: CircularProgressIndicator(),
       ),
     );
@@ -373,11 +375,13 @@ only that section of the screen to repaint:
 <?code-excerpt "lib/highlight_repaints.dart (AreaRepaints)"?>
 ```dart
 class AreaRepaintsPage extends StatelessWidget {
+  const AreaRepaintsPage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Repaint Example')),
-      body: Center(
+      appBar: AppBar(title: const Text('Repaint Example')),
+      body: const Center(
         child: RepaintBoundary(
           child: CircularProgressIndicator(),
         ),
@@ -436,6 +440,8 @@ parameters on the `Image` constructor:
 <?code-excerpt "lib/oversized_images.dart (ResizedImage)"?>
 ```dart
 class ResizedImage extends StatelessWidget {
+  const ResizedImage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Image.asset(
@@ -457,8 +463,6 @@ This property can also be set in code:
 
 <?code-excerpt "lib/oversized_images.dart (Toggle)"?>
 ```dart
-import 'package:flutter/painting.dart';
-
 void showOversizedImages() {
   debugInvertOversizedImages = true;
 }


### PR DESCRIPTION
Update the sample code in `examples/visual_debugging` to get rid of lint warnings

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
