### PR TITLE
Add Windows run loop migration

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -206,6 +206,8 @@
           children:
             - title: Building Windows apps
               permalink: /development/platform-integration/windows/building
+            - title: Run loop migration
+              permalink: /development/platform-integration/windows/run-loop-migration
             - title: Version information migration
               permalink: /development/platform-integration/windows/version-migration
     - title: Packages & plugins

--- a/src/development/platform-integration/windows/run-loop-migration.md
+++ b/src/development/platform-integration/windows/run-loop-migration.md
@@ -33,4 +33,4 @@ Flutter SDK
 6. Review the changes to files in the `windows/runner` folder
 7. Reapply any custom changes made to the files in the
 `windows/runner` folder prior to this migration
-8. Verify your app builds using `flutter build windows`
+8. Verify that your app builds using `flutter build windows`

--- a/src/development/platform-integration/windows/run-loop-migration.md
+++ b/src/development/platform-integration/windows/run-loop-migration.md
@@ -25,7 +25,9 @@ Your project can be updated using these steps:
 1. Verify you are on Flutter version 2.5 or newer using `flutter --version`
 2. If needed, use `flutter upgrade` to update to the latest version of the
 Flutter SDK
-3. Backup your project, possibly using git or some other version control system
+3. Backup your project, possibly using git or some other version control system,
+   since you'll need to reapply any local changes you've made  (if any) to your
+   project in a later step
 4. Delete all files under the `windows/runner` folder
 5. Run `flutter create --platforms=windows .` to recreate the Windows project
 6. Review the changes to files in the `windows/runner` folder

--- a/src/development/platform-integration/windows/run-loop-migration.md
+++ b/src/development/platform-integration/windows/run-loop-migration.md
@@ -14,10 +14,10 @@ file exists in your project.
 ## Migration steps
 
 {{site.alert.note}}
-  You will need to recreate the Windows project for this
-  migration. Any custom changes to the files in the
-  `windows/runner` folder will need to be reapplied after
-  the project has been recreated.
+ As part of this migration, you must recreate your Windows project,
+  which clobbers any custom changes to the
+  files in the `windows/runner` folder.  The following steps
+  include instructions for this scenario.
 {{site.alert.end}}
 
 Your project can be updated using these steps:

--- a/src/development/platform-integration/windows/run-loop-migration.md
+++ b/src/development/platform-integration/windows/run-loop-migration.md
@@ -25,8 +25,8 @@ Your project can be updated using these steps:
 1. Verify you are on Flutter version 2.5 or newer using `flutter --version`
 2. If needed, use `flutter upgrade` to update to the latest version of the
 Flutter SDK
-3. Backup your project, possibly using git or some other version control system,
-   since you'll need to reapply any local changes you've made  (if any) to your
+3. Backup your project with git (or your preferred version control system),
+   since you need to reapply any local changes you've made (if any) to your
    project in a later step
 4. Delete all files under the `windows/runner` folder
 5. Run `flutter create --platforms=windows .` to recreate the Windows project

--- a/src/development/platform-integration/windows/run-loop-migration.md
+++ b/src/development/platform-integration/windows/run-loop-migration.md
@@ -1,0 +1,34 @@
+---
+title: Migrate a Windows project to the idiomatic run loop
+description: How to update a Windows project to use the idiomatic run loop
+---
+
+Flutter 2.5 replaced Windows apps' run loop with an idiomatic
+Windows message pump to reduce CPU usage.
+
+Projects created before Flutter version 2.5 need to be
+migrated to get this improvement. You should follow the
+migration steps below if the `windows/runner/run_loop.h`
+file exists in your project.
+
+## Migration steps
+
+{{site.alert.note}}
+  You will need to recreate the Windows project for this
+  migration. Any custom changes to the files in the
+  `windows/runner` folder will need to be reapplied after
+  the project has been recreated.
+{{site.alert.end}}
+
+Your project can be updated using these steps:
+
+1. Verify you are on Flutter version 2.5 or newer using `flutter --version`
+2. If needed, use `flutter upgrade` to update to the latest version of the
+Flutter SDK
+3. Backup your project, possibly using git or some other version control system
+4. Delete all files under the `windows/runner` folder
+5. Run `flutter create --platforms=windows .` to recreate the Windows project
+6. Review the changes to files in the `windows/runner` folder
+7. Reapply any custom changes made to the files in the
+`windows/runner` folder prior to this migration
+8. Verify your app builds using `flutter build windows`

