### PR TITLE
Move sidenav code and styles to repo

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -36,7 +36,7 @@
       <div class="site-header__sheet">
         <ul class="navbar-nav">
           <div class="site-sidebar site-sidebar--header d-md-none">
-            {% include shared/sidenav-level-1.html nav=site.data.sidenav %}
+            {% include sidenav-level-1.html nav=site.data.sidenav %}
           </div>
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" id="platform-navbar-dropdown"

--- a/src/_includes/sidenav-level-1.html
+++ b/src/_includes/sidenav-level-1.html
@@ -1,0 +1,37 @@
+{% comment %} Canonicalize page URL path {% endcomment -%}
+{% assign page_url_path = page.url | regex_replace: '/index$|/index\.html$|\.html$|/$' -%}
+
+{% assign active_entries = include.nav | active_nav_entry_index_array: page_url_path -%}
+{% assign show_entries_wo_pages = false -%}
+
+<ul class="nav flex-column">
+  {%- for entry1 in include.nav -%}
+
+    {% assign class1 = '' -%}
+    {% assign id1 = 'sidenav-' | append: forloop.index -%}
+    {% assign isActive1 = false -%}
+    {% if forloop.index == active_entries[0] -%}
+      {% assign isActive1 = true -%}
+      {% assign class1 = 'active' -%}
+    {% endif -%}
+
+    {% if isActive1 or entry1.expanded -%}
+      {% assign expanded = 'true' -%}
+      {% assign show = 'show' -%}
+    {% else -%}
+      {% assign class1 = 'collapsed' -%}
+      {% assign expanded = 'false' -%}
+      {% assign show = '' -%}
+    {% endif -%}
+
+    <li class="nav-item">
+      <a class="nav-link {{class1}}" data-toggle="collapse" href="#{{id1}}" role="button"
+        aria-expanded="{{expanded}}" aria-controls="{{id1}}"
+      >{{entry1.title}}</a>
+
+      <ul class="nav flex-column flex-nowrap collapse {{show}}" id="{{id1}}">
+        {% include sidenav-level-2.html -%}
+      </ul>
+    </li>
+  {%- endfor -%}
+</ul>

--- a/src/_includes/sidenav-level-2.html
+++ b/src/_includes/sidenav-level-2.html
@@ -1,0 +1,61 @@
+{% for entry2 in entry1.children -%}
+
+{% assign class2 = 'nav-link' -%}
+{% assign isActive2 = false -%}
+{% if isActive1 and forloop.index == active_entries[1] -%}
+  {% assign isActive2 = true -%}
+  {% assign class2 = class2 | append: ' active' -%}
+{% endif -%}
+
+{% if entry2 == 'divider' -%}
+
+  <div class="dropdown-divider"></div>
+
+{%- elsif entry2.children == nil and entry2.permalink or show_entries_wo_pages -%}
+
+  <li class="nav-item">
+    <a class="{{class2}} {%- unless entry2.permalink %} disabled {%- endunless %}"
+      {%- if entry2.permalink %} href="{{entry2.permalink}}" {%- endif -%}
+      {%- if entry2.permalink contains '://' %} target="_blank" rel="noopener" {%- endif -%}
+    >{{entry2.title}}
+    {%- if entry2.permalink == nil %} (TBC)
+    {%- elsif entry2.permalink contains '://' -%}
+      <span class="material-icons md-24">
+        open_in_new
+      </span>
+    {%- endif -%}
+    </a>
+  </li>
+
+{%- elsif entry2.children -%}
+
+  {% assign class2 = class2 | append: ' collapsable' -%}
+
+  {% if isActive2 or entry2.expanded -%}
+    {% assign expanded = 'true' -%}
+    {% assign show = 'show' -%}
+  {% else -%}
+    {% assign class2 = class2 | append: ' collapsed' -%}
+    {% assign expanded = 'false' -%}
+    {% assign show = '' -%}
+  {% endif -%}
+
+  {% assign id2 = id1 | append: '-' | append: forloop.index -%}
+  {% assign href = entry2.permalink -%}
+  {% unless href -%}
+    {% assign href = '#' | append: id2 -%}
+  {% endunless -%}
+
+  <li class="nav-item">
+    <a class="{{class2}}"
+      data-toggle="collapse" data-target="#{{id2}}"
+      href="{{href}}" role="button"
+      aria-expanded="{{expanded}}" aria-controls="{{id2}}"
+    >{{entry2.title}}
+    </a>
+    <ul class="nav flex-column flex-nowrap collapse {{show}}" id="{{id2}}">
+      {% include sidenav-level-3.html -%}
+    </ul>
+  </li>
+{% endif -%}
+{% endfor %}

