### PR TITLE
Replace battery package link with battery_plus

### DIFF
--- a/src/development/packages-and-plugins/using-packages.md
+++ b/src/development/packages-and-plugins/using-packages.md
@@ -41,7 +41,7 @@ Existing packages enable many use cases—for example,
 making network requests ([`http`][]),
 navigation/route handling ([`go_router`][]),
 integration with device APIs
-([`url_launcher`][] and [`battery`][]),
+([`url_launcher`][] and [`battery_plus`][]),
 and using third-party platform SDKs like Firebase
 ([FlutterFire][]).
 
@@ -52,7 +52,7 @@ see [Adding assets and images][].
 
 
 [Adding assets and images]: {{site.url}}/development/ui/assets-and-images
-[`battery`]: {{site.pub-pkg}}/battery
+[`battery_plus`]: {{site.pub-pkg}}/battery_plus
 [developing packages]: {{site.url}}/development/packages-and-plugins/developing-packages
 [FlutterFire]: {{site.github}}/firebase/flutterfire
 


### PR DESCRIPTION
Saw that page about using packages has a link to `battery` package, which is discontinued. Replaced that link with a link to `battery_plus`, so the page mentions only actively maintained plugins.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
