### PR TITLE
Adds migration guide from deprecated splash screen API

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -165,6 +165,8 @@
               permalink: /development/platform-integration/android/plugin-api-migration
             - title: AndroidX migration
               permalink: /development/platform-integration/android/androidx-migration
+            - title: Deprecated Splash Screen API Migration
+              permalink: /development/platform-integration/android/splash-screen-migration
         - title: iOS
           permalink: /development/platform-integration/ios
           children:

--- a/src/development/add-to-app/android/add-flutter-fragment.md
+++ b/src/development/add-to-app/android/add-flutter-fragment.md
@@ -327,7 +327,7 @@ even if a pre-warmed `FlutterEngine` is used.
 To help improve the user experience around
 this brief waiting period, Flutter supports the
 display of a splash screen (also known as "launch screen") until Flutter
-renders its first frame. For instructions about how to show a lanch
+renders its first frame. For instructions about how to show a launch
 screen, see the [splash screen guide][].
 
 ## Run Flutter with a specified initial route

--- a/src/development/add-to-app/android/add-flutter-fragment.md
+++ b/src/development/add-to-app/android/add-flutter-fragment.md
@@ -326,9 +326,9 @@ The initial display of Flutter content requires some wait time,
 even if a pre-warmed `FlutterEngine` is used.
 To help improve the user experience around
 this brief waiting period, Flutter supports the
-display of a splash screen until Flutter renders
-its first frame. For instructions about how to show a splash screen,
-see the [splash screen guide][].
+display of a splash screen (also known as "launch screen") until Flutter
+renders its first frame. For instructions about how to show a lanch
+screen, see the [splash screen guide][].
 
 ## Run Flutter with a specified initial route
 

--- a/src/development/platform-integration/android/splash-screen-migration.md
+++ b/src/development/platform-integration/android/splash-screen-migration.md
@@ -8,11 +8,11 @@ screen by defining it within the metadata of their application manifest file
 (`AndroidManifest.xml`), or by implementing [`provideSplashScreen`][] within
 their [`FlutterActivity`][]. This would display momentarily in between
 the time after the Android launch screen is shown and when Flutter has
-drawn the first frame. This approach is now deprecated as of Flutter 2.5;
+drawn the first frame. This approach is now deprecated as of Flutter 2.5.
 Flutter now automatically keeps the Android launch screen displayed
 until it draws the first frame.
 
-To migrate from defining a custom splash screen to defining a custom
+To migrate from defining a custom splash screen to just defining a custom
 launch screen for your application, follow the steps that correspond
 to how your application's custom splash screen was defined
 prior to the 2.5 release.
@@ -22,7 +22,7 @@ prior to the 2.5 release.
 1. Locate your application's implementation of `provideSplashScreen()`
    within its `FlutterActivity`. This implementation should involve
    the construction of your application's custom splash screen
-   as a `Drawable`, for example:
+   as a `Drawable`. For example:
 
    ```java
    @Override
@@ -34,10 +34,10 @@ prior to the 2.5 release.
    }
    ```
 
-2. In the next step, you'll specify this `Drawable` as your application's
-    launch theme, so delete this implementation.
+   In the next step, you'll specify this `Drawable` as your application's
+   launch theme, so delete this implementation.
 
-3. Use the steps in the section directly following to ensure that your
+2. Use the steps in the section directly following to ensure that your
    `Drawable` splash screen (`R.some_splash_screen` in the previous example)
    is properly configured as your application's custom launch screen.
 
@@ -72,7 +72,7 @@ prior to the 2.5 release.
 4. Locate the definition of the theme specified by the `android:theme` attribute
    within your application's `style` resources. This theme specifies the
    launch theme of your application. Ensure that the `style` attribute configures the
