### PR TITLE
Pin dependencies by hash.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install firebase tools
-        run: npm install -g firebase-tools
+        run: npm install -g firebase/firebase-tools#23dc81fd065f4cfaa172cff535cafdd9a8c11c23
       - name: Build
         run: make build
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ RUN bundle install
 # Install Node deps
 ENV NODE_ENV=development
 COPY package.json package-lock.json ./
-RUN npm install -g npm@8.5.3 firebase-tools@v10.2.2 superstatic@7.1.0
-RUN npm i re2@1.17.4
+RUN npm install -g npm/cli#f66290ecbbc1f766597013ed0d8e624455372de4 firebase/firebase-tools#23dc81fd065f4cfaa172cff535cafdd9a8c11c23 firebase/superstatic#2a85409ff30950a15e6da41d599a20b371e70c1d
+RUN npm i uhop/node-re2#6b1255ce38245805ff2502e320a567a3601f7459
 
 COPY ./ ./
 


### PR DESCRIPTION
Turns out that pinning by version is still considered a bad practice.
Updating npm pins to use hash.

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
