### PR TITLE
Add Learning to Fly to videos page

### DIFF
--- a/src/resources/videos.md
+++ b/src/resources/videos.md
@@ -112,6 +112,20 @@ Introducing the Boring Flutter show<br>
 
 [The Boring Flutter show playlist]: {{site.youtube-site}}/playlist?list=PLjxrf2q8roU3ahJVrSgAnPjzkpGmL9Czl
 
+### Learning to Fly
+
+Follow along with Khanh’s journey as she builds her first Flutter app. 
+From ideation down to the moments of confusion,
+learn alongside her as she asks important questions like: 
+“What is the best way to build out a theme? How to approach using fonts?” 
+And more!
+
+<iframe width="560" height="315" src="{{site.youtube-site}}/embed/CkcvVZZEsJE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+Building my first Flutter app | Learning to Fly<br>
+[Learning to Fly playlist][]
+
+[Learning to Fly playlist]: {{site.youtube-site}}/playlist?list=PLjxrf2q8roU3X18pAQWLyCJaa79RpqWnn
+
 ## Conference talks
 
 Here are a some Flutter talks given at various conferences.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Learning to Fly is a great series as it follows along a pretty natural learning progression. It would be a great addition to the page :D

I just used the description from the first video but am open to suggestions.

_Issues fixed by this PR (if any):_ N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.