### PR TITLE
fix: Added missing const constructor in SQLite example

### DIFF
--- a/examples/cookbook/persistence/sqlite/lib/main.dart
+++ b/examples/cookbook/persistence/sqlite/lib/main.dart
@@ -103,7 +103,7 @@ void main() async {
 
   // #docregion fido
   // Create a Dog and add it to the dogs table
-  var fido = Dog(
+  var fido = const Dog(
     id: 0,
     name: 'Fido',
     age: 35,

--- a/examples/cookbook/persistence/sqlite/lib/main.dart
+++ b/examples/cookbook/persistence/sqlite/lib/main.dart
@@ -143,7 +143,7 @@ class Dog {
   final String name;
   final int age;
 
-  Dog({
+  const Dog({
     required this.id,
     required this.name,
     required this.age,

--- a/examples/cookbook/persistence/sqlite/lib/step2.dart
+++ b/examples/cookbook/persistence/sqlite/lib/step2.dart
@@ -3,7 +3,7 @@ class Dog {
   final String name;
   final int age;
 
-  Dog({
+  const Dog({
     required this.id,
     required this.name,
     required this.age,

--- a/src/cookbook/persistence/sqlite.md
+++ b/src/cookbook/persistence/sqlite.md
@@ -217,7 +217,7 @@ Future<void> insertDog(Dog dog) async {
 <?code-excerpt "lib/main.dart (fido)"?>
 ```dart
 // Create a Dog and add it to the dogs table
-var fido = Dog(
+var fido = const Dog(
   id: 0,
   name: 'Fido',
   age: 35,
@@ -443,7 +443,7 @@ void main() async {
   }
 
   // Create a Dog and add it to the dogs table
-  var fido = Dog(
+  var fido = const Dog(
     id: 0,
     name: 'Fido',
     age: 35,

--- a/src/cookbook/persistence/sqlite.md
+++ b/src/cookbook/persistence/sqlite.md
@@ -77,7 +77,7 @@ class Dog {
   final String name;
   final int age;
 
-  Dog({
+  const Dog({
     required this.id,
     required this.name,
     required this.age,
@@ -170,7 +170,7 @@ class Dog {
   final String name;
   final int age;
 
-  Dog({
+  const Dog({
     required this.id,
     required this.name,
     required this.age,
@@ -477,7 +477,7 @@ class Dog {
   final String name;
   final int age;
 
-  Dog({
+  const Dog({
     required this.id,
     required this.name,
     required this.age,


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ There was a missing `const` constructor in a model class. It should be there since all fields are `final`, so the class is immutable

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
