### PR TITLE
Fix lint errors in Codelabs samples/code snippets

### DIFF
--- a/src/_includes/docs/explicit-animations/animation-controller-starter-code-1.md
+++ b/src/_includes/docs/explicit-animations/animation-controller-starter-code-1.md
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 class AnimationControllerDemo extends StatefulWidget {
   @override
-  _AnimationControllerDemo createState() => _AnimationControllerDemo();
+  State<AnimationControllerDemo> createState() => _AnimationControllerDemo();
 }
 
 class _AnimationControllerDemo extends State<AnimationControllerDemo> with SingleTickerProviderStateMixin {
@@ -17,7 +17,7 @@ class _AnimationControllerDemo extends State<AnimationControllerDemo> with Singl
     super.initState();
     controller = AnimationController(
       vsync: this,
-      duration: Duration(seconds: 1),
+      duration: const Duration(seconds: 1),
       lowerBound: 0,
       upperBound: 100,
     );

--- a/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-1.md
+++ b/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-1.md
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 
 class BouncingBallDemo extends StatefulWidget {
   @override
-  _BouncingBallDemoState createState() => _BouncingBallDemoState();
+  State<BouncingBallDemo> createState() => _BouncingBallDemoState();
 }
 
 class _BouncingBallDemoState extends State<BouncingBallDemo> {

--- a/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-2.md
+++ b/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-2.md
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 
 class BouncingBallDemo extends StatefulWidget {
   @override
-  _BouncingBallDemoState createState() => _BouncingBallDemoState();
+  State<BouncingBallDemo> createState() => _BouncingBallDemoState();
 }
 
 class _BouncingBallDemoState extends State<BouncingBallDemo> {

--- a/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-3.md
+++ b/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-3.md
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 
 class BouncingBallDemo extends StatefulWidget {
   @override
-  _BouncingBallDemoState createState() => _BouncingBallDemoState();
+  State<BouncingBallDemo> createState() => _BouncingBallDemoState();
 }
 
 class _BouncingBallDemoState extends State<BouncingBallDemo> {

--- a/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-4.md
+++ b/src/_includes/docs/explicit-animations/bouncing-ball-starter-code-4.md
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 
 class BouncingBallDemo extends StatefulWidget {
   @override
-  _BouncingBallDemoState createState() => _BouncingBallDemoState();
+  State<BouncingBallDemo> createState() => _BouncingBallDemoState();
 }
 
 class _BouncingBallDemoState extends State<BouncingBallDemo>

--- a/src/_includes/docs/implicit-animations/fade-in-complete.md
+++ b/src/_includes/docs/implicit-animations/fade-in-complete.md
@@ -9,7 +9,7 @@ class FadeInDemo extends StatefulWidget {
   const FadeInDemo({Key? key}) : super(key: key);
 
   @override
-  _FadeInDemoState createState() => _FadeInDemoState();
+  State<FadeInDemo> createState() => _FadeInDemoState();
 }
 
 class _FadeInDemoState extends State<FadeInDemo> {

--- a/src/_includes/docs/implicit-animations/fade-in-starter-code.md
+++ b/src/_includes/docs/implicit-animations/fade-in-starter-code.md
@@ -9,7 +9,7 @@ class FadeInDemo extends StatefulWidget {
   const FadeInDemo({Key? key}) : super(key: key);
 
   @override
-  _FadeInDemoState createState() => _FadeInDemoState();
+  State<FadeInDemo> createState() => _FadeInDemoState();
 }
 
 class _FadeInDemoState extends State<FadeInDemo> {

--- a/src/_includes/docs/implicit-animations/shape-shifting-complete.md
+++ b/src/_includes/docs/implicit-animations/shape-shifting-complete.md
@@ -22,7 +22,7 @@ class AnimatedContainerDemo extends StatefulWidget {
   const AnimatedContainerDemo({Key? key}) : super(key: key);
 
   @override
-  _AnimatedContainerDemoState createState() => _AnimatedContainerDemoState();
+  State<AnimatedContainerDemo> createState() => _AnimatedContainerDemoState();
 }
 
 class _AnimatedContainerDemoState extends State<AnimatedContainerDemo> {

--- a/src/_includes/docs/implicit-animations/shape-shifting-starter-code.md
+++ b/src/_includes/docs/implicit-animations/shape-shifting-starter-code.md
@@ -20,7 +20,7 @@ class AnimatedContainerDemo extends StatefulWidget {
   const AnimatedContainerDemo({Key? key}) : super(key: key);
 
   @override
-  _AnimatedContainerDemoState createState() => _AnimatedContainerDemoState();
+  State<AnimatedContainerDemo> createState() => _AnimatedContainerDemoState();
 }
 
 class _AnimatedContainerDemoState extends State<AnimatedContainerDemo> {

--- a/src/codelabs/layout-basics.md
+++ b/src/codelabs/layout-basics.md
@@ -96,8 +96,8 @@ class MyApp extends StatelessWidget {
         color: const Color(0xffeeeeee),
         child: Center(
           child: Container(
-            child: MyWidget(),
             color: const Color(0xffcccccc),
+            child: MyWidget(),
           ),
         ),
       ),
@@ -119,7 +119,7 @@ Future<void> main() async {
   
   runApp(MyApp());
 
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   final columns = controller.widgetList(find.byType(Column));
 
@@ -238,8 +238,8 @@ class MyApp extends StatelessWidget {
         color: const Color(0xffeeeeee),
         child: Center(
           child: Container(
-            child: MyWidget(),
             color: const Color(0xffcccccc),
+            child: MyWidget(),
           ),
         ),
       ),
@@ -259,7 +259,7 @@ Future<void> main() async {
 
   await completer.future;
 
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   final rows = controller.widgetList(find.byType(Row));
 
@@ -380,8 +380,8 @@ class MyApp extends StatelessWidget {
         color: const Color(0xffeeeeee),
         child: Center(
           child: Container(
-            child: MyWidget(),
             color: const Color(0xffcccccc),
+            child: MyWidget(),
           ),
         ),
       ),
@@ -400,7 +400,7 @@ Future<void> main() async {
   });
 
   await completer.future;
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   final rows = controller.widgetList(find.byType(Row));
 
@@ -554,8 +554,8 @@ class MyApp extends StatelessWidget {
         color: const Color(0xffeeeeee),
         child: Center(
           child: Container(
-            child: MyWidget(),
             color: const Color(0xffcccccc),
+            child: MyWidget(),
           ),
         ),
       ),
@@ -575,7 +575,7 @@ Future<void> main() async {
   
   await completer.future;
 
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   final rows = controller.widgetList(find.byType(Row));
 
@@ -715,8 +715,8 @@ class MyApp extends StatelessWidget {
         color: const Color(0xffeeeeee),
         child: Center(
           child: Container(
-            child: MyWidget(),
             color: const Color(0xffcccccc),
+            child: MyWidget(),
           ),
         ),
       ),
@@ -736,7 +736,7 @@ Future<void> main() async {
   
   await completer.future;
 
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   final rows = controller.widgetList(find.byType(Row));
 
@@ -873,8 +873,8 @@ class MyApp extends StatelessWidget {
         color: const Color(0xffeeeeee),
         child: Center(
           child: Container(
-            child: MyWidget(),
             color: const Color(0xffcccccc),
+            child: MyWidget(),
           ),
         ),
       ),
@@ -894,7 +894,7 @@ Future<void> main() async {
   
   await completer.future;
 
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   final rows = controller.widgetList(find.byType(Row));
 
@@ -1031,8 +1031,8 @@ class MyApp extends StatelessWidget {
         color: const Color(0xffeeeeee),
         child: Center(
           child: Container(
-            child: MyWidget(),
             color: const Color(0xffcccccc),
+            child: MyWidget(),
           ),
         ),
       ),
@@ -1052,7 +1052,7 @@ Future<void> main() async {
   
   await completer.future;
 
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   final rows = controller.widgetList(find.byType(Row));
 
@@ -1163,8 +1163,8 @@ class MyApp extends StatelessWidget {
         color: const Color(0xffeeeeee),
         child: Center(
           child: Container(
-            child: MyWidget(),
             color: const Color(0xffcccccc),
+            child: MyWidget(),
           ),
         ),
       ),
@@ -1184,7 +1184,7 @@ Future<void> main() async {
   
   await completer.future;
 
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   final rows = controller.widgetList(find.byType(Row));
 
@@ -1272,7 +1272,7 @@ class MyWidget extends StatelessWidget {
     return Row(
       children: [
         BlueBox(),
-        SizedBox(width: 50),
+        const SizedBox(width: 50),
         BlueBox(),
         BlueBox(),
       ],
@@ -1304,8 +1304,8 @@ class MyApp extends StatelessWidget {
         color: const Color(0xffeeeeee),
         child: Center(
           child: Container(
-            child: MyWidget(),
             color: const Color(0xffcccccc),
+            child: MyWidget(),
           ),
         ),
       ),
@@ -1325,7 +1325,7 @@ Future<void> main() async {
   
   await completer.future;
 
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   final rows = controller.widgetList(find.byType(Row));
 
@@ -1440,7 +1440,7 @@ class MyWidget extends StatelessWidget {
     return Row(
       children: [
         BlueBox(),
-        Spacer(flex: 1),
+        const Spacer(flex: 1),
         BlueBox(),
         BlueBox(),
       ],
@@ -1472,8 +1472,8 @@ class MyApp extends StatelessWidget {
         color: const Color(0xffeeeeee),
         child: Center(
           child: Container(
-            child: MyWidget(),
             color: const Color(0xffcccccc),
+            child: MyWidget(),
           ),
         ),
       ),
@@ -1493,7 +1493,7 @@ Future<void> main() async {
   
   await completer.future;
 
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   final rows = controller.widgetList(find.byType(Row));
 
@@ -1579,7 +1579,7 @@ class MyWidget extends StatelessWidget {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.center,
       textBaseline: TextBaseline.alphabetic,
-      children: [
+      children: const [
         Text(
           'Hey!',
           style: TextStyle(
@@ -1619,8 +1619,8 @@ class MyApp extends StatelessWidget {
         color: const Color(0xffeeeeee),
         child: Center(
           child: Container(
-            child: MyWidget(),
             color: const Color(0xffcccccc),
+            child: MyWidget(),
           ),
         ),
       ),
@@ -1640,7 +1640,7 @@ Future<void> main() async {
   
   await completer.future;
 
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   final rows = controller.widgetList(find.byType(Row));
 
@@ -1718,7 +1718,7 @@ class MyWidget extends StatelessWidget {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.center,
       textBaseline: TextBaseline.alphabetic,
-      children: [
+      children: const [
         Icon(
           Icons.widgets,
           size: 50,
@@ -1744,8 +1744,8 @@ class MyApp extends StatelessWidget {
         color: const Color(0xffeeeeee),
         child: Center(
           child: Container(
-            child: MyWidget(),
             color: const Color(0xffcccccc),
+            child: MyWidget(),
           ),
         ),
       ),
@@ -1765,7 +1765,7 @@ Future<void> main() async {
   
   await completer.future;
 
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   final rows = controller.widgetList(find.byType(Row));
 
@@ -1861,8 +1861,8 @@ class MyApp extends StatelessWidget {
         color: const Color(0xffeeeeee),
         child: Center(
           child: Container(
-            child: MyWidget(),
             color: const Color(0xffcccccc),
+            child: MyWidget(),
           ),
         ),
       ),
@@ -1882,7 +1882,7 @@ Future<void> main() async {
   
   await completer.future;
 
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   final rows = controller.widgetList(find.byType(Row));
 
@@ -2054,7 +2054,7 @@ Future<void> main() async {
   
   await completer.future;
 
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   // Check MyWidget starts with one Column
 
@@ -2247,7 +2247,7 @@ Future<void> main() async {
   
   await completer.future;
 
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   // Check MyWidget starts with one Column
 
@@ -2503,7 +2503,7 @@ Future<void> main() async {
   
   await completer.future;
 
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   // Check MyWidget starts with one Column
 
@@ -2682,7 +2682,7 @@ class MyWidget extends StatelessWidget {
         Row(
           children: [
             const Padding(
-              padding: const EdgeInsets.all(8.0),
+              padding: EdgeInsets.all(8.0),
               child: Icon(Icons.account_circle, size: 50),
             ),
             Column(
@@ -2814,7 +2814,7 @@ Future<void> main() async {
   
   await completer.future;
 
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   // Check MyWidget starts with one Column
 
@@ -3155,7 +3155,7 @@ Future<void> main() async {
   
   await completer.future;
 
-  final controller = LiveWidgetController(WidgetsBinding.instance!);
+  final controller = LiveWidgetController(WidgetsBinding.instance);
 
   // Check MyWidget starts with one Column
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ This PR removes the lint warnings from Codelabs samples/code snippets.

- https://docs.flutter.dev/codelabs/explicit-animations
- https://docs.flutter.dev/codelabs/implicit-animations
- https://docs.flutter.dev/codelabs/layout-basics

_Issues fixed by this PR (if any):_ Parts of #6155

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.