### PR TITLE
[Windows] Add go/windows-arm64

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -459,6 +459,7 @@
       { "source": "/go/widgetspan-in-selectabletext", "destination": "https://docs.google.com/document/d/1nrVRytWVF-1hr8LvUKyENE5s074UInni9ZiColtIIxI", "type": 301 },
       { "source": "/go/widget-budget", "destination": "https://docs.google.com/document/d/1JTmf7ae8hWJ3zzqhI-__I9DcUJdQ3TopWsJbKyNDO5A/edit?usp=sharing&resourcekey=0--A0AbM19K-zDXRmIIzaUAg", "type": 301 },
       { "source": "/go/windows-x86-arm64-support", "destination": "https://docs.google.com/document/d/1gAGqtTAjO0GntR8bPonIO1aZJnTghPCI_PHJPdNzEmo/edit?resourcekey=0-l1tL7iai47yw3bMl9IcpHw", "type": 301 },
+      { "source": "/go/windows-arm64", "destination": "https://docs.google.com/document/d/1yuexY-EtzeVhU3V6RGBII_kH-znLSkQCspzW70jayZk/edit?resourcekey=0-8pQRSXSHQlwOo7QtCVLvBA#heading=h.pub7jnop54q0", "type": 301 },
       { "source": "/go/wrap-layout", "destination": "https://docs.google.com/document/d/1auZtWT1T5CkUKOUTUld8rF91iN7PvQoOF0IlBNXiDSo/edit?usp=sharing", "type": 301 },
       { "source": "/go/wrap-popupmenu-with-safearea", "destination": "https://docs.google.com/document/d/15uBmyEKiOeYGYt1PuBVf4SFK5YhH07EP9ylWP-H9mVE/edit?usp=sharing", "type": 301 }
     ],


### PR DESCRIPTION
Adds a link to Pierrick Bouvier's design doc for Windows arm64 support.

Related issue: https://github.com/flutter/flutter/issues/62597
Related issue: https://github.com/flutter/flutter/issues/116196

## Presubmit checklist
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
