### PR TITLE
Minor include cleanup

### DIFF
--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -8,9 +8,9 @@
     See how Flutter is pushing UI development at Flutter Forward;<br>
     streaming live from Kenya on January 25, 2023.
     <a href="https://flutter.dev/events/flutter-forward">Register now</a>
-<!--
+    {% comment %}
     <br>The Flutter and Dart teams are hiring.
     <a href="https://docs.flutter.dev/jobs">Learn more</a><br>
--->
+    {% endcomment %}
   </div>
 {% endif -%}

--- a/src/_includes/body.html
+++ b/src/_includes/body.html
@@ -1,4 +1,0 @@
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-ND4LWWZ"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->

--- a/src/_includes/docs/run-profile.md
+++ b/src/_includes/docs/run-profile.md
@@ -1,7 +1,5 @@
 ## Profile or release runs
 
-
-
 {{site.alert.important}}
   Do _not_ test the performance of your app with debug and
   hot reload enabled.

--- a/src/_includes/next-prev-nav.html
+++ b/src/_includes/next-prev-nav.html
@@ -1,7 +1,8 @@
 {% if page.next or page.prev -%}
-  {% assign nav_class = 'site-nextprev-nav__single' -%}
   {% if page.next and page.prev -%}
     {% assign nav_class = 'site-nextprev-nav' -%}
+  {% else -%}
+    {% assign nav_class = 'site-nextprev-nav__single' -%}
   {% endif -%}
   <nav class="{{nav_class}}">
     <ul>


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

- `banner.html` - Comment was included in rendered HTML when it didn't need to be
- `next-prev-nav.html` - Could avoid an unnecessary assign
- `body.html` - The google tag manager includes are now in [`base.html#L82-85`](https://github.com/flutter/website/blob/main/src/_layouts/base.html#L82-L85)

_Issues fixed by this PR (if any):_ Fixes N/A

