### PR TITLE
Update unsupported Android platforms

### DIFF
--- a/src/development/tools/sdk/release-notes/supported-platforms.md
+++ b/src/development/tools/sdk/release-notes/supported-platforms.md
@@ -87,7 +87,7 @@ see [go/rfc-ios8-deprecation] for details.
 
 |Platform|Version               |
 |--------|----------------------|
-|Android |Android SDK 15 & below|
+|Android |Android SDK 18 & below|
 |iOS     |iOS 8 & below         |
 |Windows |Windows Vista & below |
 |Windows |Any 32-bit platform   |   


### PR DESCRIPTION
Above this table, it clearly states that we support 19 and above. We shouldn't leave 16, 17, and 18 in limbo :)

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
