### PR TITLE
[Windows] Remove warning on minimum Flutter SDK version

### DIFF
--- a/src/get-started/install/_windows-desktop-setup.md
+++ b/src/get-started/install/_windows-desktop-setup.md
@@ -1,13 +1,5 @@
 ## Windows setup
 
-{{site.alert.warning}}
-  **Windows support!**
-  As of Flutter 2.10, Windows support is available
-  on the `stable` channel! For more information, see
-  [Announcing Flutter for Windows][], a free article
-  on Medium.
-{{site.alert.end}}
-
 [Announcing Flutter for Windows]: {{site.flutter-medium}}/announcing-flutter-for-windows-6979d0d01fed
 
 ### Additional Windows requirements


### PR DESCRIPTION
The Windows setup docs warn that Flutter SDK v2.10.0 or newer is required for Windows support. This warning can be removed as v2.10.0 has been on the stable release channel for over 3 months now.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.