### PR TITLE
Update dart tool info

### DIFF
--- a/src/reference/flutter-cli.md
+++ b/src/reference/flutter-cli.md
@@ -4,7 +4,8 @@ description: "The reference page for using 'flutter' in a terminal window."
 ---
 
 The `flutter` command-line tool is how developers (or IDEs on behalf of
-developers) interact with Flutter.
+developers) interact with Flutter. For Dart related commands,
+you can use the [`dart`][] command-line tool.
 
 Here's how you might use the `flutter` tool to create, analyze, test, and run an
 app:
@@ -45,7 +46,7 @@ The following table shows which commands you can use with the `flutter` tool:
 |---------+--------------------------------+-----------------------------------|
 | Command | Example of use                 | More information                  |
 |---------|--------------------------------|-----------------------------------|
-| analyze | `flutter analyze -d <DEVICE_ID>`     | Analyzes the project's Dart source code.<br>Use instead of [`dartanalyzer`][]. |
+| analyze | `flutter analyze -d <DEVICE_ID>`     | Analyzes the project's Dart source code.<br>Use instead of [`dart analyze`][]. |
 | assemble | `flutter assemble -o <DIRECTORY>` | Assemble and build flutter resources. |
 | attach | `flutter attach -d <DEVICE_ID>` | Attach to a running application. |
 | bash-completion | `flutter bash-completion` | Output command line shell completion setup scripts. |
@@ -58,12 +59,12 @@ The following table shows which commands you can use with the `flutter` tool:
 | downgrade | `flutter downgrade` | Downgrade Flutter to the last active version for the current channel. |
 | drive | `flutter drive` | Runs Flutter Driver tests for the current project. |
 | emulators | `flutter emulators` | List, launch and create emulators. |
-| format  | `flutter format <DIRECTORY|DART_FILE>` | Formats Flutter source code.<br>Use instead of [`dartfmt`][]. | 
+| format  | `flutter format <DIRECTORY|DART_FILE>` | Formats Flutter source code.<br>Use instead of [`dart format`][]. | 
 | gen-l10n | `flutter gen-l10n <DIRECTORY>` | Generate localizations for the Flutter project. |
 | install | `flutter install -d <DEVICE_ID>` | Install a Flutter app on an attached device. |
 | logs | `flutter logs` | Show log output for running Flutter apps. | 
 | precache | `flutter precache <ARGUMENTS>` | Populates the Flutter tool's cache of binary artifacts. |
-| pub     | `flutter pub <PUB_COMMAND>`       | Works with packages.<br>Use instead of [`pub`][]. | 
+| pub     | `flutter pub <PUB_COMMAND>`       | Works with packages.<br>Use instead of [`dart pub`][]. | 
 | run     | `flutter run <DART_FILE>`         | Runs a Flutter program. | 
 | symbolize | `flutter symbolize --input=<STACK_TRACK_FILE>` | Symbolize a stack trace from the AOT compiled flutter application. |
 | test    | `flutter test [<DIRECTORY|DART_FILE>]` | Runs tests in this package.<br>Use instead of [`pub run test`][`pub`]. |
@@ -75,6 +76,7 @@ or follow the links in the **More information** column.
 You can also get details on `pub` commands — for example,
 `flutter help pub outdated`.
 
-[`dartanalyzer`]: {{site.dart-site}}/tools/dartanalyzer
-[`dartfmt`]: {{site.dart-site}}/tools/dartfmt
-[`pub`]: {{site.dart-site}}/tools/pub/cmd
+[`dart`]: {{site.dart-site}}/tools/dart-tool
+[`dart analyze`]: {{site.dart-site}}/tools/dart-analyze
+[`dart format`]: {{site.dart-site}}/tools/dart-format
+[`dart pub`]: {{site.dart-site}}/tools/dart-pub

--- a/src/reference/flutter-cli.md
+++ b/src/reference/flutter-cli.md
@@ -18,7 +18,7 @@ $ flutter test
 $ flutter run lib/main.dart
 ```
 
-To run [`pub`][] commands using the `flutter` tool:
+To run [`pub`][`dart pub`] commands using the `flutter` tool:
 
 ```terminal
 $ flutter pub get

--- a/src/reference/flutter-cli.md
+++ b/src/reference/flutter-cli.md
@@ -67,7 +67,7 @@ The following table shows which commands you can use with the `flutter` tool:
 | pub     | `flutter pub <PUB_COMMAND>`       | Works with packages.<br>Use instead of [`dart pub`][]. | 
 | run     | `flutter run <DART_FILE>`         | Runs a Flutter program. | 
 | symbolize | `flutter symbolize --input=<STACK_TRACK_FILE>` | Symbolize a stack trace from the AOT compiled flutter application. |
-| test    | `flutter test [<DIRECTORY|DART_FILE>]` | Runs tests in this package.<br>Use instead of [`pub run test`][`pub`]. |
+| test    | `flutter test [<DIRECTORY|DART_FILE>]` | Runs tests in this package.<br>Use instead of [`dart test`][`dart test`]. |
 | upgrade | `flutter upgrade` | Upgrade your copy of Flutter. |
 {:.table .table-striped .nowrap}
 
@@ -80,3 +80,4 @@ You can also get details on `pub` commands — for example,
 [`dart analyze`]: {{site.dart-site}}/tools/dart-analyze
 [`dart format`]: {{site.dart-site}}/tools/dart-format
 [`dart pub`]: {{site.dart-site}}/tools/dart-pub
+[`dart test`]: {{site.dart-site}}/tools/dart-test


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
- Adds a more prominent cross-link to the `dart` tool as some mentioned having trouble locating docs for that
- Fixes a few outdated dart links

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [v] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [v] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [v] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
