### PR TITLE
Fixed broken store link, removed hardcoded language location from URLs

### DIFF
--- a/src/deployment/windows.md
+++ b/src/deployment/windows.md
@@ -123,17 +123,17 @@ To validate the application:
 The report may contain important warnings and information, 
 even if the certification passes. 
 
-[azureadassociation]: https://docs.microsoft.com/en-us/windows/uwp/publish/associate-azure-ad-with-partner-center
+[azureadassociation]: https://docs.microsoft.com/windows/uwp/publish/associate-azure-ad-with-partner-center
 [cmworkfloweditor]: https://docs.codemagic.io/flutter-publishing/publishing-to-microsoft-store/
 [cmyaml]: https://docs.codemagic.io/yaml-publishing/microsoft-store/
 [codemagic]: https://codemagic.io/start/
-[microsoftstore]: https://www.microsoft.com/en-us/store/apps/windows/
-[microsoftpartner]: https://partner.microsoft.com/en-GB/
+[microsoftstore]: https://www.microsoft.com/store/apps/windows
+[microsoftpartner]: https://partner.microsoft.com/
 [msix package]: {{site.pub}}/packages/msix
 [msix packaging]: {{site.url}}/desktop#msix-packaging
-[partnercenterapi]: https://docs.microsoft.com/en-us/azure/marketplace/azure-app-apis
-[storepolicies]: https://docs.microsoft.com/en-us/windows/uwp/publish/store-policies/
-[visualstudiopackaging]: https://docs.microsoft.com/en-us/windows/msix/package/packaging-uwp-apps
-[visualstudiosubmission]: https://docs.microsoft.com/en-us/windows/msix/package/packaging-uwp-apps#automate-store-submissions
-[windowspackageversioning]: https://docs.microsoft.com/en-us/windows/uwp/publish/package-version-numbering
-[windowsappcertification]: https://docs.microsoft.com/en-us/windows/uwp/debug-test-perf/windows-app-certification-kit
+[partnercenterapi]: https://docs.microsoft.com/azure/marketplace/azure-app-apis
+[storepolicies]: https://docs.microsoft.com/windows/uwp/publish/store-policies/
+[visualstudiopackaging]: https://docs.microsoft.com/windows/msix/package/packaging-uwp-apps
+[visualstudiosubmission]: https://docs.microsoft.com/windows/msix/package/packaging-uwp-apps#automate-store-submissions
+[windowspackageversioning]: https://docs.microsoft.com/windows/uwp/publish/package-version-numbering
+[windowsappcertification]: https://docs.microsoft.com/windows/uwp/debug-test-perf/windows-app-certification-kit


### PR DESCRIPTION
Removing the en-us allows the site to localize to whatever language the user has their browser set to rather than forcing the English version.

_Description of what this PR is changing or adding, and why:_
Fix broken link and remove hardcoded language identifiers

_Issues fixed by this PR (if any):_
Link fixed.
User can now view content at these links based on their selected language preference.

## Presubmit checklist
- [x ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
