### PR TITLE
Tweaks to wasm page

### DIFF
--- a/src/development/platform-integration/web/wasm.md
+++ b/src/development/platform-integration/web/wasm.md
@@ -16,8 +16,8 @@ Compiling Dart to this new target requires
 [WebAssembly Garbage Collection (WasmGC)](https://github.com/WebAssembly/gc/tree/main/proposals/gc),
 an upcoming addition to the WebAssembly standard. The Chrome team is actively
 [working on WasmGC](https://chromestatus.com/feature/6062715726462976). You can
-see the status of the Garbage Collection proposal—and all other Wasm 
-proposals—on the [WebAssembly roadmap](https://webassembly.org/roadmap/).
+see the status of the Garbage Collection proposal–and all other Wasm 
+proposals–on the [WebAssembly roadmap](https://webassembly.org/roadmap/).
 
 In the mean time, check out Flutter's
 [existing support for the web]({{site.main-url}}/multi-platform/web). We are

--- a/src/development/platform-integration/web/wasm.md
+++ b/src/development/platform-integration/web/wasm.md
@@ -4,8 +4,9 @@ description: Current status of Flutter's experimental support for WebAssembly (W
 short-title: Wasm
 ---
 
-_WebAssembly support for Dart and Flutter is under active development. We hope
-to have the feature ready to try out later in 2023._
+_WebAssembly support for Dart and Flutter is under active development,
+and is currently considered experimental.
+We hope to have the feature ready to try out later in 2023._
 
 The Flutter and Dart teams are excited to add
 [WebAssembly](https://webassembly.org/) as a compilation target when building
@@ -15,8 +16,8 @@ Compiling Dart to this new target requires
 [WebAssembly Garbage Collection (WasmGC)](https://github.com/WebAssembly/gc/tree/main/proposals/gc),
 an upcoming addition to the WebAssembly standard. The Chrome team is actively
 [working on WasmGC](https://chromestatus.com/feature/6062715726462976). You can
-see the status of the GC proposal–and all other Wasm proposals–on the
-[WebAssembly roadmap](https://webassembly.org/roadmap/).
+see the status of the Garbage Collection proposal
+— and all other Wasm proposals — on the [WebAssembly roadmap](https://webassembly.org/roadmap/).
 
 In the mean time, check out Flutter's
 [existing support for the web]({{site.main-url}}/multi-platform/web). We are

--- a/src/development/platform-integration/web/wasm.md
+++ b/src/development/platform-integration/web/wasm.md
@@ -16,8 +16,8 @@ Compiling Dart to this new target requires
 [WebAssembly Garbage Collection (WasmGC)](https://github.com/WebAssembly/gc/tree/main/proposals/gc),
 an upcoming addition to the WebAssembly standard. The Chrome team is actively
 [working on WasmGC](https://chromestatus.com/feature/6062715726462976). You can
-see the status of the Garbage Collection proposal–and all other Wasm 
-proposals–on the [WebAssembly roadmap](https://webassembly.org/roadmap/).
+see the status of the Garbage Collection proposal—and all other Wasm 
+proposals—on the [WebAssembly roadmap](https://webassembly.org/roadmap/).
 
 In the mean time, check out Flutter's
 [existing support for the web]({{site.main-url}}/multi-platform/web). We are

--- a/src/development/platform-integration/web/wasm.md
+++ b/src/development/platform-integration/web/wasm.md
@@ -16,8 +16,8 @@ Compiling Dart to this new target requires
 [WebAssembly Garbage Collection (WasmGC)](https://github.com/WebAssembly/gc/tree/main/proposals/gc),
 an upcoming addition to the WebAssembly standard. The Chrome team is actively
 [working on WasmGC](https://chromestatus.com/feature/6062715726462976). You can
-see the status of the Garbage Collection proposal
-— and all other Wasm proposals — on the [WebAssembly roadmap](https://webassembly.org/roadmap/).
+see the status of the Garbage Collection proposal—and all other Wasm 
+proposals—on the [WebAssembly roadmap](https://webassembly.org/roadmap/).
 
 In the mean time, check out Flutter's
 [existing support for the web]({{site.main-url}}/multi-platform/web). We are


### PR DESCRIPTION
Tweaks to wasm page:
* Clarify the feature is formally experimental.
* Use the full Garbage Collection term as that is what the linked to page uses.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
