### PR TITLE
Added NSMicrophoneUsageDescription to Info.plis

### DIFF
--- a/src/cookbook/plugins/picture-using-camera.md
+++ b/src/cookbook/plugins/picture-using-camera.md
@@ -50,10 +50,12 @@ dependencies:
 ```
 {{site.alert.tip}}
   - For android, You must have to update `minSdkVersion` to 21 (or higher).
-  - On iOS, lines below have to be added inside `ios/Runner/Info.plist` in order the access the camera.
+  - On iOS, lines below have to be added inside `ios/Runner/Info.plist` in order the access the camera and microphone.
     ```
     <key>NSCameraUsageDescription</key>
     <string>Explanation on why the camera access is needed.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Explanation on why the microphone access is needed.</string>
     ```
 {{site.alert.end}}
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
The cookbook recipe for [Take a picture using the camera](https://docs.flutter.dev/cookbook/plugins/picture-using-camera#3-create-and-initialize-the-cameracontroller) was not working for me (iOS 16.0) because the permission for microphone usage was missing. I think it is required at least for the camera preview.

I added the missing key (NSMicrophoneUsageDescription) to the note on what to add in `Info.plis`

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
