### PR TITLE
Update information on upgrading ephemeral files

### DIFF
--- a/src/development/platform-integration/web/initialization.md
+++ b/src/development/platform-integration/web/initialization.md
@@ -168,14 +168,12 @@ see the [initialization code][gallery-init] for the Flutter Gallery.
 
 ## Upgrading an older project
 
-If your project was created in Flutter 2.10 or earlier,
-you can create a new `index.html` file
-with the latest initialization template by running `flutter create`.
+You can create a new `index.html` file
+with the latest template by deleting the old files 
+from the `web` directory and running `flutter create`.
 
 From your project directory, run the following:
 
 ```
-$ flutter create .
+$ flutter create . --platforms=web
 ```
-
-You can now customize the startup process as described above.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Add the `platforms` flag to help contextualize that the `.` is part of the command.

@yjbanov, I'm not seeing old web index.html files being updated when running `flutter create .` (I installed 2.10 and then upgraded to 3.0; the command didn't automatically upgrade the web ephemeral files.) As a result, I've suggested in the text here that developers simply delete the old ephemeral files. Let me know if you think that's wrong, and I'll file a bug. 

_Issues fixed by this PR (if any):_
Fixes #7142. 

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.