### PR TITLE
add '=' in the command

### DIFF
--- a/src/get-started/install/_android-setup.md
+++ b/src/get-started/install/_android-setup.md
@@ -15,7 +15,7 @@
     when developing for Android.
  1. Run `flutter doctor` to confirm that Flutter has located
     your installation of Android Studio. If Flutter cannot locate it,
-    run `flutter config --android-studio-dir <directory>` to set the
+    run `flutter config --android-studio-dir=<directory>` to set the
     directory that Android Studio is installed to.
 
 ### Set up your Android device


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ add the missing '=' in the command `flutter config --android-studio-dir`

_Issues fixed by this PR (if any):_ Fixes #8341

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
