### PR TITLE
Fix discord link

### DIFF
--- a/src/security/index.md
+++ b/src/security/index.md
@@ -50,7 +50,7 @@ Flutter does not have a bug bounty program.
 ## Receiving security updates
 
 The best way to receive security updates is to subscribe to the 
-[flutter-announce](https://groups.google.com/forum/#!forum/flutter-announce) mailing list or updates to the Discord [channel](https://discord.com/invite/N7Yshp4).
+[flutter-announce](https://groups.google.com/forum/#!forum/flutter-announce) mailing list or updates to the Discord [channel](https://discord.gg/BS8KZyg).
 We will also announce security updates in the technical release blog post.
 
 ## Best practices

--- a/src/security/index.md
+++ b/src/security/index.md
@@ -50,7 +50,7 @@ Flutter does not have a bug bounty program.
 ## Receiving security updates
 
 The best way to receive security updates is to subscribe to the 
-[flutter-announce](https://groups.google.com/forum/#!forum/flutter-announce) mailing list or updates to the Discord [channel](https://discord.com/channels/608014603317936148/608116355836805126).
+[flutter-announce](https://groups.google.com/forum/#!forum/flutter-announce) mailing list or updates to the Discord [channel](https://discord.com/invite/N7Yshp4).
 We will also announce security updates in the technical release blog post.
 
 ## Best practices


### PR DESCRIPTION
Changes the discord link to properly invite users to the Flutter server.
Fixes #7110

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.