### PR TITLE
Remove outdated video covering GetX

### DIFF
--- a/src/development/data-and-backend/state-mgmt/options.md
+++ b/src/development/data-and-backend/state-mgmt/options.md
@@ -235,7 +235,6 @@ A simplified reactive state management solution.
 * [GetX package][]
 * [GetX Flutter Firebase Auth Example][], by Jeff McMorris
 
-[Complete GetX State Management]: {{site.youtube-site}}/watch?v=CNpXbeI_slw
 [GetX package]: {{site.pub-pkg}}/get
 [GetX Flutter Firebase Auth Example]: {{site.medium}}/@jeffmcmorris/getx-flutter-firebase-auth-example-b383c1dd1de2
 

--- a/src/development/data-and-backend/state-mgmt/options.md
+++ b/src/development/data-and-backend/state-mgmt/options.md
@@ -233,7 +233,6 @@ This package promotes the separation of concerns.
 A simplified reactive state management solution.
 
 * [GetX package][]
-* [Complete GetX State Management][], a video by Tadas Petra
 * [GetX Flutter Firebase Auth Example][], by Jeff McMorris
 
 [Complete GetX State Management]: {{site.youtube-site}}/watch?v=CNpXbeI_slw


### PR DESCRIPTION
I made this video almost 3 years ago about GetX package, and it has been outdated for a while. I don't believe this is a good source to learn GetX anymore. I haven't been keeping up with the development of the project, and in general there hasn't been any updates to the package in over 10 months. 

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
