### PR TITLE
Allow leading spaces when stripping `$` from terminal clipboard content

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -170,7 +170,7 @@ function setupClipboardJS() {
     text: function (trigger) {
       var targetId = trigger.getAttribute('data-clipboard-target');
       var target = document.querySelector(targetId);
-      var terminalRegExp = /^(\$\s*)|(C:\\(.*)>\s*)/gm;
+      var terminalRegExp = /^(\s*\$\s*)|(C:\\(.*)>\s*)/gm;
       var copy = target.textContent.replace(terminalRegExp, '');
       return copy;
     }

--- a/src/get-started/install/_get-sdk-linux.md
+++ b/src/get-started/install/_get-sdk-linux.md
@@ -17,7 +17,7 @@ $ sudo snap install flutter --classic
 ```
 
 {{site.alert.note}}
-  Once the snap is installed, you can
+  Once you install the snap,
   use the following command to display your Flutter SDK path:
 
   ```terminal

--- a/src/get-started/install/_get-sdk-linux.md
+++ b/src/get-started/install/_get-sdk-linux.md
@@ -17,7 +17,8 @@ $ sudo snap install flutter --classic
 ```
 
 {{site.alert.note}}
-  Once the snap is installed, you can use the following command to display your Flutter SDK path:
+  Once the snap is installed, you can
+  use the following command to display your Flutter SDK path:
 
   ```terminal
   $ flutter sdk-path


### PR DESCRIPTION
Kramdown (our Markdown processor) has different indentation rules than other Markdown processors, and in this case the indentation is tied to the start of the line, not the indentation of the opening tag (```). We could move all alert code blocks to the beginning, but it will result in inconsistency and a lot more changes. 

For now, this adjusts the script which handles removing the leading `$` when clicking the copy to clipboard button on terminal snippets, so that the `$` is removed even if there are extra leading spaces. This also removes those leading spaces when copying.

Fixes https://github.com/flutter/website/issues/8286