### PR TITLE
Remove iOS 9.3.6 from the "Supported" list

### DIFF
--- a/src/development/tools/sdk/release-notes/supported-platforms.md
+++ b/src/development/tools/sdk/release-notes/supported-platforms.md
@@ -53,7 +53,6 @@ We define three tiers of support for the platforms on which Flutter runs:
 |Android|Android SDK 21        |
 |Android|Android SDK 19        |
 |iOS    | 14-15                |
-|iOS    | 9.3.6                |
 |Web    | Chrome 84            |
 |Web    | Firefox 72.0         |
 |Web    | Safari / Catalina    |


### PR DESCRIPTION
flutter.dev/go/rfc-32-bit-ios-support
