### PR TITLE
Make supported platforms styled correctly

### DIFF
--- a/src/development/tools/sdk/release-notes/supported-platforms.md
+++ b/src/development/tools/sdk/release-notes/supported-platforms.md
@@ -25,6 +25,8 @@ which Flutter runs:
 As of the current release,
 Flutter supports the following platforms as part of Google-tested and best-effort platform tier:
 
+<div class="table-wrapper" markdown="1">
+
 |Platform|Version                       |Channels |
 |--------|------------------------------|---------|
 |Android | API 16 (Android 4.1) & above | All     |
@@ -37,10 +39,15 @@ Flutter supports the following platforms as part of Google-tested and best-effor
 |Web     | Edge 1.2.0 & above           | All     |
 |Windows | Windows 7 & above, 64-bit    | All     |
 
+{:.table.table-striped}
+</div>
+
 All channels include master, beta,
 and stable channels.
 
 ### Google-tested platforms
+
+<div class="table-wrapper" markdown="1">
 
 |Platform|Version               |
 |--------|----------------------|
@@ -55,11 +62,16 @@ and stable channels.
 |Web     |Edge 1.2.0            |
 |Windows |Windows 10            |
 
+{:.table.table-striped}
+</div>
+
 \* Passing tests on Android SDK 19 also confers a passing result on SDK 20.
   This is because Android SDK 20 has additional support for Android Wear,
   but otherwise no new or deprecated API.
 
 ### Best-effort platforms
+
+<div class="table-wrapper" markdown="1">
 
 |Platform|Version             |
 |--------|--------------------|
@@ -74,9 +86,14 @@ and stable channels.
 |Windows |Windows 8           |
 |Windows |Windows 7           |
 
+{:.table.table-striped}
+</div>
+
 \* Flutter 3.0 is the last stable release with iOS 9 and 10 best-effort support.
 
 ### Unsupported platforms
+
+<div class="table-wrapper" markdown="1">
 
 |Platform|Version                                     |
 |--------|--------------------------------------------|
@@ -86,6 +103,9 @@ and stable channels.
 |macOS   |Yosemite (10.10) & below                    |
 |Windows |Windows Vista & below                       |
 |Windows |Any 32-bit platform                         |
+
+{:.table.table-striped}
+</div>
 
 [iOS 8]: {{site.url}}/go/rfc-ios8-deprecation
 [`arm7v` 32-bit iOS]: {{site.url}}/go/rfc-32-bit-ios-unsupported

--- a/src/development/tools/sdk/release-notes/supported-platforms.md
+++ b/src/development/tools/sdk/release-notes/supported-platforms.md
@@ -26,7 +26,6 @@ As of the current release,
 Flutter supports the following platforms as part of Google-tested and best-effort platform tier:
 
 <div class="table-wrapper" markdown="1">
-
 |Platform|Version                       |Channels |
 |--------|------------------------------|---------|
 |Android | API 16 (Android 4.1) & above | All     |
@@ -38,7 +37,6 @@ Flutter supports the following platforms as part of Google-tested and best-effor
 |Web     | Safari on El Capitan & above | All     |
 |Web     | Edge 1.2.0 & above           | All     |
 |Windows | Windows 7 & above, 64-bit    | All     |
-
 {:.table.table-striped}
 </div>
 
@@ -48,7 +46,6 @@ and stable channels.
 ### Google-tested platforms
 
 <div class="table-wrapper" markdown="1">
-
 |Platform|Version               |
 |--------|----------------------|
 |Android |Android SDK 19–30*    |
@@ -61,7 +58,6 @@ and stable channels.
 |Web     |Safari / Catalina     |
 |Web     |Edge 1.2.0            |
 |Windows |Windows 10            |
-
 {:.table.table-striped}
 </div>
 
@@ -72,7 +68,6 @@ and stable channels.
 ### Best-effort platforms
 
 <div class="table-wrapper" markdown="1">
-
 |Platform|Version             |
 |--------|--------------------|
 |Android |Android SDK 16–18   |
@@ -85,7 +80,6 @@ and stable channels.
 |Windows |Windows 11 (Aspirational Google-tested platform)          |
 |Windows |Windows 8           |
 |Windows |Windows 7           |
-
 {:.table.table-striped}
 </div>
 
@@ -94,7 +88,6 @@ and stable channels.
 ### Unsupported platforms
 
 <div class="table-wrapper" markdown="1">
-
 |Platform|Version                                     |
 |--------|--------------------------------------------|
 |Android |Android SDK 15 & below                      |
@@ -106,6 +99,5 @@ and stable channels.
 
 {:.table.table-striped}
 </div>
-
 [iOS 8]: {{site.url}}/go/rfc-ios8-deprecation
 [`arm7v` 32-bit iOS]: {{site.url}}/go/rfc-32-bit-ios-unsupported


### PR DESCRIPTION
Current:
<img width="540" alt="Screen Shot 2022-08-10 at 15 14 40" src="https://user-images.githubusercontent.com/13644170/183910622-d624cd39-c2b8-43ff-a91b-4d185ee8cb3f.png">



After fix:
<img width="975" alt="Screen Shot 2022-08-10 at 15 13 05" src="https://user-images.githubusercontent.com/13644170/183910553-d5f237f5-9d4f-4829-ba5c-f1f499a0bafe.png">


_Issues fixed by this PR (if any):_

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.