### PR TITLE
Document UWP plugin details

### DIFF
--- a/src/desktop/index.md
+++ b/src/desktop/index.md
@@ -386,6 +386,34 @@ the command line as follows:
 PS C:\myapp> flutter run -d winuwp
 ```
 
+### UWP plugins
+
+To add UWP support to a plugin, add a `supportedVariants`
+entry to the `windows` plugin section in `pubspec.yaml`:
+
+```yaml
+flutter:
+  plugin:
+    platforms:
+      windows:
+        pluginClass: YourClassHere
+        supportedVariants:
+          - win32
+          - uwp
+```
+
+The Win32 and UWP plugins share the same build. To
+use Win32-specific or UWP-specific code, use the
+`WINUWP` define that is automatically set:
+
+```c
+#ifdef WINUWP
+// UWP-specific code goes here.
+#else
+// Win32-specific code goes here.
+#endif
+```
+
 ## Build a release app
 
 To generate a release build,


### PR DESCRIPTION
Since UWP is alpha and `master`-only this documentation doesn't belong on the normal plugin docs pages yet, but it should be documented for people experimenting with UWP.

Fixes https://github.com/flutter/flutter/issues/85756

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
