### PR TITLE
Temporarily comment out mentions to memory perf doc like battery entry

### DIFF
--- a/src/perf/index.md
+++ b/src/perf/index.md
@@ -56,7 +56,7 @@ in some future pages.
 
 {% comment %}
 
-TODO: Reintroduce this article and add this link back.
+TODO(https://github.com/flutter/website/issues/8249): Reintroduce this article and add this link back.
 
 ## Memory
 
@@ -74,7 +74,7 @@ the quicker it is to download.
 
 {% comment %}
 
-TODO: Reintroduce this article and add this link back.
+TODO(https://github.com/flutter/website/issues/8249): Reintroduce this article and add this link back.
 
 ## Energy
 

--- a/src/perf/index.md
+++ b/src/perf/index.md
@@ -38,10 +38,10 @@ database: "[perf: speed][speed]", "[perf: memory][memory]",
 
 The rest of the content is organized using those four categories.
 
-<!--
+{% comment %}
 Let's put "speed" (rendering) first as it's the most popular performance issue
 category.
--->
+{% endcomment -%}
 ## Speed
 
 Are your animations janky (not smooth)? Learn how to 
@@ -52,12 +52,17 @@ evaluate and fix rendering issues.
 {% comment %}
 Do your apps take a long time to open? We'll also cover the startup speed issue
 in some future pages.
-{% endcomment %}
+{% endcomment -%}
 
+{% comment %}
+
+TODO: Reintroduce this article and add this link back.
 
 ## Memory
 
 [Using memory wisely]({{site.url}}/perf/memory)
+
+{% endcomment -%}
 
 
 ## App size
@@ -69,6 +74,7 @@ the quicker it is to download.
 
 {% comment %}
 
+TODO: Reintroduce this article and add this link back.
 
 ## Energy
 
@@ -76,7 +82,7 @@ How to ensure a longer battery life when running your app.
 
 [Preserving your battery]({{site.url}}/perf/power)
 
-{% endcomment %}
+{% endcomment -%}
 
 [Measuring your app's size]: {{site.url}}/perf/app-size
 


### PR DESCRIPTION
We removed these docs as they were empty and causing confusion. This comments out the broken link to it, but we should write the articles and link to them. Tracking in https://github.com/flutter/website/issues/8249

Fixes https://github.com/flutter/website/issues/8221