-   `android:windowBackground` attribute with your custom splash screen:
+   `android:windowBackground` attribute with your custom splash screen. For example:
 
    ```xml
    <resources>

--- a/src/development/platform-integration/android/splash-screen-migration.md
+++ b/src/development/platform-integration/android/splash-screen-migration.md
@@ -1,0 +1,95 @@
+---
+title: Splash Screen migration
+description: How to migrate from Manifest / Activity defined custom splash
+             screen to launch screen.
+---
+
+Prior to Flutter 2.5, Flutter apps could add a splash
+screen by defining it within the metadata of their application manifest file
+(`AndroidManifest.xml`), or by implementing [`provideSplashScreen`][] within
+their [`FlutterActivity`][]. This would display momentarily in between
+the time after the Android launch screen is shown and when Flutter has
+drawn the first frame. This approach is now deprecated as of Flutter 2.5;
+Flutter now automatically keeps the Android launch screen displayed
+until it draws the first frame.
+
+To migrate from defining a custom splash screen to defining a custom
+launch screen for your application, follow the steps that correspond
+to how your application's custom splash screen was defined
+prior to the 2.5 release.
+
+**Custom splash screen defined in [`FlutterActivity`][]**
+
+1. Locate your application's implementation of `provideSplashScreen()`
+   within its `FlutterActivity`. This implementation should involve
+   the construction of your application's custom splash screen:
+   as a `Drawable`, for example:
+
+   ```Java
+   @Override
+   public SplashScreen provideSplashScreen() {
+       // ...
+       return new DrawableSplashScreen(
+           new SomeDrawable(
+               ContextCompat.getDrawable(this, R.some_splash_screen)));
+   }
+   ```
+
+2. In the next step, you'll specify this `Drawable` as your application's
+    launch theme, so delete this implementation.
+
+3. Use the following steps to ensure that your `Drawable` splash screen
+   (`R.some_splash_screen` in the previous example) is properly
+   configured as your application's custom launch screen.
+
+**Custom splash screen defined in Manifest**
+
+1. Locate your application's `AndroidManifest.xml` file.
+   Within this file, find the `activity` element.
+   Within this element, identify the `android:theme` attribute
+   and the `meta-data` element that defines
+   a splash screen as an
+   `io.flutter.embedding.android.SplashScreenDrawable`:
+
+   ```xml
+   <activity
+       // ...
+       android:theme="@style/SomeTheme">
+     // ...
+     <meta-data
+         android:name="io.flutter.embedding.android.SplashScreenDrawable"
+         android:resource="@drawable/some_splash_screen"
+         />
+   </activity>
+   ```
+
+2. If the `android:theme` attribute isn't specified, add the attribute and
+   [define a launch theme][define a theme] for your application's launch screen.
+
+3. Delete the `meta-data` tag, as Flutter no longer
+   displays that information.
+
+4. Locate the definition of the theme specified by the `android:theme` attribute
+   within your application's `style` resources. This theme is what specifies the
+   launch theme of your application. Ensure that this `style` configures the
+   `android:windowBackground` attribute with your custom splash screen:
+
+   ```xml
+   <resources>
+       <style
+           name="SomeTheme"
+           // ...
+           >
+           <!-- Show a splash screen on the activity. Automatically removed when
+                Flutter draws its first frame -->
+           <item name="android:windowBackground">@drawable/some_splash_screen</item>
+       </style>
+   </resources>
+   ```
+
+   [`provideSplashScreen`]: {{site.api}}/javadoc/io/flutter/embedding/android/SplashScreenProvider.html#provideSplashScreen--
+[must use an Xcode storyboard]: {{site.apple-dev}}/news/?id=03042020b
+[Human Interface Guidelines]: {{site.apple-dev}}/design/human-interface-guidelines/ios/visual-design/launch-screen/
+[`FlutterActivity`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterActivity.html
+[define a theme]:  #initializing-the-app
+[Android splash screen sample app]: {{site.github}}/flutter/samples/tree/main/android_splash_screen

--- a/src/development/platform-integration/android/splash-screen-migration.md
+++ b/src/development/platform-integration/android/splash-screen-migration.md
@@ -89,4 +89,3 @@ prior to the 2.5 release.
 [`provideSplashScreen`]: {{site.api}}/javadoc/io/flutter/embedding/android/SplashScreenProvider.html#provideSplashScreen--
 [`FlutterActivity`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterActivity.html
 [define a theme]:  {{site.url}}/development/ui/advanced/splash-screen?tab=android-splash-alignment-kotlin-tab#initializing-the-app
-[Android splash screen sample app]: {{site.github}}/flutter/samples/tree/main/android_splash_screen

--- a/src/development/platform-integration/android/splash-screen-migration.md
+++ b/src/development/platform-integration/android/splash-screen-migration.md
@@ -21,7 +21,7 @@ prior to the 2.5 release.
 
 1. Locate your application's implementation of `provideSplashScreen()`
    within its `FlutterActivity`. This implementation should involve
-   the construction of your application's custom splash screen:
+   the construction of your application's custom splash screen
    as a `Drawable`, for example:
 
    ```Java

--- a/src/development/platform-integration/android/splash-screen-migration.md
+++ b/src/development/platform-integration/android/splash-screen-migration.md
@@ -48,7 +48,8 @@ prior to the 2.5 release.
    Within this element, identify the `android:theme` attribute
    and the `meta-data` element that defines
    a splash screen as an
-   `io.flutter.embedding.android.SplashScreenDrawable`:
+   `io.flutter.embedding.android.SplashScreenDrawable`,
+   and update it. For example:
 
    ```xml
    <activity

--- a/src/development/platform-integration/android/splash-screen-migration.md
+++ b/src/development/platform-integration/android/splash-screen-migration.md
@@ -1,7 +1,6 @@
 ---
-title: Splash Screen migration
-description: How to migrate from Manifest / Activity defined custom splash
-             screen to launch screen.
+title: Deprecated Splash Screen API Migration
+description: How to migrate from Manifest/Activity defined splash screen.
 ---
 
 Prior to Flutter 2.5, Flutter apps could add a splash
@@ -87,9 +86,7 @@ prior to the 2.5 release.
    </resources>
    ```
 
