### PR TITLE
Scroll active sidenav entry into view on load

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -1,6 +1,7 @@
 $(function () {
   adjustToc();
   initFixedColumns();
+  scrollSidebarIntoView();
   initVideoModal();
   initCarousel();
   initSnackbar();
@@ -19,6 +20,24 @@ $(function () {
 
   prettyPrint();
 });
+
+function scrollSidebarIntoView() {
+  const fixedSidebar = document.querySelector('.site-sidebar--fixed');
+
+  if (!fixedSidebar) {
+    return;
+  }
+
+  const activeEntries = fixedSidebar.querySelectorAll('a.nav-link.active');
+
+  if (activeEntries.length > 0) {
+    const activeEntry = activeEntries[activeEntries.length - 1];
+
+    fixedSidebar.scrollTo({
+      top: activeEntry.offsetTop - window.innerHeight / 3,
+    });
+  }
+}
 
 function adjustToc() {
   // Adjustments to the jekyll-toc TOC.


### PR DESCRIPTION
Right now the sidenav always resets to scrolling to the top when loading the page, interrupting the user flow, especially when the active entry is below their view port. This is becoming an increasingly apparent issue as the sidenav and its categories gain more entries, particularly with future IA work.

This PR adds JS code to automatically scroll the fixed sidenav on load so that deepest active entry is in view.

Fixes https://github.com/flutter/website/issues/3435

Try it on this [staged site](https://parlough-docs-flutter-dev.web.app/), with links far down in the sidenav and/or reducing the height of your browser window.
