### PR TITLE
[Windows] Remove outdated architectural plans

### DIFF
--- a/src/resources/architectural-overview.md
+++ b/src/resources/architectural-overview.md
@@ -733,9 +733,6 @@ platform-specific notes:
   rendered using
   [ANGLE](https://chromium.googlesource.com/angle/angle/+/master/README.md), a
   library that translates OpenGL API calls to the DirectX 11 equivalents.
-  Efforts are currently underway to also offer a Windows embedder using the UWP
-  app model, as well as to replace ANGLE with a more direct path to the GPU via
-  DirectX 12.
 
 ## Integrating with other code
 


### PR DESCRIPTION
We removed the UWP embedder as UWP was deprecated by Microsoft. We also don't plan to replace the ANGLE backend in the short-term.

![image](https://user-images.githubusercontent.com/737941/201223919-cbc8d5ab-ff40-47a5-a99e-b43f96906c35.png)

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
