### PR TITLE
Add go/dash-xcode-plan-brief

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -188,6 +188,7 @@
       { "source": "/go/custom-tabs-support", "destination": "https://docs.google.com/document/d/1GvsmPQz6aKixNUphL10XmSOL7M6nOH7W1jYwNp0LwnA", "type": 301 },
       { "source": "/go/dart-flutterbuffers", "destination": "https://docs.google.com/document/d/1rqKq6DwqaeBfTLTixxurrdT9HwZ02DyRjFigO9SiB1Q/edit#", "type": 301 },
       { "source": "/go/dartle", "destination": "https://docs.google.com/document/d/1Ei0ZIqdqNjxTHoGB3Ay6SWQg3DMSsKKWl70XoBUCFTA", "type": 301 },
+      { "source": "/go/dash-xcode-plan-brief", "destination": "https://docs.google.com/document/d/1QKHf2YBs21Mm89Exj0z0aOqE-GR6wYuLsiqXI-LofvQ/edit?resourcekey=0-l9DaaVR-N9SSA3B7OhhGPA#", "type": 301 },
       { "source": "/go/data-sync", "destination": "https://docs.google.com/document/d/1yH96-p-SkMmt6hL5xHHDtMvCKRz2XGrMuw9ZY_nE954", "type": 301 },
       { "source": "/go/default-scroll-action", "destination": "https://docs.google.com/document/d/1SJvom6k4YW4EtFIY4VpAhAOH-jWhRkHVfpVsOBB56KM/edit?usp=sharing", "type": 301 },
       { "source": "/go/deferred-image-decoding", "destination": "https://docs.google.com/document/d/1f-NCEF0lrHGd3DsieS1tZ_NWbYTjA4GTqESMbGFsU2U/edit?ts=5e17a77d&pli=1#", "type": 301 },


### PR DESCRIPTION
Add a go link for the xcode brief

Apple releases a new major release of Xcode version at least once a year, with smaller updates throughout the year. Each time there is a new update, the Flutter team must include the updated version in their SDK. This brief talks about the challenges we face updating Xcode each time and will propose a way to improve.

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.