### PR TITLE
Add redirect for old rendering doc

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -132,6 +132,7 @@
       { "source": "/reference/widgets/:catalogpage+", "destination": "/development/ui/widgets/:catalogpage+", "type": 301 },
       { "source": "/reference/widgets/widgetindex", "destination": "/reference/widgets", "type": 301 },
       { "source": "/release/breaking-changes/scrollable_alert_dialog", "destination": "/release/breaking-changes/scrollable-alert-dialog", "type": 301 },
+      { "source": "/resources/rendering", "destination": "/resources/architectural-overview#rendering-and-layout", "type": 301 },
       { "source": "/resources/technical-overview", "destination": "/resources/architectural-overview", "type": 301 },
       { "source": "/testing/best-practices", "destination": "/perf/best-practices", "type": 301 },
       { "source": "/testing/ui-performance", "destination": "/perf/ui-performance", "type": 301 },


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ This was an old rendering document and after a search it is still referenced in a few discussions and posts, including someones thesis :o

_Issues fixed by this PR (if any):_ Fixes https://github.com/flutter/website/issues/4096

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
