### PR TITLE
Fix broken bitrise links

### DIFF
--- a/src/deployment/cd.md
+++ b/src/deployment/cd.md
@@ -303,7 +303,7 @@ information.
 [Android app signing steps]: {{site.url}}/deployment/android#signing-the-app
 [Appcircle]: https://appcircle.io/blog/guide-to-automated-mobile-ci-cd-for-flutter-projects-with-appcircle/
 [Apple Developer Account console]: {{site.apple-dev}}/account/ios/certificate/
-[Bitrise]: https://devcenter.bitrise.io/getting-started/getting-started-with-flutter-apps/
+[Bitrise]: https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps
 [CI Options and Examples]: #reference-and-examples
 [Cirrus]: https://cirrus-ci.org
 [Cirrus script]: {{site.repo.flutter}}/blob/master/.cirrus.yml

--- a/src/testing/index.md
+++ b/src/testing/index.md
@@ -120,7 +120,7 @@ integration services, see the following:
 [code coverage]: https://en.wikipedia.org/wiki/Code_coverage
 [Codemagic CI/CD for Flutter]: https://blog.codemagic.io/getting-started-with-codemagic/
 [Continuous delivery using fastlane with Flutter]: {{site.url}}/deployment/cd#fastlane
-[Flutter CI/CD with Bitrise]: https://devcenter.bitrise.io/getting-started/getting-started-with-flutter-apps/
+[Flutter CI/CD with Bitrise]: https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps
 [How to test a Flutter app]: {{site.codelabs}}/codelabs/flutter-app-testing
 [mocked out]: {{site.url}}/cookbook/testing/unit/mocking
 [Test Flutter apps on Appcircle]: https://appcircle.io/blog/guide-to-automated-mobile-ci-cd-for-flutter-projects-with-appcircle/#testing-the-flutter-app


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Their site must not handle redirecting based off of locale, since the original link was leading me to a 404 page.

_Issues fixed by this PR (if any):_ Fixes N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
