### PR TITLE
Finalize followup adjustments for the new "First Flutter app" codelab

### DIFF
--- a/examples/layout/base/lib/main.dart
+++ b/examples/layout/base/lib/main.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// #docregion all
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());
@@ -29,3 +30,4 @@ class MyApp extends StatelessWidget {
     );
   }
 }
+// #enddocregion all

--- a/src/development/accessibility-and-localization/accessibility.md
+++ b/src/development/accessibility-and-localization/accessibility.md
@@ -226,33 +226,40 @@ Test your app using Flutter's
 This API checks if your app's UI meets Flutter's accessibility recommendations.
 These cover recommendations for text contrast, target size, and target labels.
 
-The following example shows how to use the Guideline API on Startup Name Generator.
-You created this app as part of the <a href="https://docs.flutter.dev/get-started/codelab/?tab=talkback">codelab</a> 
+The following example shows how to use the Guideline API on Name Generator.
+You created this app as part of the <a href="https://docs.flutter.dev/get-started/codelab/">codelab</a>
 on how to create your first Flutter app.
-Each list tile on the app's main screen serves as a tappable target
-with text represented in 18 point. You can add Guideline API tests
-in `test/widget_test.dart` of your app directory.
+Each button on the app's main screen serves as a tappable target
+with text represented in 18 point.
 
-<?code-excerpt path-base="codelabs/startup_namer/step3_stateful_widget"?>
-<?code-excerpt "test/widget_test.dart (a11yAPI)" indent-by="2"?>
+<?code-excerpt path-base="codelabs/namer/step_08"?>
+<?code-excerpt "test/a11y_test.dart (insideTest)" indent-by="2"?>
 ```dart
   final SemanticsHandle handle = tester.ensureSemantics();
-  await tester.pumpWidget(const MaterialApp(home: MyApp()));
+  await tester.pumpWidget(MyApp());
 
-  // Checks that tappable nodes have a minimum size of 48 by 48 pixels for android.
+  // Checks that tappable nodes have a minimum size of 48 by 48 pixels
+  // for Android.
   await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
 
-  // Checks that tappable nodes have a minimum size of 44 by 44 pixels for iOS.
+  // Checks that tappable nodes have a minimum size of 44 by 44 pixels
+  // for iOS.
   await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
 
   // Checks that touch targets with a tap or long press action are labeled.
   await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
 
   // Checks whether semantic nodes meet the minimum text contrast levels.
-  // The recommended text contrast is 3:1 for larger text (18 point and above regular)
+  // The recommended text contrast is 3:1 for larger text
+  // (18 point and above regular).
   await expectLater(tester, meetsGuideline(textContrastGuideline));
   handle.dispose();
 ```
+
+You can add Guideline API tests
+in `test/widget_test.dart` of your app directory, or as a separate test
+file (such as `test/a11y_test.dart` in the case of the Name Generator).
+
 
 ## Testing accessibility on web
 

--- a/src/development/ui/interactive.md
+++ b/src/development/ui/interactive.md
@@ -114,7 +114,7 @@ If you've already built the app in the
 skip to the next section.
 
  1. Make sure you've [set up][] your environment.
- 1. [Create a basic "Hello World" Flutter app][hello-world].
+ 1. [Create a new Flutter app][new-flutter-app].
  1. Replace the `lib/main.dart` file with [`main.dart`][].
  1. Replace the `pubspec.yaml` file with [`pubspec.yaml`][].
  1. Create an `images` directory in your project, and add
@@ -797,7 +797,7 @@ Flutter Gallery [running app][], [repo][]
 [Gestures]: {{site.url}}/cookbook/gestures
 [Gestures in Flutter]: {{site.url}}/development/ui/advanced/gestures
 [Handling gestures]: {{site.url}}/development/ui/widgets-intro#handling-gestures
-[hello-world]: {{site.url}}/get-started/codelab#step-1-create-the-starter-flutter-app
+[new-flutter-app]: {{site.url}}/get-started/test-drive
 [`IconButton`]: {{site.api}}/flutter/material/IconButton-class.html
 [`Icon`]: {{site.api}}/flutter/widgets/Icon-class.html
 [`InkWell`]: {{site.api}}/flutter/material/InkWell-class.html

