### PR TITLE
Standardize lower SDK constraint to a released version

### DIFF
--- a/examples/_animation/basic_hero_animation/pubspec.yaml
+++ b/examples/_animation/basic_hero_animation/pubspec.yaml
@@ -2,7 +2,7 @@ name: basic_hero_transition
 description: Shows how to create a simple or Hero animation using the Hero class directly.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/_animation/basic_radial_hero_animation/pubspec.yaml
+++ b/examples/_animation/basic_radial_hero_animation/pubspec.yaml
@@ -2,7 +2,7 @@ name: basic_radial_hero_transition
 description: Shows how to apply a radial transformation to the Hero as it animates to the new route.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/_animation/basic_staggered_animation/pubspec.yaml
+++ b/examples/_animation/basic_staggered_animation/pubspec.yaml
@@ -2,7 +2,7 @@ name: basic_staggered
 description: A new Flutter project.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/_animation/hero_animation/pubspec.yaml
+++ b/examples/_animation/hero_animation/pubspec.yaml
@@ -2,7 +2,7 @@ name: hero_animation
 description: Shows how to create a simple Hero transition.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/_animation/radial_hero_animation/pubspec.yaml
+++ b/examples/_animation/radial_hero_animation/pubspec.yaml
@@ -2,7 +2,7 @@ name: radial_hero_animation
 description: Shows how to apply a radial transformation to the Hero as it animates to the new route.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/_animation/radial_hero_animation_animate_rectclip/pubspec.yaml
+++ b/examples/_animation/radial_hero_animation_animate_rectclip/pubspec.yaml
@@ -2,7 +2,7 @@ name: radial_hero_animation_animate_rectclip
 description: Shows how to apply a radial transformation to the Hero as it animates to the new route.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/_animation/staggered_pic_selection/pubspec.yaml
+++ b/examples/_animation/staggered_pic_selection/pubspec.yaml
@@ -2,7 +2,7 @@ name: staggered_pic_selection
 description: A new Flutter project.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/animation/animate0/pubspec.yaml
+++ b/examples/animation/animate0/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/animation/animate1/pubspec.yaml
+++ b/examples/animation/animate1/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/animation/animate2/pubspec.yaml
+++ b/examples/animation/animate2/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/animation/animate3/pubspec.yaml
+++ b/examples/animation/animate3/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/animation/animate4/pubspec.yaml
+++ b/examples/animation/animate4/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/animation/animate5/pubspec.yaml
+++ b/examples/animation/animate5/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/animation/explicit/pubspec.yaml
+++ b/examples/animation/explicit/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/animation/implicit/pubspec.yaml
+++ b/examples/animation/implicit/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/basics/pubspec.yaml
+++ b/examples/basics/pubspec.yaml
@@ -3,7 +3,7 @@ description: Some code to demonstrate null safety.
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/animation/animated_container/pubspec.yaml
+++ b/examples/cookbook/animation/animated_container/pubspec.yaml
@@ -2,7 +2,7 @@ name: animated_container
 description: Sample code for cookbook.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/animation/opacity_animation/pubspec.yaml
+++ b/examples/cookbook/animation/opacity_animation/pubspec.yaml
@@ -2,7 +2,7 @@ name: opacity_animation
 description: Sample code for cookbook.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/animation/page_route_animation/pubspec.yaml
+++ b/examples/cookbook/animation/page_route_animation/pubspec.yaml
@@ -2,7 +2,7 @@ name: page_route_animation
 description: Sample code for cookbook.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/animation/physics_simulation/pubspec.yaml
+++ b/examples/cookbook/animation/physics_simulation/pubspec.yaml
@@ -2,7 +2,7 @@ name: physics_simulation
 description: Sample code for cookbook.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/design/drawer/pubspec.yaml
+++ b/examples/cookbook/design/drawer/pubspec.yaml
@@ -2,7 +2,7 @@ name: drawer
 description: Sample code for drawer cookbook recipe.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/design/fonts/pubspec.yaml
