### PR TITLE
Add Developer Mode information for Windows

### DIFF
--- a/src/get-started/install/windows.md
+++ b/src/get-started/install/windows.md
@@ -16,6 +16,7 @@ your development environment must meet these minimum requirements:
 
 - **Operating Systems**: Windows 7 SP1 or later (64-bit), x86-64 based.
 - **Disk Space**: 1.64 GB (does not include disk space for IDE/tools).
+- **Settings**: Developer Mode must be enabled on Windows 10/11.
 - **Tools**: Flutter depends on these tools being available in your environment.
   - [Windows PowerShell 5.0][] or newer (this is pre-installed with Windows 10)
   - [Git for Windows][] 2.x, with the


### PR DESCRIPTION
Adds a line to specify that Developer Mode must be enabled on Windows versions that have it. This prevents issues caused by Developer Mode not being enabled.
Fixes #6932

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.