### PR TITLE
add anchor hyperlink for VM acceleration

### DIFF
--- a/src/get-started/install/_android-setup.md
+++ b/src/get-started/install/_android-setup.md
@@ -43,7 +43,7 @@ To prepare to run and test your Flutter app on the Android emulator,
 follow these steps:
 
  1. Enable
-    [VM acceleration]({{site.android-dev}}/studio/run/emulator-acceleration)
+    [VM acceleration]({{site.android-dev}}/studio/run/emulator-acceleration#accel-vm)
     on your machine.
  1. Launch **Android Studio**, click the **AVD Manager**
     icon, and select **Create Virtual Device...**


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Copied description from the filed issue, hence quoted. I know what/why I change though :D
> "Configure hardware acceleration for the Android Emulator" is a long page. If the anchor text on our page is accurate and only VM acceleration is required, then it should go straight to the "Configuring VM acceleration"

_Issues fixed by this PR (if any):_ Fixes #7461

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
