### PR TITLE
Fix url of owl.jpg in examples

### DIFF
--- a/examples/animation/implicit/opacity0/lib/main.dart
+++ b/examples/animation/implicit/opacity0/lib/main.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 
 const owlUrl =
-    'https://raw.githubusercontent.com/flutter/website/main/src/images/owl.jpg';
+    'https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg';
 
 class FadeInDemo extends StatelessWidget {
   const FadeInDemo({super.key});

--- a/examples/animation/implicit/opacity1/lib/main.dart
+++ b/examples/animation/implicit/opacity1/lib/main.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 
 const owlUrl =
-    'https://raw.githubusercontent.com/flutter/website/main/src/images/owl.jpg';
+    'https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg';
 
 class FadeInDemo extends StatefulWidget {
   const FadeInDemo({super.key});

--- a/examples/animation/implicit/opacity10/lib/main.dart
+++ b/examples/animation/implicit/opacity10/lib/main.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 
 const owlUrl =
-    'https://raw.githubusercontent.com/flutter/website/main/src/images/owl.jpg';
+    'https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg';
 
 class FadeInDemo extends StatefulWidget {
   const FadeInDemo({super.key});

--- a/examples/animation/implicit/opacity2/lib/main.dart
+++ b/examples/animation/implicit/opacity2/lib/main.dart
@@ -7,7 +7,7 @@
 import 'package:flutter/material.dart';
 
 const owlUrl =
-    'https://raw.githubusercontent.com/flutter/website/main/src/images/owl.jpg';
+    'https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg';
 
 class FadeInDemo extends StatefulWidget {
   const FadeInDemo({super.key});

--- a/examples/animation/implicit/opacity3/lib/main.dart
+++ b/examples/animation/implicit/opacity3/lib/main.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 
 const owlUrl =
-    'https://raw.githubusercontent.com/flutter/website/main/src/images/owl.jpg';
+    'https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg';
 
 class FadeInDemo extends StatefulWidget {
   const FadeInDemo({super.key});

--- a/examples/animation/implicit/opacity4/lib/main.dart
+++ b/examples/animation/implicit/opacity4/lib/main.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 
 const owlUrl =
-    'https://raw.githubusercontent.com/flutter/website/main/src/images/owl.jpg';
+    'https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg';
 
 class FadeInDemo extends StatefulWidget {
   const FadeInDemo({super.key});

--- a/examples/animation/implicit/opacity5/lib/main.dart
+++ b/examples/animation/implicit/opacity5/lib/main.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 
 const owlUrl =
-    'https://raw.githubusercontent.com/flutter/website/main/src/images/owl.jpg';
+    'https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg';
 
 class FadeInDemo extends StatefulWidget {
   const FadeInDemo({super.key});

--- a/examples/animation/implicit/opacity9/lib/main.dart
+++ b/examples/animation/implicit/opacity9/lib/main.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 
 const owlUrl =
-    'https://raw.githubusercontent.com/flutter/website/main/src/images/owl.jpg';
+    'https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg';
 
 class FadeInDemo extends StatelessWidget {
   const FadeInDemo({super.key});

--- a/src/_includes/docs/implicit-animations/fade-in-complete.md
+++ b/src/_includes/docs/implicit-animations/fade-in-complete.md
@@ -3,7 +3,7 @@
 import 'package:flutter/material.dart';
 
 const owlUrl =
-    'https://raw.githubusercontent.com/flutter/website/main/src/images/owl.jpg';
+    'https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg';
 
 class FadeInDemo extends StatefulWidget {
   const FadeInDemo({Key? key}) : super(key: key);

--- a/src/_includes/docs/implicit-animations/fade-in-starter-code.md
+++ b/src/_includes/docs/implicit-animations/fade-in-starter-code.md
@@ -3,7 +3,7 @@
 import 'package:flutter/material.dart';
 
 const owlUrl =
-    'https://raw.githubusercontent.com/flutter/website/main/src/images/owl.jpg';
+    'https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg';
 
 class FadeInDemo extends StatefulWidget {
   const FadeInDemo({Key? key}) : super(key: key);


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

This PR fixes the url of owl.jpg in the examples which is currently incorrect (404).

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
