### PR TITLE
Update implicit animations page to use current code examples

### DIFF
--- a/src/_includes/docs/implicit-animations/fade-in-complete.md
+++ b/src/_includes/docs/implicit-animations/fade-in-complete.md
@@ -1,34 +1,42 @@
 ```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-532px:ga_id-fade_in_complete
 {$ begin main.dart $}
+// Copyright 2019 the Dart project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 
-const owl_url = 'https://raw.githubusercontent.com/flutter/website/master/src/images/owl.jpg';
+const owlUrl =
+    'https://raw.githubusercontent.com/flutter/website/master/src/images/owl.jpg';
 
 class FadeInDemo extends StatefulWidget {
+  const FadeInDemo({Key? key}) : super(key: key);
+
+  @override
   _FadeInDemoState createState() => _FadeInDemoState();
 }
 
 class _FadeInDemoState extends State<FadeInDemo> {
-  double opacityLevel = 0.0;
+  double opacity = 0.0;
 
   @override
   Widget build(BuildContext context) {
     return Column(children: <Widget>[
-      Image.network(owl_url),
+      Image.network(owlUrl),
       TextButton(
-        child: Text(
-          'Show details',
+        child: const Text(
+          'Show Details',
           style: TextStyle(color: Colors.blueAccent),
         ),
         onPressed: () => setState(() {
-          opacityLevel = 1.0;
+          opacity = 1;
         }),
       ),
       AnimatedOpacity(
-        duration: Duration(seconds: 3),
-        opacity: opacityLevel,
+        duration: const Duration(seconds: 2),
+        opacity: opacity,
         child: Column(
-          children: <Widget>[
+          children: const [
             Text('Type: Owl'),
             Text('Age: 39'),
             Text('Employment: None'),
@@ -40,10 +48,11 @@ class _FadeInDemoState extends State<FadeInDemo> {
 }
 
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
+    return const MaterialApp(
       home: Scaffold(
         body: Center(
           child: FadeInDemo(),
@@ -55,7 +64,7 @@ class MyApp extends StatelessWidget {
 
 void main() {
   runApp(
-    MyApp(),
+    const MyApp(),
   );
 }
 {$ end main.dart $}

--- a/src/_includes/docs/implicit-animations/fade-in-complete.md
+++ b/src/_includes/docs/implicit-animations/fade-in-complete.md
@@ -1,9 +1,5 @@
 ```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-532px:ga_id-fade_in_complete
 {$ begin main.dart $}
-// Copyright 2019 the Dart project authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license
-// that can be found in the LICENSE file.
-
 import 'package:flutter/material.dart';
 
 const owlUrl =

--- a/src/_includes/docs/implicit-animations/fade-in-starter-code.md
+++ b/src/_includes/docs/implicit-animations/fade-in-starter-code.md
@@ -1,10 +1,18 @@
 ```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-532px:ga_id-fade_in_starter_code
 {$ begin main.dart $}
+// Copyright 2019 the Dart project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 
-const owl_url = 'https://raw.githubusercontent.com/flutter/website/master/src/images/owl.jpg';
+const owlUrl =
+    'https://raw.githubusercontent.com/flutter/website/master/src/images/owl.jpg';
 
 class FadeInDemo extends StatefulWidget {
+  const FadeInDemo({Key? key}) : super(key: key);
+
+  @override
   _FadeInDemoState createState() => _FadeInDemoState();
 }
 
@@ -12,32 +20,30 @@ class _FadeInDemoState extends State<FadeInDemo> {
   @override
   Widget build(BuildContext context) {
     return Column(children: <Widget>[
-      Image.network(owl_url),
+      Image.network(owlUrl),
       TextButton(
-        child: Text(
-          'Show details',
-          style: TextStyle(color: Colors.blueAccent),
-        ),
-        onPressed: () => null,
-      ),
-      Container(
-        child: Column(
-          children: <Widget>[
-            Text('Type: Owl'),
-            Text('Age: 39'),
-            Text('Employment: None'),
-          ],
-        ),
+          child: const Text(
+            'Show Details',
+            style: TextStyle(color: Colors.blueAccent),
+          ),
+          onPressed: () => {}),
+      Column(
+        children: const [
+          Text('Type: Owl'),
+          Text('Age: 39'),
+          Text('Employment: None'),
+        ],
       )
     ]);
   }
 }
 
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
+    return const MaterialApp(
       home: Scaffold(
         body: Center(
           child: FadeInDemo(),
@@ -49,7 +55,7 @@ class MyApp extends StatelessWidget {
 
 void main() {
   runApp(
-    MyApp(),
+    const MyApp(),
   );
 }
 {$ end main.dart $}

--- a/src/_includes/docs/implicit-animations/fade-in-starter-code.md
+++ b/src/_includes/docs/implicit-animations/fade-in-starter-code.md
@@ -1,9 +1,5 @@
 ```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-532px:ga_id-fade_in_starter_code
 {$ begin main.dart $}
