### PR TITLE
Fix web initialization page formatting

### DIFF
--- a/src/development/platform-integration/web/initialization.md
+++ b/src/development/platform-integration/web/initialization.md
@@ -11,12 +11,12 @@ or wait until the user presses a button before showing the app.
 
 The initialization process is split into the following stages:
 
-**Loading the entrypoint script**
+* **Loading the entrypoint script**
 :  Fetches the `main.dart.js` script and initializes the service worker.
-**Initializing the Flutter engine**
+* **Initializing the Flutter engine**
 : Initializes Flutter's web engine by downloading required resources
   such as assets, fonts, and CanvasKit.
-**Running the app**
+* **Running the app**
 :  Prepares the DOM for your Flutter app and runs it.
 
 This page shows how to customize the behavior


### PR DESCRIPTION
This fixes the formatting for the first section of the [Customizing web app initialization
](https://docs.flutter.dev/development/platform-integration/web/initialization) page:

<img width="927" alt="Screen Shot 2022-04-27 at 10 05 49 AM" src="https://user-images.githubusercontent.com/1145719/165581184-73b407e4-bd12-4197-a6b9-05a6cd0d6b58.png">

