### PR TITLE
Fix named route alert formatting

### DIFF
--- a/src/cookbook/navigation/named-routes.md
+++ b/src/cookbook/navigation/named-routes.md
@@ -18,7 +18,7 @@ js:
   Named routes are no longer recommended for most
   applications. For more information, see
   [Limitations][] in the [navigation overview][] page.
-{{site.alert.note}}
+{{site.alert.end}}
 
 [Limitations]: {{site.url}}/development/ui/navigation#limitations
 [navigation overview]: {{site.url}}/development/ui/navigation

--- a/src/cookbook/navigation/navigate-with-arguments.md
+++ b/src/cookbook/navigation/navigate-with-arguments.md
@@ -25,7 +25,7 @@ pass information about the user to that route.
   Named routes are no longer recommended for most
   applications. For more information, see
   [Limitations][] in the [navigation overview][] page.
-{{site.alert.note}}
+{{site.alert.end}}
 
 [Limitations]: {{site.url}}/development/ui/navigation#limitations
 [navigation overview]: {{site.url}}/development/ui/navigation

--- a/src/development/ui/navigation/deep-linking.md
+++ b/src/development/ui/navigation/deep-linking.md
@@ -14,7 +14,7 @@ using the [`Router`][Router] widget.
   Named routes are no longer recommended for most
   applications. For more information, see
   [Limitations][] in the [navigation overview][] page.
-{{site.alert.note}}
+{{site.alert.end}}
 
 [Limitations]: {{site.url}}/development/ui/navigation#limitations
 [navigation overview]: {{site.url}}/development/ui/navigation

--- a/src/get-started/flutter-for/react-native-devs.md
+++ b/src/get-started/flutter-for/react-native-devs.md
@@ -1678,7 +1678,7 @@ The following example specifies named routes in the `MaterialApp` widget.
   Named routes are no longer recommended for most
   applications. For more information, see
   [Limitations][] in the [navigation overview][] page.
-{{site.alert.note}}
+{{site.alert.end}}
 
 [Limitations]: {{site.url}}/development/ui/navigation#limitations
 [navigation overview]: {{site.url}}/development/ui/navigation


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ The alerts for named routes had the wrong closing tag.

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