-   [`provideSplashScreen`]: {{site.api}}/javadoc/io/flutter/embedding/android/SplashScreenProvider.html#provideSplashScreen--
-[must use an Xcode storyboard]: {{site.apple-dev}}/news/?id=03042020b
-[Human Interface Guidelines]: {{site.apple-dev}}/design/human-interface-guidelines/ios/visual-design/launch-screen/
+[`provideSplashScreen`]: {{site.api}}/javadoc/io/flutter/embedding/android/SplashScreenProvider.html#provideSplashScreen--
 [`FlutterActivity`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterActivity.html
-[define a theme]:  #initializing-the-app
+[define a theme]:  {{site.url}}/development/ui/advanced/splash-screen?tab=android-splash-alignment-kotlin-tab#initializing-the-app
 [Android splash screen sample app]: {{site.github}}/flutter/samples/tree/main/android_splash_screen

--- a/src/development/platform-integration/android/splash-screen-migration.md
+++ b/src/development/platform-integration/android/splash-screen-migration.md
@@ -5,8 +5,8 @@ description: How to migrate from Manifest/Activity defined splash screen.
 
 Prior to Flutter 2.5, Flutter apps could add a splash
 screen by defining it within the metadata of their application manifest file
-(`AndroidManifest.xml`), or by implementing [`provideSplashScreen`][] within
-their [`FlutterActivity`][]. This would display momentarily in between
+(`AndroidManifest.xml`), by implementing [`provideSplashScreen`][] within
+their [`FlutterActivity`][], or both. This would display momentarily in between
 the time after the Android launch screen is shown and when Flutter has
 drawn the first frame. This approach is now deprecated as of Flutter 2.5.
 Flutter now automatically keeps the Android launch screen displayed

--- a/src/development/platform-integration/android/splash-screen-migration.md
+++ b/src/development/platform-integration/android/splash-screen-migration.md
@@ -37,9 +37,9 @@ prior to the 2.5 release.
 2. In the next step, you'll specify this `Drawable` as your application's
     launch theme, so delete this implementation.
 
-3. Use the following steps to ensure that your `Drawable` splash screen
-   (`R.some_splash_screen` in the previous example) is properly
-   configured as your application's custom launch screen.
+3. Use the steps in the section directly following to ensure that your
+   `Drawable` splash screen (`R.some_splash_screen` in the previous example)
+   is properly configured as your application's custom launch screen.
 
 **Custom splash screen defined in Manifest**
 
@@ -63,10 +63,10 @@ prior to the 2.5 release.
    ```
 
 2. If the `android:theme` attribute isn't specified, add the attribute and
-   [define a launch theme][define a theme] for your application's launch screen.
+   [define a launch theme][] for your application's launch screen.
 
-3. Delete the `meta-data` tag, as Flutter no longer
-   displays that information.
+3. Delete the `meta-data` element, as Flutter no longer
+   displays that splash screen.
 
 4. Locate the definition of the theme specified by the `android:theme` attribute
    within your application's `style` resources. This theme is what specifies the
@@ -88,4 +88,4 @@ prior to the 2.5 release.
 
 [`provideSplashScreen`]: {{site.api}}/javadoc/io/flutter/embedding/android/SplashScreenProvider.html#provideSplashScreen--
 [`FlutterActivity`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterActivity.html
-[define a theme]:  {{site.url}}/development/ui/advanced/splash-screen?tab=android-splash-alignment-kotlin-tab#initializing-the-app
+[define a launch theme]:  {{site.url}}/development/ui/advanced/splash-screen?tab=android-splash-alignment-kotlin-tab#initializing-the-app

--- a/src/development/platform-integration/android/splash-screen-migration.md
+++ b/src/development/platform-integration/android/splash-screen-migration.md
@@ -70,8 +70,8 @@ prior to the 2.5 release.
    displays that splash screen.
 
 4. Locate the definition of the theme specified by the `android:theme` attribute
-   within your application's `style` resources. This theme is what specifies the
-   launch theme of your application. Ensure that this `style` configures the
+   within your application's `style` resources. This theme specifies the
+   launch theme of your application. Ensure that the `style` attribute configures the
    `android:windowBackground` attribute with your custom splash screen:
 
    ```xml

--- a/src/development/platform-integration/android/splash-screen-migration.md
+++ b/src/development/platform-integration/android/splash-screen-migration.md
@@ -34,9 +34,6 @@ prior to the 2.5 release.
    }
    ```
 
-   In the next step, you'll specify this `Drawable` as your application's
-   launch theme, so delete this implementation.
-
 2. Use the steps in the section directly following to ensure that your
    `Drawable` splash screen (`R.some_splash_screen` in the previous example)
    is properly configured as your application's custom launch screen.

--- a/src/development/platform-integration/android/splash-screen-migration.md
+++ b/src/development/platform-integration/android/splash-screen-migration.md
@@ -24,7 +24,7 @@ prior to the 2.5 release.
    the construction of your application's custom splash screen
    as a `Drawable`, for example:
 
-   ```Java
+   ```java
    @Override
    public SplashScreen provideSplashScreen() {
        // ...

--- a/src/development/platform-integration/android/splash-screen-migration.md
+++ b/src/development/platform-integration/android/splash-screen-migration.md
@@ -67,7 +67,7 @@ prior to the 2.5 release.
    [define a launch theme][] for your application's launch screen.
 
 3. Delete the `meta-data` element, as Flutter no longer
-   displays that splash screen.
+   uses that, but it can cause a crash.
 
 4. Locate the definition of the theme specified by the `android:theme` attribute
    within your application's `style` resources. This theme specifies the

--- a/src/development/platform-integration/android/splash-screen-migration.md
+++ b/src/development/platform-integration/android/splash-screen-migration.md
@@ -20,7 +20,7 @@ prior to the 2.5 release.
 **Custom splash screen defined in [`FlutterActivity`][]**
 
 1. Locate your application's implementation of `provideSplashScreen()`
-   within its `FlutterActivity`. This implementation should involve
+   within its `FlutterActivity` and **delete it**. This implementation should involve
    the construction of your application's custom splash screen
    as a `Drawable`. For example:
 

--- a/src/development/platform-integration/web/initialization.md
+++ b/src/development/platform-integration/web/initialization.md
@@ -24,6 +24,12 @@ The initialization process is split into the following stages:
 This page shows how to customize the behavior
 at each stage of the initialization process.
 
+{{site.alert.note}}
+For more information on implementing splash screens
+on mobile platforms, see the
+[Adding a splash screen to your mobile app][].
+{{site.alert.end}}
+
 ## Getting started
 
 By default, the `index.html` file
@@ -180,3 +186,5 @@ Then, from your project directory, run the following:
 ```
 $ flutter create . --platforms=web
 ```
+
+[Adding a splash screen to your mobile app]: {{site.url}}/development/ui/advanced/splash-screen

--- a/src/development/platform-integration/web/initialization.md
+++ b/src/development/platform-integration/web/initialization.md
@@ -26,7 +26,7 @@ at each stage of the initialization process.
 
 {{site.alert.note}}
 For more information on implementing splash screens
-on mobile platforms, see the
+on mobile platforms, see
 [Adding a splash screen to your mobile app][].
 {{site.alert.end}}
 

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -210,20 +210,20 @@ to how your application's custom splash screen is defined.
    the construction of your application's custom splash screen
    `Drawable`, for example:
 
-```Java
-@Override
-public SplashScreen provideSplashScreen() {
-    // ...
-    return new DrawableSplashScreen(
-        new SomeDrawable(
-            ContextCompat.getDrawable(this, R.some_splash_screen)));
-}
-```
+   ```Java
+   @Override
+   public SplashScreen provideSplashScreen() {
+       // ...
+       return new DrawableSplashScreen(
+           new SomeDrawable(
+               ContextCompat.getDrawable(this, R.some_splash_screen)));
+   }
+   ```
 
-   Note this `Drawable`, as this is the `Drawable` that you will specify
+2. Note this `Drawable`, as this is the `Drawable` that you will specify
    in your application's launch theme. Then, delete this implementation.
 
-2. Follow the steps below to ensure your splash screen `Drawable`
+3. Follow the steps below to ensure your splash screen `Drawable`
    (`R.some_splash_screen` in the example above) is properly
    configured as your application's custom launch screen.
 
@@ -235,45 +235,41 @@ public SplashScreen provideSplashScreen() {
    some splash screen as the
    `io.flutter.embedding.android.SplashScreenDrawable`:
 
-```xml
-<activity
-    // ...
-    android:theme="@style/SomeTheme">
-  // ...
-  <meta-data
-      android:name="io.flutter.embedding.android.SplashScreenDrawable"
-      android:resource="@drawable/some_splash_screen"
-      />
-</activity>
-```
+   ```xml
+   <activity
+       // ...
+       android:theme="@style/SomeTheme">
+     // ...
+     <meta-data
+         android:name="io.flutter.embedding.android.SplashScreenDrawable"
+         android:resource="@drawable/some_splash_screen"
+         />
+   </activity>
+   ```
 
-   If no `android:theme` attribute is specified, add the attribute and
+2. If the `android:theme` attribute is not specified, add the attribute and
    [define a launch theme][] for your application's launch screen.
-2. Delete the `meta-data` tag, as Flutter no longer displays the `Drawable`
+
+3. Delete the `meta-data` tag, as Flutter no longer displays the `Drawable`
    that it specifies before showing the application's launch screen.
-3. Locate the definition of the theme specified by the `android:theme` attribute
+
+4. Locate the definition of the theme specified by the `android:theme` attribute
    within your application's `style` resources. This theme is what specifies the
    launch theme of your application. Ensure that this `style` configures the
    `android:windowBackground` attribute with your custom splash screen:
 
-```xml
-<resources>
-    <style
-        name="SomeTheme"
-        // ...
-        >
-        <!-- Show a splash screen on the activity. Automatically removed when
-             Flutter draws its first frame -->
-        <item name="android:windowBackground">@drawable/some_splash_screen</item>
-    </style>
-</resources>
-```
-
-This custom splash screen `Drawable` will automatically be shown as your
-Flutter application's launch screen until Flutter draws its first frame.
-If you wish to specify a theme to show briefly between the time
-that the launch screen disappears and during orientation change and
-`Activity` restoration, [define a normal theme][].
+   ```xml
+   <resources>
+       <style
+           name="SomeTheme"
+           // ...
+           >
+           <!-- Show a splash screen on the activity. Automatically removed when
+                Flutter draws its first frame -->
+           <item name="android:windowBackground">@drawable/some_splash_screen</item>
+       </style>
+   </resources>
+   ```
 
 [Android Splash Screens]: {{site.android-dev}}/about/versions/12/features/splash-screen
 [launch screen]: {{site.android-dev}}/topic/performance/vitals/launch-time#themed

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -278,6 +278,6 @@ to how your application's custom splash screen is defined.
 [must use an Xcode storyboard]: {{site.apple-dev}}/news/?id=03042020b
 [Human Interface Guidelines]: {{site.apple-dev}}/design/human-interface-guidelines/ios/visual-design/launch-screen/
 [`FlutterActivity`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterActivity.html
-[define a launch theme]: {{site.url}}/development/ui/advanced/splash-screen?tab=android-splash-alignment-kotlin-tab#initializing-the-app
+[define a theme]:  #initializing-the-app
 [Android splash screen sample app]: {{site.github}}/flutter/samples/blob/3a0a652984e9b974342d172b9f0ffa161d0dcb2f/android_splash_screen/android/app/src/main/res/values-night/styles.xml
 [define a normal theme]: {{site.url}}/development/ui/advanced/splash-screen?tab=android-splash-alignment-kotlin-tab#initializing-the-app

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -208,8 +208,8 @@ prior to the 2.5 release.
 
 1. Locate your application's implementation of `provideSplashScreen()`
    within its `FlutterActivity`. This implementation should involve
-   the construction of your application's custom splash screen
-   `Drawable`, for example:
+   the construction of your application's custom splash screen:
+   as a `Drawable`, for example:
 
    ```Java
    @Override

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -224,8 +224,8 @@ prior to the 2.5 release.
 2. In the next step, you'll specify this `Drawable` as your application's
     launch theme, so delete this implementation.
 
