### PR TITLE
remove redundant link to archive.js

### DIFF
--- a/src/development/tools/sdk/releases.md
+++ b/src/development/tools/sdk/releases.md
@@ -3,8 +3,6 @@ title: Flutter SDK releases
 short-title: Releases
 description: All current Flutter SDK releases, stable, beta, and master.
 toc: false
-js:
-  - url: /assets/js/archive.js
 ---
 
 <style>


### PR DESCRIPTION
In https://github.com/flutter/website/pull/6195, the JavaScript file archive.js was added globally to the site. This file was already explicitly required from the releases page https://github.com/flutter/website/blame/main/src/development/tools/sdk/releases.md#L7. This resulted in the JS file being included twice on that page. This script writes rows to the release table; thus, with the script running twice, it would write the entire set of releases twice to the table.

_Issues fixed by this PR (if any):_ Fixes https://github.com/flutter/website/issues/6930

I ran this locally and confirmed that the release table looks correct.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
