### PR TITLE
Add link to table development doc

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -403,6 +403,7 @@
       { "source": "/go/system-mouse-cursor", "destination": "https://docs.google.com/document/d/1bJLRy6flZ0wDCbpl2QA8SURUWXIvRJKMRRemxlOo1cA/edit", "type": 301 },
       { "source": "/go/tabs-and-text-fields", "destination": "https://docs.google.com/document/d/1aHucsI0NWGWu2Dm_XFsBLxiTgJRM8h2XBB7PVAnVxlU/edit?usp=sharing&resourcekey=0-zLbXFlP_A2e_Yoi43vdiiw", "type": 301 },
       { "source": "/go/take-flutter-home", "destination": "https://github.com/flutter/put-flutter-to-work", "type": 301 },
+      { "source": "/go/table-development", "destination": "https://docs.google.com/document/d/1fCE-zQNql0nnqJXhycpg902lhL7jrOOz-6sT8s8tv5c/edit?usp=sharing", "type": 301 },
       { "source": "/go/template", "destination": "https://docs.google.com/document/d/1SFRO8U2toOlAaZ38dsuEU7Wm5fn41wvBCWKiwADqfmw/edit", "type": 301 },
       { "source": "/go/test-all-platforms", "destination": "https://docs.google.com/document/d/1-gw2zYFs_jBqsFPpXRonRNLYn6XNgvm34jc9HT84VKE/edit?usp=sharing", "type": 301 },
       { "source": "/go/test-widgets-flutter-binding-clock", "destination": "https://docs.google.com/document/d/1EkkLbECNBwHgddBQAZqEy7iQLTIxR1rgChKzxcLwhio/edit", "type": 301 },


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
This adds a go link to the table development doc, which includes public information about the development of the TableView widget that we're getting ready.

_Issues fixed by this PR (if any):_

Part of https://github.com/orgs/flutter/projects/32

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
