### PR TITLE
Remove alert about needing to install Rosetta on Apple Silicon Mac

### DIFF
--- a/src/get-started/install/macos.md
+++ b/src/get-started/install/macos.md
@@ -20,14 +20,6 @@ your development environment must meet these minimum requirements:
   installing [Xcode][], which includes `git`, but you can also 
   [install `git` separately][]. 
 
-{{site.alert.important}}
-  If you're installing on an [Apple Silicon Mac][], you must also have the Rosetta
-  translation environment available, which you can install manually by running:
-  ```terminal
-  $ sudo softwareupdate --install-rosetta --agree-to-license
-  ```
-{{site.alert.end}}
-
 {% include_relative _get-sdk-mac.md %}
 
 {% include_relative _path-mac.md %}


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
With the release of Flutter 3.0.0 with native Arm64 support on macOS, I believe Rosetta is not necessary anymore.
I was able to install Flutter SDK version 3.0.0 on my M1 MacBook Pro and create a new app, launch a simulator etc... without ever installing Rosetta.

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.