### PR TITLE
Fix error in explicit animations codelab and cleanup related JS

### DIFF
--- a/src/assets/js/codelabs/animations_examples.js
+++ b/src/assets/js/codelabs/animations_examples.js
@@ -3,7 +3,7 @@ const animation1PlayButton =
 const animation1 =
     document.getElementById("animation_1");
 
-if (animation1PlayButton) {
+if (animation1PlayButton && animation1) {
   animation1PlayButton.addEventListener('click', function (_) {
     if (animation1.paused) {
       animation1.play();
@@ -13,9 +13,7 @@ if (animation1PlayButton) {
       this.style.display = 'block';
     }
   }, false);
-}
 
-if (animation1) {
   animation1.addEventListener('click', function (_) {
     if (this.paused) {
       this.play();

--- a/src/assets/js/codelabs/animations_examples.js
+++ b/src/assets/js/codelabs/animations_examples.js
@@ -1,22 +1,28 @@
-var animation_1_play_button_=document.getElementById("animation_1_play_button_");
-var animation_1=document.getElementById("animation_1");
+const animation1PlayButton =
+    document.getElementById('animation_1_play_button_');
+const animation1 =
+    document.getElementById("animation_1");
 
-animation_1_play_button_.addEventListener('click', function (event) {
-  if (animation_1.paused) {
-    animation_1.play();
-    this.style.display = 'none';
-  } else {
-    animation_1.pause();
-    this.style.display = 'block';
-  }
-}, false);
+if (animation1PlayButton) {
+  animation1PlayButton.addEventListener('click', function (_) {
+    if (animation1.paused) {
+      animation1.play();
+      this.style.display = 'none';
+    } else {
+      animation1.pause();
+      this.style.display = 'block';
+    }
+  }, false);
+}
 
-animation_1.addEventListener('click', function(event) {
-  if (this.paused) {
-    this.play();
-    animation_1_play_button_.style.display = 'none';
-  } else {
-    this.pause();
-    animation_1_play_button_.style.display = 'block';
-  }
-});
+if (animation1) {
+  animation1.addEventListener('click', function (_) {
+    if (this.paused) {
+      this.play();
+      animation1PlayButton.style.display = 'none';
+    } else {
+      this.pause();
+      animation1PlayButton.style.display = 'block';
+    }
+  });
+}

--- a/src/codelabs/explicit-animations.md
+++ b/src/codelabs/explicit-animations.md
@@ -6,8 +6,8 @@ diff2html: true
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js
-  - defer: true
-    url: /assets/js/codelabs/animations_examples.js
+#  - defer: true
+#    url: /assets/js/codelabs/animations_examples.js
 ---
 
 <?code-excerpt path-base="animation/explicit"?>


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ The script was included on the explicit animation codelab as well but not used there causing an error when it tried to add the event listeners. This PR comments out that inclusion and also cleans up the JS script's formatting, naming, and introduces a check to make sure the elements exist before using them.

_Issues fixed by this PR (if any):_ Fixes N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
