### PR TITLE
Fix formatting of 'Unsupported platforms' table

### DIFF
--- a/src/development/tools/sdk/release-notes/supported-platforms.md
+++ b/src/development/tools/sdk/release-notes/supported-platforms.md
@@ -97,7 +97,7 @@ best-effort support.
 |macOS   |Yosemite (10.10) & below                    |
 |Windows |Windows Vista & below                       |
 |Windows |Any 32-bit platform                         |
-
 {:.table.table-striped}
 </div>
+
 [iOS 10 & below and `arm7v` 32-bit iOS]: {{site.url}}/go/rfc-32-bit-ios-unsupported


### PR DESCRIPTION
**Before:**
<img width="472" alt="Broken unsupported platform table" src="https://user-images.githubusercontent.com/18372958/211179922-6ba0676e-e816-42fc-897d-5e1676290a7d.png">

**After:**
<img width="882" alt="Fixed unsupported platform table" src="https://user-images.githubusercontent.com/18372958/211179917-2ed87e90-bb07-4a0c-9c24-852e22c09c31.png">
