### PR TITLE
typo in codelab-web

### DIFF
--- a/src/get-started/codelab-web.md
+++ b/src/get-started/codelab-web.md
@@ -629,7 +629,7 @@ Now that you have DevTools running,
 select the **Debugger** tab in the blue bar along the top.
 The debugger pane appears and, in the lower left,
 see a list of libraries used in the example.
-Select `signin/main.dart` to display your Dart code
+Select `lib/main.dart` to display your Dart code
 in the center pane.
 
 {% indent %}


### PR DESCRIPTION
Fixes #6731

## Presubmit checklist
- [ x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
