### PR TITLE
fix DartPad in typing-indicator.md cookbook

### DIFF
--- a/src/cookbook/effects/typing-indicator.md
+++ b/src/cookbook/effects/typing-indicator.md
@@ -667,6 +667,8 @@ Run the app:
   of the screen to turn the typing indicator bubble
   on and off.
 
+<!-- Start DartPad -->
+
 <?code-excerpt "lib/main.dart"?>
 ```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'dart:math';


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ fix DartPad in typing-indicator.md cookbook :cook: :book: by adding an HTML comment. Got to know about it from here: https://github.com/flutter/website/commit/6e9687458fad1f371ed095685950eb5d37cd211e

_Issues fixed by this PR (if any):_ #7482

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
