### PR TITLE
Adds ignoringSemantics migration guide

### DIFF
--- a/src/release/breaking-changes/ignoringsemantics-migration.md
+++ b/src/release/breaking-changes/ignoringsemantics-migration.md
@@ -1,0 +1,89 @@
+---
+title: Migration guide for ignoringSemantics in IgnorePointer and its friend
+description: Removal of ignoringSemantics in IgnorePointer and its friend.
+---
+
+## Summary
+
+The `ignoringSemantics` properties are removed in [`IgnorePointer`][],
+[`AbsorbPointer`][], [`SliverIgnorePointer`][], [`RenderSliverIgnorePointer`][],
+[`RenderIgnorePointer`][], and [`RenderAbsorbPointer`][].
+
+## Context
+
+The `ignoreSemantics` was introduced as a workaround to mitigate the result of
+`IgnorePointer` and its related widgets dropping entire semantics subtrees. This
+issue was later fixed, thus no longer needs the workaround now.
+
+## Description of change
+
+`ignoringSemantics` was removed
+
+## Migration guide
+
+If you are setting this parameter to true in these widgets, consider using
+ExcludeSemantics instead.
+
+Code before migration:
+
+```dart
+IgnorePointer(``
+  ignoringSemantics: true,
+  child: const PlaceHolder(),
+);
+```
+
+Code after migration:
+
+```dart
+ExcludeSemantics(
+  child: IgnorePointer(
+    child: const PlaceHolder(),
+  ),
+);
+```
+
+The behavior of setting `ignoringSemantics` to false is no longer supported.
+Consider creating your own custom widget.
+
+```dart
+/// A widget ignores pointer event but still keeps semantics actions.
+class _IgnorePointerWithSemantics extends SingleChildRenderObjectWidget {
+  const _IgnorePointerWithSemantics({
+    super.child,
+  });
+
+  @override
+  _RenderIgnorePointerWithSemantics createRenderObject(BuildContext context) {
+    return _RenderIgnorePointerWithSemantics();
+  }
+}
+
+class _RenderIgnorePointerWithSemantics extends RenderProxyBox {
+  _RenderIgnorePointerWithSemantics();
+
+  @override
+  bool hitTest(BoxHitTestResult result, { required Offset position }) => false;
+}
+```
+
+
+## Timeline
+
+Landed in version: TBD  <br>
+In stable release: TBD
+
+## References
+
+Relevant PRs:
+
+* [PR 120619][]: Fixes IgnorePointer and AbsorbPointer to only block user
+interactions in a11y.
+
+[PR 120619]: {{site.repo.flutter}}/pull/120619
+[`IgnorePointer`]: {{site.api}}/flutter/widgets/IgnorePointer-class.html
+[`AbsorbPointer`]: {{site.api}}/flutter/widgets/AbsorbPointer-class.html
+[`SliverIgnorePointer`]: {{site.api}}/flutter/widgets/SliverIgnorePointer-class.html
+[`RenderSliverIgnorePointer`]: {{site.api}}/flutter/rendering/RenderSliverIgnorePointer-class.html
+[`RenderIgnorePointer`]: {{site.api}}/flutter/rendering/RenderIgnorePointer-class.html
+[`RenderAbsorbPointer`]: {{site.api}}/flutter/rendering/RenderAbsorbPointer-class.html

--- a/src/release/breaking-changes/ignoringsemantics-migration.md
+++ b/src/release/breaking-changes/ignoringsemantics-migration.md
@@ -1,5 +1,5 @@
 ---
-title: Migration guide for ignoringSemantics in IgnorePointer and its friend
+title: Migration guide for ignoringSemantics in IgnorePointer and related classes
 description: Removal of ignoringSemantics in IgnorePointer and related classes.
 ---
 

--- a/src/release/breaking-changes/ignoringsemantics-migration.md
+++ b/src/release/breaking-changes/ignoringsemantics-migration.md
@@ -1,6 +1,6 @@
 ---
 title: Migration guide for ignoringSemantics in IgnorePointer and its friend
-description: Removal of ignoringSemantics in IgnorePointer and its friend.
+description: Removal of ignoringSemantics in IgnorePointer and related classes.
 ---
 
 ## Summary

--- a/src/release/breaking-changes/ignoringsemantics-migration.md
+++ b/src/release/breaking-changes/ignoringsemantics-migration.md
@@ -12,8 +12,8 @@ The `ignoringSemantics` properties are removed in [`IgnorePointer`][],
 ## Context
 
 The `ignoreSemantics` was introduced as a workaround to mitigate the result of
-`IgnorePointer` and its related widgets dropping entire semantics subtrees. This
-issue was later fixed, thus no longer needed
+`IgnorePointer` and its related widgets dropping entire semantics subtrees.
+Therefore, this workaround is no longer needed.
 
 ## Description of change
 

--- a/src/release/breaking-changes/ignoringsemantics-migration.md
+++ b/src/release/breaking-changes/ignoringsemantics-migration.md
@@ -21,8 +21,8 @@ Therefore, this workaround is no longer needed.
 
 ## Migration guide
 
-If you are setting this parameter to true in these widgets, consider using
-ExcludeSemantics instead.
+If you set this parameter to true in these widgets, consider using
+`ExcludeSemantics` instead.
 
 Code before migration:
 

--- a/src/release/breaking-changes/ignoringsemantics-migration.md
+++ b/src/release/breaking-changes/ignoringsemantics-migration.md
@@ -13,7 +13,7 @@ The `ignoringSemantics` properties are removed in [`IgnorePointer`][],
 
 The `ignoreSemantics` was introduced as a workaround to mitigate the result of
 `IgnorePointer` and its related widgets dropping entire semantics subtrees. This
-issue was later fixed, thus no longer needs the workaround now.
+issue was later fixed, thus no longer needed
 
 ## Description of change
 

--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -16,11 +16,11 @@ release, and listed in alphabetical order:
 [Flutter announce]: {{site.groups}}/forum/#!forum/flutter-announce
 [Dart announce]: https://groups.google.com/a/dartlang.org/g/announce
 
-{% comment %}
-Uncomment this anchor when there are more items that aren't yet released.
 ### Not yet released to stable
-{% endcomment %}
 
+* [Removed `ignoringSemantics`][]
+
+[Removed `ignoringSemantics`]: {{site.url}}/release/breaking-changes/ignoringsemantics-migration
 
 ### Released in Flutter 3.7
 
@@ -29,7 +29,6 @@ Uncomment this anchor when there are more items that aren't yet released.
 * [Deprecated API removed after v3.3][]
 * [iOS FlutterViewController splashScreenView made nullable][]
 * [ThemeData's toggleableActiveColor property has been deprecated][]
-
 
 [Deprecated API removed after v3.3]: {{site.url}}/release/breaking-changes/3-3-deprecations
 [iOS FlutterViewController splashScreenView made nullable]: {{site.url}}/release/breaking-changes/ios-flutterviewcontroller-splashscreenview-nullable


### PR DESCRIPTION
migration guide for https://github.com/flutter/flutter/pull/120619

## Presubmit checklist
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
