### PR TITLE
Add `const` for `localizationsDelegates` and `supportedLocales`

### DIFF
--- a/examples/internationalization/add_language/lib/main.dart
+++ b/examples/internationalization/add_language/lib/main.dart
@@ -7,12 +7,12 @@ void main() {
   runApp(
     // #docregion MaterialApp
     const MaterialApp(
-      localizationsDelegates: [
+      localizationsDelegates: const [
         GlobalWidgetsLocalizations.delegate,
         GlobalMaterialLocalizations.delegate,
         NnMaterialLocalizations.delegate, // Add the newly created delegate
       ],
-      supportedLocales: [
+      supportedLocales: const [
         Locale('en', 'US'),
         Locale('nn'),
       ],

--- a/examples/internationalization/add_language/lib/main.dart
+++ b/examples/internationalization/add_language/lib/main.dart
@@ -7,12 +7,12 @@ void main() {
   runApp(
     // #docregion MaterialApp
     const MaterialApp(
-      localizationsDelegates: const [
+      localizationsDelegates: [
         GlobalWidgetsLocalizations.delegate,
         GlobalMaterialLocalizations.delegate,
         NnMaterialLocalizations.delegate, // Add the newly created delegate
       ],
-      supportedLocales: const [
+      supportedLocales: [
         Locale('en', 'US'),
         Locale('nn'),
       ],

--- a/examples/internationalization/gen_l10n_example/lib/examples.dart
+++ b/examples/internationalization/gen_l10n_example/lib/examples.dart
@@ -32,7 +32,7 @@ void examples(BuildContext context) {
 
   const MaterialApp(
 // #docregion SupportedLocales
-    supportedLocales: [
+    supportedLocales: const [
       Locale.fromSubtags(languageCode: 'zh'), // generic Chinese 'zh'
       Locale.fromSubtags(
           languageCode: 'zh',

--- a/examples/internationalization/gen_l10n_example/lib/main.dart
+++ b/examples/internationalization/gen_l10n_example/lib/main.dart
@@ -16,13 +16,13 @@ class MyApp extends StatelessWidget {
 // #docregion MaterialApp
     return const MaterialApp(
       title: 'Localizations Sample App',
-      localizationsDelegates: [
+      localizationsDelegates: const [
         AppLocalizations.delegate, // Add this line
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
-      supportedLocales: [
+      supportedLocales: const [
         Locale('en', ''), // English, no country code
         Locale('es', ''), // Spanish, no country code
       ],

--- a/src/development/accessibility-and-localization/internationalization.md
+++ b/src/development/accessibility-and-localization/internationalization.md
@@ -81,12 +81,12 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 ```dart
 return const MaterialApp(
   title: 'Localizations Sample App',
-  localizationsDelegates: [
+  localizationsDelegates: const [
     GlobalMaterialLocalizations.delegate,
     GlobalWidgetsLocalizations.delegate,
     GlobalCupertinoLocalizations.delegate,
   ],
-  supportedLocales: [
+  supportedLocales: const [
     Locale('en', ''), // English, no country code
     Locale('es', ''), // Spanish, no country code
   ],
@@ -211,13 +211,13 @@ project called `l10n.yaml` with the following content:
    ```dart
    return const MaterialApp(
      title: 'Localizations Sample App',
-     localizationsDelegates: [
+     localizationsDelegates: const [
        AppLocalizations.delegate, // Add this line
        GlobalMaterialLocalizations.delegate,
        GlobalWidgetsLocalizations.delegate,
        GlobalCupertinoLocalizations.delegate,
      ],
-     supportedLocales: [
+     supportedLocales: const [
        Locale('en', ''), // English, no country code
        Locale('es', ''), // Spanish, no country code
      ],
@@ -319,7 +319,7 @@ locales should include:
 
 <?code-excerpt "gen_l10n_example/lib/examples.dart (SupportedLocales)"?>
 ```dart
-supportedLocales: [
+supportedLocales: const [
   Locale.fromSubtags(languageCode: 'zh'), // generic Chinese 'zh'
   Locale.fromSubtags(
       languageCode: 'zh',
@@ -711,12 +711,12 @@ adds the `NnMaterialLocalizations` delegate instance to the app's
 <?code-excerpt "add_language/lib/main.dart (MaterialApp)"?>
 ```dart
 const MaterialApp(
-  localizationsDelegates: [
+  localizationsDelegates: const [
     GlobalWidgetsLocalizations.delegate,
     GlobalMaterialLocalizations.delegate,
     NnMaterialLocalizations.delegate, // Add the newly created delegate
   ],
-  supportedLocales: [
+  supportedLocales: const [
     Locale('en', 'US'),
     Locale('nn'),
   ],


### PR DESCRIPTION
This PR adds missing `const`, which is reported as [Flutter lint](https://dart-lang.github.io/linter/lints/prefer_const_literals_to_create_immutables.html).



## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.