### PR TITLE
Split Flutter for iOS developers into pages for SwiftUI and UIKit

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -128,6 +128,7 @@
       { "source": "/development/ui/widgets/widgetindex", "destination": "/reference/widgets", "type": 301 },
       { "source": "/get-started", "destination": "/get-started/install", "type": 301 },
       { "source": "/get-started/flutter-for", "destination": "/get-started/flutter-for/android-devs", "type": 301 },
+      { "source": "/get-started/ios-devs", "destination": "/get-started/flutter-for/swiftui-devs", "type": 301 },
       { "source": "/get-started/install/null", "destination": "/get-started/install", "type": 301 },
       { "source": "/reference/widgets/:catalogpage+", "destination": "/development/ui/widgets/:catalogpage+", "type": 301 },
       { "source": "/reference/widgets/widgetindex", "destination": "/reference/widgets", "type": 301 },

--- a/firebase.json
+++ b/firebase.json
@@ -128,7 +128,7 @@
       { "source": "/development/ui/widgets/widgetindex", "destination": "/reference/widgets", "type": 301 },
       { "source": "/get-started", "destination": "/get-started/install", "type": 301 },
       { "source": "/get-started/flutter-for", "destination": "/get-started/flutter-for/android-devs", "type": 301 },
-      { "source": "/get-started/ios-devs", "destination": "/get-started/flutter-for/swiftui-devs", "type": 301 },
+      { "source": "/get-started/flutter-for/ios-devs", "destination": "/get-started/flutter-for/swiftui-devs", "type": 301 },
       { "source": "/get-started/install/null", "destination": "/get-started/install", "type": 301 },
       { "source": "/reference/widgets/:catalogpage+", "destination": "/development/ui/widgets/:catalogpage+", "type": 301 },
       { "source": "/reference/widgets/widgetindex", "destination": "/reference/widgets", "type": 301 },

--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -16,8 +16,10 @@
       children:
         - title: Flutter for Android devs
           permalink: /get-started/flutter-for/android-devs
-        - title: Flutter for iOS devs
-          permalink: /get-started/flutter-for/ios-devs
+        - title: Flutter for SwiftUI devs
+          permalink: /get-started/flutter-for/swiftui-devs
+        - title: Flutter for UIKit devs
+          permalink: /get-started/flutter-for/uikit-devs
         - title: Flutter for React Native devs
           permalink: /get-started/flutter-for/react-native-devs
         - title: Flutter for web devs