-3. Follow the steps below to ensure your splash screen `Drawable`
-   (`R.some_splash_screen` in the example above) is properly
+3. Use the following steps to ensure that your `Drawable` splash screen
+   (`R.some_splash_screen` in the previous example) is properly
    configured as your application's custom launch screen.
 
 **Custom splash screen defined in Manifest**

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -15,6 +15,12 @@ engine to load and your app to initialize.
 This guide teaches you how to use splash screens
 appropriately on iOS and Android.
 
+{{site.alert.note}}
+For more information on implementing splash screens
+on web and desktop platforms, see the
+[Customizing web app initialization guide][].
+{{site.alert.end}}
+
 ## iOS launch screen
 
 All apps submitted to the Apple App Store
@@ -206,3 +212,4 @@ For an example of this, see the [Android splash screen sample app][].
 [Human Interface Guidelines]: {{site.apple-dev}}/design/human-interface-guidelines/ios/visual-design/launch-screen/
 [Android splash screen sample app]: {{site.github}}/flutter/samples/tree/main/android_splash_screen
 [Deprecated Splash Screen API Migration]: {{site.url}}/development/platform-integration/android/splash-screen-migration
+[Customizing web app initialization guide]: {{site.url}}/development/platform-integration/web/initialization

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -252,8 +252,8 @@ prior to the 2.5 release.
 2. If the `android:theme` attribute isn't specified, add the attribute and
    [define a launch theme][define a theme] for your application's launch screen.
 
