### PR TITLE
comma to be followed by a space

### DIFF
--- a/examples/layout/constraints/lib/main.dart
+++ b/examples/layout/constraints/lib/main.dart
@@ -283,7 +283,7 @@ class Example3 extends Example {
       '   child: Container(width: 100, height: 100, color: red))';
   @override
   final String explanation =
-      'The screen forces the Center to be exactly the same size as the screen,'
+      'The screen forces the Center to be exactly the same size as the screen, '
       'so the Center fills the screen.'
       '\n\n'
       'The Center tells the Container that it can be any size it wants, but not bigger than the screen.'
@@ -339,7 +339,7 @@ class Example5 extends Example {
       '              height: double.infinity))';
   @override
   final String explanation =
-      'The screen forces the Center to be exactly the same size as the screen,'
+      'The screen forces the Center to be exactly the same size as the screen, '
       'so the Center fills the screen.'
       '\n\n'
       'The Center tells the Container that it can be any size it wants, but not bigger than the screen.'
@@ -365,7 +365,7 @@ class Example6 extends Example {
   final code = 'Center(child: Container(color: red))';
   @override
   final String explanation =
-      'The screen forces the Center to be exactly the same size as the screen,'
+      'The screen forces the Center to be exactly the same size as the screen, '
       'so the Center fills the screen.'
       '\n\n'
       'The Center tells the Container that it can be any size it wants, but not bigger than the screen.'
@@ -397,7 +397,7 @@ class Example7 extends Example {
       '      child: Container(color: green, width: 30, height: 30)))';
   @override
   final String explanation =
-      'The screen forces the Center to be exactly the same size as the screen,'
+      'The screen forces the Center to be exactly the same size as the screen, '
       'so the Center fills the screen.'
       '\n\n'
       'The Center tells the red Container that it can be any size it wants, but not bigger than the screen.'
@@ -1110,7 +1110,7 @@ class Example28 extends Example {
 
   @override
   final String explanation =
-      'The screen forces the Scaffold to be exactly the same size as the screen,'
+      'The screen forces the Scaffold to be exactly the same size as the screen, '
       'so the Scaffold fills the screen.'
       '\n\n'
       'The Scaffold tells the Container that it can be any size it wants, but not bigger than the screen.'

--- a/src/development/ui/layout/constraints.md
+++ b/src/development/ui/layout/constraints.md
@@ -401,7 +401,7 @@ class Example3 extends Example {
       '   child: Container(width: 100, height: 100, color: red))';
   @override
   final String explanation =
-      'The screen forces the Center to be exactly the same size as the screen,'
+      'The screen forces the Center to be exactly the same size as the screen, '
       'so the Center fills the screen.'
       '\n\n'
       'The Center tells the Container that it can be any size it wants, but not bigger than the screen.'
@@ -453,7 +453,7 @@ class Example5 extends Example {
       '              height: double.infinity))';
   @override
   final String explanation =
-      'The screen forces the Center to be exactly the same size as the screen,'
+      'The screen forces the Center to be exactly the same size as the screen, '
       'so the Center fills the screen.'
       '\n\n'
       'The Center tells the Container that it can be any size it wants, but not bigger than the screen.'
@@ -477,7 +477,7 @@ class Example6 extends Example {
   final code = 'Center(child: Container(color: red))';
   @override
   final String explanation =
-      'The screen forces the Center to be exactly the same size as the screen,'
+      'The screen forces the Center to be exactly the same size as the screen, '
       'so the Center fills the screen.'
       '\n\n'
       'The Center tells the Container that it can be any size it wants, but not bigger than the screen.'
@@ -507,7 +507,7 @@ class Example7 extends Example {
       '      child: Container(color: green, width: 30, height: 30)))';
   @override
   final String explanation =
-      'The screen forces the Center to be exactly the same size as the screen,'
+      'The screen forces the Center to be exactly the same size as the screen, '
       'so the Center fills the screen.'
       '\n\n'
       'The Center tells the red Container that it can be any size it wants, but not bigger than the screen.'
@@ -1178,7 +1178,7 @@ class Example28 extends Example {
 
   @override
   final String explanation =
-      'The screen forces the Scaffold to be exactly the same size as the screen,'
+      'The screen forces the Scaffold to be exactly the same size as the screen, '
       'so the Scaffold fills the screen.'
       '\n\n'
       'The Scaffold tells the Container that it can be any size it wants, but not bigger than the screen.'


### PR DESCRIPTION
The examples in [Understanding constraints](https://docs.flutter.dev/development/ui/layout/constraints) contain comma without a following space.

![image](https://user-images.githubusercontent.com/2410127/157207436-7940f9fa-788b-4e6a-9421-6373eaa4aaec.png)



## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
