### PR TITLE
Updating docs: Cleanup and embedded video

### DIFF
--- a/src/_data/docs_cards.yml
+++ b/src/_data/docs_cards.yml
@@ -1,10 +1,10 @@
-- name: Get Started
+- name: Get started
   description: Set up your environment and start building.
   url: /get-started/install
-- name: Widgets Catalog
+- name: Widgets catalog
   description: Dip into the rich set of Flutter widgets available in the SDK.
   url: /development/ui/widgets
-- name: API Docs
+- name: API docs
   description: Bookmark the API reference docs for the Flutter framework.
   url: https://api.flutter.dev/
 - name: Cookbook

--- a/src/development/packages-and-plugins/using-packages.md
+++ b/src/development/packages-and-plugins/using-packages.md
@@ -33,9 +33,9 @@ an app without having to develop everything from scratch.
     or any combination thereof.
     For example, a plugin might provide Flutter apps
     with the ability to use a device's camera.
-{{site.alert.end}}
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/Y9WifT8aN6o?start=1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/Y9WifT8aN6o?start=1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+{{site.alert.end}}
 
 Existing packages enable many use cases—for example,
 making network requests ([`http`][]),

--- a/src/development/packages-and-plugins/using-packages.md
+++ b/src/development/packages-and-plugins/using-packages.md
@@ -35,6 +35,8 @@ an app without having to develop everything from scratch.
     with the ability to use a device's camera.
 {{site.alert.end}}
 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/Y9WifT8aN6o?start=1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 Existing packages enable many use cases—for example,
 making network requests ([`http`][]),
 custom navigation/route handling ([`fluro`][]),


### PR DESCRIPTION
**IMPORTANT:** Due to work on the flutter.dev infrastructure, **all open pull requests will be closed April 29.**

If your PR needs to be merged by April 29, please say that in your PR. 

Otherwise, please [file an issue](https://github.com/flutter/website/issues/new/choose) about the needed change, and (if you submit a PR) be prepared to recreate the PR May 11 or later.

---

_Description of what this PR is changing or adding, and why:_

- Makes cards Flutter documentation cards sentence case on https://docs.flutter.dev/
- Adds an embedded video explaining packages v. plugins on https://docs.flutter.dev/development/packages-and-plugins/using-packages

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
