### PR TITLE
Fix 404 page style and adjust links

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -9,17 +9,17 @@ permalink: /404.html
 <div class="not-found__wrapper">
   <h1>404</h1>
   <p>Sorry, we couldn’t find that page…</p>
-  <img src='/assets/images/404/dash_nest.png' class='not-found__illo'>
+  <img src='/assets/images/404/dash_nest.png' class='not-found__illo' alt="Dash pointing you in the right direction">
   <p>But Dash is here to help - maybe one of these will point you in the right direction?</p>
   <ul class="not-found__link-list">
-    <li><a href="/">Homepage</a></li>
-    <li><a href="https://pub.dev/">Package site</a></li>
-    <li><a href="https://api.flutter.dev/">API reference</a></li>
-    <li><a href="/">Documentation</a></li>
+    <li><a href="{{site.main-url}}/">Homepage</a></li>
+    <li><a href="{{site.pub}}/">Package site</a></li>
+    <li><a href="{{site.api}}/">API reference</a></li>
+    <li><a href="{{site.url}}/">Documentation</a></li>
     <li><a href="https://flutter.github.io/samples">Samples</a></li>
     <li><a href="{{site.main-url}}/community">Community</a></li>
-    <li><a href="https://medium.com/flutter">Medium</a></li>
-    <li><a href="https://twitter.com/flutterdev">Twitter</a></li>
-    <li><a href="/resources/faq">FAQ</a></li>
+    <li><a href="{{site.medium}}/flutter">Medium</a></li>
+    <li><a href="{{site.social.twitter}}/">Twitter</a></li>
+    <li><a href="{{site.url}}/resources/faq">FAQ</a></li>
   </ul>
 </div>

--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -77,7 +77,7 @@
       <link rel="stylesheet" href="{{ asset_path | append: cache_bust }}">
     {% endfor -%}
   </head>
-  <body{% if page.body_class %}class="{{ page.body_class }}"{% endif %}>
+  <body{% if page.body_class %} class="{{ page.body_class }}"{% endif %}>
 
     {% include_cached cookie-notice.html %}
   


### PR DESCRIPTION
Looks like I accidentally removed the space before the `body_class` (in [#8003](https://github.com/flutter/website/pull/8003/files#diff-5b3e4b1d3efdb3c91df0102f9588c1959298094c776da640e681e92014148d5dL76)) which the `404.html` page uses to configures its styles, but it is necessary for the `class` attribute to work. This fixes the HTML in that case so the space is included only if a `body_class` is set.

Also:

- Uses site variables for the links on the page in case they change in the future and changes **Homepage** to link to `flutter.dev` since **Documentation** already links to `docs.flutter.dev`.
- Adds an `alt` tag to the Dash image

