### PR TITLE
Remove Rosetta instructions from macOS page

### DIFF
--- a/src/get-started/install/macos.md
+++ b/src/get-started/install/macos.md
@@ -20,21 +20,13 @@ your development environment must meet these minimum requirements:
   installing [Xcode][], which includes `git`, but you can also 
   [install `git` separately][]. 
 
-{{site.alert.important}}
-  If you're installing on an [Apple Silicon Mac][], you must also have the Rosetta
-  translation environment available, which you can install manually by running:
-  ```terminal
-  $ sudo softwareupdate --install-rosetta --agree-to-license
-  ```
-{{site.alert.end}}
-
 {% include_relative _get-sdk-mac.md %}
 
 {% include_relative _path-mac.md %}
 
 ## Platform setup
 
-macOS supports developing Flutter apps in iOS, Android,
+macOS supports developing Flutter apps for iOS, Android, macOS itself 
 and the web. Complete at least one of the platform setup steps now,
 to be able to build and run your first Flutter app.
 

--- a/src/get-started/install/macos.md
+++ b/src/get-started/install/macos.md
@@ -20,6 +20,15 @@ your development environment must meet these minimum requirements:
   installing [Xcode][], which includes `git`, but you can also 
   [install `git` separately][]. 
 
+{{site.alert.important}}
+  If you're installing on an [Apple Silicon Mac][], you must have the Rosetta
+  translation environment available for [some ancillary tools]. 
+  You can install this manually by running:
+  ```terminal
+  $ sudo softwareupdate --install-rosetta --agree-to-license
+  ```
+{{site.alert.end}}
+
 {% include_relative _get-sdk-mac.md %}
 
 {% include_relative _path-mac.md %}
@@ -43,6 +52,7 @@ to be able to build and run your first Flutter app.
 Set up your preferred editor.
 
 [Apple Silicon Mac]: https://support.apple.com/en-us/HT211814
+[some ancillary tools]: https://github.com/flutter/website/pull/7119#issuecomment-1124537969
 [these supplementary notes]: {{site.repo.flutter}}/wiki/Developing-with-Flutter-on-Apple-Silicon
 [Xcode]: {{site.apple-dev}}/xcode/
 [install `git` separately]: https://git-scm.com/download/mac


### PR DESCRIPTION
Removes Rosetta instructions now that we have M1 support. Also clarifies that you can build macOS apps with a macOS developer workstation. 

_Issues fixed by this PR (if any):_
https://github.com/flutter/website/issues/7137

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.