### PR TITLE
Add link to flutter/plugin migration doc

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -252,6 +252,7 @@
       { "source": "/go/flutter-nonhost", "destination": "https://docs.google.com/document/d/1rTLxAxsshEir-B2vE6DU_MaqMMusOdCgLGEGpBYG3CM", "type": 301 },
       { "source": "/go/flutter-platform-idling", "destination": "https://docs.google.com/document/d/1RhSluOcHED6wEckY8CGK1mowRcWGAEGWraN6REPaORs/edit", "type": 301 },
       { "source": "/go/flutter-plugin-languages", "destination": "https://docs.google.com/document/d/1Ok_mUPgmw8_l-ynLueEKtXm2Fs48lEVB0JqZd7M7uyA/edit", "type": 301 },
+      { "source": "/go/flutter-plugins-repo-migration", "destination": "https://docs.google.com/document/d/1VihAgx1e-X_H8VRc9WmUv_7qqsi81eeHrrhwhHgwtjQ/edit?usp=sharing", "type": 301 },
       { "source": "/go/flutter-skia-ios-font-problem", "destination": "https://docs.google.com/document/d/1UkAhEKUEWNUjfKlqoBjJnx8zXrqErIqidPYjd9FBwsg", "type": 301 },
       { "source": "/go/flutter-support-multi-architecture", "destination": "https://docs.google.com/document/d/19tzWySgtgtTA99XQsjx5Pg0SFJeZKXyUlYavR0EXv8c/edit?usp=sharing", "type": 301 },
       { "source": "/go/flutter-web-scenelets", "destination": "https://docs.google.com/document/d/1GUAx3aqdtEoaBMTNpsS1-i59QZlwTi6vUCASbaanPCo", "type": 301 },


### PR DESCRIPTION
Adds a link to the public document proposing merging flutter/plugins into flutter/packages

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
