### PR TITLE
Avoid extra border on embedded DartPads

### DIFF
--- a/src/_sass/components/_code.scss
+++ b/src/_sass/components/_code.scss
@@ -49,11 +49,12 @@ pre > span.strike { text-decoration: line-through; }
 
 .code-excerpt {
   &__code {
-    @include code-excerpt-border;
     margin-bottom: bs-spacer(4);
     position: relative;
 
     pre {
+      @include code-excerpt-border;
+
       background-color: $gray-100;
       margin-bottom: 0;
     }


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Embedded DartPads had an extra border, most clearly seen on the bottom side, causing an awkward look. These come from borders used for all code-excerpt `div`s. This fixes the issue by moving the code excerpt border to the `pre` elements used by snippets rather than the `code-excerpt__code` `div` itself.

**Before (with extra border):**
<img width="936" alt="Before (with extra border)" src="https://user-images.githubusercontent.com/18372958/210661528-40567a93-1edb-4c05-8e36-cc7440d85d69.png">

**After (without extra border):**
<img width="932" alt="After (without extra border)" src="https://user-images.githubusercontent.com/18372958/210651181-0f454927-87d6-4ab9-a5ce-b7dac38116c5.png">


_Issues fixed by this PR (if any):_ Fixes N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
