### PR TITLE
Remove `/` for `flutter run` command in `accessibility.md`

### DIFF
--- a/src/development/accessibility-and-localization/accessibility.md
+++ b/src/development/accessibility-and-localization/accessibility.md
@@ -149,8 +149,7 @@ widgets to offer a dramatically more accessible experience.
 You can debug accessibility by visualizing the semantic nodes created for your web app
 using the following command line flag in profile and release modes:
 
-`$ flutter run -d chrome --profile \
- --dart-define=FLUTTER_WEB_DEBUG_SHOW_SEMANTICS=true`
+`$ flutter run -d chrome --profile --dart-define=FLUTTER_WEB_DEBUG_SHOW_SEMANTICS=true`
  
 With the flag activated, the semantic nodes appear on top of the widgets;
 you can verify that the semantic elements are placed where they should be.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Is there a purpose for adding the `/`? It has no effect.

Backslash followed by a new line formats a shell command over multiple lines. But the command is displayed as one-liner. So the backslash has no effect.

![image](https://user-images.githubusercontent.com/24459435/174760430-e38b9e12-c140-4ba8-8597-67a4c9c10d0b.png)

https://docs.flutter.dev/development/accessibility-and-localization/accessibility#testing-accessibility-on-web

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.