### PR TITLE
Enable Jekyll frontmatter and some liquid validation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,8 +57,12 @@ youtube-site: https://youtube.com
 ########### Jekyll ###########
 
 source: src
+strict_front_matter: true
 permalink: pretty
 exclude: []
+liquid:
+  error_mode: strict
+  strict_filters: true
 sass:
   sass_dir: _sass
   cache: false


### PR DESCRIPTION
This will help catch future issues during development and build relating to ill-formed front matter as well as incorrect Liquid usage. From testing locally, the impact on build time is minimal or non-existent, with runs with and without taking the same amount of time.

 Fixes #3489
