### PR TITLE
Avoid using library private types in public APIs.

### DIFF
--- a/examples/cookbook/forms/focus/lib/main.dart
+++ b/examples/cookbook/forms/focus/lib/main.dart
@@ -19,7 +19,7 @@ class MyCustomForm extends StatefulWidget {
   const MyCustomForm({super.key});
 
   @override
-  _MyCustomFormState createState() => _MyCustomFormState();
+  State<MyCustomForm> createState() => _MyCustomFormState();
 }
 
 // Define a corresponding State class.

--- a/examples/cookbook/testing/unit/counter_app/analysis_options.yaml
+++ b/examples/cookbook/testing/unit/counter_app/analysis_options.yaml
@@ -2,4 +2,4 @@
 # file. If necessary for a particular example, this file can also include
 # overrides for individual lints.
 
-include: ../../../analysis_options.yaml
+include: ../../../../analysis_options.yaml

--- a/examples/cookbook/testing/unit/counter_app/test/counter_test.dart
+++ b/examples/cookbook/testing/unit/counter_app/test/counter_test.dart
@@ -1,6 +1,6 @@
 // Import the test package and Counter class
-import 'package:test/test.dart';
 import 'package:counter_app/counter.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('Counter value should be incremented', () {

--- a/examples/cookbook/testing/unit/counter_app/test/group.dart
+++ b/examples/cookbook/testing/unit/counter_app/test/group.dart
@@ -1,5 +1,5 @@
-import 'package:test/test.dart';
 import 'package:counter_app/counter.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Counter', () {

--- a/examples/cookbook/testing/unit/mocking/test/fetch_album_test.mocks.dart
+++ b/examples/cookbook/testing/unit/mocking/test/fetch_album_test.mocks.dart
@@ -12,8 +12,7 @@ import 'package:http/src/response.dart' as _i2;
 import 'package:http/src/streamed_response.dart' as _i4;
 import 'package:mockito/mockito.dart' as _i1;
 
-// ignore_for_file: comment_references
-// ignore_for_file: unnecessary_parenthesis
+// ignore_for_file: comment_references, unnecessary_parenthesis, subtype_of_disallowed_type
 
 class _FakeResponse extends _i1.Fake implements _i2.Response {}
 

--- a/src/cookbook/forms/focus.md
+++ b/src/cookbook/forms/focus.md
@@ -166,7 +166,7 @@ class MyCustomForm extends StatefulWidget {
   const MyCustomForm({super.key});
 
   @override
-  _MyCustomFormState createState() => _MyCustomFormState();
+  State<MyCustomForm> createState() => _MyCustomFormState();
 }
 
 // Define a corresponding State class.

--- a/src/cookbook/testing/unit/introduction.md
+++ b/src/cookbook/testing/unit/introduction.md
@@ -100,8 +100,8 @@ Both of these functions come from the `test` package.
 <?code-excerpt "test/counter_test.dart"?>
 ```dart
 // Import the test package and Counter class
-import 'package:test/test.dart';
 import 'package:counter_app/counter.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('Counter value should be incremented', () {
@@ -121,8 +121,8 @@ combine them using the `group` function provided by the `test` package.
 
 <?code-excerpt "test/group.dart"?>
 ```dart
-import 'package:test/test.dart';
 import 'package:counter_app/counter.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Counter', () {


### PR DESCRIPTION
Fixing a linter warning in [DartPad sample code](https://docs.flutter.dev/cookbook/forms/focus#interactive-example).

<img width="935" alt="Screen Shot 2022-06-11 at 12 39 07 am" src="https://user-images.githubusercontent.com/30503/173089773-76916896-09e6-471a-89d3-4213bda09887.png">

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.