### PR TITLE
Makes  vscode the default editor

### DIFF
--- a/src/get-started/editor.md
+++ b/src/get-started/editor.md
@@ -25,7 +25,7 @@ that's OK, skip ahead to the [next step: Test drive][].
   <li class="nav-item">
     <a class="nav-link active" id="vscode-tab" href="#vscode" role="tab" aria-controls="vscode" aria-selected="true">Visual Studio Code</a>
   </li>
-    <li class="nav-item">
+  <li class="nav-item">
     <a class="nav-link" id="androidstudio-tab" href="#androidstudio" role="tab" aria-controls="androidstudio" aria-selected="false">Android Studio and IntelliJ</a>
   </li>
   <li class="nav-item">

--- a/src/get-started/editor.md
+++ b/src/get-started/editor.md
@@ -23,10 +23,10 @@ that's OK, skip ahead to the [next step: Test drive][].
 {% comment %} Nav tabs {% endcomment -%}
 <ul class="nav nav-tabs" id="editor-setup" role="tablist">
   <li class="nav-item">
-    <a class="nav-link active" id="androidstudio-tab" href="#androidstudio" role="tab" aria-controls="androidstudio" aria-selected="true">Android Studio and IntelliJ</a>
+    <a class="nav-link" id="vscode-tab" href="#vscode" role="tab" aria-controls="vscode" aria-selected="true">Visual Studio Code</a>
   </li>
-  <li class="nav-item">
-    <a class="nav-link" id="vscode-tab" href="#vscode" role="tab" aria-controls="vscode" aria-selected="false">Visual Studio Code</a>
+    <li class="nav-item">
+    <a class="nav-link" id="androidstudio-tab" href="#androidstudio" role="tab" aria-controls="androidstudio" aria-selected="false">Android Studio and IntelliJ</a>
   </li>
   <li class="nav-item">
     <a class="nav-link" id="emacs-tab" href="#emacs" role="tab" aria-controls="emacs" aria-selected="false">Emacs</a>
@@ -35,7 +35,29 @@ that's OK, skip ahead to the [next step: Test drive][].
 
 {% comment %} Tab panes {% endcomment -%}
 <div class="tab-content">
+<div class="tab-pane" id="vscode" role="tabpanel" aria-labelledby="vscode-tab" markdown="1">
 
+## Install VS Code
+
+VS Code is a lightweight editor with complete Flutter app execution and debug support.
+
+* [VS Code][], latest stable version
+
+## Install the Flutter and Dart plugins
+
+ 1. Start VS Code.
+ 1. Invoke **View > Command Palette...**.
+ 1. Type "install", and select **Extensions: Install Extensions**.
+ 1. Type "flutter" in the extensions search field, select **Flutter** in the list,
+    and click **Install**. This also installs the required Dart plugin.
+
+## Validate your setup with the Flutter Doctor
+
+ 1. Invoke **View > Command Palette...**.
+ 1. Type "doctor", and select the **Flutter: Run Flutter Doctor**.
+ 1. Review the output in the **OUTPUT** pane for any issues. Make sure to select Flutter from the dropdown in the different Output Options.
+
+</div>
 <div class="tab-pane active" id="androidstudio" role="tabpanel" aria-labelledby="androidstudio-tab" markdown="1">
 
 ## Install Android Studio
@@ -72,29 +94,6 @@ Use the following instructions for Linux or Windows:
    1. Open plugin preferences (**File > Settings > Plugins**).
    1. Select **Marketplace**,  select the Flutter plugin and click
       **Install**.
-
-</div>
-<div class="tab-pane" id="vscode" role="tabpanel" aria-labelledby="vscode-tab" markdown="1">
-
-## Install VS Code
-
-VS Code is a lightweight editor with complete Flutter app execution and debug support.
-
-* [VS Code][], latest stable version
-
-## Install the Flutter and Dart plugins
-
- 1. Start VS Code.
- 1. Invoke **View > Command Palette...**.
- 1. Type "install", and select **Extensions: Install Extensions**.
- 1. Type "flutter" in the extensions search field, select **Flutter** in the list,
-    and click **Install**. This also installs the required Dart plugin.
-
-## Validate your setup with the Flutter Doctor
-
- 1. Invoke **View > Command Palette...**.
- 1. Type "doctor", and select the **Flutter: Run Flutter Doctor**.
- 1. Review the output in the **OUTPUT** pane for any issues. Make sure to select Flutter from the dropdown in the different Output Options.
 
 </div>
 <div class="tab-pane" id="emacs" role="tabpanel" aria-labelledby="emacs-tab" markdown="1">

--- a/src/get-started/editor.md
+++ b/src/get-started/editor.md
@@ -23,7 +23,7 @@ that's OK, skip ahead to the [next step: Test drive][].
 {% comment %} Nav tabs {% endcomment -%}
 <ul class="nav nav-tabs" id="editor-setup" role="tablist">
   <li class="nav-item">
-    <a class="nav-link" id="vscode-tab" href="#vscode" role="tab" aria-controls="vscode" aria-selected="true">Visual Studio Code</a>
+    <a class="nav-link active" id="vscode-tab" href="#vscode" role="tab" aria-controls="vscode" aria-selected="true">Visual Studio Code</a>
   </li>
     <li class="nav-item">
     <a class="nav-link" id="androidstudio-tab" href="#androidstudio" role="tab" aria-controls="androidstudio" aria-selected="false">Android Studio and IntelliJ</a>
