### PR TITLE
Update chat links to wiki chat page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ or the [flutter.dev website][doc-issues].
 Other ways you can contribute:
 
 * [Ask HOW-TO questions that can be answered with specific solutions][so]
-* [Live chat with Flutter engineers and users][gitter]
+* [Live chat with Flutter engineers and users][chat]
 * [Discuss Flutter, best practices, app design, and more on our
    mailing list][mailinglist]
 * [Report bugs and request features][issues]
@@ -61,5 +61,5 @@ Happy Fluttering!
 [doc-PRs]: https://github.com/flutter/website/pulls
 [so]: https://stackoverflow.com/tags/flutter
 [mailinglist]: https://groups.google.com/d/forum/flutter-dev
-[gitter]: https://gitter.im/flutter/flutter
+[chat]: https://github.com/flutter/flutter/wiki/Chat
 [reddit]: https://www.reddit.com/r/FlutterDev

--- a/firebase.json
+++ b/firebase.json
@@ -149,7 +149,7 @@
       { "source": "/catalog/samples", "destination": "https://flutter.github.io/samples/#", "type": 301 },
       { "source": "/catalog/samples", "destination": "https://flutter.github.io/samples/#", "type": 301 },
       { "source": "/catalog/samples/*", "destination": "https://flutter.github.io/samples/#", "type": 301 },
-      { "source": "/chat", "destination": "https://gitter.im/flutter/flutter", "type": 302 },
+      { "source": "/chat", "destination": "https://github.com/flutter/flutter/wiki/Chat", "type": 302 },
       { "source": "/custom-deferred-components", "destination": "https://github.com/flutter/flutter/wiki/Deferred-Components#custom-implementations", "type": 301 },
       { "source": "/deferred-components-wiki", "destination": "https://github.com/flutter/flutter/wiki/Deferred-Components", "type": 301 },
       { "source": "/design-principles", "destination": "https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo", "type": 301 },


### PR DESCRIPTION
The gitter channel is archived. Instead link to the Flutter wiki's [Chat](https://github.com/flutter/flutter/wiki/Chat) entry which discusses the Discord, its policies and use of different channels.
