### PR TITLE
Update git dependencies to use HTTPS or SSH

### DIFF
--- a/src/development/packages-and-plugins/using-packages.md
+++ b/src/development/packages-and-plugins/using-packages.md
@@ -290,7 +290,18 @@ additional dependency options are available:
   dependencies:
     plugin1:
       git:
-        url: git://github.com/flutter/plugin1.git
+        url: https://github.com/flutter/plugin1.git
+  ```
+
+**Git dependency using SSH**
+: If the repository is private and you can connect to it using SSH,
+  depend on the package by using the repo's SSH url:
+
+  ```yaml
+  dependencies:
+    plugin1:
+      git:
+        url: git@github.com:flutter/plugin1.git
   ```
 
 **Git dependency on a package in a folder**
@@ -303,7 +314,7 @@ additional dependency options are available:
   dependencies:
     package1:
       git:
-        url: git://github.com/flutter/packages.git
+        url: https://github.com/flutter/packages.git
         path: packages/package1
   ```
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ GitHub has deprecated support for the Git protocol, so switch to HTTPS and document SSH as an alternative.

_Issues fixed by this PR (if any):_ Fixes #7874

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
