### PR TITLE
Added note about background platform channels not being available for iOS yet

### DIFF
--- a/src/development/platform-integration/platform-channels.md
+++ b/src/development/platform-integration/platform-channels.md
@@ -823,7 +823,7 @@ destined for the platform side, they need to be invoked on the root Isolate. The
 platform side's handlers can execute on the platform's main thread or they can
 execute on a background thread if a Task Queue is used. The result of the
 platform side handlers can be invoked asynchronously and on any thread when the
-Task Queue API is available, otherwise they must be invoked on the platform
+Task Queue API is available; otherwise, they must be invoked on the platform
 thread.
 
 {{site.alert.note}}The Task Queue API is available for Android on the `stable`

--- a/src/development/platform-integration/platform-channels.md
+++ b/src/development/platform-integration/platform-channels.md
@@ -827,8 +827,8 @@ Task Queue API is available; otherwise, they must be invoked on the platform
 thread.
 
 {{site.alert.note}}
-  The Task Queue API is available for Android on the `stable` channel. For iOS,
-  it is available on the `master` channel after [177cfc4][].
+  In release 2.10, the Task Queue API is available for Android. For iOS, it is
+  only available on the `master` channel.
 {{site.alert.end}}
 
 {{site.alert.note}}
@@ -879,8 +879,8 @@ override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.Flu
 In Swift:
 
 {{site.alert.note}}
-  The Task Queue API is only available on the `master` channel for iOS after
-  [177cfc4][].
+  In release 2.10, the Task Queue API is only available on the `master` channel
+  for iOS.
 {{site.alert.end}}
 
 ```swift
@@ -898,8 +898,8 @@ public static func register(with registrar: FlutterPluginRegistrar) {
 In Objective-C:
 
 {{site.alert.note}}
-  The Task Queue API is only available on the `master` channel for iOS after
-  [177cfc4][].
+  In release 2.10, the Task Queue API is only available on the `master` channel
+  for iOS.
 {{site.alert.end}}
 
 ```objc
