### PR TITLE
Fixed typo in intro to integration testing doc

### DIFF
--- a/src/cookbook/testing/integration/introduction.md
+++ b/src/cookbook/testing/integration/introduction.md
@@ -142,7 +142,7 @@ counter_app/
 
 ### 4. Write the integration test
 
-Now you can write tests. This involves four steps:
+Now you can write tests. This involves three steps:
 
   1. Initialize `IntegrationTestWidgetsFlutterBinding`, a singleton service that
      executes tests on a physical device.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Fixed typo in step 4 (Write the integration test).
There are 3 steps to write integration test in documentation but the line under title was saying four.

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
