### PR TITLE
Add Dart SDK version and architecture to the archive table

### DIFF
--- a/src/assets/js/archive.js
+++ b/src/assets/js/archive.js
@@ -37,7 +37,7 @@ function updateTable(releases, os) {
           $(this).closest("tr").remove();
           event.preventDefault();
         });
-        $("<tr>").append($("<td colspan=\"3\"></td></tr>").append(showAll)).appendTo(table);
+        $("<tr>").append($("<td colspan=\"5\"></td></tr>").append(showAll)).appendTo(table);
       }
 
       var className = index >= releasesToShow ? "overflow" : "";
@@ -45,10 +45,18 @@ function updateTable(releases, os) {
       var row = $("<tr />").addClass(className).appendTo(table);
       var hashLabel = $("<span />").text(release.hash.substr(0, 7)).addClass("git-hash");
       var downloadLink = $("<a />").attr("href", url).text(release.version);
+      var dartSdkVersion = $("<span />").text(
+        release.dart_sdk_version ? release.dart_sdk_version.split(' ')[0]: '-',
+      );
+      var dartSdkArch = $("<span />").text(
+        release.dart_sdk_arch ? release.dart_sdk_version: 'x64',
+      );
       var date = new Date(Date.parse(release.release_date));
       $("<td />").append(downloadLink).appendTo(row);
+      $("<td />").append(dartSdkArch).appendTo(row);
       $("<td />").append(hashLabel).appendTo(row);
       $("<td />").addClass("date").text(date.toLocaleDateString()).appendTo(row);
+      $("<td />").append(dartSdkVersion).appendTo(row);
     });
   }
 }

--- a/src/development/tools/sdk/_os.md
+++ b/src/development/tools/sdk/_os.md
@@ -12,8 +12,8 @@ Select from the following scrollable list:
 
 <div class="scrollable-table">
   <table id="downloads-{{id}}-{{channel}}" class="table table-striped">
-  <thead><tr><th>Version</th><th>Ref</th><th class="date">Release Date</th></tr></thead>
-  <tr class="loading"><td colspan="3">Loading...</td></tr>
+  <thead><tr><th>Version</th><th>Architecture</th><th>Ref</th><th class="date">Release Date</th><th>Dart SDK</th></tr></thead>
+  <tr class="loading"><td colspan="5">Loading...</td></tr>
   </table>
 </div>
 {% endfor -%}


### PR DESCRIPTION
This PR displays information about the Dart SDK version included with the Flutter SDK, and the target architecture of the Dart SDK in the tables here: https://docs.flutter.dev/development/tools/sdk/releases

The Dart SDK version data is already being populated by the packaging script.

Following the PR here https://github.com/flutter/flutter/pull/97278 the Dart SDK target architecture will also be included by the packaging script.

The result will look like this:

<img width="938" alt="Screen Shot 2022-01-27 at 9 54 51 PM" src="https://user-images.githubusercontent.com/6343103/151495151-70802563-3e9b-49af-9a75-4045b90f1628.png">
