### PR TITLE
Fix sidebar text overlaying banner

### DIFF
--- a/src/_sass/components/_banner.scss
+++ b/src/_sass/components/_banner.scss
@@ -6,6 +6,7 @@
   padding: bs-spacer(5);
   position: relative;
   text-align: center;
+  z-index: 50;
 
   p {
     margin-bottom: bs-spacer(3);


### PR DESCRIPTION
Currently if you scroll the sidebar up, its text ends up overlaying the banner:

![Sidebar text overlaying banner](https://user-images.githubusercontent.com/18372958/216454947-35ed1218-b31f-4a46-916d-9d4eef2c4dbf.png)

This PR adds a `z-index` to the banner that is greater than the sidebar, but less than the top-nav to make sure it stays above the sidebar text.

![Sidebar text no longer overlaying banner](https://user-images.githubusercontent.com/18372958/216455252-075a1605-f484-4b08-af1f-848398e3e62d.png)
