### PR TITLE
Ignore codelab_rebuild files in code excerpter

### DIFF
--- a/build.excerpt.yaml
+++ b/build.excerpt.yaml
@@ -14,6 +14,7 @@ targets:
         - '**/ios/**'
         - '**/node_modules/**'
         - '**/*.jar'
+        - '**/codelab_rebuild.yaml'
     builders:
       code_excerpter|code_excerpter:
         enabled: true


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ The excerpter was finding docregions in the codelab rebuild files, causing warnings when the updater ran.

_Issues fixed by this PR (if any):_ Fixes N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
