### PR TITLE
[VS Code] move 'status bar change to orange' message to 'run app with breakpoints'

### DIFF
--- a/src/development/tools/vs-code.md
+++ b/src/development/tools/vs-code.md
@@ -130,14 +130,13 @@ running or debugging.
 
  1. Click **Run > Start Without Debugging** in the
     main IDE window, or press `Ctrl`+`F5`.
-    The status bar turns orange to show you are in a debug session.<br>
-    ![Debug console]({{site.url}}/assets/images/docs/tools/vs-code/debug_console.png){:.mw-100.pt-1}
 
 ### Run app with breakpoints
 
  1. If desired, set breakpoints in your source code.
  1. Click **Run > Start Debugging** in the main IDE window,
-    or press `F5`.
+    or press `F5`. The status bar turns orange to show you are in a debug session.<br>
+    ![Debug console]({{site.url}}/assets/images/docs/tools/vs-code/debug_console.png){:.mw-100.pt-1}
 
     * The left **Debug Sidebar** shows stack frames and variables.
     * The bottom **Debug Console** pane shows detailed logging output.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Move 'The Status Bar turns to orange...' line (with image) to ' Run app with breakpoints' section.

_Issues fixed by this PR (if any):_ Fixes #7712

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
