### PR TITLE
Use simpler @flutterdev youtube handle

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ sdk:
   channel: stable # When changing this value also update it in src/_assets/js/archive.js
 social:
   twitter: https://twitter.com/FlutterDev
-  youtube: https://www.youtube.com/flutterdev
+  youtube: https://www.youtube.com/@flutterdev
 dart-site: https://dart.dev
 news: https://news.dartlang.org
 api: https://api.flutter.dev

--- a/firebase.json
+++ b/firebase.json
@@ -151,7 +151,7 @@
       { "source": "/research-signup", "destination": "https://docs.google.com/forms/d/e/1FAIpQLSe0i4De809KXVCdljGKrjMj3lxhuzbuFKCtY5PEQPCYtGxFMg/viewform?usp=sf_link", "type": 301 },
       { "source": "/resources/design-principles", "destination": "https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo", "type": 301 },
       { "source": "/style-guide*", "destination": "https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo", "type": 301 },
-      { "source": "/youtube", "destination": "https://youtube.com/flutterdev", "type": 301 },
+      { "source": "/youtube", "destination": "https://youtube.com/@flutterdev", "type": 301 },
 
       { "source": "/go/a11y-text-attributes", "destination": "https://docs.google.com/document/d/1vhbwxFOTRTUvW2C_onFffEH5Fn2pAfMQDyv-gekias0/edit?usp=sharing&resourcekey=0-ChQvjIoWYO7jXcaCXMj5Qw", "type": 301 },
       { "source": "/go/actions-and-shortcuts-design-revision", "destination": "https://docs.google.com/document/d/1A9yald55O_C6Weqp4tOtyMisfOC1ZC0UMq7Yc-pNfVQ/edit", "type": 301 },

--- a/src/_data/docs_cards.yml
+++ b/src/_data/docs_cards.yml
@@ -15,4 +15,4 @@
   url: https://flutter.github.io/samples
 - name: Videos
   description: View the many videos on the Flutter YouTube channel.
-  url: https://www.youtube.com/flutterdev
+  url: https://www.youtube.com/@flutterdev

--- a/src/codelabs/layout-basics.md
+++ b/src/codelabs/layout-basics.md
@@ -3342,7 +3342,7 @@ You can download Flutter from the [install][] page.
 [Building layouts]: {{site.url}}/development/ui/layout
 [Cupertino]: {{site.api}}/flutter/cupertino/CupertinoApp-class.html
 [DartPad issue]: {{site.github}}/dart-lang/dart-pad/issues/new
