### PR TITLE
Remove lint warnings from "Create a scrolling parallax Scrolling

### DIFF
--- a/src/cookbook/effects/parallax-scrolling.md
+++ b/src/cookbook/effects/parallax-scrolling.md
@@ -120,7 +120,7 @@ class LocationListItem extends StatelessWidget {
            colors: [Colors.transparent, Colors.black.withOpacity(0.7)],
            begin: Alignment.topCenter,
            end: Alignment.bottomCenter,
-           stops: [0.6, 0.95],
+           stops: const [0.6, 0.95],
          ),
        ),
      ),
@@ -559,11 +559,10 @@ Run the app:
 
 <!--skip-->
 ```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
-final Color darkBlue = Color.fromARGB(255, 18, 32, 47);
+const Color darkBlue = Color.fromARGB(255, 18, 32, 47);
 
 void main() {
   runApp(MyApp());
@@ -575,7 +574,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       theme: ThemeData.dark().copyWith(scaffoldBackgroundColor: darkBlue),
       debugShowCheckedModeBanner: false,
-      home: Scaffold(
+      home: const Scaffold(
         body: Center(
           child: ExampleParallax(),
         ),
@@ -664,7 +663,7 @@ class LocationListItem extends StatelessWidget {
             colors: [Colors.transparent, Colors.black.withOpacity(0.7)],
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
-            stops: [0.6, 0.95],
+            stops: const [0.6, 0.95],
           ),
         ),
       ),
@@ -763,7 +762,7 @@ class ParallaxFlowDelegate extends FlowDelegate {
 }
 
 class Parallax extends SingleChildRenderObjectWidget {
-  Parallax({
+  const Parallax({
     required Widget background,
   }) : super(child: background);
 


### PR DESCRIPTION
Removes the lint info warnings from https://docs.flutter.dev/cookbook/effects/parallax-scrolling

_Description of what this PR is changing or adding, and why:_ This PR removes the lint warnings from the Cookbook element below to be able to give a better overview to the new comers. Ohterwise Lint warnings might be confusing. 

_Issues fixed by this PR (if any):_ N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
