### PR TITLE
Configure Dependabot to automatically check submodules for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,11 @@ updates:
       interval: "daily"
     allow:
       - dependency-type: "production"
+  # Automatically update submodules
+  - package-ecosystem: 'gitsubmodule'
+    directory: '/'
+    schedule:
+      interval: 'daily'
   - package-ecosystem: "pub"
     directory: "/"
     schedule:


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Dependabot will check daily for submodule updates and open a PR. Eliminates the need for manual submodule updates. 

Discussed with @johnpryan @domesticmouse and determined that a daily update cadence was best for timeliness when submodules are updated.  

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
