### PR TITLE
Fix CODEOWNERS error

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sfshaza2 @khanhnwin @kwalrath @domesticmouse @johnpryan
+* @sfshaza2 @khanhnwin @domesticmouse @johnpryan


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ GitHub marks the CODEOWNERS file as having errors and being invalid due to @kwalrath no longer having write access 😞:

<img width="624" alt="image" src="https://user-images.githubusercontent.com/18372958/158353494-b4a4b7d9-88bd-41e9-b768-1eed396050d3.png">

This PR removes her old GitHub ID from the list to fix the error.

_Issues fixed by this PR (if any):_ N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
