### PR TITLE
Documented the use of `flutter pub add` and `flutter pub remove`

### DIFF
--- a/src/development/packages-and-plugins/using-packages.md
+++ b/src/development/packages-and-plugins/using-packages.md
@@ -102,6 +102,31 @@ To add the package, `css_colors`, to an app:
      Hot reload and hot restart only update the Dart code,
      so a full restart of the app might be required to avoid
      errors like `MissingPluginException` when using the package.
+     
+### Adding a package dependency to an app using `flutter pub add`
+
+To add the package, `css_colors`, to an app:
+
+1. Issue the command while being inside the project directory
+   * `flutter pub add css_colors`
+
+1. Import it
+   * Add a corresponding `import` statement in the Dart code.
+
+1. Stop and restart the app, if necessary
+   * If the package brings platform-specific code
+     (Kotlin/Java for Android, Swift/Objective-C for iOS),
+     that code must be built into your app.
+     Hot reload and hot restart only update the Dart code,
+     so a full restart of the app might be required to avoid
+     errors like `MissingPluginException` when using the package.
+     
+### Removing a package dependency to an app using `flutter pub remove`
+
+To remove the package, `css_colors`, to an app:
+
+1. Issue the command while being inside the project directory
+   * `flutter pub remove css_colors`
 
 The [Installing tab][],
 available on any package page on pub.dev,


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
There was no mention of `flutter pub add` and `flutter pub remove` to work with flutter packages. Added these in the documentation.

_Issues fixed by this PR (if any):_ Fixes #7654

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.