### PR TITLE
Bump android support versions to 19+

### DIFF
--- a/src/development/tools/sdk/release-notes/supported-platforms.md
+++ b/src/development/tools/sdk/release-notes/supported-platforms.md
@@ -38,7 +38,7 @@ as part of Google-tested and best-effort platform tier:
 <div class="table-wrapper" markdown="1">
 |Platform|Version                       |Channels |
 |--------|------------------------------|---------|
-|Android | API 16 (Android 4.1) & above | All     |
+|Android | API 19 (Android 4.1) & above | All     |
 |iOS     | iOS 11 & above               | All     |
 |Linux   | Debian, 64-bit               | All     |
 |macOS   | Mojave (10.14) & above       | All     |
@@ -58,7 +58,7 @@ and stable channels.
 <div class="table-wrapper" markdown="1">
 |Platform|Version               |
 |--------|----------------------|
-|Android |Android SDK 19–30*    |
+|Android |Android SDK 21–30*    |
 |iOS     |14-15                 |
 |Linux   |Debian 10             |
 |Linux   |Ubuntu 18.04 LTS      |
@@ -71,16 +71,13 @@ and stable channels.
 {:.table.table-striped}
 </div>
 
-\* Passing tests on Android SDK 19 also confers a passing result on SDK 20.
-  This is because Android SDK 20 has additional support for Android Wear,
-  but otherwise no new or deprecated API.
 
 ### Best-effort platforms
 
 <div class="table-wrapper" markdown="1">
 |Platform|Version             |
 |--------|--------------------|
-|Android |Android SDK 16–18   |
+|Android |Android SDK 19      |
 |iOS     |iOS 11-13           |
 |Linux   |Debian 11           |
 |Linux   |Debian 9 & below    |
@@ -98,7 +95,7 @@ and stable channels.
 <div class="table-wrapper" markdown="1">
 |Platform|Version                                     |
 |--------|--------------------------------------------|
-|Android |Android SDK 15 & below                      |
+|Android |Android SDK 18 & below                      |
 |iOS     |[iOS 10 & below and `arm7v` 32-bit iOS][]   |
 |Linux   |Any 32-bit platform                         |
 |macOS   |High Sierra (10.13) & below                 |


### PR DESCRIPTION
Following public documentation https://docs.google.com/document/d/1wWNly2SZRDqupSsHkBWDI_lS2MohBGEwPSXF6W05NOc/edit.  Additionally moved api 19 to best effort because Firebase Test Lab dropped support for api 19 devices after GMS core removed api 19 from their required list of supported apis https://critique.corp.google.com/cl/501633259 since most android testing in CI happens on real devices.
[
flutter/flutter/109709](https://github.com/flutter/flutter/issues/109709)
https://okrs-tool.corp.google.com/team/1492951161877/2023/q1#kr=20641801

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
