### PR TITLE
Making `chrome://tracing` not a link

### DIFF
--- a/src/cookbook/testing/integration/profiling.md
+++ b/src/cookbook/testing/integration/profiling.md
@@ -90,7 +90,7 @@ to review the results:
      number of skipped frames, slowest build times, and more.
   2. Saving the complete `Timeline` as a json file on disk.
      This file can be opened with the Chrome browser's
-     tracing tools found at [chrome://tracing][].
+     tracing tools found at `chrome://tracing`.
 
 To capture the results, create a file named `perf_driver.dart`
 in the `test_driver` folder and add the following code:
@@ -164,7 +164,7 @@ the project contains two files:
      time the test runs and create a graph of the results.
   2. `scrolling_timeline.timeline.json` contains the complete timeline data.
      Open the file using the Chrome browser's tracing tools found at
-     [chrome://tracing][]. The tracing tools provide a
+     `chrome://tracing`. The tracing tools provide a
      convenient interface for inspecting the timeline data to discover
      the source of a performance issue.
 
@@ -265,7 +265,6 @@ Future<void> main() {
 ```
 
 
-[chrome://tracing]: chrome://tracing
 [`IntegrationTestWidgetsFlutterBinding`]: {{site.api}}/flutter/package-integration_test_integration_test/IntegrationTestWidgetsFlutterBinding-class.html
 [Scrolling]: {{site.url}}/cookbook/testing/widget/scrolling
 [`Timeline`]: {{site.api}}/flutter/flutter_driver/Timeline-class.html


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ It appears chrome blocks links to `chrome://tracing`.  Users have to open a new tab/window and type or paste `chrome://tracing` into the URL bar.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.