### PR TITLE
add correct options for flutter config options

### DIFF
--- a/src/development/platform-integration/desktop.md
+++ b/src/development/platform-integration/desktop.md
@@ -177,8 +177,9 @@ $ flutter config --no-enable-ios
 
 Other available flags:
 
-* `--no-enable-windows`
-* `--no-enable-linux`
+* `--no-enable-windows-desktop`
+* `--no-enable-linux-desktop`
+* `--no-enable-macos-desktop`
 * `--no-enable-web`
 * `--no-enable-android`
 * `--no-enable-ios`


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ In flutter stable 3.3.3 following options have been renamed: (1) `--no-enable-windows` to `--no-enable-windows-desktop`, (2) `--no-enable-linux` to `--no-enable-linux-desktop`. I also added one for macos since it was missing in the list.

_Issues fixed by this PR (if any):_ Fixes #7609

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
