### PR TITLE
fix typo in doc

### DIFF
--- a/src/cookbook/plugins/picture-using-camera.md
+++ b/src/cookbook/plugins/picture-using-camera.md
@@ -49,7 +49,7 @@ dependencies:
   path:
 ```
 {{site.alert.tip}}
-  - For android, You have to update `minSdkVersion` to 21 (or higher).
+  - For android, You must update `minSdkVersion` to 21 (or higher).
   - On iOS, lines below have to be added inside `ios/Runner/Info.plist` in order the access the camera and microphone.
     ```
     <key>NSCameraUsageDescription</key>

--- a/src/cookbook/plugins/picture-using-camera.md
+++ b/src/cookbook/plugins/picture-using-camera.md
@@ -49,7 +49,7 @@ dependencies:
   path:
 ```
 {{site.alert.tip}}
-  - For android, You must have to update `minSdkVersion` to 21 (or higher).
+  - For android, You have to update `minSdkVersion` to 21 (or higher).
   - On iOS, lines below have to be added inside `ios/Runner/Info.plist` in order the access the camera and microphone.
     ```
     <key>NSCameraUsageDescription</key>


### PR DESCRIPTION
Fix the typo "must have to" to "have to"

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).