### PR TITLE
Change flutter_app reference to my_app, for consistency

### DIFF
--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -118,7 +118,7 @@ see [Write a Flutter desktop application][].
 
 Create a simple, templated Flutter app, using the instructions in
 [Getting Started with your first Flutter app][].
-Name the project **startup_namer** (instead of _flutter_app_).
+Name the project **startup_namer** (instead of _my_app_).
 
 {{site.alert.tip}}
   If you don't see "New Flutter Project" as an option in your IDE,


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

In https://docs.flutter.dev/get-started/codelab#step-1-create-the-starter-flutter-app (“Create the starter Flutter app”), this change replaces a reference to `flutter_app` with `my_app` — because https://docs.flutter.dev/get-started/test-drive#create-app (“Test drive » Create the app”, the previous section in the “Get started” guide), shows the project being created with the name `my_app`, not `flutter_app`.

_Issues fixed by this PR (if any):_ [no related issues]

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.