### PR TITLE
Update error docs to use PlatformDispatcher instead of Zones

### DIFF
--- a/examples/testing/errors/lib/excerpts.dart
+++ b/examples/testing/errors/lib/excerpts.dart
@@ -2,19 +2,17 @@
 
 import './backend.dart';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 // #docregion CatchError
-import 'dart:async';
+import 'package:flutter/material.dart';
 
 void main() {
   MyBackend myBackend = MyBackend();
-  runZonedGuarded(() {
-    runApp(const MyApp());
-  }, (error, stack) {
+  PlatformDispatcher.instance.onError = (error, stack) {
     myBackend.sendError(error, stack);
-  });
+  };
+  runApp(const MyApp());
 }
 // #enddocregion CatchError
 

--- a/examples/testing/errors/lib/main.dart
+++ b/examples/testing/errors/lib/main.dart
@@ -2,24 +2,18 @@
 
 import './error_handler.dart';
 // #docregion Main
-import 'dart:async';
-import 'dart:io';
 import 'package:flutter/material.dart';
 
-void main() {
-  runZonedGuarded(() async {
-    WidgetsFlutterBinding.ensureInitialized();
-    await myErrorsHandler.initialize();
-    FlutterError.onError = (details) {
-      FlutterError.presentError(details);
-      myErrorsHandler.onErrorDetails(details);
-      exit(1);
-    };
-    runApp(const MyApp());
-  }, (error, stack) {
+Future<void> main() async {
+  await myErrorsHandler.initialize();
+  FlutterError.onError = (details) {
+    FlutterError.presentError(details);
+    myErrorsHandler.onErrorDetails(details);
+  };
+  PlatformDispatcher.instance.onError = (error, stack) {
     myErrorsHandler.onError(error, stack);
-    exit(1);
-  });
+  };
+  runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {

--- a/src/testing/errors.md
+++ b/src/testing/errors.md
@@ -9,7 +9,8 @@ The Flutter framework catches errors that occur during callbacks
 triggered by the framework itself, including errors encountered
 during the build, layout, and paint phases. Errors that don't occur
 within Flutter's callbacks can't be caught by the framework,
-but you can handle them by setting up a [`Zone`][].
+but you can handle them by setting up a error handler on the
+[`PlatformDispatcher`][].
 
 All errors caught by Flutter are routed to the
 [`FlutterError.onError`][] handler. By default,
@@ -34,8 +35,8 @@ in debug mode this shows an error message in red,
 and in release mode this shows a gray background.
 
 When errors occur without a Flutter callback on the call stack,
-they are handled by the `Zone` where they occur. By default,
-a `Zone` only prints errors and does nothing else.
+they are handled by the `PlatformDispatcher`'s error callback. By default,
+this only prints errors and does nothing else.'
 
 You can customize these behaviors,
 typically by setting them to values in
@@ -75,7 +76,7 @@ void main() {
 {{site.alert.end}}
 
 This handler can also be used to report errors to a logging service.
-For more details, see our cookbook chapter for 
+For more details, see our cookbook chapter for
 [reporting errors to a service][].
 
 ## Define a custom error widget for build phase errors
@@ -123,43 +124,21 @@ OutlinedButton(
 ```
 
 If `invokeMethod` throws an error, it won't be forwarded to `FlutterError.onError`.
-Instead, it's forwarded to the `Zone` where `runApp` was run.
+Instead, it's forwarded to the `PlatformDispatcher`.
 
-To catch such an error, use [`runZonedGuarded`][].
+To catch such an error, use [`PlatformDispatcher.onError`][].
 
 <?code-excerpt "lib/excerpts.dart (CatchError)" replace="/MyBackend myBackend = MyBackend\(\);\n//g"?>
 ```dart
-import 'dart:async';
+import 'package:flutter/material.dart';
 
 void main() {
-    runZonedGuarded(() {
-    runApp(const MyApp());
-  }, (error, stack) {
+  PlatformDispatcher.instance.onError = (error, stack) {
     myBackend.sendError(error, stack);
-  });
+  };
+  runApp(const MyApp());
 }
 ```
-
-Note that if in your app you call `WidgetsFlutterBinding.ensureInitialized()`
-manually to perform some initialization before calling `runApp` (e.g.
-`Firebase.initializeApp()`), you **must** call
-`WidgetsFlutterBinding.ensureInitialized()` inside `runZonedGuarded`:
-
-<?code-excerpt "lib/run_zoned_guarded.dart (Initialize)"?>
-```dart
-runZonedGuarded(() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp();
-  runApp(const MyApp());
-}, (error, stack) {
-  myBackend.sendError(error, stack);
-});
-```
-
-{{site.alert.note}}
-    Error handling wouldn't work if `WidgetsFlutterBinding.ensureInitialized()`
-    was called from the outside.
-{{site.alert.end}}
 
 ## Handling all types of errors
 
@@ -169,24 +148,18 @@ your errors handling on next code snippet:
 
 <?code-excerpt "lib/main.dart (Main)"?>
 ```dart
-import 'dart:async';
-import 'dart:io';
 import 'package:flutter/material.dart';
 
-void main() {
-  runZonedGuarded(() async {
-    WidgetsFlutterBinding.ensureInitialized();
-    await myErrorsHandler.initialize();
-    FlutterError.onError = (details) {
-      FlutterError.presentError(details);
-      myErrorsHandler.onErrorDetails(details);
-      exit(1);
-    };
-    runApp(const MyApp());
-  }, (error, stack) {
+Future<void> main() async {
+  await myErrorsHandler.initialize();
+  FlutterError.onError = (details) {
+    FlutterError.presentError(details);
+    myErrorsHandler.onErrorDetails(details);
+  };
+  PlatformDispatcher.instance.onError = (error, stack) {
     myErrorsHandler.onError(error, stack);
-    exit(1);
-  });
+  };
+  runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
@@ -215,5 +188,5 @@ class MyApp extends StatelessWidget {
 [`kReleaseMode`]:  {{site.api}}/flutter/foundation/kReleaseMode-constant.html
 [`MaterialApp.builder`]: {{site.api}}/flutter/material/MaterialApp/builder.html
 [reporting errors to a service]: {{site.url}}/cookbook/maintenance/error-reporting
-[`runZonedGuarded`]: {{site.api}}/flutter/dart-async/runZonedGuarded.html
-[`Zone`]: {{site.api}}/flutter/dart-async/Zone-class.html
+[`PlatformDispatcher.instance.onError`]: {{site.api}}/flutter/dart-ui/PlatformDispatcher/onError.html
+[`PlatformDispatcher`]: {{site.api}}/flutter/dart-ui/PlatformDispatcher-class.html


### PR DESCRIPTION
New API will be available for the upcoming stable release. This should not be published until available in stable.

We are trying to discourage people from using Zones - it causes performance issues and generally contributes to confusion. The new API handles all errors without the need for custom zones. Current docs are available here: https://master-api.flutter.dev/flutter/dart-ui/PlatformDispatcher/onError.html

@zanderso FYI