### PR TITLE
Standardize 'Linux' capitalization

### DIFF
--- a/src/development/platform-integration/linux/index.md
+++ b/src/development/platform-integration/linux/index.md
@@ -1,5 +1,5 @@
 ---
 layout: toc
-title: linux
-description: Content covering integration with linux in Flutter apps.
+title: Linux
+description: Content covering integration with Linux in Flutter apps.
 ---


### PR DESCRIPTION
This title is used for the breadcrumbs in Linux platform integration docs and all others use sentence case, this should too.

See an example here: https://docs.flutter.dev/development/platform-integration/linux/building