+++ b/examples/cookbook/design/fonts/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/design/orientation/pubspec.yaml
+++ b/examples/cookbook/design/orientation/pubspec.yaml
@@ -2,7 +2,7 @@ name: orientation
 description: Sample code for orientation cookbook recipe.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/design/package_fonts/pubspec.yaml
+++ b/examples/cookbook/design/package_fonts/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/design/snackbars/pubspec.yaml
+++ b/examples/cookbook/design/snackbars/pubspec.yaml
@@ -2,7 +2,7 @@ name: snackbars
 description: Sample code for snackbars cookbook recipe.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/design/tabs/pubspec.yaml
+++ b/examples/cookbook/design/tabs/pubspec.yaml
@@ -2,7 +2,7 @@ name: tabs
 description: Sample code for tabs cookbook recipe.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/design/themes/pubspec.yaml
+++ b/examples/cookbook/design/themes/pubspec.yaml
@@ -2,7 +2,7 @@ name: themes
 description: Sample code for themes cookbook recipe.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/effects/download_button/pubspec.yaml
+++ b/examples/cookbook/effects/download_button/pubspec.yaml
@@ -4,7 +4,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
+
 dependencies:
   flutter:
     sdk: flutter

--- a/examples/cookbook/effects/drag_a_widget/pubspec.yaml
+++ b/examples/cookbook/effects/drag_a_widget/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/effects/expandable_fab/pubspec.yaml
+++ b/examples/cookbook/effects/expandable_fab/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/effects/gradient_bubbles/pubspec.yaml
+++ b/examples/cookbook/effects/gradient_bubbles/pubspec.yaml
@@ -4,7 +4,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
+
 dependencies:
   flutter:
     sdk: flutter

