### PR TITLE
Only show Google Docs links in the design documents page

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -419,7 +419,7 @@
       permalink: /resources/bug-reports
     - title: Dart resources
       permalink: /resources/bootstrap-into-dart
-    - title: Design Documents
+    - title: Design documents
       permalink: /resources/design-docs
     - title: FAQ
       permalink: /resources/faq

--- a/src/resources/design-docs.md
+++ b/src/resources/design-docs.md
@@ -1,14 +1,15 @@
 ---
-title: Flutter Design Documents
+title: Flutter design documents
 description: Design documents for Flutter.
 js:
   - defer: true
     url: /assets/js/go_link_index.js
 ---
 
-This is a collection of design documents written by engineers working on
-Flutter. New design documents can be added by following the instructions in the
-[template].
+This is a collection of design documents
+written by engineers working on Flutter. 
+New design documents can be added by following the instructions
+in the [design doc template][template].
 
 [template]: {{site.url}}/go/template
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

- Only shows docs.google.com links which are mostly design docs
- Updates titles to [sentence case](https://developers.google.com/style/headings)
- Replace jquery code with vanilla JS

_Issues fixed by this PR (if any):_ Fixes #7213

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
