### PR TITLE
Remove unnecessary null safety query parameters from DartPads

### DIFF
--- a/src/_includes/docs/explicit-animations/animation-controller-starter-code-1.md
+++ b/src/_includes/docs/explicit-animations/animation-controller-starter-code-1.md
@@ -1,4 +1,4 @@
-```run-dartpad:theme-light:mode-flutter:split-100:width-100%:height-500px:null_safety-true
+```run-dartpad:theme-light:mode-flutter:split-100:width-100%:height-500px
 {$ begin main.dart $}
 import 'dart:async';
 

--- a/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-1.md
+++ b/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-1.md
@@ -1,4 +1,4 @@
-```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px:null_safety-true
+```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';

--- a/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-2.md
+++ b/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-2.md
@@ -1,4 +1,4 @@
-```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px:null_safety-true
+```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';

--- a/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-3.md
+++ b/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-3.md
@@ -1,4 +1,4 @@
-```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px:null_safety-true
+```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';

--- a/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-4.md
+++ b/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-4.md
@@ -1,4 +1,4 @@
-```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px:null_safety-true
+```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';

--- a/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-5.md
+++ b/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-5.md
@@ -1,4 +1,4 @@
-```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px:null_safety-true
+```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px
 {$ begin main.dart $}
 {$ end main.dart $}
 ```

--- a/src/_includes/docs/implicit-animations/fade-in-complete.md
+++ b/src/_includes/docs/implicit-animations/fade-in-complete.md
@@ -1,4 +1,4 @@
-```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-532px:ga_id-fade_in_complete:null_safety-true
+```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-532px:ga_id-fade_in_complete
 {$ begin main.dart $}
 import 'package:flutter/material.dart';
 

--- a/src/_includes/docs/implicit-animations/fade-in-starter-code.md
+++ b/src/_includes/docs/implicit-animations/fade-in-starter-code.md
@@ -1,4 +1,4 @@
-```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-532px:ga_id-fade_in_starter_code:null_safety-true
+```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-532px:ga_id-fade_in_starter_code
 {$ begin main.dart $}
 import 'package:flutter/material.dart';
 

--- a/src/_includes/docs/implicit-animations/shape-shifting-complete.md
+++ b/src/_includes/docs/implicit-animations/shape-shifting-complete.md
@@ -1,4 +1,4 @@
-```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px:ga_id-shape_shifting_complete:null_safety-true
+```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px:ga_id-shape_shifting_complete
 {$ begin main.dart $}
 import 'dart:math';
 

--- a/src/_includes/docs/implicit-animations/shape-shifting-starter-code.md
+++ b/src/_includes/docs/implicit-animations/shape-shifting-starter-code.md
@@ -1,4 +1,4 @@
-```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px:ga_id-shape_shifting_starter_code:null_safety-true
+```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px:ga_id-shape_shifting_starter_code
 {$ begin main.dart $}
 import 'dart:math';
 

--- a/src/codelabs/layout-basics.md
+++ b/src/codelabs/layout-basics.md
@@ -53,7 +53,7 @@ and `Column` lays out its widgets vertically.
 {{site.alert.end}}
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -194,7 +194,7 @@ The `mainAxisSize` property has two possible values:
 {{site.alert.end}}
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -336,7 +336,7 @@ can position their children in that extra space.
 {{site.alert.end}}
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -495,7 +495,7 @@ The `crossAxisAlignment` property has five possible values:
 {{site.alert.end}}
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -664,7 +664,7 @@ the widgets are resized according to their
 {{site.alert.end}}
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -822,7 +822,7 @@ Future<void> main() async {
 {{site.alert.end}}
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -988,7 +988,7 @@ wrap a widget and force the widget to fill extra space.
 {{site.alert.end}}
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -1116,7 +1116,7 @@ create empty space.
 {{site.alert.end}}
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -1260,7 +1260,7 @@ Future<void> main() async {
 {{site.alert.end}}
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -1428,7 +1428,7 @@ can create space between widgets.
 {{site.alert.end}}
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -1567,7 +1567,7 @@ for different fonts, sizes, and colors.
 {{site.alert.end}}
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -1706,7 +1706,7 @@ Flutter is preloaded with icon packages for
 {{site.alert.end}}
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -1833,7 +1833,7 @@ the following example uses an image from the network.
 {{site.alert.end}}
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -1968,7 +1968,7 @@ which are positioned below the contact information.
 {{site.alert.end}}
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -2143,7 +2143,7 @@ Future<void> main() async {
   ```
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -2381,7 +2381,7 @@ Future<void> main() async {
 {{site.alert.end}}
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -2666,7 +2666,7 @@ Future<void> main() async {
 {{site.alert.end}}
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';
@@ -2997,7 +2997,7 @@ Future<void> main() async {
 {{site.alert.end}}
 
 <!-- skip -->
-```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60:null_safety-true
+```run-dartpad:theme-dark:mode-flutter:width-100%:height-400px:split-60
 {$ begin main.dart $}
 import 'dart:async';
 import 'package:flutter/material.dart';

--- a/src/cookbook/animation/animated-container.md
+++ b/src/cookbook/animation/animated-container.md
@@ -145,7 +145,7 @@ FloatingActionButton(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'dart:math';
 
 import 'package:flutter/material.dart';

--- a/src/cookbook/animation/opacity-animation.md
+++ b/src/cookbook/animation/opacity-animation.md
@@ -152,7 +152,7 @@ AnimatedOpacity(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/cookbook/animation/page-route-animation.md
+++ b/src/cookbook/animation/page-route-animation.md
@@ -231,7 +231,7 @@ transitionsBuilder: (context, animation, secondaryAnimation, child) {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/cookbook/animation/physics-simulation.md
+++ b/src/cookbook/animation/physics-simulation.md
@@ -344,7 +344,7 @@ onPanEnd: (details) {
 ## Interactive Example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
 

--- a/src/cookbook/design/drawer.md
+++ b/src/cookbook/design/drawer.md
@@ -134,7 +134,7 @@ ListTile(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/cookbook/design/orientation.md
+++ b/src/cookbook/design/orientation.md
@@ -82,7 +82,7 @@ body: OrientationBuilder(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-500px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-500px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/cookbook/design/snackbars.md
+++ b/src/cookbook/design/snackbars.md
@@ -100,7 +100,7 @@ final snackBar = SnackBar(
 {{site.alert.end}}
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() => runApp(const SnackBarDemo());

--- a/src/cookbook/design/tabs.md
+++ b/src/cookbook/design/tabs.md
@@ -107,7 +107,7 @@ body: const TabBarView(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/cookbook/design/themes.md
+++ b/src/cookbook/design/themes.md
@@ -134,7 +134,7 @@ Container(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/cookbook/effects/download-button.md
+++ b/src/cookbook/effects/download-button.md
@@ -447,7 +447,7 @@ Run the app:
   to open the downloaded asset.
 
 <!--skip-->
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 

--- a/src/cookbook/effects/drag-a-widget.md
+++ b/src/cookbook/effects/drag-a-widget.md
@@ -241,7 +241,7 @@ Run the app:
   and watch the charges accumulate.
 
 <!--skip-->
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/cookbook/effects/expandable-fab.md
+++ b/src/cookbook/effects/expandable-fab.md
@@ -413,7 +413,7 @@ Run the app:
 
 
 <!--skip-->
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';

--- a/src/cookbook/effects/nested-nav.md
+++ b/src/cookbook/effects/nested-nav.md
@@ -392,7 +392,7 @@ Run the app:
   first screen.
 
 <!--skip-->
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 // Copyright 2020, the Flutter project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.

--- a/src/cookbook/effects/parallax-scrolling.md
+++ b/src/cookbook/effects/parallax-scrolling.md
@@ -558,7 +558,7 @@ Run the app:
 * Scroll up and down to observe the parallax effect.
 
 <!--skip-->
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/src/cookbook/effects/photo-filter-carousel.md
+++ b/src/cookbook/effects/photo-filter-carousel.md
@@ -503,7 +503,7 @@ You now have a draggable, tappable photo filter carousel.
 ## Interactive example
 
 <!--skip-->
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';

--- a/src/cookbook/effects/staggered-menu-animation.md
+++ b/src/cookbook/effects/staggered-menu-animation.md
@@ -370,7 +370,7 @@ pops into place.
 ## Interactive example
 
 <!--skip-->
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/cookbook/effects/typing-indicator.md
+++ b/src/cookbook/effects/typing-indicator.md
@@ -460,7 +460,7 @@ Run the app:
   on and off.
 
 <!--skip-->
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'dart:math';
 
 import 'package:flutter/cupertino.dart';

--- a/src/cookbook/forms/focus.md
+++ b/src/cookbook/forms/focus.md
@@ -144,7 +144,7 @@ FloatingActionButton(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/cookbook/forms/retrieve-input.md
+++ b/src/cookbook/forms/retrieve-input.md
@@ -118,7 +118,7 @@ FloatingActionButton(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/cookbook/forms/text-field-changes.md
+++ b/src/cookbook/forms/text-field-changes.md
@@ -160,7 +160,7 @@ void dispose() {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/cookbook/forms/text-input.md
+++ b/src/cookbook/forms/text-input.md
@@ -68,7 +68,7 @@ TextFormField(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart" replace="/^child\: //g"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/cookbook/forms/validation.md
+++ b/src/cookbook/forms/validation.md
@@ -161,7 +161,7 @@ rebuilds the form to display any error messages and returns `false`.
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/cookbook/gestures/dismissible.md
+++ b/src/cookbook/gestures/dismissible.md
@@ -133,7 +133,7 @@ provide a `background` parameter to the `Dismissible`.
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/cookbook/gestures/handling-taps.md
+++ b/src/cookbook/gestures/handling-taps.md
@@ -59,7 +59,7 @@ GestureDetector(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/cookbook/gestures/ripples.md
+++ b/src/cookbook/gestures/ripples.md
@@ -51,7 +51,7 @@ InkWell(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/cookbook/images/network-image.md
+++ b/src/cookbook/images/network-image.md
@@ -50,7 +50,7 @@ the following recipes:
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/cookbook/lists/basic-list.md
+++ b/src/cookbook/lists/basic-list.md
@@ -48,7 +48,7 @@ ListView(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/cookbook/lists/floating-app-bar.md
+++ b/src/cookbook/lists/floating-app-bar.md
@@ -149,7 +149,7 @@ SliverList(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/cookbook/lists/grid-lists.md
+++ b/src/cookbook/lists/grid-lists.md
@@ -46,7 +46,7 @@ GridView.count(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/cookbook/lists/horizontal-list.md
+++ b/src/cookbook/lists/horizontal-list.md
@@ -54,7 +54,7 @@ ListView(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/cookbook/lists/long-lists.md
+++ b/src/cookbook/lists/long-lists.md
@@ -58,7 +58,7 @@ ListView.builder(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/cookbook/lists/mixed-list.md
+++ b/src/cookbook/lists/mixed-list.md
@@ -128,7 +128,7 @@ ListView.builder(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/cookbook/navigation/hero-animations.md
+++ b/src/cookbook/navigation/hero-animations.md
@@ -148,7 +148,7 @@ Hero(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() => runApp(const HeroApp());

--- a/src/cookbook/navigation/named-routes.md
+++ b/src/cookbook/navigation/named-routes.md
@@ -162,7 +162,7 @@ onPressed: () {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/cookbook/navigation/navigate-with-arguments.md
+++ b/src/cookbook/navigation/navigate-with-arguments.md
@@ -197,7 +197,7 @@ MaterialApp(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/cookbook/navigation/navigation-basics.md
+++ b/src/cookbook/navigation/navigation-basics.md
@@ -136,7 +136,7 @@ onPressed: () {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/cookbook/navigation/passing-data.md
+++ b/src/cookbook/navigation/passing-data.md
@@ -194,7 +194,7 @@ body: ListView.builder(
 ### Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 class Todo {

--- a/src/cookbook/navigation/returning-data.md
+++ b/src/cookbook/navigation/returning-data.md
@@ -203,7 +203,7 @@ void _navigateAndDisplaySelection(BuildContext context) async {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/development/ui/advanced/actions_and_shortcuts.md
+++ b/src/development/ui/advanced/actions_and_shortcuts.md
@@ -425,7 +425,7 @@ invoke actions to accomplish their work. All the invoked actions and
 shortcuts are logged.
 
 <?code-excerpt "ui/advanced/actions_and_shortcuts/lib/copyable_text.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-starting_code
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 

--- a/src/development/ui/layout/constraints.md
+++ b/src/development/ui/layout/constraints.md
@@ -119,7 +119,7 @@ Use the numbered horizontal scrolling bar to switch between
 29 different examples.
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-starting_code
 import 'package:flutter/material.dart';
 
 void main() => runApp(const HomePage());

--- a/src/development/ui/widgets-intro.md
+++ b/src/development/ui/widgets-intro.md
@@ -32,7 +32,7 @@ The minimal Flutter app simply calls the [`runApp()`][]
 function with a widget:
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-310px:split-60:ga_id-starting_code:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-310px:split-60:ga_id-starting_code
 import 'package:flutter/material.dart';
 
 void main() {
@@ -99,7 +99,7 @@ of which the following are commonly used:
 Below are some simple widgets that combine these and other widgets:
 
 <?code-excerpt "lib/main_myappbar.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code
 import 'package:flutter/material.dart';
 
 class MyAppBar extends StatelessWidget {
@@ -231,7 +231,7 @@ between screens of your application. Using the [`MaterialApp`][]
 widget is entirely optional but a good practice.
 
 <?code-excerpt "lib/main_tutorial.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code
 import 'package:flutter/material.dart';
 
 void main() {
@@ -313,7 +313,7 @@ The first step in building an interactive application is to detect
 input gestures. See how that works by creating a simple button:
 
 <?code-excerpt "lib/main_mybutton.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code
 import 'package:flutter/material.dart';
 
 class MyButton extends StatelessWidget {
@@ -386,7 +386,7 @@ this idea. `StatefulWidgets` are special widgets that know how to generate
 Consider this basic example, using the [`ElevatedButton`][] mentioned earlier:
 
 <?code-excerpt "lib/main_counter.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code
 import 'package:flutter/material.dart';
 
 class Counter extends StatefulWidget {
@@ -477,7 +477,7 @@ The following slightly more complex example shows how
 this works in practice:
 
 <?code-excerpt "lib/main_counterdisplay.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code
 import 'package:flutter/material.dart';
 
 class CounterDisplay extends StatelessWidget {
@@ -570,7 +570,7 @@ intended purchases. Start by defining the presentation class,
 `ShoppingListItem`:
 
 <?code-excerpt "lib/main_shoppingitem.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code
 import 'package:flutter/material.dart';
 
 class Product {
@@ -674,7 +674,7 @@ built widgets and applies only the differences to the underlying
 Here's an example parent widget that stores mutable state:
 
 <?code-excerpt "lib/main_shoppinglist.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code
 import 'package:flutter/material.dart';
 
 class Product {

--- a/src/get-started/codelab-web.md
+++ b/src/get-started/codelab-web.md
@@ -121,7 +121,7 @@ of the Flutter DevTools tooling.
 <li markdown="1">The starting app is displayed in the following DartPad.
 
 <!-- skip -->
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-starting_code
 {$ begin main.dart $}
 import 'package:flutter/material.dart';
 
@@ -804,7 +804,7 @@ the animation works, and that clicking the
 ### Complete sample
 
 <!-- skip -->
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-starting_code:null_safety-true
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-starting_code
 import 'package:flutter/material.dart';
 
 void main() => runApp(const SignUpApp());


### PR DESCRIPTION
DartPad only supports null safety now and this query parameter was removed, so it is not doing anything and can be removed.