### PR TITLE
Remove documentation about handleStatusBarTouches

### DIFF
--- a/src/development/add-to-app/ios/add-flutter-screen.md
+++ b/src/development/add-to-app/ios/add-flutter-screen.md
@@ -294,15 +294,6 @@ didFinishLaunchingWithOptions:(NSDictionary<UIApplicationLaunchOptionsKey, id>*)
     return nil;
 }
 
-- (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event {
-    [super touchesBegan:touches withEvent:event];
-
-    // Pass status bar taps to key window Flutter rootViewController.
-    if (self.rootFlutterViewController != nil) {
-        [self.rootFlutterViewController handleStatusBarTouches:event];
-    }
-}
-
 - (void)application:(UIApplication*)application
 didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings {
     [_lifeCycleDelegate application:application


### PR DESCRIPTION
`handleStatusBarTouches` is removed in https://github.com/flutter/engine/pull/16820, this part of the documentation is obsolete. 

Fixes https://github.com/flutter/flutter/issues/63051#issuecomment-1322910522

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_ Fixes #ISSUE-NUMBER

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
