### PR TITLE
Correction on Hybrid composition's behavior on Android 10 and above

### DIFF
--- a/src/_includes/docs/platform-view-perf.md
+++ b/src/_includes/docs/platform-view-perf.md
@@ -12,9 +12,9 @@ which competes with other tasks like handling OS or plugin messages.
 
 Prior to Android 10, Hybrid composition copied each Flutter frame
 out of the graphic memory into main memory, and then copied it back
-to a GPU texture. In Android 10 or above, the graphics memory is
-copied twice. As this copy happens per frame, the performance of
-the entire Flutter UI may be impacted.
+to a GPU texture. As this copy happens per frame, the performance of
+the entire Flutter UI may be impacted. In Android 10 or above, the
+graphics memory is copied once.
 
 Virtual display, on the other hand,
 makes each pixel of the native view
@@ -36,7 +36,9 @@ For more information, see:
 * [`TextureLayer`][]
 * [`TextureRegistry`][]
 * [`FlutterTextureRegistry`][]
+* [`FlutterImageView`][]
 
+[`FlutterImageView`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterImageView.html
 [`FlutterTextureRegistry`]: {{site.api}}/objcdoc/Protocols/FlutterTextureRegistry.html
 [`TextureLayer`]: {{site.api}}/flutter/rendering/TextureLayer-class.html
 [`TextureRegistry`]: {{site.api}}/javadoc/io/flutter/view/TextureRegistry.html

--- a/src/_includes/docs/platform-view-perf.md
+++ b/src/_includes/docs/platform-view-perf.md
@@ -13,7 +13,7 @@ which competes with other tasks like handling OS or plugin messages.
 Prior to Android 10, Hybrid composition copied each Flutter frame
 out of the graphic memory into main memory, and then copied it back
 to a GPU texture. As this copy happens per frame, the performance of
-the entire Flutter UI may be impacted. In Android 10 or above, the
+the entire Flutter UI might be impacted. In Android 10 or above, the
 graphics memory is copied once.
 
 Virtual display, on the other hand,


### PR DESCRIPTION
__Description of what this PR is changing or adding, and why:__  This PR made a correction on Hybrid composition's behavior. Referring to go/flutter-android-sync and the implementation in [FlutterImageView.java](https://github.com/flutter/engine/blob/6cd744bb9706bc7435ca7d5da01abc235926106f/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java), the memory is copied twice on Android 10 and below, but once on Android 10 and above.

__Issues fixed by this PR (if any):__ N/A (minor documentation inaccuracy)

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.