### PR TITLE
Fix link checker ignoring links during GitHub workflow

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -19,4 +19,6 @@ jobs:
         with:
           submodules: "recursive"
       - name: Build and check links
-        run: make build # Runs tool/check-links.sh as part of build
+        # Runs tool/check-links.sh as part of build
+        # Overrides {{site.url}} to localhost:5500 since the site use absolute URLs
+        run: make build BUILD_CONFIGS=_config.yml,_config_link_check.yml

--- a/_config_link_check.yml
+++ b/_config_link_check.yml
@@ -1,0 +1,3 @@
+url: http://localhost:5500
+host: 0.0.0.0
+port: 5500

--- a/_config_link_check.yml
+++ b/_config_link_check.yml
@@ -1,3 +1,3 @@
 url: http://localhost:5500
-host: 0.0.0.0
+host: localhost
 port: 5500

--- a/src/whats-new.md
+++ b/src/whats-new.md
@@ -1019,7 +1019,7 @@ Happy Fluttering!
 [ToggleButtons demo]: {{site.github}}/csells/flutter_toggle_buttons
 [Try it out]: {{site.url}}/codelabs/layout-basics
 [Upgrading from package:flutter_web to the Flutter SDK]: {{site.repo.flutter}}/wiki/Upgrading-from-package:flutter_web-to-the-Flutter-SDK
-[using the dart:ffi library]: {{site.url}}/development/platform-integration/c-interop
+[using the dart:ffi library]: {{site.url}}/development/platform-integration/android/c-interop
 [web FAQ]: {{site.url}}/development/platform-integration/web
 
 ## July 9, 2019: 1.7 release


### PR DESCRIPTION
The link checker has been ignoring local links (docs.flutter.dev to docs.flutter.dev), at least since https://github.com/flutter/website/pull/7580, since we use absolute URLs through `{{site.url}}`. When emulating the site locally, the url set as `docs.flutter.dev` was seen as external (from `localhost:5500`) which we currently don't check on CI, therefore we were not checking if links were valid.

This PR introduces an override to the `{{site.url}}` variable through an extra `_config_link_check.yml` when running the link checker on GitHub actions, so that it matches the emulator.

There may be a better way to fix this, but without restructuring some of the Docker workflow, this seems like the easiest way for now.