### PR TITLE
Changed Docker settings to allow Dart and Flutter websites to both run locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,12 +97,12 @@ RUN npm install
 COPY ./ ./
 
 # Jekyl ports
-EXPOSE 35729
+EXPOSE 35730
 EXPOSE 4002
 
 # Firebase emulator port
 # Airplay runs on :5000 by default now
-EXPOSE 5500
+EXPOSE 5502
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ serve:
 		--port ${JEKYLL_SITE_PORT} \
 		--config _config.yml,_config_dev.yml \
 		--livereload \
+		--livereload_port 37530 \
 		--incremental \
 		--trace
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       - JEKYLL_ENV=development
     ports:
       - "4002:4002"
-      - "35729:35729"
-      - "5500:5500"
+      - "35730:35730"
+      - "5502:5502"
     volumes:
       - ./:/app
       - site_bundle:/usr/local/bundle


### PR DESCRIPTION
@khanhnwin : I got both sites to build local and staged. You can checkout this PR to try the local builds, but the staged builds are:

- [Dart](https://dart--staging.web.app/)
- [Flutter](https://flutter-docs-prod.web.app/)

