### PR TITLE
Fixes for web init PR

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -108,6 +108,7 @@
       { "source": "/development/tools/inspector", "destination": "/development/tools/devtools/inspector", "type": 301 },
       { "source": "/development/tools/sdk", "destination": "/development/tools/sdk/upgrading", "type": 301 },
       { "source": "/development/tools/sdk/archive", "destination": "/development/tools/sdk/releases", "type": 301 },
+      { "source": "/development/tools/web-renderers", "destination": "/development/platform-integration/web/renderers", "type": 301 },
       { "source": "/development/ui/layout/responsive", "destination": "/development/ui/layout/adaptive-responsive", "type": 301 },
       { "source": "/development/ui/splash-screen", "destination": "/development/ui/advanced/splash-screen", "type": 301 },
       { "source": "/development/ui/splash-screen/android-splash-screen", "destination": "/development/ui/advanced/splash-screen", "type": 301 },

--- a/src/development/platform-integration/web/initialization.md
+++ b/src/development/platform-integration/web/initialization.md
@@ -12,12 +12,14 @@ or wait until the user presses a button before showing the app.
 The initialization process is split into the following stages:
 
 **Loading the entrypoint script**
-:  Fetches the `main.dart.js` script and initializes the service worker.
+: Fetches the `main.dart.js` script and initializes the service worker.
+
 **Initializing the Flutter engine**
 : Initializes Flutter's web engine by downloading required resources
   such as assets, fonts, and CanvasKit.
+
 **Running the app**
-:  Prepares the DOM for your Flutter app and runs it.
+: Prepares the DOM for your Flutter app and runs it.
 
 This page shows how to customize the behavior
 at each stage of the initialization process.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Fixes formatting issues in https://github.com/flutter/website/pull/7069 and adds missing redirect.

Supersedes https://github.com/flutter/website/pull/7080

_Issues fixed by this PR (if any):_ N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
