### PR TITLE
Update some migration docs for Flutter 3 breaking changes

### DIFF
--- a/src/release/breaking-changes/2-10-deprecations.md
+++ b/src/release/breaking-changes/2-10-deprecations.md
@@ -623,5 +623,5 @@ Relevant PRs:
 
 ## Timeline
 
-In stable release: TBD
+In stable release: 3.0.0
 

--- a/src/release/breaking-changes/chip-usedeletebuttontooltip-migration.md
+++ b/src/release/breaking-changes/chip-usedeletebuttontooltip-migration.md
@@ -71,11 +71,9 @@ RawChip(
 ## Timeline
 
 Landed in version: 2.11.0-0.1.pre<br>
-In stable release: not yet
+In stable release: 3.0.0
 
 ## References
-
-{% include docs/master-api.md %}
 
 API documentation:
 
@@ -87,9 +85,9 @@ Relevant PRs:
 
 * [Deprecate `useDeleteButtonTooltip` for Chips][]
 
-[`Chip`]: {{site.master-api}}/flutter/material/Chip-class.html
-[`InputChip`]: {{site.master-api}}/flutter/material/InputChip-class.html
-[`RawChip`]: {{site.master-api}}/flutter/material/RawChip-class.html
+[`Chip`]: {{site.api}}/flutter/material/Chip-class.html
+[`InputChip`]: {{site.api}}/flutter/material/InputChip-class.html
+[`RawChip`]: {{site.api}}/flutter/material/RawChip-class.html
 
 [Deprecate `useDeleteButtonTooltip` for Chips]: {{site.repo.flutter}}/pull/96174
 [Flutter fix]: {{site.url}}/development/tools/flutter-fix


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
- Updates stable release
- Replaces master api with stable api link

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.