### PR TITLE
[codelab] fix first-point in step-4's second sub-step

### DIFF
--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -538,7 +538,7 @@ lazily, on demand.
     ```
 
     {:.numbered-code-notes}
-     1. The `itemBuilder` callback is called once per suggested word pairing,
+     1. The `itemBuilder` callback is called once per row,
         and places each suggestion into a `ListTile` row. For even rows, the
         function adds a `ListTile` row for the word pairing. For odd rows, the
         function adds a `Divider` widget to visually separate the entries. Note


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Changed `"The itemBuilder callback is called once per suggested word pairing"` to `"The itemBuilder callback is called once per row"` as `itemBuilder` is called for all rows.

_Issues fixed by this PR (if any):_ Fixes #6723

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
