### PR TITLE
Update site-shared to new main branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,4 +5,4 @@ _Issues fixed by this PR (if any):_
 ## Presubmit checklist
 - [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
 - [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
-- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
+- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

--- a/README.md
+++ b/README.md
@@ -286,14 +286,14 @@ For more information see [Code excerpts][] .
 
 The [site-shared](https://github.com/dart-lang/site-shared) repo 
 contains infrastructure shared by most of our Dart and Flutter websites. 
-Some of this README is in the [doc](https://github.com/dart-lang/site-shared/tree/master/doc)
+Some of this README is in the [doc](https://github.com/dart-lang/site-shared/tree/main/doc)
 directory in the site-shared repo.
 
 For more information on using and writing for this repo, refer to the following docs:
 
-* [Infrastructure](https://github.com/dart-lang/site-shared/blob/master/doc/infrastructure.md)
-* [Markdown](https://github.com/dart-lang/site-shared/blob/master/doc/markdown.md)
-* [Examples](https://github.com/dart-lang/site-shared/blob/master/doc/examples.md)
+* [Infrastructure](https://github.com/dart-lang/site-shared/blob/main/doc/infrastructure.md)
+* [Markdown](https://github.com/dart-lang/site-shared/blob/main/doc/markdown.md)
+* [Examples](https://github.com/dart-lang/site-shared/blob/main/doc/examples.md)
 * [Code excerpts][]
 
 Also check out the site-shared [wiki](https://github.com/dart-lang/site-shared/wiki):
@@ -311,10 +311,10 @@ Also check out the site-shared [wiki](https://github.com/dart-lang/site-shared/w
 [`firebase use` command]: https://firebase.googleblog.com/2016/07/deploy-to-multiple-environments-with.html
 [forking]: https://docs.github.com/en/get-started/quickstart/fork-a-repo
 [Flutter install]: https://docs.flutter.dev/get-started/install
-[Flutter logo]: https://github.com/dart-lang/site-shared/blob/master/src/_assets/image/flutter/icon/64.png?raw=1
+[Flutter logo]: https://github.com/dart-lang/site-shared/blob/main/src/_assets/image/flutter/icon/64.png?raw=1
 [Firebase]: https://firebase.google.com/
 [Google Developer Documentation Style Guidelines]: https://developers.google.com/style
 [DartPad embedding guide]: https://github.com/dart-lang/dart-pad/wiki/Embedding-Guide
 [`Makefile`]: https://github.com/flutter/website/blob/main/Makefile
 [Repo on GitHub Actions]: https://github.com/flutter/website/actions?query=workflow%3Abuild+branch%3Amaster
-[Code excerpts]: https://github.com/dart-lang/site-shared/blob/master/doc/code-excerpts.md
+[Code excerpts]: https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md

--- a/examples/_animation/README.md
+++ b/examples/_animation/README.md
@@ -11,4 +11,4 @@ As these changes are completed for a given app/sample folder, then move the
 folder into `examples/animation`. One `examples/_animation` is empty, it can be
 deleted.
 
-[Code excerpts]: https://github.com/dart-lang/site-shared/blob/master/doc/code-excerpts.md
+[Code excerpts]: https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md

--- a/examples/internationalization/README.md
+++ b/examples/internationalization/README.md
@@ -7,4 +7,4 @@ appear in some pages none-the-less. What needs to be done is the following:
   integrated as proper code excerpts. See [Code excerpts][] for details.
 - Each app/sample should be tested, at least with a smoke test.
 
-[Code excerpts]: https://github.com/dart-lang/site-shared/blob/master/doc/code-excerpts.md
+[Code excerpts]: https://github.com/dart-lang/site-shared/blob/main/doc/code-excerpts.md

--- a/src/release/breaking-changes/template.md
+++ b/src/release/breaking-changes/template.md
@@ -7,7 +7,7 @@ description: Brief description similar to the "context" section below. The descr
   PLEASE READ THESE GENERAL INSTRUCTIONS:
   * All lines of text should be 80 chars OR LESS.
     The writers strongly prefer semantic line breaks:
-    https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks
+    https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks
   * DON'T SUBMIT a PR weeks and weeks in advance.
     Doing this causes it to get stanky in the website
     repo and usually develops conflicts in the index file.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ site-shared has now switched to `main` as its primary branch. This updates the submodule to its latest commit and updates related links.

_Issues fixed by this PR (if any):_ N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
