### PR TITLE
add `--delete-conflicting-outputs` switch

### DIFF
--- a/src/development/data-and-backend/json.md
+++ b/src/development/data-and-backend/json.md
@@ -463,7 +463,9 @@ class User {
 }
 ```
 
-Running `flutter pub run build_runner build --delete-conflicting-outputs` in the terminal creates
+Running 
+`flutter pub run build_runner build --delete-conflicting-outputs`
+in the terminal creates
 the `*.g.dart` file, but the private `_$UserToJson()` function
 looks something like the following:
 

--- a/src/development/data-and-backend/json.md
+++ b/src/development/data-and-backend/json.md
@@ -371,7 +371,7 @@ There are two ways of running the code generator.
 
 #### One-time code generation
 
-By running `flutter pub run build_runner build` in the project root,
+By running `flutter pub run build_runner build --delete-conflicting-outputs` in the project root,
 you generate JSON serialization code for your models whenever they are needed.
 This triggers a one-time build that goes through the source files, picks the
 relevant ones, and generates the necessary serialization code for them.
@@ -384,7 +384,7 @@ build manually every time you make changes in your model classes.
 A _watcher_ makes our source code generation process more convenient. It
 watches changes in our project files and automatically builds the necessary
 files when needed. Start the watcher by running
-`flutter pub run build_runner watch` in the project root.
+`flutter pub run build_runner watch --delete-conflicting-outputs` in the project root.
 
 It is safe to start the watcher once and leave it running in the background.
 
@@ -463,7 +463,7 @@ class User {
 }
 ```
 
-Running `flutter pub run build_runner build` in the terminal creates
+Running `flutter pub run build_runner build --delete-conflicting-outputs` in the terminal creates
 the `*.g.dart` file, but the private `_$UserToJson()` function
 looks something like the following:
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ add `--delete-conflicting-outputs` switch in build and watch commands of build_runner.

_Issues fixed by this PR (if any):_ Fixes #6584

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
