### PR TITLE
Remove links to old “First app” codelab

### DIFF
--- a/src/codelabs/explicit-animations.md
+++ b/src/codelabs/explicit-animations.md
@@ -773,7 +773,7 @@ the `value` property to a new value.
 [Material app]: {{site.api}}/flutter/material/MaterialApp-class.html
 [performance profiling]: {{site.url}}/perf/ui-performance
 [implicit animations]: {{site.url}}/development/ui/animations/implicit-animations
-[make a Flutter app]: {{site.codelabs}}/codelabs/first-flutter-app-pt1
+[make a Flutter app]: {{site.codelabs}}/codelabs/flutter-codelab-first
 [stateful widgets]: {{site.url}}/development/ui/interactive#stateful-and-stateless-widgets
 [step 1]: #1-use-a-tickerprovider-mixin
 [`SingleTickerProviderStateMixin`]: {{site.api}}/flutter/widgets/SingleTickerProviderStateMixin-mixin.html

--- a/src/codelabs/implicit-animations.md
+++ b/src/codelabs/implicit-animations.md
@@ -512,7 +512,7 @@ here are some suggestions for where to go next:
 [linear curve]: {{site.api}}/flutter/animation/Curves/linear-constant.html
 [list of common implicitly animated widgets]: {{site.api}}/flutter/widgets/ImplicitlyAnimatedWidget-class.html
 [list of curve constants]: {{site.api}}/flutter/animation/Curves-class.html
-[make a Flutter app]: {{site.codelabs}}/codelabs/first-flutter-app-pt1/
+[make a Flutter app]: {{site.codelabs}}/codelabs/flutter-codelab-first
 [Material App]: {{site.api}}/flutter/material/MaterialApp-class.html
 [shape-shifting complete]: #shape-shifting-complete
 [Shape-shifting effect]: #example-shape-shifting-effect

--- a/src/codelabs/index.md
+++ b/src/codelabs/index.md
@@ -25,25 +25,19 @@ which tells you where to find the associated DartPad link.
 If you're new to Flutter, we recommend starting with
 one of these codelabs:
 
+{% comment %}
+TODO(filiph): add the video for the new codelab when ready
+
 * [Building your first Flutter app][] (workshop)<br>
   An instructor-led version of our very popular
   "Write your first Flutter app, part 1" codelab
   (listed below).
+{% endcomment %}
 
-* [Write your first Flutter app, part 1][]<br>
-  Create a simple mobile app that generates proposed names
-  for a startup company. In part one, you'll use a package
-  that returns pairs of words at random and inserts them into
-  an infinite scrolling list. You can also find this
-  [codelab on docs.flutter.dev][].
-
-* [Write your first Flutter app, part 2][]<br>
-  Create a simple mobile app that generates proposed names
-  for a startup company. In part two, you'll extend the
-  example from part 1 to allow the user to select favorite
-  word pairs, and add a second "Saved Favorites"
-  page where users can view the selected names.
-  Finally, you'll change the app's theme color.
+* [Your first Flutter app][]<br>
+  Create a simple app that automatically generates cool-sounding names,
+  such as "newstay", "lightstream", "mainbrake", or "graypine".
+  This app is responsive and runs on mobile, desktop, and web.
 
 * [Write your first Flutter app on the web][]<br>
   Implement a simple web app in DartPad (no downloads
@@ -56,9 +50,7 @@ one of these codelabs:
   works on Android and iOS devices, as well.
 
 [Building your first Flutter app]: {{site.youtube-site}}/watch?v=Z6KZ3cTGBWw
-[codelab on docs.flutter.dev]: {{site.url}}/get-started/codelab
-[Write your First Flutter app, part 1]: {{site.codelabs}}/codelabs/first-flutter-app-pt1
-[Write your First Flutter app, part 2]: {{site.codelabs}}/codelabs/first-flutter-app-pt2
+[Your first Flutter app]: {{site.codelabs}}/codelabs/flutter-codelab-first
 [Write your first Flutter app on the web]: {{site.url}}/get-started/codelab-web
 
 ## Next steps

--- a/src/get-started/flutter-for/react-native-devs.md
+++ b/src/get-started/flutter-for/react-native-devs.md
@@ -857,8 +857,8 @@ return ListView.builder(
 
 {% include docs/android-ios-figure-pair.md image="react-native/flatlist.gif" alt="Flat list" class="border" %}
 
-To learn how to implement an infinite scrolling list, see the
-[Write Your First Flutter App, Part 1][] codelab.
+To learn how to implement an infinite scrolling list, see the official
+[`infinite_list`][infinite_list] sample.
 
 ### How do I use a Canvas to draw or paint?
 
@@ -2693,4 +2693,4 @@ and common widget properties.
 [Using Packages]: {{site.url}}/development/packages-and-plugins/using-packages
 [variables]: {{site.dart-site}}/guides/language/language-tour#variables
 [`WidgetBuilder`]: {{site.api}}/flutter/widgets/WidgetBuilder.html
-[Write Your First Flutter App, Part 1]: {{site.codelabs}}/codelabs/first-flutter-app-pt1
+[infinite_list]: {{site.repo.samples}}/tree/main/infinite_list

--- a/src/get-started/flutter-for/xamarin-forms-devs.md
+++ b/src/get-started/flutter-for/xamarin-forms-devs.md
@@ -2122,8 +2122,7 @@ Finally, but most importantly, notice that the `onTap()` function
 doesn't recreate the list anymore, but instead adds to it.
 
 For more information, see
-[Write your first Flutter app, part 1][]
-and [Write your first Flutter app, part 2][].
+[Your first Flutter app][first_codelab] codelab.
 
 ## Working with text
 
@@ -2590,6 +2589,5 @@ For more information on using the Firebase Cloud Messaging API, see the
 [widget]: {{site.url}}/resources/architectural-overview#widgets
 [widget catalog]: {{site.url}}/development/ui/widgets/layout
 [`Window.locale`]: {{site.api}}/flutter/dart-ui/Window/locale.html
-[Write your first Flutter app, part 1]: {{site.codelabs}}/codelabs/first-flutter-app-pt1
-[Write your first Flutter app, part 2]: {{site.codelabs}}/codelabs/first-flutter-app-pt2
+[first_codelab]: {{site.codelabs}}/codelabs/flutter-codelab-first
 [write your own]: {{site.url}}/development/packages-and-plugins/developing-packages


### PR DESCRIPTION
A pass through flutter/website to weed out links to the old "First Flutter app" codelab (part 1 and 2).


## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
