### PR TITLE
Update shader compilation jank docs

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -371,7 +371,7 @@
       permalink: /perf/rendering-performance
     - title: Performance profiling
       permalink: /perf/ui-performance
-    - title: Reduce shader compilation jank
+    - title: Shader compilation jank
       permalink: /perf/shader
     - title: Performance metrics
       permalink: /perf/metrics


### PR DESCRIPTION
This PR updates the shader compilation jank docs to warn users off trying to use it on Android, and to ask users to try Impeller on iOS.

## Presubmit checklist
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
