### PR TITLE
Fix broken testing cookbox toc and anchor links

### DIFF
--- a/src/_includes/docs/cookbook-toc.md
+++ b/src/_includes/docs/cookbook-toc.md
@@ -8,7 +8,7 @@
 {% for dir in dirs %}
 
   {% assign dir_name = dir.name | capitalize %}
-  <h2>{{ dir_name }}</h2>
+  <h2 id="{{dir.name}}">{{ dir_name }}</h2>
 
   {% assign items = dir.items | where_exp: "item", "item.title != dir_name" | sort: "title" %}
   {% for item in items %}


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ On the [testing cookbox](https://docs.flutter.dev/cookbook/testing) the anchor/toc links were broken due to not including the ID on the header. This fixes the generation logic and the resulting links.

_Issues fixed by this PR (if any):_ Fixes N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
