### PR TITLE
Update best-practices.md with advice for operator==

### DIFF
--- a/src/perf/best-practices.md
+++ b/src/perf/best-practices.md
@@ -71,6 +71,9 @@ Here are some things to keep in mind when designing your UI:
     the [source code for `SlideTransition`][],
     which uses this principle to avoid rebuilding its
     descendents when animating.
+    ("Same instance" is evaluated using `operator ==`,
+    but see the pitfalls section at the end of this page
+    for advice on when to avoid overriding `operator ==`.)
   * Use `const` constructors on widgets as much as possible,
     since they allow Flutter to short-circuit most
     of the rebuild work. To be automatically reminded
@@ -409,6 +412,20 @@ your app's performance.
   of children (such as `Column()` or `ListView()`)
   if most of the children are not visible
   on screen to avoid the build cost.
+  
+* Avoid overriding `operator ==` on `Widget` objects.
+  While it may seem like it would help by avoiding unnecessary rebuilds,
+  in practice it hurts performance because it results in O(N²) behavior.
+  The only exception to this rule is leaf widgets (widgets with no children),
+  in the specific case where comparing the properties of the widget
+  is likely to be significantly more efficient than rebuilding the widget
+  and where the widget will rarely change configuration.
+  Even in such cases,
+  it is generally preferable to rely on caching the widgets,
+  because even one override of `operator ==`
+  can result in across-the-board performance degradation
+  as the compiler can no longer assume that the call is always static.
+
 
 ## Resources
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/38740

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
