### PR TITLE
Set default permissions to read-all to resolve code scan alert

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
* Sets default permission to read-all to resolve a code scanning alert

_Issues fixed by this PR (if any):_
* https://github.com/flutter/website/security/code-scanning/33

_Regarding the code freeze:_
If you would prefer this get merged later, I can make an issue and open a PR on May 11, just let me know!

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
