### PR TITLE
Update add-to-app iOS arm64 simulator instructions

### DIFF
--- a/src/development/add-to-app/ios/project-setup.md
+++ b/src/development/add-to-app/ios/project-setup.md
@@ -420,8 +420,11 @@ for local network permission. The permission can also be allowed by enabling
 
 ## Apple Silicon (`arm64` Macs)
 
-Flutter does not yet support `arm64` iOS simulators. To run your host app on an Apple Silicon
-Mac, exclude `arm64` from the simulator architectures.
+On an Apple Silicon (M1) Mac, the host app will build for an `arm64` simulator.
+While Flutter does support `arm64` simulators, some plugins may not. If you use
+one of these plugins, you may see a compilation error like **Undefined symbols
+for architecture arm64** and you must exclude `arm64` from the simulator
+architectures in your host app.
 
 In your host app target, find the **Excluded Architectures** (`EXCLUDED_ARCHS`) build setting.
 Click the right arrow disclosure indicator icon to expand the available build configurations.

--- a/src/development/add-to-app/ios/project-setup.md
+++ b/src/development/add-to-app/ios/project-setup.md
@@ -420,9 +420,9 @@ for local network permission. The permission can also be allowed by enabling
 
 ## Apple Silicon (`arm64` Macs)
 
-On an Apple Silicon (M1) Mac, the host app will build for an `arm64` simulator.
-While Flutter does support `arm64` simulators, some plugins may not. If you use
-one of these plugins, you may see a compilation error like **Undefined symbols
+On an Apple Silicon (M1) Mac, the host app builds for an `arm64` simulator.
+While Flutter supports `arm64` simulators, some plugins might not. If you use
+one of these plugins, you might see a compilation error like **Undefined symbols
 for architecture arm64** and you must exclude `arm64` from the simulator
 architectures in your host app.
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Flutter has supported `arm64` iOS simulators since https://github.com/flutter/flutter/pull/85059. Users may still see issues when they use plugins that do not support `arm64` simulators (like google_sign_in or google_maps).

_Issues fixed by this PR (if any):_ Brought up in https://github.com/flutter/flutter/issues/99392

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
