### PR TITLE
Fix incorrect migration sample in RenderObjectElement migrations

### DIFF
--- a/src/release/breaking-changes/2-10-deprecations.md
+++ b/src/release/breaking-changes/2-10-deprecations.md
@@ -593,8 +593,8 @@ Code after migration:
 
 ```dart
 element.insertRenderObjectChild(child, slot);
-element.moveChildRenderObject(child, oldSlot, newSlot);
-element.removeChildRenderObject(child, slot);
+element.moveRenderObjectChild(child, oldSlot, newSlot);
+element.removeRenderObjectChild(child, slot);
 ```
 
 **References**


### PR DESCRIPTION
Likely due to a copy-paste error, the second two method names weren't updated to their replacement.

Fixes #7133