### PR TITLE
Update codelab-web.md step 0 observations

### DIFF
--- a/src/get-started/codelab-web.md
+++ b/src/get-started/codelab-web.md
@@ -278,7 +278,7 @@ From your IDE, editor, or at the command line,
 * If you know Java, the Dart language should feel very familiar.
 * All of the app's UI is created in Dart code.
   For more information, see [Introduction to declarative UI][].
-* The app’s UI adheres [Material Design][],
+* The app’s UI adheres to [Material Design][],
   a visual design language that runs on any device or platform.
   You can customize the Material Design widgets,
   but if you prefer something else,


### PR DESCRIPTION

_Description of what this PR is changing or adding, and why:_
This change adds the word "to" to where it seems to belong. Under the observations for Step 0, there's mention of how "the app's UI adheres Material Design" which doesn't sound quite right and would demonstrate an atypical use of the word 'adheres'. It seems more likely this is a typo.

_Issues fixed by this PR (if any):_
n/a

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
