### PR TITLE
Fix multiple API doc links

### DIFF
--- a/src/development/tools/devtools/inspector.md
+++ b/src/development/tools/devtools/inspector.md
@@ -537,7 +537,7 @@ of the Flutter inspector.
 [DevTools written in Flutter]: {{site.url}}/development/tools/devtools/overview#how-do-i-try-devtools-written-in-flutter
 [`Flex`]: {{site.api}}/flutter/widgets/Flex-class.html
 [flex layouts]: {{site.api}}/flutter/widgets/Flex-class.html
-[`FlexFit`]: {{site.api}}/flutter/widgets/FlexFit-class.html
+[`FlexFit`]: {{site.api}}/flutter/rendering/FlexFit.html
 [`FlexParentData.fit`]: {{site.api}}/flutter/rendering/FlexParentData/fit.html
 [`FlexParentData.flex`]: {{site.api}}/flutter/rendering/FlexParentData/flex.html
 [Flutter performance profiling]: {{site.url}}/perf/ui-performance

--- a/src/development/tools/devtools/memory.md
+++ b/src/development/tools/devtools/memory.md
@@ -374,7 +374,7 @@ The quantities plotted on the y-axis are as follows:
 [Custom Flutter engine embedders]: {{site.github}}/flutter/flutter/wiki/Custom-Flutter-Engine-Embedders
 [Dart VM internals]: https://mrale.ph/dartvm/
 [DevTools Performance view]: {{site.url}}/development/tools/devtools/performance
-[Flutter architectural overview]: {{site.url}}/architectural-overview
+[Flutter architectural overview]: {{site.url}}/resources/architectural-overview
 [frog]: https://dartfrog.vgv.dev/
 [heroku]: {{site.youtube-site}}/watch?v=nkTUMVNelXA
 

--- a/src/development/ui/advanced/focus.md
+++ b/src/development/ui/advanced/focus.md
@@ -545,7 +545,7 @@ in the highlight mode.
 
 [`Actions`]: {{site.api}}/flutter/widgets/Actions-class.html
 [`Builder`]: {{site.api}}/flutter/widgets/Builder-class.html
-[`DirectionalFocusTraversalPolicyMixin`]: {{site.api}}/flutter/widgets/DirectionalFocusTraversalPolicyMixin-class.html
+[`DirectionalFocusTraversalPolicyMixin`]: {{site.api}}/flutter/widgets/DirectionalFocusTraversalPolicyMixin-mixin.html
 [`Focus`]: {{site.api}}/flutter/widgets/Focus-class.html
 [`FocusableActionDetector`]: {{site.api}}/flutter/widgets/FocusableActionDetector-class.html
 [`FocusManager`]: {{site.api}}/flutter/widgets/FocusManager-class.html
@@ -562,4 +562,4 @@ in the highlight mode.
 [`OrderedTraversalPolicy`]: {{site.api}}/flutter/widgets/OrderedTraversalPolicy-class.html
 [`ReadingOrderTraversalPolicy`]: {{site.api}}/flutter/widgets/ReadingOrderTraversalPolicy-class.html
 [`Shortcuts`]: {{site.api}}/flutter/widgets/Shortcuts-class.html
-[`UnfocusDisposition.scope`]: {{site.api}}/flutter/widgets/UnfocusDisposition-class.html
+[`UnfocusDisposition.scope`]: {{site.api}}/flutter/widgets/UnfocusDisposition.html

--- a/src/development/ui/animations/overview.md
+++ b/src/development/ui/animations/overview.md
@@ -301,7 +301,7 @@ the `Animatable` but is driven from the given parent.
 [`AnimationController`]: {{site.api}}/flutter/animation/AnimationController-class.html
 [`AnimatedWidget`]: {{site.api}}/flutter/widgets/AnimatedWidget-class.html
 [`Animation`]: {{site.api}}/flutter/animation/Animation-class.html
-[`AnimationStatus`]: {{site.api}}/flutter/animation/AnimationStatus-class.html
+[`AnimationStatus`]: {{site.api}}/flutter/animation/AnimationStatus.html
 [`begin`]: {{site.api}}/flutter/animation/Tween/begin.html
 [`BouncingScrollSimulation`]: {{site.api}}/flutter/widgets/BouncingScrollSimulation-class.html
 [`build`]: {{site.api}}/flutter/widgets/AnimatedWidget/build.html

