### PR TITLE
Fixes og_image_path.

### DIFF
--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -31,7 +31,7 @@
     {% endif %}
 
     {% assign desc = page.description %}
-    {% assign og_image = page.image | default: layout.image | default: site.default_share_image %}
+    {% assign og_image_path = page.image.path | default: layout.image.path | default: site.default_share_image %}
 
     <meta name="description" content="{{desc}}">
     <meta name="keywords" content="{% if page.tags %}{{page.tags}}, {% endif %}{{page.keywords}}">


### PR DESCRIPTION
This PR is to fix the missing value of `og:image` on the website.
Already tested on the .cn site, please check [this tweet](https://twitter.com/FlutterChina/status/1526770455906242560) out for an example.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.