### PR TITLE
Fix for FFI links

### DIFF
--- a/src/development/packages-and-plugins/developing-packages.md
+++ b/src/development/packages-and-plugins/developing-packages.md
@@ -68,7 +68,7 @@ Packages can contain more than one kind of content:
 **FFI Plugin packages**
 : A specialized Dart package that contains an API written in
   Dart code combined with one or more platform-specific
-  implementations that use [Dart FFI][FFI].
+  implementations that use Dart FFI([Android][Android], [iOS][iOS], [macOS][macOS]).
 
 ## Developing Dart packages {#dart}
 
@@ -537,7 +537,7 @@ If this command displays a message about updating the
 Usually plugin implementations involve platform channels
 and a second language, as described above.
 In some cases, however, some platforms can be
-implemented entirely in Dart (for example, using [FFI][]).
+implemented entirely in Dart (for example, using FFI).
 For a Dart-only platform implementation,
 replace the `pluginClass` in pubspec.yaml with a `dartPluginClass`.
 Here is the `hello_windows` example above modified for a
@@ -586,7 +586,7 @@ a section in [Supporting the new Android plugins APIs][].
 ## Developing FFI plugin packages {#plugin-ffi}
 
 If you want to develop a package that calls into native APIs using
-[Dart's FFI][FFI], you need to develop an FFI plugin package.
+Dart's FFI, you need to develop an FFI plugin package.
 
 ### Step 1: Create the package
 
@@ -925,7 +925,9 @@ PENDING
 [`device_info`]: {{site.pub-api}}/device_info/latest
 [Effective Dart Documentation]: {{site.dart-site}}/guides/language/effective-dart/documentation
 [federated plugins]: #federated-plugins
-[FFI]: {{site.url}}/development/platform-integration/c-interop
+[Android]: {{site.url}}/development/platform-integration/android/c-interop
+[iOS]: {{site.url}}/development/platform-integration/ios/c-interop
+[macOS]: {{site.url}}/development/platform-integration/macos/c-interop
 [`fluro`]: {{site.pub}}/packages/fluro
 [Flutter editor]: {{site.url}}/get-started/editor
 [Flutter Favorites]: {{site.pub}}/flutter/favorites


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

- fixes the FFI links on the Developing Packages and Plugins page
- adds links to platform-specific FFI

_Issues fixed by this PR (if any):_
#7339 Additional link fixes
## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.