### PR TITLE
Migrate usages of flutter format to dart format

### DIFF
--- a/src/development/tools/formatting.md
+++ b/src/development/tools/formatting.md
@@ -38,10 +38,10 @@ To automatically format code whenever you save a file, set the
 ## Automatically formatting code with the 'flutter' command
 
 You can also automatically format code in the command line interface
-(CLI) using the `flutter format` command:
+(CLI) using the `dart format` command:
 
 ```terminal
-$ flutter format path1 path2 ...
+$ dart format path1 path2 ...
 ```
 
 ## Using trailing commas

--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -171,8 +171,8 @@ where the Dart code lives.
 
       * VS Code: Right-click and select **Format Document**.
       * Android Studio and IntelliJ IDEA: Right-click the code and
-        select **Reformat Code with dartfmt**.
-      * Terminal: Run `flutter format <filename>`.
+        select **Reformat Code with 'dart format'**.
+      * Terminal: Run `dart format <filename>`.
     {{site.alert.end}}
 
  2. Run the app [in the way your IDE describes][].


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Followup to https://github.com/flutter/website/pull/7895 as `flutter format` is going to be deprecated in favor of `dart format`. Also updates an old mention to `dartfmt` in IntelliJ with the new text.

_Issues fixed by this PR (if any):_ Fixes N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
