### PR TITLE
replace launch (deprecated) with launchUrl

### DIFF
--- a/examples/development/plugin_api_migration/lib/url_launcher.dart
+++ b/examples/development/plugin_api_migration/lib/url_launcher.dart
@@ -3,6 +3,7 @@
 // #docregion UrlLauncher
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:path/path.dart' as p;
 
 void main() {
   runApp(const MyApp());
@@ -23,7 +24,7 @@ class DemoPage extends StatelessWidget {
   const DemoPage({Key? key}) : super(key: key);
 
   launchURL() {
-    launch('https://flutter.dev');
+    launchUrl(p.toUri('https://flutter.dev'));
   }
 
   @override

--- a/src/development/packages-and-plugins/using-packages.md
+++ b/src/development/packages-and-plugins/using-packages.md
@@ -379,6 +379,7 @@ To use this plugin:
     ```dart
     import 'package:flutter/material.dart';
     import 'package:url_launcher/url_launcher.dart';
+    import 'package:path/path.dart' as p;
 
     void main() {
       runApp(const MyApp());
@@ -399,7 +400,7 @@ To use this plugin:
       const DemoPage({Key? key}) : super(key: key);
 
       launchURL() {
-        launch('https://flutter.dev');
+        launchUrl(p.toUri('https://flutter.dev'));
       }
 
       @override


### PR DESCRIPTION
**IMPORTANT:** Due to work on the flutter.dev infrastructure, **all open pull requests will be closed April 29.**

If your PR needs to be merged by April 29, please say that in your PR. 

Otherwise, please [file an issue](https://github.com/flutter/website/issues/new/choose) about the needed change, and (if you submit a PR) be prepared to recreate the PR May 11 or later.

---

_Description of what this PR is changing or adding, and why:_ Stable build is failing because launch has been deprecated so `dart analyze` fails. 

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
