### PR TITLE
Added Riverpod to dependency injection section

### DIFF
--- a/src/resources/faq.md
+++ b/src/resources/faq.md
@@ -193,7 +193,7 @@ called Dart DevTools). For more information, see
 We don't ship with an opinionated solution,
 but there are a variety of packages that offer
 dependency injection and service location, such as [injectable][],
-[get_it][], and [kiwi][].
+[get_it][], [kiwi][] and [riverpod][].
 
 ## Technology
 
@@ -1118,3 +1118,4 @@ apps built with Flutter should follow Apple's
 [`Widget`]: {{site.api}}/flutter/widgets/Widget-class.html
 [widgets]: {{site.url}}/development/ui/widgets
 [supported platforms]: {{site.url}}/development/tools/sdk/release-notes/supported-platforms
+[riverpod]: {{site.pub}}/packages/riverpod

--- a/src/resources/faq.md
+++ b/src/resources/faq.md
@@ -193,7 +193,7 @@ called Dart DevTools). For more information, see
 We don't ship with an opinionated solution,
 but there are a variety of packages that offer
 dependency injection and service location, such as [injectable][],
-[get_it][], [kiwi][] and [riverpod][].
+[get_it][], [kiwi][], and [riverpod][].
 
 ## Technology
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Added rivepod to dependency injection section.
_Issues fixed by this PR (if any):_
#7294
## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.