@@ -35,7 +35,7 @@ that's OK, skip ahead to the [next step: Test drive][].
 
 {% comment %} Tab panes {% endcomment -%}
 <div class="tab-content">
-<div class="tab-pane" id="vscode" role="tabpanel" aria-labelledby="vscode-tab" markdown="1">
+<div class="tab-pane active" id="vscode" role="tabpanel" aria-labelledby="vscode-tab" markdown="1">
 
 ## Install VS Code
 
@@ -58,7 +58,7 @@ VS Code is a lightweight editor with complete Flutter app execution and debug su
  1. Review the output in the **OUTPUT** pane for any issues. Make sure to select Flutter from the dropdown in the different Output Options.
 
 </div>
-<div class="tab-pane active" id="androidstudio" role="tabpanel" aria-labelledby="androidstudio-tab" markdown="1">
+<div class="tab-pane" id="androidstudio" role="tabpanel" aria-labelledby="androidstudio-tab" markdown="1">
 
 ## Install Android Studio
 

--- a/src/get-started/test-drive/_androidstudio.md
+++ b/src/get-started/test-drive/_androidstudio.md
@@ -1,4 +1,4 @@
-<div class="tab-pane active" id="androidstudio" role="tabpanel" aria-labelledby="androidstudio-tab" markdown="1">
+<div class="tab-pane" id="androidstudio" role="tabpanel" aria-labelledby="androidstudio-tab" markdown="1">
 
 ## Create the app {#create-app}
 

--- a/src/get-started/test-drive/_vscode.md
+++ b/src/get-started/test-drive/_vscode.md
@@ -1,4 +1,4 @@
-<div class="tab-pane" id="vscode" role="tabpanel" aria-labelledby="vscode-tab" markdown="1">
+<div class="tab-pane active" id="vscode" role="tabpanel" aria-labelledby="vscode-tab" markdown="1">
 
 ## Create the app {#create-app}
 

--- a/src/get-started/test-drive/index.md
+++ b/src/get-started/test-drive/index.md
@@ -19,10 +19,10 @@ Flutter apps.
 {% comment %} Nav tabs {% endcomment -%}
 <ul class="nav nav-tabs" id="editor-setup" role="tablist">
   <li class="nav-item">
-    <a class="nav-link active" id="androidstudio-tab" href="#androidstudio" role="tab" aria-controls="androidstudio" aria-selected="true">Android Studio and IntelliJ</a>
+    <a class="nav-link" id="vscode-tab" href="#vscode" role="tab" aria-controls="vscode" aria-selected="false">Visual Studio Code</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" id="vscode-tab" href="#vscode" role="tab" aria-controls="vscode" aria-selected="false">Visual Studio Code</a>
+    <a class="nav-link active" id="androidstudio-tab" href="#androidstudio" role="tab" aria-controls="androidstudio" aria-selected="true">Android Studio and IntelliJ</a>
   </li>
   <li class="nav-item">
     <a class="nav-link" id="terminal-tab" href="#terminal" role="tab" aria-controls="terminal" aria-selected="false">Terminal & editor</a>
@@ -31,8 +31,8 @@ Flutter apps.
 
 {% comment %} Tab panes {% endcomment -%}
 <div class="tab-content">
-  {% include_relative _androidstudio.md %}
   {% include_relative _vscode.md %}
+  {% include_relative _androidstudio.md %}
   {% include_relative _terminal.md %}
 </div>
 

--- a/src/get-started/test-drive/index.md
+++ b/src/get-started/test-drive/index.md
@@ -19,10 +19,10 @@ Flutter apps.
 {% comment %} Nav tabs {% endcomment -%}
 <ul class="nav nav-tabs" id="editor-setup" role="tablist">
   <li class="nav-item">
-    <a class="nav-link" id="vscode-tab" href="#vscode" role="tab" aria-controls="vscode" aria-selected="false">Visual Studio Code</a>
+    <a class="nav-link active" id="vscode-tab" href="#vscode" role="tab" aria-controls="vscode" aria-selected="true">Visual Studio Code</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link active" id="androidstudio-tab" href="#androidstudio" role="tab" aria-controls="androidstudio" aria-selected="true">Android Studio and IntelliJ</a>
+    <a class="nav-link" id="androidstudio-tab" href="#androidstudio" role="tab" aria-controls="androidstudio" aria-selected="false">Android Studio and IntelliJ</a>
   </li>
   <li class="nav-item">
     <a class="nav-link" id="terminal-tab" href="#terminal" role="tab" aria-controls="terminal" aria-selected="false">Terminal & editor</a>


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
[Set up editor staging](https://sm-flutter-web.web.app/get-started/editor/)
[Test drive staging](https://sm-flutter-web.web.app/get-started/test-drive/)

This PR makes VS code the default editor on pages with multiple editors. 
_Issues fixed by this PR (if any):_ Fixes #ISSUE-NUMBER
#7531 
![Screen Shot 2022-09-08 at 10 28 06 AM](https://user-images.githubusercontent.com/23406866/189164663-13cddab2-be86-42af-940d-57dd569c8b9a.png)


## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
