### PR TITLE
add 'Firebase Crashlytics' error-reporting tool

### DIFF
--- a/src/cookbook/maintenance/error-reporting.md
+++ b/src/cookbook/maintenance/error-reporting.md
@@ -23,7 +23,7 @@ How can you determine how often your users experiences bugs?
 Whenever an error occurs, create a report containing the
 error that occurred and the associated stacktrace.
 You can then send the report to an error tracking
-service, such as [Bugsnag][], Fabric, [Rollbar][], or Sentry.
+service, such as [Bugsnag][], Fabric, Firebase Crashlytics, [Rollbar][], or Sentry.
 
 The error tracking service aggregates all of the crashes your users
 experience and groups them together. This allows you to know how often your

--- a/src/cookbook/maintenance/error-reporting.md
+++ b/src/cookbook/maintenance/error-reporting.md
@@ -23,7 +23,7 @@ How can you determine how often your users experiences bugs?
 Whenever an error occurs, create a report containing the
 error that occurred and the associated stacktrace.
 You can then send the report to an error tracking
-service, such as [Bugsnag][], Fabric, Firebase Crashlytics, [Rollbar][], or Sentry.
+service, such as [Bugsnag][], Fabric, [Firebase Crashlytics][], [Rollbar][], or Sentry.
 
 The error tracking service aggregates all of the crashes your users
 experience and groups them together. This allows you to know how often your
@@ -121,3 +121,4 @@ see the [Sentry flutter example][] app.
 [`sentry_flutter`]: {{site.pub-pkg}}/sentry_flutter
 [Sentry API]: {{site.pub-api}}/sentry_flutter/latest/sentry_flutter/sentry_flutter-library.html
 [Sentry's site]: https://docs.sentry.io/platforms/flutter/
+[Firebase Crashlytics]: https://firebase.google.com/docs/crashlytics


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ added 'Firebase Crashlytics' as recommended error-reporting tool in the list.

_Issues fixed by this PR (if any):_ Fixes #7239

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
