### PR TITLE
fix: missing master-api pages

### DIFF
--- a/src/release/breaking-changes/mock-platform-channels.md
+++ b/src/release/breaking-changes/mock-platform-channels.md
@@ -171,7 +171,7 @@ Relevant PRs:
 * [PR #76288: Migrate to ChannelBuffers.push][]
 
 <!-- Master channel link: -->
-[`TestDefaultBinaryMessenger`]: {{site.master-api}}/flutter/[link_to_relevant_page].html
-[`TestDefaultBinaryMessengerBinding`]: {{site.master-api}}/flutter/[link_to_relevant_page].html
+[`TestDefaultBinaryMessenger`]: {{site.master-api}}/flutter/flutter_test/TestDefaultBinaryMessenger-class.html
+[`TestDefaultBinaryMessengerBinding`]: {{site.master-api}}/flutter/flutter_test/TestDefaultBinaryMessengerBinding-mixin.html
 
 [PR #76288: Migrate to ChannelBuffers.push]: {{site.repo.flutter}}/pull/76288


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Add pages for classes `TestDefaultBinaryMessenger` and `TestDefaultBinaryMessengerBinding` on `/release/breaking-changes/mock-platform-channels/` page

_Issues fixed by this PR (if any):_

[#6815](https://github.com/flutter/website/issues/6815)

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
