### PR TITLE
Update list of supported platforms for http package

### DIFF
--- a/src/development/data-and-backend/networking.md
+++ b/src/development/data-and-backend/networking.md
@@ -6,7 +6,7 @@ description: Internet network calls in Flutter.
 ## Cross-platform http networking
 
 The [`http`][] package provides the simplest way to issue http requests. This
-package is supported on Android, iOS, and the web.
+package is supported on Android, iOS, macOS, Windows, Linux and the web.
 
 ## Platform notes
 


### PR DESCRIPTION
http package that the link points to shows all platforms as supported on pub.dev

_Description of what this PR is changing or adding, and why:_

Updating text that refers to http package and mentions only three platforms although on the 
pub.dev page for the same package it shows that all platforms as supported

_Issues fixed by this PR (if any):_

Added platforms macOS, Windows and Linux to the list.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
