### PR TITLE
Add info for the `flutter_reactive_widget` state management library

### DIFF
--- a/src/development/data-and-backend/state-mgmt/options.md
+++ b/src/development/data-and-backend/state-mgmt/options.md
@@ -291,7 +291,8 @@ A simple but powerful state management solution inspired by SolidJS.
 
 ## flutter_reactive_widget
 
-An ultra-low-boilerplate solution for state management, which defines
+An ultra-low-boilerplate solution for state management,
+flutter_reactive_widget defines
 `ReactiveWidget` and `ReactiveValue`. Any read of a `ReactiveValue`'s
 value within a `ReactiveWidget` definition automatically causes the
 `ReactiveWidget` to listen for changes on the `ReactiveValue`.

--- a/src/development/data-and-backend/state-mgmt/options.md
+++ b/src/development/data-and-backend/state-mgmt/options.md
@@ -288,3 +288,17 @@ A simple but powerful state management solution inspired by SolidJS.
 [Official Documentation]: https://docs.page/nank1ro/solidart
 [solidart package]: {{site.pub-pkg}}/solidart
 [flutter_solidart package]: {{site.pub-pkg}}/flutter_solidart
+
+## flutter_reactive_widget
+
+An ultra-low-boilerplate solution for state management, which defines `ReactiveWidget` and `ReactiveValue`.
+Any read of a `ReactiveValue`'s value within a `ReactiveWidget` definition automatically causes the `ReactiveWidget`
+to listen for changes on the `ReactiveValue`.
+
+Also includes a definition for `PersistentReactiveValue`, a subclass of `ReactiveValue` whose latest value is persisted,
+surviving app restarts.
+
+* [`flutter_reactive_widget`][] source and documentation
+
+[`flutter_reactive_widget`]: {{site.github}}/lukehutch/flutter_reactive_widget
+

--- a/src/development/data-and-backend/state-mgmt/options.md
+++ b/src/development/data-and-backend/state-mgmt/options.md
@@ -291,12 +291,14 @@ A simple but powerful state management solution inspired by SolidJS.
 
 ## flutter_reactive_widget
 
-An ultra-low-boilerplate solution for state management, which defines `ReactiveWidget` and `ReactiveValue`.
-Any read of a `ReactiveValue`'s value within a `ReactiveWidget` definition automatically causes the `ReactiveWidget`
-to listen for changes on the `ReactiveValue`.
+An ultra-low-boilerplate solution for state management, which defines
+`ReactiveWidget` and `ReactiveValue`. Any read of a `ReactiveValue`'s
+value within a `ReactiveWidget` definition automatically causes the
+`ReactiveWidget` to listen for changes on the `ReactiveValue`.
 
-Also includes a definition for `PersistentReactiveValue`, a subclass of `ReactiveValue` whose latest value is persisted,
-surviving app restarts.
+Also includes a definition for `PersistentReactiveValue`, a subclass
+of `ReactiveValue` whose latest value is persisted, surviving app
+restarts.
 
 * [`flutter_reactive_widget`][] source and documentation
 

--- a/src/development/data-and-backend/state-mgmt/options.md
+++ b/src/development/data-and-backend/state-mgmt/options.md
@@ -298,7 +298,7 @@ value within a `ReactiveWidget` definition automatically causes the
 `ReactiveWidget` to listen for changes on the `ReactiveValue`.
 
 Also includes a definition for `PersistentReactiveValue`, a subclass
-of `ReactiveValue` whose latest value is persisted, surviving app
+of `ReactiveValue` whose latest value persists, surviving app
 restarts.
 
 * [`flutter_reactive_widget`][] source and documentation


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Added info for `flutter_reactive_widget`, my state management library

_Issues fixed by this PR (if any):_

N/A

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
