### PR TITLE
Update building.md

### DIFF
--- a/src/development/platform-integration/macos/building.md
+++ b/src/development/platform-integration/macos/building.md
@@ -64,7 +64,8 @@ the App Sandbox, and the Hardened Runtime
 impact your distributable application.
 
 [Build and release a macOS app][] provides a more detailed
-step-by-step walkthrough.
+step-by-step walkthrough of releasing a Flutter app to the
+App Store.
 
 [distribute it through the macOS App Store]: {{site.apple-dev}}/macos/submit/
 [documentation on notarizing macOS Applications]:{{site.apple-dev}}/documentation/xcode/notarizing_macos_software_before_distribution


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

As mentioned earlier in this section, one can either
* distribute their Flutter app through the macOS App Store, or
* distribute the .app itself, perhaps from their own website.
 
The linked article in the modified paragraph is a walkthrough of the App Store route only, so we need to make it explicit.


## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
