### PR TITLE
Create migration guide for RouteSettings.copywith

### DIFF
--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -22,6 +22,7 @@ release, and listed in alphabetical order:
 * [iOS FlutterViewController splashScreenView made nullable][]
 * [ThemeData's toggleableActiveColor property has been deprecated][]
 
+[Removed RouteSettings.copyWith]: {{site.url}}/release/breaking-changes/routesettings-copywith-migration
 [Deprecated API removed after v3.3]: {{site.url}}/release/breaking-changes/3-3-deprecations
 [ThemeData's toggleableActiveColor property has been deprecated]: {{site.url}}/release/breaking-changes/toggleable-active-color
 [iOS FlutterViewController splashScreenView made nullable]: {{site.url}}/release/breaking-changes/ios-flutterviewcontroller-splashscreenview-nullable

--- a/src/release/breaking-changes/routesettings-copywith-migration.md
+++ b/src/release/breaking-changes/routesettings-copywith-migration.md
@@ -33,8 +33,8 @@ RouteSettings newSettings = RouteSettings(name: 'new name', arguments: oldSettin
 
 ## Timeline
 
-Landed in version: 1.20.0-8.0<br>
-In stable release: 1.22
+Landed in version: 3.5.0-9.0.pre-137-gc6f6095acd<br>
+In stable release: NEXT
 
 ## References
 

--- a/src/release/breaking-changes/routesettings-copywith-migration.md
+++ b/src/release/breaking-changes/routesettings-copywith-migration.md
@@ -20,7 +20,7 @@ the `RouteSettings.copyWith` was no longer a viable API.
 
 ## Migration guide
 
-Existing apps:
+Code before migration:
 
 ```dart
 RouteSettings newSettings = oldSettings.copyWith(name: 'new name');

--- a/src/release/breaking-changes/routesettings-copywith-migration.md
+++ b/src/release/breaking-changes/routesettings-copywith-migration.md
@@ -9,7 +9,7 @@ RouteSettings copyWith was removed, and existing apps needed to use the construc
 
 ## Context
 
-With the introduction of [Page](https://api.flutter.dev/flutter/widgets/Page-class.html) class,
+With the introduction of [`Page`][] class,
 the RouteSettings.copyWith was no longer a viable API.
 
 ## Description of change
@@ -40,4 +40,7 @@ In stable release: 1.22
 
 Relevant PRs:
 
-* [PR 113860][]: Removes RouteSetting.copyWith
+* [PR 113860][]: Removes RouteSetting.copyWith.
+
+[PR 113860]: {{site.repo.flutter}}/pull/113860
+[`Page`]: {{site.api}}/flutter/widgets/Page-class.html

--- a/src/release/breaking-changes/routesettings-copywith-migration.md
+++ b/src/release/breaking-changes/routesettings-copywith-migration.md
@@ -26,7 +26,7 @@ Code before migration:
 RouteSettings newSettings = oldSettings.copyWith(name: 'new name');
 ```
 
-After migrations:
+Code after migration:
 
 ```dart
 RouteSettings newSettings = RouteSettings(name: 'new name', arguments: oldSettings.arguments);

--- a/src/release/breaking-changes/routesettings-copywith-migration.md
+++ b/src/release/breaking-changes/routesettings-copywith-migration.md
@@ -5,16 +5,16 @@ description: Removal of RouteSettings copyWith and how to migrate
 
 ## Summary
 
-RouteSettings copyWith was removed, and existing apps needed to use the constructor to create a new RouteSettings instead.
+`RouteSettings.copyWith` was removed, and existing apps needed to use the constructor to create a new `RouteSettings` instead.
 
 ## Context
 
 With the introduction of [`Page`][] class,
-the RouteSettings.copyWith was no longer a viable API.
+the `RouteSettings.copyWith` was no longer a viable API.
 
 ## Description of change
 
-RouteSettings copyWith was removed
+`RouteSettings.copyWith` was removed
 
 ## Migration guide
 
@@ -34,7 +34,7 @@ RouteSettings newSettings = RouteSettings(name: 'new name', arguments: oldSettin
 ## Timeline
 
 Landed in version: 3.5.0-9.0.pre-137-gc6f6095acd<br>
-In stable release: NEXT
+In stable release: TBD
 
 ## References
 

--- a/src/release/breaking-changes/routesettings-copywith-migration.md
+++ b/src/release/breaking-changes/routesettings-copywith-migration.md
@@ -34,7 +34,7 @@ RouteSettings newSettings = RouteSettings(name: 'new name', arguments: oldSettin
 ## Timeline
 
 Landed in version: 3.5.0-9.0.pre-137-gc6f6095acd<br>
-In stable release: TBD
+In stable release: TBA
 
 ## References
 

--- a/src/release/breaking-changes/routesettings-copywith-migration.md
+++ b/src/release/breaking-changes/routesettings-copywith-migration.md
@@ -11,7 +11,7 @@ instance instead.
 
 ## Context
 
-With the introduction of [`Page`][] class,
+With the introduction of the [`Page`][] class,
 the `RouteSettings.copyWith` was no longer a viable API.
 
 ## Description of change

--- a/src/release/breaking-changes/routesettings-copywith-migration.md
+++ b/src/release/breaking-changes/routesettings-copywith-migration.md
@@ -1,0 +1,43 @@
+---
+title: Migration guide for RouteSettings copyWith
+description: Removal of RouteSettings copyWith and how to migrate
+---
+
+## Summary
+
+RouteSettings copyWith was removed, and existing apps needed to use the constructor to create a new RouteSettings instead.
+
+## Context
+
+With the introduction of [Page](https://api.flutter.dev/flutter/widgets/Page-class.html) class,
+the RouteSettings.copyWith was no longer a viable API.
+
+## Description of change
+
+RouteSettings copyWith was removed
+
+## Migration guide
+
+Existing apps:
+
+```dart
+RouteSettings newSettings = oldSettings.copyWith(name: 'new name');
+```
+
+After migrations:
+
+```dart
+RouteSettings newSettings = RouteSettings(name: 'new name', arguments: oldSettings.arguments);
+```
+
+
+## Timeline
+
+Landed in version: 1.20.0-8.0<br>
+In stable release: 1.22
+
+## References
+
+Relevant PRs:
+
+* [PR 113860][]: Removes RouteSetting.copyWith

--- a/src/release/breaking-changes/routesettings-copywith-migration.md
+++ b/src/release/breaking-changes/routesettings-copywith-migration.md
@@ -5,7 +5,9 @@ description: Removal of RouteSettings copyWith and how to migrate
 
 ## Summary
 
-`RouteSettings.copyWith` was removed, and existing apps needed to use the constructor to create a new `RouteSettings` instead.
+The `RouteSettings.copyWith` method is removed, and apps that use
+it need to use the constructor to create a new `RouteSettings`
+instance instead.
 
 ## Context
 


### PR DESCRIPTION
needs to wait for pr to land https://github.com/flutter/flutter/pull/113860

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_ Fixes #ISSUE-NUMBER

## Presubmit checklist
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
