### PR TITLE
Fix typo in cookbook integration test intro

### DIFF
--- a/examples/cookbook/testing/integration/introduction/lib/integration_test/app_test.dart
+++ b/examples/cookbook/testing/integration/introduction/lib/integration_test/app_test.dart
@@ -2,7 +2,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-import '../main.dart' as app;
+import 'package:counter_app/main.dart' as app;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/src/cookbook/testing/integration/introduction.md
+++ b/src/cookbook/testing/integration/introduction.md
@@ -154,7 +154,7 @@ Now you can write tests. This involves three steps:
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-import '../main.dart' as app;
+import '../lib/main.dart' as app;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/src/cookbook/testing/integration/introduction.md
+++ b/src/cookbook/testing/integration/introduction.md
@@ -154,7 +154,7 @@ Now you can write tests. This involves three steps:
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-import '../lib/main.dart' as app;
+import 'package:counter_app/main.dart' as app;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Fixed the path to main.dart in the app_test.dart code on the integration test introduction page. When copying the current app_test.dart code into an editor like vscode, the path is underlined in red, as it's incorrect relative to the project layout outline mentioned right before.

_Issues fixed by this PR (if any):_

I searched but didn't find any reported issues matching this one.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.