### PR TITLE
Update site-shared with activesupport fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'jekyll', '4.2.2'
 gem 'webrick'
 
 # Used for custom _plugins
-gem 'activesupport', '~> 6.1.4'
+gem 'activesupport', '~> 7.0.2'
 gem 'liquid-tag-parser', '~> 2.0.2'
 
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4.1)
+    activesupport (7.0.2.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
@@ -57,7 +56,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     mini_portile2 (2.8.0)
-    minitest (5.14.4)
+    minitest (5.15.0)
     nokogiri (1.13.4)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -83,7 +82,6 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
     webrick (1.7.0)
-    zeitwerk (2.4.2)
 
 PLATFORMS
   aarch64-linux
@@ -91,11 +89,11 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activesupport (~> 6.1.4)
+  activesupport (~> 7.0.2)
   jekyll (= 4.2.2)
   jekyll-toc (~> 0.17.1)
   liquid-tag-parser (~> 2.0.2)
   webrick
 
 BUNDLED WITH
-   2.2.27
+   2.3.12


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ When updating activesupport [in site-www](https://github.com/dart-lang/site-www/pull/4008) I found our own custom plugins didn't support the new version. I had to add a new require statement in https://github.com/dart-lang/site-shared/pull/154. This will break with old activesupport versions though, so we also need to update activesupport while updating the submodule.

_Issues fixed by this PR (if any):_ N/A
 
## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
