### PR TITLE
Adding quick Swift example

### DIFF
--- a/src/development/ui/assets-and-images.md
+++ b/src/development/ui/assets-and-images.md
@@ -376,6 +376,15 @@ NSString* key = [registrar lookupKeyForAsset:@"icons/heart.png"];
 NSString* path = [[NSBundle mainBundle] pathForResource:key ofType:nil];
 ```
 
+To access `icons/heart.png` from your Swift app you
+would do the following:
+
+```swift
+let key = controller.lookupKey(forAsset: "icons/heart.png")
+let mainBundle = Bundle.main
+let path = mainBundle.path(forResource: key, ofType: nil)
+```
+
 For a more complete example, see the implementation of the
 Flutter [`video_player` plugin][] on pub.dev.
 


### PR DESCRIPTION
This just adds a quick Swift example to the assets page, which only had an example using Objective-C.

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
