### PR TITLE
fix: Updated the get-started codelab

### DIFF
--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -571,8 +571,9 @@ lazily, on demand.
       }
     ```
 
- 4. We not have the `_RandomWordsState` class using a `ListView.builder`
-    rather than directly calling the word generation library.  ([`Scaffold`][]
+ 4. In the `_RandomWordsState` class, update the `build()` method to use
+    the `ListView.builder`, rather than directly calling the word
+    generation library. ([`Scaffold`][]
     implements the basic Material Design visual layout.)
     Replace the method body with the highlighted code:
 

--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -521,22 +521,23 @@ lazily, on demand.
 
     <?code-excerpt "lib/main.dart (itemBuilder)" title indent-by="2"?>
     ```dart
-      Widget _buildSuggestions() {
-        return ListView.builder(
-          padding: const EdgeInsets.all(16),
-          itemBuilder: /*1*/ (context, i) {
-            if (i.isOdd) {
-              return const Divider(); /*2*/
-            }
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16.0),
+        itemBuilder: /*1*/ (context, i) {
+          if (i.isOdd) return const Divider(); /*2*/
 
-            final index = i ~/ 2; /*3*/
-            if (index >= _suggestions.length) {
-              _suggestions.addAll(generateWordPairs().take(10)); /*4*/
-            }
-            return _buildRow(_suggestions[index]);
-          },
-        );
-      }
+          final index = i ~/ 2; /*3*/
+          if (index >= _suggestions.length) {
+            _suggestions.addAll(generateWordPairs().take(10)); /*4*/
+          }
+          return ListTile(
+            title: Text(
+              _suggestions[index].asPascalCase,
+              style: _biggerFont,
+            ),
+          );
+        },
+      ),
     ```
 
     {:.numbered-code-notes}
@@ -561,14 +562,12 @@ lazily, on demand.
 
     <?code-excerpt "lib/main.dart (listTile)" title indent-by="2"?>
     ```dart
-      Widget _buildRow(WordPair pair) {
-        return ListTile(
-          title: Text(
-            pair.asPascalCase,
-            style: _biggerFont,
-          ),
-        );
-      }
+      return ListTile(
+        title: Text(
+          _suggestions[index].asPascalCase,
+          style: _biggerFont,
+        ),
+      );
     ```
 
  4. In the `_RandomWordsState` class, update the `build()` method to use

--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -503,7 +503,7 @@ lazily, on demand.
       }
     ```
 
-    Next, you'll add a `_buildSuggestions()` function to the
+    Next, you'll add a `ListView.builder` widget to the
     `_RandomWordsState` class. This method builds the
     `ListView` that displays the suggested word pairing.
 
@@ -517,9 +517,9 @@ lazily, on demand.
     This model allows the suggested list to continue growing
     as the user scrolls.
 
- 2. Add a `_buildSuggestions()` function to the `_RandomWordsState` class:
+ 2. Add a `ListView.builder` widget to the `build` method of the `_RandomWordsState` class:
 
