### PR TITLE
Add .ttc font format

### DIFF
--- a/src/cookbook/design/fonts.md
+++ b/src/cookbook/design/fonts.md
@@ -59,6 +59,7 @@ awesome_app/
 
 Flutter supports the following font formats:
 
+* `.ttc`
 * `.ttf`
 * `.otf`
 


### PR DESCRIPTION
Adds .`ttc` as supported font format in "Use a custom font" cookbook.

Ref: https://api.flutter.dev/flutter/painting/TextStyle-class.html
