### PR TITLE
Remove spurious `flutter pub add` output.

### DIFF
--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -254,7 +254,6 @@ The output will look something like the following:
 
 ```terminal
 Resolving dependencies...
-These packages are no longer being depended on:
 + english_words 4.0.0
 Downloading english_words 4.0.0...
 


### PR DESCRIPTION
I don't believe `flutter pub add` outputs this line when adding a dependency. In my local experiment it didn't.

_Issues fixed by this PR (if any):_ Fixes #ISSUE-NUMBER

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