--- a/src/get-started/flutter-for/react-native-devs.md
+++ b/src/get-started/flutter-for/react-native-devs.md
@@ -2594,7 +2594,7 @@ and common widget properties.
 [`Animation`]: {{site.api}}/flutter/animation/Animation-class.html
 [`AnimationController`]: {{site.api}}/flutter/animation/AnimationController-class.html
 [async and await]: {{site.dart-site}}/guides/language/language-tour#asynchrony-support
-[`Axis`]: {{site.api}}/flutter/painting/Axis-class.html
+[`Axis`]: {{site.api}}/flutter/painting/Axis.html
 [`BuildContext`]: {{site.api}}/flutter/widgets/BuildContext-class.html
 [`Center`]: {{site.api}}/flutter/widgets/Center-class.html
 [color palette]: {{site.material}}/design/color
@@ -2678,7 +2678,7 @@ and common widget properties.
 [`TabBarView`]: {{site.api}}/flutter/material/TabBarView-class.html
 [`TabController`]: {{site.api}}/flutter/material/TabController-class.html
 [`Text`]: {{site.api}}/flutter/widgets/Text-class.html
-[`TextAlign`]: {{site.api}}/flutter/dart-ui/TextAlign-class.html
+[`TextAlign`]: {{site.api}}/flutter/dart-ui/TextAlign.html
 [`TextEditingController`]: {{site.api}}/flutter/widgets/TextEditingController-class.html
 [`TextField`]: {{site.api}}/flutter/material/TextField-class.html
 [`TextFormField`]: {{site.api}}/flutter/material/TextFormField-class.html

--- a/src/release/breaking-changes/eliminating-nullok-parameters.md
+++ b/src/release/breaking-changes/eliminating-nullok-parameters.md
@@ -54,7 +54,7 @@ return a non-nullable value:
 * [`FocusTraversalOrder.of`][]
 * [`FocusTraversalGroup.of`][]
 * [`Focus.of`][]
-* [`Shortcuts.of`][]
+* `Shortcuts.of`
 * [`Actions.handler`][]
 * [`Actions.find`][]
 * [`Actions.invoke`][]
@@ -81,7 +81,7 @@ value:
 * [`FocusTraversalOrder.maybeOf`][]
 * [`FocusTraversalGroup.maybeOf`][]
 * [`Focus.maybeOf`][]
-* [`Shortcuts.maybeOf`][]
+* `Shortcuts.maybeOf`
 * [`Actions.maybeFind`][]
 * [`Actions.maybeInvoke`][]
 * [`AnimatedList.maybeOf`][]
@@ -98,13 +98,13 @@ instances of calls that include `nullOk = true` as a parameter to use the
 
 So this:
 
-```
+```dart
 MediaQueryData? data = MediaQuery.of(context, nullOk: true);
 ```
 
 becomes:
 
-```
+```dart
 MediaQueryData? data = MediaQuery.maybeOf(context);
 ```
 
@@ -113,13 +113,15 @@ false` (often the default), to accept non-nullable return values, or remove any
 `!` operators:
 
 So either of:
-```
+
+```dart
 MediaQueryData data = MediaQuery.of(context)!; // nullOk false by default.
 MediaQueryData? data = MediaQuery.of(context); // nullOk false by default.
 ```
 
 both become:
