### PR TITLE
Clean up and fix some issues on 'Android views' page

### DIFF
--- a/src/_includes/docs/platform-view-perf.md
+++ b/src/_includes/docs/platform-view-perf.md
@@ -6,15 +6,15 @@ For example, in a typical Flutter app, the Flutter UI is composed
 on a dedicated raster thread. This allows Flutter apps to be fast,
 as the main platform thread is rarely blocked.
 
-While a platform view is rendered with Hybrid composition,
+While a platform view is rendered with hybrid composition,
 the Flutter UI is composed from the platform thread,
 which competes with other tasks like handling OS or plugin messages.
 
-Prior to Android 10, Hybrid composition copied each Flutter frame
+Prior to Android 10, hybrid composition copied each Flutter frame
 out of the graphic memory into main memory, and then copied it back
 to a GPU texture. As this copy happens per frame, the performance of
 the entire Flutter UI might be impacted. In Android 10 or above, the
-graphics memory is copied once.
+graphics memory is copied only once.
 
 Virtual display, on the other hand,
 makes each pixel of the native view

--- a/src/development/platform-integration/android/platform-views.md
+++ b/src/development/platform-integration/android/platform-views.md
@@ -85,7 +85,7 @@ use the following instructions:
      const String viewType = '<platform-view-type>';
      // Pass parameters to the platform side.
      const Map<String, dynamic> creationParams = <String, dynamic>{};
