### PR TITLE
Update Shanghai Jiao Tong mirror links

### DIFF
--- a/src/community/china.md
+++ b/src/community/china.md
@@ -4,14 +4,14 @@ description: Where to find a version of the Flutter site that is localized to Si
 toc: true
 ---
 
-{% assign path = 'flutter_infra_release/releases/stable/windows/flutter_windows_v1.0.0-stable.zip' -%}
+{% assign path = 'flutter_infra_release/releases/stable/windows/flutter_windows_3.3.0-stable.zip' -%}
 
 The Flutter community has made a Simplified Chinese version of the
 Flutter website available at
 [https://flutter.cn](https://flutter.cn).
 
-If you’d like to install Flutter using an [installation
-bundle]({{site.url}}/development/tools/sdk/releases),
+If you’d like to install Flutter using an 
+[installation bundle]({{site.url}}/development/tools/sdk/releases),
 you can replace the domain of the original URL with a trusted mirror
 to speed it up. For example:
 
@@ -37,7 +37,7 @@ To instruct the Flutter tool to use an alternate storage location,
 you need to set two environment variables, `PUB_HOSTED_URL` and
 `FLUTTER_STORAGE_BASE_URL`, before running the `flutter` command.
 
-Taking MacOS or Linux as an example, here are the first few steps in
+Taking macOS or Linux as an example, here are the first few steps in
 the setup process for using a mirror site. Run the following in a Bash
 shell from the directory where you wish to store your local Flutter clone:
 
@@ -67,6 +67,6 @@ for assistance.
 
 ## Community-run mirror sites
 
-* Shanghai Jiaotong University Linux User Group
-  * `FLUTTER_STORAGE_BASE_URL`: [https://mirrors.sjtug.sjtu.edu.cn/](https://mirrors.sjtug.sjtu.edu.cn)
-  * `PUB_HOSTED_URL`: [https://dart-pub.mirrors.sjtug.sjtu.edu.cn/](https://dart-pub.mirrors.sjtug.sjtu.edu.cn)
+* Shanghai Jiao Tong University Linux User Group
+  * `FLUTTER_STORAGE_BASE_URL`: [https://mirror.sjtu.edu.cn/](https://mirror.sjtu.edu.cn)
+  * `PUB_HOSTED_URL`: [https://mirror.sjtu.edu.cn/dart-pub/](https://mirror.sjtu.edu.cn/dart-pub)


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ 

- Updates to the new links specified on their [Flutter help page](https://mirrors.sjtug.sjtu.edu.cn/docs/flutter_infra)
- Uses a modern installation link example since the format no longer has a v before the version number 

_Issues fixed by this PR (if any):_ Fixes [#ISSUE-NUMBER](https://github.com/flutter/website/issues/7908)

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
