### PR TITLE
Removes link to retired codelab

### DIFF
--- a/src/codelabs/index.md
+++ b/src/codelabs/index.md
@@ -203,12 +203,6 @@ Learn how to use Flutter with other technologies.
   and iOS using Flutter, authenticating users with Firebase
   Authentication and sync data using Cloud Firestore.
 
-* [Multi-platform Firestore Flutter][]<br>
-  Build a multi-platform restaurant recommendation app
-  powered by Flutter and Cloud Firestore.
-  The finished app runs on Android, iOS, and web,
-  from a single Dart codebase.
-
 [Adding AdMob Ads to a Flutter app]: {{site.codelabs}}/codelabs/admob-ads-in-flutter
 [Adding an AdMob banner and native inline ads to a Flutter app]: {{site.codelabs}}/codelabs/admob-inline-ads-in-flutter
 [Adding Google Maps to a Flutter app]: {{site.codelabs}}/codelabs/google-maps-in-flutter
@@ -219,7 +213,6 @@ Learn how to use Flutter with other technologies.
 [Adding WebView to your Flutter app]: {{site.codelabs}}/codelabs/flutter-webview
 [firebase-ws]: {{site.youtube-site}}/watch?v=wUSkeTaBonA
 [Get to know Firebase for Flutter]: {{site.firebase}}/learn/codelabs/firebase-get-to-know-flutter
-[Multi-platform Firestore Flutter]: {{site.codelabs}}/codelabs/friendlyeats-flutter
 
 ## Testing
 

--- a/src/development/data-and-backend/firebase.md
+++ b/src/development/data-and-backend/firebase.md
@@ -15,7 +15,6 @@ Firebase supports Flutter. For more information, see:
 * [Get to know Firebase for Flutter][workshop] video workshop
   based on the codelab
 * [Get to know Firebase for Flutter][codelab1] codelab
-* [Multi Platform Firebase Flutter][codelab2] codelab
 * [Use Firebase to host your Flutter app on the web][article]
 
 Also, the Flutter community has created docs and
@@ -30,7 +29,6 @@ videos that you might find useful. Here are a few:
 [article]: {{site.flutter-medium}}/must-try-use-firebase-to-host-your-flutter-app-on-the-web-852ee533a469
 [chat app]: {{site.medium}}/flutter-community/building-a-chat-app-with-flutter-and-firebase-from-scratch-9eaa7f41782e
 [codelab1]: {{site.codelabs}}/codelabs/firebase-get-to-know-flutter
-[codelab2]: {{site.codelabs}}/codelabs/friendlyeats-flutter
 [FlutterFire]: {{site.flutterfire}}
 [started]: {{site.flutterfire}}/docs/overview
 [video]: {{site.youtube-site}}/watch?v=DqJ_KjFzL9I&t=38s


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
The pr removes the references and links to the retired `friendlyeats-flutter` codelab. 
_Issues fixed by this PR (if any):_ Fixes #ISSUE-NUMBER
#7539 
## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
