### PR TITLE
Add iOS bitcode deprecation notes

### DIFF
--- a/src/development/platform-integration/ios/ios-app-clip.md
+++ b/src/development/platform-integration/ios/ios-app-clip.md
@@ -21,11 +21,6 @@ existing Flutter project or [add-to-app][] project.
   for audience with a working knowledge of iOS development.
 {{site.alert.end}}
 
-{{site.alert.warning}}
-  CocoaPods version 1.10.0.beta.1 or higher is required
-  to run Flutter apps with plugins.
-{{site.alert.end}}
-
 To see a working sample, see the [App Clip sample][] on GitHub.
 
 [App Clip sample]: {{site.github}}/flutter/samples/tree/master/ios_app_clip
@@ -306,7 +301,8 @@ into the App Clip bundle.
 ## Step 8 - Disable Bitcode
 
 In the App Clip target's **Build Settings** tab,
-set the **Enable Bitcode** setting to No.
+set the **Enable Bitcode** setting to No. On Xcode 14
+and higher bitcode has been deprecated and this step is unnecessary.
 
 {% include docs/app-figure.md
 image="development/platform-integration/ios-app-clip/bitcode.png"

--- a/src/get-started/install/_ios-setup.md
+++ b/src/get-started/install/_ios-setup.md
@@ -26,8 +26,6 @@ To develop Flutter apps for iOS, you need a Mac with Xcode installed.
 
 Versions older than the latest stable version may still work,
 but are not recommended for Flutter development.
-Using old versions of Xcode to target bitcode is not
-supported, and is likely not to work.
 
 With Xcode, you’ll be able to run Flutter apps on
 an iOS device or on the simulator.

--- a/src/perf/app-size.md
+++ b/src/perf/app-size.md
@@ -77,7 +77,6 @@ Then:
 1. Select a method of distribution. **Development** is the simplest if you don't
    intend to distribute the application.
 1. In **App Thinning**, select 'all compatible device variants'.
-1. Select **Rebuild from Bitcode** (available if bitcode is enabled on your project).
 1. Select **Strip Swift symbols**.
 
 Sign and export the IPA. The exported directory contains

--- a/src/resources/faq.md
+++ b/src/resources/faq.md
@@ -430,7 +430,8 @@ Whether you ship with bitcode or not,
 the increased size of the release framework is
 stripped out during the final steps of the build.
 These steps happen after archiving your app and
-shipping it to the store.
+shipping it to the store. Note bitcode has been deprecated
+and will be removed from Flutter in a future release.
 
 Of course, we recommend that you measure your own app.
 To do that, see [Measuring your app's size][].


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Apple has deprecated bitcode.  Flutter has already dropped some support for bitcode on master, but it has not yet made it to stable.  Add notes that deprecation is coming, and remove some references.

_Issues fixed by this PR (if any):_ Part of https://github.com/flutter/flutter/issues/107887

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