-// Copyright 2019 the Dart project authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license
-// that can be found in the LICENSE file.
-
 import 'package:flutter/material.dart';
 
 const owlUrl =

--- a/src/_includes/docs/implicit-animations/shape-shifting-complete.md
+++ b/src/_includes/docs/implicit-animations/shape-shifting-complete.md
@@ -1,9 +1,5 @@
 ```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px:ga_id-shape_shifting_complete
 {$ begin main.dart $}
-// Copyright 2019 the Dart project authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license
-// that can be found in the LICENSE file.
-
 import 'dart:math';
 
 import 'package:flutter/material.dart';

--- a/src/_includes/docs/implicit-animations/shape-shifting-complete.md
+++ b/src/_includes/docs/implicit-animations/shape-shifting-complete.md
@@ -1,5 +1,9 @@
 ```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px:ga_id-shape_shifting_complete
 {$ begin main.dart $}
+// Copyright 2019 the Dart project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -19,6 +23,9 @@ Color randomColor() {
 }
 
 class AnimatedContainerDemo extends StatefulWidget {
+  const AnimatedContainerDemo({Key? key}) : super(key: key);
+
+  @override
   _AnimatedContainerDemoState createState() => _AnimatedContainerDemoState();
 }
 
@@ -28,9 +35,9 @@ class _AnimatedContainerDemoState extends State<AnimatedContainerDemo> {
   late double margin;
 
   @override
-  void initState() {
+  initState() {
     super.initState();
-    color = Colors.deepPurple;
+    color = randomColor();
     borderRadius = randomBorderRadius();
     margin = randomMargin();
   }
@@ -62,7 +69,7 @@ class _AnimatedContainerDemoState extends State<AnimatedContainerDemo> {
               ),
             ),
             ElevatedButton(
-              child: Text('change'),
+              child: const Text('change'),
               onPressed: () => change(),
             ),
           ],
@@ -73,9 +80,11 @@ class _AnimatedContainerDemoState extends State<AnimatedContainerDemo> {
 }
 
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return const MaterialApp(
       debugShowCheckedModeBanner: false,
       home: AnimatedContainerDemo(),
     );
@@ -84,7 +93,7 @@ class MyApp extends StatelessWidget {
 
 void main() {
   runApp(
-    MyApp(),
+    const MyApp(),
   );
 }
 {$ end main.dart $}

--- a/src/_includes/docs/implicit-animations/shape-shifting-starter-code.md
+++ b/src/_includes/docs/implicit-animations/shape-shifting-starter-code.md
@@ -1,5 +1,9 @@
 ```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px:ga_id-shape_shifting_starter_code
 {$ begin main.dart $}
+// Copyright 2019 the Dart project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -17,6 +21,9 @@ Color randomColor() {
 }
 
 class AnimatedContainerDemo extends StatefulWidget {
+  const AnimatedContainerDemo({Key? key}) : super(key: key);
+
+  @override
   _AnimatedContainerDemoState createState() => _AnimatedContainerDemoState();
 }
 
@@ -51,8 +58,8 @@ class _AnimatedContainerDemoState extends State<AnimatedContainerDemo> {
               ),
             ),
             ElevatedButton(
-              child: Text('change'),
-              onPressed: () => null,
+              child: const Text('change'),
+              onPressed: () => {},
             ),
           ],
         ),
@@ -62,9 +69,11 @@ class _AnimatedContainerDemoState extends State<AnimatedContainerDemo> {
 }
 
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return const MaterialApp(
       debugShowCheckedModeBanner: false,
       home: AnimatedContainerDemo(),
     );
@@ -73,7 +82,7 @@ class MyApp extends StatelessWidget {
 
 void main() {
   runApp(
-    MyApp(),
+    const MyApp(),
   );
 }
 {$ end main.dart $}

--- a/src/_includes/docs/implicit-animations/shape-shifting-starter-code.md
+++ b/src/_includes/docs/implicit-animations/shape-shifting-starter-code.md
@@ -1,9 +1,5 @@
 ```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px:ga_id-shape_shifting_starter_code
 {$ begin main.dart $}
-// Copyright 2019 the Dart project authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license
-// that can be found in the LICENSE file.
-
 import 'dart:math';
 
 import 'package:flutter/material.dart';


### PR DESCRIPTION
Fixes the implicit animation page's linting error by updating the iframe code to use the correct starter / complete code from the examples folder. 
Fixes #6897