### PR TITLE
[cookbook] [networking] delete-data tutorial after update-data tutorial

### DIFF
--- a/src/cookbook/index.md
+++ b/src/cookbook/index.md
@@ -82,12 +82,12 @@ reference to help you build up an application.
 
 
 ## Networking
-- [Delete data on the internet]({{site.url}}/cookbook/networking/delete-data)
 - [Fetch data from the internet]({{site.url}}/cookbook/networking/fetch-data)
 - [Make authenticated requests]({{site.url}}/cookbook/networking/authenticated-requests)
 - [Parse JSON in the background]({{site.url}}/cookbook/networking/background-parsing)
 - [Send data to the internet]({{site.url}}/cookbook/networking/send-data)
 - [Update data over the internet]({{site.url}}/cookbook/networking/update-data)
+- [Delete data on the internet]({{site.url}}/cookbook/networking/delete-data)
 - [Work with WebSockets]({{site.url}}/cookbook/networking/web-sockets)
 
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ put delete-data tutorial after update-data tutorial in networking section of cookbook. Tried fixing an (old) filed issue. Please close this if it is irrelevant.

_Issues fixed by this PR (if any):_ Fixes #7135

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
