### PR TITLE
Clean up supported platform descriptions

### DIFF
--- a/src/development/tools/sdk/release-notes/supported-platforms.md
+++ b/src/development/tools/sdk/release-notes/supported-platforms.md
@@ -11,25 +11,18 @@ Flutter supports the following platforms:
 
 |Platform|Version                       |Channels |
 |--------|------------------------------|---------|
-|Android | API 19 & above               | All     |
+|Android | API 16 (Android 4.1) & above | All     |
 |iOS     | iOS 9 & above                | All     |
-|Linux   | Debian 10 & above            | All     |
-|macOS   | El Capitan & above           | All     |
+|Linux   | Debian, 64-bit               | All     |
+|macOS   | El Capitan (10.11) & above   | All     |
 |Web     | Chrome 84  & above           | All     |
 |Web     | Firefox 72.0 & above         | All     |
 |Web     | Safari on El Capitan & above | All     |
 |Web     | Edge 1.2.0 & above           | All     |
-|Windows | Windows 10 & above           | All     |
+|Windows | Windows 7 & above, 64-bit    | All     |
 
 All channels include master, beta,
 and stable channels. 
-
-{{site.alert.note}}
-  The dev channel is retired. For more information,
-  refer to [What's new in Flutter 2.8][].
-{{site.alert.end}}
-
-[What's new in Flutter 2.8]: {{site.medium}}/flutter/whats-new-in-flutter-2-8-d085b763d181
 
 ## How we define a supported platform
 
@@ -39,7 +32,7 @@ which Flutter runs:
 1. Supported Google-tested platforms,
    which are platforms the Flutter team at 
    Google tests in continuous integration at every commit. 
-1. Best effort platforms, supported through community
+1. Best-effort platforms, supported through community
    testing, are platforms we believe we support through
    coding practices and ad-hoc testing,
    but rely on the community for testing.
@@ -51,16 +44,7 @@ which Flutter runs:
 
 |Platform|Version               |
 |--------|----------------------|
-|Android |Android SDK 30        |
-|Android |Android SDK 29        |
-|Android |Android SDK 28        |
-|Android |Android SDK 27        |
-|Android |Android SDK 26        |
-|Android |Android SDK 25        |
-|Android |Android SDK 24        |
-|Android |Android SDK 23        |
-|Android |Android SDK 22        |
-|Android |Android SDK 21        |
+|Android |Android SDK 21–30     |
 |Android |Android SDK 19        |
 |iOS     |14-15                 |
 |Web     |Chrome 84             |
@@ -75,28 +59,29 @@ Note that Android SDK 20 is covered by
 testing Android SDK 19, as the differences
 between the two platform versions are minimal.
 
-### Best effort platforms tested by the community
+### Best-effort platforms
 
-|Platform|Version       |
-|--------|---------------|
-|Android |Android SDK 20 |
-|Android |Android SDK 18 |
-|Android |Android SDK 17 |
-|Android |Android SDK 16 |
-|iOS     |iOS 9-13       |
-|Windows |Windows 8      |
-|Windows |Windows 7      |
-|Linux   |Debian & below |
+|Platform|Version             |
+|--------|--------------------|
+|Android |Android SDK 20      |
+|Android |Android SDK 16–18   |
+|Android |Android SDK 17      |
+|Android |Android SDK 16      |
+|iOS     |iOS 9-13            |
+|Windows |Windows 8           |
+|Windows |Windows 7           |
+|Linux   |Debian 9 & below    |
 
 ### Unsupported platforms
 
 |Platform|Version                                     |
 |--------|--------------------------------------------|
-|Android |Android SDK 18 & below                      |
+|Android |Android SDK 15 & below                      |
 |iOS     |[iOS 8][] & below and [`arm7v` 32-bit iOS][]|
 |Windows |Windows Vista & below                       |
 |Windows |Any 32-bit platform                         |
-|macOS   |Yosemite & below                            |
+|macOS   |Yosemite (10.10) & below                    |
+|Linux   |Any 32-bit platform                         |
 
 [iOS 8]: {{site.url}}/go/rfc-ios8-deprecation
 [`arm7v` 32-bit iOS]: {{site.url}}/go/rfc-32-bit-ios-unsupported


### PR DESCRIPTION
Fixes inconsistencies in the listings:
- The initial listing now includes both Google-tested and best-effort support tiers for all platforms; it included both for some platforms, but only Google-tested for others.
- Fixes the Unsupported platforms section for Android; it was listing best-effort platforms as unsupported.
- Adds a missing version number to the Linux best-effort entry.
- Adds 32-bit Linux to the Unsupported section for consistency with the Windows entry.
- Uses ranges for Android versions instead of listing each one, as we do for iOS.

Other minor changes:
- Explicitly lists 64-bit as a requirement for Windows in the main listing, instead of relying on people finding the note about 32-bit in the Unsupported section.
- Explicitly lists 64-bit as a requirement for Linux in the main listing.
- Adds OS version numbers for macOS, since it's hard to remember the name->version mapping for every macOS version.
- Adds an Android OS version number in the mail listing, to make it easy to map the support to user-visible OS numbers instead of needing to know the SDK->OS version mapping.

Fixes https://github.com/flutter/flutter/issues/106301

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.