### PR TITLE
[Content update] src/get-started/flutter-for/web-devs.md

### DIFF
--- a/src/get-started/flutter-for/web-devs.md
+++ b/src/get-started/flutter-for/web-devs.md
@@ -863,10 +863,10 @@ with some formatting characteristics.
 To display text that uses multiple styles
 (in this example, a single word with emphasis),
 use a [`RichText`][]widget instead.
-Its `text` property can specify one or more [`TextSpan`][] widgets
+Its `text` property can specify one or more [`TextSpan`][]
 that can be individually styled.
 
-In the following example, "Lorem" is in a `TextSpan` widget
+In the following example, "Lorem" is in a `TextSpan`
 with the default (inherited) text styling,
 and "ipsum" is in a separate `TextSpan` with custom styling.
 

--- a/src/get-started/flutter-for/web-devs.md
+++ b/src/get-started/flutter-for/web-devs.md
@@ -863,7 +863,7 @@ with some formatting characteristics.
 To display text that uses multiple styles
 (in this example, a single word with emphasis),
 use a [`RichText`][]widget instead.
-Its `text` property can specify one or more [`TextSpan`][]
+Its `text` property can specify one or more [`TextSpan`][]s
 that can be individually styled.
 
 In the following example, "Lorem" is in a `TextSpan`

--- a/src/get-started/flutter-for/web-devs.md
+++ b/src/get-started/flutter-for/web-devs.md
@@ -863,8 +863,8 @@ with some formatting characteristics.
 To display text that uses multiple styles
 (in this example, a single word with emphasis),
 use a [`RichText`][]widget instead.
-Its `text` property can specify one or more [`TextSpan`][]s
-that can be individually styled.
+Its `text` property can specify one or more
+[`TextSpan`][] objects that can be individually styled.
 
 In the following example, "Lorem" is in a `TextSpan`
 with the default (inherited) text styling,


### PR DESCRIPTION
Continue from #7009, and should be the last about the web.

`TextSpan` is not a `Widget`, the PR corrects the description.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
