### PR TITLE
Mark 32-bit iOS platform as unsupported

### DIFF
--- a/src/development/tools/sdk/release-notes/supported-platforms.md
+++ b/src/development/tools/sdk/release-notes/supported-platforms.md
@@ -78,17 +78,15 @@ minimal.
 |Windows |Windows 7      |
 |Linux   |Debian & below |
 
-We have dropped iOS8 support. For more information,
-see [go/rfc-ios8-deprecation] for details.
-
-[go/rfc-ios8-deprecation]: {{site.url}}/go/rfc-ios8-deprecation
-
 ### Unsupported platforms
 
 |Platform|Version               |
 |--------|----------------------|
 |Android |Android SDK 18 & below|
-|iOS     |iOS 8 & below         |
+|iOS     |[iOS 8] & below and [`arm7v` 32-bit iOS]|
 |Windows |Windows Vista & below |
 |Windows |Any 32-bit platform   |   
 |macOS   | Yosemite & below     |
+
+[iOS 8]: {{site.url}}/go/rfc-ios8-deprecation
+[`arm7v` 32-bit iOS]: {{site.url}}/go/rfc-32-bit-ios-unsupported

--- a/src/development/tools/sdk/release-notes/supported-platforms.md
+++ b/src/development/tools/sdk/release-notes/supported-platforms.md
@@ -80,13 +80,13 @@ minimal.
 
 ### Unsupported platforms
 
-|Platform|Version               |
-|--------|----------------------|
-|Android |Android SDK 18 & below|
+|Platform|Version                                 |
+|--------|----------------------------------------|
+|Android |Android SDK 18 & below                  |
 |iOS     |[iOS 8] & below and [`arm7v` 32-bit iOS]|
-|Windows |Windows Vista & below |
-|Windows |Any 32-bit platform   |   
-|macOS   | Yosemite & below     |
+|Windows |Windows Vista & below                   |
+|Windows |Any 32-bit platform                     |   
+|macOS   | Yosemite & below                       |
 
 [iOS 8]: {{site.url}}/go/rfc-ios8-deprecation
 [`arm7v` 32-bit iOS]: {{site.url}}/go/rfc-32-bit-ios-unsupported


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Indicate that 32-bit iOS is now unsupported.

https://github.com/flutter/flutter/pull/97341 just merged so it will technically still work until that hits stable, but it's certainly untested as of https://github.com/flutter/flutter/pull/97385

_Issues fixed by this PR (if any):_ Fixes https://github.com/flutter/website/issues/6729

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
