### PR TITLE
[SwiftUI guide] Fix alignment for CupertinoApp widget

### DIFF
--- a/examples/get-started/flutter-for/ios_devs/lib/cupertino_themes.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/cupertino_themes.dart
@@ -14,8 +14,8 @@ class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const
-        // #docregion Theme
-        CupertinoApp(
+     // #docregion Theme
+     CupertinoApp(
       theme: CupertinoThemeData(
         brightness: Brightness.dark,
       ),


### PR DESCRIPTION
- Fix alignment for the CupertinoApp widget

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