-    <?code-excerpt "lib/main.dart (_buildSuggestions)" title indent-by="2"?>
+    <?code-excerpt "lib/main.dart (build)" title indent-by="2"?>
     ```dart
       Widget _buildSuggestions() {
         return ListView.builder(
@@ -553,13 +553,13 @@ lazily, on demand.
      4. If you've reached the end of the available word pairings,
         then generate 10 more and add them to the suggestions list.
 
-    The `_buildSuggestions()` function calls `_buildRow()` once per
+    The `ListView.builder` wigets creates a `ListTile` once per
     word pair. This function displays each new pair in a `ListTile`,
     which allows you to make the rows more attractive in the next step.
 
- 3. Add a `_buildRow()` function to `_RandomWordsState`:
+ 3. Add a `ListTile` in the `itemBuilder` body of the `ListView.builder` in `_RandomWordsState`:
 
-    <?code-excerpt "lib/main.dart (_buildRow)" title indent-by="2"?>
+    <?code-excerpt "lib/main.dart (itemBuilder)" title indent-by="2"?>
     ```dart
       Widget _buildRow(WordPair pair) {
         return ListTile(
@@ -571,9 +571,8 @@ lazily, on demand.
       }
     ```
 
- 4. In the `_RandomWordsState` class, update the `build()` method to use
-    `_buildSuggestions()`, rather than directly calling the word
-    generation library.  ([`Scaffold`][]
+ 4. We not have the `_RandomWordsState` class using a `ListView.builder`
+    rather than directly calling the word generation library.  ([`Scaffold`][]
     implements the basic Material Design visual layout.)
     Replace the method body with the highlighted code:
 

--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -519,7 +519,7 @@ lazily, on demand.
 
  2. Add a `ListView.builder` widget to the `build` method of the `_RandomWordsState` class:
 
-    <?code-excerpt "lib/main.dart (build)" title indent-by="2"?>
+    <?code-excerpt "lib/main.dart (itemBuilder)" title indent-by="2"?>
     ```dart
       Widget _buildSuggestions() {
         return ListView.builder(
@@ -559,7 +559,7 @@ lazily, on demand.
 
  3. Add a `ListTile` in the `itemBuilder` body of the `ListView.builder` in `_RandomWordsState`:
 
-    <?code-excerpt "lib/main.dart (itemBuilder)" title indent-by="2"?>
+    <?code-excerpt "lib/main.dart (listTile)" title indent-by="2"?>
     ```dart
       Widget _buildRow(WordPair pair) {
         return ListTile(

--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -498,7 +498,7 @@ lazily, on demand.
     ```dart
       class _RandomWordsState extends State<RandomWords> {
         [!final _suggestions = <WordPair>[];!]
-        [!final _biggerFont = const TextStyle(fontSize: 18);!]
+        [!final _biggerFont = const TextStyle(fontSize: 18.0);!]
         // ···
       }
     ```
@@ -585,7 +585,23 @@ lazily, on demand.
         [!  appBar: AppBar(!]
         [!    title: const Text('Startup Name Generator'),!]
         [!  ),!]
-        [!  body: _buildSuggestions(),!]
+        [!  body: ListView.builder(!]
+        [!    padding: const EdgeInsets.all(16.0),!]
+        [!    itemBuilder: /*1*/ (context, i) {!]
+        [!      if (i.isOdd) return const Divider(); /*2*/!]
+
+        [!      final index = i ~/ 2; /*3*/!]
+        [!      if (index >= _suggestions.length) {!]
+        [!        _suggestions.addAll(generateWordPairs().take(10)); /*4*/!]
+        [!      }!]
+        [!      return ListTile(!]
+        [!        title: Text(!]
+        [!          _suggestions[index].asPascalCase,!]
+        [!          style: _biggerFont,!]
+        [!        ),!]
+        [!      );!]
+        [!    },!]
+        [!  ),!]
         [!);!]
       }
     ```
@@ -598,7 +614,7 @@ lazily, on demand.
     ```diff
     --- step3_stateful_widget/lib/main.dart
     +++ step4_infinite_list/lib/main.dart
-    @@ -13,27 +13,53 @@
+    @@ -13,27 +13,43 @@
        const MyApp({Key? key}) : super(key: key);
 
        @override
@@ -622,33 +638,7 @@ lazily, on demand.
 
      class _RandomWordsState extends State<RandomWords> {
     +  final _suggestions = <WordPair>[];
-    +  final _biggerFont = const TextStyle(fontSize: 18);
-    +
-    +  Widget _buildSuggestions() {
-    +    return ListView.builder(
-    +      padding: const EdgeInsets.all(16),
-    +      itemBuilder: /*1*/ (context, i) {
-    +        if (i.isOdd) {
-    +          return const Divider(); /*2*/
-    +        }
-    +
-    +        final index = i ~/ 2; /*3*/
-    +        if (index >= _suggestions.length) {
-    +          _suggestions.addAll(generateWordPairs().take(10)); /*4*/
-    +        }
-    +        return _buildRow(_suggestions[index]);
-    +      },
-    +    );
-    +  }
-    +
-    +  Widget _buildRow(WordPair pair) {
-    +    return ListTile(
-    +      title: Text(
-    +        pair.asPascalCase,
-    +        style: _biggerFont,
-    +      ),
-    +    );
-    +  }
+    +  final _biggerFont = const TextStyle(fontSize: 18.0);
     +
        @override
        Widget build(BuildContext context) {
@@ -658,7 +648,23 @@ lazily, on demand.
     +      appBar: AppBar(
     +        title: const Text('Startup Name Generator'),
     +      ),
-    +      body: _buildSuggestions(),
+    +      body: ListView.builder(
+    +        padding: const EdgeInsets.all(16.0),
+    +        itemBuilder: /*1*/ (context, i) {
+    +          if (i.isOdd) return const Divider(); /*2*/
+    +
+    +          final index = i ~/ 2; /*3*/
+    +          if (index >= _suggestions.length) {
+    +            _suggestions.addAll(generateWordPairs().take(10)); /*4*/
+    +          }
+    +          return ListTile(
+    +            title: Text(
+    +              _suggestions[index].asPascalCase,
+    +              style: _biggerFont,
+    +            ),
+    +          );
+    +        },
+    +      ),
     +    );
        }
      }


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Here we are with another try, hopefully the correct one!

Please @domesticmouse @khanhnwin help me in this PR is anything is wrong. You merged https://github.com/flutter/codelabs/pull/279 so the examples are now updated. I've updated submodules and the example itself

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
