### PR TITLE
Clarify note about IDE formatting imports

### DIFF
--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -298,8 +298,8 @@ Process finished with exit code 0
       import 'package:flutter/material.dart';
     ```
 
-    Depending on your IDE, you may see suggestions for libraries to import
-    as you type. Some IDEs will even render the import string in gray, letting 
+    Your IDE might provide suggestions for libraries to import
+    as you type. Some IDEs render the import string in gray to let
     you know that the imported library is unused (so far).
 
  4. Use the English words package to generate the text instead of

--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -298,9 +298,9 @@ Process finished with exit code 0
       import 'package:flutter/material.dart';
     ```
 
-    As you type, the IDE gives you suggestions for libraries to import.
-    It then renders the import string in gray, letting you know that the
-    imported library is unused (so far).
+    Depending on your IDE, you may see suggestions for libraries to import
+    as you type. Some IDEs will even render the import string in gray, letting 
+    you know that the imported library is unused (so far).
 
  4. Use the English words package to generate the text instead of
     using the string "Hello World":


### PR DESCRIPTION
This proposed change clarifies a note about how the IDE formats import statements. The way it's presently written is not always true. For example, users of some high-contrast accessible themes will not experience the grayed out import statements.

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
