### PR TITLE
Fix design doc list not updating

### DIFF
--- a/src/assets/js/go_link_index.js
+++ b/src/assets/js/go_link_index.js
@@ -1,8 +1,8 @@
 // Fetches Go link redirects from firebase.json
-// Since we can't access it from the site directly, fetch it from GitHub master.
+// Since we can't access it from the site directly, fetch it from GitHub main.
 const fetchGoLinks = function (callback, errorCallback) {
   // OS: windows, macos, linux
-  var url = "https://raw.githubusercontent.com/flutter/website/master/firebase.json";
+  var url = "https://raw.githubusercontent.com/flutter/website/main/firebase.json";
   $.ajax({
     type: "GET",
     url: url,

--- a/src/assets/js/go_link_index.js
+++ b/src/assets/js/go_link_index.js
@@ -2,7 +2,7 @@
 // Since we can't access it from the site directly, fetch it from GitHub main.
 const fetchGoLinks = function (callback, errorCallback) {
   // OS: windows, macos, linux
-  var url = "https://raw.githubusercontent.com/flutter/website/main/firebase.json";
+  const url = "https://raw.githubusercontent.com/flutter/website/main/firebase.json";
   $.ajax({
     type: "GET",
     url: url,
@@ -21,9 +21,12 @@ function updateList(links) {
   }
 
   links.hosting.redirects.filter(
-    redirect => redirect.source.startsWith('/go/') && redirect.source != '/go/template'
+      redirect =>
+          redirect.source &&
+          redirect.source.startsWith('/go/') &&
+          redirect.source !== '/go/template'
   ).forEach(
-    redirect => go_links.append(`<li><a href="${redirect.destination}">${redirect.source}</a></li>`)
+      redirect => go_links.append(`<li><a href="${redirect.destination}">${redirect.source}</a></li>`)
   );
 }
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ The design list page at https://docs.flutter.dev/resources/design-docs was outdated due to not pulling from the new `main` branch.

_Issues fixed by this PR (if any):_ Fixes #6737

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
