### PR TITLE
Added the missing option "Google APIs" in Data & Backend tab

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -141,6 +141,8 @@
           permalink: /development/data-and-backend/json
         - title: Firebase
           permalink: /development/data-and-backend/firebase
+        - title: Google APIs
+          permalink: /development/data-and-backend/google-apis
     - title: Accessibility & internationalization # TODO: use: Accessibility & localization
       permalink: /development/accessibility-and-localization
       children:


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Added the missing option "Google APIs" in Data & Backend tab oo the sidenav of the website.

_Issues fixed by this PR (if any):_

* Fixes the issue - #8418 

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
