### PR TITLE
[Deployment] [Obfuscating Dart code] fix selection of commands by adding `$` sign

### DIFF
--- a/src/deployment/obfuscate.md
+++ b/src/deployment/obfuscate.md
@@ -112,4 +112,3 @@ expect(foo.runtimeType.toString(), equals('Foo'));
 [minified]: https://en.wikipedia.org/wiki/Minification_(programming)
 [obfuscation instructions]: {{site.repo.flutter}}/wiki/Obfuscating-Dart-Code
 [release build]: {{site.url}}/testing/build-modes
-

--- a/src/deployment/obfuscate.md
+++ b/src/deployment/obfuscate.md
@@ -112,3 +112,4 @@ expect(foo.runtimeType.toString(), equals('Foo'));
 [minified]: https://en.wikipedia.org/wiki/Minification_(programming)
 [obfuscation instructions]: {{site.repo.flutter}}/wiki/Obfuscating-Dart-Code
 [release build]: {{site.url}}/testing/build-modes
+

--- a/src/deployment/obfuscate.md
+++ b/src/deployment/obfuscate.md
@@ -47,7 +47,7 @@ channels.)
 For example:
 
 ```terminal
-flutter build apk --obfuscate --split-debug-info=/<project-name>/<directory>
+$ flutter build apk --obfuscate --split-debug-info=/<project-name>/<directory>
 ```
 
 Once you've obfuscated your binary, save
@@ -63,7 +63,7 @@ For detailed information on these flags, run
 the help command for your specific target, for example:
 
 ```terminal
-flutter build apk -h
+$ flutter build apk -h
 ```
 
 If these flags are not listed in the output,
@@ -83,7 +83,7 @@ use the following steps to make it human readable:
    For example:
 
 ```terminal
-flutter symbolize -i <stack trace file> -d out/android/app.android-arm64.symbols
+$ flutter symbolize -i <stack trace file> -d out/android/app.android-arm64.symbols
 ```
 
    For more information on the `symbolize` command,


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ fix selection of commands by adding `$` sign in the start of the commands in [Obfuscating Dart code](https://docs.flutter.dev/deployment/obfuscate) Page.

Since there is no `$` sign in start of the commands, `.highlight .gp` css class (`user-select: none`) is applied to command portion prior to command-flags which prevents selection-via-mouse/manual-selection

![Screenshot at 2022-09-24 01-16-30](https://user-images.githubusercontent.com/13456345/192046005-3f87e027-cfdf-4a06-af8c-9b8adc5faee3.png)

![Screenshot at 2022-09-24 01-16-36](https://user-images.githubusercontent.com/13456345/192046027-754249ff-4387-4df5-944c-17f4a1dd86d3.png)

![Screenshot at 2022-09-24 01-19-25](https://user-images.githubusercontent.com/13456345/192046210-41332bc1-0879-4ae6-adc4-b86e3cdb8d86.png)

_Issues fixed by this PR (if any):_ Fixes #6174

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
