### PR TITLE
Add dart fix video to website

### DIFF
--- a/src/development/tools/flutter-fix.md
+++ b/src/development/tools/flutter-fix.md
@@ -58,6 +58,8 @@ A sample code action in VS Code
 
 ## Applying project-wide fixes
 
+[dart fix Decoding Flutter][]
+
 To see or apply changes to an entire project,
 you can use the command-line tool, [`dart fix`][].
 
@@ -84,3 +86,4 @@ on Flutter's Medium publication.
 
 [Deprecation lifetime in Flutter]: {{site.flutter-medium}}/deprecation-lifetime-in-flutter-e4d76ee738ad
 [`dart fix`]: {{site.dart-site}}/tools/dart-fix
+[dart fix Decoding Flutter]: {{site.youtube-site}}/watch?v=OBIuSrg_Quo


### PR DESCRIPTION
This adds the youtube video for dart fix to the page that discusses it on the website.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
