### PR TITLE
Click "Contents" in side TOC to jump to top of page

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -42,12 +42,13 @@ function scrollSidebarIntoView() {
 function adjustToc() {
   // Adjustments to the jekyll-toc TOC.
 
-  var tocId = '#site-toc--side';
-  // Uncomment to enable 'page top' button
-  // var tocWrapper = $(tocId);
-  // $(tocWrapper).find('.site-toc--button__page-top').click(function () {
-  //   $('html, body').animate({ scrollTop: 0 }, 'fast');
-  // })
+  const tocId = '#site-toc--side';
+
+  document
+      .querySelector(tocId + ' header')
+      .addEventListener('click', function (_) {
+        $('html, body').animate({ scrollTop: 0 }, 'fast');
+      });
 
   $('body').scrollspy({ offset: 100, target: tocId });
 }


### PR DESCRIPTION
Enables clicking the "Contents" text in the right TOC to jump to the top of the page, similar to dart.dev.

**Staged for testing:** https://parlough-docs-flutter-dev.web.app/