### PR TITLE
Fix a typo in Navigation and routing doc

### DIFF
--- a/src/development/ui/navigation/index.md
+++ b/src/development/ui/navigation/index.md
@@ -104,7 +104,7 @@ same screen(s) when a deep link is received.
 {{site.alert.secondary}}
   **Note for advanced developers**:  If you prefer not to use a routing package
   and would like full control over navigation and routing in your app, override
-  `RouteInformationParser` and a`RouterDelegate`. When the state in your app
+  `RouteInformationParser` and `RouterDelegate`. When the state in your app
   changes, you can precisely control the stack of screens by providing a list of
   `Page` objects using the `Navigator.pages` parameter. For more details, see the
   `Router` API documentation.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
