### PR TITLE
[Shortcuts] Show how to use CallbackShortcuts

### DIFF
--- a/examples/ui/advanced/actions_and_shortcuts/lib/samples.dart
+++ b/examples/ui/advanced/actions_and_shortcuts/lib/samples.dart
@@ -179,33 +179,40 @@ class LoggingActionDispatcherExample extends StatelessWidget {
 // #enddocregion LoggingActionDispatcherExample
 }
 
-// #docregion CallbackShortcuts
-class CallbackShortcuts extends StatelessWidget {
-  const CallbackShortcuts({
-    super.key,
-    required this.bindings,
-    required this.child,
-  });
 
-  final Map<ShortcutActivator, VoidCallback> bindings;
-  final Widget child;
+class CallbackShortcutsExample extends StatefulWidget {
+  const CallbackShortcutsExample({super.key});
 
   @override
+  State<CallbackShortcutsExample> createState() => _CallbackShortcutsExampleState();
+}
+
+class _CallbackShortcutsExampleState extends State<CallbackShortcutsExample> {
+  int count = 0;
+
+// #docregion CallbackShortcuts
+  @override
   Widget build(BuildContext context) {
-    return Focus(
-      onKey: (node, event) {
-        KeyEventResult result = KeyEventResult.ignored;
-        // Activates all key bindings that match, returns handled if any handle it.
-        for (final ShortcutActivator activator in bindings.keys) {
-          if (activator.accepts(event, RawKeyboard.instance)) {
-            bindings[activator]!.call();
-            result = KeyEventResult.handled;
-          }
-        }
-        return result;
+    return CallbackShortcuts(
+      bindings: <ShortcutActivator, VoidCallback>{
+        const SingleActivator(LogicalKeyboardKey.arrowUp): () {
+          setState(() => count = count + 1);
+        },
+        const SingleActivator(LogicalKeyboardKey.arrowDown): () {
+          setState(() => count = count - 1);
+        },
       },
-      child: child,
+      child: Focus(
+        autofocus: true,
+        child: Column(
+          children: <Widget>[
+            const Text('Press the up arrow key to add to the counter'),
+            const Text('Press the down arrow key to subtract from the counter'),
+            Text('count: $count'),
+          ],
+        ),
+      ),
     );
   }
-}
 // #enddocregion CallbackShortcuts
+}

--- a/src/development/ui/advanced/actions-and-shortcuts.md
+++ b/src/development/ui/advanced/actions-and-shortcuts.md
@@ -76,46 +76,35 @@ object? The main reason is that it's useful for actions to decide whether they
 are enabled by implementing `isEnabled`. Also, it is often helpful if the key
 bindings, and the implementation of those bindings, are in different places.
 
-If indeed all that is needed is a callback, without all the complexity (or
-flexibility) of `Actions` and `Shortcuts`, you can already use a `Focus` widget
-for this. For example, here's the implementation of Flutter's simple
-[`CallbackShortcuts`][] widget that takes a map of activators and executes 
-callbacks for them:
-
+If all you need are callbacks without the flexibility of `Actions` and
+`Shortcuts`, you can use the [`CallbackShortcuts`][] widget:
 
 <?code-excerpt "ui/advanced/actions_and_shortcuts/lib/samples.dart (CallbackShortcuts)"?>
 ```dart
-class CallbackShortcuts extends StatelessWidget {
-  const CallbackShortcuts({
-    super.key,
-    required this.bindings,
-    required this.child,
-  });
-
-  final Map<ShortcutActivator, VoidCallback> bindings;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return Focus(
-      onKey: (node, event) {
-        KeyEventResult result = KeyEventResult.ignored;
-        // Activates all key bindings that match, returns handled if any handle it.
-        for (final ShortcutActivator activator in bindings.keys) {
-          if (activator.accepts(event, RawKeyboard.instance)) {
-            bindings[activator]!.call();
-            result = KeyEventResult.handled;
-          }
-        }
-        return result;
+@override
+Widget build(BuildContext context) {
+  return CallbackShortcuts(
+    bindings: <ShortcutActivator, VoidCallback>{
+      const SingleActivator(LogicalKeyboardKey.arrowUp): () {
+        setState(() => count = count + 1);
       },
-      child: child,
-    );
-  }
+      const SingleActivator(LogicalKeyboardKey.arrowDown): () {
+        setState(() => count = count - 1);
+      },
+    },
+    child: Focus(
+      autofocus: true,
+      child: Column(
+        children: <Widget>[
+          const Text('Press the up arrow key to add to the counter'),
+          const Text('Press the down arrow key to subtract from the counter'),
+          Text('count: $count'),
+        ],
+      ),
+    ),
+  );
 }
 ```
-
-This may be all that is needed for some apps.
 
 ## Shortcuts
 


### PR DESCRIPTION
Instead of explaining how `CallbackShortcuts` are implemented, show an example of how to use `CallbackShortcuts`.

The example is copied from this pending sample: https://github.com/flutter/flutter/pull/123944

Screenshot:

<img width="729" alt="image" src="https://user-images.githubusercontent.com/737941/229977150-37b17f0c-c359-4540-b4ba-d504c0bc2173.png">


## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
