### PR TITLE
Misc 'Supported Platforms' changes and cleanup

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -123,6 +123,7 @@
       { "source": "/development/tools/sdk", "destination": "/development/tools/sdk/upgrading", "type": 301 },
       { "source": "/development/tools/sdk/archive", "destination": "/development/tools/sdk/releases", "type": 301 },
       { "source": "/development/tools/sdk/release-notes/changelogs/changelog-1.17.0", "destination": "/development/tools/sdk/release-notes/release-notes-1.17.0", "type": 301 },
+      { "source": "/development/tools/sdk/release-notes/supported-platforms", "destination": "/reference/supported-platforms", "type": 301 },
       { "source": "/development/tools/web-renderers", "destination": "/development/platform-integration/web/renderers", "type": 301 },
       { "source": "/development/ui/advanced/splash-screen", "destination": "/development/platform-integration/android/splash-screen", "type": 301 },
       { "source": "/development/ui/advanced/actions_and_shortcuts", "destination": "/development/ui/advanced/actions-and-shortcuts", "type": 301 },

--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -154,7 +154,7 @@
       permalink: /development/platform-integration
       children:
         - title: Supported platforms
-          permalink: /development/tools/sdk/release-notes/supported-platforms
+          permalink: /reference/supported-platforms
         - title: Building desktop apps with Flutter
           permalink: /development/platform-integration/desktop
         - title: Writing platform-specific code

--- a/src/_sass/base/_base.scss
+++ b/src/_sass/base/_base.scss
@@ -194,3 +194,10 @@ blockquote {
     margin-bottom: 0;
   }
 }
+
+.table-centered-after-first {
+  // Text aligns all elements in a table besides the first column to the center
+  th:not(:first-child), td:not(:first-child) {
+    text-align: center;
+  }
+}

--- a/src/reference/supported-platforms.md
+++ b/src/reference/supported-platforms.md
@@ -27,7 +27,7 @@ make sure to make a corresponding change in the get started pages:
   * /src/get-started/install/macos.md
   * /src/get-started/install/windows.md
   * /src/get-started/install/linux.md
-{% endcomment %}
+{% endcomment -%}
 
 
 ## Deploying Flutter
@@ -37,19 +37,19 @@ support for deploying Flutter apps is shown in the
 following table:
 
 <div class="table-wrapper" markdown="1">
-|Platform version|<center>Supported</center>|<center>Best effort</center>|<center>Unsupported</center>|
+|Platform version|Supported|Best effort|Unsupported|
 |----------------|---------|-----------|-----------|
-| Android SDK    |<center>21-30</center>|<center>19-20</center>|<center>18-</center>|
-| iOS            |<center>14-15</center>|<center>11-13</center>|<center>10-, arm7v 32-bit</center>|
-| Linux Debian   |<center>10-11</center>|<center>9-</center>|<center></center>|
-| Linux Ubuntu   |<center>18.04 LTS</center>|<center>20.04</center>|<center>any 32-bit</center>|
-| macOS          |<center>Monterey (12+)</center>|<center>Mojave (10.14) to Big Sur (11)</center>|<center>High Sierra (10.13-)</center> |
-| web - Chrome   |<center>latest 2 releases</center>|<center>96+</center>| |
-| web - Firefox  |<center>latest 2 releases</center>|<center>99+</center>| |
-| web - Safari   |<center>latest 2 releases</center>|<center>| |
-| web - Edge     | |<center>96+</center>| |
-| Windows        |<center>10</center>|<center>7 & 8</center>|<center>Vista-, any 32-bit</center>|
-{:.table.table-striped}
+| Android SDK    |21-30|19-20|18-|
+| iOS            |14-15|11-13|10-, arm7v 32-bit|
+| Linux Debian   |10-11|9-||
+| Linux Ubuntu   |18.04 LTS|20.04|any 32-bit|
+| macOS          |Monterey (12+)|Mojave (10.14) to Big Sur (11)|High Sierra (10.13-) |
+| web - Chrome   |latest 2 releases|96+| |
+| web - Firefox  |latest 2 releases|99+| |
+| web - Safari   |latest 2 releases|| |
+| web - Edge     | |96+| |
+| Windows        |10|7 & 8|Vista-, any 32-bit|
+{:.table.table-striped.table-centered-after-first}
 </div>
 
 {{site.alert.note}}

--- a/src/resources/faq.md
+++ b/src/resources/faq.md
@@ -1100,5 +1100,5 @@ apps built with Flutter should follow Apple's
 [web instructions]: {{site.url}}/development/platform-integration/web/building
 [`Widget`]: {{site.api}}/flutter/widgets/Widget-class.html
 [widgets]: {{site.url}}/development/ui/widgets
-[supported platforms]: {{site.url}}/development/tools/sdk/release-notes/supported-platforms
+[supported platforms]: {{site.url}}/reference/supported-platforms
 [riverpod]: {{site.pub}}/packages/riverpod


### PR DESCRIPTION
- Moves supported platforms from being deeply nested under release notes to being under `/reference`, since it is a sort of reference and can be linked to from multiple locations. Open to feedback here :)
- Removes the page's unrelated breadcrumbs (through the above change)
- Replaces `<center>` usage with a table class that centers all entries not in the first column.

**Staged:** https://parlough-docs-flutter-dev.web.app/reference/supported-platforms
