### PR TITLE
Add import clarification to the send data cookbook

### DIFF
--- a/examples/cookbook/networking/send_data/lib/create_album.dart
+++ b/examples/cookbook/networking/send_data/lib/create_album.dart
@@ -1,4 +1,6 @@
+// #docregion convert-import
 import 'dart:convert';
+// #enddocregion convert-import
 
 import 'package:http/http.dart' as http;
 

--- a/src/cookbook/networking/send-data.md
+++ b/src/cookbook/networking/send-data.md
@@ -40,7 +40,9 @@ Import the `http` package.
 import 'package:http/http.dart' as http;
 ```
 
-If you develop for android, add the following permission inside manifest tag in the AndroidManifest.xml file located at android/app/src/main.
+If you develop for android, 
+add the following permission inside the manifest tag
+in the `AndroidManifest.xml` file located at `android/app/src/main`.
 
 ```xml
 <uses-permission android:name="android.permission.INTERNET"/>
@@ -53,6 +55,15 @@ This recipe covers how to create an `Album`
 by sending an album title to the
 [JSONPlaceholder][] using the
 [`http.post()`][] method.
+
+Import `dart:convert` for encoding the data:
+
+<?code-excerpt "lib/create_album.dart (convert-import)"?>
+```dart
+import 'dart:convert';
+```
+
+Use the `http.post()` method to send the encoded data:
 
 <?code-excerpt "lib/create_album.dart (CreateAlbum)"?>
 ```dart

--- a/src/cookbook/networking/send-data.md
+++ b/src/cookbook/networking/send-data.md
@@ -56,7 +56,7 @@ by sending an album title to the
 [JSONPlaceholder][] using the
 [`http.post()`][] method.
 
-Import `dart:convert` for encoding the data:
+Import `dart:convert` for access to `jsonEncode` to encode the data:
 
 <?code-excerpt "lib/create_album.dart (convert-import)"?>
 ```dart


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ If someone is just looking for the details in step 2 of creating a simple `post` request, it may not be clear that a `dart:convert` import is needed.

This PR outlines adding the `dart:convert` important. Also adds semantic breaks to an existing long line.

_Issues fixed by this PR (if any):_ Fixes #7726

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
