### PR TITLE
Correct site-shared branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "site-shared"]
 	path = site-shared
-	url = https://github.com/dart-lang/site-shared.git
-	branch = rearch
+	url = https://github.com/dart-lang/site-shared
+	branch = main
 [submodule "flutter"]
 	path = flutter
 	url = https://github.com/flutter/flutter


### PR DESCRIPTION
`rearch` is no longer a valid branch for [site-shared](https://github.com/dart-lang/site-shared), switch back to the main branch.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
