### PR TITLE
sidebar typo fixes.

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -163,7 +163,7 @@
         - title: Writing platform-specific code
           permalink: /development/platform-integration/platform-channels
         - title: Desktop
-          permalinkn: /desktop
+          permalink: /desktop
     - title: Packages & plugins
       permalink: /development/packages-and-plugins
       children:


### PR DESCRIPTION
Found this issue while sync the docs to flutter.cn, we should fix this typo so that we could see the Desktop URL in the sidebar.

Thanks!

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
