### PR TITLE
[macOS] Bump minimum macOS support to 10.14

### DIFF
--- a/src/development/tools/sdk/release-notes/supported-platforms.md
+++ b/src/development/tools/sdk/release-notes/supported-platforms.md
@@ -31,7 +31,7 @@ Flutter supports the following platforms as part of Google-tested and best-effor
 |Android | API 16 (Android 4.1) & above | All     |
 |iOS     | iOS 11 & above               | All     |
 |Linux   | Debian, 64-bit               | All     |
-|macOS   | El Capitan (10.11) & above   | All     |
+|macOS   | Mojave (10.14) & above       | All     |
 |Web     | Chrome 84  & above           | All     |
 |Web     | Firefox 72.0 & above         | All     |
 |Web     | Safari on El Capitan & above | All     |
@@ -76,15 +76,12 @@ and stable channels.
 |Linux   |Debian 9 & below    |
 |Linux   |Ubuntu 20.04        |
 |Linux   |Ubuntu 22.04 (Aspirational Google-tested platform)        |
-|macOS   |El Capitan (10.11) - Big Sur (11)*   |
+|macOS   |Mojave (10.14) - Big Sur (11)  |
 |Windows |Windows 11 (Aspirational Google-tested platform)          |
 |Windows |Windows 8           |
 |Windows |Windows 7           |
 {:.table.table-striped}
 </div>
-
-\* Flutter 3.3 is the last stable release with macOS 10.11 through 10.13
-best-effort support.
 
 ### Unsupported platforms
 
@@ -94,7 +91,7 @@ best-effort support.
 |Android |Android SDK 15 & below                      |
 |iOS     |[iOS 10 & below and `arm7v` 32-bit iOS][]   |
 |Linux   |Any 32-bit platform                         |
-|macOS   |Yosemite (10.10) & below                    |
+|macOS   |High Sierra (10.13) & below                 |
 |Windows |Windows Vista & below                       |
 |Windows |Any 32-bit platform                         |
 {:.table.table-striped}


### PR DESCRIPTION
Flutter 3.3 was the last stable release to support macOS 10.11 through 10.13. As of Flutter 3.7, the minimum supported version of macOS is 10.14 (Mojave). This should have landed with the release rollout, but I missed updating the website.

This also removes [the footnote I'd added](https://github.com/flutter/website/pull/7857) prior to release 3.7 about 3.3 being the last version to support macOS 10.11 through 10.13 now that we've bumped the minimum.

RFC: https://flutter.dev/go/flutter-drop-macOS-10.13-2022-q4

Issue: https://github.com/flutter/flutter/issues/114445

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
