### PR TITLE
Migrate text styles used in layout codelab

### DIFF
--- a/src/codelabs/layout-basics.md
+++ b/src/codelabs/layout-basics.md
@@ -1996,7 +1996,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         scaffoldBackgroundColor: const Color(0xffeeeeee),
         textTheme: const TextTheme(
-          bodyText2: TextStyle(
+          bodyMedium: TextStyle(
             fontSize: 16,
           ),
         ),
@@ -2187,7 +2187,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         scaffoldBackgroundColor: const Color(0xffeeeeee),
         textTheme: const TextTheme(
-          bodyText2: TextStyle(
+          bodyMedium: TextStyle(
             fontSize: 16,
           ),
         ),
@@ -2441,7 +2441,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         scaffoldBackgroundColor: const Color(0xffeeeeee),
         textTheme: const TextTheme(
-          bodyText2: TextStyle(
+          bodyMedium: TextStyle(
             fontSize: 16,
           ),
         ),
@@ -2751,7 +2751,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         scaffoldBackgroundColor: const Color(0xffeeeeee),
         textTheme: const TextTheme(
-          bodyText2: TextStyle(
+          bodyMedium: TextStyle(
             fontSize: 16,
           ),
         ),
@@ -3091,7 +3091,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         scaffoldBackgroundColor: const Color(0xffeeeeee),
         textTheme: const TextTheme(
-          bodyText2: TextStyle(
+          bodyMedium: TextStyle(
             fontSize: 16,
           ),
         ),

--- a/src/codelabs/layout-basics.md
+++ b/src/codelabs/layout-basics.md
@@ -1940,7 +1940,7 @@ which are positioned below the contact information.
 <ul markdown="1">
   <li markdown="1">
   The first `Text` widget has the name `Flutter McFlutter` and
-  the `style` property set to `Theme.of(context).textTheme.headline5`.
+  the `style` property set to `Theme.of(context).textTheme.headlineSmall`.
   </li>
   <li markdown="1">
   The second `Text` widget contains the title `Experienced App Developer`.
@@ -1979,7 +1979,7 @@ class MyWidget extends StatelessWidget {
       children: [
         Text(
           'Flutter McFlutter', 
-          style: Theme.of(context).textTheme.headline5,
+          style: Theme.of(context).textTheme.headlineSmall,
         ),
         const Text('Experienced App Developer'),
       ],
@@ -2080,7 +2080,7 @@ Future<void> main() async {
   final nameText = innerColumnWidget.children[0] as Text;
 
   if (nameText.style?.fontSize != 24) {
-    _result(false, ['The Text widget for the name should use the "headline5" textStyle.']);
+    _result(false, ['The Text widget for the name should use the "headlineSmall" textStyle.']);
     return;
   }
 
@@ -2140,7 +2140,7 @@ class MyWidget extends StatelessWidget {
       children: [
         Text(
           'Flutter McFlutter',
-          style: Theme.of(context).textTheme.headline5,
+          style: Theme.of(context).textTheme.headlineSmall,
         ),
         const Text('Experienced App Developer'),
       ],
@@ -2168,7 +2168,7 @@ class MyWidget extends StatelessWidget {
           children: [
             Text(
               'Flutter McFlutter',
-              style: Theme.of(context).textTheme.headline5,
+              style: Theme.of(context).textTheme.headlineSmall,
             ),
             const Text('Experienced App Developer'),
           ],
@@ -2311,7 +2311,7 @@ Future<void> main() async {
   final nameText = innerColumnWidget.children[0] as Text;
 
   if (nameText.style?.fontSize != 24) {
-    _result(false, ['The Text widget for the name should use the "headline" textStyle.']);
+    _result(false, ['The Text widget for the name should use the "headlineSmall" textStyle.']);
     return;
   }
 
@@ -2382,7 +2382,7 @@ class MyWidget extends StatelessWidget {
           children: [
             Text(
               'Flutter McFlutter',
-              style: Theme.of(context).textTheme.headline5,
+              style: Theme.of(context).textTheme.headlineSmall,
             ),
             const Text('Experienced App Developer'),
           ],
@@ -2416,7 +2416,7 @@ class MyWidget extends StatelessWidget {
               children: [
                 Text(
                   'Flutter McFlutter',
-                  style: Theme.of(context).textTheme.headline5,
+                  style: Theme.of(context).textTheme.headlineSmall,
                 ),
                 const Text('Experienced App Developer'),
               ],
@@ -2597,7 +2597,7 @@ Future<void> main() async {
   final nameText = innerColumnWidget.children[0] as Text;
 
   if (nameText.style?.fontSize != 24) {
-    _result(false, ['The Text widget for the name should use the "headline" textStyle.']);
+    _result(false, ['The Text widget for the name should use the "headlineSmall" textStyle.']);
     return;
   }
 
@@ -2670,7 +2670,7 @@ class MyWidget extends StatelessWidget {
               children: [
                 Text(
                   'Flutter McFlutter',
-                  style: Theme.of(context).textTheme.headline5,
+                  style: Theme.of(context).textTheme.headlineSmall,
                 ),
                 const Text('Experienced App Developer'),
               ],
@@ -2714,7 +2714,7 @@ class MyWidget extends StatelessWidget {
               children: [
                 Text(
                   'Flutter McFlutter',
-                  style: Theme.of(context).textTheme.headline5,
+                  style: Theme.of(context).textTheme.headlineSmall,
                 ),
                 const Text('Experienced App Developer'),
               ],
@@ -2907,7 +2907,7 @@ Future<void> main() async {
   final nameText = innerColumnWidget.children[0] as Text;
 
   if (nameText.style?.fontSize != 24) {
-    _result(false, ['The Text widget for the name should use the "headline" textStyle.']);
+    _result(false, ['The Text widget for the name should use the "headlineSmall" textStyle.']);
     return;
   }
 
@@ -3000,7 +3000,7 @@ class MyWidget extends StatelessWidget {
               children: [
                 Text(
                   'Flutter McFlutter',
-                  style: Theme.of(context).textTheme.headline5,
+                  style: Theme.of(context).textTheme.headlineSmall,
                 ),
                 const Text('Experienced App Developer'),
               ],
@@ -3048,7 +3048,7 @@ class MyWidget extends StatelessWidget {
               children: [
                 Text(
                   'Flutter McFlutter',
-                  style: Theme.of(context).textTheme.headline5,
+                  style: Theme.of(context).textTheme.headlineSmall,
                 ),
                 const Text('Experienced App Developer'),
               ],
@@ -3247,7 +3247,7 @@ Future<void> main() async {
   final nameText = innerColumnWidget.children[0] as Text;
 
   if (nameText.style?.fontSize != 24) {
-    _result(false, ['The Text widget for the name should use the "headline" textStyle.']);
+    _result(false, ['The Text widget for the name should use the "headlineSmall" textStyle.']);
     return;
   }
 


### PR DESCRIPTION
`headline5` and `bodyText2` are deprecated in favor of `headlineSmall` and `bodyMedium` respectively, causing lint diagnostics in the embedded DartPads.

I realized the exercise tests are broken in this too. I have prepared a fix at https://github.com/dart-lang/dart-pad/pull/2474