### PR TITLE
reshuffle step 3 and step 4 of fade-in example

### DIFF
--- a/src/codelabs/implicit-animations.md
+++ b/src/codelabs/implicit-animations.md
@@ -167,7 +167,28 @@ the starting value for `opacity` to zero:
              Text('Type: Owl'),
 ```
 
-#### 3. Set up a trigger for the animation, and choose an end value
+#### 3. Set the duration of the animation
+
+In addition to an `opacity` parameter, `AnimatedOpacity` requires a
+[duration] to use for its animation. For this example,
+you can start with 2 seconds:
+
+<?code-excerpt "opacity{3,4}/lib/main.dart"?>
+```diff
+--- opacity3/lib/main.dart
++++ opacity4/lib/main.dart
+@@ -28,7 +28,7 @@
+           ),
+           onPressed: () => {}),
+       AnimatedOpacity(
+-        duration: const Duration(seconds: 3),
++        duration: const Duration(seconds: 2),
+         opacity: opacity,
+         child: Column(
+           children: const [
+```
+
+#### 4. Set up a trigger for the animation, and choose an end value
 
 Configure the animation to trigger when the user clicks the **Show details**
 button. To do this, change `opacity` state using the `onPressed()` handler for
@@ -205,27 +226,6 @@ to set `opacity` to 1:
   Notice that you only need to set the start and end values of `opacity`.
   The `AnimatedOpacity` widget manages everything in between.
 {{site.alert.end}}
-
-#### 4. Set the duration of the animation
-
-In addition to an `opacity` parameter, `AnimatedOpacity` requires a
-[duration] to use for its animation. For this example,
-you can start with 2 seconds:
-
-<?code-excerpt "opacity{3,4}/lib/main.dart"?>
-```diff
---- opacity3/lib/main.dart
-+++ opacity4/lib/main.dart
-@@ -28,7 +28,7 @@
-           ),
-           onPressed: () => {}),
-       AnimatedOpacity(
--        duration: const Duration(seconds: 3),
-+        duration: const Duration(seconds: 2),
-         opacity: opacity,
-         child: Column(
-           children: const [
-```
 
 ### Fade-in (complete)
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Reshuffled _step-3_ and _step-4_ in **Implicit Animations Fade-in** example as they were out of order.

_Issues fixed by this PR (if any):_ Fixes #6928 

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
