### PR TITLE
Fix broken link on a migration guide

### DIFF
--- a/src/release/breaking-changes/scribble-text-input-client.md
+++ b/src/release/breaking-changes/scribble-text-input-client.md
@@ -98,4 +98,4 @@ Relevant PRs:
 
 [24224: Support Scribble Handwriting (engine)]: {{site.github}}/flutter/engine/pull/24224
 [97437: Re-land Support Scribble Handwriting]: {{site.github}}/flutter/flutter/pull/97437
-[75472: Support Scribble Handwriting]: ({{site.github}}/flutter/flutter/pull/75472)
+[75472: Support Scribble Handwriting]: {{site.github}}/flutter/flutter/pull/75472


### PR DESCRIPTION
Just fixing a broken link where it seems the markdown got messed up.

Fixes https://github.com/flutter/website/issues/7033