### PR TITLE
Fix macOS deployment Codemagic CLI tools Point 13 snippet

### DIFF
--- a/src/deployment/macos.md
+++ b/src/deployment/macos.md
@@ -382,7 +382,7 @@ PACKAGE_NAME=$(basename "$APP_NAME" .app).pkg
 xcrun productbuild --component "$APP_NAME" /Applications/ unsigned.pkg
 
 INSTALLER_CERT_NAME=$(keychain list-certificates \
-          | jq '.[0]
+          | jq '.[]
             | select(.common_name
             | contains("Mac Developer Installer"))
             | .common_name' \


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

The snippet update assures that the right certificate is found in the case of multiple certificates. The fix was suggested in the issue marked below and was deemed to be accurate.

_Issues fixed by this PR (if any):_

[Issue 7211](https://github.com/flutter/website/issues/7211)
