### PR TITLE
Add headers to url-strategies page for readability

### DIFF
--- a/src/development/ui/navigation/url-strategies.md
+++ b/src/development/ui/navigation/url-strategies.md
@@ -34,6 +34,8 @@ Instead of using these setup instructions,
 you can also use the [`url_strategy`][] package.
 {{site.alert.end}}
 
+## Web setup
+
 First, add `flutter_web_plugins` to your `pubspec.yaml`:
 
 ```yaml
@@ -54,6 +56,7 @@ void main() {
 }
 ```
 
+## Cross platform setup
 If your app is cross-platform, use Dart's conditional imports feature by
 creating three files:
 

--- a/src/development/ui/navigation/url-strategies.md
+++ b/src/development/ui/navigation/url-strategies.md
@@ -57,6 +57,7 @@ void main() {
 ```
 
 ## Cross platform setup
+
 If your app is cross-platform, use Dart's conditional imports feature by
 creating three files:
 


### PR DESCRIPTION
This reads poorly, this page needed some headers to make clear that there are two ways of setting up the URL strategies.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
