### PR TITLE
fix typo from `stateful` to `stateless`

### DIFF
--- a/src/cookbook/effects/download-button.md
+++ b/src/cookbook/effects/download-button.md
@@ -28,7 +28,7 @@ The following animation shows the app's behavior:
 
 ![The download button cycles through its stages]({{site.url}}/assets/images/docs/cookbook/effects/DownloadButton.gif){:.site-mobile-screenshot}
 
-## Define a new stateful widget
+## Define a new stateless widget
 
 Your button widget needs to change its appearance over time.
 Therefore, you need to implement your button with a custom


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Title is misleading. It should be `stateless` not `stateful` because example is a stateless-widget.

_Issues fixed by this PR (if any):_ Fixes #7508

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
