### PR TITLE
Document when to use pluginFfi vs plugin

### DIFF
--- a/src/development/packages-and-plugins/developing-packages.md
+++ b/src/development/packages-and-plugins/developing-packages.md
@@ -614,6 +614,15 @@ a section in [Supporting the new Android plugins APIs][].
 If you want to develop a package that calls into native APIs using
 Dart's FFI, you need to develop an FFI plugin package.
 
+Both FFI plugin packages and (non-FFI) plugin packages support
+bundling native code, but FFI plugin packages do not support
+method channels and do include method channel registration code.
+If you want to implement a plugin that uses both method channels
+and FFI, use a (non-FFI) plugin. You can chose this per platform.
+
+FFI plugin packages were introduced in Flutter 3.0, if you're
+targeting older Flutter versions, you can use a (non-FFI) plugin.
+
 ### Step 1: Create the package
 
 To create a starter FFI plugin package,

--- a/src/development/packages-and-plugins/developing-packages.md
+++ b/src/development/packages-and-plugins/developing-packages.md
@@ -618,7 +618,8 @@ Both FFI plugin packages and (non-FFI) plugin packages support
 bundling native code, but FFI plugin packages do not support
 method channels and do include method channel registration code.
 If you want to implement a plugin that uses both method channels
-and FFI, use a (non-FFI) plugin. You can chose this per platform.
+and FFI, use a (non-FFI) plugin. You can chose per platform to
+use an FFI or (non-FFI) plugin.
 
 FFI plugin packages were introduced in Flutter 3.0, if you're
 targeting older Flutter versions, you can use a (non-FFI) plugin.


### PR DESCRIPTION
Adds documentation from the questions answered in:

* https://github.com/flutter/flutter/issues/108974

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.