### PR TITLE
docs: 'Implicit animations' error word

### DIFF
--- a/src/codelabs/implicit-animations.md
+++ b/src/codelabs/implicit-animations.md
@@ -85,7 +85,7 @@ Click the **Run** button to run the example:
 #### 1. Pick a widget property to animate
 
 To create a fade-in effect, you can animate the `opacity` property using the
-`AnimatedOpacity` widget. Change the `Container` widget to an
+`AnimatedOpacity` widget. Change the `Column` widget to an
 `AnimatedOpacity` widget:
 
 <?code-excerpt "opacity{1,2}/lib/main.dart"?>


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ The problematic line is in https://docs.flutter.dev/codelabs/implicit-animations#1-pick-a-widget-property-to-animate. "Change the Container widget to an AnimatedOpacity widget: " should be "Change the Column widget to an AnimatedOpacity widget: ".

_Issues fixed by this PR (if any):_ Fixes #7720

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
