### PR TITLE
Revert "Bump ossf/scorecard-action from 2.1.0 to 2.1.1"

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@15c10fcf1cf912bd22260bfec67569a359ab87da
+        uses: ossf/scorecard-action@937ffa90d79c7d720498178154ad4c7ba1e4ad8c
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Based off the commits for this update, I'm not yet sure what change would have have caused the the scorecard workflow to start failing as seen in https://github.com/flutter/website/actions/runs/3743935449/jobs/6356696644. Reverting for now since it seems to be the cause of the `main` branch showing up as failing.

Reverts flutter/website#7966