### PR TITLE
Fix iOS platform views import code excerpt

### DIFF
--- a/examples/development/platform_integration/lib/platform_views/native_view_example_3.dart
+++ b/examples/development/platform_integration/lib/platform_views/native_view_example_3.dart
@@ -1,9 +1,9 @@
 // ignore_for_file: unused_local_variable
 
-// #enddocregion Import
+// #docregion import
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-// #docregion Import
+// #enddocregion import
 import 'package:flutter/widgets.dart';
 
 class IOSCompositionWidget extends StatelessWidget {

--- a/src/development/platform-integration/ios/platform-views.md
+++ b/src/development/platform-integration/ios/platform-views.md
@@ -44,49 +44,10 @@ do the following in `native_view_example.dart`:
 <ol markdown="1">
 <li markdown="1">Add the following imports:
 
-<?code-excerpt "lib/platform_views/native_view_example_3.dart (Import)"?>
+<?code-excerpt "lib/platform_views/native_view_example_3.dart (import)"?>
 ```dart
-import 'package:flutter/widgets.dart';
-
-class IOSCompositionWidget extends StatelessWidget {
-  const IOSCompositionWidget({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    // This is used in the platform side to register the view.
-    const String viewType = '<platform-view-type>';
-    // Pass parameters to the platform side.
-    final Map<String, dynamic> creationParams = <String, dynamic>{};
-
-    return UiKitView(
-      viewType: viewType,
-      layoutDirection: TextDirection.ltr,
-      creationParams: creationParams,
-      creationParamsCodec: const StandardMessageCodec(),
-    );
-  }
-}
-
-class TogetherWidget extends StatelessWidget {
-  const TogetherWidget({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    // This is used in the platform side to register the view.
-    const String viewType = '<platform-view-type>';
-    // Pass parameters to the platform side.
-    final Map<String, dynamic> creationParams = <String, dynamic>{};
-
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.android:
-      // return widget on Android.
-      case TargetPlatform.iOS:
-      // return widget on iOS.
-      default:
-        throw UnsupportedError('Unsupported platform view');
-    }
-  }
-}
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 ```
 </li>
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

The doc region tags were flipped, causing the remainder of the page being included in the snippet.

_Issues fixed by this PR (if any):_ Fixes N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
