### PR TITLE
Fix platform to choose when creating app

### DIFF
--- a/src/deployment/macos.md
+++ b/src/deployment/macos.md
@@ -55,7 +55,7 @@ Register your app on App Store Connect:
 1. Click **+** in the top-left corner of the My Apps page,
    then select **New App**.
 1. Fill in your app details in the form that appears.
-   In the Platforms section, ensure that iOS is checked.
+   In the Platforms section, ensure that macOS is checked.
    Since Flutter does not currently support tvOS,
    leave that checkbox unchecked. Click **Create**.
 1. Navigate to the application details for your app and select


### PR DESCRIPTION
This PR fixes the name of platform developer need to choose when creating app in App Store Connect. As the page is about how to release macOS app developer should ensure macOS is checked (but not iOS mentioned on the page).

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.