### PR TITLE
Fix link in Windows deployment page

### DIFF
--- a/src/deployment/windows.md
+++ b/src/deployment/windows.md
@@ -177,7 +177,7 @@ even if the certification passes.
 [msidocs]: https://docs.microsoft.com/en-us/windows/win32/msi/windows-installer-portal
 [microsoftpartner]: https://partner.microsoft.com/
 [msix package]: {{site.pub}}/packages/msix
-[msix packaging]: {{site.url}}/desktop#msix-packaging
+[msix packaging]: {{site.url}}/development/platform-integration/windows/building#msix-packaging
 [partnercenterapi]: https://docs.microsoft.com/azure/marketplace/azure-app-apis
 [storepolicies]: https://docs.microsoft.com/windows/uwp/publish/store-policies/
 [visualstudiopackaging]: https://docs.microsoft.com/windows/msix/package/packaging-uwp-apps


### PR DESCRIPTION
Fix a link to "MSIX packaging" in Windows deployment page

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.