### PR TITLE
Add documentation on how to use `dart-define` with `gradlew`

### DIFF
--- a/src/testing/integration-tests/index.md
+++ b/src/testing/integration-tests/index.md
@@ -211,6 +211,15 @@ popd
 Where `<name>_test.dart` is the file created in the
 **Project Setup** section.
 
+{{site.alert.note}}
+  If you want to use `--dart-define` in with `gradlew`,
+  you have to `base64` encode all parameters,
+  and pass them to gradle in a comma separated list:
+  ```bash
+  ./gradlew project:task -Pdart-defines="{base64(key1=value1)},{base64(key2=value2)}"
+  ```
+{{site.alert.end}}
+
 Drag the "debug" APK from
 `<flutter_project_directory>/build/app/outputs/apk/debug`
 into the **Android Robo Test** target on the web page.

--- a/src/testing/integration-tests/index.md
+++ b/src/testing/integration-tests/index.md
@@ -212,7 +212,7 @@ Where `<name>_test.dart` is the file created in the
 **Project Setup** section.
 
 {{site.alert.note}}
-  If you want to use `--dart-define` with `gradlew` you have to `base64` encode
+  To use `--dart-define` with `gradlew`, you must `base64` encode
   all parameters, and pass them to gradle in a comma separated list:
   ```bash
   ./gradlew project:task -Pdart-defines="{base64(key=value)},[...]"

--- a/src/testing/integration-tests/index.md
+++ b/src/testing/integration-tests/index.md
@@ -212,11 +212,10 @@ Where `<name>_test.dart` is the file created in the
 **Project Setup** section.
 
 {{site.alert.note}}
-  If you want to use `--dart-define` in with `gradlew`,
-  you have to `base64` encode all parameters,
-  and pass them to gradle in a comma separated list:
+  If you want to use `--dart-define` with `gradlew` you have to `base64` encode
+  all parameters, and pass them to gradle in a comma separated list:
   ```bash
-  ./gradlew project:task -Pdart-defines="{base64(key1=value1)},{base64(key2=value2)}"
+  ./gradlew project:task -Pdart-defines="{base64(key=value)},[...]"
   ```
 {{site.alert.end}}
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Add documentation on how to use `--dart-define` command line arguments when building the app via `gradlew`.

_Issues fixed by this PR:_
Resolves flutter/flutter#100292

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
