### PR TITLE
fix: useless spaces in .desktop

### DIFF
--- a/src/deployment/linux.md
+++ b/src/deployment/linux.md
@@ -310,14 +310,14 @@ same as your app name in yaml file!
 For example:
 
 ```desktop
-  [Desktop Entry]
-  Name=Super Cool App
-  Comment=Super Cool App that does everything
-  Exec=super-cool-app 
-  Icon=${SNAP}/meta/gui/super-cool-app.png # replace name to your app name
-  Terminal=false
-  Type=Application
-  Categories=Education; #adjust accordingly your snap category
+[Desktop Entry]
+Name=Super Cool App
+Comment=Super Cool App that does everything
+Exec=super-cool-app 
+Icon=${SNAP}/meta/gui/super-cool-app.png # replace name to your app name
+Terminal=false
+Type=Application
+Categories=Education; #adjust accordingly your snap category
 ```
 
 Place your icon with .png extension in your Flutter 


### PR DESCRIPTION
Prevents [this issue](https://stackoverflow.com/questions/71556021/not-able-to-create-flutter-linux-desktop-application-snapcraft-build).  

```
Could not find 'Exec=' in desktop file
Could not find 'Type=Application' in desktop file**
```