### PR TITLE
remove concurrency property from deploy workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,6 @@ jobs:
 
   deploy:
     needs: test
-    concurrency: 
-      group: prod-deploy-group
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push'


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ #7179 added the concurrency flag to test. However, "When concurrency is specified at the job level, order is not guaranteed for jobs or runs that queue within 5 minutes of each other." Also, instead of being a queue there's only an "active" job and a single "pending" job. This has the potential to prevent newer PRs from being deployed when multiple are approved + merged in a short time (a few seconds/minutes): [Example Run](https://github.com/flutter/website/actions/runs/2497217013)

cc: @btobin 

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.