### PR TITLE
Update polar coordinate gist on 'Architectural Overview' page

### DIFF
--- a/src/resources/architectural-overview.md
+++ b/src/resources/architectural-overview.md
@@ -639,7 +639,7 @@ The base class for every node in the render tree is
 defines an abstract model for layout and painting. This is extremely general: it
 does not commit to a fixed number of dimensions or even a Cartesian coordinate
 system (demonstrated by [this example of a polar coordinate
-system]({{site.dartpad}}/0f020197a5d4c980342d5c7d9e935cee)). Each
+system]({{site.dartpad}}/596b1d6331e3b9d7b00420085fab3e27)). Each
 `RenderObject` knows its parent, but knows little about its children other than
 how to _visit_ them and their constraints. This provides `RenderObject` with
 sufficient abstraction to be able to handle a variety of use cases.


### PR DESCRIPTION
Eventually it would be nice to incorporate or test this on the site (https://github.com/flutter/website/issues/6912), but for now this updates the gist to null safety, by just copying the latest changes from the [original example on flutter/flutter](https://github.com/flutter/flutter/blob/master/examples/layers/rendering/src/sector_layout.dart).

Staged: https://dartpad.dev/?id=596b1d6331e3b9d7b00420085fab3e27

I also cleaned up the filename and title of the gist: https://gist.github.com/parlough/596b1d6331e3b9d7b00420085fab3e27

Fixes https://github.com/flutter/website/issues/8474
