### PR TITLE
Fix Happy Paths Routing

### DIFF
--- a/src/_data/happy_paths_cards.yml
+++ b/src/_data/happy_paths_cards.yml
@@ -1,24 +1,24 @@
 - name: Ads
   image: /assets/images/docs/happy-paths/HappyPaths_Icon_Ad_2d.png
   description: Monetize your mobile app with in-app ads.
-  url: /development/packages-and-plugins/happy-paths/recommended/#ads-
+  url: /development/packages-and-plugins/happy-paths-recommended/#ads-
 - name: Background processing
   image: /assets/images/docs/happy-paths/HappyPaths_Icon_Processing_2d.png
   description: Enable headless execution of Dart code. 
-  url: /development/packages-and-plugins/happy-paths/recommended/#background-processing-
+  url: /development/packages-and-plugins/happy-paths-recommended/#background-processing-
 - name: Geolocation
   image: /assets/images/docs/happy-paths/HappyPaths_Icon_Geolocation_2d.png
   description: Determine a user's location for enhanced app functionality.
-  url: /development/packages-and-plugins/happy-paths/recommended/#geolocation-
+  url: /development/packages-and-plugins/happy-paths-recommended/#geolocation-
 - name: Immutable data
   image: /assets/images/docs/happy-paths/HappyPaths_Icon_ImmutableData_2d.png
   description: Handle immutable data structures.
-  url: /development/packages-and-plugins/happy-paths/recommended/#immutable-data--
+  url: /development/packages-and-plugins/happy-paths-recommended/#immutable-data--
 - name: Structured local storage
   image: /assets/images/docs/happy-paths/HappyPaths_Icon_Storage_2d.png
   description: Maintain and preserve data.
-  url: /development/packages-and-plugins/happy-paths/recommended/#structured-local-storage-
+  url: /development/packages-and-plugins/happy-paths-recommended/#structured-local-storage-
 - name: Web sockets
   image: /assets/images/docs/happy-paths/HappyPaths_Icon_WebSockets_2d.png
   description: Handle client and server connections.
-  url: /development/packages-and-plugins/happy-paths/recommended/#web-sockets-
+  url: /development/packages-and-plugins/happy-paths-recommended/#web-sockets-

--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -176,7 +176,7 @@
         - title: Happy paths project NEW
           permalink: /development/packages-and-plugins/happy-paths
         - title: Happy paths recommendations NEW
-          permalink: /development/packages-and-plugins/happy-paths/recommended
+          permalink: /development/packages-and-plugins/happy-paths-recommended
         - title: Developing packages & plugins
           permalink: /development/packages-and-plugins/developing-packages
         - title: Flutter Favorites program


### PR DESCRIPTION
Fixes the routing for `/happy-paths/recommended` by changing it to `/happy-paths-recommended`. This also should fix the sidebar issues this page has had.

Fixes #7115

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.