### PR TITLE
Renaming widget name

### DIFF
--- a/src/_data/catalog/widgets.json
+++ b/src/_data/catalog/widgets.json
@@ -170,7 +170,7 @@
     "image": "<img alt='' src='/assets/images/docs/catalog-widget-placeholder.png'>"
   },
   {
-    "name": "Appbar",
+    "name": "AppBar",
     "description": "A Material Design app bar. An app bar consists of a toolbar and potentially other widgets, such as a TabBar and a FlexibleSpaceBar.",
     "categories": [
       "Basics"


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Renaming the widget name in catalog.
Since the widget is `AppBar`, it's good to have name in card reflect the widget name.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
