### PR TITLE
Missing `ImageProvider.loadBuffer` BC from list

### DIFF
--- a/src/release/breaking-changes/image-provider-load-buffer.md
+++ b/src/release/breaking-changes/image-provider-load-buffer.md
@@ -115,16 +115,16 @@ to give users of your code time to migrate as well.
 
 ## Timeline
 
-Landed in version: 3.1.0-0.0.pre.976
+Landed in version: 3.1.0-0.0.pre.976<br>
 In stable release: not yet
 
 ## References
 
 API documentation:
 
-* [`ImmutableBuffer`]: {{site.master-api}}/flutter/dart-ui/ImmutableBuffer-class.html
-* [`ImageProvider`]: {{site.master-api}}/painting/ImageProvider-class.html
+* [`ImmutableBuffer`]({{site.master-api}}/flutter/dart-ui/ImmutableBuffer-class.html)
+* [`ImageProvider`]({{site.master-api}}/painting/ImageProvider-class.html)
 
 Relevant PRs:
 
-* [Use immutable buffer for loading asset images]: {{site.repo.flutter}}/pull/103496
+* [Use immutable buffer for loading asset images]({{site.repo.flutter}}/pull/103496)

--- a/src/release/breaking-changes/image-provider-load-buffer.md
+++ b/src/release/breaking-changes/image-provider-load-buffer.md
@@ -116,7 +116,7 @@ to give users of your code time to migrate as well.
 ## Timeline
 
 Landed in version: 3.1.0-0.0.pre.976<br>
-In stable release: not yet
+In stable release: 3.3.0
 
 ## References
 

--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -18,10 +18,12 @@ release, and listed in alphabetical order:
 
 ### Not yet released to stable
 
+* [Adding ImageProvider.loadBuffer][]
 * [Default PrimaryScrollController on Desktop][]
 * [ThemeData's toggleableActiveColor property has been deprecated][]
 * [iOS FlutterViewController splashScreenView made nullable][]
 
+[Adding ImageProvider.loadBuffer]: {{site.url}}/release/breaking-changes/image-provider-load-buffer
 [Default PrimaryScrollController on Desktop]: {{site.url}}/release/breaking-changes/primary-scroll-controller-desktop
 [ThemeData's toggleableActiveColor property has been deprecated]: {{site.url}}/release/breaking-changes/toggleable-active-color
 [iOS FlutterViewController splashScreenView made nullable]: {{site.url}}/release/breaking-changes/ios-flutterviewcontroller-splashscreenview-nullable


### PR DESCRIPTION
https://github.com/flutter/website/pull/7207 doesn't bring it to the list. Also, fix the trailing format issues.

![image](https://user-images.githubusercontent.com/15884415/187429775-10e1782c-6713-4148-9a75-27aa56689d1b.png)