### PR TITLE
Fix outdated content since hot reload supports font now

### DIFF
--- a/src/development/tools/hot-reload.md
+++ b/src/development/tools/hot-reload.md
@@ -141,11 +141,6 @@ class Color {
 }
 ```
 
-### Changing fonts
-
-Hot reload supports changing assets, for the most part.
-However, if you change fonts, you'll need to hot restart.
-
 ### Generic types
 
 Hot reload won't work when generic type declarations


### PR DESCRIPTION
Related: https://github.com/flutter/flutter/issues/49230 and https://github.com/flutter/engine/pull/35213
"Support hot reload of asset fonts"
So the content is outdated

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_ Fixes #ISSUE-NUMBER

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
