### PR TITLE
Move "Our Values" section from individual job descriptions into the overview page

### DIFF
--- a/src/jobs/_template.md
+++ b/src/jobs/_template.md
@@ -20,37 +20,6 @@ toc: false
 
 <TODO: Role Description>
 
-## Our values
-
-### Mentorship
-
-Upon joining Google, you will be paired with a formal mentor,
-who will help guide you in the process of ramping up, forging relationships,
-and learning the systems you’ll need to do your job.
-Your manager can also help you find mentors who can coach you
-as you navigate your career at Google. In addition to formal mentors,
-we work and train together so that we are always learning from one another,
-and we celebrate and support the career progression of our team members.
-
-### Inclusion
-
-Here on the Flutter team and at Google, we embrace our differences
-and are [committed to furthering our culture of inclusion](https://flutter.dev/culture).
-In addition to groups like the [Flutteristas](https://flutteristas.org/),
-[Employee Resource Groups (ERGs)](https://diversity.google/commitments/)
-are employee-initiated networks for supporting underrepresented employees
-and their allies with shared values of creating belonging 
-across their communities and Google.
-
-### Work-Life Balance
-
-Our team also puts a high value on work-life balance.
-Striking a healthy balance between your personal and professional life
-is crucial to your happiness and success here, which is why we aren’t focused
-on how many hours you spend at work or online. Instead,
-we’re happy to offer a flexible schedule so you can have a more productive and
-well-balanced life—both in and outside of work.
-
 ## Job location
 
 <TODO: Location>

--- a/src/jobs/android.md
+++ b/src/jobs/android.md
@@ -24,36 +24,6 @@ Flutter on Android the absolute best it can be, including:
 *   Nurturing a thriving community of contributions from open-source developers by reviewing
      GitHub pull requests (PRs).
 
-## Our values
-
-### Mentorship
-
-Upon joining Google, you will be paired with a formal mentor,
-who will help guide you in the process of ramping up, forging relationships,
-and learning the systems you’ll need to do your job.
-Your manager can also help you find mentors who can coach you
-as you navigate your career at Google. In addition to formal mentors,
-we work and train together so that we are always learning from one another,
-and we celebrate and support the career progression of our team members.
-
-### Inclusion
-
-Here on the Flutter team and at Google, we embrace our differences
-and are [committed to furthering our culture of inclusion](https://flutter.dev/culture).
-In addition to groups like the [Flutteristas](https://flutteristas.org/),
-[Employee Resource Groups (ERGs)](https://diversity.google/commitments/)
-are employee-initiated networks for supporting underrepresented employees
-and their allies with shared values of creating belonging across their communities and Google.
-
-### Work-Life Balance
-
-Our team also puts a high value on work-life balance.
-Striking a healthy balance between your personal and professional life
-is crucial to your happiness and success here, which is why we aren’t focused
-on how many hours you spend at work or online. Instead,
-we’re happy to offer a flexible schedule so you can have a more productive and
-well-balanced life—both in and outside of work.
-
 ## Job location
 
 Any Google office location, or fully remote in a timezone 3 hours

--- a/src/jobs/android_tl.md
+++ b/src/jobs/android_tl.md
@@ -34,37 +34,6 @@ include:
 *   Improving developer experience to delight Android developers with the ease
     of development for Flutter.
 
-## Our values
-
-### Mentorship
-
-Upon joining Google, you will be paired with a formal mentor,
-who will help guide you in the process of ramping up, forging relationships,
-and learning the systems you’ll need to do your job.
-Your manager can also help you find mentors who can coach you
-as you navigate your career at Google. In addition to formal mentors,
-we work and train together so that we are always learning from one another,
-and we celebrate and support the career progression of our team members.
-
-### Inclusion
-
-Here on the Flutter team and at Google, we embrace our differences
-and are [committed to furthering our culture of inclusion](https://flutter.dev/culture).
-In addition to groups like the [Flutteristas](https://flutteristas.org/),
-[Employee Resource Groups (ERGs)](https://diversity.google/commitments/)
-are employee-initiated networks for supporting underrepresented employees
-and their allies with shared values of creating belonging 
-across their communities and Google.
-
-### Work-Life Balance
-
-Our team also puts a high value on work-life balance.
-Striking a healthy balance between your personal and professional life
-is crucial to your happiness and success here, which is why we aren’t focused
-on how many hours you spend at work or online. Instead,
-we’re happy to offer a flexible schedule so you can have a more productive and
-well-balanced life—both in and outside of work.
-
 ## Job location
 
 Any Google office location in a timezone 3 hours behind or ahead of Pacific

--- a/src/jobs/dre.md
+++ b/src/jobs/dre.md
@@ -19,37 +19,6 @@ A few of our projects:
 * Partnership with engineering on Dart/Flutter's developer experience
 * A worldwide community of Flutter Meetups, conferences, and other groups.
 
-## Our values
-
-### Mentorship
-
-Upon joining Google, you will be paired with a formal mentor,
-who will help guide you in the process of ramping up, forging relationships,
-and learning the systems you’ll need to do your job.
-Your manager can also help you find mentors who can coach you
-as you navigate your career at Google. In addition to formal mentors,
-we work and train together so that we are always learning from one another,
-and we celebrate and support the career progression of our team members.
-
-### Inclusion
-
-Here on the Flutter team and at Google, we embrace our differences
-and are [committed to furthering our culture of inclusion](https://flutter.dev/culture).
-In addition to groups like the [Flutteristas](https://flutteristas.org/),
-[Employee Resource Groups (ERGs)](https://diversity.google/commitments/)
-are employee-initiated networks for supporting underrepresented employees
-and their allies with shared values of creating belonging across their
-communities and Google.
-
-### Work-Life Balance
-
-Our team also puts a high value on work-life balance.
-Striking a healthy balance between your personal and professional life
-is crucial to your happiness and success here, which is why we aren’t focused
-on how many hours you spend at work or online. Instead,
-we’re happy to offer a flexible schedule so you can have a more productive and
-well-balanced life—both in and outside of work.
-
 ## Job location
 
 Within the United States, either at a Google office or fully remote

--- a/src/jobs/index.md
+++ b/src/jobs/index.md
@@ -19,3 +19,34 @@ The following jobs are open:
 * [Tech Lead Manager]({{site.url}}/jobs/tlm)
 * [Developer Relations Engineer, iOS Focus]({{site.url}}/jobs/dre)
 
+## Our values
+
+### Mentorship
+
+Upon joining Google, you will be paired with a formal mentor,
+who will help guide you in the process of ramping up, forging relationships,
+and learning the systems you’ll need to do your job.
+Your manager can also help you find mentors who can coach you
+as you navigate your career at Google. In addition to formal mentors,
+we work and train together so that we are always learning from one another,
+and we celebrate and support the career progression of our team members.
+
+### Inclusion
+
+Here on the Flutter team and at Google, we embrace our differences
+and are [committed to furthering our culture of inclusion](https://flutter.dev/culture).
+In addition to groups like the [Flutteristas](https://flutteristas.org/),
+[Employee Resource Groups (ERGs)](https://diversity.google/commitments/)
+are employee-initiated networks for supporting underrepresented employees
+and their allies with shared values of creating belonging
+across their communities and Google.
+
+### Work-Life Balance
+
+Our team also puts a high value on work-life balance.
+Striking a healthy balance between your personal and professional life
+is crucial to your happiness and success here, which is why we aren’t focused
+on how many hours you spend at work or online. Instead,
+we’re happy to offer a flexible schedule so you can have a more productive and
+well-balanced life—both in and outside of work.
+

--- a/src/jobs/ios.md
+++ b/src/jobs/ios.md
@@ -24,37 +24,6 @@ Flutter on iOS the absolute best it can be, including:
 *   Nurturing a thriving community of contributions from open-source developers
     by reviewing GitHub pull requests (PRs).
 
-## Our values
-
-### Mentorship
-
-Upon joining Google, you will be paired with a formal mentor,
-who will help guide you in the process of ramping up, forging relationships,
-and learning the systems you’ll need to do your job. Your manager
-can also help you find mentors who can coach you as you navigate
-your career at Google. In addition to formal mentors,
-we work and train together so that we are always learning from one another,
-and we celebrate and support the career progression of our team members.
-
-### Inclusion
-
-Here on the Flutter team and at Google,
-we embrace our differences and are
-[committed to furthering our culture of inclusion](https://flutter.dev/culture).
-In addition to groups like the [Flutteristas](https://flutteristas.org/),
-[Employee Resource Groups (ERGs)](https://diversity.google/commitments/)
-are employee-initiated networks for supporting underrepresented employees
-and their allies with shared values of creating belonging across their communities and Google.
-
-### Work-Life Balance
-
-Our team also puts a high value on work-life balance.
-Striking a healthy balance between your personal and professional
-life is crucial to your happiness and success here, which is why we aren’t
-focused on how many hours you spend at work or online. Instead,
-we’re happy to offer a flexible schedule so you can have a more productive
-and well-balanced life&mdash;both in and outside of work.
-
 ## Job location
 
 Any Google office location, or fully remote in a timezone 3 hours

--- a/src/jobs/tlm.md
+++ b/src/jobs/tlm.md
@@ -19,37 +19,6 @@ A few of our projects:
 * Partnership with engineering on Dart/Flutter's developer experience
 * A worldwide community of Flutter Meetups, conferences, and other groups.
 
-## Our values
-
-### Mentorship
-
-Upon joining Google, you will be paired with a formal mentor,
-who will help guide you in the process of ramping up, forging relationships,
-and learning the systems you’ll need to do your job.
-Your manager can also help you find mentors who can coach you
-as you navigate your career at Google. In addition to formal mentors,
-we work and train together so that we are always learning from one another,
-and we celebrate and support the career progression of our team members.
-
-### Inclusion
-
-Here on the Flutter team and at Google, we embrace our differences
-and are [committed to furthering our culture of inclusion](https://flutter.dev/culture).
-In addition to groups like the [Flutteristas](https://flutteristas.org/),
-[Employee Resource Groups (ERGs)](https://diversity.google/commitments/)
-are employee-initiated networks for supporting underrepresented employees
-and their allies with shared values of creating belonging across their
-communities and Google.
-
-### Work-Life Balance
-
-Our team also puts a high value on work-life balance.
-Striking a healthy balance between your personal and professional life
-is crucial to your happiness and success here, which is why we aren’t focused
-on how many hours you spend at work or online. Instead,
-we’re happy to offer a flexible schedule so you can have a more productive and
-well-balanced life—both in and outside of work.
-
 ## Job location
 
 Within the United States, either at a Google office or fully remote


### PR DESCRIPTION
This makes individual job postings more concise and avoids differences
in the "Our Values" section across postings.