### PR TITLE
Add overrides to fix print styles

### DIFF
--- a/src/_sass/base/_print_overrides.scss
+++ b/src/_sass/base/_print_overrides.scss
@@ -1,0 +1,38 @@
+// Overrides for printing so only page content is printed
+@media print {
+  // Ignore navigation elements and other non-necessary interactive ones
+  .site-header, .subnav, .site-footer, .site-sidebar, .navbar,
+  #site-toc--side, #page-github-links, #cookie-notice, .site-banner,
+  .code-excerpt__copy-btn, .breadcrumb {
+    display: none !important;
+  }
+
+  // Make sure content fills up 100% of width
+  .site-content {
+    max-width: 100% !important;
+    margin-left: 0;
+    padding-left: 0;
+    border: none;
+    flex: 1;
+  }
+
+  // Remove DartPad iframes since they are not functional
+  .code-excerpt iframe {
+    display: none;
+  }
+
+  // Display underlines under links
+  a {
+    text-decoration: underline;
+  }
+
+  // Remove external link icon and link path
+  a:after {
+    content: none !important;
+  }
+
+  // Show borders around notes and code blocks
+  .alert, pre {
+    border: 1px solid black;
+  }
+}

--- a/src/_sass/main.scss
+++ b/src/_sass/main.scss
@@ -53,3 +53,4 @@
 
 // -- Overrides
 @import 'base/site_overrides';
+@import 'base/print_overrides';


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Some users like to print out documents for studying, review, etc. This PR improves styles when printing so only content is displayed.

**After:**
<img width="514" alt="After adding print overrides" src="https://user-images.githubusercontent.com/18372958/210644122-f964c005-2157-4171-91d9-2c22513fa27b.png">

**Before:**
<img width="514" alt="Before adding print overrides" src="https://user-images.githubusercontent.com/18372958/210644176-c0d264bd-0f88-4745-9443-08260d20c290.png">

_Issues fixed by this PR (if any):_ Fixes #2974

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
