### PR TITLE
chore: Removed outdated warning

### DIFF
--- a/src/development/ui/animations/hero-animations.md
+++ b/src/development/ui/animations/hero-animations.md
@@ -134,17 +134,6 @@ widgets: one describing the widget in the source route,
 and another describing the widget in the destination route.
 From the user’s point of view, the hero appears to be shared, and
 only the programmer needs to understand this implementation detail.
-
-{{site.alert.secondary}}
-  **Note about dialogs:**
-  Heroes fly from one `PageRoute` to another. Dialogs
-  (displayed with `showDialog()`, for example), use `PopupRoute`s,
-  which are not `PageRoute`s.  At least for now,
-  you can't animate a hero to a `Dialog`.
-  For further developments (and a possible workaround),
-  [watch this issue][].
-{{site.alert.end}}
-
 Hero animation code has the following structure:
 
 1. Define a starting Hero widget, referred to as the _source


### PR DESCRIPTION
The issue was fixed (https://github.com/flutter/flutter/pull/37341) so we don't need this warning anymore

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.