### PR TITLE
chore: Added missing constant constructors in networking examples

### DIFF
--- a/examples/cookbook/networking/authenticated_requests/lib/main.dart
+++ b/examples/cookbook/networking/authenticated_requests/lib/main.dart
@@ -24,7 +24,7 @@ class Album {
   final int id;
   final String title;
 
-  Album({
+  const Album({
     required this.userId,
     required this.id,
     required this.title,

--- a/examples/cookbook/networking/delete_data/lib/main.dart
+++ b/examples/cookbook/networking/delete_data/lib/main.dart
@@ -46,7 +46,7 @@ class Album {
   final int? id;
   final String? title;
 
-  Album({this.id, this.title});
+  const Album({this.id, this.title});
 
   factory Album.fromJson(Map<String, dynamic> json) {
     return Album(

--- a/examples/cookbook/networking/send_data/lib/main.dart
+++ b/examples/cookbook/networking/send_data/lib/main.dart
@@ -33,7 +33,7 @@ class Album {
   final int id;
   final String title;
 
-  Album({required this.id, required this.title});
+  const Album({required this.id, required this.title});
 
   factory Album.fromJson(Map<String, dynamic> json) {
     return Album(

--- a/examples/cookbook/networking/update_data/lib/main.dart
+++ b/examples/cookbook/networking/update_data/lib/main.dart
@@ -51,7 +51,7 @@ class Album {
   final int id;
   final String title;
 
-  Album({required this.id, required this.title});
+  const Album({required this.id, required this.title});
 
   factory Album.fromJson(Map<String, dynamic> json) {
     return Album(

--- a/examples/cookbook/networking/update_data/lib/main_step5.dart
+++ b/examples/cookbook/networking/update_data/lib/main_step5.dart
@@ -46,7 +46,7 @@ class Album {
   final int id;
   final String title;
 
-  Album({required this.id, required this.title});
+  const Album({required this.id, required this.title});
 
   factory Album.fromJson(Map<String, dynamic> json) {
     return Album(

--- a/src/cookbook/networking/authenticated-requests.md
+++ b/src/cookbook/networking/authenticated-requests.md
@@ -64,7 +64,7 @@ class Album {
   final int id;
   final String title;
 
-  Album({
+  const Album({
     required this.userId,
     required this.id,
     required this.title,

--- a/src/cookbook/networking/delete-data.md
+++ b/src/cookbook/networking/delete-data.md
@@ -194,7 +194,7 @@ class Album {
   final int? id;
   final String? title;
 
-  Album({this.id, this.title});
+  const Album({this.id, this.title});
 
   factory Album.fromJson(Map<String, dynamic> json) {
     return Album(

--- a/src/cookbook/networking/send-data.md
+++ b/src/cookbook/networking/send-data.md
@@ -103,7 +103,7 @@ class Album {
   final int id;
   final String title;
 
-  Album({required this.id, required this.title});
+  const Album({required this.id, required this.title});
 
   factory Album.fromJson(Map<String, dynamic> json) {
     return Album(
@@ -268,7 +268,7 @@ class Album {
   final int id;
   final String title;
 
-  Album({required this.id, required this.title});
+  const Album({required this.id, required this.title});
 
   factory Album.fromJson(Map<String, dynamic> json) {
     return Album(

--- a/src/cookbook/networking/update-data.md
+++ b/src/cookbook/networking/update-data.md
@@ -96,7 +96,7 @@ class Album {
   final int id;
   final String title;
 
-  Album({required this.id, required this.title});
+  const Album({required this.id, required this.title});
 
   factory Album.fromJson(Map<String, dynamic> json) {
     return Album(
@@ -308,7 +308,7 @@ class Album {
   final int id;
   final String title;
 
-  Album({required this.id, required this.title});
+  const Album({required this.id, required this.title});
 
   factory Album.fromJson(Map<String, dynamic> json) {
     return Album(


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

There are a few missing `const` constructors in immutable model classes used to represent JSON data. Code excerpts have been updated too

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
