### PR TITLE
Link to js-to-dart article from Bootstrap into Dart page

### DIFF
--- a/src/resources/bootstrap-into-dart.md
+++ b/src/resources/bootstrap-into-dart.md
@@ -23,6 +23,11 @@ you to learn, too.
   Learn about Dart's support for collections, async,
   math, numbers, strings, JSON, and more.
 
+[Learning Dart as a JavaScript developer][]
+: Use your JavaScript knowledge to get up and running quickly with Dart.
+  Learn about the key similarities and differences between the languages
+  as well as concepts and conventions not present in vanilla JavaScript.
+
 [Intro to Dart for Java Developers][] codelab
 : Use your Java knowledge to get up and running quickly with Dart.
   Learn about classes, constructors, parameters,
@@ -52,6 +57,7 @@ Check out the [Dart community][].
 [Dart is easy and fun to learn]: {{site.url}}/resources/faq#why-did-flutter-choose-to-use-dart
 [Effective Dart]: {{site.dart-site}}/guides/language/effective-dart
 [`File`]: {{site.api}}/flutter/dart-io/File-class.html
+[Learning Dart as a JavaScript developer]: {{site.dart-site}}/guides/language/coming-from/js-to-dart
 [Intro to Dart for Java Developers]: {{site.codelabs}}/codelabs/from-java-to-dart
 [Language tour]: {{site.dart-site}}/guides/language/language-tour
 [Library tour]: {{site.dart-site}}/guides/libraries/library-tour


### PR DESCRIPTION
Links to the new [Learning Dart as a JavaScript developer](https://dart.dev/guides/language/coming-from/js-to-dart) from the bootstrap into Dart page, following a similar wording as the Java codelab entry.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.