### PR TITLE
[cookbook] [shimmer-loading] add null checks in isSized getter

### DIFF
--- a/examples/cookbook/effects/shimmer_loading/lib/shimmer_state.dart
+++ b/examples/cookbook/effects/shimmer_loading/lib/shimmer_state.dart
@@ -27,7 +27,7 @@ class ShimmerState extends State<Shimmer> {
         end: widget.linearGradient.end,
       );
 
-  bool get isSized => (context.findRenderObject() as RenderBox).hasSize;
+  bool get isSized => (context.findRenderObject() as RenderBox?)?.hasSize ?? false;
 
   Size get size => (context.findRenderObject() as RenderBox).size;
 

--- a/src/cookbook/effects/shimmer-loading.md
+++ b/src/cookbook/effects/shimmer-loading.md
@@ -369,7 +369,7 @@ class ShimmerState extends State<Shimmer> {
         end: widget.linearGradient.end,
       );
 
-  bool get isSized => (context.findRenderObject() as RenderBox).hasSize;
+  bool get isSized => (context.findRenderObject() as RenderBox?)?.hasSize ?? false;
 
   Size get size => (context.findRenderObject() as RenderBox).size;
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ add null checks for `isSized` getter because `findRenderObject` could be `null`.

_Issues fixed by this PR (if any):_ Fixes #7633

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
