### PR TITLE
Fix DevTools release notes titles

### DIFF
--- a/src/development/tools/devtools/release-notes/release-notes-2.7.0-src.md
+++ b/src/development/tools/devtools/release-notes/release-notes-2.7.0-src.md
@@ -1,3 +1,5 @@
+# DevTools 2.7.0 release notes
+
 Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 
 ## General Updates

--- a/src/development/tools/devtools/release-notes/release-notes-2.7.0.md
+++ b/src/development/tools/devtools/release-notes/release-notes-2.7.0.md
@@ -1,7 +1,7 @@
 ---
-title: DevTools 2.7.0 release notes
 short-title: 2.7.0 release notes
 description: Release notes for Flutter and Dart DevTools 2.7.0
+toc: false
 ---
 
 {% include_relative release-notes-2.7.0-src.md %}

--- a/src/development/tools/devtools/release-notes/release-notes-2.8.0-src.md
+++ b/src/development/tools/devtools/release-notes/release-notes-2.8.0-src.md
@@ -1,3 +1,5 @@
+# DevTools 2.8.0 release notes
+
 Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 
 ## General Updates

--- a/src/development/tools/devtools/release-notes/release-notes-2.8.0.md
+++ b/src/development/tools/devtools/release-notes/release-notes-2.8.0.md
@@ -1,7 +1,7 @@
 ---
-title: DevTools 2.8.0 release notes
 short-title: 2.8.0 release notes
 description: Release notes for Flutter and Dart DevTools 2.8.0
+toc: false
 ---
 
 {% include_relative release-notes-2.8.0-src.md %}

--- a/src/development/tools/devtools/release-notes/release-notes-2.9.1-src.md
+++ b/src/development/tools/devtools/release-notes/release-notes-2.9.1-src.md
@@ -1,3 +1,5 @@
+# DevTools 2.9.1 release notes
+
 Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter.
 
 ## Debugger Updates

--- a/src/development/tools/devtools/release-notes/release-notes-2.9.1.md
+++ b/src/development/tools/devtools/release-notes/release-notes-2.9.1.md
@@ -1,7 +1,7 @@
 ---
-title: DevTools 2.9.1 release notes
 short-title: 2.9.1 release notes
 description: Release notes for Flutter and Dart DevTools 2.9.1
+toc: false
 ---
 
 {% include_relative release-notes-2.9.1-src.md %}

--- a/src/development/tools/devtools/release-notes/release-notes-2.9.2-src.md
+++ b/src/development/tools/devtools/release-notes/release-notes-2.9.2-src.md
@@ -1,3 +1,5 @@
+# DevTools 2.9.2 release notes
+
 Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 
 ## General Updates

--- a/src/development/tools/devtools/release-notes/release-notes-2.9.2.md
+++ b/src/development/tools/devtools/release-notes/release-notes-2.9.2.md
@@ -1,7 +1,7 @@
 ---
-title: DevTools 2.9.2 release notes
 short-title: 2.9.2 release notes
 description: Release notes for Flutter and Dart DevTools 2.9.2
+toc: false
 ---
 
 {% include_relative release-notes-2.9.2-src.md %}


### PR DESCRIPTION
In order to show the title in DevTools, we need to display it in Markdown rather than using Jekyll front-matter. This also removes the TOC from these pages.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
