### PR TITLE
Don't expand 'From another platform?' by default

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -12,7 +12,6 @@
       permalink: /get-started/learn-more
     - divider
     - title: From another platform?
-      expanded: true
       children:
         - title: Flutter for Android devs
           permalink: /get-started/flutter-for/android-devs


### PR DESCRIPTION
Closes https://github.com/flutter/website/issues/8367
