### PR TITLE
change filename style.xml to styles.xml

### DIFF
--- a/src/development/platform-integration/android/splash-screen.md
+++ b/src/development/platform-integration/android/splash-screen.md
@@ -67,7 +67,7 @@ whose `windowBackground` is set to the
 </style>
 ```
 
-In addition, `style.xml` defines a _normal theme_
+In addition, `styles.xml` defines a _normal theme_
 to be applied to `FlutterActivity` after the launch
 screen is gone. The normal theme background only shows
 for a very brief moment after the splash screen disappears,


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ The relevant Android filename is `styles.xml`, so this fixes what I assume is just a typo that left the 's' off originally.

_Issues fixed by this PR (if any):_ n/a

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
