### PR TITLE
Fixes Firebase links

### DIFF
--- a/src/development/data-and-backend/firebase.md
+++ b/src/development/data-and-backend/firebase.md
@@ -10,7 +10,7 @@ remote configuration, and hosting for your static files.
 
 Firebase supports Flutter. For more information, see:
 
-* The [FlutterFire][] site
+* The [Firebase plugins][] page
 * [Getting started with Firebase and Flutter][started]
 * [Get to know Firebase for Flutter][workshop] video workshop
   based on the codelab
@@ -29,8 +29,8 @@ videos that you might find useful. Here are a few:
 [article]: {{site.flutter-medium}}/must-try-use-firebase-to-host-your-flutter-app-on-the-web-852ee533a469
 [chat app]: {{site.medium}}/flutter-community/building-a-chat-app-with-flutter-and-firebase-from-scratch-9eaa7f41782e
 [codelab1]: {{site.codelabs}}/codelabs/firebase-get-to-know-flutter
-[FlutterFire]: {{site.flutterfire}}
-[started]: {{site.flutterfire}}/docs/overview
+[Firebase plugins]: {{site.firebase}}/docs/flutter/setup#available-plugins
+[started]: {{site.firebase}}/docs/flutter/setup
 [video]: {{site.youtube-site}}/watch?v=DqJ_KjFzL9I&t=38s
 [video2]: {{site.youtube-site}}/watch?v=OlcYP6UXlm8
 [video3]: {{site.youtube-site}}/watch?v=u_Lyx8KJWpg


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
This PR updates some obsolete links that point to firebase.flutter.dev. Clean up PR removing the rest of the references in the repo to follow. 
_Issues fixed by this PR (if any):_ Fixes #ISSUE-NUMBER
#7707
## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
