### PR TITLE
Add go link for iOS spell-check document

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -273,6 +273,7 @@
       { "source": "/go/ios-platform-view-focus", "destination": "https://docs.google.com/document/d/1GG8VfYeuVtTQHiMWQXbrSG5HEUorzqU8IGbNySVJ-bY", "type": 301 },
       { "source": "/go/ios-pull-to-refresh", "destination": "https://docs.google.com/document/d/1oUgNd3fsJ1QVuEmA6ENBT8vq3o6QKCRUPGCB6q91VgI/edit", "type": 301 },
       { "source": "/go/ios-scribble", "destination": "https://docs.google.com/document/d/1mjQbsSRQnHuAgMNdouaSgTS-Xv-w57fdKfOUUafWpRo", "type": 301 },
+      { "source": "/go/ios-spell-check", "destination": "https://docs.google.com/document/d/10Lvkz802QpzAGFi3Q9WVTMVUV-SPJyG3_xs8XfxG59Q/edit?usp=sharing", "type": 301 },
       { "source": "/go/ios-switch-controll-scrolling", "destination": "https://docs.google.com/document/d/1CZ2CRXihPQ1hBUXWODpyPVJ_2Yc0es6tkXrJSnpDajA", "type": 301 },
       { "source": "/go/issue-priority-standards", "destination": "https://docs.google.com/document/d/1x-BpbFHUKndv2ojd6LmS-At-pxd6SrIbgfYUepjP7D4/", "type": 301 },
       { "source": "/go/issue-triage-changes", "destination": "https://docs.google.com/document/d/1KJVPMxzfFaL_gIB6Z3oNRTBKA-NP25YpM8xi3xUKbBY", "type": 301 },


### PR DESCRIPTION
Add a go link for the iOS spell-check document.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.