### PR TITLE
Warn against `targetSdkVersion` 21+ purely for multidex

### DIFF
--- a/src/deployment/android.md
+++ b/src/deployment/android.md
@@ -260,7 +260,7 @@ Flutter to automatically depend on `androidx.multidex:multidex` and use a
 generated `FlutterMultiDexApplication` as the project's application.
 
 {{site.alert.note}}
-  Multidex support is natively included when targeting min sdk 21+.
+  Multidex support is natively included when targeting min sdk 21+. However, we do not recommend targeting API 21+ purely to resolve the multidex issue as this may inadvertently exclude potential users running older devices.
 {{site.alert.end}}
 
 You might also choose to manually support multidex by following Android's guides

--- a/src/deployment/android.md
+++ b/src/deployment/android.md
@@ -260,7 +260,9 @@ Flutter to automatically depend on `androidx.multidex:multidex` and use a
 generated `FlutterMultiDexApplication` as the project's application.
 
 {{site.alert.note}}
-  Multidex support is natively included when targeting min sdk 21+. However, we do not recommend targeting API 21+ purely to resolve the multidex issue as this may inadvertently exclude potential users running older devices.
+  Multidex support is natively included when targeting min sdk 21+. However,
+  we do not recommend targeting API 21+ purely to resolve the multidex issue
+  as this may inadvertently exclude users running older devices.
 {{site.alert.end}}
 
 You might also choose to manually support multidex by following Android's guides

--- a/src/deployment/android.md
+++ b/src/deployment/android.md
@@ -260,9 +260,9 @@ Flutter to automatically depend on `androidx.multidex:multidex` and use a
 generated `FlutterMultiDexApplication` as the project's application.
 
 {{site.alert.note}}
-  Multidex support is natively included when targeting min sdk 21+. However,
-  it is not recommended to target API 21+ purely to resolve the multidex issue
-  as this may inadvertently exclude users running older devices.
+  Multidex support is natively included when targeting Android SDK 21 or later.
+  However, it isn't recommended to target API 21+ purely to resolve the multidex issue
+  as this might inadvertently exclude users running older devices.
 {{site.alert.end}}
 
 You might also choose to manually support multidex by following Android's guides

--- a/src/deployment/android.md
+++ b/src/deployment/android.md
@@ -261,7 +261,7 @@ generated `FlutterMultiDexApplication` as the project's application.
 
 {{site.alert.note}}
   Multidex support is natively included when targeting min sdk 21+. However,
-  we do not recommend targeting API 21+ purely to resolve the multidex issue
+  it is not recommended to target API 21+ purely to resolve the multidex issue
   as this may inadvertently exclude users running older devices.
 {{site.alert.end}}
 


### PR DESCRIPTION
In https://github.com/flutter/flutter/issues/100125, we decided to better link devs so they better understand the native multidex support in API 21+. However, we still wish to discourage raising target SDK just for multidex support as they may accidentally exclude users.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.