-```
+
+```dart
 MediaQueryData data = MediaQuery.of(context); // No ! or ? operator here now.
 ```
 
@@ -137,6 +139,7 @@ In stable release: 2.0.0
 ## References
 
 API documentation:
+
  * [`MediaQuery.of`][]
  * [`Navigator.of`][]
  * [`ScaffoldMessenger.of`][]
@@ -146,7 +149,7 @@ API documentation:
  * [`FocusTraversalOrder.of`][]
  * [`FocusTraversalGroup.of`][]
  * [`Focus.of`][]
- * [`Shortcuts.of`][]
+ * `Shortcuts.of`
  * [`Actions.handler`][]
  * [`Actions.find`][]
  * [`Actions.invoke`][]
@@ -169,7 +172,7 @@ API documentation:
  * [`FocusTraversalOrder.maybeOf`][]
  * [`FocusTraversalGroup.maybeOf`][]
  * [`Focus.maybeOf`][]
- * [`Shortcuts.maybeOf`][]
+ * `Shortcuts.maybeOf`
  * [`Actions.maybeFind`][]
  * [`Actions.maybeInvoke`][]
  * [`AnimatedList.maybeOf`][]
@@ -203,7 +206,6 @@ Relevant PRs:
 [`FocusTraversalOrder.of`]: {{site.api}}/flutter/widgets/FocusTraversalOrder/of.html
 [`FocusTraversalGroup.of`]: {{site.api}}/flutter/widgets/FocusTraversalGroup/of.html
 [`Focus.of`]: {{site.api}}/flutter/widgets/Focus/of.html
-[`Shortcuts.of`]: {{site.api}}/flutter/widgets/Shortcuts/of.html
 [`Actions.handler`]: {{site.api}}/flutter/widgets/Actions/handler.html
 [`Actions.find`]: {{site.api}}/flutter/widgets/Actions/find.html
 [`Actions.invoke`]: {{site.api}}/flutter/widgets/Actions/invoke.html
@@ -216,7 +218,7 @@ Relevant PRs:
 [`CupertinoThemeData.resolveFrom`]: {{site.api}}/flutter/cupertino/CupertinoThemeData/resolveFrom.html
 [`NoDefaultCupertinoThemeData.resolveFrom`]: {{site.api}}/flutter/cupertino/NoDefaultCupertinoThemeData/resolveFrom.html
 [`CupertinoTextThemeData.resolveFrom`]: {{site.api}}/flutter/cupertino/CupertinoTextThemeData/resolveFrom.html
-[`MaterialBasedCupertinoThemeData.resolveFrom`]: {{site.api}}/flutter/cupertino/MaterialBasedCupertinoThemeData/resolveFrom.html
+[`MaterialBasedCupertinoThemeData.resolveFrom`]: {{site.api}}/flutter/material/MaterialBasedCupertinoThemeData/resolveFrom.html
 [`MediaQuery.maybeOf`]: {{site.api}}/flutter/widgets/MediaQuery/maybeOf.html
 [`Navigator.maybeOf`]: {{site.api}}/flutter/widgets/Navigator/maybeOf.html
 [`ScaffoldMessenger.maybeOf`]: {{site.api}}/flutter/material/ScaffoldMessenger/maybeOf.html
@@ -226,7 +228,6 @@ Relevant PRs:
 [`FocusTraversalOrder.maybeOf`]: {{site.api}}/flutter/widgets/FocusTraversalOrder/maybeOf.html
 [`FocusTraversalGroup.maybeOf`]: {{site.api}}/flutter/widgets/FocusTraversalGroup/maybeOf.html
 [`Focus.maybeOf`]: {{site.api}}/flutter/widgets/Focus/maybeOf.html
-[`Shortcuts.maybeOf`]: {{site.api}}/flutter/widgets/Shortcuts/maybeOf.html
 [`Actions.maybeFind`]: {{site.api}}/flutter/widgets/Actions/maybeFind.html
 [`Actions.maybeInvoke`]: {{site.api}}/flutter/widgets/Actions/maybeInvoke.html
 [`AnimatedList.maybeOf`]: {{site.api}}/flutter/widgets/AnimatedList/maybeOf.html
@@ -248,4 +249,3 @@ Relevant PRs:
 [Remove `nullOk` parameter from Cupertino color resolution APIs]: {{site.repo.flutter}}/pull/68905
 [Remove vestigial `nullOk` parameter from `Localizations.localeOf`]: {{site.repo.flutter}}/pull/74657
 [Remove `nullOk` from `Actions.invoke`, add `Actions.maybeInvoke`]: {{site.repo.flutter}}/pull/74680
-

--- a/tool/config/linkcheck-skip-list.txt
+++ b/tool/config/linkcheck-skip-list.txt
@@ -6,6 +6,7 @@
 # sometimes too long for Travis, so it is simpler just to skip all site links.
 
 https://github.com
+https://master-api.flutter.dev
 
 # -----------------------------------------------------------------------------
 # Valid external links that result in connection failures too often:
@@ -19,6 +20,7 @@ https://now.qq.com
 # Links with "anchors" that aren't really anchors
 # (and so linkcheck reports the anchors as missing)
 
+https://flutter.dev/events/flutter-forward/#17-days-of-flutter
 https://codelabs.developers.google.com/codelabs/flutter/\#6
 https://groups.google.com/forum/\#!forum/flutter-dev
 https://groups.google.com/forum/\#!forum/flutter-announce
@@ -31,6 +33,7 @@ https://material.io/guidelines/motion/transforming-material.html\#transforming-m
 
 # -----------------------------------------------------------------------------
 # Preconnect links that return 404s
+
 fonts.gstatic.com
 fonts.googleapis.com
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Fixes some broken API docs links. A few due to the targets being removed and others due to being rendered enums instead of classes.

_Issues fixed by this PR (if any):_ Fixes N/A

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
