### PR TITLE
Remove stray parenthetical in terminal setup docs

### DIFF
--- a/src/get-started/test-drive/_terminal.md
+++ b/src/get-started/test-drive/_terminal.md
@@ -10,7 +10,7 @@ $ cd my_app
 ```
 
 It is also possible to pass other arguments to `flutter create`,
-such as the project name (*pubspec.yml*), the organization name,
+such as the project name, the organization name,
 or to specify the programming language used for the native platform:
 
 ```terminal


### PR DESCRIPTION
Not sure what this parenthetical was referring to...

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
