### PR TITLE
[cookbook] Update link to websockets echo page

### DIFF
--- a/src/cookbook/networking/web-sockets.md
+++ b/src/cookbook/networking/web-sockets.md
@@ -17,7 +17,7 @@ you can connect to servers using `WebSockets`.
 without polling.
 
 In this example, connect to a
-[test server provided by websocket.org][].
+[test WebSocket server sponsored by Lob.com][].
 The server sends back the same message you send to it.
 This recipe uses the following steps:
 
@@ -206,6 +206,6 @@ class _MyHomePageState extends State<MyHomePage> {
 [`Stream`]: {{site.api}}/flutter/dart-async/Stream-class.html
 [`StreamBuilder`]: {{site.api}}/flutter/widgets/StreamBuilder-class.html
 [`StreamSink`]: {{site.api}}/flutter/dart-async/StreamSink-class.html
-[test server provided by websocket.org]: http://www.websocket.org/echo.html
+[test WebSocket server sponsored by Lob.com]: https://www.lob.com/blog/websocket-org-is-down-here-is-an-alternative
 [`Text`]: {{site.api}}/flutter/widgets/Text-class.html
 [`web_socket_channel`]: {{site.pub-pkg}}/web_socket_channel


### PR DESCRIPTION
This PR updates the WebSocket test server link to point to Lob.com's article introducing their `echo.websockets.events` server, and scrubs the reference to the (now defunct) websocket.org.

Fixes #7459

_(Should have been part of #6933)_

---

**IMPORTANT:** Due to work on the docs.flutter.dev infrastructure, this repo is **not accepting pull requests**.

Instead of creating a PR, please file an issue (https://github.com/flutter/website/issues/new/choose) about the needed change.

We expect to start accepting PRs again the week of August 31.

---

(Woops, I can reopen this after September 1st if needed)