### PR TITLE
Add a small margin below nav tabs

### DIFF
--- a/src/_sass/base/_bootstrap_adjust.scss
+++ b/src/_sass/base/_bootstrap_adjust.scss
@@ -76,6 +76,7 @@ a.card {
 
 .nav-tabs {
   font-family: $site-font-family-alt;
+  margin-bottom: 1rem;
 }
 
 .nav-tabs .nav-item:not(:last-child) {

--- a/src/_sass/base/_bootstrap_adjust.scss
+++ b/src/_sass/base/_bootstrap_adjust.scss
@@ -76,7 +76,7 @@ a.card {
 
 .nav-tabs {
   font-family: $site-font-family-alt;
-  margin-bottom: 1rem;
+  margin-bottom: 0.75rem;
 }
 
 .nav-tabs .nav-item:not(:last-child) {


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Adds a small margin below nav tabs so paragraph text is not directly lined up against them.

**Before:**
<img width="578" alt="Without extra margin" src="https://user-images.githubusercontent.com/18372958/210044323-9ea2d19f-f5b9-4d6b-927d-306578e1484a.png">

**After:**
<img width="554" alt="With extra margin" src="https://user-images.githubusercontent.com/18372958/210044483-219245e7-dc39-43c0-9a4e-8f056fe3345b.png">

_Issues fixed by this PR (if any):_ Fixes #ISSUE-NUMBER

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
