### PR TITLE
Update and fix multiple redirected or outdated links

### DIFF
--- a/src/deployment/android.md
+++ b/src/deployment/android.md
@@ -563,7 +563,7 @@ The resulting app bundle or APK files are located in
 [obfuscating your Dart code]: {{site.url}}/deployment/obfuscate
 [official Play Store documentation]: https://support.google.com/googleplay/android-developer/answer/7384423?hl=en
 [permissiontag]: {{site.android-dev}}/guide/topics/manifest/uses-permission-element
-[Platform Views]: {{site.url}}/development/platform-integration/platform-views
+[Platform Views]: {{site.url}}/development/platform-integration/android/platform-views
 [play]: {{site.android-dev}}/distribute/googleplay/start
 [plugin]: {{site.android-dev}}/studio/releases/gradle-plugin
 [R8]: {{site.android-dev}}/studio/build/shrink-code

--- a/src/deployment/web.md
+++ b/src/deployment/web.md
@@ -145,11 +145,11 @@ PWA support remains a work in progress,
 so please [give us feedback][] if you see something that doesn’t look right.
 
 [dhttpd]: {{site.pub}}/packages/dhttpd
-[Displaying images on the web]: {{site.url}}/development/platform-integration/web-images
+[Displaying images on the web]: {{site.url}}/development/platform-integration/web/web-images
 [Firebase Hosting]: {{site.firebase}}/docs/hosting
 [GitHub Pages]: https://pages.github.com/
 [give us feedback]: {{site.repo.flutter}}/issues/new?title=%5Bweb%5D:+%3Cdescribe+issue+here%3E&labels=%E2%98%B8+platform-web&body=Describe+your+issue+and+include+the+command+you%27re+running,+flutter_web%20version,+browser+version
 [Google Cloud Hosting]: https://cloud.google.com/solutions/web-hosting
 [`iframe`]: https://html.com/tags/iframe/
-[Web renderers]: {{site.url}}/development/tools/web-renderers
+[Web renderers]: {{site.url}}/development/platform-integration/web/renderers
 

--- a/src/development/data-and-backend/networking.md
+++ b/src/development/data-and-backend/networking.md
@@ -26,6 +26,7 @@ manifest (`AndroidManifest.xml `):
 ```
 
 ### macOS
+
 macOS apps must allow network access in the relevant `.entitlements` files. 
 
 ```
