### PR TITLE
Document the new `canvasKitVariant` runtime configuration

### DIFF
--- a/src/development/platform-integration/web/initialization.md
+++ b/src/development/platform-integration/web/initialization.md
@@ -130,7 +130,7 @@ You can pass in the following (optional) parameters:
 | Name | Description | Dart&nbsp;Type |
 |-|-|-|
 |`canvasKitBaseUrl`| The base URL from where `canvaskit.wasm` is downloaded. |`String`|
-|`canvasKitVariant`| The variant of CanvasKit to be downloaded. Available options are:<br><br>1. "auto": Chooses the most optimal variant for the browser (this is the default).<br><br>2. "full": Downloads the full variant of CanvasKit that works in all browsers.<br><br>3. "chromium": Downloads a smaller variant of CanvasKit that takes advantage of APIs that are only available in Chromium (**_WARNING_**: don't use the "chromium" option unless you know what you are doing. If you use it, your app will break on non-Chromium browsers). |`String`|
+|`canvasKitVariant`| The variant of CanvasKit to be downloaded. Available options are:<br><br>1. `auto`: Chooses the most optimal variant for the browser. The option defaults to this value.<br><br>2. `full`: Downloads the full variant of CanvasKit that works in all browsers.<br><br>3. `chromium`: Downloads a smaller variant of CanvasKit that uses APIs compatible with Chromium. **_Warning_**: Don't use the `chromium` option unless you plan on only using Chromium-based browsers. |`String`|
 |`canvasKitForceCpuOnly`| When `true`, forces CPU-only rendering in CanvasKit (the engine won't use WebGL). |`bool`|
 |`canvasKitMaximumSurfaces`| The maximum number of overlay surfaces that the CanvasKit renderer can use. |`double`|
 |`debugShowSemanticNodes`| If `true`, Flutter visibly renders the semantics tree onscreen (for debugging).  |`bool`|

--- a/src/development/platform-integration/web/initialization.md
+++ b/src/development/platform-integration/web/initialization.md
@@ -130,7 +130,7 @@ You can pass in the following (optional) parameters:
 | Name | Description | Dart&nbsp;Type |
 |-|-|-|
 |`canvasKitBaseUrl`| The base URL from where `canvaskit.wasm` is downloaded. |`String`|
-|`canvasKitVariant`| The variant of CanvasKit to be downloaded. Available options are:<br><br>1. "auto": Chooses the most optimal variant for the browser (this is the default).<br><br>2. "full": Downloads the full variant of CanvasKit that works in all browsers.<br><br>3. "chromium": Downloads a smaller variant of CanvasKit that takes advantage of APIs that are only available in Chromium (**_WARNING_**: don't use this option unless you know what you are doing. If you use it, your app will break on non-Chromium browsers). |`String`|
+|`canvasKitVariant`| The variant of CanvasKit to be downloaded. Available options are:<br><br>1. "auto": Chooses the most optimal variant for the browser (this is the default).<br><br>2. "full": Downloads the full variant of CanvasKit that works in all browsers.<br><br>3. "chromium": Downloads a smaller variant of CanvasKit that takes advantage of APIs that are only available in Chromium (**_WARNING_**: don't use the "chromium" option unless you know what you are doing. If you use it, your app will break on non-Chromium browsers). |`String`|
 |`canvasKitForceCpuOnly`| When `true`, forces CPU-only rendering in CanvasKit (the engine won't use WebGL). |`bool`|
 |`canvasKitMaximumSurfaces`| The maximum number of overlay surfaces that the CanvasKit renderer can use. |`double`|
 |`debugShowSemanticNodes`| If `true`, Flutter visibly renders the semantics tree onscreen (for debugging).  |`bool`|

--- a/src/development/platform-integration/web/initialization.md
+++ b/src/development/platform-integration/web/initialization.md
@@ -130,6 +130,7 @@ You can pass in the following (optional) parameters:
 | Name | Description | Dart&nbsp;Type |
 |-|-|-|
 |`canvasKitBaseUrl`| The base URL from where `canvaskit.wasm` is downloaded. |`String`|
+|`canvasKitVariant`| The variant of CanvasKit to be downloaded. Available options are:<br><br>1. "auto": Chooses the most optimal variant for the browser (this is the default).<br><br>2. "full": Downloads the full variant of CanvasKit that works in all browsers.<br><br>3. "chromium": Downloads a smaller variant of CanvasKit that takes advantage of APIs that are only available in Chromium (**_WARNING_**: don't use this option unless you know what you are doing. If you use it, your app will break on non-Chromium browsers). |`String`|
 |`canvasKitForceCpuOnly`| When `true`, forces CPU-only rendering in CanvasKit (the engine won't use WebGL). |`bool`|
 |`canvasKitMaximumSurfaces`| The maximum number of overlay surfaces that the CanvasKit renderer can use. |`double`|
 |`debugShowSemanticNodes`| If `true`, Flutter visibly renders the semantics tree onscreen (for debugging).  |`bool`|


### PR DESCRIPTION
Add documentation for the new [`canvasKitVariant`](https://github.com/flutter/engine/blob/0776f38b87137ad2535d77e91a79b8b6c80f16fb/lib/web_ui/lib/src/engine/configuration.dart#L221-L224) runtime configuration.

Closes https://github.com/flutter/flutter/issues/123048

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
