### PR TITLE
Adjust paragraph positioning in Get Started codelab

### DIFF
--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -503,8 +503,8 @@ lazily, on demand.
       }
     ```
 
-    Next, you'll add a `ListView` widget to the
-    `_RandomWordsState` class with the `ListView.builder` constructor. 
+ 2. Next, you'll add a `ListView` widget to the
+    `_RandomWordsState` class with the `ListView.builder` constructor.
     This method creates the `ListView` that displays the suggested word pairing.
 
     The `ListView` class provides a builder property, `itemBuilder`,
@@ -517,7 +517,7 @@ lazily, on demand.
     This model allows the suggested list to continue growing
     as the user scrolls.
 
- 2. Return a `ListView` widget from the `build` method
+    Return a `ListView` widget from the `build` method
     of the `_RandomWordsState` class using the `ListView.builder` constructor:
 
     <?code-excerpt "lib/main.dart (itemBuilder)" title replace="/ListTile([\S\s]*?)\);/Text(_suggestions[index].asPascalCase);/g" indent-by="2"?>


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ These paragraphs are technically describing the next step (2) so should adjust the positioning.

_Issues fixed by this PR (if any):_ Fixes #7236

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.