### PR TITLE
fix TOC on auto generated index pages

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -47,6 +47,7 @@
       permalink: /reference/tutorials
 
 - title: Development
+  permalink: /development
   expanded: true
   children:
     - title: User interface
@@ -116,8 +117,10 @@
         - title: Widget catalog
           permalink: /development/ui/widgets
     - title: Data & backend
+      permalink: /development/data-and-backend
       children:
         - title: State management
+          permalink: /development/data-and-backend/state-mgmt
           children:
             - title: Introduction
               permalink: /development/data-and-backend/state-mgmt/intro

--- a/src/_layouts/toc.html
+++ b/src/_layouts/toc.html
@@ -9,8 +9,6 @@ toc: false
 
 {% comment %}
   - path_parts[0] == '' because page.url always starts with '/'
-  - (path_parts | size) > 2 since we don't use this layout at
-    the top level, nor at the second level (under our current IA)
 {% endcomment -%}
 
 {% for path_part in path_parts -%}

--- a/src/_layouts/toc.html
+++ b/src/_layouts/toc.html
@@ -19,7 +19,7 @@ toc: false
   {% else -%}
     {% assign path = path | append: '/' | append: path_part -%}
   {% endif -%}
-  {% if forloop.index0 > 1 -%}
+  {% if forloop.index0 > 0 -%}
     {% assign topics = topics | where: "permalink", path -%}
     {% assign topics = topics[0].children -%}
   {% endif -%}


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ When the website was refactored to live on their own in #6454, the code that autogenerates the TOC on index pages wasn't updated. As a result, the index pages were empty since the code assumed that the TOC wasn't relevant at the top most level. 

**Example**
Paths used to be: `/docs/development/...`
Paths now: `/development/...`

_Issues fixed by this PR (if any):_ #7172 

This PR also reverts the changes the changes that I made to sidenav.yml in #6785 thinking that I was solving the problem by deleting the empty index pages. (The root cause was the code for the TOC itself, which is now fixed in this PR.)

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.