--- a/src/development/ui/layout/tutorial.md
+++ b/src/development/ui/layout/tutorial.md
@@ -40,26 +40,35 @@ start with [Flutter's approach to layout][].
 Make sure to [set up][] your environment,
 then do the following:
 
- 1. [Create a basic "Hello World" Flutter app][hello-world].
- 2. Change the app bar title and the app title as follows:
+<?code-excerpt path-base="layout/base"?>
 
-    <?code-excerpt "layout/base/lib/{main_starter,main}.dart"?>
-    ```diff
-    --- layout/base/lib/main_starter.dart
-    +++ layout/base/lib/main.dart
-    @@ -12,10 +12,10 @@
-       @override
-       Widget build(BuildContext context) {
-         return MaterialApp(
-    -      title: 'Welcome to Flutter',
-    +      title: 'Flutter layout demo',
-           home: Scaffold(
-             appBar: AppBar(
-    -          title: const Text('Welcome to Flutter'),
-    +          title: const Text('Flutter layout demo'),
-             ),
-             body: const Center(
-               child: Text('Hello World'),
+ 1. [Create a new Flutter app][new-flutter-app].
+ 2. Replace the contents in `lib/main.dart` with the following code:
+
+    <?code-excerpt "lib/main.dart (all)" title?>
+    ```dart
+    import 'package:flutter/material.dart';
+
+    void main() => runApp(const MyApp());
+
+    class MyApp extends StatelessWidget {
+      const MyApp({super.key});
+
+      @override
+      Widget build(BuildContext context) {
+        return MaterialApp(
+          title: 'Flutter layout demo',
+          home: Scaffold(
+            appBar: AppBar(
+              title: const Text('Flutter layout demo'),
+            ),
+            body: const Center(
+              child: Text('Hello World'),
+            ),
+          ),
+        );
+      }
+    }
     ```
 
 ## Step 1: Diagram the layout
@@ -164,7 +173,7 @@ Widget titleSection = Container(
 ```diff
 --- ../base/lib/main.dart
 +++ step2/lib/main.dart
-@@ -14,11 +48,13 @@
+@@ -14,13 +48,15 @@
      return MaterialApp(
        title: 'Flutter layout demo',
        home: Scaffold(
@@ -180,6 +189,10 @@ Widget titleSection = Container(
          ),
        ),
      );
+   }
+-}
+\ No newline at end of file
++}
 ```
 
 {{site.alert.tip}}
@@ -443,7 +456,7 @@ You can add interactivity to this layout by following
 [automatic reformatting support]: {{site.url}}/development/tools/formatting
 [available online]: https://images.unsplash.com/photo-1471115853179-bb1d604434e0?dpr=1&amp;auto=format&amp;fit=crop&amp;w=767&amp;h=583&amp;q=80&amp;cs=tinysrgb&amp;crop=
 [Flutter's approach to layout]: {{site.url}}/development/ui/layout
-[hello-world]: {{site.url}}/get-started/codelab#step-1-create-the-starter-flutter-app
+[new-flutter-app]: {{site.url}}/get-started/test-drive
 [images]: {{examples}}/layout/lakes/step6/images
 [`lake.jpg`]: {{rawExFile}}/layout/lakes/step5/images/lake.jpg
 [`lib/main.dart`]: {{examples}}/layout/lakes/step2/lib/main.dart


### PR DESCRIPTION
This updates the following:

- [Testing accessibility on mobile](https://docs.flutter.dev/development/accessibility-and-localization/accessibility#testing-accessibility-on-mobile) relying on and referencing the old, created app and the [Accessibility Guideline API](https://api.flutter.dev/flutter/flutter_test/AccessibilityGuideline-class.html)
- The [Building layouts (step 0)](https://docs.flutter.dev/development/ui/layout/tutorial#step-0-create-the-app-base-code) tutorial which links to and references the old code/codelab (ADDRESSED IN #8087)
- The [Adding interactivity (step 0)](https://docs.flutter.dev/development/ui/interactive#step-0-get-ready) which also links to and references the old code/codelab (ADDRESSED IN #8087)

Landing this final PR has 2 prerequisites:

- hard requirement of https://github.com/flutter/codelabs/pull/1339, without which the changed excerpts will fail to validate
- soft requirement of #8087, with which some of the changes here are redundant

_Issues fixed by this PR (if any):_ Fixes #8054

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
