### PR TITLE
docs: Hot restart only works in debug mode

### DIFF
--- a/src/development/tools/hot-reload.md
+++ b/src/development/tools/hot-reload.md
@@ -19,7 +19,7 @@ To hot reload a Flutter app:
 
 1. Run the app from a supported [Flutter editor][] or a terminal window.
    Either a physical or virtual device can be the target.
-   **Only Flutter apps in debug mode can be hot reloaded.**
+   **Only Flutter apps in debug mode can be hot reloaded or hot restarted.**
 1. Modify one of the Dart files in your project.
    Most types of code changes can be hot reloaded;
    for a list of changes that require a hot restart,


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

> Right now, you can't hot restart in profile/release mode. This page says "Only Flutter apps in debug mode can be hot reloaded." I think it should say "Only Flutter apps in debug mode can be hot reloaded or hot restarted."

_Issues fixed by this PR (if any):_ Fixes #7843

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
