### PR TITLE
Fix localization files generation

### DIFF
--- a/src/development/accessibility-and-localization/internationalization.md
+++ b/src/development/accessibility-and-localization/internationalization.md
@@ -196,7 +196,7 @@ project called `l10n.yaml` with the following content:
    }
    ```
 
-6. Now, run your app so that codegen takes place. You should see generated files in
+6. Now, run `flutter gen-l10n` so that codegen takes place. You should see generated files in
    `${FLUTTER_PROJECT}/.dart_tool/flutter_gen/gen_l10n`.
 
 7. Add the import statement on `app_localizations.dart` and `AppLocalizations.delegate`


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ fixing incorrect or outdated documentation. Localization files are not generated automatically on `flutter run`, they must be generated by running `flutter gen-l10n`. At least for `3.x.x` version.

_Issues fixed by this PR (if any):_ [7434](https://github.com/flutter/website/issues/7434)

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.