### PR TITLE
Fix first web app codelab returning private state lint

### DIFF
--- a/examples/get-started/codelab_web/lib/main.dart
+++ b/examples/get-started/codelab_web/lib/main.dart
@@ -50,7 +50,7 @@ class WelcomeScreen extends StatelessWidget {
 
 class SignUpForm extends StatefulWidget {
   @override
-  _SignUpFormState createState() => _SignUpFormState();
+  State<SignUpForm> createState() => _SignUpFormState();
 }
 
 class _SignUpFormState extends State<SignUpForm> {
@@ -145,7 +145,7 @@ class AnimatedProgressIndicator extends StatefulWidget {
   });
 
   @override
-  State<StatefulWidget> createState() {
+  State<AnimatedProgressIndicator> createState() {
     return _AnimatedProgressIndicatorState();
   }
 }

--- a/examples/get-started/codelab_web/lib/starter.dart
+++ b/examples/get-started/codelab_web/lib/starter.dart
@@ -39,7 +39,7 @@ class SignUpForm extends StatefulWidget {
   const SignUpForm();
 
   @override
-  _SignUpFormState createState() => _SignUpFormState();
+  State<SignUpForm> createState() => _SignUpFormState();
 }
 
 class _SignUpFormState extends State<SignUpForm> {

--- a/examples/get-started/codelab_web/lib/step1.dart
+++ b/examples/get-started/codelab_web/lib/step1.dart
@@ -56,7 +56,7 @@ class SignUpForm extends StatefulWidget {
   const SignUpForm();
 
   @override
-  _SignUpFormState createState() => _SignUpFormState();
+  State<SignUpForm> createState() => _SignUpFormState();
 }
 
 class _SignUpFormState extends State<SignUpForm> {

--- a/examples/get-started/codelab_web/lib/step2.dart
+++ b/examples/get-started/codelab_web/lib/step2.dart
@@ -52,7 +52,7 @@ class SignUpForm extends StatefulWidget {
   const SignUpForm();
 
   @override
-  _SignUpFormState createState() => _SignUpFormState();
+  State<SignUpForm> createState() => _SignUpFormState();
 }
 
 class _SignUpFormState extends State<SignUpForm> {

--- a/examples/get-started/codelab_web/lib/step3.dart
+++ b/examples/get-started/codelab_web/lib/step3.dart
@@ -52,7 +52,7 @@ class SignUpForm extends StatefulWidget {
   const SignUpForm();
 
   @override
-  _SignUpFormState createState() => _SignUpFormState();
+  State<SignUpForm> createState() => _SignUpFormState();
 }
 
 class _SignUpFormState extends State<SignUpForm> {
@@ -151,7 +151,7 @@ class AnimatedProgressIndicator extends StatefulWidget {
   });
 
   @override
-  State<StatefulWidget> createState() {
+  State<AnimatedProgressIndicator> createState() {
     return _AnimatedProgressIndicatorState();
   }
 }

--- a/src/get-started/codelab-web.md
+++ b/src/get-started/codelab-web.md
@@ -172,7 +172,7 @@ class SignUpForm extends StatefulWidget {
   const SignUpForm();
 
   @override
-  _SignUpFormState createState() => _SignUpFormState();
+  State<SignUpForm> createState() => _SignUpFormState();
 }
 
 class _SignUpFormState extends State<SignUpForm> {
@@ -727,7 +727,7 @@ class AnimatedProgressIndicator extends StatefulWidget {
   });
 
   @override
-  State<StatefulWidget> createState() {
+  State<AnimatedProgressIndicator> createState() {
     return _AnimatedProgressIndicatorState();
   }
 }
@@ -869,7 +869,7 @@ class WelcomeScreen extends StatelessWidget {
 
 class SignUpForm extends StatefulWidget {
   @override
-  _SignUpFormState createState() => _SignUpFormState();
+  State<SignUpForm> createState() => _SignUpFormState();
 }
 
 class _SignUpFormState extends State<SignUpForm> {
@@ -964,7 +964,7 @@ class AnimatedProgressIndicator extends StatefulWidget {
   });
 
   @override
-  State<StatefulWidget> createState() {
+  State<AnimatedProgressIndicator> createState() {
     return _AnimatedProgressIndicatorState();
   }
 }


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Write now the code in the codelab is triggering the [`library_private_types_in_public_api`](https://dart-lang.github.io/linter/lints/library_private_types_in_public_api.html) lint due to leaking the private state types. This encapsulates PR that by using `State` with the widget itself.

_Issues fixed by this PR (if any):_ Fixes N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