@@ -33,8 +34,9 @@ macOS apps must allow network access in the relevant `.entitlements` files.
 <true/>
 ```
 
-Learn more about
-[setting up entitlements]({{site.url}}/desktop/macos#setting-up-entitlements).
+Learn more about [setting up entitlements][].
+
+[setting up entitlements]: {{site.url}}/development/platform-integration/macos/building#setting-up-entitlements
 
 ## Samples
 

--- a/src/development/platform-integration/ios/c-interop.md
+++ b/src/development/platform-integration/ios/c-interop.md
@@ -241,42 +241,6 @@ use the following instructions:
 1. Also add it to the **Linked Frameworks & Libraries**
    section of the target in Xcode.
 
-#### Compiled (dynamic) library (macOS)
-
-To add a closed source library to a
-[Flutter macOS Desktop][] app,
-use the following instructions:
-
-1. Follow the instructions for Flutter desktop to create
-   a Flutter desktop app.
-1. Open the `yourapp/macos/Runner.xcworkspace` in Xcode.
-   1. Drag your precompiled library (`libyourlibrary.dylib`)
-      into `Runner/Frameworks`.
-   1. Click `Runner` and go to the `Build Phases` tab.
-      1. Drag `libyourlibrary.dylib` into the
-         `Copy Bundle Resources` list.
-      1. Under `Embed Libraries`, check `Code Sign on Copy`.
-      1. Under `Link Binary With Libraries`,
-         set status to `Optional`. (We use dynamic linking,
-         no need to statically link.)
-   1. Click `Runner` and go to the `General` tab.
-      1. Drag `libyourlibrary.dylib` into the `Frameworks,
-         Libararies and Embedded Content` list.
-      1. Select `Embed & Sign`.
-   1. Click `Runner` and go to the `Build Settings` tab.
-      1. In the `Search Paths` section configure the
-         `Library Search Paths` to include the path
-         where `libyourlibrary.dylib` is located.
-1. Edit `lib/main.dart`.
-   1. Use `DynamicLibrary.open('libyourlibrary.dylib')`
-      to dynamically link to the symbols.
-   1. Call your native function somewhere in a widget.
-1. Run `flutter run` and check that your native function gets called.
-1. Run `flutter build macos` to build a self-contained release
-   version of your app.
-
-[Flutter macOS Desktop]: {{site.url}}/desktop
-
 #### Open-source third-party library
 
 To create a Flutter plugin that includes both

--- a/src/development/platform-integration/macos/c-interop.md
+++ b/src/development/platform-integration/macos/c-interop.md
@@ -267,7 +267,7 @@ use the following instructions:
 1. Run `flutter build macos` to build a self-contained release
    version of your app.
 
-[Flutter macOS Desktop]: {{site.url}}/desktop
+[Flutter macOS Desktop]: {{site.url}}/development/platform-integration/macos/building
 
 {% comment %}
 

--- a/src/development/ui/navigation/index.md
+++ b/src/development/ui/navigation/index.md
@@ -169,7 +169,7 @@ resources:
 [`Router`]: {{site.api}}/flutter/widgets/Router-class.html
 [Deep linking]: {{site.url}}/development/ui/navigation/deep-linking
 [navigation recipes]: {{site.url}}/cookbook#navigation
-[`MaterialApp.routes`]: {{site.url}}/flutter/material/MaterialApp/routes.html
+[`MaterialApp.routes`]: {{site.api}}/flutter/material/MaterialApp/routes.html
 [Navigate with named routes]: {{site.url}}/cookbook/navigation/named-routes
 [go_router]: {{site.pub}}/packages/go_router
 [`Page`]: {{site.api}}/flutter/widgets/Page-class.html

--- a/src/get-started/install/_windows-desktop-setup.md
+++ b/src/get-started/install/_windows-desktop-setup.md
@@ -16,8 +16,8 @@ you need the following in addition to the Flutter SDK:
   **Visual Studio** is different than Visual Studio _Code_.
 {{site.alert.end}}
 
-For more information, see [Desktop support for Flutter][]
+For more information, see [Building Windows apps][].
 
-[Desktop support for Flutter]: {{site.url}}/desktop
+[Building Windows apps]: {{site.url}}/development/platform-integration/windows/building
 [Visual Studio 2022]: https://visualstudio.microsoft.com/downloads/
 [Visual Studio Build Tools 2022]: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022

--- a/src/get-started/web.md
+++ b/src/get-started/web.md
@@ -80,8 +80,7 @@ than [creating a new Flutter project][] for other platforms.
 #### IDE
 
 Create a new app in your IDE and it automatically
-creates iOS, Android, and web versions of your app.
-(And macOS, too, if you've enabled [desktop support][].)
+creates iOS, Android, [desktop][], and web versions of your app.
 From the device pulldown, select **Chrome (web)**
 and run your app to see it launch in Chrome.
 
@@ -154,7 +153,7 @@ $ flutter create --platforms web .
 [Build and release a web app]: {{site.url}}/deployment/web
 [creating a new Flutter project]: {{site.url}}/get-started/test-drive
 [dart2js]: {{site.dart-site}}/tools/dart2js
-[desktop support]: {{site.url}}/desktop
+[desktop]: {{site.url}}/development/platform-integration/desktop
 [development compiler]: {{site.dart-site}}/tools/dartdevc
 [file an issue]: {{site.repo.flutter}}/issues/new?title=[web]:+%3Cdescribe+issue+here%3E&labels=%E2%98%B8+platform-web&body=Describe+your+issue+and+include+the+command+you%27re+running,+flutter_web%20version,+browser+version
 [install the Flutter and Dart plugins]: {{site.url}}/get-started/editor
@@ -162,4 +161,4 @@ $ flutter create --platforms web .
 [web FAQ]: {{site.url}}/development/platform-integration/web
 [Chrome]: https://www.google.com/chrome/
 [Flutter SDK]: {{site.url}}/get-started/install
-[Web renderers]: {{site.url}}/development/tools/web-renderers
+[Web renderers]: {{site.url}}/development/platform-integration/web/renderers

--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -32,7 +32,7 @@ release, and listed in alphabetical order:
 
 [Deprecated API removed after v3.3]: {{site.url}}/release/breaking-changes/3-3-deprecations
 [iOS FlutterViewController splashScreenView made nullable]: {{site.url}}/release/breaking-changes/ios-flutterviewcontroller-splashscreenview-nullable
-[Migrate `of` to non-nullable return values, and add `maybeOf`]: {{site.url}}/docs/release/breaking-changes/supplemental-maybeOf-migration
+[Migrate `of` to non-nullable return values, and add `maybeOf`]: {{site.url}}/release/breaking-changes/supplemental-maybeOf-migration
 [Removed RouteSettings.copyWith]: {{site.url}}/release/breaking-changes/routesettings-copywith-migration
 [ThemeData's toggleableActiveColor property has been deprecated]: {{site.url}}/release/breaking-changes/toggleable-active-color
 

--- a/src/resources/faq.md
+++ b/src/resources/faq.md
@@ -1007,7 +1007,7 @@ apps built with Flutter should follow Apple's
 [Dart]: {{site.dart-site}}/
 [Dart DevTools]: {{site.url}}/development/tools/devtools
 [Debugging with Flutter]: {{site.url}}/testing/debugging
-[desktop]: {{site.url}}/desktop
+[desktop]: {{site.url}}/development/platform-integration/desktop
 [detailed discussion on the API docs for `State.build`]: {{site.api}}/flutter/widgets/State/build.html
 [Discord]: https://discord.gg/N7Yshp4
 [`Divider`]: {{site.api}}/flutter/material/Divider-class.html

--- a/src/web/index.md
+++ b/src/web/index.md
@@ -91,4 +91,4 @@ The following resources can help you get started:
 [Progressive Web Application]: https://web.dev/progressive-web-apps/
 [web FAQ]: {{site.url}}/development/platform-integration/web
 [web samples for Flutter]: https://flutter.github.io/samples/#?platform=web
-[Web renderers]: {{site.url}}/development/tools/web-renderers
+[Web renderers]: {{site.url}}/development/platform-integration/web/renderers

--- a/src/whats-new.md
+++ b/src/whats-new.md
@@ -302,7 +302,7 @@ and the [Flutter 3 release notes][].
 [Customizing web app initialization]: {{site.url}}/development/platform-integration/web/initialization
 [dart-whats-new]: {{site.dart-site}}/guides/whats-new
 [dart.dev]: {{site.dart-site}}
-[Desktop]: {{site.url}}/desktop
+[Desktop]: {{site.url}}/development/platform-integration/desktop
 [Flutter Firebase get started guide]: https://firebase.google.com/docs/flutter/setup
 [Games page]: {{site.main-url}}/games
 [Games doc page]: {{site.url}}/resources/games-toolkit
@@ -480,7 +480,7 @@ publication since the last stable release:
 [DartPad Sharing Guide (using a Gist file)]: {{site.github}}/dart-lang/dart-pad/wiki/Sharing-Guide
 [DartPad Workshop Authoring Guide]: {{site.github}}/dart-lang/dart-pad/wiki/Workshop-Authoring-Guide
 [Deferred components]: {{site.url}}/perf/deferred-components
-[desktop]: {{site.url}}/desktop
+[desktop]: {{site.url}}/development/platform-integration/desktop
 [Embedded Support for Flutter]: {{site.url}}/embedded
 [Embedding DartPad in your web page]: {{site.github}}/dart-lang/dart-pad/wiki/Embedding-Guide
 [Firebase for Flutter]: {{site.youtube-site}}/watch?v=4wunbF29Kkg
@@ -582,7 +582,7 @@ publication since the last stable release:
 [Creating responsive and adaptive apps]: {{site.url}}/development/ui/layout/adaptive-responsive
 [Dart sound null safety: technical preview 2]: {{site.flutter-medium}}/null-safety-flutter-tech-preview-cb5c98aba187
 [Deprecation Lifetime in Flutter]: {{site.flutter-medium}}/deprecation-lifetime-in-flutter-e4d76ee738ad
-[Desktop support for Flutter]: {{site.url}}/desktop
+[Desktop support for Flutter]: {{site.url}}/development/platform-integration/desktop
 [Devtools]: {{site.url}}/development/tools/devtools/overview
 [Flutter Ads]: {{site.main-url}}/monetization
 [Flutter 2 release notes]: {{site.url}}/development/tools/sdk/release-notes/release-notes-2.0.0
@@ -629,9 +629,9 @@ Flutter 1.22 is live! For details, see
 * Added a page that describes how to [migrate your app to use the
   new icon glyphs available in
   `CupertinoIcons`][cupertino-icons].
-* Added a page that describes the new [implementation for
-  Platform Views and how to use them to host native Android
-  and iOS views in your Flutter app][platform-views].
+* Added a page that describes the new implementation for
+  Platform Views and how to use them to host native [Android views]
+  and [iOS views][] in your Flutter app platform-views.
   This feature has enabled the [google_maps_flutter][]
   and [webview_flutter][] plugins to be
   updated to production-ready release 1.0.
@@ -664,21 +664,22 @@ publication since the last stable release:
 * [Updates on Flutter and Firebase][]
 
 
-[add an iOS App Clip]: {{site.url}}/development/platform-integration/ios-app-clip
+[add an iOS App Clip]: {{site.url}}/development/platform-integration/ios/ios-app-clip
 [animations]: {{site.pub}}/packages/animations
 [Announcing Flutter 1.22]: {{site.flutter-medium}}/announcing-flutter-1-22-44f146009e5f
 [Announcing Flutter Windows Alpha]: {{site.flutter-medium}}/announcing-flutter-windows-alpha-33982cd0f433
 [App Size tool]: {{site.url}}/development/tools/devtools/app-size
 [Building Beautiful Transitions with Material Motion for Flutter]: {{site.codelabs}}/codelabs/material-motion-flutter
 [cupertino-icons]: {{site.url}}/release/breaking-changes/cupertino-icons-1.0.0
-[Developing for iOS 14]: {{site.url}}/development/ios-14
+[Developing for iOS 14]: {{site.url}}/development/platform-integration/ios/ios-debugging
 [google_maps_flutter]: {{site.pub}}/packages/google_maps_flutter
 [Handling web gestures in Flutter]: {{site.flutter-medium}}/handling-web-gestures-in-flutter-e16946a04745
 [Integration testing with flutter_driver]: {{site.flutter-medium}}/integration-testing-with-flutter-driver-36f66ede5cf2
 [Learn testing with the new Flutter sample]: {{site.flutter-medium}}/learn-testing-with-the-new-flutter-sample-gsoc20-work-product-e872c7f6492a
 [Learning Flutter's new navigation and routing]: {{site.flutter-medium}}/learning-flutters-new-navigation-and-routing-system-7c9068155ade
 [Platform channel examples]: {{site.flutter-medium}}/platform-channel-examples-7edeaeba4a66
-[platform-views]: {{site.url}}/development/platform-integration/platform-views
+[Android views]: {{site.url}}/development/platform-integration/android/platform-views
+[iOS views]: {{site.url}}/development/platform-integration/ios/platform-views
 [Supporting iOS 14 and Xcode 12 with Flutter]: {{site.flutter-medium}}/supporting-ios-14-and-xcode-12-with-flutter-15fe0062e98b
 [Updates on Flutter and Firebase]: {{site.flutter-medium}}/updates-on-flutter-and-firebase-8076f70bc90e
 [webview_flutter]: {{site.pub}}/packages/webview_flutter
@@ -759,9 +760,9 @@ publication since the last stable release:
 [Announcing Flutter 1.20]: {{site.flutter-medium}}/announcing-flutter-1-20-2aaf68c89c75
 [Building performant Flutter widgets]: {{site.flutter-medium}}/building-performant-flutter-widgets-3b2558aa08fa
 [codelabs landing]: {{site.url}}/codelabs
-[Desktop support]: {{site.url}}/desktop
+[Desktop support]: {{site.url}}/development/platform-integration/desktop
 [dev-tools]: {{site.flutter-medium}}/new-tools-for-flutter-developers-built-in-flutter-a122cb4eec86
-[Developing for iOS 14 beta]: {{site.url}}/development/ios-14
+[Developing for iOS 14 beta]: {{site.url}}/development/platform-integration/ios/ios-debugging
 [Enums with Extensions in Dart]: {{site.flutter-medium}}/enums-with-extensions-dart-460c42ea51f7
 [Flutter and Desktop apps]: {{site.flutter-medium}}/flutter-and-desktop-3a0dd0f8353e
 [Flutter architectural overview]: {{site.url}}/resources/architectural-overview
@@ -816,7 +817,7 @@ Docs added and updated since the last announcement include:
   * [Writing custom platform-specific code][]
 * Added an [Obfuscating Dart code][] page.
   (Moved from the wiki and updated as of 1.16.2.)
-* Added a page on using [Xcode 11.4][] and how to manually update
+* Added a page on using Xcode 11.4 and how to manually update
   your project. The tooling, which automatically updates your
   configuration when possible, may direct you to this page
   if it detects that it's needed.
@@ -854,7 +855,7 @@ Other newness:
 [Announcing CodePen support for Flutter]: {{site.flutter-medium}}/announcing-codepen-support-for-flutter-bb346406fe50
 [Announcing Flutter 1.17]: {{site.flutter-medium}}/announcing-flutter-1-17-4182d8af7f8e
 [Custom implicit animations in Flutter…with TweenAnimationBuilder]: {{site.flutter-medium}}/custom-implicit-animations-in-flutter-with-tweenanimationbuilder-c76540b47185
-[Desktop]: {{site.url}}/desktop
+[Desktop]: {{site.url}}/development/platform-integration/desktop
 [Developing packages and plugins]: {{site.url}}/development/packages-and-plugins/developing-packages
 [Developing plugin packages]: {{site.url}}/development/packages-and-plugins/developing-packages#federated-plugins
 [Directional animations with build-in explicit animations]: {{site.flutter-medium}}/directional-animations-with-built-in-explicit-animations-3e7c5e6fbbd7
@@ -877,7 +878,6 @@ Other newness:
 [Understanding constraints]: {{site.url}}/development/ui/layout/constraints
 [When should I use AnimatedBuilder or AnimatedWidget?]: {{site.flutter-medium}}/when-should-i-useanimatedbuilder-or-animatedwidget-57ecae0959e8
 [Writing custom platform-specific code]: {{site.url}}/development/platform-integration/platform-channels
-[Xcode 11.4]: {{site.url}}/development/ios-project-migration
 
 ## Dec 11, 2019, Flutter Interact Edition: 1.12 release
 
@@ -931,7 +931,7 @@ Happy Fluttering!
 [Announcing Flutter 1.12: What a year!]: {{site.flutter-medium}}/announcing-flutter-1-12-what-a-year-22c256ba525d
 [app size]: {{site.url}}/perf/app-size#ios
 [building a web app with Flutter]: {{site.url}}/get-started/web
-[Desktop support for Flutter]: {{site.url}}/desktop
+[Desktop support for Flutter]: {{site.url}}/development/platform-integration/desktop
 [Flutter: the first UI platform designed for ambient computing]: {{site.google-blog}}/2019/12/flutter-ui-ambient-computing.html?m=1
 [Flutter Favorite program]: {{site.url}}/development/packages-and-plugins/favorites
 [Flutter 1.12.13]: {{site.url}}/development/tools/sdk/release-notes/release-notes-1.12.13


### PR DESCRIPTION
These links were being redirected, sometimes to not the most accurate place. This PR updates all internal links to their current most-accurate location.

flutter.cn and perhaps other translated sites don't support the Firebase redirects currently, so these links would fail for them before this change.