### PR TITLE
Make AnimationStatus Consistent

### DIFF
--- a/examples/animation/animate3/lib/main.dart
+++ b/examples/animation/animate3/lib/main.dart
@@ -47,7 +47,7 @@ class _LogoAppState extends State<LogoApp> with SingleTickerProviderStateMixin {
         }
       })
       // #docregion print-state
-      ..addStatusListener((state) => print('$state'));
+      ..addStatusListener((status) => print('$status'));
     controller.forward();
   }
   // #enddocregion print-state

--- a/src/development/ui/animations/tutorial.md
+++ b/src/development/ui/animations/tutorial.md
@@ -572,7 +572,7 @@ class _LogoAppState extends State<LogoApp> with SingleTickerProviderStateMixin {
     controller =
         AnimationController(duration: const Duration(seconds: 2), vsync: this);
     animation = Tween<double>(begin: 0, end: 300).animate(controller)
-      [!..addStatusListener((state) => print('$state'));!]
+      [!..addStatusListener((status) => print('$status'));!]
     controller.forward();
   }
   // ...
@@ -607,7 +607,7 @@ at the beginning or the end. This creates a "breathing" effect:
 +          controller.forward();
 +        }
 +      })
-+      ..addStatusListener((state) => print('$state'));
++      ..addStatusListener((status) => print('$status'));
      controller.forward();
    }
 ```


### PR DESCRIPTION
Improves animation tutorial by consistently referring to the AnimationStatus as `status` in the code.
Fixes #6914