--- a/src/development/platform-integration/windows/version-migration.md
+++ b/src/development/platform-integration/windows/version-migration.md
@@ -37,7 +37,8 @@ files
 
 ## Example
 
-Here's an example of migrating a project: [flutter/gallery#721][].
+[PR 721][] shows the migration work for the
+[Flutter Gallery][] app.
 
 [Build and release a Windows app]: {{site.url}}/deployment/windows#updating-the-apps-version-number
 [run loop migration guide]: {{site.url}}/development/platform-integration/windows/run-loop-migration

--- a/src/development/platform-integration/windows/version-migration.md
+++ b/src/development/platform-integration/windows/version-migration.md
@@ -42,4 +42,5 @@ files
 
 [Build and release a Windows app]: {{site.url}}/deployment/windows#updating-the-apps-version-number
 [run loop migration guide]: {{site.url}}/development/platform-integration/windows/run-loop-migration
-[flutter/gallery#721]: {{site.github}}/flutter/gallery/pull/721/files
+[PR 721]: {{site.github}}/flutter/gallery/pull/721/files
+[Flutter Gallery]: https://gallery.flutter.dev/

--- a/src/development/platform-integration/windows/version-migration.md
+++ b/src/development/platform-integration/windows/version-migration.md
@@ -24,11 +24,21 @@ files
 5. Run `flutter create --platforms=windows .`
 6. Review the changes to your `windows/runner/CMakeLists.txt` and
 `windows/runner/Runner.rc` files
+7. Verify your app builds using `flutter build windows`
+
+{{site.alert.note}}
+  Follow the [run loop migration guide][] if the build fails
+  with the following error message:
+
+  ```
+  flutter_window.obj : error LNK2019: unresolved external symbol "public: void __cdecl RunLoop::RegisterFlutterInstance(class flutter::FlutterEngine *)" (?RegisterFlutterInstance@RunLoop@@QEAAXPEAVFlutterEngine@flutter@@@Z) referenced in function "protected: virtual bool __cdecl FlutterWindow::OnCreate(void)" (?OnCreate@FlutterWindow@@MEAA_NXZ)
+  ```
+{{site.alert.end}}
 
 ## Example
 
 Here's an example of migrating a project: [flutter/gallery#721][].
 
 [Build and release a Windows app]: {{site.url}}/deployment/windows#updating-the-apps-version-number
-[`flutter migrate` command]: https://flutter.dev/go/flutter-migrate
+[run loop migration guide]: {{site.url}}/development/platform-integration/windows/run-loop-migration
 [flutter/gallery#721]: {{site.github}}/flutter/gallery/pull/721/files


### PR DESCRIPTION
Flutter 2.5 changed the Windows app template and replaced its custom run loop implementation with an idiomatic Windows message pump: https://github.com/flutter/flutter/pull/79969. This adds a migration guide for this app template change.

This also updates Flutter 3.3's version migration guide as this run loop migration is a prerequisite. Without doing this migration first, folks run into problems like: https://github.com/flutter/flutter/issues/110660

Fixes:
1. https://github.com/flutter/website/issues/7483
2. https://github.com/flutter/flutter/issues/80057
3. https://github.com/flutter/flutter/issues/110660

<details>
<summary>Manual test plan...</summary>

1. In Flutter repo: `git checkout tags/2.0.3`
2. Create a new project: `flutter create x2`
3. Verify the `windows/runner/run_loop.h` file exists
4. Switch back to latest SDK: `flutter channel master ; flutter upgrade`
5. Follow steps from migration guide

</details>

<img width="1314" alt="Screen Shot 2022-09-21 at 1 56 03 PM" src="https://user-images.githubusercontent.com/737941/191609079-cc284039-4144-45af-8f4e-b5a0d78f221e.png">


## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
