### PR TITLE
Update best-efforts macOS supported platforms note

### DIFF
--- a/src/development/tools/sdk/release-notes/supported-platforms.md
+++ b/src/development/tools/sdk/release-notes/supported-platforms.md
@@ -83,7 +83,8 @@ and stable channels.
 {:.table.table-striped}
 </div>
 
-\* Flutter 3.3 is the last stable release with macOS 10.11 and 10.12 best-effort support.
+\* Flutter 3.3 is the last stable release with macOS 10.11 through 10.13
+best-effort support.
 
 ### Unsupported platforms
 


### PR DESCRIPTION
Flutter 3.3 is the last stable release to support macOS 10.11 through 10.13. As of the next stable release, the minimum supported version of macOS will be 10.14 (Mojave).

RFC: https://flutter.dev/go/flutter-drop-macOS-10.13-2022-q4

Issue: https://github.com/flutter/flutter/issues/114445

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
