### PR TITLE
Remove unnecessary import from `typing-indicator` cookbook

### DIFF
--- a/src/cookbook/effects/typing-indicator.md
+++ b/src/cookbook/effects/typing-indicator.md
@@ -465,7 +465,6 @@ import 'dart:math';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 
 void main() {
   runApp(


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ It removes an unused import in the typing indicator cookbook interactive example.

_Issues fixed by this PR (if any):_ #6880 

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
