### PR TITLE
[Proposal] Link to breaking changes & migrations from release notes index

### DIFF
--- a/src/development/tools/sdk/release-notes/index.md
+++ b/src/development/tools/sdk/release-notes/index.md
@@ -15,36 +15,46 @@ releases to the stable channel.
 * 3.7.0
   * [3.7.0 announcement][]
   * [3.7.0 release notes & change log][]
+  * [3.7.0 breaking changes & migrations][]
 * 3.3.0
   * [3.3.0 announcement][]
   * [3.3.0 release notes & change log][]
+  * [3.3.0 breaking changes & migrations][]
 * 3.0.0
   * [3.0.0 announcement][]
   * [3.0.0 release notes & change log][]
+  * [3.0.0 breaking changes & migrations][]
 * 2.10.0
   * [2.10.0 announcement][]
   * [2.10.0 release notes & change log][]
+  * [2.10.0 breaking changes & migrations][]
 * 2.8.0
   * [2.8.0 announcement][]
   * [2.8.0 release notes & change log][]
 * 2.5.0
   * [2.5.0 announcement][]
   * [2.5.0 release notes & change log][]
+  * [2.5.0 breaking changes & migrations][]
 * 2.2.0
   * [2.2.0 announcement][]
   * [2.2.0 release notes & change log][]
+  * [2.2.0 breaking changes & migrations][]
 * 2.0.0
   * [2.0.0 announcement][]
   * [2.0.0 release notes & change log][]
+  * [2.0.0 breaking changes & migrations][]
 * 1.22.0
   * [1.22.0 announcement][]
   * [1.22.0 release notes & change log][]
+  * [1.22.0 breaking changes & migrations][]
 * 1.20.0
   * [1.20.0 announcement][]
   * [1.20.0 release notes & change log][]
+  * [1.20.0 breaking changes & migrations][]
 * 1.17.0
   * [1.17.0 announcement][]
   * [1.17.0 release notes and change log][]
+  * [1.17.0 breaking changes & migrations][]
 * 1.12.13
   * [1.12.13 announcement][]
   * [1.12.13 release notes and change log][]
@@ -53,26 +63,36 @@ releases to the stable channel.
 
 [3.7.0 announcement]: {{site.flutter-medium}}/whats-new-in-flutter-3-7-38cbea71133c
 [3.7.0 release notes & change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-3.7.0
+[3.7.0 breaking changes & migrations]: {{site.url}}/release/breaking-changes#released-in-flutter-37
 [3.3.0 announcement]: {{site.flutter-medium}}/announcing-flutter-3-3-at-flutter-vikings-6f213e068793
 [3.3.0 release notes & change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-3.3.0
+[3.3.0 breaking changes & migrations]: {{site.url}}/release/breaking-changes#released-in-flutter-33
 [3.0.0 announcement]: {{site.flutter-medium}}/whats-new-in-flutter-3-8c74a5bc32d0
 [3.0.0 release notes & change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-3.0.0
+[3.0.0 breaking changes & migrations]: {{site.url}}/release/breaking-changes#released-in-flutter-30
 [2.10.0 announcement]: {{site.flutter-medium}}/whats-new-in-flutter-2-10-5aafb0314b12
 [2.10.0 release notes & change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-2.10.0
+[2.10.0 breaking changes & migrations]: {{site.url}}/release/breaking-changes#released-in-flutter-210
 [2.8.0 announcement]: {{site.flutter-medium}}/whats-new-in-flutter-2-8-d085b763d181
 [2.8.0 release notes & change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-2.8.0
 [2.5.0 announcement]: {{site.flutter-medium}}/whats-new-in-flutter-2-5-6f080c3f3dc
 [2.5.0 release notes & change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-2.5.0
+[2.5.0 breaking changes & migrations]: {{site.url}}/release/breaking-changes#released-in-flutter-25
 [2.2.0 announcement]: {{site.flutter-medium}}/whats-new-in-flutter-2-2-fd00c65e2039
 [2.2.0 release notes & change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-2.2.0
+[2.2.0 breaking changes & migrations]: {{site.url}}/release/breaking-changes#released-in-flutter-22
 [2.0.0 announcement]: {{site.flutter-medium}}/whats-new-in-flutter-2-0-fe8e95ecc65
 [2.0.0 release notes & change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-2.0.0
+[2.0.0 breaking changes & migrations]: {{site.url}}/release/breaking-changes#released-in-flutter-20
 [1.22.0 announcement]: {{site.flutter-medium}}/announcing-flutter-1-22-stable-44f146009e5f
 [1.22.0 release notes & change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-1.22.0
+[1.22.0 breaking changes & migrations]: {{site.url}}/release/breaking-changes#released-in-flutter-122
 [1.20.0 announcement]: {{site.flutter-medium}}/announcing-flutter-1-20-2aaf68c89c75
 [1.20.0 release notes & change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-1.20.0
+[1.20.0 breaking changes & migrations]: {{site.url}}/release/breaking-changes#released-in-flutter-120
 [1.17.0 announcement]: {{site.flutter-medium}}/announcing-flutter-1-17-4182d8af7f8e
 [1.17.0 release notes and change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-1.17.0
+[1.17.0 breaking changes & migrations]: {{site.url}}/release/breaking-changes#released-in-flutter-17 
 [1.12.13 announcement]: {{site.flutter-medium}}/announcing-flutter-1-12-what-a-year-22c256ba525d
 [1.12.13 release notes and change log]: {{site.url}}/development/tools/sdk/release-notes/release-notes-1.12.13
 [Archived release notes]: {{site.url}}/development/tools/sdk/release-notes/release-notes-archive


### PR DESCRIPTION
We already collect release blogs and notes on the "Release notes" page already, but not the associated breaking changes/migration docs, which are potentially the most impactful.