### PR TITLE
chore: add note to `README.md` for Git line endings on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ If you are working in the Windows desktop environment, make sure you have Git
 `autocrlf` set to `input` **before** initialising the submodules. This will
 ensure that line endings are handled correctly _before_ any Bash scripts are
 executed within the submodules.
-See flutter/website#6201 for details.
+See [issue 6201](https://github.com/flutter/website#6201) for details.
 
 If you're outside of the Flutter organization, 
 we recommend you **create a fork** of the repo under your own account, 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ If you are working in the Windows desktop environment, make sure you have Git
 `autocrlf` set to `input` **before** initializing the submodules. This
 ensures that line endings are handled correctly _before_ any Bash scripts are
 executed within the submodules.
-See [issue 6201](https://github.com/flutter/website#6201) for details.
+See [issue 6201](https://github.com/flutter/website/issues/6201) for details.
 
 If you're outside of the Flutter organization, 
 we recommend you **create a fork** of the repo under your own account, 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ Install the following tools, if you don't have them already:
 > The GitHub documentation has general help on [forking][] and [cloning][] repos.
 
 If you are working in the Windows desktop environment, make sure you have Git
-`autocrlf` set to `input` **before** initialising the submodules. This will
-ensure that line endings are handled correctly _before_ any Bash scripts are
+`autocrlf` set to `input` **before** initializing the submodules. This
+ensures that line endings are handled correctly _before_ any Bash scripts are
 executed within the submodules.
 See [issue 6201](https://github.com/flutter/website#6201) for details.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ Install the following tools, if you don't have them already:
 > which affects how you clone it. 
 > The GitHub documentation has general help on [forking][] and [cloning][] repos.
 
+If you are working in the Windows desktop environment, make sure you have Git
+`autocrlf` set to `input` **before** initialising the submodules. This will
+ensure that line endings are handled correctly _before_ any Bash scripts are
+executed within the submodules.
+See flutter/website#6201 for details.
+
 If you're outside of the Flutter organization, 
 we recommend you **create a fork** of the repo under your own account, 
 and then submit a PR from that fork. 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Updates the `REAMD.md` file with a note for Windows users, instructing them to set Git's `autocrlf` configuration option to `input` before initializing the submodules.

This ensures that line endings are handled correctly by Git _before_ any Bash commands are executed inside the aforementioned submodules.

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.