-   
+
      return PlatformViewLink(
        viewType: viewType,
        surfaceFactory:
@@ -147,7 +147,7 @@ use the following instructions:
      const String viewType = '<platform-view-type>';
      // Pass parameters to the platform side.
      final Map<String, dynamic> creationParams = <String, dynamic>{};
-   
+
      return AndroidView(
        viewType: viewType,
        layoutDirection: TextDirection.ltr,

--- a/src/development/platform-integration/android/platform-views.md
+++ b/src/development/platform-integration/android/platform-views.md
@@ -24,25 +24,23 @@ directly inside your Flutter app.
 [Hosting native iOS views]: {{site.url}}/development/platform-integration/ios/platform-views
 
 Flutter supports two modes:
-Virtual displays and Hybrid composition.
+Hybrid composition and virtual displays.
 
 Which one to use depends on the use case.
 Let's take a look:
 
-* Virtual displays render the `android.view.View`
-  instance to a texture, so it's not embedded within
-  the Android Activity's view hierachy.
+* [Hybrid composition](#hybrid-composition)
+  appends the native `android.view.View` to the view hierarchy. 
+  Therefore, keyboard handling, and accessibility work out of the box.
+  Prior to Android 10, this mode might significantly
+  reduce the frame throughput (FPS) of the Flutter UI.
+  For more context, see [Performance](#performance).
+
+* [Virtual displays](#virtual-display)
+  render the `android.view.View` instance to a texture, 
+  so it's not embedded within the Android Activity's view hierarchy.
   Certain platform interactions such as keyboard handling
   and accessibility features might not work.
-
-* Hybrid composition appends the native `android.view.View`
-  to the view hierarchy. Therefore, keyboard
-  handling, and accessibility work out of the box.
-  Prior to Android 10, this mode might significantly
-  reduce the frame throughput (FPS) of the
-  Flutter UI. See [performance][] for more info.
-
-[performance]: #performance
 
 To create a platform view on Android,
 use the following steps:
@@ -50,7 +48,7 @@ use the following steps:
 ### On the Dart side
 
 On the Dart side, create a `Widget`
-and add the following build implementation.
+and add one of the following build implementations.
 
 {{site.alert.warning}}
   For this to work, your plugin or app must use
@@ -61,64 +59,60 @@ and add the following build implementation.
 
 [plugin migration guide]: {{site.url}}/development/platform-integration/android/plugin-api-migration
 
-#### Virtual Display
+#### Hybrid composition
 
 In your Dart file,
 for example `native_view_example.dart`,
 use the following instructions:
 
-<ol markdown="1">
-<li markdown="1">Add the following imports:
-
-<?code-excerpt "lib/platform_views/native_view_example_1.dart (Import)"?>
-```dart
-import 'package:flutter/foundation.dart';
-import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
-import 'package:flutter/services.dart';
-```
-</li>
-
-<li markdown="1">Implement a `build()` method:
-
-<?code-excerpt "lib/platform_views/native_view_example_1.dart (HybridCompositionWidget)"?>
-```dart
-Widget build(BuildContext context) {
-  // This is used in the platform side to register the view.
-  const String viewType = '<platform-view-type>';
-  // Pass parameters to the platform side.
-  const Map<String, dynamic> creationParams = <String, dynamic>{};
-
-  return PlatformViewLink(
-    viewType: viewType,
-    surfaceFactory:
-        (context, controller) {
-      return AndroidViewSurface(
-        controller: controller as AndroidViewController,
-        gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
-        hitTestBehavior: PlatformViewHitTestBehavior.opaque,
-      );
-    },
-    onCreatePlatformView: (params) {
-      return PlatformViewsService.initSurfaceAndroidView(
-        id: params.id,
-        viewType: viewType,
-        layoutDirection: TextDirection.ltr,
-        creationParams: creationParams,
-        creationParamsCodec: const StandardMessageCodec(),
-        onFocus: () {
-          params.onFocusChanged(true);
-        },
-      )
-        ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
-        ..create();
-    },
-  );
-}
-```
-</li>
-</ol>
+1. Add the following imports:  
+   
+   <?code-excerpt "lib/platform_views/native_view_example_1.dart (Import)"?>
+   ```dart
+   import 'package:flutter/foundation.dart';
+   import 'package:flutter/gestures.dart';
+   import 'package:flutter/material.dart';
+   import 'package:flutter/rendering.dart';
+   import 'package:flutter/services.dart';
+   ```  
+    
+2. Implement a `build()` method:
+  
+   <?code-excerpt "lib/platform_views/native_view_example_1.dart (HybridCompositionWidget)"?>
+   ```dart
+   Widget build(BuildContext context) {
+     // This is used in the platform side to register the view.
+     const String viewType = '<platform-view-type>';
+     // Pass parameters to the platform side.
+     const Map<String, dynamic> creationParams = <String, dynamic>{};
+   
+     return PlatformViewLink(
+       viewType: viewType,
+       surfaceFactory:
+           (context, controller) {
+         return AndroidViewSurface(
+           controller: controller as AndroidViewController,
+           gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+           hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+         );
+       },
+       onCreatePlatformView: (params) {
+         return PlatformViewsService.initSurfaceAndroidView(
+           id: params.id,
+           viewType: viewType,
+           layoutDirection: TextDirection.ltr,
+           creationParams: creationParams,
+           creationParamsCodec: const StandardMessageCodec(),
+           onFocus: () {
+             params.onFocusChanged(true);
+           },
+         )
+           ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
+           ..create();
+       },
+     );
+   }
+   ```
 
 For more information, see the API docs for:
 
@@ -130,42 +124,38 @@ For more information, see the API docs for:
 [`PlatformViewLink`]: {{site.api}}/flutter/widgets/PlatformViewLink-class.html
 [`PlatformViewsService`]: {{site.api}}/flutter/services/PlatformViewsService-class.html
 
-#### Hybrid Composition
+#### Virtual display
 
 In your Dart file,
 for example `native_view_example.dart`,
 use the following instructions:
 
-<ol markdown="1">
-<li markdown="1">Add the following imports:
+1. Add the following imports:
+   
+   <?code-excerpt "lib/platform_views/native_view_example_2.dart (Import)"?>
+   ```dart
+   import 'package:flutter/material.dart';
+   import 'package:flutter/services.dart';
+   ```
 
-<?code-excerpt "lib/platform_views/native_view_example_2.dart (Import)"?>
-```dart
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-```
-</li>
+2. Implement a `build()` method:
 
-<li markdown="1">Implement a `build()` method:
-
-<?code-excerpt "lib/platform_views/native_view_example_2.dart (VirtualDisplayWidget)"?>
-```dart
-Widget build(BuildContext context) {
-  // This is used in the platform side to register the view.
-  const String viewType = '<platform-view-type>';
-  // Pass parameters to the platform side.
-  final Map<String, dynamic> creationParams = <String, dynamic>{};
-
-  return AndroidView(
-    viewType: viewType,
-    layoutDirection: TextDirection.ltr,
-    creationParams: creationParams,
-    creationParamsCodec: const StandardMessageCodec(),
-  );
-}
-```
-</li>
-</ol>
+   <?code-excerpt "lib/platform_views/native_view_example_2.dart (VirtualDisplayWidget)"?>
+   ```dart
+   Widget build(BuildContext context) {
+     // This is used in the platform side to register the view.
+     const String viewType = '<platform-view-type>';
+     // Pass parameters to the platform side.
+     final Map<String, dynamic> creationParams = <String, dynamic>{};
+   
+     return AndroidView(
+       viewType: viewType,
+       layoutDirection: TextDirection.ltr,
+       creationParams: creationParams,
+       creationParamsCodec: const StandardMessageCodec(),
+     );
+   }
+   ```
 
 For more information, see the API docs for:
 
@@ -185,8 +175,8 @@ in either Java or Kotlin:
 In your native code, implement the following:
 
 Extend `io.flutter.plugin.platform.PlatformView`
-to provide a reference to the `android.view.View`,
-For example, `NativeView.kt`:
+to provide a reference to the `android.view.View`
+(for example, `NativeView.kt`):
 
 ```kotlin
 package dev.flutter.example
@@ -216,8 +206,8 @@ internal class NativeView(context: Context, id: Int, creationParams: Map<String?
 ```
 
 Create a factory class that creates an instance of the
-`NativeView` created earlier,
-for example, `NativeViewFactory.kt`:
+`NativeView` created earlier
+(for example, `NativeViewFactory.kt`):
 
 ```kotlin
 package dev.flutter.example
@@ -285,8 +275,8 @@ class PlatformViewPlugin : FlutterPlugin {
 In your native code, implement the following:
 
 Extend `io.flutter.plugin.platform.PlatformView`
-to provide a reference to the `android.view.View`,
-For example, `NativeView.java`:
+to provide a reference to the `android.view.View`
+(for example, `NativeView.java`):
 
 ```java
 package dev.flutter.example;
@@ -322,8 +312,8 @@ class NativeView implements PlatformView {
 ```
 
 Create a factory class that creates an
-instance of the `NativeView` created earlier,
-for example, `NativeViewFactory.java`:
+instance of the `NativeView` created earlier
+(for example, `NativeViewFactory.java`):
 
 ```java
 package dev.flutter.example;
@@ -418,8 +408,8 @@ to require one of the minimal Android SDK versions:
 ```gradle
 android {
     defaultConfig {
-        minSdkVersion 19 // if using Hybrid composition.
-        minSdkVersion 20 // if using Virtual display.
+        minSdkVersion 19 // if using hybrid composition
+        minSdkVersion 20 // if using virtual display.
     }
 }
 ```


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ 

- Fixes the titles for the sections on Hybrid composition and virtual display section being located with the opposite snippet
- Use sentence case for sections and references to hybrid composition and virtual displays
- Moves hybrid composition first in the intro to match order of code snippets
- Links to the related sections
- Uses a consistent "(for example, `file_name.dart`)" format in the native example introductions
- Simplifies some Markdown formatting and removes HTML where not necessary

_Issues fixed by this PR (if any):_ Fixes https://github.com/flutter/website/issues/8064

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
