### PR TITLE
fix typo issues in add-flutter-screen.md for line 370

### DIFF
--- a/src/development/add-to-app/ios/add-flutter-screen.md
+++ b/src/development/add-to-app/ios/add-flutter-screen.md
@@ -367,7 +367,7 @@ The `FlutterAppDelegate` performs functions such as:
 Creating a subclass of the the `FlutterAppDelegate` in UIKit apps was shown 
 in the [Start a FlutterEngine and FlutterViewController section][]. 
 In a SwiftUI app, you can create a subclass of the 
-`FlutterAppDelegate` that conforms to the `ObservabeObject` protocol as follows:
+`FlutterAppDelegate` that conforms to the `ObservableObject` protocol as follows:
 
 ```swift
 import SwiftUI


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
fix typo issues of `ObservabeObject` in add-flutter-screen.md for line 370

_Issues fixed by this PR (if any):_ Fixes #ISSUE-NUMBER

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
