### PR TITLE
Switch to material icon based external link icon in sidebar

### DIFF
--- a/src/_sass/base/_site_overrides.scss
+++ b/src/_sass/base/_site_overrides.scss
@@ -7,7 +7,7 @@
 
 // NOTE external link icons in toc were tiny - 
 // correct sizing and spacing
-.site-sidebar .nav-item .nav-link span {
+.site-sidebar .nav-item .nav-link span.material-icons {
   vertical-align: middle;
   margin-left: 5px;
   font-size: 12px;

--- a/src/_sass/base/_site_overrides.scss
+++ b/src/_sass/base/_site_overrides.scss
@@ -7,10 +7,12 @@
 
 // NOTE external link icons in toc were tiny - 
 // correct sizing and spacing
-.site-sidebar .nav-item .nav-link i {
-  color: rgba(0, 0, 0, 0.6);
-  margin-left: 7px;
-  font-size: 10px;
+.site-sidebar .nav-item .nav-link span {
+  vertical-align: middle;
+  margin-left: 5px;
+  font-size: 12px;
+  color: inherit;
+  opacity: 0.8;
 }
 
 // TODO this should be added to shared/toc


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ We've switched the icon from a FA based one to a Material Icon to be consistent on the dart.dev side. This introduces some new styles to keep it formatted properly.


_Issues fixed by this PR (if any):_ N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

New:
<img width="201" alt="image" src="https://user-images.githubusercontent.com/18372958/155229321-e8488cad-94e3-4c8c-91fd-25f5e64bbef4.png">
