### PR TITLE
fix: typo

### DIFF
--- a/src/testing/errors.md
+++ b/src/testing/errors.md
@@ -9,7 +9,7 @@ The Flutter framework catches errors that occur during callbacks
 triggered by the framework itself, including errors encountered
 during the build, layout, and paint phases. Errors that don't occur
 within Flutter's callbacks can't be caught by the framework,
-but you can handle them by setting up a error handler on the
+but you can handle them by setting up an error handler on the
 [`PlatformDispatcher`][].
 
 All errors caught by Flutter are routed to the


### PR DESCRIPTION
`a error` -> `an error` [link](https://owl.purdue.edu/owl/general_writing/grammar/articles_a_versus_an.html#:~:text=%22A%22%20goes%20before%20words%20that%20begin%20with%20consonants.&text=%22An%22%20goes%20before%20words%20that,an%20apricot)

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_ Fixes #ISSUE-NUMBER

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
