### PR TITLE
Fixing typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Some DartPad example code remains in this repo:
 This code must be manually compiled, 
 which also regenerates the associated JavaScript file in `src/assets/js`:
 ```bash
-$ cd `src/_packages/dartpad_picker
+$ cd src/_packages/dartpad_picker
 $ ./compile.sh
 ```
 


### PR DESCRIPTION
fixing typo in README.md file


## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.