### PR TITLE
Fix applicationId mention and formatting in Android flavors section

### DIFF
--- a/src/deployment/flavors.md
+++ b/src/deployment/flavors.md
@@ -3,7 +3,9 @@ title: Creating flavors for Flutter
 short-title: Flavors
 description: How to create build flavors specific to different release types or development environments.
 ---
+
 ## What are flavors
+
 Have you ever wondered how to set up different environments in your Flutter app?
 Flavors (known as _build configurations_ in iOS), allow you (the developer) to 
 create separate environments for your app using the same code base. 
@@ -155,16 +157,18 @@ Setting up flavors in Android can be done in your project's
 navigate to **android**/**app**/**build.gradle**.     
 
 2. Add a flavor object with the specified environments along with values for 
-**dimension**, **resValue**, and **applicationId**. 
+**dimension**, **resValue**, and **applicationId** or **applicationSuffix**. 
   * The name of the application for each build is located in **resValue** 
 (as shown in the snippet below from VSCode).
+  * If you specify a **applicationSuffix** instead of a **applicationId**, 
+    it is appended to the "base" application id.
 
-```ruby
+```gradle
 flavor {
     free {
         dimension "default"
         resValue "string", "app_name", "free flavor example"
-        applicationId ".free"
+        applicationSuffix ".free"
     }
 }
 ```


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

- Mentions both **applicationId** and **applicationSuffix**
- Fix sample to use **applicationSuffix**
- Update snippet language from ruby to gradle(groovy) for better highlighting

_Issues fixed by this PR (if any):_ Fixes #8038

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

\cc @MiraMarshall 