### PR TITLE
Added Bugsnag to error reporting services and alphabetized

### DIFF
--- a/src/cookbook/maintenance/error-reporting.md
+++ b/src/cookbook/maintenance/error-reporting.md
@@ -23,7 +23,7 @@ How can you determine how often your users experiences bugs?
 Whenever an error occurs, create a report containing the
 error that occurred and the associated stacktrace.
 You can then send the report to an error tracking
-service, such as Sentry, Fabric, or [Rollbar][].
+service, such as [Bugsnag][], Fabric, [Rollbar][], or Sentry.
 
 The error tracking service aggregates all of the crashes your users
 experience and groups them together. This allows you to know how often your
@@ -115,6 +115,7 @@ see the [Sentry flutter example][] app.
 
 [Sentry flutter example]: {{site.github}}/getsentry/sentry-dart/tree/main/flutter/example
 [Create an account with Sentry]: https://sentry.io/signup/
+[Bugsnag]: https://www.bugsnag.com/platforms/flutter
 [Rollbar]: https://rollbar.com/
 [Sentry]: https://sentry.io/welcome/
 [`sentry_flutter`]: {{site.pub-pkg}}/sentry_flutter


### PR DESCRIPTION
Adding [Bugsnag](https://www.bugsnag.com/platforms/flutter) to the list of error reporting services.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.