### PR TITLE
Add `Overlay.of` to 3.7 breaking changes

### DIFF
--- a/src/release/breaking-changes/supplemental-maybeOf-migration.md
+++ b/src/release/breaking-changes/supplemental-maybeOf-migration.md
@@ -44,6 +44,7 @@ exception in release mode.
 * [`Form.of`]
 * [`HeroControllerScope.of`]
 * [`Material.of`]
+* [`Overlay.of`]
 * [`PageStorage.of`]
 * [`PrimaryScrollController.of`]
 * [`RenderAbstractViewport.of`]
@@ -61,6 +62,7 @@ value is not found, without throwing any exceptions.
 * [`Form.maybeOf`]
 * [`HeroControllerScope.maybeOf`]
 * [`Material.maybeOf`]
+* [`Overlay.maybeOf`]
 * [`PageStorage.maybeOf`]
 * [`PrimaryScrollController.maybeOf`]
 * [`RenderAbstractViewport.maybeOf`]
@@ -126,6 +128,7 @@ API documentation:
 Relevant PRs:
 
 * [Add `maybeOf` for all the cases when `of` returns nullable][]
+* [Add `Overlay.maybeOf`, make `Overlay.of` return a non-nullable instance][]
 
 [previous migration]: eliminating-nullok-parameters
 [`unnecessary_non_null_assertion`]: {{site.dart-site}}/tools/diagnostic-messages#unnecessary_non_null_assertion
@@ -145,6 +148,8 @@ Relevant PRs:
 [`InheritedWidget`]: {{site.api}}/flutter/widgets/InheritedWidget-class.html
 [`Material.maybeOf`]: {{site.api}}/flutter/material/Material/maybeOf.html
 [`Material.of`]: {{site.api}}/flutter/material/Material/of.html
+[`Overlay.maybeOf`]: {{site.api}}/flutter/widgets/Overlay/maybeOf.html
+[`Overlay.of`]: {{site.api}}/flutter/widgets/Overlay/of.html
 [`PageStorage.maybeOf`]: {{site.api}}/flutter/widgets/PageStorage/maybeOf.html
 [`PageStorage.of`]: {{site.api}}/flutter/widgets/PageStorage/of.html
 [`PrimaryScrollController.maybeOf`]: {{site.api}}/flutter/widgets/PrimaryScrollController/maybeOf.html
@@ -158,3 +163,5 @@ Relevant PRs:
 [`ScrollNotificationObserver.maybeOf`]: {{site.api}}/flutter/widgets/ScrollNotificationObserver/maybeOf.html
 [`ScrollNotificationObserver.of`]: {{site.api}}/flutter/widgets/ScrollNotificationObserver/of.html
 [Add `maybeOf` for all the cases when `of` returns nullable]: {{site.repo.flutter}}/pull/114120
+[Add `Overlay.maybeOf`, make `Overlay.of` return a non-nullable instance]: {{site.repo.flutter}}/pull/110811
+


### PR DESCRIPTION
The `Overlay.of` breaking change is missing in 3.7 breaking changes doc page. It was done in a separate PR https://github.com/flutter/flutter/pull/110811 earlier than the bulk of the other changes in https://github.com/flutter/flutter/pull/114120

_Description of what this PR is changing or adding, and why:_ 

Adds missing breaking change in 3.7

_Issues fixed by this PR (if any):_ 

* FIX https://github.com/flutter/website/issues/8187

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