--- a/src/get-started/flutter-for/swiftui-devs.md
+++ b/src/get-started/flutter-for/swiftui-devs.md
@@ -1,0 +1,1386 @@
+---
+title: Flutter for SwiftUI Developers
+description: Learn how to apply SwiftUI developer knowledge when building Flutter apps.
+---
+
+<?code-excerpt path-base="get-started/flutter-for/ios_devs"?>
+
+{% assign sample_path = "blob/main/examples/get-started/flutter-for/ios_devs" %}
+
+SwiftUI developers who want to write mobile apps using Flutter
+should review this guide.
+It explains how to apply existing SwiftUI knowledge to Flutter.
+
+{{site.alert.note}}
+  If you instead have experience building apps for iOS with UIKit,
+  see [Flutter for UIKit developers][].
+{{site.alert.end}}
+
+Flutter is a framework for building cross-platform applications
+that uses the Dart programming language.
+To understand some differences between programming with Dart
+and programming with Swift, see [Learning Dart as a Swift Developer][]
+and [Flutter concurrency for Swift developers][].
+
+Your SwiftUI knowledge and experience
+are highly valuable when building with Flutter.
+{% comment %}
+  TODO: Add talk about plugin system for interacting with OS and hardware
+  when [iOS and Apple hardware interactions with Flutter][] is released.
+{% endcomment %}
+
+Flutter also makes a number of adaptations
+to app behavior when running on iOS and macOS.
+To learn how, see [Platform adaptations][].
+
+{{site.alert.info}}
+  To integrate Flutter code into an **existing** iOS app, 
+  check out [Add Flutter to existing app][].
+{{site.alert.end}}
+
+This document can be used as a cookbook by jumping around
+and finding questions that are most relevant to your needs.
+This guide embeds sample code.
+You can test full working examples on DartPad or view them on GitHub.
+
+## Overview
+
+Flutter and SwiftUI code describes how the UI looks and works.
+Developers call this type of code a _declarative framework_.
+
+### Views vs. Widgets
+
+**SwiftUI** represents UI components as _views_.
+You configure views using _modifiers_.
+
+```swift
+Text("Hello, World!") // <-- This is a View
+  .padding(10)        // <-- This is a modifier of that View
+```
+
+**Flutter** represents UI components as _widgets_.
+
+Both views and widgets only exist until they need to be changed.
+These languages call this property _immutability_.
+SwiftUI represents a UI component property as a View modifier.
+By contrast, Flutter uses widgets for both UI components and
+their properties.
+
+{:.include-lang}
+```dart
+Padding(                         // <-- This is a Widget
+  padding: EdgeInsets.all(10.0), // <-- So is this
+  child: Text("Hello, World!"),  // <-- This, too
+)));
+```
+
+To compose layouts, both SwiftUI and Flutter nest UI components
+within one another.
+SwiftUI nests Views while Flutter nests Widgets.
+
+### Layout process
+
+**SwiftUI** lays out views using the following process:
+
+1. The parent view proposes a size to its child view.
+1. All subsequent child views:
+    - propose a size to _their_ child's view
+    - ask that child what size it wants
+1. Each parent view renders its child view at the returned size.
+
+**Flutter** differs somewhat with its process:
+
+1. The parent widget passes constraints down to its children.
+   Constraints include minimum and maximum values for height and width.
+1. The child tries to decide its size. It repeats the same process with its own list of children:
+    - It informs its child of the child's constraints.
+    - It asks its child what size it wishes to be.
+
+1. The parent lays out the child.
+    - If the requested size fits in the constraints,
+      the parent uses that size.
+    - If the requested size doesn't fit in the constraints,
+      the parent limits the height, width, or both to fit in
+      its constraints.
+
+Flutter differs from SwiftUI because the parent component can override
+the child’s desired size. The widget cannot have any size it wants.
+It also cannot know or decide its position on screen as its parent
+makes that decision.
+
+To force a child widget to render at a specific size,
+the parent must set tight constraints.
+A constraint becomes tight when its constraint's minimum size value
+equals its maximum size value.
+
+In **SwiftUI**, views may expand to the available space or
+limit their size to that of its content.
+**Flutter** widgets behave in similar manner.
+
+However, in Flutter parent widgets can offer unbounded constraints.
+Unbounded constraints set their maximum values to infinity.
+
+{:.include-lang}
+```dart
+UnboundedBox(
+  child: Container(
+      width: double.infinity, height: double.infinity, color: red),
+)
+```
+
+If the child expands and it has unbounded constraints,
+Flutter returns an overflow warning:
+
+{:.include-lang}
+```dart
+UnconstrainedBox(
+  child: Container(color: red, width: 4000, height: 50),
+)
+```
+
+<img src="/assets/images/docs/ui/layout/layout-14.png" alt="When parents pass unbounded constraints to children, and the children are expanding, then there is an overflow warning">
+
+To learn how constraints work in Flutter,
+see [Understanding constraints][].
+
+### Design system
+
+Because Flutter targets multiple platforms, your app doesn’t need
+to conform to any design system.
+Though this guide features [Material][] widgets,
+your Flutter app can use many different design systems:
+
+- Custom Material widgets
+- Community built widgets
+- Your own custom widgets
+- [Cupertino widgets][] that follow Apple’s Human Interface Guidelines
+
+<iframe width="560" height="315" src="{{site.youtube-site}}/embed/3PdUaidHc-E?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+If you're looking for a great reference app that features a
+custom design system, check out [Wonderous][].
+
+## UI Basics
+
+This section covers the basics of UI development in
+Flutter and how it compares to SwiftUI.
+This includes how to start developing your app, display static text,
+create buttons, react to on-press events, display lists, grids, and more.
+
+### Getting started
+
+In **SwiftUI**, you use `App` to start your app.
+
+```swift
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            HomePage()
+        }
+    }
+}
+```
+
+Another common SwiftUI practice places the app body within a `struct`
+that conforms to the `View` protocol as follows:
+
+```swift
+struct HomePage: View {
+  var body: some View {
+    Text("Hello, World!")
+  }
+}
+```
+
+To start your **Flutter** app, pass in an instance of your app to
+the `runApp` function.
+
+<nav class="navbar bg-primary">
+ <ul class="navbar-nav navbar-code ml-auto">
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=d3d38ae68f7d6444421d0485a1fd02db">Test in DartPad</a>
+  </li>
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/get_started.dart">View on GitHub</a>
+  </li>
+</ul>
+</nav>
+
+<?code-excerpt "lib/get_started.dart (main)"?>
+```dart
+void main() {
+  runApp(const MyApp());
+}
+```
+
+`App` is a widget. The build method describes the part of the
+user interface it represents.
+It’s common to begin your app with a [`WidgetApp`][] class,
+like [`CupertinoApp`][].
+
+<nav class="navbar bg-primary">
+ <ul class="navbar-nav navbar-code ml-auto">
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=d3d38ae68f7d6444421d0485a1fd02db">Test in DartPad</a>
+  </li>
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/get_started.dart">View on GitHub</a>
+  </li>
+</ul>
+</nav>
+
+<?code-excerpt "lib/get_started.dart (myapp)"?>
+```dart
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // Returns a CupertinoApp that, by default,
+    // has the look and feel of an iOS app.
+    return const CupertinoApp(
+      home: HomePage(),
+    );
+  }
+}
+```
+
+The widget used in `HomePage` might begin with the `Scaffold` class.
+`Scaffold` implements a basic layout structure for an app.
+
+<nav class="navbar bg-primary">
+ <ul class="navbar-nav navbar-code ml-auto">
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=d3d38ae68f7d6444421d0485a1fd02db">Test in DartPad</a>
+  </li>
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/get_started.dart">View on GitHub</a>
+  </li>
+</ul>
+</nav>
+
+<?code-excerpt "lib/get_started.dart (homepage)"?>
+```dart
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text(
+          'Hello, World!',
+        ),
+      ),
+    );
+  }
+}
+```
+
+Note how Flutter uses the [`Center`][] widget.
+SwiftUI renders a view's contents in its center by default.
+That’s not always the case with Flutter.
+`Scaffold` doesn’t render its `body` widget at the center of the screen.
+To center the text, wrap it in a `Center` widget.
+To learn about different widgets and their default behaviors, check out
+the [Widget catalog][].
+
+### Adding Buttons
+
+In **SwiftUI**, you use the `Button` struct to create a button.
+
+{:.include-lang}
+```swift
+Button("Do something") {
+  // this closure gets called when your
+  // button is tapped
+}
+```
+
+To achieve the same result in **Flutter**,
+use the `CupertinoButton` class:
+
+<nav class="navbar bg-primary">
+ <ul class="navbar-nav navbar-code ml-auto">
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=b776dfe43c91e580c66b2b93368745eb">Test in DartPad</a>
+  </li>
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/text_button.dart">View on GitHub</a>
+  </li>
+</ul>
+</nav>
+
+<?code-excerpt "lib/text_button.dart (textbutton)"?>
+```dart
+        CupertinoButton(
+  onPressed: () {
+    // This closure is called when your button is tapped.
+  },
+  child: const Text('Do something'),
+)
+```
+
+**Flutter** gives you access to a variety of buttons with predefined styles.
+The [`CupertinoButton`][] class comes from the Cupertino library.
+Widgets in the Cupertino library use Apple's design system.
+
+### Aligning components horizontally
+
+In **SwiftUI**, stack views play a big part in designing your layouts.
+Two separate structures allow you to create stacks:
+
+1. `HStack` for horizontal stack views
+
+2. `VStack` for vertical stack views
+
+The following SwiftUI view adds a globe image and
+text to a horizontal stack view:
+
+{:.include-lang}
+```swift
+HStack {
+  Image(systemName: "globe")
+  Text("Hello, world!")
+}
+```
+
+**Flutter** uses [`Row`][] rather than `HStack`:
+
+<nav class="navbar bg-primary">
+ <ul class="navbar-nav navbar-code ml-auto">
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=5715d4f269f629d274ef1b0e9546853b">Test in DartPad</a>
+  </li>
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/row.dart">View on GitHub</a>
+  </li>
+</ul>
+</nav>
+
+<?code-excerpt "lib/row.dart (row)"?>
+```dart
+Row(
+  mainAxisAlignment: MainAxisAlignment.center,
+  children: const [
+    Icon(CupertinoIcons.globe),
+    Text('Hello, world!'),
+  ],
+),
+```
+
+The `Row` widget requires a `List<Widget>` in the `children` parameter.
+The `mainAxisAlignment` property tells Flutter how to position children
+with extra space. `MainAxisAlignment.center` positions children in the
+center of the main axis. For `Row`, the main axis is the horizontal
+axis.
+
+### Aligning components vertically
+
+The following examples build on those in the previous section.
+
+In **SwiftUI**, you use `VStack` to arrange the components into a
+vertical pillar.
+
+{:.include-lang}
+```swift
+VStack {
+  Image(systemName: "globe")
+  Text("Hello, world!")
+}
+```
+
+**Flutter** uses the same Dart code from the previous example,
+except it swaps [`Column`][] for `Row`:
+
+<nav class="navbar bg-primary">
+ <ul class="navbar-nav navbar-code ml-auto">
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=5e85473354959c0712f05e86d111c584">Test in DartPad</a>
+  </li>
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/column.dart">View on GitHub</a>
+  </li>
+</ul>
+</nav>
+
+<?code-excerpt "lib/column.dart (column)"?>
+```dart
+Column(
+  mainAxisAlignment: MainAxisAlignment.center,
+  children: const [
+    Icon(CupertinoIcons.globe),
+    Text('Hello, world!'),
+  ],
+),
+```
+
+### Displaying a list view
+
+In **SwiftUI**, you use the `List` base component to display sequences
+of items.
+To display a sequence of model objects, make sure that the user can
+identify your model objects.
+To make an object identifiable, use the `Identifiable` protocol.
+
+{:.include-lang}
+```swift
+struct Person: Identifiable {
+  var name: String
+}
+
+var persons = [
+  Person(name: "Person 1"),
+  Person(name: "Person 2"),
+  Person(name: "Person 3"),
+]
+
+struct ListWithPersons: View {
+  let persons: [Person]
+  var body: some View {
+    List {
+      ForEach(persons) { person in
+        Text(person.name)
+      }
+    }
+  }
+}
+```
+
+This resembles how **Flutter** prefers to build its list widgets.
+Flutter doesn't need the list items to be identifiable.
+You set the number of items to display then build a widget for each item.
+
+<nav class="navbar bg-primary">
+ <ul class="navbar-nav navbar-code ml-auto">
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=66e6728e204021e3b9e0190be50d014b">Test in DartPad</a>
+  </li>
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/list.dart">View on GitHub</a>
+  </li>
+</ul>
+</nav>
+
+<?code-excerpt "lib/list.dart (SimpleList)"?>
+```dart
+class Person {
+  String name;
+  Person(this.name);
+}
+
+var items = [
+  Person('Person 1'),
+  Person('Person 2'),
+  Person('Person 3'),
+];
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: ListView.builder(
+        itemCount: items.length,
+        itemBuilder: (context, index) {
+          return ListTile(
+            title: Text(items[index].name),
+          );
+        },
+      ),
+    );
+  }
+}
+```
+
+Flutter has some caveats for lists:
+
+- The [`ListView`] widget has a builder method.
+  This works like the `ForEach` within SwiftUI's `List` struct.
+
+- The `itemCount` parameter of the `ListView` sets how many items
+  the `ListView` displays.
+
+- The `itemBuilder` has an index parameter that will be between zero
+  and one less than itemCount.
+
+The previous example returned a [`ListTile`][] widget for each item.
+The `ListTile` widget includes properties like `height` and `font-size`.
+These properties help build a list. However, Flutter allows you to return
+almost any widget that represents your data.
+
+### Displaying a grid
+
+When constructing non-conditional grids in **SwiftUI**,
+you use `Grid` with `GridRow`.
+
+{:.include-lang}
+```swift
+Grid {
+  GridRow {
+    Text("Row 1")
+    Image(systemName: "square.and.arrow.down")
+    Image(systemName: "square.and.arrow.up")
+  }
+  GridRow {
+    Text("Row 2")
+    Image(systemName: "square.and.arrow.down")
+    Image(systemName: "square.and.arrow.up")
+  }
+}
+```
+
+To display grids in **Flutter**, use the [`GridView`] widget.
+This widget has various constructors. Each constructor has
+a similar goal, but uses different input parameters.
+The following example uses the `.builder()` initializer:
+
+<nav class="navbar bg-primary">
+ <ul class="navbar-nav navbar-code ml-auto">
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=4ac2d2433390042d25c97f1e819ec337">Test in DartPad</a>
+  </li>
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/grid.dart">View on GitHub</a>
+  </li>
+</ul>
+</nav>
+
+<?code-excerpt "lib/grid.dart (GridExample)"?>
+```dart
+const widgets = [
+  Text('Row 1'),
+  Icon(CupertinoIcons.arrow_down_square),
+  Icon(CupertinoIcons.arrow_up_square),
+  Text('Row 2'),
+  Icon(CupertinoIcons.arrow_down_square),
+  Icon(CupertinoIcons.arrow_up_square),
+];
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: GridView.builder(
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 3,
+          mainAxisExtent: 40.0,
+        ),
+        itemCount: widgets.length,
+        itemBuilder: (context, index) => widgets[index],
+      ),
+    );
+  }
+}
+```
+
+The `SliverGridDelegateWithFixedCrossAxisCount` delegate determines
+various parameters that the grid uses to lay out its components.
+This includes `crossAxisCount` that dictates the number of items
+displayed on each row.
+
+How SwiftUI's `Grid` and Flutter's `GridView` differ in that `Grid`
+requires `GridRow`. `GridView` uses the delegate to decide how the
+grid should lay out its components.
+
+### Creating a scroll view
+
+In **SwiftUI**, you use `ScrollView` to create custom scrolling
+components.
+The following example displays a series of `PersonView` instances
+in a scrollable fashion.
+
+{:.include-lang}
+```swift
+ScrollView {
+  VStack(alignment: .leading) {
+    ForEach(persons) { person in
+      PersonView(person: person)
+    }
+  }
+}
+```
+
+To create a scrolling view, **Flutter** uses [`SingleChildScrollView`][].
+In the following example, the function `mockPerson` mocks instances
+of the `Person` class to create the custom `PersonView` widget.
+
+<nav class="navbar bg-primary">
+ <ul class="navbar-nav navbar-code ml-auto">
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=63039c5371995ae53d971d613a936f7b">Test in DartPad</a>
+  </li>
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/scroll.dart">View on GitHub</a>
+  </li>
+</ul>
+</nav>
+
+<?code-excerpt "lib/scroll.dart (ScrollExample)"?>
+```dart
+    SingleChildScrollView(
+  child: Column(
+    children: mockPersons
+        .map(
+          (person) => PersonView(
+            person: person,
+          ),
+        )
+        .toList(),
+  ),
+),
+```
+
+### Responsive and adaptive design
+
+In **SwiftUI**, you use `GeometryReader` to create relative view sizes.
+
+For example, you could:
+* Multiply `geometry.size.width` by some factor to set the _width_.
+* Use `GeometryReader` as a breakpoint to change the design of your app.
+
+You can also see if the size class has `.regular` or `.compact`
+using `horizontalSizeClass`.
+
+To create relative views in **Flutter**, you can use one of two options:
+* Get the `BoxConstraints` object in the [`LayoutBuilder`][] class.
+* Use the [`MediaQuery.of()`][] in your build functions
+  to get the size and orientation of your current app.
+
+To learn more, check out [Creating responsive and adaptive apps][].
+
+### Managing state
+
+In **SwiftUI**, you use the `@State` property wrapper to represent the
+internal state of a SwiftUI view.
+
+{:.include-lang}
+```swift
+struct ContentView: View {
+  @State private var counter = 0;
+  var body: some View {
+    VStack{
+      Button("+") { counter+=1 }
+      Text(String(counter))
+    }
+  }}
+```
+
+**SwiftUI** also includes several options for more complex state
+management such as the `ObservableObject` protocol.
+
+**Flutter** manages local state using a [`StatefulWidget`][].
+Implement a stateful widget with the following two classes:
+- a subclass of `StatefulWidget`
+- a subclass of `State`
+
+The `State` object stores the widget's state.
+To change a widget’s state, call `setState()` from the `State` subclass
+to tell the framework to redraw the widget.
+
+The following example shows a part of a counter app:
+
+<nav class="navbar bg-primary">
+ <ul class="navbar-nav navbar-code ml-auto">
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=c5fcf5897c21456c518ea954c2587ada">Test in DartPad</a>
+  </li>
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/state.dart">View on GitHub</a>
+  </li>
+</ul>
+</nav>
+
+<?code-excerpt "lib/state.dart (State)"?>
+```dart
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({super.key});
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  int _counter = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text('$_counter'),
+            TextButton(
+              onPressed: () => setState(() {
+                _counter++;
+              }),
+              child: const Text('+'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+```
+
+To learn more ways to manage state, check out [State management][].
+
+### Animations
+
+Two main types of UI animations exist.
+- Implicit that animated from a current value to a new target.
+- Explicit that animates when asked.
+
+#### Implicit Animation
+
+SwiftUI and Flutter take a similar approach to animation.
+In both frameworks, you specify parameters like `duration`, and `curve`.
+
+In **SwiftUI**, you use the `animate()` modifier to handle implicit
+animation.
+
+{:.include-lang}
+```swift
+Button(“Tap me!”){
+   angle += 45
+}
+.rotationEffect(.degrees(angle))
+.animation(.easeIn(duration: 1))
+```
+
+**Flutter** includes widgets for implicit animation.
+This simplifies animating common widgets.
+Flutter names these widgets with the following format: `AnimatedFoo`.
+
+For example: To rotate a button, use the [`AnimatedRotation`][] class.
+This animates the `Transform.rotate` widget.
+
+<nav class="navbar bg-primary">
+ <ul class="navbar-nav navbar-code ml-auto">
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=4b9cfedfe9ca09baeb83456fdf7cbe32">Test in DartPad</a>
+  </li>
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/simple_animation.dart">View on GitHub</a>
+  </li>
+</ul>
+</nav>
+
+<?code-excerpt "lib/simple_animation.dart (AnimatedButton)"?>
+```dart
+AnimatedRotation(
+  duration: const Duration(seconds: 1),
+  turns: turns,
+  curve: Curves.easeIn,
+  child: TextButton(
+      onPressed: () {
+        setState(() {
+          turns += .125;
+        });
+      },
+      child: const Text('Tap me!')),
+),
+```
+
+Flutter allows you to create custom implicit animations.
+To compose a new animated widget, use the [`TweenAnimationBuilder`][].
+
+#### Explicit Animation
+
+For explicit animations, **SwiftUI** uses the `withAnimation()` function.
+
+**Flutter** includes explicitly animated widgets with names formatted
+like `FooTransition`.
+One example would be the [`RotationTransition`][] class.
+
+Flutter also allows you to create a custom explicit animation using
+`AnimatedWidget` or `AnimatedBuilder`.
+
+To learn more about animations in Flutter, see [Animations overview][].
+
+### Drawing on the Screen
+
+In **SwiftUI**, you use `CoreGraphics` to draw lines and shapes to the
+screen.
+
+**Flutter** has an API based on the `Canvas` class,
+with two classes that help you draw:
+
+1. [`CustomPaint`][] that requires a painter:
+
+    <nav class="navbar bg-primary">
+    <ul class="navbar-nav navbar-code ml-auto">
+      <li class="nav-item">
+        <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=fccb26fc4bca4c08ca37931089a837e7">Test in DartPad</a>
+      </li>
+      <li class="nav-item">
+        <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/canvas.dart">View on GitHub</a>
+      </li>
+    </ul>
+    </nav>
+
+    <?code-excerpt "lib/canvas.dart (CustomPaint)"?>
+    ```dart
+    CustomPaint(
+      painter: SignaturePainter(_points),
+      size: Size.infinite,
+    ),
+    ```
+
+2. [`CustomPainter`][] that implements your algorithm to draw to the canvas.
+
+    <nav class="navbar bg-primary">
+    <ul class="navbar-nav navbar-code ml-auto">
+      <li class="nav-item">
+        <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=fccb26fc4bca4c08ca37931089a837e7">Test in DartPad</a>
+      </li>
+      <li class="nav-item">
+        <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/canvas.dart">View on GitHub</a>
+      </li>
+    </ul>
+    </nav>
+
+    <?code-excerpt "lib/canvas.dart (CustomPainter)"?>
+    ```dart
+    class SignaturePainter extends CustomPainter {
+      SignaturePainter(this.points);
+
+      final List<Offset?> points;
+
+      @override
+      void paint(Canvas canvas, Size size) {
+        final Paint paint = Paint()
+          ..color = Colors.black
+          ..strokeCap = StrokeCap.round
+          ..strokeWidth = 5.0;
+        for (int i = 0; i < points.length - 1; i++) {
+          if (points[i] != null && points[i + 1] != null) {
+            canvas.drawLine(points[i]!, points[i + 1]!, paint);
+          }
+        }
+      }
+
+      @override
+      bool shouldRepaint(SignaturePainter oldDelegate) =>
+          oldDelegate.points != points;
+    }
+    ```
+
+## Navigation
+
+This section explains how to navigate between pages of an app,
+the push and pop mechanism, and more.
+
+### Navigating between pages
+
+Developers build iOS and macOS apps with different pages called
+_navigation routes_.
+
+In **SwiftUI**, the `NavigationStack` represents this stack of pages.
+
+The following example creates an app that displays a list of persons.
+To display a person's details in a new navigation link,
+tap on that person.
+
+{:.include-lang}
+```swift
+NavigationStack(path: $path) {
+      List {
+        ForEach(persons) { person in
+          NavigationLink(
+            person.name,
+            value: person
+          )
+        }
+      }
+      .navigationDestination(for: Person.self) { person in
+        PersonView(person: person)
+      }
+    }
+```
+
+If you have a small **Flutter** app without complex linking,
+use [`Navigator`][] with named routes.
+After defining your navigation routes,
+call your navigation routes using their names.
+
+1. Name each route in the class passed to the `runApp()` function.
+   The following example uses `App`:
+
+    <nav class="navbar bg-primary">
+    <ul class="navbar-nav navbar-code ml-auto">
+      <li class="nav-item">
+        <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=5ae0624689958c4775b064d39d108d9e">Test in DartPad</a>
+      </li>
+      <li class="nav-item">
+        <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/navigation.dart">View on GitHub</a>
+      </li>
+    </ul>
+    </nav>
+
+    <?code-excerpt "lib/navigation.dart (Routes)"?>
+    ```dart
+    // Defines the route name as a constant
+    // so that it's reusable.
+    const detailsPageRouteName = '/details';
+
+    class App extends StatelessWidget {
+      const App({
+        super.key,
+      });
+
+      @override
+      Widget build(BuildContext context) {
+        return CupertinoApp(
+          home: const HomePage(),
+          // The [routes] property defines the available named routes
+          // and the widgets to build when navigating to those routes.
+          routes: {
+            detailsPageRouteName: (context) => const DetailsPage(),
+          },
+        );
+      }
+    }
+    ```
+
+   The following sample generates a list of persons using
+   `mockPersons()`. Tapping a person pushes the person's detail page
+   to the `Navigator` using `pushNamed()`.
+
+    <nav class="navbar bg-primary">
+    <ul class="navbar-nav navbar-code ml-auto">
+      <li class="nav-item">
+        <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=5ae0624689958c4775b064d39d108d9e">Test in DartPad</a>
+      </li>
+      <li class="nav-item">
+        <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/navigation.dart">View on GitHub</a>
+      </li>
+    </ul>
+    </nav>
+
+    <?code-excerpt "lib/navigation.dart (ListView)"?>
+    ```dart
+    ListView.builder(
+      itemCount: mockPersons.length,
+      itemBuilder: (context, index) {
+        final person = mockPersons.elementAt(index);
+        final age = '${person.age} years old';
+        return ListTile(
+          title: Text(person.name),
+          subtitle: Text(age),
+          trailing: const Icon(
+            Icons.arrow_forward_ios,
+          ),
+          onTap: () {
+            // When a [ListTile] that represents a person is
+            // tapped, push the detailsPageRouteName route
+            // to the Navigator and pass the person's instance
+            // to the route.
+            Navigator.of(context).pushNamed(
+              detailsPageRouteName,
+              arguments: person,
+            );
+          },
+        );
+      },
+    ),
+    ```
+
+1. Define the `DetailsPage` widget that displays the details of
+   each person. In Flutter, you can pass arguments into the
+   widget when navigating to the new route.
+   Extract the arguments using `ModalRoute.of()`:
+
+    <nav class="navbar bg-primary">
+    <ul class="navbar-nav navbar-code ml-auto">
+      <li class="nav-item">
+        <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=5ae0624689958c4775b064d39d108d9e">Test in DartPad</a>
+      </li>
+      <li class="nav-item">
+        <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/navigation.dart">View on GitHub</a>
+      </li>
+    </ul>
+    </nav>
+
+    <?code-excerpt "lib/navigation.dart (DetailsPage)"?>
+    ```dart
+    class DetailsPage extends StatelessWidget {
+      const DetailsPage({super.key});
+
+      @override
+      Widget build(BuildContext context) {
+        // Read the person instance from the arguments.
+        final Person person = ModalRoute.of(
+          context,
+        )?.settings.arguments as Person;
+        // Extract the age.
+        final age = '${person.age} years old';
+        return Scaffold(
+          // Display name and age.
+          body: Column(children: [Text(person.name), Text(age)]),
+        );
+      }
+    }
+    ```
+
+To create more advanced navigation and routing requirements,
+use a routing package such as [go_router][].
+
+To learn more, check out [Navigation and routing][].
+
+### Manually pop back
+
+In **SwiftUI**, you use the `dismiss` environment value to pop-back to
+the previous screen.
+
+{:.include-lang}
+```swift
+Button("Pop back") {
+        dismiss()
+      }
+```
+
+In **Flutter**, use the `pop()` function of the `Navigator` class:
+
+<nav class="navbar bg-primary">
+ <ul class="navbar-nav navbar-code ml-auto">
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=0cf352feaeaea2eb107f784d879e480d">Test in DartPad</a>
+  </li>
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/popback.dart">View on GitHub</a>
+  </li>
+</ul>
+</nav>
+
+<?code-excerpt "lib/popback.dart (PopBackExample)"?>
+```dart
+TextButton(
+  onPressed: () {
+    // This code allows the
+    // view to pop back to its presenter.
+    Navigator.of(context).pop();
+  },
+  child: const Text('Pop back'),
+),
+```
+
+### Navigating to another app
+
+In **SwiftUI**, you use the `openURL` environment variable to open a
+URL to another application.
+
+{:.include-lang}
+```swift
+@Environment(\.openURL) private var openUrl
+
+// View code goes here
+
+ Button("Open website") {
+      openUrl(
+        URL(
+          string: "https://google.com"
+        )!
+      )
+    }
+```
+
+In **Flutter**, use the [`url_launcher`][] plugin.
+
+<nav class="navbar bg-primary">
+ <ul class="navbar-nav navbar-code ml-auto">
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/openapp.dart">View on GitHub</a>
+  </li>
+</ul>
+</nav>
+
+<?code-excerpt "lib/openapp.dart (OpenAppExample)"?>
+```dart
+ CupertinoButton(
+   onPressed: () async {
+     await launchUrl(
+       Uri.parse('https://google.com'),
+     );
+   },
+   child: const Text(
+     'Open website',
+   ),
+),
+```
+
+## Themes, styles, and media
+
+You can style Flutter apps with little effort.
+Styling includes switching between light and dark themes,
+changing the design of your text and UI components,
+and more. This section covers how to style your apps.
+
+### Using dark mode
+
+In **SwiftUI**, you call the `preferredColorScheme()`
+function on a `View` to use dark mode.
+
+In **Flutter**, you can control light and dark mode at the app-level.
+To control the brightness mode, use the `theme` property
+of the `App` class:
+
+<nav class="navbar bg-primary">
+ <ul class="navbar-nav navbar-code ml-auto">
+ <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=c446775c3224787e51fb18b054a08a1c">Test in DartPad</a>
+  </li>
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/cupertino_themes.dart">View on GitHub</a>
+  </li>
+</ul>
+</nav>
+
+<?code-excerpt "lib/cupertino_themes.dart (Theme)"?>
+```dart
+    CupertinoApp(
+  theme: CupertinoThemeData(
+    brightness: Brightness.dark,
+  ),
+  home: HomePage(),
+);
+```
+
+### Styling text
+
+In **SwiftUI**, you use modifier functions to style text.
+For example, to change the font of a `Text` string,
+use the `font()` modifier:
+
+{:.include-lang}
+```swift
+Text("Hello, world!")
+  .font(.system(size: 30, weight: .heavy))
+  .foregroundColor(.yellow)
+```
+
+To style text in **Flutter**, add a `TextStyle` widget as the value
+of the `style` parameter of the `Text` widget.
+
+<nav class="navbar bg-primary">
+ <ul class="navbar-nav navbar-code ml-auto">
+ <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=c446775c3224787e51fb18b054a08a1c">Test in DartPad</a>
+  </li>
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/cupertino_themes.dart">View on GitHub</a>
+  </li>
+</ul>
+</nav>
+
+<?code-excerpt "lib/cupertino_themes.dart (StylingTextExample)"?>
+```dart
+Text(
+  'Hello, world!',
+  style: TextStyle(
+    fontSize: 30,
+    fontWeight: FontWeight.bold,
+    color: CupertinoColors.systemYellow,
+  ),
+),
+```
+
+### Styling buttons
+
+In **SwiftUI**, you use modifier functions to style buttons.
+
+{:.include-lang}
+```swift
+Button("Do something") {
+    // do something when button is tapped
+  }
+  .font(.system(size: 30, weight: .bold))
+  .background(Color.yellow)
+  .foregroundColor(Color.blue)
+}
+```
+
+To style button widgets in **Flutter**, set the style of its child,
+or modify properties on the button itself.
+
+In the following example:
+- The `color` property of `CupertinoButton` sets its `color`.
+- The `color` property of the child `Text` widget sets the button
+  text color.
+
+<nav class="navbar bg-primary">
+ <ul class="navbar-nav navbar-code ml-auto">
+ <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=8ffd244574c98f510c29712f6e6c2204">Test in DartPad</a>
+  </li>
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/stylingbutton.dart">View on GitHub</a>
+  </li>
+</ul>
+</nav>
+
+<?code-excerpt "lib/stylingbutton.dart (StylingButtonExample)"?>
+```dart
+child: CupertinoButton(
+  color: CupertinoColors.systemYellow,
+  onPressed: () {},
+  padding: const EdgeInsets.all(16),
+  child: const Text(
+    'Do something',
+    style: TextStyle(
+      color: CupertinoColors.systemBlue,
+      fontSize: 30,
+      fontWeight: FontWeight.bold,
+    ),
+  ),
+),
+```
+
+### Using custom fonts
+
+In **SwiftUI**, you can use a custom font in your app in two steps.
+First, add the font file to your SwiftUI project. After adding the file,
+use the `.font()` modifier to apply it to your UI components.
+
+{:.include-lang}
+```swift
+Text("Hello")
+  .font(
+    Font.custom(
+      "BungeeSpice-Regular",
+      size: 40
+    )
+  )
+```
+
+In **Flutter**, you control your resources with a file
+named `pubspec.yaml`. This file is platform agnostic.
+To add a custom font to your project, follow these steps:
+
+1. Create a folder called `fonts` in the project's root directory.
+   This optional step helps to organize your fonts.
+1. Add your `.ttf`, `.otf`, or `.ttc` font file into the `fonts` folder.
+1. Open the `pubspec.yaml` file within the project.
+1. Find the `flutter` section.
+1. Add your custom font(s) under the `fonts` section.
+
+    ```
+    flutter:
+      fonts:
+        - family: BungeeSpice
+          fonts:
+            - asset: fonts/BungeeSpice-Regular.ttf
+    ```
+
+After you add the font to your project, you can use it as in the
+following example:
+
+<nav class="navbar bg-primary">
+ <ul class="navbar-nav navbar-code ml-auto">
+  <li class="nav-item">
+    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/stylingbutton.dart">View on GitHub</a>
+  </li>
+</ul>
+</nav>
+
+<?code-excerpt "lib/stylingbutton.dart (CustomFont)"?>
+```dart
+Text(
+  'Cupertino',
+  style: TextStyle(
+    fontSize: 40,
+    fontFamily: 'BungeeSpice',
+  ),
+)
+```
+
+{{site.alert.note}}
+  To download custom fonts to use in your apps,
+  check out [Google Fonts](https://fonts.google.com).
+{{site.alert.end}}
+
+### Bundling images in apps
+
+In **SwiftUI**, you first add the image files to `Assets.xcassets`,
+then use the `Image` view to display the images.
+
+To add images in **Flutter**, follow a method similar to how you added
+custom fonts.
+1. Add an `images` folder to the root directory.
+1. Add this asset to the `pubspec.yaml` file.
+
+    ```
+    flutter:
+      assets:
+        - images/Blueberries.jpg
+    ```
+
+After adding your image, display it using the `Image` widget's
+`.asset()` constructor. This constructor:
+1. Instantiates the given image using the provided path.
+1. Reads the image from the assets bundled with your app.
+1. Displays the image on the screen.
+
+To review a complete example, check out the [`Image`][] docs.
+
+### Bundling videos in apps
+
+In **SwiftUI**, you bundle a local video file with your app in two
+steps.
+First, you import the `AVKit` framework, then you instantiate a
+`VideoPlayer` view.
+
+In **Flutter**, add the [video_player][] plugin to your project.
+This plugin allows you to create a video player that works on
+Android, iOS, and on the web from the same codebase.
+
+1. Add the plugin to your app and add the video file to your project.
+1. Add the asset to your `pubspec.yaml` file.
+1. Use the `VideoPlayerController` class to load and play your video
+   file.
+
+To review a complete walkthrough, check out the [video_player example][].
+
+[Flutter for UIKit developers]: {{site.url}}/get-started/flutter-for/uikit-devs
+[Add Flutter to existing app]: {{site.url}}/development/add-to-app
+[Animations overview]: {{site.url}}/development/ui/animations
+[Cupertino widgets]: {{site.url}}/development/ui/widgets/cupertino
+[Flutter concurrency for Swift developers]: {{site.url}}/resources/dart-swift-concurrency
+[Navigation and routing]: {{site.url}}/development/ui/navigation
+[Material]: {{site.material}}/develop/flutter/
+[Platform adaptations]: {{site.url}}/resources/platform-adaptations
+[`url_launcher`]: {{site.pub-pkg}}/url_launcher
+[widget catalog]: {{site.url}}/development/ui/widgets/layout
+[Understanding constraints]: {{site.url}}/development/ui/layout/constraints
+[`WidgetApp`]: {{site.api}}/flutter/widgets/WidgetsApp-class.html
+[`CupertinoApp`]: {{site.api}}/flutter/cupertino/CupertinoApp-class.html
+[`Center`]: {{site.api}}/flutter/widgets/Center-class.html
+[`CupertinoButton`]: {{site.api}}/flutter/cupertino/CupertinoButton-class.html
+[`Row`]: {{site.api}}/flutter/widgets/Row-class.html
+[`Column`]: {{site.api}}/flutter/widgets/Column-class.html
+[Learning Dart as a Swift Developer]: {{site.dart-site}}/guides/language/coming-from/swift-to-dart
+[`ListView`]: {{site.api}}/flutter/widgets/ListView-class.html
+[`ListTile`]: {{site.api}}/flutter/widgets/ListTitle-class.html
+[`GridView`]: {{site.api}}/flutter/widgets/GridView-class.html
+[`SingleChildScrollView`]: {{site.api}}/flutter/widgets/SingleChildScrollView-class.html
+[`LayoutBuilder`]: {{site.api}}/flutter/widgets/LayoutBuilder-class.html
+[`AnimatedRotation`]: {{site.api}}/flutter/widgets/AnimatedRotation-class.html
+[`TweenAnimationBuilder`]: {{site.api}}/flutter/widgets/TweenAnimationBuilder-class.html
+[`RotationTransition`]: {{site.api}}/flutter/widgets/RotationTransition-class.html
+[`Navigator`]: {{site.api}}/flutter/widgets/Navigator-class.html
+[`StatefulWidget`]: {{site.api}}/flutter/widgets/StatefulWidget-class.html
+[State management]:  {{site.url}}/development/data-and-backend/state-mgmt
+[Wonderous]: https://flutter.gskinner.com/wonderous/?utm_source=flutterdocs&utm_medium=docs&utm_campaign=iosdevs
+[video_player]: {{site.pub-pkg}}/video_player
+[video_player example]: {{site.pub-pkg}}/video_player/example
+[Creating responsive and adaptive apps]: {{site.url}}/development/ui/layout/adaptive-responsive
+[`MediaQuery.of()`]: {{site.api}}/flutter/widgets/MediaQuery-class.html
+[`CustomPaint`]: {{site.api}}/flutter/widgets/CustomPaint-class.html
+[`CustomPainter`]: {{site.api}}/flutter/rendering/CustomPainter-class.html
+[`Image`]: {{site.api}}/flutter/widgets/Image-class.html
+[go_router]: {{site.pub-pkg}}/go_router

--- a/src/get-started/flutter-for/uikit-devs.md
+++ b/src/get-started/flutter-for/uikit-devs.md
@@ -1,19 +1,18 @@
 ---
-title: Flutter for iOS developers
-description: Learn how to apply iOS developer knowledge when building Flutter apps.
+title: Flutter for UIKit developers
+description: Learn how to apply iOS and UIKit developer knowledge when building Flutter apps.
 ---
 
 <?code-excerpt path-base="get-started/flutter-for/ios_devs"?>
 
-{% assign sample_path = "blob/main/examples/get-started/flutter-for/ios_devs" %}
-
-iOS developers who want to write mobile apps using Flutter
+iOS developers with experience using UIKit
+who want to write mobile apps using Flutter
 should review this guide.
-It explains how to apply existing iOS knowledge to Flutter.
+It explains how to apply existing UIKit knowledge to Flutter.
 
 {{site.alert.note}}
-  To integrate Flutter code into your **existing** iOS app, check out
-  [Add Flutter to existing app][].
+  If you have experience building apps with SwiftUI,
+  check out [Flutter for SwiftUI developers][] instead.
 {{site.alert.end}}
 
 Flutter is a framework for building cross-platform applications
@@ -22,1347 +21,26 @@ To understand some differences between programming with Dart
 and programming with Swift, see [Learning Dart as a Swift Developer][]
 and [Flutter concurrency for Swift developers][].
 
-Your iOS knowledge helps when building Flutter apps.
-<!-- Add this sentence once published -->
-<!-- To learn more, check out [iOS and Apple hardware interactions with Flutter][] -->
+Your iOS and UIKit knowledge and experience
+are highly valuable when building with Flutter.
+{% comment %}
+  TODO: Add talk about plugin system for interacting with OS and hardware
+  when [iOS and Apple hardware interactions with Flutter][] is released.
+{% endcomment -%}
 
-Flutter adapts its framework when running on iOS.
-To learn how, check out [Platform adaptations][].
+Flutter also makes a number of adaptations
+to app behavior when running on iOS.
+To learn how, see [Platform adaptations][].
+
+{{site.alert.info}}
+  To integrate Flutter code into an **existing** iOS app, 
+  check out [Add Flutter to existing app][].
+{{site.alert.end}}
 
 This document can be used as a cookbook by jumping around
 and finding questions that are most relevant to your needs.
-This guide embeds sample code.
-You can test full working examples on DartPad or view them on GitHub.
 
-<!-- Embed intro to iOS video when published -->
-
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="editor-setup" role="tablist">
-  <li class="nav-item">
-    <a class="nav-link active" id="swiftui-tab" href="#swiftui" role="tab" aria-controls="swiftui" aria-selected="true">SwiftUI</a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link" id="uikit-tab" href="#uikit" role="tab" aria-controls="uikit" aria-selected="false">UIKit</a>
-  </li>
-</ul>
-
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-
-<div class="tab-pane active" id="swiftui" role="tabpanel" aria-labelledby="swiftui-tab" markdown="1">
-
-## SwiftUI Overview
-
-This section outlines how SwiftUI resembles and differs from Flutter.
-
-### Views vs. Widgets
-
-Flutter and SwiftUI code describes how the UI looks and works.
-Developers call this type of code a _declarative framework_.
-
-**SwiftUI** represents UI components as _views_.
-You configure views using _modifiers_.
-
-```swift
-Text("Hello, World!") // <-- This is a View
-  .padding(10)        // <-- This is a modifier of that View
-```
-
-**Flutter** represents UI components as _widgets_.
-
-Both views and widgets only exist until they need to be changed.
-These languages call this property _immutability_.
-SwiftUI represents a UI component property as a View modifier.
-By contrast, Flutter uses widgets for both UI components and
-their properties.
-
-{:.include-lang}
-```dart
-Padding(                         // <-- This is a Widget
-  padding: EdgeInsets.all(10.0), // <-- So is this
-  child: Text("Hello, World!"),  // <-- This, too
-)));
-```
-
-To compose layouts, both SwiftUI and Flutter nest UI components
-within one another.
-SwiftUI nests Views while Flutter nests Widgets.
-
-### Layout process
-
-**SwiftUI** lays out views using the following process:
-
-1. The parent view proposes a size to its child view.
-1. All subsequent child views:
-   - propose a size to _their_ child's view
-   - ask that child what size it wants
-1. Each parent view renders its child view at the returned size.
-
-**Flutter** differs somewhat with its process:
-
-1. The parent widget passes constraints down to its children.
-Constraints include minimum and maximum values for height and width.
-1. The child tries to decide its size. It repeats the same process with its own list of children:
-   - It informs its child of the child's constraints.
-   - It asks its child what size it wishes to be.
-
-1. The parent lays out the child.
-   - If the requested size fits in the constraints,
-     the parent uses that size.
-   - If the requested size doesn't fit in the constraints,
-     the parent limits the height, width, or both to fit in
-     its constraints.
-
-Flutter differs from SwiftUI because the parent component can override
-the child’s desired size. The widget cannot have any size it wants.
-It also cannot know or decide its position on screen as its parent
-makes that decision.
-
-To force a child widget to render at a specific size,
-the parent must set tight constraints.
-A constraint becomes tight when its constraint's minimum size value
-equals its maximum size value.
-
-In **SwiftUI**, views may expand to the available space or
-limit their size to that of its content.
-**Flutter** widgets behave in similar manner.
-
-However, in Flutter parent widgets can offer unbounded constraints.
-Unbounded constraints set their maximum values to infinity.
-
-{:.include-lang}
-```dart
-UnboundedBox(
-  child: Container(
-      width: double.infinity, height: double.infinity, color: red),
-)
-```
-
-If the child expands and it has unbounded constraints,
-Flutter returns an overflow warning:
-
-{:.include-lang}
-```dart
-UnconstrainedBox(
-  child: Container(color: red, width: 4000, height: 50),
-)
-```
-
-<img src="/assets/images/docs/ui/layout/layout-14.png" alt="When parents pass unbounded constraints to children, and the children are expanding, then there is an overflow warning">
-
-To learn how constraints work in Flutter,
-see [Understanding constraints][].
-
-### Design system
-
-Because Flutter targets multiple platforms, your app doesn’t need
-to conform to any design system.
-Though this guide features [Material][] widgets,
-your Flutter app can use many different design systems:
-
-- Custom Material widgets
-- Community built widgets
-- Your own custom widgets
-- [Cupertino widgets][] that follow Apple’s Human Interface Guidelines
-
-<iframe width="560" height="315" src="{{site.youtube-site}}/embed/3PdUaidHc-E?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-If you're looking for a great reference app that features a
-custom design system, check out [Wonderous][].
-
-## UI Basics
-
-This section covers the basics of UI development in
-Flutter and how it compares to SwiftUI.
-This includes how to start developing your app, display static text,
-create buttons, react to on-press events, display lists, grids, and more.
-
-### Getting started
-
-In **SwiftUI**, you use `App` to start your app.
-
-```swift
-@main
-struct MyApp: App {
-    var body: some Scene {
-        WindowGroup {
-            HomePage()
-        }
-    }
-}
-```
-
-Another common SwiftUI practice places the app body within a `struct`
-that conforms to the `View` protocol as follows:
-
-```swift
-struct HomePage: View {
-  var body: some View {
-    Text("Hello, World!")
-  }
-}
-```
-
-To start your **Flutter** app, pass in an instance of your app to
-the `runApp` function.
-
-<nav class="navbar bg-primary">
- <ul class="navbar-nav navbar-code ml-auto">
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=d3d38ae68f7d6444421d0485a1fd02db">Test in DartPad</a>
-  </li>
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/get_started.dart">View on GitHub</a>
-  </li>
-</ul>
-</nav>
-
-<?code-excerpt "lib/get_started.dart (main)"?>
-```dart
-void main() {
-  runApp(const MyApp());
-}
-```
-
-`App` is a widget. The build method describes the part of the
-user interface it represents.
-It’s common to begin your app with a [`WidgetApp`][] class,
-like [`CupertinoApp`][].
-
-<nav class="navbar bg-primary">
- <ul class="navbar-nav navbar-code ml-auto">
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=d3d38ae68f7d6444421d0485a1fd02db">Test in DartPad</a>
-  </li>
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/get_started.dart">View on GitHub</a>
-  </li>
-</ul>
-</nav>
-
-<?code-excerpt "lib/get_started.dart (myapp)"?>
-```dart
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    // Returns a CupertinoApp that, by default,
-    // has the look and feel of an iOS app.
-    return const CupertinoApp(
-      home: HomePage(),
-    );
-  }
-}
-```
-
-The widget used in `HomePage` might begin with the `Scaffold` class.
-`Scaffold` implements a basic layout structure for an app.
-
-<nav class="navbar bg-primary">
- <ul class="navbar-nav navbar-code ml-auto">
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=d3d38ae68f7d6444421d0485a1fd02db">Test in DartPad</a>
-  </li>
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/get_started.dart">View on GitHub</a>
-  </li>
-</ul>
-</nav>
-
-<?code-excerpt "lib/get_started.dart (homepage)"?>
-```dart
-class HomePage extends StatelessWidget {
-  const HomePage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: Text(
-          'Hello, World!',
-        ),
-      ),
-    );
-  }
-}
-```
-
-Note how Flutter uses the [`Center`][] widget.
-SwiftUI renders a view's contents in its center by default.
-That’s not always the case with Flutter.
-`Scaffold` doesn’t render its `body` widget at the center of the screen.
-To center the text, wrap it in a `Center` widget.
-To learn about different widgets and their default behaviors, check out
-the [Widget catalog][].
-
-### Adding Buttons
-
-In **SwiftUI**, you use the `Button` struct to create a button.
-
-{:.include-lang}
-```swift
-Button("Do something") {
-  // this closure gets called when your
-  // button is tapped
-}
-```
-
-To achieve the same result in **Flutter**,
-use the `CupertinoButton` class:
-
-<nav class="navbar bg-primary">
- <ul class="navbar-nav navbar-code ml-auto">
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=b776dfe43c91e580c66b2b93368745eb">Test in DartPad</a>
-  </li>
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/text_button.dart">View on GitHub</a>
-  </li>
-</ul>
-</nav>
-
-<?code-excerpt "lib/text_button.dart (textbutton)"?>
-```dart
-        CupertinoButton(
-  onPressed: () {
-    // This closure is called when your button is tapped.
-  },
-  child: const Text('Do something'),
-)
-```
-
-**Flutter** gives you access to a variety of buttons with predefined styles.
-The [`CupertinoButton`][] class comes from the Cupertino library.
-Widgets in the Cupertino library use Apple's design system.
-
-### Aligning components horizontally
-
-In **SwiftUI**, stack views play a big part in designing your layouts.
-Two separate structures allow you to create stacks:
-
-1. `HStack` for horizontal stack views
-
-2. `VStack` for vertical stack views
-
-The following SwiftUI view adds a globe image and
-text to a horizontal stack view:
-
-{:.include-lang}
-```swift
-HStack {
-  Image(systemName: "globe")
-  Text("Hello, world!")
-}
-```
-
-**Flutter** uses [`Row`][] rather than `HStack`:
-
-<nav class="navbar bg-primary">
- <ul class="navbar-nav navbar-code ml-auto">
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=5715d4f269f629d274ef1b0e9546853b">Test in DartPad</a>
-  </li>
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/row.dart">View on GitHub</a>
-  </li>
-</ul>
-</nav>
-
-<?code-excerpt "lib/row.dart (row)"?>
-```dart
-Row(
-  mainAxisAlignment: MainAxisAlignment.center,
-  children: const [
-    Icon(CupertinoIcons.globe),
-    Text('Hello, world!'),
-  ],
-),
-```
-
-The `Row` widget requires a `List<Widget>` in the `children` parameter.
-The `mainAxisAlignment` property tells Flutter how to position children
-with extra space. `MainAxisAlignment.center` positions children in the
-center of the main axis. For `Row`, the main axis is the horizontal
-axis.
-
-### Aligning components vertically
-
-The following examples build on those in the previous section.
-
-In **SwiftUI**, you use `VStack` to arrange the components into a
-vertical pillar.
-
-{:.include-lang}
-```swift
-VStack {
-  Image(systemName: "globe")
-  Text("Hello, world!")
-}
-```
-
-**Flutter** uses the same Dart code from the previous example,
-except it swaps [`Column`][] for `Row`:
-
-<nav class="navbar bg-primary">
- <ul class="navbar-nav navbar-code ml-auto">
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=5e85473354959c0712f05e86d111c584">Test in DartPad</a>
-  </li>
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/column.dart">View on GitHub</a>
-  </li>
-</ul>
-</nav>
-
-<?code-excerpt "lib/column.dart (column)"?>
-```dart
-Column(
-  mainAxisAlignment: MainAxisAlignment.center,
-  children: const [
-    Icon(CupertinoIcons.globe),
-    Text('Hello, world!'),
-  ],
-),
-```
-
-### Displaying a list view
-
-In **SwiftUI**, you use the `List` base component to display sequences
-of items.
-To display a sequence of model objects, make sure that the user can
-identify your model objects.
-To make an object identifiable, use the `Identifiable` protocol.
-
-{:.include-lang}
-```swift
-struct Person: Identifiable {
-  var name: String
-}
-
-var persons = [
-  Person(name: "Person 1"),
-  Person(name: "Person 2"),
-  Person(name: "Person 3"),
-]
-
-struct ListWithPersons: View {
-  let persons: [Person]
-  var body: some View {
-    List {
-      ForEach(persons) { person in
-        Text(person.name)
-      }
-    }
-  }
-}
-```
-
-This resembles how **Flutter** prefers to build its list widgets.
-Flutter doesn't need the list items to be identifiable.
-You set the number of items to display then build a widget for each item.
-
-<nav class="navbar bg-primary">
- <ul class="navbar-nav navbar-code ml-auto">
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=66e6728e204021e3b9e0190be50d014b">Test in DartPad</a>
-  </li>
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/list.dart">View on GitHub</a>
-  </li>
-</ul>
-</nav>
-
-<?code-excerpt "lib/list.dart (SimpleList)"?>
-```dart
-class Person {
-  String name;
-  Person(this.name);
-}
-
-var items = [
-  Person('Person 1'),
-  Person('Person 2'),
-  Person('Person 3'),
-];
-
-class HomePage extends StatelessWidget {
-  const HomePage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: ListView.builder(
-        itemCount: items.length,
-        itemBuilder: (context, index) {
-          return ListTile(
-            title: Text(items[index].name),
-          );
-        },
-      ),
-    );
-  }
-}
-```
-
-Flutter has some caveats for lists:
-
-- The [`ListView`] widget has a builder method.
-This works like the `ForEach` within SwiftUI's `List` struct.
-
-- The `itemCount` parameter of the `ListView` sets how many items 
-the `ListView` displays.
-
-- The `itemBuilder` has an index parameter that will be between zero 
-and one less than itemCount.
-
-The previous example returned a [`ListTile`][] widget for each item.
-The `ListTile` widget includes properties like `height` and `font-size`.
-These properties help build a list. However, Flutter allows you to return
-almost any widget that represents your data.
-
-### Displaying a grid
-
-When constructing non-conditional grids in **SwiftUI**,
-you use `Grid` with `GridRow`.
-
-{:.include-lang}
-```swift
-Grid {
-  GridRow {
-    Text("Row 1")
-    Image(systemName: "square.and.arrow.down")
-    Image(systemName: "square.and.arrow.up")
-  }
-  GridRow {
-    Text("Row 2")
-    Image(systemName: "square.and.arrow.down")
-    Image(systemName: "square.and.arrow.up")
-  }
-}
-```
-
-To display grids in **Flutter**, use the [`GridView`] widget.
-This widget has various constructors. Each constructor has
-a similar goal, but uses different input parameters.
-The following example uses the `.builder()` initializer:
-
-<nav class="navbar bg-primary">
- <ul class="navbar-nav navbar-code ml-auto">
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=4ac2d2433390042d25c97f1e819ec337">Test in DartPad</a>
-  </li>
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/grid.dart">View on GitHub</a>
-  </li>
-</ul>
-</nav>
-
-<?code-excerpt "lib/grid.dart (GridExample)"?>
-```dart
-const widgets = [
-  Text('Row 1'),
-  Icon(CupertinoIcons.arrow_down_square),
-  Icon(CupertinoIcons.arrow_up_square),
-  Text('Row 2'),
-  Icon(CupertinoIcons.arrow_down_square),
-  Icon(CupertinoIcons.arrow_up_square),
-];
-
-class HomePage extends StatelessWidget {
-  const HomePage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: GridView.builder(
-        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: 3,
-          mainAxisExtent: 40.0,
-        ),
-        itemCount: widgets.length,
-        itemBuilder: (context, index) => widgets[index],
-      ),
-    );
-  }
-}
-```
-
-The `SliverGridDelegateWithFixedCrossAxisCount` delegate determines
-various parameters that the grid uses to lay out its components.
-This includes `crossAxisCount` that dictates the number of items
-displayed on each row.
-
-How SwiftUI's `Grid` and Flutter's `GridView` differ in that `Grid`
-requires `GridRow`. `GridView` uses the delegate to decide how the
-grid should lay out its components.
-
-### Creating a scroll view
-
-In **SwiftUI**, you use `ScrollView` to create custom scrolling
-components.
-The following example displays a series of `PersonView` instances
-in a scrollable fashion.
-
-{:.include-lang}
-```swift
-ScrollView {
-  VStack(alignment: .leading) {
-    ForEach(persons) { person in
-      PersonView(person: person)
-    }
-  }
-}
-```
-
-To create a scrolling view, **Flutter** uses [`SingleChildScrollView`][].
-In the following example, the function `mockPerson` mocks instances
-of the `Person` class to create the custom `PersonView` widget.
-
-<nav class="navbar bg-primary">
- <ul class="navbar-nav navbar-code ml-auto">
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=63039c5371995ae53d971d613a936f7b">Test in DartPad</a>
-  </li>
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/scroll.dart">View on GitHub</a>
-  </li>
-</ul>
-</nav>
-
-<?code-excerpt "lib/scroll.dart (ScrollExample)"?>
-```dart
-    SingleChildScrollView(
-  child: Column(
-    children: mockPersons
-        .map(
-          (person) => PersonView(
-            person: person,
-          ),
-        )
-        .toList(),
-  ),
-),
-```
-
-### Responsive and adaptive design
-
-In **SwiftUI**, you use `GeometryReader` to create relative view sizes.
-
-For example, you could:
-* Multiply `geometry.size.width` by some factor to set the _width_.
-* Use `GeometryReader` as a breakpoint to change the design of your app.
-
-You can also see if the size class has `.regular` or `.compact`
-using `horizontalSizeClass`.
-
-To create relative views in **Flutter**, you can use one of two options:
-* Get the `BoxConstraints` object in the [`LayoutBuilder`][] class.
-* Use the [`MediaQuery.of()`][] in your build functions
-to get the size and orientation of your current app.
-
-To learn more, check out [Creating responsive and adaptive apps][].
-
-### Managing state
-
-In **SwiftUI**, you use the `@State` property wrapper to represent the
-internal state of a SwiftUI view.
-
-{:.include-lang}
-```swift
-struct ContentView: View {
-  @State private var counter = 0;
-  var body: some View {
-    VStack{
-      Button("+") { counter+=1 }
-      Text(String(counter))
-    }
-  }}
-```
-
-**SwiftUI** also includes several options for more complex state
-management such as the `ObservableObject` protocol.
-
-**Flutter** manages local state using a [`StatefulWidget`][].
-Implement a stateful widget with the following two classes:
-- a subclass of `StatefulWidget`
-- a subclass of `State`
-
-The `State` object stores the widget's state.
-To change a widget’s state, call `setState()` from the `State` subclass
-to tell the framework to redraw the widget.
-
-The following example shows a part of a counter app:
-
-<nav class="navbar bg-primary">
- <ul class="navbar-nav navbar-code ml-auto">
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=c5fcf5897c21456c518ea954c2587ada">Test in DartPad</a>
-  </li>
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/state.dart">View on GitHub</a>
-  </li>
-</ul>
-</nav>
-
-<?code-excerpt "lib/state.dart (State)"?>
-```dart
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key});
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Text('$_counter'),
-            TextButton(
-              onPressed: () => setState(() {
-                _counter++;
-              }),
-              child: const Text('+'),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-```
-
-To learn more ways to manage state, check out [State management][].
-
-### Animations
-
-Two main types of UI animations exist.
-- Implicit that animated from a current value to a new target.
-- Explicit that animates when asked.
-
-#### Implicit Animation
-
-SwiftUI and Flutter take a similar approach to animation.
-In both frameworks, you specify parameters like `duration`, and `curve`.
-
-In **SwiftUI**, you use the `animate()` modifier to handle implicit
-animation.
-
-{:.include-lang}
-```swift
-Button(“Tap me!”){
-   angle += 45
-}
-.rotationEffect(.degrees(angle))
-.animation(.easeIn(duration: 1))
-```
-
-**Flutter** includes widgets for implicit animation.
-This simplifies animating common widgets.
-Flutter names these widgets with the following format: `AnimatedFoo`.
-
-For example: To rotate a button, use the [`AnimatedRotation`][] class.
-This animates the `Transform.rotate` widget.
-
-<nav class="navbar bg-primary">
- <ul class="navbar-nav navbar-code ml-auto">
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=4b9cfedfe9ca09baeb83456fdf7cbe32">Test in DartPad</a>
-  </li>
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/simple_animation.dart">View on GitHub</a>
-  </li>
-</ul>
-</nav>
-
-<?code-excerpt "lib/simple_animation.dart (AnimatedButton)"?>
-```dart
-AnimatedRotation(
-  duration: const Duration(seconds: 1),
-  turns: turns,
-  curve: Curves.easeIn,
-  child: TextButton(
-      onPressed: () {
-        setState(() {
-          turns += .125;
-        });
-      },
-      child: const Text('Tap me!')),
-),
-```
-
-Flutter allows you to create custom implicit animations.
-To compose a new animated widget, use the [`TweenAnimationBuilder`][].
-
-#### Explicit Animation
-
-For explicit animations, **SwiftUI** uses the `withAnimation()` function.
-
-**Flutter** includes explicitly animated widgets with names formatted
-like `FooTransition`.
-One example would be the [`RotationTransition`][] class.
-
-Flutter also allows you to create a custom explicit animation using
-`AnimatedWidget` or `AnimatedBuilder`.
-
-To learn more about animations in Flutter, see [Animations overview][].
-
-### Drawing on the Screen
-
-In **SwiftUI**, you use `CoreGraphics` to draw lines and shapes to the
-screen.
-
-**Flutter** has an API based on the `Canvas` class,
-with two classes that help you draw:
-
-1. [`CustomPaint`][] that requires a painter:
-
-    <nav class="navbar bg-primary">
-    <ul class="navbar-nav navbar-code ml-auto">
-      <li class="nav-item">
-        <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=fccb26fc4bca4c08ca37931089a837e7">Test in DartPad</a>
-      </li>
-      <li class="nav-item">
-        <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/canvas.dart">View on GitHub</a>
-      </li>
-    </ul>
-    </nav>
-
-    <?code-excerpt "lib/canvas.dart (CustomPaint)"?>
-    ```dart
-    CustomPaint(
-      painter: SignaturePainter(_points),
-      size: Size.infinite,
-    ),
-    ```
-
-2. [`CustomPainter`][] that implements your algorithm to draw to the canvas.
-
-    <nav class="navbar bg-primary">
-    <ul class="navbar-nav navbar-code ml-auto">
-      <li class="nav-item">
-        <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=fccb26fc4bca4c08ca37931089a837e7">Test in DartPad</a>
-      </li>
-      <li class="nav-item">
-        <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/canvas.dart">View on GitHub</a>
-      </li>
-    </ul>
-    </nav>
-
-    <?code-excerpt "lib/canvas.dart (CustomPainter)"?>
-    ```dart
-    class SignaturePainter extends CustomPainter {
-      SignaturePainter(this.points);
-
-      final List<Offset?> points;
-
-      @override
-      void paint(Canvas canvas, Size size) {
-        final Paint paint = Paint()
-          ..color = Colors.black
-          ..strokeCap = StrokeCap.round
-          ..strokeWidth = 5.0;
-        for (int i = 0; i < points.length - 1; i++) {
-          if (points[i] != null && points[i + 1] != null) {
-            canvas.drawLine(points[i]!, points[i + 1]!, paint);
-          }
-        }
-      }
-
-      @override
-      bool shouldRepaint(SignaturePainter oldDelegate) =>
-          oldDelegate.points != points;
-    }
-    ```
-
-## Navigation
-
-This section explains how to navigate between pages of an app,
-the push and pop mechanism, and more.
-
-### Navigating between pages
-
-Developers build iOS and macOS apps with different pages called
-_navigation routes_.
-
-In **SwiftUI**, the `NavigationStack` represents this stack of pages.
-
-The following example creates an app that displays a list of persons.
-To display a person's details in a new navigation link,
-tap on that person.
-
-{:.include-lang}
-```swift
-NavigationStack(path: $path) {
-      List {
-        ForEach(persons) { person in
-          NavigationLink(
-            person.name,
-            value: person
-          )
-        }
-      }
-      .navigationDestination(for: Person.self) { person in
-        PersonView(person: person)
-      }
-    }
-```
-
-If you have a small **Flutter** app without complex linking,
-use [`Navigator`][] with named routes.
-After defining your navigation routes,
-call your navigation routes using their names.
-
-1. Name each route in the class passed to the `runApp()` function.
-    The following example uses `App`:
-
-    <nav class="navbar bg-primary">
-    <ul class="navbar-nav navbar-code ml-auto">
-      <li class="nav-item">
-        <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=5ae0624689958c4775b064d39d108d9e">Test in DartPad</a>
-      </li>
-      <li class="nav-item">
-        <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/navigation.dart">View on GitHub</a>
-      </li>
-    </ul>
-    </nav>
-
-    <?code-excerpt "lib/navigation.dart (Routes)"?>
-    ```dart
-    // Defines the route name as a constant
-    // so that it's reusable.
-    const detailsPageRouteName = '/details';
-
-    class App extends StatelessWidget {
-      const App({
-        super.key,
-      });
-
-      @override
-      Widget build(BuildContext context) {
-        return CupertinoApp(
-          home: const HomePage(),
-          // The [routes] property defines the available named routes
-          // and the widgets to build when navigating to those routes.
-          routes: {
-            detailsPageRouteName: (context) => const DetailsPage(),
-          },
-        );
-      }
-    }
-    ```
-
-    The following sample generates a list of persons using
-    `mockPersons()`. Tapping a person pushes the person's detail page
-    to the `Navigator` using `pushNamed()`.
-
-    <nav class="navbar bg-primary">
-    <ul class="navbar-nav navbar-code ml-auto">
-      <li class="nav-item">
-        <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=5ae0624689958c4775b064d39d108d9e">Test in DartPad</a>
-      </li>
-      <li class="nav-item">
-        <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/navigation.dart">View on GitHub</a>
-      </li>
-    </ul>
-    </nav>
-
-    <?code-excerpt "lib/navigation.dart (ListView)"?>
-    ```dart
-    ListView.builder(
-      itemCount: mockPersons.length,
-      itemBuilder: (context, index) {
-        final person = mockPersons.elementAt(index);
-        final age = '${person.age} years old';
-        return ListTile(
-          title: Text(person.name),
-          subtitle: Text(age),
-          trailing: const Icon(
-            Icons.arrow_forward_ios,
-          ),
-          onTap: () {
-            // When a [ListTile] that represents a person is
-            // tapped, push the detailsPageRouteName route
-            // to the Navigator and pass the person's instance
-            // to the route.
-            Navigator.of(context).pushNamed(
-              detailsPageRouteName,
-              arguments: person,
-            );
-          },
-        );
-      },
-    ),
-    ```
-
-1. Define the `DetailsPage` widget that displays the details of
-each person. In Flutter, you can pass arguments into the
-widget when navigating to the new route.
-Extract the arguments using `ModalRoute.of()`:
-
-    <nav class="navbar bg-primary">
-    <ul class="navbar-nav navbar-code ml-auto">
-      <li class="nav-item">
-        <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=5ae0624689958c4775b064d39d108d9e">Test in DartPad</a>
-      </li>
-      <li class="nav-item">
-        <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/navigation.dart">View on GitHub</a>
-      </li>
-    </ul>
-    </nav>
-
-    <?code-excerpt "lib/navigation.dart (DetailsPage)"?>
-    ```dart
-    class DetailsPage extends StatelessWidget {
-      const DetailsPage({super.key});
-
-      @override
-      Widget build(BuildContext context) {
-        // Read the person instance from the arguments.
-        final Person person = ModalRoute.of(
-          context,
-        )?.settings.arguments as Person;
-        // Extract the age.
-        final age = '${person.age} years old';
-        return Scaffold(
-          // Display name and age.
-          body: Column(children: [Text(person.name), Text(age)]),
-        );
-      }
-    }
-    ```
-
-To create more advanced navigation and routing requirements,
-use a routing package such as [go_router][].
-
-To learn more, check out [Navigation and routing][].
-
-### Manually pop back
-
-In **SwiftUI**, you use the `dismiss` environment value to pop-back to
-the previous screen.
-
-{:.include-lang}
-```swift
-Button("Pop back") {
-        dismiss()
-      }
-```
-
-In **Flutter**, use the `pop()` function of the `Navigator` class:
-
-<nav class="navbar bg-primary">
- <ul class="navbar-nav navbar-code ml-auto">
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=0cf352feaeaea2eb107f784d879e480d">Test in DartPad</a>
-  </li>
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/popback.dart">View on GitHub</a>
-  </li>
-</ul>
-</nav>
-
-<?code-excerpt "lib/popback.dart (PopBackExample)"?>
-```dart
-TextButton(
-  onPressed: () {
-    // This code allows the
-    // view to pop back to its presenter.
-    Navigator.of(context).pop();
-  },
-  child: const Text('Pop back'),
-),
-```
-
-### Navigating to another app
-
-In **SwiftUI**, you use the `openURL` environment variable to open a
-URL to another application.
-
-{:.include-lang}
-```swift
-@Environment(\.openURL) private var openUrl
-
-// View code goes here
-
- Button("Open website") {
-      openUrl(
-        URL(
-          string: "https://google.com"
-        )!
-      )
-    }
-```
-
-In **Flutter**, use the [`url_launcher`][] plugin.
-
-<nav class="navbar bg-primary">
- <ul class="navbar-nav navbar-code ml-auto">
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/openapp.dart">View on GitHub</a>
-  </li>
-</ul>
-</nav>
-
-<?code-excerpt "lib/openapp.dart (OpenAppExample)"?>
-```dart
- CupertinoButton(
-   onPressed: () async {
-     await launchUrl(
-       Uri.parse('https://google.com'),
-     );
-   },
-   child: const Text(
-     'Open website',
-   ),
-),
-```
-
-## Themes, styles, and media
-
-You can style Flutter apps with little effort.
-Styling includes switching between light and dark themes,
-changing the design of your text and UI components,
-and more. This section covers how to style your apps.
-
-### Using dark mode
-
-In **SwiftUI**, you call the `preferredColorScheme()`
-function on a `View` to use dark mode.
-
-In **Flutter**, you can control light and dark mode at the app-level.
-To control the brightness mode, use the `theme` property
-of the `App` class:
-
-<nav class="navbar bg-primary">
- <ul class="navbar-nav navbar-code ml-auto">
- <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=c446775c3224787e51fb18b054a08a1c">Test in DartPad</a>
-  </li>
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/cupertino_themes.dart">View on GitHub</a>
-  </li>
-</ul>
-</nav>
-
-<?code-excerpt "lib/cupertino_themes.dart (Theme)"?>
-```dart
-    CupertinoApp(
-  theme: CupertinoThemeData(
-    brightness: Brightness.dark,
-  ),
-  home: HomePage(),
-);
-```
-
-### Styling text
-
-In **SwiftUI**, you use modifier functions to style text.
-For example, to change the font of a `Text` string,
-use the `font()` modifier:
-
-{:.include-lang}
-```swift
-Text("Hello, world!")
-  .font(.system(size: 30, weight: .heavy))
-  .foregroundColor(.yellow)
-```
-
-To style text in **Flutter**, add a `TextStyle` widget as the value
-of the `style` parameter of the `Text` widget.
-
-<nav class="navbar bg-primary">
- <ul class="navbar-nav navbar-code ml-auto">
- <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=c446775c3224787e51fb18b054a08a1c">Test in DartPad</a>
-  </li>
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/cupertino_themes.dart">View on GitHub</a>
-  </li>
-</ul>
-</nav>
-
-<?code-excerpt "lib/cupertino_themes.dart (StylingTextExample)"?>
-```dart
-Text(
-  'Hello, world!',
-  style: TextStyle(
-    fontSize: 30,
-    fontWeight: FontWeight.bold,
-    color: CupertinoColors.systemYellow,
-  ),
-),
-```
-
-### Styling buttons
-
-In **SwiftUI**, you use modifier functions to style buttons.
-
-{:.include-lang}
-```swift
-Button("Do something") {
-    // do something when button is tapped
-  }
-  .font(.system(size: 30, weight: .bold))
-  .background(Color.yellow)
-  .foregroundColor(Color.blue)
-}
-```
-
-To style button widgets in **Flutter**, set the style of its child,
-or modify properties on the button itself.
-
-In the following example:
-- The `color` property of `CupertinoButton` sets its `color`.
-- The `color` property of the child `Text` widget sets the button
-text color.
-
-<nav class="navbar bg-primary">
- <ul class="navbar-nav navbar-code ml-auto">
- <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.dartpad}}/?id=8ffd244574c98f510c29712f6e6c2204">Test in DartPad</a>
-  </li>
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/stylingbutton.dart">View on GitHub</a>
-  </li>
-</ul>
-</nav>
-
-<?code-excerpt "lib/stylingbutton.dart (StylingButtonExample)"?>
-```dart
-child: CupertinoButton(
-  color: CupertinoColors.systemYellow,
-  onPressed: () {},
-  padding: const EdgeInsets.all(16),
-  child: const Text(
-    'Do something',
-    style: TextStyle(
-      color: CupertinoColors.systemBlue,
-      fontSize: 30,
-      fontWeight: FontWeight.bold,
-    ),
-  ),
-),
-```
-
-### Using custom fonts
-
-In **SwiftUI**, you can use a custom font in your app in two steps.
-First, add the font file to your SwiftUI project. After adding the file,
-use the `.font()` modifier to apply it to your UI components.
-
-{:.include-lang}
-```swift
-Text("Hello")
-  .font(
-    Font.custom(
-      "BungeeSpice-Regular",
-      size: 40
-    )
-  )
-```
-
-In **Flutter**, you control your resources with a file
-named `pubspec.yaml`. This file is platform agnostic.
-To add a custom font to your project, follow these steps:
-
-1. Create a folder called `fonts` in the project's root directory.
-This optional step helps to organize your fonts.
-1. Add your `.ttf`, `.otf`, or `.ttc` font file into the `fonts` folder.
-1. Open the `pubspec.yaml` file within the project.
-1. Find the `flutter` section.
-1. Add your custom font(s) under the `fonts` section.
-
-    ```
-    flutter:
-      fonts:
-        - family: BungeeSpice
-          fonts:
-            - asset: fonts/BungeeSpice-Regular.ttf
-    ```
-
-After you add the font to your project, you can use it as in the
-following example:
-
-<nav class="navbar bg-primary">
- <ul class="navbar-nav navbar-code ml-auto">
-  <li class="nav-item">
-    <a class="btn btn-navbar-code" href="{{site.repo.this}}/{{sample_path}}/lib/stylingbutton.dart">View on GitHub</a>
-  </li>
-</ul>
-</nav>
-
-<?code-excerpt "lib/stylingbutton.dart (CustomFont)"?>
-```dart
-Text(
-  'Cupertino',
-  style: TextStyle(
-    fontSize: 40,
-    fontFamily: 'BungeeSpice',
-  ),
-)
-```
-
-{{site.alert.note}}
-   To download custom fonts to use in your apps,
-   check out [Google Fonts](https://fonts.google.com).
-{{site.alert.end}}
-
-### Bundling images in apps
-
-In **SwiftUI**, you first add the image files to `Assets.xcassets`,
-then use the `Image` view to display the images.
-
-To add images in **Flutter**, follow a method similar to how you added
-custom fonts.
-1. Add an `images` folder to the root directory.
-1. Add this asset to the `pubspec.yaml` file.
-
-    ```
-    flutter:
-      assets:
-        - images/Blueberries.jpg
-    ```
-
-After adding your image, display it using the `Image` widget's
-`.asset()` constructor. This constructor:
-1. Instantiates the given image using the provided path.
-1. Reads the image from the assets bundled with your app.
-1. Displays the image on the screen.
-
-To review a complete example, check out the [`Image`][] docs.
-
-### Bundling videos in apps
-
-In **SwiftUI**, you bundle a local video file with your app in two
-steps.
-First, you import the `AVKit` framework, then you instantiate a
-`VideoPlayer` view.
-
-In **Flutter**, add the [video_player][] plugin to your project.
-This plugin allows you to create a video player that works on
-Android, iOS, and on the web from the same codebase.
-
-1. Add the plugin to your app and add the video file to your project.
-1. Add the asset to your `pubspec.yaml` file.
-1. Use the `VideoPlayerController` class to load and play your video
-   file.
-
-To review a complete walkthrough, check out the [video_player example][].
-
-</div>
-<div class="tab-pane" id="uikit" role="tabpanel" aria-labelledby="uikit-tab" markdown="1">
-
-## UIKit Overview
-
-This section gives an overview of the core similarities 
-and differences between UIKit and Flutter.
+## Overview
 
 ### Views vs. Widgets
 
@@ -1864,7 +542,7 @@ Widget build(BuildContext context) {
 
 ## Navigation
 
-This section of the document discusses navigation 
+This section of the document discusses navigation
 between pages of an app, the push and pop mechanism, and more.
 
 ### Navigating between pages
@@ -2065,8 +743,8 @@ A good place to find great packages for Flutter is on [pub.dev][].
 
 ## ViewControllers
 
-This section of the document discusses the equivalent 
-of ViewController in Flutter and how to listen to 
+This section of the document discusses the equivalent
+of ViewController in Flutter and how to listen to
 lifecycle events.
 
 ### Equivalent of ViewController in Flutter
@@ -2097,26 +775,26 @@ The observable lifecycle events are:
 
 **`inactive`**
 : The application is in an inactive state and is not receiving
-  user input. This event only works on iOS,
-  as there is no equivalent event on Android.
+user input. This event only works on iOS,
+as there is no equivalent event on Android.
 
 **`paused`**
 : The application is not currently visible to the user,
-  is not responding to user input, but is running in the background.
+is not responding to user input, but is running in the background.
 
 **`resumed`**
 : The application is visible and responding to user input.
 
 **`suspending`**
 : The application is suspended momentarily.
-  The iOS platform has no equivalent event.
+The iOS platform has no equivalent event.
 
 For more details on the meaning of these states, see
 [`AppLifecycleState` documentation][].
 
 ## Layouts
 
-This section discusses different layouts in Flutter 
+This section discusses different layouts in Flutter
 and how they compare with UIKit.
 
 ### Displaying a list view
@@ -2460,8 +1138,8 @@ see the [layout tutorial][].
 
 ## Gesture detection and touch event handling
 
-This section discusses how to detect gestures 
-and handle different events in Flutter, 
+This section discusses how to detect gestures
+and handle different events in Flutter,
 and how they compare with UIKit.
 
 ### Adding a click listener
@@ -2523,61 +1201,61 @@ to a wide range of gestures such as:
 
   **`onTapDown`**
   : A pointer that might cause a tap has contacted the
-    screen at a particular location.
+  screen at a particular location.
 
   **`onTapUp`**
   : A pointer that triggers a tap has stopped contacting the
-    screen at a particular location.
+  screen at a particular location.
 
   **`onTap`**
   : A tap has occurred.
 
   **`onTapCancel`**
   : The pointer that previously triggered the `onTapDown`
-    won't cause a tap.
+  won't cause a tap.
 
 * **Double tapping**
 
   **`onDoubleTap`**
   : The user tapped the screen at the same location twice in
-    quick succession.
+  quick succession.
 
 * **Long pressing**
 
   **`onLongPress`**
   : A pointer has remained in contact with the screen
-    at the same location for a long period of time.
+  at the same location for a long period of time.
 
 * **Vertical dragging**
 
   **`onVerticalDragStart`**
   : A pointer has contacted the screen and might begin to
-    move vertically.
+  move vertically.
 
   **`onVerticalDragUpdate`**
   : A pointer in contact with the screen
-    has moved further in the vertical direction.
+  has moved further in the vertical direction.
 
   **`onVerticalDragEnd`**
   : A pointer that was previously in contact with the
-    screen and moving vertically is no longer in contact
-    with the screen and was moving at a specific velocity
-    when it stopped contacting the screen.
+  screen and moving vertically is no longer in contact
+  with the screen and was moving at a specific velocity
+  when it stopped contacting the screen.
 
 * **Horizontal dragging**
 
   **`onHorizontalDragStart`**
   : A pointer has contacted the screen and might begin
-    to move horizontally.
+  to move horizontally.
 
   **`onHorizontalDragUpdate`**
   : A pointer in contact with the screen
-    has moved further in the horizontal direction.
+  has moved further in the horizontal direction.
 
   **`onHorizontalDragEnd`**
   : A pointer that was previously in contact with the
-    screen and moving horizontally is no longer in
-    contact with the screen.
+  screen and moving horizontally is no longer in
+  contact with the screen.
 
 The following example shows a `GestureDetector`
 that rotates the Flutter logo on a double tap:
@@ -2636,10 +1314,10 @@ class _SampleAppState extends State<SampleApp>
 
 ## Themes, styles, and media
 
-Flutter applications are easy to style; you can switch 
-between light and dark themes, 
-change the style of your text and UI components, 
-and more. This section covers aspects of styling your Flutter apps 
+Flutter applications are easy to style; you can switch
+between light and dark themes,
+change the style of your text and UI components,
+and more. This section covers aspects of styling your Flutter apps
 and compares how you might do the same in UIKit.
 
 ### Using a theme
@@ -2832,7 +1510,7 @@ For more details, see
 
 ## Form input
 
-This section discusses how to use forms in Flutter 
+This section discusses how to use forms in Flutter
 and how they compare with UIKit.
 
 ### Retrieving user input
@@ -2992,7 +1670,7 @@ class _SampleAppPageState extends State<SampleAppPage> {
 
 ## Threading & asynchronicity
 
-This section discusses concurrency in Flutter and 
+This section discusses concurrency in Flutter and
 how it compares with UIKit.
 
 ### Writing asynchronous code
@@ -3469,9 +2147,7 @@ class _SampleAppPageState extends State<SampleAppPage> {
 }
 ```
 
-</div>
-</div>{% comment %} End: Tab panes. {% endcomment -%}
-
+[Flutter for SwiftUI developers]: {{site.url}}/get-started/flutter-for/swiftui-devs
 [Add Flutter to existing app]: {{site.url}}/development/add-to-app
 [Adding Assets and Images in Flutter]: {{site.url}}/development/ui/assets-and-images
 [Animation & Motion widgets]: {{site.url}}/development/ui/widgets/animation
@@ -3488,9 +2164,6 @@ class _SampleAppPageState extends State<SampleAppPage> {
 [existing plugin]: {{site.pub}}/flutter
 [Flutter concurrency for Swift developers]: {{site.url}}/resources/dart-swift-concurrency
 [Flutter cookbook]: {{site.url}}/cookbook
-[Flutter Youtube channel]: {{site.social.youtube}}
-[`geolocator`]: {{site.pub-pkg}}/geolocator
-[Navigation and routing]: {{site.url}}/development/ui/navigation
 [`http` package]: {{site.pub-pkg}}/http
 [Human Interface Guidelines]: {{site.apple-dev}}/ios/human-interface-guidelines/overview/themes/
 [internationalization guide]: {{site.url}}/development/accessibility-and-localization/internationalization
@@ -3499,7 +2172,6 @@ class _SampleAppPageState extends State<SampleAppPage> {
 [Introduction to declarative UI]: {{site.url}}/get-started/flutter-for/declarative
 [layout tutorial]: {{site.url}}/development/ui/widgets/layout
 [`Localizations`]: {{site.api}}/flutter/widgets/Localizations-class.html
-[Material]: {{site.material}}/develop/flutter/
 [Material Components]: {{site.material}}/develop/flutter/
 [Material Design guidelines]: {{site.material}}/design/
 [optimized for all platforms]: {{site.material}}/design/platform-guidance/cross-platform-adaptation.html#cross-platform-guidelines
@@ -3512,31 +2184,4 @@ class _SampleAppPageState extends State<SampleAppPage> {
 [widget]: {{site.url}}/resources/architectural-overview#widgets
 [widget catalog]: {{site.url}}/development/ui/widgets/layout
 [`Window.locale`]: {{site.api}}/flutter/dart-ui/Window/locale.html
-[Understanding constraints]: {{site.url}}/development/ui/layout/constraints
-[`WidgetApp`]: {{site.api}}/flutter/widgets/WidgetsApp-class.html
-[`CupertinoApp`]: {{site.api}}/flutter/cupertino/CupertinoApp-class.html
-[`Center`]: {{site.api}}/flutter/widgets/Center-class.html
-[`CupertinoButton`]: {{site.api}}/flutter/cupertino/CupertinoButton-class.html
-[`Row`]: {{site.api}}/flutter/widgets/Row-class.html
-[`Column`]: {{site.api}}/flutter/widgets/Column-class.html
 [Learning Dart as a Swift Developer]: {{site.dart-site}}/guides/language/coming-from/swift-to-dart
-[`ListView`]: {{site.api}}/flutter/widgets/ListView-class.html
-[`ListTile`]: {{site.api}}/flutter/widgets/ListTitle-class.html
-[`GridView`]: {{site.api}}/flutter/widgets/GridView-class.html
-[`SingleChildScrollView`]: {{site.api}}/flutter/widgets/SingleChildScrollView-class.html
-[`LayoutBuilder`]: {{site.api}}/flutter/widgets/LayoutBuilder-class.html
-[`AnimatedRotation`]: {{site.api}}/flutter/widgets/AnimatedRotation-class.html
-[`TweenAnimationBuilder`]: {{site.api}}/flutter/widgets/TweenAnimationBuilder-class.html
-[`RotationTransition`]: {{site.api}}/flutter/widgets/RotationTransition-class.html
-[`Navigator`]: {{site.api}}/flutter/widgets/Navigator-class.html
-[`StatefulWidget`]: {{site.api}}/flutter/widgets/StatefulWidget-class.html
-[State management]:  {{site.url}}/development/data-and-backend/state-mgmt
-[Wonderous]: https://flutter.gskinner.com/wonderous/?utm_source=flutterdocs&utm_medium=docs&utm_campaign=iosdevs
-[video_player]: {{site.pub-pkg}}/video_player
-[video_player example]: {{site.pub-pkg}}/video_player/example
-[Creating responsive and adaptive apps]: {{site.url}}/development/ui/layout/adaptive-responsive
-[`MediaQuery.of()`]: {{site.api}}/flutter/widgets/MediaQuery-class.html
-[`CustomPaint`]: {{site.api}}/flutter/widgets/CustomPaint-class.html
-[`CustomPainter`]: {{site.api}}/flutter/rendering/CustomPainter-class.html
-[`Image`]: {{site.api}}/flutter/widgets/Image-class.html
-[go_router]:{{site.pub-pkg}}/go_router

--- a/src/get-started/learn-more.md
+++ b/src/get-started/learn-more.md
@@ -18,7 +18,8 @@ Learn more about the Flutter framework from the following pages:
 
 * [Flutter for Android developers][]
 * [From Java to Dart][] codelab
-* [Flutter for iOS developers][]
+* [Flutter for SwiftUI developers][]
+* [Flutter for UIKit developers][]
 * [Flutter for React Native developers][]
 * [Flutter for web developers][]
 * [Flutter for Xamarin.Forms developers][]
@@ -43,7 +44,8 @@ Happy Fluttering!
 [Flutter API Docs]: {{site.api}}
 [Flutter cookbook]: {{site.url}}/cookbook
 [Flutter for Android developers]: {{site.url}}/get-started/flutter-for/android-devs
-[Flutter for iOS developers]: {{site.url}}/get-started/flutter-for/ios-devs
+[Flutter for SwiftUI developers]: {{site.url}}/get-started/flutter-for/swiftui-devs
+[Flutter for UIKit developers]: {{site.url}}/get-started/flutter-for/uikit-devs
 [Flutter for React Native developers]: {{site.url}}/get-started/flutter-for/react-native-devs
 [Flutter samples]: https://flutter.github.io/samples
 [Flutter for web developers]: {{site.url}}/get-started/flutter-for/web-devs

--- a/src/index.md
+++ b/src/index.md
@@ -37,7 +37,7 @@ here are some next steps.
 ### Docs
 
 Coming from another platform? Check out Flutter for:
-[Android][], [iOS][], [web][], [React Native][], and
+[Android][], [SwiftUI][], [SwiftUI][], [UIKit][], [React Native][], and
 [Xamarin.Forms][] developers.
 
 [Building layouts][]
@@ -65,7 +65,8 @@ Coming from another platform? Check out Flutter for:
 [FAQ]: {{site.url}}/resources/faq
 [Get started]: {{site.url}}/get-started/install
 [interactivity]: {{site.url}}/development/ui/interactive
-[iOS]: {{site.url}}/get-started/flutter-for/ios-devs
+[SwiftUI]: {{site.url}}/get-started/flutter-for/swiftui-devs
+[UIKit]: {{site.url}}/get-started/flutter-for/uikit-devs
 [React Native]: {{site.url}}/get-started/flutter-for/react-native-devs
 [Understanding constraints]: {{site.url}}/development/ui/layout/constraints
 [web]: {{site.url}}/get-started/flutter-for/web-devs

--- a/src/index.md
+++ b/src/index.md
@@ -37,7 +37,7 @@ here are some next steps.
 ### Docs
 
 Coming from another platform? Check out Flutter for:
-[Android][], [SwiftUI][], [SwiftUI][], [UIKit][], [React Native][], and
+[Android][], [SwiftUI][], [UIKit][], [React Native][], and
 [Xamarin.Forms][] developers.
 
 [Building layouts][]

--- a/src/resources/dart-swift-concurrency.md
+++ b/src/resources/dart-swift-concurrency.md
@@ -303,5 +303,11 @@ Map<String, dynamic> getNumberOfKeys(String jsonString) {
 ```
 
 
-You can find more information on Dart at [Learning Dart as a Swift developer]({{site.dart-site}}/guides/language/coming-from/swift-to-dart), 
-and more information on Flutter at [Flutter for iOS developers]({{site.url}}/get-started/flutter-for/ios-devs).
+You can find more information on Dart at
+[Learning Dart as a Swift developer][], 
+and more information on Flutter at
+[Flutter for SwiftUI developers][] or [Flutter for UIKit developers][].
+
+[Learning Dart as a Swift developer]: {{site.dart-site}}/guides/language/coming-from/swift-to-dart
+[Flutter for SwiftUI developers]: {{site.url}}/get-started/flutter-for/swiftui-devs
+[Flutter for UIKit developers]: {{site.url}}/get-started/flutter-for/uikit-devs


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Splits the two pages into separate pages, for a few reasons:

- TOC does not handle split tabs (https://github.com/flutter/website/issues/8019)
- SwiftUI is not just used for iOS but also other platforms
- The content is quite different due UIKit being an imperative framework unlike SwiftUI and Flutter

This PR for the most part copies the original contents, but out of necessity needs to make minor changes to the opening. 
I plan to create an issue to track necessary follow-up work and other improvements to make reviewing those changes easier and get this fix out faster.

Also redirects the replaced flutter-for/ios-devs link to the SwiftUI page since that will likely be the more popular page in the future and more permanent.

** **Please review** the opening changes and the note additions. Now the opening has two notes, one for the other guide and one for Add to app. I feel like I picked okay locations for them, but it's still a bit crowded if anyone has any suggestions.

**Staged SwiftUI link:** https://parlough-docs-flutter-dev.web.app/get-started/flutter-for/swiftui-devs
**Staged UIKit link:** https://parlough-docs-flutter-dev.web.app/get-started/flutter-for/uikit-devs

_Issues fixed by this PR (if any):_ Fixes https://github.com/flutter/website/issues/8019

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