--- a/src/_includes/sidenav-level-3.html
+++ b/src/_includes/sidenav-level-3.html
@@ -1,0 +1,61 @@
+{% for entry3 in entry2.children -%}
+
+{% assign class3 = 'nav-link' -%}
+{% assign isActive3 = false -%}
+{% if isActive2 and forloop.index == active_entries[2] -%}
+  {% assign isActive3 = true -%}
+  {% assign class3 = class3 | append: ' active' -%}
+{% endif -%}
+
+{% if entry3 == 'divider' -%}
+
+  <div class="dropdown-divider"></div>
+
+{%- elsif entry3.children == nil and entry3.permalink or show_entries_wo_pages -%}
+
+  <li class="nav-item">
+    <a class="{{class3}} {%- unless entry3.permalink %} disabled {%- endunless %}"
+      {%- if entry3.permalink %} href="{{entry3.permalink}}" {%- endif -%}
+      {%- if entry3.permalink contains '://' %} target="_blank" rel="noopener" {%- endif -%}
+    >{{entry3.title}}
+    {%- if entry3.permalink == nil %} (TBC)
+    {%- elsif entry3.permalink contains '://' -%}
+      <span class="material-icons md-24">
+        open_in_new
+      </span>
+    {%- endif -%}
+    </a>
+  </li>
+
+{%- elsif entry3.children -%}
+
+  {% assign class3 = class3 | append: ' collapsable' -%}
+
+  {% if isActive3 or entry3.expanded -%}
+    {% assign expanded = 'true' -%}
+    {% assign show = 'show' -%}
+  {% else -%}
+    {% assign class3 = class3 | append: ' collapsed' -%}
+    {% assign expanded = 'false' -%}
+    {% assign show = '' -%}
+  {% endif -%}
+
+  {% assign id3 = id2 | append: '-' | append: forloop.index -%}
+  {% assign href = entry3.permalink -%}
+  {% unless href -%}
+    {% assign href = '#' | append: id3 -%}
+  {% endunless -%}
+
+  <li class="nav-item">
+    <a class="{{class3}}"
+      data-toggle="collapse" data-target="#{{id3}}"
+      href="{{href}}" role="button"
+      aria-expanded="{{expanded}}" aria-controls="{{id3}}"
+    >{{entry3.title}}
+    </a>
+    <ul class="nav flex-column flex-nowrap collapse {{show}}" id="{{id3}}">
+      {% include sidenav-level-4.html -%}
+    </ul>
+  </li>
+{% endif -%}
+{% endfor -%}

--- a/src/_includes/sidenav-level-4.html
+++ b/src/_includes/sidenav-level-4.html
@@ -1,0 +1,25 @@
+{% for entry4 in entry3.children -%}
+  {% if entry4.permalink or show_entries_wo_pages -%}
+
+  {% assign class4 = 'nav-link' -%}
+  {% assign isActive4 = false -%}
+  {% if isActive3 and forloop.index == active_entries[3] -%}
+    {% assign isActive4 = true -%}
+    {% assign class4 = class4 | append: ' active' -%}
+  {% endif -%}
+
+  <li class="nav-item">
+    <a class="{{class4}} {%- unless entry4.permalink %} disabled {%- endunless %}"
+      {%- if entry4.permalink %} href="{{entry4.permalink}}" {%- endif -%}
+      {%- if entry4.permalink contains '://' %} target="_blank" rel="noopener" {%- endif -%}
+    >{{entry4.title}}
+      {%- if entry4.permalink == nil %} (TBC)
+      {%- elsif entry4.permalink contains '://' -%}
+        <span class="material-icons md-24">
+          open_in_new
+        </span>
+      {%- endif -%}
+    </a>
+  </li>
+  {% endif -%}
+{% endfor -%}

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -13,7 +13,7 @@ layout: base
 <div class="container-fluid position-relative">
   <div class="row flex-xl-nowrap">
     <div class="fixed-col site-sidebar site-sidebar--fixed {{sidebar-col}} d-none d-md-block" data-fixed-column>
-      {% include shared/sidenav-level-1.html nav=site.data.sidenav %}
+      {% include sidenav-level-1.html nav=site.data.sidenav %}
     </div>
 
     {% if page.toc and layout.toc != false -%}

