### PR TITLE
Fix sidebar collapse icon vertical alignment

### DIFF
--- a/src/_sass/components/_sidebar.scss
+++ b/src/_sass/components/_sidebar.scss
@@ -16,6 +16,12 @@
       .nav-link {
         padding-bottom: bs-spacer(2);
         padding-top: bs-spacer(2);
+
+        &.collapsable {
+          &::before {
+            top: 6px;
+          }
+        }
       }
     }
   }
@@ -85,7 +91,7 @@
             font: $site-font-icon;
             left: -24px;
             position: absolute;
-            top: 4px;
+            top: 2px;
             transition: transform .25s ease-in-out;
           }
 


### PR DESCRIPTION
The inner collapse icon was not vertically centered with the included text.

**After:**
<img width="148" alt="Fixed vertical alignment" src="https://user-images.githubusercontent.com/18372958/211083817-abb57ee0-aafd-4798-9649-51cb1ec46e9d.png">

**Before:**
<img width="181" alt="Before fix of vertical alignment" src="https://user-images.githubusercontent.com/18372958/211083726-173403b4-1301-41e7-88b0-53f01abb7de5.png">
