### PR TITLE
Typo in federated plugin docs

### DIFF
--- a/src/development/packages-and-plugins/developing-packages.md
+++ b/src/development/packages-and-plugins/developing-packages.md
@@ -307,7 +307,7 @@ dependencies:
 ```
 
 Note that as shown here, an app-facing package can have
-some platforms implementated within the package,
+some platforms implemented within the package,
 and others in endorsed federated implementations.
 
 ### Step 1: Create the package


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Typo in federated plugin docs, It should be `implemented` instead of 'implementated'.

_Issues fixed by this PR (if any):_ Fixes #7873

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
