### PR TITLE
Fix robots.txt syntax and include sitemap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,7 @@ RUN npm ci
 
 COPY ./ ./
 
-RUN echo $'User-agent: *\nAllow: /' > src/robots.txt
+RUN echo 'User-agent: *\nDisallow:\n\nSitemap: https://docs.flutter.dev/sitemap.xml' > src/robots.txt
 
 ARG BUILD_CONFIGS=_config.yml
 ENV BUILD_CONFIGS=$BUILD_CONFIGS


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ The previous `robots.txt` was including a `$` on accident, seeming to break some bots: `$User-agent: *` and the sitemap was not referenced. This PR aligns the format with dart.dev's, allowing all bots and linking to the sitemap.

_Issues fixed by this PR (if any):_ Fixes N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
