### PR TITLE
Fix YAML link

### DIFF
--- a/src/development/tools/pubspec.md
+++ b/src/development/tools/pubspec.md
@@ -21,7 +21,7 @@ needs to know. The pubspec is written in
 [YAML][], which is human readable, but be aware
 that _white space (tabs v spaces) matters_.
 
-[YAML]: https://yaml.org/spec/spec.html
+[YAML]: https://yaml.org/
 
 The pubspec file specifies dependencies
 that the project requires, such as particular packages


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Updates YAML link as the old `/spec/spec` link no longer works. There is `/spec` but it just lists links to multiple specs. The home page also links to the latest spec while being easier to navigate and providing extra information. 

_Issues fixed by this PR (if any):_ Fixes #6724

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
