### PR TITLE
Suggested name convention for "short-title" property

### DIFF
--- a/src/development/accessibility-and-localization/index.md
+++ b/src/development/accessibility-and-localization/index.md
@@ -1,7 +1,7 @@
 ---
 layout: toc
 title: Accessibility & internationalization
-short-title: a11y & i18n
+short-title: Accessibility & internationalization
 description: >
   Content covering accessibility and internationalization in Flutter apps.
 ---

--- a/src/development/accessibility-and-localization/internationalization.md
+++ b/src/development/accessibility-and-localization/internationalization.md
@@ -1,6 +1,6 @@
 ---
 title: Internationalizing Flutter apps
-short-title: i18n
+short-title: Internationalizing
 description: How to internationalize your Flutter app.
 ---
 


### PR DESCRIPTION
 "a11y & i18n" is not justifying its working, the name should be instead Accessibility & Internationalization rather previous name.

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