-[Flutter's YouTube channel]: {{site.youtube-site}}/channel/UCwXdFgeE9KYzlDdR7TG9cMw
+[Flutter's YouTube channel]: {{site.youtube-site}}/@flutterdev
 [GitHub]: {{site.repo.this}}/tree/{{site.branch}}/examples/layout/sizing/images
 [install]: {{site.url}}/get-started/install
 [Material]: {{site.api}}/flutter/material/MaterialApp-class.html

--- a/src/codelabs/layout-basics.md
+++ b/src/codelabs/layout-basics.md
@@ -3342,7 +3342,7 @@ You can download Flutter from the [install][] page.
 [Building layouts]: {{site.url}}/development/ui/layout
 [Cupertino]: {{site.api}}/flutter/cupertino/CupertinoApp-class.html
 [DartPad issue]: {{site.github}}/dart-lang/dart-pad/issues/new
-[Flutter's YouTube channel]: {{site.youtube-site}}/@flutterdev
+[Flutter's YouTube channel]: {{site.social.youtube}}
 [GitHub]: {{site.repo.this}}/tree/{{site.branch}}/examples/layout/sizing/images
 [install]: {{site.url}}/get-started/install
 [Material]: {{site.api}}/flutter/material/MaterialApp-class.html

--- a/src/development/ui/animations/index.md
+++ b/src/development/ui/animations/index.md
@@ -228,7 +228,7 @@ Learn more about Flutter animations at the following links:
 [animation library]: {{site.api}}/flutter/animation/animation-library.html
 [Animation recipes]: {{site.url}}/cookbook/animation
 [Animation samples]: {{site.github}}/flutter/samples/tree/main/animations#animation-samples
-[Animation videos]: {{site.youtube-site}}/@flutterdev/search?query=animation
+[Animation videos]: {{site.social.youtube}}/search?query=animation
 [Animations in Flutter done right]: {{site.youtube-site}}/watch?v=wnARLByOtKA&t=3s
 [Animations: overview]: {{site.url}}/development/ui/animations/overview
 [animations package]: {{site.pub}}/packages/animations

--- a/src/development/ui/animations/index.md
+++ b/src/development/ui/animations/index.md
@@ -228,7 +228,7 @@ Learn more about Flutter animations at the following links:
 [animation library]: {{site.api}}/flutter/animation/animation-library.html
 [Animation recipes]: {{site.url}}/cookbook/animation
 [Animation samples]: {{site.github}}/flutter/samples/tree/main/animations#animation-samples
-[Animation videos]: {{site.youtube-site}}/channel/UCwXdFgeE9KYzlDdR7TG9cMw/search?query=animation
+[Animation videos]: {{site.youtube-site}}/@flutterdev/search?query=animation
 [Animations in Flutter done right]: {{site.youtube-site}}/watch?v=wnARLByOtKA&t=3s
 [Animations: overview]: {{site.url}}/development/ui/animations/overview
 [animations package]: {{site.pub}}/packages/animations

--- a/src/get-started/flutter-for/ios-devs.md
+++ b/src/get-started/flutter-for/ios-devs.md
@@ -2280,7 +2280,7 @@ plugin documentation.
 [first party plugins]: {{site.pub}}/flutter/packages?q=firebase
 [`flutter_facebook_login`]: {{site.pub-pkg}}/flutter_facebook_login
 [Flutter cookbook]: {{site.url}}/cookbook
-[Flutter Youtube channel]: {{site.youtube-site}}/flutterdev
+[Flutter Youtube channel]: {{site.social.youtube}}
 [`geolocator`]: {{site.pub-pkg}}/geolocator
 [`http` package]: {{site.pub-pkg}}/http
 [Human Interface Guidelines]: {{site.apple-dev}}/ios/human-interface-guidelines/overview/themes/

--- a/src/index.md
+++ b/src/index.md
@@ -131,7 +131,7 @@ see our [videos][] page.
 
 We release new videos almost every week on the Flutter YouTube channel:
 
-<a class="btn btn-primary" target="_blank" href="https://www.youtube.com/c/flutterdev">Explore more Flutter videos</a>
+<a class="btn btn-primary" target="_blank" href="https://www.youtube.com/@flutterdev">Explore more Flutter videos</a>
 
 **The documentation on this site reflects the
 latest stable release of Flutter.**

--- a/src/jobs/dre.md
+++ b/src/jobs/dre.md
@@ -14,7 +14,7 @@ A few of our projects:
 
 * Learning tools like the online code editor [DartPad](https://dartpad.dev)
 * Learning resources like [codelabs, guides, and samples](https://docs.flutter.dev)
-* Outreach via channels like [YouTube](https://youtube.com/flutterdev), social
+* Outreach via channels like [YouTube](https://youtube.com/@flutterdev), social
   media, and events
 * Partnership with engineering on Dart/Flutter's developer experience
 * A worldwide community of Flutter Meetups, conferences, and other groups.

--- a/src/jobs/tlm.md
+++ b/src/jobs/tlm.md
@@ -14,7 +14,7 @@ A few of our projects:
 
 * Learning tools like the online code editor [DartPad](https://dartpad.dev)
 * Learning resources like [codelabs, guides, and samples](https://docs.flutter.dev)
-* Outreach via channels like [YouTube](https://youtube.com/flutterdev), social
+* Outreach via channels like [YouTube](https://youtube.com/@flutterdev), social
   media, and events
 * Partnership with engineering on Dart/Flutter's developer experience
 * A worldwide community of Flutter Meetups, conferences, and other groups.

--- a/src/resources/videos.md
+++ b/src/resources/videos.md
@@ -18,7 +18,7 @@ but there are many others.
 Here are some of the series offered on the
 [flutterdev YouTube channel][].
 
-[flutterdev YouTube channel]: {{site.youtube-site}}/@flutterdev
+[flutterdev YouTube channel]: {{site.social.youtube}}
 
 ### Flutter at Google I/O 2022
 

--- a/src/resources/videos.md
+++ b/src/resources/videos.md
@@ -18,7 +18,7 @@ but there are many others.
 Here are some of the series offered on the
 [flutterdev YouTube channel][].
 
-[flutterdev YouTube channel]: {{site.youtube-site}}/channel/UCwXdFgeE9KYzlDdR7TG9cMw
+[flutterdev YouTube channel]: {{site.youtube-site}}/@flutterdev
 
 ### Flutter at Google I/O 2022
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Now that YouTube handles are out, we can use the simplified URL.

_Issues fixed by this PR (if any):_ Fixes N/A
