### PR TITLE
Updated the platform channels documentation for background isolate channels

### DIFF
--- a/src/development/platform-integration/platform-channels.md
+++ b/src/development/platform-integration/platform-channels.md
@@ -969,15 +969,13 @@ types than the default types.
 
 ## Channels and platform threading
 
-When invoking channels on the platform side destined
-for Flutter, invoke them on the platform's main thread.
-When invoking channels in Flutter destined
-for the platform side, invoke on the root `Isolate`.
-The platform side's handlers can execute
-on the platform's main thread or they can execute on
-a background thread if using a Task Queue.
-You can invoke the platform side handlers asynchronously
-and on any thread when the Task Queue API is available;
+When invoking channels on the platform side destined for Flutter, invoke them on
+the platform's main thread. When invoking channels in Flutter destined for the
+platform side, they can be invoked from any `Isolate` that is the root
+`Isolate`, or is registered as a background `Isolate`. The platform side's
+handlers can execute on the platform's main thread or they can execute on a
+background thread if using a Task Queue. You can invoke the platform side
+handlers asynchronously and on any thread when the Task Queue API is available;
 otherwise, they must be invoked on the platform thread.
 
 {{site.alert.note}}
@@ -988,6 +986,31 @@ otherwise, they must be invoked on the platform thread.
   On iOS, this thread is officially
   referred to as [the main thread][].
 {{site.alert.end}}
+
+### Using plugins and channels from background isolates
+
+Plugins and channels can be used by any `Isolate`, but that `Isolate` has to be
+a root `Isolate` (the one created by Flutter) or registered as a background
+`Isolate` for a root `Isolate`.
+
+The following example shows how to register a background `Isolate` in order to
+use a plugin from a background `Isolate`.
+
+```dart
+import 'package:flutter/services.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void _isolateMain(RootIsolateToken rootIsolateToken) async {
+  BackgroundIsolateBinaryMessenger.ensureInitialized(rootIsolateToken);
+  SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
+  print(sharedPreferences.getBool('isDebug'));
+}
+
+void main() {
+  RootIsolateToken rootIsolateToken = RootIsolateToken.instance!;
+  Isolate.spawn(_isolateMain, rootIsolateToken);
+}
+```
 
 ### Executing channel handlers on background threads
 

--- a/src/development/platform-integration/platform-channels.md
+++ b/src/development/platform-integration/platform-channels.md
@@ -969,13 +969,15 @@ types than the default types.
 
 ## Channels and platform threading
 
-When invoking channels on the platform side destined for Flutter, invoke them on
-the platform's main thread. When invoking channels in Flutter destined for the
-platform side, they can be invoked from any `Isolate` that is the root
-`Isolate`, or is registered as a background `Isolate`. The platform side's
-handlers can execute on the platform's main thread or they can execute on a
-background thread if using a Task Queue. You can invoke the platform side
-handlers asynchronously and on any thread when the Task Queue API is available;
+When invoking channels on the platform side destined for Flutter,
+invoke them on the platform's main thread.
+When invoking channels in Flutter destined for the platform side,
+either invoke them from any `Isolate` that is the root
+`Isolate`, _or_ that is registered as a background `Isolate`.
+The handlers for the platform side can execute on the platform's main thread
+or they can execute on a background thread if using a Task Queue.
+You can invoke the platform side handlers asynchronously
+and on any thread when the Task Queue API is available;
 otherwise, they must be invoked on the platform thread.
 
 {{site.alert.note}}


### PR DESCRIPTION
This adds documentation for the new feature that allows us to use plugins and channels from background isolates.

issue: https://github.com/flutter/flutter/issues/13937

**Do not land until that feature is on stable.**

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
