### PR TITLE
[cookbook] [animation] remove `final` keyword from state variables

### DIFF
--- a/examples/cookbook/animation/animated_container/lib/starter.dart
+++ b/examples/cookbook/animation/animated_container/lib/starter.dart
@@ -12,10 +12,10 @@ class AnimatedContainerApp extends StatefulWidget {
 class _AnimatedContainerAppState extends State<AnimatedContainerApp> {
   // Define the various properties with default values. Update these properties
   // when the user taps a FloatingActionButton.
-  final double _width = 50;
-  final double _height = 50;
-  final Color _color = Colors.green;
-  final BorderRadiusGeometry _borderRadius = BorderRadius.circular(8);
+  double _width = 50;
+  double _height = 50;
+  Color _color = Colors.green;
+  BorderRadiusGeometry _borderRadius = BorderRadius.circular(8);
 
   @override
   Widget build(BuildContext context) {

--- a/examples/cookbook/animation/animated_container/lib/starter.dart
+++ b/examples/cookbook/animation/animated_container/lib/starter.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_field
+// ignore_for_file: unused_field, prefer_final_fields
 import 'package:flutter/material.dart';
 
 // #docregion Starter

--- a/src/cookbook/animation/animated-container.md
+++ b/src/cookbook/animation/animated-container.md
@@ -61,10 +61,10 @@ class AnimatedContainerApp extends StatefulWidget {
 class _AnimatedContainerAppState extends State<AnimatedContainerApp> {
   // Define the various properties with default values. Update these properties
   // when the user taps a FloatingActionButton.
-  final double _width = 50;
-  final double _height = 50;
-  final Color _color = Colors.green;
-  final BorderRadiusGeometry _borderRadius = BorderRadius.circular(8);
+  double _width = 50;
+  double _height = 50;
+  Color _color = Colors.green;
+  BorderRadiusGeometry _borderRadius = BorderRadius.circular(8);
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Remove `final` from state variables as they would be mutated via setState.

_Issues fixed by this PR (if any):_ Fixes #5791

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
