### PR TITLE
Remove mentions to retired Google Group

### DIFF
--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -7,7 +7,6 @@
         </div>
         <div class="site-footer__content">
           <ul class="site-footer__link-list">
-              <li><a href="https://groups.google.com/forum/#!forum/flutter-dev">{{ site.email  | regex_replace: '(.*?@).*', '\1' }}</a></li>
               <li><a href="/tos">terms</a></li>
               <li><a href="/brand">brand usage</a></li>
               <li><a href="/security">security</a></li>

--- a/src/development/tools/sdk/upgrading.md
+++ b/src/development/tools/sdk/upgrading.md
@@ -85,12 +85,10 @@ $ flutter pub outdated
 
 We publish breaking change announcements to the
 [Flutter announcements mailing list][flutter-announce].
-You can also ask questions on the [Flutter dev mailing list][flutter-dev].
 Aside from subscribing to receive announcements,
 we'd love to hear from you!
 
 [Flutter SDK releases]: {{site.url}}/development/tools/sdk/releases
 [release channels]: {{site.repo.flutter}}/wiki/Flutter-build-release-channels
 [flutter-announce]: {{site.groups}}/forum/#!forum/flutter-announce
-[flutter-dev]: {{site.groups}}/forum/#!forum/flutter-dev
 [pubspec.yaml]: {{site.dart-site}}/tools/pub/pubspec


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

The Google Group has been [retired](https://groups.google.com/g/flutter-dev/c/LEbTZs_JVpI) so this PR removes directions to the group. This helps avoid potential confusion and prevents users finding outdated information. 

_Issues fixed by this PR (if any):_ Fixes N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
