### PR TITLE
Add migration guide for deprecating useDeleteButtonTooltip of chips

### DIFF
--- a/src/release/breaking-changes/chip-usedeletebuttontooltip-migration.md
+++ b/src/release/breaking-changes/chip-usedeletebuttontooltip-migration.md
@@ -1,0 +1,96 @@
+---
+title: Migrate useDeleteButtonTooltip to deleteButtonTooltipMessage of Chips
+description: Deprecated useDeleteButtonTooltip of chips that have a delete button in favor of deleteButtonTooltipMessage.
+---
+
+## Summary
+
+Using `useDeleteButtonTooltip` of any chip that has a delete button gives a
+deprecation warning, or no longer exists when referenced. This includes the
+`Chip`, `InputChip` and `RawChip` widget.
+
+## Context
+
+`useDeleteButtonTooltip` of `Chip`, `InputChip` and `RawChip` widget was
+deprecated in favor of `deleteButtonTooltipMessage`, as the latter can be used
+to disable the tooltip of the chip's delete button.
+
+## Description of change
+
+For displaying a tooltip for its delete button the chip widgets use the
+`Tooltip` widget, which has the ability to disable itself when an empty string
+is provided as the message to show on the tooltip window.
+
+This means that users can disable delete button tooltip of chips by providing an
+empty string to `deleteButtonTooltipMessage`.
+
+To avoid redundancy of the API, this change deprecated `useDeleteButtonTooltip`
+that was specifically introduced for this exact functionality. A flutter fix is
+available to help users migrate existing code from `useDeleteButtonTooltip` to
+`deleteButtonTooltipMessage`, depending on whether they explicity disabled the
+tooltip.
+
+## Migration guide
+
+By default, the tooltip of the delete button is always enabled. If you want to
+explicitly disable the tooltip, provide an empty string to
+`deleteButtonTooltipMessage`. The following code snippets show the migration
+changes, which are applicable for `Chip`, `InputChip` and `RawChip` widget.
+
+Code before migration:
+
+<!-- skip -->
+```dart
+Chip(
+  label: const Text('Disabled delete button tooltip'),
+  onDeleted: _handleDeleteChip,
+  useDeleteButtonTooltip: false,
+);
+
+RawChip(
+  label: const Text('Enabled delete button tooltip'),
+  onDeleted: _handleDeleteChip,
+  useDeleteButtonTooltip: true,
+);
+```
+
+Code after migration:
+
+<!-- skip -->
+```dart
+Chip(
+  label: const Text('Disabled delete button tooltip'),
+  onDeleted: _handleDeleteChip,
+  deleteButtonTooltipMessage: '',
+);
+
+RawChip(
+  label: const Text('Enabled delete button tooltip'),
+  onDeleted: _handleDeleteChip,
+);
+```
+
+## Timeline
+
+Landed in version: 2.11.0-0.1.pre<br>
+In stable release: not yet
+
+## References
+
+{% include docs/master-api.md %}
+
+API documentation:
+
+* [`Chip`][]
+* [`InputChip`][]
+* [`RawChip`][]
+
+Relevant PRs:
+
+* [Deprecate `useDeleteButtonTooltip` for Chips][]
+
+[`Chip`]: {{site.master-api}}/flutter/material/Chip-class.html
+[`InputChip`]: {{site.master-api}}/flutter/material/InputChip-class.html
+[`RawChip`]: {{site.master-api}}/flutter/material/RawChip-class.html
+
+[Deprecate `useDeleteButtonTooltip` for Chips]: {{site.repo.flutter}}/pull/96174

--- a/src/release/breaking-changes/chip-usedeletebuttontooltip-migration.md
+++ b/src/release/breaking-changes/chip-usedeletebuttontooltip-migration.md
@@ -7,35 +7,33 @@ description: Deprecated useDeleteButtonTooltip of chips that have a delete butto
 
 Using `useDeleteButtonTooltip` of any chip that has a delete button gives a
 deprecation warning, or no longer exists when referenced. This includes the