--- a/src/_plugins/sidenav-active-entry-filter.rb
+++ b/src/_plugins/sidenav-active-entry-filter.rb
@@ -1,1 +1,30 @@
-../../site-shared/src/_plugins/sidenav-active-entry-filter.rb
+module ActiveNavEntries
+
+  def active_nav_entry_index_array(nav_entry_tree, page_url_path = '')
+    active_entry_indexes = _get_active_nav_entries(nav_entry_tree, page_url_path)
+    active_entry_indexes.empty? ? nil : active_entry_indexes
+  end
+
+  # @return array of indices to active nav entries.
+  def _get_active_nav_entries(nav_entry_tree, page_url_path = '')
+    nav_entry_tree.each_with_index do |entry, i|
+      if entry['children']
+        descendant_indexes = _get_active_nav_entries(entry['children'], page_url_path)
+        return [i+1] + descendant_indexes unless descendant_indexes.empty?
+      end
+
+      next unless entry['permalink']
+
+      is_active = if entry['match-page-url-exactly']
+                    page_url_path == entry['permalink']
+                  else
+                    page_url_path.include? entry['permalink']
+                  end
+
+      return [i+1] if is_active
+    end
+    []
+  end
+end
+
+Liquid::Template.register_filter(ActiveNavEntries)

--- a/src/_sass/components/_sidebar.scss
+++ b/src/_sass/components/_sidebar.scss
@@ -1,0 +1,101 @@
+.site-sidebar {
+  padding: $site-content-top-padding $site-sidebar-side-padding;
+
+  // Customization for sidebar in mobile nav
+  &.site-sidebar--header {
+    padding-left: bs-spacer(2);
+    padding-top: 0;
+    padding-bottom: 0;
+
+    > .nav > .nav-item {
+      font-size: $font-size-base;
+    }
+
+    > .nav > .nav-item,
+    > .nav > .nav-item .nav .nav-item {
+      .nav-link {
+        padding-bottom: bs-spacer(2);
+        padding-top: bs-spacer(2);
+      }
+    }
+  }
+
+  .nav-link {
+    padding: bs-spacer(1) 0;
+    position: relative;
+    color: inherit;
+    &.disabled { opacity: 0.5; }
+  }
+
+  @mixin collapsable() {
+    align-items: flex-end;
+    display: flex;
+    justify-content: space-between;
+
+    &::after {
+      content: 'keyboard_arrow_down';
+      font: $site-font-icon;
+      transition: transform .25s ease-in-out;
+    }
+
+    &:not(.collapsed) {
+      &::after {
+        transform: rotate(180deg);
+      }
+    }
+  }
+
+  // Top-level nav item
+  > .nav > .nav-item {
+    font-family: $site-font-family-alt;
+
+    &:first-child {
+      > .nav-link {
+        padding-top: 0;
+      }
+    }
+
+    > .nav-link {
+      padding: bs-spacer(3) 0;
+
+      @include collapsable();
+    }
+  }
+
+  // Sub navs
+  > .nav .nav {
+    padding-left: bs-spacer(4);
+
+    .nav-item {
+      font-size: $font-size-sm;
+
+      > .nav-link {
+        color: $site-color-body-light;
+
+        &.active {
+          font-weight: $font-weight-bold;
+          &:not(.collapsable) {
+            color: $site-color-primary;
+          }
+        }
+
+        &.collapsable {
+          &::before{
+            content: 'arrow_drop_down';
+            font: $site-font-icon;
+            left: -24px;
+            position: absolute;
+            top: 4px;
+            transition: transform .25s ease-in-out;
+          }
+
+          &.collapsed {
+            &::before {
+              transform: rotate(-90deg);
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/_sass/main.scss
+++ b/src/_sass/main.scss
@@ -19,7 +19,6 @@
 @import 'shared/prettify_shared';
 @import 'shared/code_shared';
 @import 'shared/header_shared';
-@import 'shared/sidebar_shared';
 @import 'shared/toc_shared';
 
 // (alpha ordered)
@@ -30,6 +29,7 @@
 @import 'd2h'; // TODO too small to be included as an entire file
 @import 'components/footer';
 @import 'components/next-prev-nav';
+@import 'components/sidebar';
 @import 'components/snackbar';
 @import 'components/tabs';
 @import 'components/cookie-notice';

--- a/src/_sass/shared/_sidebar_shared.scss
+++ b/src/_sass/shared/_sidebar_shared.scss
@@ -1,1 +1,0 @@
-../../../site-shared/src/_assets/css/_sidebar_shared.scss


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ I'm going to work on some fixes and optimizations to the sidenav generation (to reduce fresh build time), then later some improvements. I'd rather do them in isolation on the Flutter site for easier review and I expect the Dart and Flutter sites to diverge in sidenav behavior anyway. So this PR moves all related files from `dart-lang/site-shared` to `flutter/website`. We can always move it back (to site-shared) in the future if needed.

_Issues fixed by this PR (if any):_ Fixes N/A
