### PR TITLE
delete comment row in the dart code

### DIFF
--- a/examples/ui/widgets_intro/lib/main_myappbar.dart
+++ b/examples/ui/widgets_intro/lib/main_myappbar.dart
@@ -15,7 +15,6 @@ class MyAppBar extends StatelessWidget {
       decoration: BoxDecoration(color: Colors.blue[500]),
       // Row is a horizontal, linear layout.
       child: Row(
-        // <Widget> is the type of items in the list.
         children: [
           const IconButton(
             icon: Icon(Icons.menu),

--- a/src/development/ui/widgets-intro.md
+++ b/src/development/ui/widgets-intro.md
@@ -117,7 +117,6 @@ class MyAppBar extends StatelessWidget {
       decoration: BoxDecoration(color: Colors.blue[500]),
       // Row is a horizontal, linear layout.
       child: Row(
-        // <Widget> is the type of items in the list.
         children: [
           const IconButton(
             icon: Icon(Icons.menu),


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Delete
> // \<Widget> is the type of items in the list.

as it seems type annotations <Widget> before [ ] were deleted in the past and this comment makes no sense anymore.

## Presubmit checklist
- [ x ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ x ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ x ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.