### PR TITLE
Remove reference to bitcode from app size section

### DIFF
--- a/src/perf/app-size.md
+++ b/src/perf/app-size.md
@@ -148,10 +148,8 @@ Through the summary, you can get a quick idea of the size usage per category
 native library is further broken down by package for quick analysis.
 
 {{site.alert.warning}}
-  This tool on iOS creates a .app rather than an IPA. It also contains bitcode
-  which drastically increases the .framework file sizes in the .app.
-
-  Use this tool to evaluate the relative size of the .app's content. To get
+  This tool on iOS creates a .app rather than an IPA. Use this tool to
+  evaluate the relative size of the .app's content. To get
   a closer estimate of the download size, reference the
   [Estimating total size](#estimating-total-size) section above.
 {{site.alert.end}}


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Apple has deprecated bitcode. Flutter has already dropped some support for bitcode on master, but it has not yet made it to stable.  I missed this reference in my first sweep https://github.com/flutter/website/pull/7623

_Issues fixed by this PR (if any):_ Part of https://github.com/flutter/flutter/issues/107887

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
