### PR TITLE
Add VoiceOver / TalkBack HowTo to a11y page

### DIFF
--- a/src/development/accessibility-and-localization/accessibility.md
+++ b/src/development/accessibility-and-localization/accessibility.md
@@ -92,7 +92,53 @@ and with the largest font setting selected in iOS accessibility settings.
 For mobile, screen readers ([TalkBack][], [VoiceOver][]) enable visually
 impaired users to get spoken feedback about the contents of the screen 
 and interact with the UI via gestures on mobile and keyboard shortcuts on desktop. 
-Turn on VoiceOver or TalkBack on your mobile device and navigate around your app. 
+Turn on VoiceOver or TalkBack on your mobile device and navigate around your app.
+
+**To turn on the screen reader on your device, complete the following steps:**
+
+{% comment %} Nav tabs {% endcomment -%}
+<ul class="nav nav-tabs" id="editor-setup" role="tablist">
+    <li class="nav-item">
+        <a class="nav-link active" id="talkback-tab" href="#talkback" role="tab" aria-controls="talkback" aria-selected="true">TalkBack on Android</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" id="voiceover-tab" href="#voiceover" role="tab" aria-controls="voiceover" aria-selected="false">VoiceOver on iPhone</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" id="browsers-tab" href="#browsers" role="tab" aria-controls="browsers" aria-selected="false">Browsers</a>
+    </li>
+</ul>
+
+{% comment %} Tab panes {% endcomment -%}
+<div class="tab-content">
+
+<div class="tab-pane active" id="talkback" role="tabpanel" aria-labelledby="talkback-tab" markdown="1">
+
+1. On your device, open **Settings**.
+2. Select **Accessibility** and then **TalkBack**.
+3. Turn 'Use TalkBack' on or off.
+4. Select Ok.
+
+To learn how to find and customize Android's accessibility features, view this video.
+
+<iframe width="560" height="315" src="{{site.youtube-site}}/embed/FQyj_XTl01w" title="Customize accessibility features on Pixel" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
+</iframe>
+
+</div>
+
+<div class="tab-pane" id="voiceover" role="tabpanel" aria-labelledby="voiceover-tab" markdown="1">
+
+1. On your device, open **Settings > Accessibility > VoiceOver**
+2. Turn the VoiceOver setting on or off
+
+To learn how to find and customize iOS accessibility features, view this video.
+
+<iframe width="560" height="315" src="{{site.youtube-site}}/embed/qDm7GiKra28" title="How to navigate your iPhone or iPad with VoiceOver" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
+</iframe>
+
+</div>
+
+<div class="tab-pane" id="browsers" role="tabpanel" aria-labelledby="browsers-tab" markdown="1">
 
 For web, the following screen readers are currently supported:
 
@@ -104,12 +150,17 @@ Desktop Browsers:
 * MacOS - VoiceOver
 * Windows - JAWs & NVDA
 
-Screen Readers users on web will need to toggle 
+Screen Readers users on web will need to toggle
 "Enable accessibility" button to build the semantics tree.
-Users can skip this step if you programmatically auto-enable 
-accessibility for your app using this API: 
+Users can skip this step if you programmatically auto-enable
+accessibility for your app using this API:
 
 `RendererBinding.instance.setSemanticsEnabled(true)`
+
+</div>
+</div>{% comment %} End: Tab panes. {% endcomment -%}
+
+<br/>
 
 Check out this [video demo][] to see 
 Victor Tsaran, who leads the Accessibility program for Material Design, 


### PR DESCRIPTION
Copies the TalkBack / VoiceOver how-to into the a11y page. Adds a third tab, **Browsers**, and puts the current information in there.

This put the information into a relevant place that is easy to link to. Codelabs, in particular, can now link to this section.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
