### PR TITLE
Jobs

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -62,6 +62,7 @@
       { "source": "/intellij-ide", "destination": "/development/tools/android-studio", "type": 301 },
       { "source": "/intellij-setup", "destination": "/get-started/editor", "type": 301 },
       { "source": "/ios-release", "destination": "/deployment/ios", "type": 301 },
+      { "source": "/jobs/**", "destination": "/jobs", "type": 301 },
       { "source": "/json", "destination": "/development/data-and-backend/json", "type": 301 },
       { "source": "/layout", "destination": "/development/ui/layout/box-constraints", "type": 301 },
       { "source": "/networking", "destination": "/cookbook/networking/fetch-data", "type": 301 },

--- a/src/jobs/index.md
+++ b/src/jobs/index.md
@@ -3,6 +3,10 @@ title: Flutter and Dart team job openings
 description: Open job listings for the Flutter and Dart teams.
 ---
 
+The Flutter team isn't currently hiring.
+Thanks for your interest!
+
+{% comment %}
 We are hiring on the Flutter and Dart teams!
 The following jobs are open:
 
@@ -11,3 +15,4 @@ The following jobs are open:
 * [Android Engineer]({{site.url}}/jobs/android)
 * [Android Technical Lead]({{site.url}}/jobs/android_tl)
 * [iOS Engineer]({{site.url}}/jobs/ios)
+{% endcomment %}

--- a/src/jobs/index.md
+++ b/src/jobs/index.md
@@ -3,7 +3,7 @@ title: Flutter and Dart team job openings
 description: Open job listings for the Flutter and Dart teams.
 ---
 
-The Flutter team isn't currently hiring.
+The Flutter and Dart teams aren't currently hiring.
 Thanks for your interest!
 
 {% comment %}


### PR DESCRIPTION
Temporarily redirecting all job inquiries to the updated page, which states that we have no current openings.

This takes precedence over PR https://github.com/flutter/website/pull/7970, which I will close.

cc @jmagman 