### PR TITLE
[cookbook] Update websocket URL.

### DIFF
--- a/examples/cookbook/networking/web_sockets/lib/main.dart
+++ b/examples/cookbook/networking/web_sockets/lib/main.dart
@@ -34,7 +34,7 @@ class _MyHomePageState extends State<MyHomePage> {
   final TextEditingController _controller = TextEditingController();
   // #docregion connect
   final _channel = WebSocketChannel.connect(
-    Uri.parse('wss://echo.websocket.org'),
+    Uri.parse('wss://echo.websocket.events'),
   );
   // #enddocregion connect
 

--- a/src/cookbook/networking/web-sockets.md
+++ b/src/cookbook/networking/web-sockets.md
@@ -41,7 +41,7 @@ create a `WebSocketChannel` that connects to a server:
 <?code-excerpt "lib/main.dart (connect)" replace="/_channel/channel/g"?>
 ```dart
 final channel = WebSocketChannel.connect(
-  Uri.parse('wss://echo.websocket.org'),
+  Uri.parse('wss://echo.websocket.events'),
 );
 ```
 
@@ -148,7 +148,7 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   final TextEditingController _controller = TextEditingController();
   final _channel = WebSocketChannel.connect(
-    Uri.parse('wss://echo.websocket.org'),
+    Uri.parse('wss://echo.websocket.events'),
   );
 
   @override


### PR DESCRIPTION
The old websocket URL used by the cookbook (`wss://echo.websocket.org`) has been taken down.

This PR updates it with a working echo websocket (`wss://echo.websocket.events`), graciously provided by Lob, here:

* [Lob.com Engineering Blog > Websocket.org Is Down, Here Is an Alternative](https://www.lob.com/blog/websocket-org-is-down-here-is-an-alternative) 

_Issues fixed by this PR (if any):_

Fixes https://github.com/flutter/website/issues/6382

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
