### PR TITLE
Update FFI example in architectural overview

### DIFF
--- a/examples/resources/architectural_overview/lib/ffi.dart
+++ b/examples/resources/architectural_overview/lib/ffi.dart
@@ -1,0 +1,31 @@
+// #docregion FFI
+import 'dart:ffi';
+import 'package:ffi/ffi.dart'; // contains .toNativeUtf16() extension method
+
+typedef MessageBoxNative = Int32 Function(
+  IntPtr hWnd,
+  Pointer<Utf16> lpText,
+  Pointer<Utf16> lpCaption,
+  Int32 uType,
+);
+
+typedef MessageBoxDart = int Function(
+  int hWnd,
+  Pointer<Utf16> lpText,
+  Pointer<Utf16> lpCaption,
+  int uType,
+);
+
+void exampleFfi() {
+  final user32 = DynamicLibrary.open('user32.dll');
+  final messageBox =
+      user32.lookupFunction<MessageBoxNative, MessageBoxDart>('MessageBoxW');
+
+  final result = messageBox(
+    0, // No owner window
+    'Test message'.toNativeUtf16(), // Message
+    'Window caption'.toNativeUtf16(), // Window title
+    0, // OK button only
+  );
+}
+// #enddocregion FFI

--- a/examples/resources/architectural_overview/lib/ffi.dart
+++ b/examples/resources/architectural_overview/lib/ffi.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: unused_local_variable
+
 // #docregion FFI
 import 'dart:ffi';
 import 'package:ffi/ffi.dart'; // contains .toNativeUtf16() extension method

--- a/examples/resources/architectural_overview/lib/main.dart
+++ b/examples/resources/architectural_overview/lib/main.dart
@@ -111,32 +111,3 @@ Future<void> exampleChannels() async {
   print(greeting);
   // #enddocregion MethodChannel
 }
-
-// #docregion FFI
-typedef MessageBoxNative = Int32 Function(
-  IntPtr hWnd,
-  Pointer<Utf16> lpText,
-  Pointer<Utf16> lpCaption,
-  Int32 uType,
-);
-
-typedef MessageBoxDart = int Function(
-  int hWnd,
-  Pointer<Utf16> lpText,
-  Pointer<Utf16> lpCaption,
-  int uType,
-);
-
-void exampleFfi() {
-  final user32 = DynamicLibrary.open('user32.dll');
-  final messageBox =
-      user32.lookupFunction<MessageBoxNative, MessageBoxDart>('MessageBoxW');
-
-  final result = messageBox(
-    0, // No owner window
-    'Test message'.toNativeUtf16(), // Message
-    'Window caption'.toNativeUtf16(), // Window title
-    0, // OK button only
-  );
-}
-// #enddocregion FFI

--- a/examples/resources/architectural_overview/lib/main.dart
+++ b/examples/resources/architectural_overview/lib/main.dart
@@ -1,8 +1,3 @@
-// ignore_for_file: unused_local_variable
-
-import 'dart:ffi';
-
-import 'package:ffi/ffi.dart';
 // #docregion Main
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/src/resources/architectural-overview.md
+++ b/src/resources/architectural-overview.md
@@ -817,6 +817,9 @@ here’s a fragment of code to call the traditional Win32 `MessageBox()` API:
 
 <?code-excerpt "lib/main.dart (FFI)"?>
 ```dart
+import 'dart:ffi';
+import 'package:ffi/ffi.dart'; // contains .toNativeUtf16() extension method
+
 typedef MessageBoxNative = Int32 Function(
   IntPtr hWnd,
   Pointer<Utf16> lpText,

--- a/src/resources/architectural-overview.md
+++ b/src/resources/architectural-overview.md
@@ -815,7 +815,7 @@ To use FFI, you create a `typedef` for each of the Dart and unmanaged method
 signatures, and instruct the Dart VM to map between them. As an example,
 here’s a fragment of code to call the traditional Win32 `MessageBox()` API:
 
-<?code-excerpt "lib/main.dart (FFI)"?>
+<?code-excerpt "lib/ffi.dart (FFI)"?>
 ```dart
 import 'dart:ffi';
 import 'package:ffi/ffi.dart'; // contains .toNativeUtf16() extension method


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Adds imports to fragment to clarify where dependencies are coming from

_Issues fixed by this PR (if any):_
Fixes #5977

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.