### PR TITLE
Update top-menu link for What's New

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -91,7 +91,7 @@
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
               <a class="dropdown-item {% if route == '/' %} active{% endif %}"
-                 href="/#whats-new-on-this-site">What's New</a>
+                 href="/whats-new">What's New</a>
               <a class="dropdown-item {% if route contains '/get-started/editor' %} active{% endif %}"
                  href="/get-started/editor?tab=androidstudio">Editor Support</a>
               <a class="dropdown-item {% if route contains '/development/tools/hot-reload' %} active{% endif %}"


### PR DESCRIPTION
This now has its own page, so we should link to that directly
