### PR TITLE
Tweak details around Dart breaking changes

### DIFF
--- a/src/resources/compatibility.md
+++ b/src/resources/compatibility.md
@@ -48,8 +48,8 @@ listed above for making breaking changes in removing the deprecated API.
 
 ## Dart and other libraries used by Flutter
 
-The Dart language itself has a separate breaking-change policy,
-[documented on the Dart wiki][].
+The Dart language itself has a [separate breaking-change policy],
+with announcements on [Dart announce][].
 
 In general, the Flutter team does not currently have any commitment
 regarding breaking changes for other dependencies. For example,
@@ -60,7 +60,8 @@ tests. Such changes would not necessarily be accompanied by a
 migration guide.
 
 
-[documented on the Dart wiki]: {{site.github}}/dart-lang/sdk/blob/master/docs/process/breaking-changes.md
 [flutter/tests repository]: {{site.github}}/flutter/tests
 [flutter-announce]: {{site.groups}}/forum/#!forum/flutter-announce
 [guides for migrating code]: {{site.url}}/release/breaking-changes
+[separate breaking-change policy]: {{site.github}}/dart-lang/sdk/blob/master/docs/process/breaking-changes.md
+[Dart announce]: https://groups.google.com/a/dartlang.org/g/announce

--- a/src/resources/compatibility.md
+++ b/src/resources/compatibility.md
@@ -48,7 +48,7 @@ listed above for making breaking changes in removing the deprecated API.
 
 ## Dart and other libraries used by Flutter
 
-The Dart language itself has a [separate breaking-change policy],
+The Dart language itself has a [separate breaking-change policy][],
 with announcements on [Dart announce][].
 
 In general, the Flutter team does not currently have any commitment


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [v] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [v] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [v] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.