-`Chip`, `InputChip` and `RawChip` widget.
+`Chip`, `InputChip`, and `RawChip` widgets.
 
 ## Context
 
-`useDeleteButtonTooltip` of `Chip`, `InputChip` and `RawChip` widget was
+The `useDeleteButtonTooltip` of `Chip`, `InputChip`, and `RawChip` widgets is
 deprecated in favor of `deleteButtonTooltipMessage`, as the latter can be used
 to disable the tooltip of the chip's delete button.
 
 ## Description of change
 
-For displaying a tooltip for its delete button the chip widgets use the
-`Tooltip` widget, which has the ability to disable itself when an empty string
-is provided as the message to show on the tooltip window.
+The `deleteButtonTooltipMessage` property provides a message to the
+tooltip on the delete button of the chip widgets.
+Subsequently, a change was made such that providing an empty string to this
+property disables the tooltip.
 
-This means that users can disable delete button tooltip of chips by providing an
-empty string to `deleteButtonTooltipMessage`.
-
-To avoid redundancy of the API, this change deprecated `useDeleteButtonTooltip`
-that was specifically introduced for this exact functionality. A flutter fix is
-available to help users migrate existing code from `useDeleteButtonTooltip` to
-`deleteButtonTooltipMessage`, depending on whether they explicity disabled the
-tooltip.
+To avoid redundancy of the API, this change deprecated `useDeleteButtonTooltip`,
+which was introduced for this exact functionality. A [Flutter fix][] is
+available to help you migrate existing code from `useDeleteButtonTooltip` to
+`deleteButtonTooltipMessage`, if you explicity disabled the tooltip.
 
 ## Migration guide
 
-By default, the tooltip of the delete button is always enabled. If you want to
-explicitly disable the tooltip, provide an empty string to
-`deleteButtonTooltipMessage`. The following code snippets show the migration
-changes, which are applicable for `Chip`, `InputChip` and `RawChip` widget.
+By default, the tooltip of the delete button is always enabled.
+To explicitly disable the tooltip, provide an empty string to the
+`deleteButtonTooltipMessage` property.
+The following code snippets show the migration changes, which are applicable for
+`Chip`, `InputChip`, and `RawChip` widgets:
 
 Code before migration:
 
@@ -94,3 +92,4 @@ Relevant PRs:
 [`RawChip`]: {{site.master-api}}/flutter/material/RawChip-class.html
 
 [Deprecate `useDeleteButtonTooltip` for Chips]: {{site.repo.flutter}}/pull/96174
+[Flutter fix]: {{site.url}}/development/tools/flutter-fix

--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -12,6 +12,10 @@ release, and listed in alphabetical order:
 
 ### Not yet released to stable
 
+* [Migrate useDeleteButtonTooltip to deleteButtonTooltipMessage of Chips][]
+* [ThemeData's toggleableActiveColor property has been deprecated][]
+
+[Migrate useDeleteButtonTooltip to deleteButtonTooltipMessage of Chips]: {{site.url}}/release/breaking-changes/chip-usedeletebuttontooltip-migration
 [ThemeData's toggleableActiveColor property has been deprecated]: {{site.url}}/release/breaking-changes/toggleable-active-color
 
 ### Released in Flutter 2.10
@@ -45,7 +49,6 @@ release, and listed in alphabetical order:
 [Introducing package:flutter_lints]: {{site.url}}/release/breaking-changes/flutter-lints-package
 [Replace AnimationSheetBuilder.display with collate]: {{site.url}}/release/breaking-changes/animation-sheet-builder-display
 [ThemeData's accent properties have been deprecated]: {{site.url}}/release/breaking-changes/theme-data-accent-properties
-
 [Transition of platform channel test interfaces to flutter_test package]: {{site.url}}/release/breaking-changes/mock-platform-channels
 [Using HTML slots to render platform views in the web]: {{site.url}}/release/breaking-changes/platform-views-using-html-slots-web
 


### PR DESCRIPTION
As title states, adds a migration guide for the change made in PR https://github.com/flutter/flutter/pull/96174.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