--- a/examples/cookbook/effects/nested_nav/pubspec.yaml
+++ b/examples/cookbook/effects/nested_nav/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/effects/parallax_scrolling/pubspec.yaml
+++ b/examples/cookbook/effects/parallax_scrolling/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/effects/photo_filter_carousel/lib/excerpt1.dart
+++ b/examples/cookbook/effects/photo_filter_carousel/lib/excerpt1.dart
@@ -57,8 +57,7 @@ class _ExampleInstagramFilterSelectionState
   Widget _buildPhotoWithFilter() {
     return ValueListenableBuilder(
       valueListenable: _filterColor,
-      builder: (context, value, child) {
-        final color = value as Color;
+      builder: (context, color, child) {
         return Image.network(
           'https://flutter.dev/docs/cookbook/img-files/effects/instagram-buttons/millenial-dude.jpg',
           color: color.withOpacity(0.5),

--- a/examples/cookbook/effects/photo_filter_carousel/lib/main.dart
+++ b/examples/cookbook/effects/photo_filter_carousel/lib/main.dart
@@ -60,8 +60,7 @@ class _ExampleInstagramFilterSelectionState
   Widget _buildPhotoWithFilter() {
     return ValueListenableBuilder(
       valueListenable: _filterColor,
-      builder: (context, value, child) {
-        final color = value as Color;
+      builder: (context, color, child) {
         return Image.network(
           'https://docs.flutter.dev/cookbook/img-files/effects/instagram-buttons/millenial-dude.jpg',
           color: color.withOpacity(0.5),

--- a/examples/cookbook/effects/photo_filter_carousel/lib/original_example.dart
+++ b/examples/cookbook/effects/photo_filter_carousel/lib/original_example.dart
@@ -56,8 +56,7 @@ class _ExampleInstagramFilterSelectionState
   Widget _buildPhotoWithFilter() {
     return ValueListenableBuilder(
       valueListenable: _filterColor,
-      builder: (context, value, child) {
-        final color = value as Color;
+      builder: (context, color, child) {
         return Image.network(
           'https://flutter.dev/docs/cookbook/img-files/effects/instagram-buttons/millenial-dude.jpg',
           color: color.withOpacity(0.5),

--- a/examples/cookbook/effects/photo_filter_carousel/pubspec.yaml
+++ b/examples/cookbook/effects/photo_filter_carousel/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/effects/shimmer_loading/pubspec.yaml
+++ b/examples/cookbook/effects/shimmer_loading/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/effects/staggered_menu_animation/pubspec.yaml
+++ b/examples/cookbook/effects/staggered_menu_animation/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/forms/focus/pubspec.yaml
+++ b/examples/cookbook/forms/focus/pubspec.yaml
@@ -2,7 +2,7 @@ name: focus
 description: Sample code for focus cookbook recipe.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/forms/retrieve_input/pubspec.yaml
+++ b/examples/cookbook/forms/retrieve_input/pubspec.yaml
@@ -2,7 +2,7 @@ name: retrieve_input
 description: Sample code for retrieve_input cookbook recipe.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/forms/text_field_changes/pubspec.yaml
+++ b/examples/cookbook/forms/text_field_changes/pubspec.yaml
@@ -2,7 +2,7 @@ name: text_field_changes
 description: Sample code for text_field_changes
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/forms/text_input/pubspec.yaml
+++ b/examples/cookbook/forms/text_input/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/forms/validation/pubspec.yaml
+++ b/examples/cookbook/forms/validation/pubspec.yaml
@@ -2,7 +2,7 @@ name: form
 description: Use Form widget to perform form validation.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/gestures/dismissible/pubspec.yaml
+++ b/examples/cookbook/gestures/dismissible/pubspec.yaml
@@ -2,7 +2,7 @@ name: dismissible
 description: Sample code for dismissible cookbook recipe.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/gestures/handling_taps/pubspec.yaml
+++ b/examples/cookbook/gestures/handling_taps/pubspec.yaml
@@ -2,7 +2,7 @@ name: handling_taps
 description: Example on handling_taps cookbook recipe.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/gestures/ripples/pubspec.yaml
+++ b/examples/cookbook/gestures/ripples/pubspec.yaml
@@ -2,7 +2,7 @@ name: ripples
 description: Example for ripples cookbook recipe
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/images/cached_images/pubspec.yaml
+++ b/examples/cookbook/images/cached_images/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/images/fading_in_images/pubspec.yaml
+++ b/examples/cookbook/images/fading_in_images/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/images/network_image/pubspec.yaml
+++ b/examples/cookbook/images/network_image/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/lists/basic_list/pubspec.yaml
+++ b/examples/cookbook/lists/basic_list/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/lists/floating_app_bar/pubspec.yaml
+++ b/examples/cookbook/lists/floating_app_bar/pubspec.yaml
@@ -2,7 +2,7 @@ name: floating_app_bar
 description: Example for floating_app_bar cookbook recipe
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/lists/grid_lists/pubspec.yaml
+++ b/examples/cookbook/lists/grid_lists/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/lists/horizontal_list/pubspec.yaml
+++ b/examples/cookbook/lists/horizontal_list/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/lists/long_lists/pubspec.yaml
+++ b/examples/cookbook/lists/long_lists/pubspec.yaml
@@ -2,7 +2,7 @@ name: long_lists
 description: Example for long_lists cookbook recipe
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/lists/mixed_list/pubspec.yaml
+++ b/examples/cookbook/lists/mixed_list/pubspec.yaml
@@ -2,7 +2,7 @@ name: mixed_lists
 description: Example for mixed_lists cookbook recipe
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/maintenance/error_reporting/pubspec.yaml
+++ b/examples/cookbook/maintenance/error_reporting/pubspec.yaml
@@ -2,7 +2,7 @@ name: error_reporting
 description: error reporting
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/navigation/hero_animations/pubspec.yaml
+++ b/examples/cookbook/navigation/hero_animations/pubspec.yaml
@@ -2,7 +2,7 @@ name: hero_animations
 description: Hero animations
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/navigation/named_routes/pubspec.yaml
+++ b/examples/cookbook/navigation/named_routes/pubspec.yaml
@@ -2,7 +2,7 @@ name: navigate_with_arguments
 description: Use Form widget to perform form validation.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/navigation/navigate_with_arguments/pubspec.yaml
+++ b/examples/cookbook/navigation/navigate_with_arguments/pubspec.yaml
@@ -2,7 +2,7 @@ name: navigate_with_arguments
 description: Use Form widget to perform form validation.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/navigation/navigation_basics/pubspec.yaml
+++ b/examples/cookbook/navigation/navigation_basics/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/navigation/passing_data/pubspec.yaml
+++ b/examples/cookbook/navigation/passing_data/pubspec.yaml
@@ -2,7 +2,7 @@ name: passing_data
 description: Passing data
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/navigation/returning_data/pubspec.yaml
+++ b/examples/cookbook/navigation/returning_data/pubspec.yaml
@@ -2,7 +2,7 @@ name: returning_data
 description: Returning data
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/networking/authenticated_requests/pubspec.yaml
+++ b/examples/cookbook/networking/authenticated_requests/pubspec.yaml
@@ -2,7 +2,7 @@ name: hero_animations
 description: Hero animations
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/networking/background_parsing/pubspec.yaml
+++ b/examples/cookbook/networking/background_parsing/pubspec.yaml
@@ -2,7 +2,7 @@ name: background_parsing
 description: Background parsing
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/networking/delete_data/pubspec.yaml
+++ b/examples/cookbook/networking/delete_data/pubspec.yaml
@@ -2,7 +2,7 @@ name: delete_data
 description: Delete Data
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/networking/fetch_data/pubspec.yaml
+++ b/examples/cookbook/networking/fetch_data/pubspec.yaml
@@ -2,7 +2,7 @@ name: fetch_data
 description: Fetch Data
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/networking/send_data/pubspec.yaml
+++ b/examples/cookbook/networking/send_data/pubspec.yaml
@@ -2,7 +2,7 @@ name: send_data
 description: Send data
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/networking/update_data/pubspec.yaml
+++ b/examples/cookbook/networking/update_data/pubspec.yaml
@@ -2,7 +2,7 @@ name: update_data
 description: Update Data
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/networking/web_sockets/pubspec.yaml
+++ b/examples/cookbook/networking/web_sockets/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_sockets
 description: Web Sockets
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/persistence/key_value/pubspec.yaml
+++ b/examples/cookbook/persistence/key_value/pubspec.yaml
@@ -2,7 +2,7 @@ name: key_value
 description: Key value
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/persistence/reading_writing_files/pubspec.yaml
+++ b/examples/cookbook/persistence/reading_writing_files/pubspec.yaml
@@ -2,7 +2,7 @@ name: reading_writing_files
 description: Reading and Writing Files
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/persistence/sqlite/pubspec.yaml
+++ b/examples/cookbook/persistence/sqlite/pubspec.yaml
@@ -2,7 +2,7 @@ name: sqlite
 description: SQLITE
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/plugins/picture_using_camera/pubspec.yaml
+++ b/examples/cookbook/plugins/picture_using_camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: picture_using_camera
 description: A new Flutter project.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/plugins/play_video/pubspec.yaml
+++ b/examples/cookbook/plugins/play_video/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/testing/integration/introduction/pubspec.yaml
+++ b/examples/cookbook/testing/integration/introduction/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/testing/integration/profiling/pubspec.yaml
+++ b/examples/cookbook/testing/integration/profiling/pubspec.yaml
@@ -2,7 +2,7 @@ name: scrolling
 description: A new Flutter project.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/testing/unit/counter_app/pubspec.yaml
+++ b/examples/cookbook/testing/unit/counter_app/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/testing/unit/mocking/pubspec.yaml
+++ b/examples/cookbook/testing/unit/mocking/pubspec.yaml
@@ -2,7 +2,7 @@ name: mocking
 description: Use the Mockito package to mimic the behavior of services for testing.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/testing/widget/finders/pubspec.yaml
+++ b/examples/cookbook/testing/widget/finders/pubspec.yaml
@@ -2,7 +2,7 @@ name: finders
 description: A new Flutter project.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/testing/widget/introduction/pubspec.yaml
+++ b/examples/cookbook/testing/widget/introduction/pubspec.yaml
@@ -2,7 +2,7 @@ name: introduction
 description: A new Flutter project.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/testing/widget/scrolling/pubspec.yaml
+++ b/examples/cookbook/testing/widget/scrolling/pubspec.yaml
@@ -2,7 +2,7 @@ name: scrolling
 description: A new Flutter project.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/cookbook/testing/widget/tap_drag/pubspec.yaml
+++ b/examples/cookbook/testing/widget/tap_drag/pubspec.yaml
@@ -2,7 +2,7 @@ name: finders
 description: A new Flutter project.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/development/data-and-backend/json/pubspec.yaml
+++ b/examples/development/data-and-backend/json/pubspec.yaml
@@ -4,7 +4,7 @@ description: Sample state management code.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   json_annotation: ^4.0.1

--- a/examples/development/platform_integration/pubspec.yaml
+++ b/examples/development/platform_integration/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/examples/development/plugin_api_migration/pubspec.yaml
+++ b/examples/development/plugin_api_migration/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/examples/development/tools/pubspec.yaml
+++ b/examples/development/tools/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/examples/development/ui/interactive/pubspec.yaml
+++ b/examples/development/ui/interactive/pubspec.yaml
@@ -2,7 +2,7 @@ name: interactive
 description: Sample code for interactive.md
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/get-started/flutter-for/react_native_devs/my_widgets/pubspec.yaml
+++ b/examples/get-started/flutter-for/react_native_devs/my_widgets/pubspec.yaml
@@ -3,7 +3,7 @@ description: A library for `react_native_devs` to import
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.5 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dev_dependencies:
   lints: ^2.0.0

--- a/examples/googleapis/pubspec.yaml
+++ b/examples/googleapis/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_example
 publish_to: none
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   collection: ^1.15.0

--- a/examples/integration_test/pubspec.yaml
+++ b/examples/integration_test/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: 'none'
 version: 0.0.1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/integration_test_migration/pubspec.yaml
+++ b/examples/integration_test_migration/pubspec.yaml
@@ -5,7 +5,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
+
 dependencies:
   flutter:
     sdk: flutter

--- a/examples/internationalization/add_language/pubspec.yaml
+++ b/examples/internationalization/add_language/pubspec.yaml
@@ -2,7 +2,7 @@ name: add_language
 description: An i18n app example that adds a supported language
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/internationalization/gen_l10n_example/pubspec.yaml
+++ b/examples/internationalization/gen_l10n_example/pubspec.yaml
@@ -2,7 +2,7 @@ name: gen_l10n_example
 description: Example of an internationalized Flutter app that uses `flutter gen-l10n`
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 # #docregion FlutterLocalizations
 # #docregion Intl

--- a/examples/internationalization/intl_example/pubspec.yaml
+++ b/examples/internationalization/intl_example/pubspec.yaml
@@ -2,7 +2,7 @@ name: intl_example
 description: Example of a Flutter app using the intl library services.
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/internationalization/minimal/pubspec.yaml
+++ b/examples/internationalization/minimal/pubspec.yaml
@@ -2,7 +2,7 @@ name: l10n_example
 description: A minimal example of a localized Flutter app
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/layout/base/pubspec.yaml
+++ b/examples/layout/base/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/layout/card_and_stack/pubspec.yaml
+++ b/examples/layout/card_and_stack/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/layout/constraints/pubspec.yaml
+++ b/examples/layout/constraints/pubspec.yaml
@@ -3,7 +3,7 @@ description: example for ui/layout/constraints
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/layout/container/pubspec.yaml
+++ b/examples/layout/container/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/layout/grid_and_list/pubspec.yaml
+++ b/examples/layout/grid_and_list/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/layout/lakes/interactive/pubspec.yaml
+++ b/examples/layout/lakes/interactive/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/layout/lakes/step2/pubspec.yaml
+++ b/examples/layout/lakes/step2/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/layout/lakes/step3/pubspec.yaml
+++ b/examples/layout/lakes/step3/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/layout/lakes/step4/pubspec.yaml
+++ b/examples/layout/lakes/step4/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/layout/lakes/step5/pubspec.yaml
+++ b/examples/layout/lakes/step5/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/layout/lakes/step6/pubspec.yaml
+++ b/examples/layout/lakes/step6/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/layout/non_material/pubspec.yaml
+++ b/examples/layout/non_material/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/layout/pavlova/pubspec.yaml
+++ b/examples/layout/pavlova/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/layout/row_column/pubspec.yaml
+++ b/examples/layout/row_column/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/layout/sizing/pubspec.yaml
+++ b/examples/layout/sizing/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/perf/deferred_components/pubspec.yaml
+++ b/examples/perf/deferred_components/pubspec.yaml
@@ -4,7 +4,7 @@ description: Sample state management code.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/resources/architectural_overview/pubspec.yaml
+++ b/examples/resources/architectural_overview/pubspec.yaml
@@ -3,7 +3,7 @@ description: samples for architectural-overview.md
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/state_mgmt/simple/pubspec.yaml
+++ b/examples/state_mgmt/simple/pubspec.yaml
@@ -4,7 +4,7 @@ description: Sample state management code.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/ui/advanced/actions_and_shortcuts/pubspec.yaml
+++ b/examples/ui/advanced/actions_and_shortcuts/pubspec.yaml
@@ -4,7 +4,7 @@ description: Sample actions and shortcuts code.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/ui/advanced/focus/pubspec.yaml
+++ b/examples/ui/advanced/focus/pubspec.yaml
@@ -4,7 +4,7 @@ description: Sample focus system code.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/ui/assets_and_images/pubspec.yaml
+++ b/examples/ui/assets_and_images/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/examples/ui/layout/adaptive_app_demos/pubspec.yaml
+++ b/examples/ui/layout/adaptive_app_demos/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/ui/widgets_intro/pubspec.yaml
+++ b/examples/ui/widgets_intro/pubspec.yaml
@@ -4,7 +4,7 @@ description: Sample state management code.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/examples/visual_debugging/pubspec.yaml
+++ b/examples/visual_debugging/pubspec.yaml
@@ -4,7 +4,7 @@ description: Examples of visual debugging
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0-0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_io_dev_tools
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.18.5 <3.0.0'
 
 dev_dependencies:
   build_runner: ^2.3.2

--- a/src/cookbook/effects/photo-filter-carousel.md
+++ b/src/cookbook/effects/photo-filter-carousel.md
@@ -573,8 +573,7 @@ class _ExampleInstagramFilterSelectionState
   Widget _buildPhotoWithFilter() {
     return ValueListenableBuilder(
       valueListenable: _filterColor,
-      builder: (context, value, child) {
-        final color = value as Color;
+      builder: (context, color, child) {
         return Image.network(
           'https://docs.flutter.dev/cookbook/img-files/effects/instagram-buttons/millenial-dude.jpg',
           color: color.withOpacity(0.5),


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Many of the pubspec constraints were depending on prerelease or greater with the `-0`. This standardizes all examples to a lower SDK constraint of `2.18.5`. The only language change along with that is some enhanced type inference.

_Issues fixed by this PR (if any):_ Fixes N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
