### PR TITLE
Clarify bundling of package assets.

### DIFF
--- a/src/development/ui/assets-and-images.md
+++ b/src/development/ui/assets-and-images.md
@@ -297,6 +297,20 @@ flutter:
 The `lib/` is implied,
 so it should not be included in the asset path.
 
+If you are developing a package, to load an asset within the package, specify it in the 'pubspec.yaml' of the package:
+
+```yaml
+flutter:
+  assets:
+    - assets/images/
+```
+
+To load the image within your package, use:
+
+```dart
+return const AssetImage('packages/fancy_backgrounds/backgrounds/background1.png');
+```
+
 ## Sharing assets with the underlying platform
 
 Flutter assets are readily available to platform code


### PR DESCRIPTION
Clarify that the solution under 'Bundling of Package Assets' doesn't imply that you can still refer to that asset as you would in an app and not a package. It's a tad unclear:
https://stackoverflow.com/q/54740732/5229301



_Issues fixed by this PR (if any):_
 #6803