### PR TITLE
Add link to RFC to drop support for macOS 10.13

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -243,6 +243,7 @@
       { "source": "/go/flame-dartpad", "destination": "https://dartpad.dev/?id=3e52ca7b51ba15f989ad880b8b3314a2", "type": 301 },
       { "source": "/go/floating-snackbar-offset", "destination": "https://docs.google.com/document/d/1elP-y83PtvfAZHNcpHCtnOFhZO9VnnlobwfQ33QO4hg/edit", "type": 301 },
       { "source": "/go/flutter-doctor-app-folder", "destination": "https://docs.google.com/document/d/1_N70oh5rl0pMlz-epE_3fIr7gqE94dgoV-DHq5OlF2I/edit", "type": 301 },
+      { "source": "/go/flutter-drop-macOS-10.13-2022-q4", "destination": "https://docs.google.com/document/d/1wHqr2cob78VfUKhOFEKjaUM_mnV4gL-mg3gSQCFhF7Y/edit", "type": 301 },
       { "source": "/go/flutter-engine-clocks", "destination": "https://docs.google.com/document/d/1Sx8QA1qXgJGw5r4ESviDnU2LSShNHiq_LjbRWPgSvXQ/edit?usp=sharing&resourcekey=0-BoBvLxgqf_nc_rwLc0zmTw", "type": 301 },
       { "source": "/go/flutter-engine-extensions", "destination": "https://docs.google.com/document/d/1xG7jR4FserdW7TdwnklF3_lXUGmt4myPQjDGF3LFtCQ/edit?resourcekey=0-Iug4D2mWuyQI6suvC_2itw#", "type": 301 },
       { "source": "/go/flutter-for-embedded-linux", "destination": "https://docs.google.com/document/d/1n4NXCk0QlGz16gUCtywR79H0Z1fzPqB2iNL8oxuexuk/edit?usp=sharing", "type": 301 },


### PR DESCRIPTION
Adds a link to an RFC proposing to bump the minimum macOS SDK from 10.13 to 10.14.

Link: https://flutter.dev/go/flutter-drop-macOS-10.13-2022-q4
Linked document: https://docs.google.com/document/d/1wHqr2cob78VfUKhOFEKjaUM_mnV4gL-mg3gSQCFhF7Y/edit

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