@@ -993,4 +993,3 @@ DispatchQueue.main.async {
 [Pigeon]: {{site.pub-pkg}}/pigeon
 [Pigeon pub.dev page]: {{site.pub-pkg}}/pigeon
 [sending structured typesafe messages]: #pigeon
-[177cfc4]: {{site.github}}/flutter/flutter/commit/177cfc491a191fad37e502bd9219794546d2a455

--- a/src/development/platform-integration/platform-channels.md
+++ b/src/development/platform-integration/platform-channels.md
@@ -822,7 +822,12 @@ be invoked on the platform's main thread. When invoking channels in Flutter
 destined for the platform side, they need to be invoked on the root Isolate. The
 platform side's handlers can execute on the platform's main thread or they can
 execute on a background thread if a Task Queue is used. The result of the
-platform side handlers can be invoked asynchronously and on any thread.
+platform side handlers can be invoked asynchronously and on any thread when the
+Task Queue API is available, otherwise they must be invoked on the platform
+thread.
+
+{{site.alert.note}}The Task Queue API is available for Android on the `stable`
+channel. For iOS, it is currently available on the `master` channel.
 
 {{site.alert.note}}On Android, the platform's main thread is sometimes called
 the "main thread", but it is technically defined as [the UI thread][]. Annotate
@@ -868,6 +873,10 @@ override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.Flu
 ```
 
 In Swift:
+
+{{site.alert.note}}The Task Queue API is only currently available on the
+`master` channel for iOS .
+
 ```swift
 public static func register(with registrar: FlutterPluginRegistrar) {
   let taskQueue = registrar.messenger.makeBackgroundTaskQueue()
@@ -881,6 +890,9 @@ public static func register(with registrar: FlutterPluginRegistrar) {
 ```
 
 In Objective-C:
+
+{{site.alert.note}}The Task Queue API is only currently available on the
+`master` channel for iOS .
 
 ```objc
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {

--- a/src/development/platform-integration/platform-channels.md
+++ b/src/development/platform-integration/platform-channels.md
@@ -827,19 +827,16 @@ Task Queue API is available; otherwise, they must be invoked on the platform
 thread.
 
 {{site.alert.note}}
-  The Task Queue API is available for Android on the `stable`
-  channel. For iOS, it is currently available on the `master` channel.
+  The Task Queue API is available for Android on the `stable` channel. For iOS,
+  it is available on the `master` channel after [177cfc4][].
 {{site.alert.end}}
 
 {{site.alert.note}}
-  On Android, the platform's main thread is sometimes called
-  the "main thread", but it is technically defined as [the UI thread][].
-  Annotate methods that need to be run on the UI thread with `@UiThread`.
-  On iOS, this thread is officially referred to as [the main thread][].
+  On Android, the platform's main thread is sometimes called the "main thread",
+  but it is technically defined as [the UI thread][]. Annotate methods that need
+  to be run on the UI thread with `@UiThread`. On iOS, this thread is officially
+  referred to as [the main thread][].
 {{site.alert.end}}
-the "main thread", but it is technically defined as [the UI thread][]. Annotate
-methods that need to be run on the UI thread with `@UiThread`. On iOS, this
-thread is officially referred to as [the main thread][].
 
 ### Executing channel handlers on background threads
 
@@ -881,8 +878,10 @@ override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.Flu
 
 In Swift:
 
-{{site.alert.note}}The Task Queue API is only currently available on the
-`master` channel for iOS .
+{{site.alert.note}}
+  The Task Queue API is only available on the `master` channel for iOS after
+  [177cfc4][].
+{{site.alert.end}}
 
 ```swift
 public static func register(with registrar: FlutterPluginRegistrar) {
@@ -898,8 +897,10 @@ public static func register(with registrar: FlutterPluginRegistrar) {
 
 In Objective-C:
 
-{{site.alert.note}}The Task Queue API is only currently available on the
-`master` channel for iOS .
+{{site.alert.note}}
+  The Task Queue API is only available on the `master` channel for iOS after
+  [177cfc4][].
+{{site.alert.end}}
 
 ```objc
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
@@ -992,3 +993,4 @@ DispatchQueue.main.async {
 [Pigeon]: {{site.pub-pkg}}/pigeon
 [Pigeon pub.dev page]: {{site.pub-pkg}}/pigeon
 [sending structured typesafe messages]: #pigeon
+[177cfc4]: {{site.github}}/flutter/flutter/commit/177cfc491a191fad37e502bd9219794546d2a455

--- a/src/development/platform-integration/platform-channels.md
+++ b/src/development/platform-integration/platform-channels.md
@@ -826,8 +826,10 @@ platform side handlers can be invoked asynchronously and on any thread when the
 Task Queue API is available; otherwise, they must be invoked on the platform
 thread.
 
-{{site.alert.note}}The Task Queue API is available for Android on the `stable`
-channel. For iOS, it is currently available on the `master` channel.
+{{site.alert.note}}
+  The Task Queue API is available for Android on the `stable`
+  channel. For iOS, it is currently available on the `master` channel.
+{{site.alert.end}}
 
 {{site.alert.note}}On Android, the platform's main thread is sometimes called
 the "main thread", but it is technically defined as [the UI thread][]. Annotate

--- a/src/development/platform-integration/platform-channels.md
+++ b/src/development/platform-integration/platform-channels.md
@@ -831,7 +831,12 @@ thread.
   channel. For iOS, it is currently available on the `master` channel.
 {{site.alert.end}}
 
-{{site.alert.note}}On Android, the platform's main thread is sometimes called
+{{site.alert.note}}
+  On Android, the platform's main thread is sometimes called
+  the "main thread", but it is technically defined as [the UI thread][].
+  Annotate methods that need to be run on the UI thread with `@UiThread`.
+  On iOS, this thread is officially referred to as [the main thread][].
+{{site.alert.end}}
 the "main thread", but it is technically defined as [the UI thread][]. Annotate
 methods that need to be run on the UI thread with `@UiThread`. On iOS, this
 thread is officially referred to as [the main thread][].


### PR DESCRIPTION
The iOS implementation for Background Platform Channels didn't make the cut for the latest stable so we are noting that it isn't available yet for iOS.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
