### PR TITLE
Make splashScreenView of FlutterViewController nullable

### DIFF
--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -20,9 +20,11 @@ release, and listed in alphabetical order:
 
 * [Default PrimaryScrollController on Desktop][]
 * [ThemeData's toggleableActiveColor property has been deprecated][]
+* [iOS FlutterViewController splashScreenView make nullable][]
 
 [Default PrimaryScrollController on Desktop]: {{site.url}}/release/breaking-changes/primary-scroll-controller-desktop
 [ThemeData's toggleableActiveColor property has been deprecated]: {{site.url}}/release/breaking-changes/toggleable-active-color
+[iOS FlutterViewController splashScreenView make nullable]: {{site.url}}/release/breaking-changes/ios-flutterviewcontroller-splashscreenview-nullable
 
 ### Released in Flutter 3
 

--- a/src/release/breaking-changes/ios-flutterviewcontroller-splashscreenview-nullable.md
+++ b/src/release/breaking-changes/ios-flutterviewcontroller-splashscreenview-nullable.md
@@ -1,0 +1,100 @@
+---
+title: iOS FlutterViewController splashScreenView make nullable
+description: FlutterViewController splashScreenView changed from nonnull to nullable.
+---
+
+## Summary
+
+We changed property `splashScreenView` of `FlutterViewController` from `nonnull` to `nullable`.
+
+Old declaration of `splashScreenView`:
+
+```objective-c
+@property(strong, nonatomic) UIView* splashScreenView;
+```
+
+New declaration of `splashScreenView`:
+
+```objective-c
+@property(strong, nonatomic, nullable) UIView* splashScreenView;
+```
+
+## Context
+
+This allows iOS add-to-app users writen in `Swift` to remove the splash screen view.
+
+However, the previous declaration would build error when set `nil` value using `Swift`, only supported if using `Objective-C`.
+
+## Description of change
+
+Before migrated, it would be a compilation error if the calling code is in Swift and gets the splash screen and stores in a nonnull UIView variable.
+
+```
+error build: Value of optional type 'UIView?' must be unwrapped to a value of type 'UIView'
+```
+
+After [PR #34743][], you need to update code to instead store in a UIView?. Instead of declare variable `splashScreenView` as type `UIView`:
+
+```swift
+@UIApplicationMain
+@objc class AppDelegate: FlutterAppDelegate {
+  var splashScreenView = UIView()
+  override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) -> Bool {
+    var flutterEngine = FlutterEngine(name: "my flutter engine")
+    let flutterViewController = FlutterViewController(engine: flutterEngine, nibName: nil, bundle: nil)
+    splashScreenView = flutterViewController.splashScreenView // compilation error: Value of optional type 'UIView?' must be unwrapped to a value of type 'UIView'
+```
+
+instead use `UIView?`:
+
+```swift
+@UIApplicationMain
+@objc class AppDelegate: FlutterAppDelegate {
+  var splashScreenView : UIView? = UIView()
+  override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) -> Bool {
+    var flutterEngine = FlutterEngine(name: "my flutter engine")
+    let flutterViewController = FlutterViewController(engine: flutterEngine, nibName: nil, bundle: nil)
+    let splashScreenView = flutterViewController.splashScreenView // compiles successfully
+    if let splashScreenView = splashScreenView {
+      
+    }
+```
+
+
+## Migration guide
+
+Code before migration:
+
+```swift
+  var splashScreenView = UIView()
+  var flutterEngine = FlutterEngine(name: "my flutter engine")
+  let flutterViewController = FlutterViewController(engine: flutterEngine, nibName: nil, bundle: nil)
+  splashScreenView = flutterViewController.splashScreenView // compilation error: Value of optional type 'UIView?' must be unwrapped to a value of type 'UIView'
+```
+
+Code after migration:
+
+```swift
+  var splashScreenView : UIView? = UIView()
+  var flutterEngine = FlutterEngine(name: "my flutter engine")
+  let flutterViewController = FlutterViewController(engine: flutterEngine, nibName: nil, bundle: nil)
+  let splashScreenView = flutterViewController.splashScreenView // compiles successfully
+  if let splashScreenView = splashScreenView {
+  }
+```
+
+## Timeline
+
+In stable release: not yet
+
+## References
+
+Related PR [][PR #34743] Make splashScreenView of FlutterViewController nullable
+
+[PR #34743]: {{site.github}}/flutter/engine/pull/34743


### PR DESCRIPTION
Make splashScreenView of FlutterViewController nullable https://github.com/flutter/engine/pull/34743.

We should make splashScreenView nullable, then Swift users can remove splashScreenView if they set nil.


## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.