### PR TITLE
clarify Android S requirements for splashscreen

### DIFF
--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -145,6 +145,18 @@ while the app initializes.
 See [Android Splash Screens][] first on how to configure your launch screen on
 Android S.
 
+From Android S and higher it is required to use the new splash screen Api in your 
+`styles.xml` consider creating an alternate resource file for Android 12 and higher.
+Also make sure that your background image is in line with the icon guidelines, see
+[Android Splash Screens][] for more details.
+
+```xml
+<style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    <item name="android:windowSplashScreenBackground">@color/bgColor</item>
+    <item name="android:windowSplashScreenAnimatedIcon">@drawable/launch_background</item>
+</style>
+```
+
 Make sure neither `io.flutter.embedding.android.SplashScreenDrawable` is set in
 your manifest, nor is `provideSplashScreen` implemented, as these APIs are
 deprecated. Doing so will cause the Android launch screen to fade smoothly into

--- a/src/development/ui/advanced/splash-screen.md
+++ b/src/development/ui/advanced/splash-screen.md
@@ -145,10 +145,10 @@ while the app initializes.
 See [Android Splash Screens][] first on how to configure your launch screen on
 Android S.
 
-From Android S and higher it is required to use the new splash screen Api in your 
-`styles.xml` consider creating an alternate resource file for Android 12 and higher.
-Also make sure that your background image is in line with the icon guidelines, see
-[Android Splash Screens][] for more details.
+As of Android S, you must use the new splash screen API in your `styles.xml` file.
+Consider creating an alternate resource file for Android 12 and higher.
+Also make sure that your background image is in line with the icon guidelines,
+see [Android Splash Screens][] for more details.
 
 ```xml
 <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

The docs regarding the splashscreen requirements for Android S are not always clear. I spend quite some time figuring out
how to create a splash screen natively and I am not alone in this, many people struggle. With this small addition I hope things will be more clear. When using the existing example in the docs on Android S and higher you will end up with a background  that is using the ic_launcher as logo and it is not directly clear why this happens. The same goes for when you provide an image that is not compliant to the new Android guidelines.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
