### PR TITLE
Link to new brand page from trademark guidelines

### DIFF
--- a/src/brand/index.md
+++ b/src/brand/index.md
@@ -15,8 +15,8 @@ as determined by Google.
 Use of the Flutter trademarks that is not expressly permitted by these
 guidelines is prohibited absent written permission from Google.
 
-The official Flutter logos can be found in the [Flutter and Dart logo
-assets](https://drive.google.com/corp/drive/folders/1KXNtO9My2AMpDOF9A9Y_4aj4_BcgmDDT).
+The official Flutter assets and further guidelines on representing the brand
+can be found at [Representing the Flutter Brand]({{site.main-url}}/brand).
 
 ## General Rules That Govern the Use of the Flutter Trademarks
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ The new brand page has the most up to date design guidelines and assets, so this updates the brand trademark guidelines to link to there.

_Issues fixed by this PR (if any):_ N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
