### PR TITLE
General cleanup while looking for "dev channel" references

### DIFF
--- a/src/development/tools/sdk/overview.md
+++ b/src/development/tools/sdk/overview.md
@@ -28,7 +28,8 @@ Note: For more information about the Flutter SDK, see its
 
 ## `flutter` command-line tool
 
-The [`flutter` CLI tool][] (`flutter/bin/flutter`) is how developers (or IDEs on behalf of developers) interact with Flutter.
+The [`flutter` CLI tool][] (`flutter/bin/flutter`) is how developers
+(or IDEs on behalf of developers) interact with Flutter.
 
 ## `dart` command-line tool
 

--- a/src/development/tools/sdk/releases.md
+++ b/src/development/tools/sdk/releases.md
@@ -1,7 +1,7 @@
 ---
 title: Flutter SDK releases
 short-title: Releases
-description: All current Flutter SDK releases, both stable, dev, and master.
+description: All current Flutter SDK releases, stable, beta, and master.
 toc: false
 js:
   - url: /assets/js/archive.js

--- a/src/development/tools/sdk/upgrading.md
+++ b/src/development/tools/sdk/upgrading.md
@@ -28,6 +28,11 @@ and then run `flutter upgrade`.
 
 Flutter has three [release channels][]:
 **stable**, **beta** and **master**.
+
+{{site.alert.info}}
+  The `dev` channel was retired as of Flutter 2.8.
+{{site.alert.end}}
+
 We recommend using the **{{site.sdk.channel}}** channel
 unless you need a more recent release.
 

--- a/src/get-started/install/_get-sdk-win.md
+++ b/src/get-started/install/_get-sdk-win.md
@@ -5,8 +5,8 @@
 
     [(loading...)](#){:.download-latest-link-{{os}}.btn.btn-primary}
 
-    For other release channels, and older builds, see the
-    [SDK releases][] page.
+    For other release channels, and older builds,
+    see the [SDK releases][] page.
  1. Extract the zip file and place the contained `flutter`
     in the desired installation location for the Flutter SDK
     (for example, `C:\Users\<your-user-name>\Documents`).

--- a/src/get-started/install/_web-setup.md
+++ b/src/get-started/install/_web-setup.md
@@ -2,8 +2,9 @@
 
 Flutter has support for building web applications in the
 `stable` channel. Any app created in Flutter 2 automatically
-builds for the web. To add web support to an existing app, follow
-the instructions on [Building a web application with Flutter][] 
+builds for the web. To add web support to an app created
+before web was in stable, follow the instructions on
+[Building a web application with Flutter][] 
 when you've completed the setup above.
 
 [Building a web application with Flutter]: {{site.url}}/get-started/web

--- a/src/get-started/web.md
+++ b/src/get-started/web.md
@@ -54,7 +54,7 @@ $ flutter upgrade
   Running `flutter channel stable` replaces your current version of Flutter
   with the stable version and can take time if your connection is slow.
   After this, running `flutter upgrade` upgrades your install to the latest
- `stable`.  Returning to another channel (beta, dev, or master) requires calling
+ `stable`.  Returning to another channel (beta or master) requires calling
  `flutter channel <channel>` explicitly.
 {{site.alert.end}}
 


### PR DESCRIPTION
The "dev" channel was retired in Flutter 2.8.