### PR TITLE
Fix text excerpts sample for HTML / CSS example

### DIFF
--- a/src/get-started/flutter-for/web-devs.md
+++ b/src/get-started/flutter-for/web-devs.md
@@ -1014,9 +1014,9 @@ and the `overflow` property for handling overflow text.
     padding: 16px;
     color: #ffffff;
     [[highlight]]overflow: hidden;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;[[/highlight]]
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;[[/highlight]]
 }
 {% endprettify %}
 </div>

--- a/src/get-started/flutter-for/web-devs.md
+++ b/src/get-started/flutter-for/web-devs.md
@@ -987,8 +987,6 @@ final container = Container(
 
 An excerpt displays the initial line(s) of text in a paragraph,
 and handles the overflow text, often using an ellipsis.
-In HTML/CSS an excerpt can be no longer than one line.
-Truncating after multiple lines requires some JavaScript code.
 
 In Flutter, use the `maxLines` property of a [`Text`][] widget
 to specify the number of lines to include in the excerpt,
@@ -1016,8 +1014,9 @@ and the `overflow` property for handling overflow text.
     padding: 16px;
     color: #ffffff;
     [[highlight]]overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;[[/highlight]]
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;[[/highlight]]
 }
 {% endprettify %}
 </div>


### PR DESCRIPTION

It's possible to create text excerpts with multiple line only in CSS. No JavaScript is needed.


## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
