### PR TITLE
Add the go router v6 migration guide

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -274,6 +274,7 @@
       { "source": "/go/go-router-v4-breaking-changes", "destination": "https://docs.google.com/document/d/1T2LmzMj5HpD7hEexXL4Xz6vqoJD81bEGaa9NsV24faw/edit?usp=sharing&resourcekey=0-PuQbtDVl7ZabpJ2B9AHWUg", "type": 301 },
       { "source": "/go/go-router-v5-breaking-changes", "destination": "https://docs.google.com/document/d/10l22o4ml4Ss83UyzqUC8_xYOv_QjZEi80lJDNE4q7wM/edit?pli=1&resourcekey=0-U-BXBQzNfkk4v241Ow-vZg", "type": 301 },
       { "source": "/go/go-router-v5-1-2-breaking-changes", "destination": "https://docs.google.com/document/d/1HMUZA-lgeGFZ5JyU4g5jOFhbYAbk9ysfz9Ok1tGvqRw/edit?resourcekey=0-7otvjyBeefkQ9xQP9S2-9w#", "type": 301 },
+      { "source": "/go/go-router-v6-breaking-changes", "destination": "https://docs.google.com/document/d/1CMJwd5Moq_scvHf-trRldy9RW5MU7_Y8IB1aTrny-6s/edit", "type": 301 },
       { "source": "/go/handling-synchronous-keyboard-events", "destination": "https://docs.google.com/document/d/1rWXSjkb2ZKv-cpg26lVK0aZi4cVeXJ8j7YmSJdq2TOM/edit", "type": 301 },
       { "source": "/go/hot-ui-early-prototype-demos", "destination": "https://docs.google.com/document/d/1ZaHqKnON8-WEhke3Y6FpHeuB5BNlxDQj1cCYB1SoI_g", "type": 301 },
       { "source": "/go/i18n-user-guide", "destination": "https://docs.google.com/document/d/10e0saTfAv32OZLRmONy866vnaw0I2jwL8zukykpgWBc/edit", "type": 301 },


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Adds the migration guide for go router v6 (See https://github.com/flutter/packages/pull/2848 and more precisely https://github.com/flutter/packages/pull/2848#issuecomment-1331191342)

_Issues fixed by this PR (if any):_ No issue to fix

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
