### PR TITLE
Misc generation cleanup and formatting fixes

### DIFF
--- a/src/_includes/docs/cookbook-group-index.md
+++ b/src/_includes/docs/cookbook-group-index.md
@@ -4,6 +4,6 @@
       | where_exp: "recipe", "recipe.url != path_base"
       | sort: 'title' %}
 
-{% for recipe in recipes %}
+{% for recipe in recipes -%}
 - [{{ recipe.title }}]({{ recipe.url }})
 {% endfor %}

--- a/src/_includes/docs/testing-toc.md
+++ b/src/_includes/docs/testing-toc.md
@@ -4,15 +4,15 @@
 
   Usage: {% include docs/testing_toc.md type='unit' %}
 {% endcomment -%}
-{% assign dir = 'cookbook/testing/' | append: include.type %}
-{% assign recipes = site.pages | where_exp:"item", "item.dir contains dir" | sort: 'title' %}
+{% assign dir = 'cookbook/testing/' | append: include.type -%}
+{% assign recipes = site.pages | where_exp:"item", "item.dir contains dir" | sort: 'title' -%}
 
-{% for recipe in recipes %}
-{% comment %}
+{% for recipe in recipes -%}
+{% comment -%}
   Omit the index page for the given type
-{% endcomment %}
+{% endcomment -%}
 {% assign frag = recipe.url | split: '/' | last %}
-{% if frag != include.type %}
+{% if frag != include.type -%}
 - [{{ recipe.title }}]({{ recipe.url }})
-{% endif %}
+{% endif -%}
 {% endfor %}

--- a/src/get-started/install/index.md
+++ b/src/get-started/install/index.md
@@ -15,12 +15,12 @@ Select the operating system on which you are installing Flutter:
     <div class="card-body">
       <header class="card-title text-center m-0">
         <span class="d-block h1">
-          {% assign icon = os | downcase %}
-          {% if icon == 'macos' %}
+          {% assign icon = os | downcase -%}
+          {% if icon == 'macos' -%}
             <i class="fab fa-apple"></i>
-          {% else %}
+          {% else -%}
             <i class="fab fa-{{icon}}"></i>
-          {% endif %}
+          {% endif -%}
         </span>
         <span class="text-muted text-nowrap">{{os}}</span>
       </header>

--- a/src/index.md
+++ b/src/index.md
@@ -5,21 +5,21 @@ description: Get started with Flutter. Widgets, examples, updates, and API docs 
 ---
 
 {% for card in site.data.docs_cards -%}
-  {% capture index0Modulo3 %}{{ forloop.index0 | modulo:3 }}{% endcapture %}
-  {% capture indexModulo3 %}{{ forloop.index | modulo:3 }}{% endcapture %}
-  {% if index0Modulo3 == '0' %}
+  {% capture index0Modulo3 -%}{{ forloop.index0 | modulo:3 }}{% endcapture -%}
+  {% capture indexModulo3 -%}{{ forloop.index | modulo:3 }}{% endcapture -%}
+  {% if index0Modulo3 == '0' -%}
   <div class="card-deck mb-4">
-  {% endif %}
+  {% endif -%}
     <a class="card" href="{{card.url}}">
       <div class="card-body">
         <header class="card-title">{{card.name}}</header>
         <p class="card-text">{{card.description}}</p>
       </div>
     </a>
-  {% if indexModulo3 == '0' %}
+  {% if indexModulo3 == '0' -%}
   </div>
-  {% endif %}
-{% endfor -%}
+  {% endif -%}
+{% endfor %}
 
 **To see changes to the site since our last release,
 see [What's new][].**

--- a/src/testing/index.md
+++ b/src/testing/index.md
@@ -58,6 +58,7 @@ or run `flutter test --help` in your terminal.
 [Plugins in Flutter tests]: {{site.url}}/development/packages-and-plugins/plugins-in-tests
 
 ### Recipes
+{:.no_toc}
 
 {% include docs/testing-toc.md type='unit' %}
 
@@ -76,6 +77,7 @@ However, like a unit test, a widget test's environment is replaced with
 an implementation much simpler than a full-blown UI system.
 
 ### Recipes
+{:.no_toc}
 
 {% include docs/testing-toc.md type='widget' %}
 
@@ -96,6 +98,7 @@ For more information on how to write integration tests, see the [integration
 testing page][].
 
 ### Recipes
+{:.no_toc}
 
 {% include docs/testing-toc.md type='integration' %}
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ 

- Removes some extra whitespace across a few generated pages
- Removes "Recipes" entries from TOC on [/testing index page](https://docs.flutter.dev/testing) since there are no other sub headings, making it a bit unnecessary

_Issues fixed by this PR (if any):_ Fixes N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
