### PR TITLE
FIx #2654, #2709

### DIFF
--- a/examples/cookbook/design/package_fonts/lib/main.dart
+++ b/examples/cookbook/design/package_fonts/lib/main.dart
@@ -29,7 +29,6 @@ class MyHomePage extends StatelessWidget {
           'Using the Raleway font from the awesome_package',
           style: TextStyle(
             fontFamily: 'Raleway',
-            package: 'awesome_package',
           ),
         ),
         // #enddocregion TextStyle

--- a/src/cookbook/design/package-fonts.md
+++ b/src/cookbook/design/package-fonts.md
@@ -89,7 +89,6 @@ child: Text(
   'Using the Raleway font from the awesome_package',
   style: TextStyle(
     fontFamily: 'Raleway',
-    package: 'awesome_package',
   ),
 ),
 ```
@@ -160,7 +159,6 @@ class MyHomePage extends StatelessWidget {
           'Using the Raleway font from the awesome_package',
           style: TextStyle(
             fontFamily: 'Raleway',
-            package: 'awesome_package',
           ),
         ),
       ),


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

When you declare font in your own app package, you should omit `package` property from the `TextStyle`. 

_Issues fixed by this PR (if any):_

#2654, #2709

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
