### PR TITLE
Fix index page table of contents

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -21,8 +21,8 @@ description: Get started with Flutter. Widgets, examples, updates, and API docs 
   {% endif %}
 {% endfor -%}
 
-<b>To see changes to the site since our last release,
-see [What's new][].</b>
+**To see changes to the site since our last release,
+see [What's new][].**
 
 [What's new]: {{site.url}}/whats-new
 
@@ -96,10 +96,10 @@ widgets in [What is State?][]
 [first-app]: {{site.youtube-site}}/watch?v=xWV71C2kp38
 [What is State?]: {{site.youtube-site}}/watch?v=QlwiL_yLh6E
 
+{:.text-center}
+#### Only have 60 seconds? Learn how to build and deploy a Flutter App!
 
 <div style="display: flex; align-items: center; justify-content: center; flex-direction: column;">
-  <h4>Only have 60 seconds? Learn how to build and deploy a Flutter App!</h4>
-
   <iframe style="max-width: 100%" width="560" height="315" src="{{site.youtube-site}}/embed/ZnufaryH43s" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
@@ -129,11 +129,11 @@ using helper methods][standalone-widgets] or
 To learn about all of the Flutter video series,
 see our [videos][] page.
 
-We release new videos most every week on the Flutter YouTube channel:
+We release new videos almost every week on the Flutter YouTube channel:
 
 <a class="btn btn-primary" target="_blank" href="https://www.youtube.com/c/flutterdev">Explore more Flutter videos</a>
 
-<b>The documentation on this site reflects the
-latest stable release of Flutter.</b>
+**The documentation on this site reflects the
+latest stable release of Flutter.**
 
 [videos]: {{site.url}}/resources/videos


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ A special div with css was added to place the "Only have 60 seconds? Learn how to build and deploy a Flutter App!" header horizontally in the center of the page, but this caused the TOC link to the header to not work (check on docs.flutter.dev). This PR moves out the header but keeps it centered, allowing it to be accessed from the TOC. This also switches some other raw HTML to markdown.

<img width="1008" alt="Look of new centered section" src="https://user-images.githubusercontent.com/18372958/203159677-074b4c82-0903-4718-bc22-18a8112b46a6.png">


_Issues fixed by this PR (if any):_ Fixes N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
