### PR TITLE
Fix typo: cmd line args -p to --port

### DIFF
--- a/src/get-started/install/chromeos.md
+++ b/src/get-started/install/chromeos.md
@@ -50,7 +50,7 @@ Flutter DevTools for an Android app with ports
 that will work:
 
 ```terminal
-$ flutter pub global run devtools -p 8000
+$ flutter pub global run devtools --port 8000
 $ cd path/to/your/app
 $ flutter run --observatory-port=8080
 ```


### PR DESCRIPTION
no `-p` flag exists on `devtools`, author meant `--port`.

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.