### PR TITLE
Re-add video embed

### DIFF
--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -41,12 +41,8 @@ that works on mobile, desktop, and web.
 
 [codelab-web]: {{site.url}}/get-started/codelab-web
 
-{% comment %}
-TODO: replace with video walkthrough once that's ready
 
 If you prefer an instructor-led version of this codelab,
 check out the following workshop:
 
-<iframe width="560" height="315" src="{{site.youtube-site}}/embed/Z6KZ3cTGBWw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-{% endcomment %}
-
+<iframe width="560" height="315" src="{{site.youtube-site}}/embed/8sAyPDLorek" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
Now that the video for the codelab is [live](https://www.youtube.com/watch?v=8sAyPDLorek), we can add the embed back to the site.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
