### PR TITLE
Fix text-field-material-localizations.md

### DIFF
--- a/src/release/breaking-changes/text-field-material-localizations.md
+++ b/src/release/breaking-changes/text-field-material-localizations.md
@@ -49,7 +49,9 @@ class Foo extends StatelessWidget {
       data: const MediaQueryData(),
       child: Directionality(
         textDirection: TextDirection.ltr,
-        child: TextField(),
+        child: Material(
+          child: TextField(),
+        ),
       ),
     );
   }
@@ -67,7 +69,9 @@ class Foo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: TextField(),
+      home: Material(
+        child: TextField(),
+      ),
     );
   }
 }
@@ -85,7 +89,7 @@ class Foo extends StatelessWidget {
   Widget build(BuildContext context) {
     return Localizations(
       locale: const Locale('en', 'US'),
-      delegates: <LocalizationsDelegate<dynamic>>[
+      delegates: const <LocalizationsDelegate<dynamic>>[
         DefaultWidgetsLocalizations.delegate,
         DefaultMaterialLocalizations.delegate,
       ],
@@ -93,7 +97,9 @@ class Foo extends StatelessWidget {
         data: const MediaQueryData(),
         child: Directionality(
           textDirection: TextDirection.ltr,
-          child: TextField(),
+          child: Material(
+            child: TextField(),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Please merge before April 29

_Issues fixed by this PR (if any): Fixes #6590

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
