### PR TITLE
Update directory listing of release-build structure

### DIFF
--- a/src/deployment/web.md
+++ b/src/deployment/web.md
@@ -97,8 +97,8 @@ following structure:
 ```
 
 {{site.alert.note}}
-The `canvaskit` directory and its contents will only be present when the
-CanvasKit renderer is selected — but not when the HTML renderer is selected.
+  The `canvaskit` directory and its contents are only present when the
+  CanvasKit renderer is selected—not when the HTML renderer is selected.
 {{site.alert.end}}
 
 Launch a web server (for example,

--- a/src/deployment/web.md
+++ b/src/deployment/web.md
@@ -75,10 +75,31 @@ following structure:
       MaterialIcons-Regular.ttf
       <other font files>
     <image files>
+    packages
+      cupertino_icons
+        assets
+          CupertinoIcons.ttf
+    shaders
+      ink_sparkle.frag
+  canvaskit
+    canvaskit.js
+    canvaskit.wasm
+    profiling
+      canvaskit.js
+      canvaskit.wasm
+  favicon.png
+  flutter.js
+  flutter_service_worker.js
   index.html
   main.dart.js
-  main.dart.js.map
+  manifest.json
+  version.json
 ```
+
+{{site.alert.note}}
+The `canvaskit` directory and its contents will only be present when the
+CanvasKit renderer is selected — but not when the HTML renderer is selected.
+{{site.alert.end}}
 
 Launch a web server (for example,
 `python -m http.server 8000`,


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

For https://docs.flutter.dev/deployment/web#building-the-app-for-release, in the section showing the structure of a release build, this change updates the directory listing to match what the current `flutter build web` output actually generates.

_Issues fixed by this PR (if any):_ [no related issues]

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.