### PR TITLE
Fix indentation in a SwiftUI example

### DIFF
--- a/examples/get-started/flutter-for/ios_devs/lib/cupertino_themes.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/cupertino_themes.dart
@@ -14,8 +14,8 @@ class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const
-        // #docregion Theme
-        CupertinoApp(
+    // #docregion Theme
+    CupertinoApp(
       theme: CupertinoThemeData(
         brightness: Brightness.dark,
       ),

--- a/src/get-started/flutter-for/swiftui-devs.md
+++ b/src/get-started/flutter-for/swiftui-devs.md
@@ -1143,7 +1143,7 @@ of the `App` class:
 
 <?code-excerpt "lib/cupertino_themes.dart (Theme)"?>
 ```dart
-    CupertinoApp(
+CupertinoApp(
   theme: CupertinoThemeData(
     brightness: Brightness.dark,
   ),


### PR DESCRIPTION
Fix indentation in the [DarkMode example](https://docs.flutter.dev/get-started/flutter-for/swiftui-devs#using-dark-mode) in the Flutter for SwiftUI devs documentation

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

## Visual Reference

![image](https://user-images.githubusercontent.com/35314270/223455344-ced1ebc2-2478-442a-ac81-0b7534ea1aab.png)

