### PR TITLE
Update whats-new.md

### DIFF
--- a/src/whats-new.md
+++ b/src/whats-new.md
@@ -49,8 +49,8 @@ and the [Flutter 3 release notes][].
   [Customizing web app initialization][],
   which has been added to the newly updated
   and collected web docs under
-  `/development/platform-integraton/web`.
-* Flutter 3 supports the Apple Silicon Mac (aka M1).
+  `/development/platform-integration/web`.
+* Flutter 3 supports Apple Silicon processors.
   We've updated the [macOS install page][]
   to offer an Apple Silicon download button.
 * In Flutter 3, the macOS and Linux platforms


### PR DESCRIPTION
Fix URL spelling nit in web section (also remove mention of M1 in favor of Apple Silicon).

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.