### PR TITLE
Add missing space to web dev page

### DIFF
--- a/src/get-started/flutter-for/web-devs.md
+++ b/src/get-started/flutter-for/web-devs.md
@@ -862,7 +862,7 @@ A [`Text`][] widget lets you display text
 with some formatting characteristics.
 To display text that uses multiple styles
 (in this example, a single word with emphasis),
-use a [`RichText`][]widget instead.
+use a [`RichText`][] widget instead.
 Its `text` property can specify one or more [`TextSpan`][] widgets
 that can be individually styled.
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Adds a missing space.

_Issues fixed by this PR (if any):_ N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
