### PR TITLE
docs(cookbook): removed mention of `flutter_driver`

### DIFF
--- a/src/cookbook/testing/integration/introduction.md
+++ b/src/cookbook/testing/integration/introduction.md
@@ -115,7 +115,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
 ### 2. Add the `integration_test` dependency
 
-Next, use the `integration_test`, `flutter_driver`, and `flutter_test` packages
+Next, use the `integration_test` and `flutter_test` packages
 to write integration tests. Add these dependencies to the `dev_dependencies`
 section of the app's `pubspec.yaml` file, specifying the Flutter SDK as the
 location of the package.


### PR DESCRIPTION
 - integration test does not require to explicitly add `flutter_driver` as `dev_dependencies`

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
