### PR TITLE
Update diff2html and necessary scripts

### DIFF
--- a/src/_sass/_d2h.scss
+++ b/src/_sass/_d2h.scss
@@ -1,3 +1,7 @@
 .d2h-wrapper {
-    margin: 35px 0px;
+    margin: 30px 0;
+}
+
+.d2h-file-header {
+    height: unset;
 }


### PR DESCRIPTION
See main differences in site-shared PR (https://github.com/dart-lang/site-shared/pull/163).

- Update to latest compatible versions of diff2html and highlightjs without larger changes
- Add integrity checking to the scripts
- Remove jquery usage with modern (and faster) built-in methods
- Fixes error caused by jquery not being present yet sometimes

After:
<img width="938" alt="After diff2html example" src="https://user-images.githubusercontent.com/18372958/202327082-a23a623d-e112-48b5-a968-48ee5631f0c9.png">

Before:
<img width="938" alt="Before diff2html example" src="https://user-images.githubusercontent.com/18372958/202327102-734e2d69-2981-4b4c-a302-42a9d7d00199.png">

_Issues fixed by this PR (if any):_ Fixes N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
