### PR TITLE
Some adjustments and fixes to cookie notice

### DIFF
--- a/src/_includes/cookie-notice.html
+++ b/src/_includes/cookie-notice.html
@@ -1,10 +1,10 @@
-<section class="cookie-notice">
+<section id="cookie-notice">
   <div class="container">
     <p>Google uses cookies to deliver its services, to personalize ads, and to 
       analyze traffic. You can adjust your privacy controls anytime in your 
       <a href="https://myaccount.google.com/data-and-personalization" target="_blank" rel="noopener">Google settings</a>. 
       <a href="https://policies.google.com/technologies/cookies" target="_blank" rel="noopener">Learn more</a>.
     </p>
-    <button id="cookie-consent" class="btn btn-primary">Okay</a>
+    <button id="cookie-consent" class="btn btn-primary">Okay</button>
   </div>
 </section>

--- a/src/_sass/components/_cookie-notice.scss
+++ b/src/_sass/components/_cookie-notice.scss
@@ -1,4 +1,4 @@
-.cookie-notice {
+#cookie-notice {
   background-color: white;
   padding: 2.5rem 0;
   position: fixed;

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -208,7 +208,7 @@ function addCopyCodeButtonsEverywhere() {
  * @returns null
  */
 function initCookieNotice() {
-  const notice = document.querySelector('.cookie-notice');
+  const notice = document.getElementById('cookie-notice');
   const agreeBtn = document.getElementById('cookie-consent');
   const cookieKey = 'cookie-consent';
   const cookieConsentValue = 'true'
@@ -222,7 +222,7 @@ function initCookieNotice() {
 
   agreeBtn.addEventListener('click', (e) => {
     e.preventDefault();
-    Cookies.set(cookieKey, cookieConsentValue);
+    Cookies.set(cookieKey, cookieConsentValue, {sameSite: 'strict', expires: 30});
     notice.classList.remove(activeClass);
   });
 }


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ This mirrors the changes in https://github.com/dart-lang/site-www/pull/4067:

- Fixes the closing tag for the `<button>`
- Adjusts the `cookie-notice` element to use an ID instead of class since there is only one
- Add an expiration date (for now one month) so the cookie notice doesn't show up every time you reopen the browser

_Issues fixed by this PR (if any):_ N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.