-3. Delete the `meta-data` tag, as Flutter no longer displays the `Drawable`
-   that it specifies before showing the application's launch screen.
+3. Delete the `meta-data` tag, as Flutter no longer
+    displays that information.
 
 4. Locate the definition of the theme specified by the `android:theme` attribute
    within your application's `style` resources. This theme is what specifies the

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -185,8 +185,8 @@ class MainActivity : FlutterActivity() {
 {% endsamplecode %}
 
 Then, you can reimplement the first frame in Flutter that shows elements of your
-Android splash screen in the same positions on screen. To see an example of this,
-see the [Android splash screen sample app][].
+Android splash screen in the same positions on screen.
+For an example of this, see the [Android splash screen sample app][].
 
 ### Migrating from Manifest / Activity defined custom splash screens
 

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -186,6 +186,7 @@ class MainActivity : FlutterActivity() {
 
 Then, you can reimplement the first frame in Flutter that shows elements of your
 Android splash screen in the same positions on screen.
+For an example of this, see the [Android splash screen sample app][].
 
 ### Migrating from Manifest / Activity defined custom splash screens
 
@@ -204,3 +205,4 @@ Developers should instead remove usage of these APIs.
 [`provideSplashScreen`]: {{site.api}}/javadoc/io/flutter/embedding/android/SplashScreenProvider.html#provideSplashScreen--
 [must use an Xcode storyboard]: {{site.apple-dev}}/news/?id=03042020b
 [Human Interface Guidelines]: {{site.apple-dev}}/design/human-interface-guidelines/ios/visual-design/launch-screen/
+[Android splash screen sample app]: {{site.github}}/flutter/samples/tree/main/android_splash_screen

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -190,7 +190,7 @@ see the [Android splash screen sample app][].
 
 ### Migrating from Manifest / Activity defined custom splash screens
 
-Previous to Flutter 2.5, Flutter apps could add a splash
+Prior to Flutter 2.5, Flutter apps could add a splash
 screen by defining it within the metadata of their application manifest
 (`AndroidManifest.xml`) or implementing [`provideSplashScreen`][] within
 their [`FlutterActivity`][]. This would show momentarily in between

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -41,14 +41,18 @@ part of the [Human Interface Guidelines][].
 
 {{site.alert.warning}}
 If you are experiencing a crash from implementing a splash screen, you might
-need to deprecate your code. See detailed instructions in the
-[Splash Screen Migration Guide][].
+need to migrate your code. See detailed instructions in the
+[Deprecated Splash Screen API Migration][].
 {{site.alert.warning}}
 
 In Android, there are two separate screens that you can control:
 a _launch screen_ shown while your Android app initializes,
 and a _splash screen_ that displays while the Flutter experience
 initializes.
+
+As of Flutter 2.5, Flutter has consolidated these two screens
+into one Android launch screen. Flutter automatically keeps this
+launch screen displayed until it draws the first frame.
 
 {{site.alert.note}}
   For apps that embed one or more Flutter screens within an
@@ -122,15 +126,15 @@ while the app initializes.
 
 ### Android S
 
-See [Android Splash Screens][] first on how to configure your splash screen on
+See [Android Splash Screens][] first on how to configure your launch screen on
 Android S.
 
 Make sure neither `io.flutter.embedding.android.SplashScreenDrawable` is set in
 your manifest, nor is `provideSplashScreen` implemented, as these APIs are
-deprecated. Doing so will cause the Android splash screen to fade smoothly into
-the Flutter when the app is launched.
+deprecated. Doing so will cause the Android launch screen to fade smoothly into
+the Flutter when the app is launched and you may experience a crash.
 
-Some apps may want to continue showing the last frame of the Android splash
+Some apps may want to continue showing the last frame of the Android launch
 screen in Flutter. For example, this preserves the illusion of a single frame
 while additional loading continues in Dart. To achieve this, the following
 Android APIs may be helpful:
@@ -191,7 +195,7 @@ class MainActivity : FlutterActivity() {
 {% endsamplecode %}
 
 Then, you can reimplement the first frame in Flutter that shows elements of your
-Android splash screen in the same positions on screen.
+Android launch screen in the same positions on screen.
 For an example of this, see the [Android splash screen sample app][].
 
 [Android Splash Screens]: {{site.android-dev}}/about/versions/12/features/splash-screen
@@ -201,4 +205,4 @@ For an example of this, see the [Android splash screen sample app][].
 [must use an Xcode storyboard]: {{site.apple-dev}}/news/?id=03042020b
 [Human Interface Guidelines]: {{site.apple-dev}}/design/human-interface-guidelines/ios/visual-design/launch-screen/
 [Android splash screen sample app]: {{site.github}}/flutter/samples/tree/main/android_splash_screen
-[Splash Screen Migration Guide]: {{site.url}}/development/platform-integration/android/splash-screen-migration
+[Deprecated Splash Screen API Migration]: {{site.url}}/development/platform-integration/android/splash-screen-migration

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -186,92 +186,17 @@ class MainActivity : FlutterActivity() {
 
 Then, you can reimplement the first frame in Flutter that shows elements of your
 Android splash screen in the same positions on screen.
-For an example of this, see the [Android splash screen sample app][].
 
 ### Migrating from Manifest / Activity defined custom splash screens
 
-Prior to Flutter 2.5, Flutter apps could add a splash
-screen by defining it within the metadata of their application manifest file
-(`AndroidManifest.xml`), or by implementing [`provideSplashScreen`][] within
-their [`FlutterActivity`][]. This would display momentarily in between
-the time after the Android launch screen is shown and when Flutter has
-drawn the first frame. This approach is now deprecated as of Flutter 2.5;
-Flutter now automatically keeps the Android launch screen displayed
-until it draws the first frame.
-
-To migrate from defining a custom splash screen to defining a custom
-launch screen for your application, follow the steps that correspond
-to how your application's custom splash screen was defined
-prior to the 2.5 release.
-
-**Custom splash screen defined in [`FlutterActivity`][]**
-
-1. Locate your application's implementation of `provideSplashScreen()`
-   within its `FlutterActivity`. This implementation should involve
-   the construction of your application's custom splash screen:
-   as a `Drawable`, for example:
-
-   ```Java
-   @Override
-   public SplashScreen provideSplashScreen() {
-       // ...
-       return new DrawableSplashScreen(
-           new SomeDrawable(
-               ContextCompat.getDrawable(this, R.some_splash_screen)));
-   }
-   ```
-
-2. In the next step, you'll specify this `Drawable` as your application's
-    launch theme, so delete this implementation.
-
-3. Use the following steps to ensure that your `Drawable` splash screen
-   (`R.some_splash_screen` in the previous example) is properly
-   configured as your application's custom launch screen.
-
-**Custom splash screen defined in Manifest**
-
-1. Locate your application's `AndroidManifest.xml` file.
-   Within this file, find the `activity` element.
-   Within this element, identify the `android:theme` attribute
-   and the `meta-data` element that defines
-   a splash screen as an
-   `io.flutter.embedding.android.SplashScreenDrawable`:
-
-   ```xml
-   <activity
-       // ...
-       android:theme="@style/SomeTheme">
-     // ...
-     <meta-data
-         android:name="io.flutter.embedding.android.SplashScreenDrawable"
-         android:resource="@drawable/some_splash_screen"
-         />
-   </activity>
-   ```
-
-2. If the `android:theme` attribute isn't specified, add the attribute and
-   [define a launch theme][define a theme] for your application's launch screen.
-
-3. Delete the `meta-data` tag, as Flutter no longer
-   displays that information.
-
-4. Locate the definition of the theme specified by the `android:theme` attribute
-   within your application's `style` resources. This theme is what specifies the
-   launch theme of your application. Ensure that this `style` configures the
-   `android:windowBackground` attribute with your custom splash screen:
-
-   ```xml
-   <resources>
-       <style
-           name="SomeTheme"
-           // ...
-           >
-           <!-- Show a splash screen on the activity. Automatically removed when
-                Flutter draws its first frame -->
-           <item name="android:windowBackground">@drawable/some_splash_screen</item>
-       </style>
-   </resources>
-   ```
+Previously, Android Flutter apps would either set
+`io.flutter.embedding.android.SplashScreenDrawable` in their application
+manifest, or implement [`provideSplashScreen`][] within their Flutter Activity.
+This would be shown momentarily in between the time after the Android launch
+screen is shown and when Flutter has drawn the first frame. This is no longer
+needed and is deprecated – in Flutter 2.5 and later, Flutter automatically keeps 
+the Android launch screen displayed until Flutter has drawn the first frame. 
+Developers should instead remove usage of these APIs.
 
 [Android Splash Screens]: {{site.android-dev}}/about/versions/12/features/splash-screen
 [launch screen]: {{site.android-dev}}/topic/performance/vitals/launch-time#themed
@@ -279,6 +204,3 @@ prior to the 2.5 release.
 [`provideSplashScreen`]: {{site.api}}/javadoc/io/flutter/embedding/android/SplashScreenProvider.html#provideSplashScreen--
 [must use an Xcode storyboard]: {{site.apple-dev}}/news/?id=03042020b
 [Human Interface Guidelines]: {{site.apple-dev}}/design/human-interface-guidelines/ios/visual-design/launch-screen/
-[`FlutterActivity`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterActivity.html
-[define a theme]:  #initializing-the-app
-[Android splash screen sample app]: {{site.github}}/flutter/samples/tree/main/android_splash_screen

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -230,10 +230,11 @@ prior to the 2.5 release.
 
 **Custom splash screen defined in Manifest**
 
-1. Locate your application's `AndroidManifest.xml` file. Within this file,
-   find the `activity` element. Within this element, identify the
-   `android:theme` attribute and `meta-data` element that defines
-   some splash screen as the
+1. Locate your application's `AndroidManifest.xml` file.
+   Within this file, find the `activity` element.
+   Within this element, identify the `android:theme` attribute
+   and the `meta-data` element that defines
+   a splash screen as an
    `io.flutter.embedding.android.SplashScreenDrawable`:
 
    ```xml

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -60,6 +60,10 @@ initializes.
   As of Flutter 2.5, the launch and splash screens have been
   consolidated—Flutter now only implements the Android launch screen,
   which is displayed until the framework draws the first frame.
+  This launch screen can act as both an Android launch screen and an
+  Android splash screen via customization, and thus, is referred to
+  as both terms. For example of such customization, see the
+  [Android splash screen sample app][].
 
   If, prior to 2.5, you used `flutter create` to create an app,
   and you run the app on 2.5 or later, it can cause the app to crash.

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -191,13 +191,13 @@ For an example of this, see the [Android splash screen sample app][].
 ### Migrating from Manifest / Activity defined custom splash screens
 
 Prior to Flutter 2.5, Flutter apps could add a splash
-screen by defining it within the metadata of their application manifest
-(`AndroidManifest.xml`) or implementing [`provideSplashScreen`][] within
-their [`FlutterActivity`][]. This would show momentarily in between
+screen by defining it within the metadata of their application manifest file
+(`AndroidManifest.xml`), or by implementing [`provideSplashScreen`][] within
+their [`FlutterActivity`][]. This would display momentarily in between
 the time after the Android launch screen is shown and when Flutter has
-drawn the first frame. This is now deprecated and no longer needed –
-in Flutter 2.5 and later, because Flutter now automatically keeps the
-Android launch screen displayed until Flutter has drawn the first frame.
+drawn the first frame. This approach is now deprecated as of Flutter 2.5;
+Flutter now automatically keeps the Android launch screen displayed
+until it draws the first frame.
 
 To migrate from defining a custom splash screen to defining a custom
 launch screen for your application, follow the steps that correspond
@@ -281,5 +281,4 @@ prior to the 2.5 release.
 [Human Interface Guidelines]: {{site.apple-dev}}/design/human-interface-guidelines/ios/visual-design/launch-screen/
 [`FlutterActivity`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterActivity.html
 [define a theme]:  #initializing-the-app
-[Android splash screen sample app]: {{site.github}}/flutter/samples/blob/3a0a652984e9b974342d172b9f0ffa161d0dcb2f/android_splash_screen/android/app/src/main/res/values-night/styles.xml
-[define a normal theme]: {{site.url}}/development/ui/advanced/splash-screen?tab=android-splash-alignment-kotlin-tab#initializing-the-app
+[Android splash screen sample app]: {{site.github}}/flutter/samples/tree/main/android_splash_screen

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -16,9 +16,9 @@ This guide teaches you how to use splash screens
 appropriately on iOS and Android.
 
 {{site.alert.note}}
-For more information on implementing splash screens
-on web and desktop platforms, see the
-[Customizing web app initialization guide][].
+    For more information on implementing splash screens
+    on web and desktop platforms, see the
+    [Customizing web app initialization guide][].
 {{site.alert.end}}
 
 ## iOS launch screen
@@ -46,9 +46,9 @@ part of the [Human Interface Guidelines][].
 ## Android launch screen
 
 {{site.alert.warning}}
-If you are experiencing a crash from implementing a splash screen, you might
-need to migrate your code. See detailed instructions in the
-[Deprecated Splash Screen API Migration][].
+    If you are experiencing a crash from implementing a splash screen, you
+    might need to migrate your code. See detailed instructions in the
+    [Deprecated Splash Screen API Migration][].
 {{site.alert.warning}}
 
 In Android, there are two separate screens that you can control:
@@ -56,9 +56,15 @@ a _launch screen_ shown while your Android app initializes,
 and a _splash screen_ that displays while the Flutter experience
 initializes.
 
-As of Flutter 2.5, Flutter has consolidated these two screens
-into one Android launch screen. Flutter automatically keeps this
-launch screen displayed until it draws the first frame.
+{{site.alert.note}}
+  As of Flutter 2.5, the launch and splash screens have been
+  consolidated—Flutter now only implements the Android launch screen,
+  which is displayed until the framework draws the first frame.
+
+  If, prior to 2.5, you used `flutter create` to create an app,
+  and you run the app on 2.5 or later, it can cause the app to crash.
+  For more info, see the [Deprecated Splash Screen API Migration][].
+{{site.alert.end}}
 
 {{site.alert.note}}
   For apps that embed one or more Flutter screens within an

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -39,6 +39,12 @@ part of the [Human Interface Guidelines][].
 
 ## Android launch screen
 
+{{site.alert.warning}}
+If you are experiencing a crash from implementing a splash screen, you might
+need to deprecate your code. See detailed instructions in the
+[Splash Screen Migration Guide][].
+{{site.alert.warning}}
+
 In Android, there are two separate screens that you can control:
 a _launch screen_ shown while your Android app initializes,
 and a _splash screen_ that displays while the Flutter experience
@@ -188,17 +194,6 @@ Then, you can reimplement the first frame in Flutter that shows elements of your
 Android splash screen in the same positions on screen.
 For an example of this, see the [Android splash screen sample app][].
 
-### Migrating from Manifest / Activity defined custom splash screens
-
-Previously, Android Flutter apps would either set
-`io.flutter.embedding.android.SplashScreenDrawable` in their application
-manifest, or implement [`provideSplashScreen`][] within their Flutter Activity.
-This would be shown momentarily in between the time after the Android launch
-screen is shown and when Flutter has drawn the first frame. This is no longer
-needed and is deprecated – in Flutter 2.5 and later, Flutter automatically keeps 
-the Android launch screen displayed until Flutter has drawn the first frame. 
-Developers should instead remove usage of these APIs.
-
 [Android Splash Screens]: {{site.android-dev}}/about/versions/12/features/splash-screen
 [launch screen]: {{site.android-dev}}/topic/performance/vitals/launch-time#themed
 [pre-warming a `FlutterEngine`]: {{site.url}}/development/add-to-app/android/add-flutter-fragment#using-a-pre-warmed-flutterengine
@@ -206,3 +201,4 @@ Developers should instead remove usage of these APIs.
 [must use an Xcode storyboard]: {{site.apple-dev}}/news/?id=03042020b
 [Human Interface Guidelines]: {{site.apple-dev}}/design/human-interface-guidelines/ios/visual-design/launch-screen/
 [Android splash screen sample app]: {{site.github}}/flutter/samples/tree/main/android_splash_screen
+[Splash Screen Migration Guide]: {{site.url}}/development/platform-integration/android/splash-screen-migration

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -253,7 +253,7 @@ prior to the 2.5 release.
    [define a launch theme][define a theme] for your application's launch screen.
 
 3. Delete the `meta-data` tag, as Flutter no longer
-    displays that information.
+   displays that information.
 
 4. Locate the definition of the theme specified by the `android:theme` attribute
    within your application's `style` resources. This theme is what specifies the

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -221,8 +221,8 @@ prior to the 2.5 release.
    }
    ```
 
-2. Note this `Drawable`, as this is the `Drawable` that you will specify
-   in your application's launch theme. Then, delete this implementation.
+2. In the next step, you'll specify this `Drawable` as your application's
+    launch theme, so delete this implementation.
 
 3. Follow the steps below to ensure your splash screen `Drawable`
    (`R.some_splash_screen` in the example above) is properly

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -249,8 +249,8 @@ prior to the 2.5 release.
    </activity>
    ```
 
-2. If the `android:theme` attribute is not specified, add the attribute and
-   [define a launch theme][] for your application's launch screen.
+2. If the `android:theme` attribute isn't specified, add the attribute and
+   [define a launch theme][define a theme] for your application's launch screen.
 
 3. Delete the `meta-data` tag, as Flutter no longer displays the `Drawable`
    that it specifies before showing the application's launch screen.

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -201,7 +201,8 @@ Android launch screen displayed until Flutter has drawn the first frame.
 
 To migrate from defining a custom splash screen to defining a custom
 launch screen for your application, follow the steps that correspond
-to how your application's custom splash screen is defined.
+to how your application's custom splash screen was defined
+prior to the 2.5 release.
 
 **Custom splash screen defined in [`FlutterActivity`][]**
 

--- a/src/development/ui/assets-and-images.md
+++ b/src/development/ui/assets-and-images.md
@@ -465,8 +465,8 @@ Flutter renders the first frame of your application.
 
 #### Android
 
-To add a "splash screen" to your Flutter application,
-navigate to `.../android/app/src/main`.
+To add a launch screen (also known as "splash screen") to your
+Flutter application, navigate to `.../android/app/src/main`.
 In `res/drawable/launch_background.xml`,
 use this [layer list drawable][] XML to customize
 the look of your launch screen. The existing template provides


### PR DESCRIPTION
Addresses https://github.com/flutter/flutter/issues/105173.

Adds a migration guide from defining a custom splash screen to defining a launch screen that will persist until the Flutter UI is loaded, and updates docs referencing splash screens across the site.

Also links docs to splash screen sample app and addresses https://github.com/flutter/website/issues/7151.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.