### PR TITLE
Add-to-app iOS flutter_post_install post_install documentation

### DIFF
--- a/src/development/add-to-app/ios/project-setup.md
+++ b/src/development/add-to-app/ios/project-setup.md
@@ -164,6 +164,26 @@ end
 
 <li markdown="1">
 
+In the `Podfile` `post_install` block, call `flutter_post_install(installer)`.
+
+<!--code-excerpt "MyApp/Podfile" title-->
+```ruby
+post_install do |installer|
+  flutter_post_install(installer) if defined?(flutter_post_install)
+end
+```
+
+{{site.alert.note}}
+  The `flutter_post_install` method has been recently added to Flutter, and
+  adds build settings to support native Apple Silicon `arm64` iOS simulators.
+  Include `if defined?(flutter_post_install)` to ensure your `Podfile`
+  is valid if you are running on older versions of Flutter that do not have this method.
+{{site.alert.end}}
+
+</li>
+
+<li markdown="1">
+
 Run `pod install`.
 
 {{site.alert.note}}

--- a/src/development/add-to-app/ios/project-setup.md
+++ b/src/development/add-to-app/ios/project-setup.md
@@ -174,10 +174,10 @@ end
 ```
 
 {{site.alert.note}}
-  The `flutter_post_install` method has been recently added to Flutter, and
+  The `flutter_post_install` method (recently added to Flutter),
   adds build settings to support native Apple Silicon `arm64` iOS simulators.
-  Include `if defined?(flutter_post_install)` to ensure your `Podfile`
-  is valid if you are running on older versions of Flutter that do not have this method.
+  Include the `if defined?(flutter_post_install)` check to ensure your `Podfile`
+  is valid if you are running on older versions of Flutter that don't have this method.
 {{site.alert.end}}
 
 </li>

--- a/src/development/add-to-app/ios/project-setup.md
+++ b/src/development/add-to-app/ios/project-setup.md
@@ -164,7 +164,7 @@ end
 
 <li markdown="1">
 
-In the `Podfile` `post_install` block, call `flutter_post_install(installer)`.
+In the `Podfile`'s `post_install` block, call `flutter_post_install(installer)`.
 
 <!--code-excerpt "MyApp/Podfile" title-->
 ```ruby


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Add-to-app host `Podfile`s will be required to call `flutter_post_install(installer)` when https://github.com/flutter/flutter/pull/101943 merges.  The addition of `defined?(flutter_post_install)` will allow `pod install` to succeed on versions of Flutter that do not yet have `flutter_post_install` available.

_Issues fixed by this PR (if any):_ None

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
