### PR TITLE
Fix typo: `int62_t` `int64_t`

### DIFF
--- a/src/development/platform-integration/platform-channels.md
+++ b/src/development/platform-integration/platform-channels.md
@@ -193,7 +193,7 @@ platform side and vice versa:
 | -------------------------- | ------------------------- |
 | null                       | FlValue()                 |
 | bool                       | FlValue(bool)             |
-| int                        | FlValue(int62_t)          |
+| int                        | FlValue(int64_t)          |
 | double                     | FlValue(double)           |
 | String                     | FlValue(gchar*)           |
 | Uint8List                  | FlValue(uint8_t*)         |


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
It's just a simple typo fix.

_Issues fixed by this PR (if any):_ 
#7813

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
