### PR TITLE
Update firebase.json

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -255,6 +255,7 @@
       { "source": "/go/flutter-drop-android-jellybean-2023", "destination": "https://docs.google.com/document/d/1wWNly2SZRDqupSsHkBWDI_lS2MohBGEwPSXF6W05NOc/edit?usp=sharing", "type": 301 },
       { "source": "/go/flutter-doctor-app-folder", "destination": "https://docs.google.com/document/d/1_N70oh5rl0pMlz-epE_3fIr7gqE94dgoV-DHq5OlF2I/edit", "type": 301 },
       { "source": "/go/flutter-drop-macOS-10.13-2022-q4", "destination": "https://docs.google.com/document/d/1wHqr2cob78VfUKhOFEKjaUM_mnV4gL-mg3gSQCFhF7Y/edit", "type": 301 },
+      { "source": "/go/flutter-android-emulator-testing", "destination": "https://docs.google.com/document/d/10wYUcLcSTF4Epg2EUGoBqOkkOe4zxKHvYKjXFZAOgGs/edit?usp=sharing&resourcekey=0-pltjPvEtVezXDADMbUwFHQ", "type": 301 },
       { "source": "/go/flutter-engine-clocks", "destination": "https://docs.google.com/document/d/1Sx8QA1qXgJGw5r4ESviDnU2LSShNHiq_LjbRWPgSvXQ/edit?usp=sharing&resourcekey=0-BoBvLxgqf_nc_rwLc0zmTw", "type": 301 },
       { "source": "/go/flutter-engine-extensions", "destination": "https://docs.google.com/document/d/1xG7jR4FserdW7TdwnklF3_lXUGmt4myPQjDGF3LFtCQ/edit?resourcekey=0-Iug4D2mWuyQI6suvC_2itw#", "type": 301 },
       { "source": "/go/flutter-for-embedded-linux", "destination": "https://docs.google.com/document/d/1n4NXCk0QlGz16gUCtywR79H0Z1fzPqB2iNL8oxuexuk/edit?usp=sharing", "type": 301 },


### PR DESCRIPTION
Add a link for Emulators for Flutter Android Testing design document.

_Description of what this PR is changing or adding, and why:_
I want to add a design document for work done in getting flutter android devicelab tests running on emulators. This will allow us to run more tests in presubmit and catch test failures before testing on google3.

_Issues fixed by this PR (if any):_
Fixes https://github.com/flutter/flutter/issues/113945

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
