### PR TITLE
Remove relative include from Performance View page

### DIFF
--- a/src/development/tools/devtools/performance.md
+++ b/src/development/tools/devtools/performance.md
@@ -108,8 +108,6 @@ with the mouse wheel / trackpad
 You can click an event to view CPU profiling information in the CPU profiler
 below, described in the next section.
 
-{% include_relative _profiler.md %}
-
 ## Import and export
 
 DevTools supports importing and exporting performance snapshots.


### PR DESCRIPTION
The CPU Profiler page is included in the Performance View page. The CPU profiler page is separate from the Performance page in DevTools, so we should align the docs to match.

<img width="269" alt="Screen Shot 2022-01-28 at 10 17 22 AM" src="https://user-images.githubusercontent.com/1145719/151600318-fe67089b-0e40-4178-b526-2e5cd1e30e2c.png">

fixes #6743 

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
