### PR TITLE
Introduce a short and sweet release note redirect

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -142,6 +142,8 @@
       { "source": "/get-started/web", "destination": "/development/platform-integration/web/building", "type": 301 },
       { "source": "/release", "destination": "/release/whats-new", "type": 301 },
       { "source": "/release/release-notes/changelogs/changelog-1.17.0", "destination": "/release/release-notes/release-notes-1.17.0", "type": 301 },
+      { "source": "/release-notes", "destination": "/release/release-notes", "type": 301 },
+      { "source": "/release-notes/:version*", "destination": "/release/release-notes/release-notes-:version*", "type": 301 },
       { "source": "/reference/widgets/:catalogpage+", "destination": "/development/ui/widgets/:catalogpage+", "type": 301 },
       { "source": "/reference/widgets/widgetindex", "destination": "/reference/widgets", "type": 301 },
       { "source": "/release/breaking-changes/scrollable_alert_dialog", "destination": "/release/breaking-changes/scrollable-alert-dialog", "type": 301 },


### PR DESCRIPTION
This PR follows up on work started in https://github.com/flutter/website/pull/8516 and introduces a simplified redirect for release notes.

`docs.flutter.dev/release-notes/3.7.0` will redirect to `docs.flutter.dev/release/release-notes/release-notes-3-7-0`.

This link will be a persistent and reliable link target for tools to link to, especially ones where copying may not be super easy or space is limited.

**Staged example:** https://parlough-docs-flutter-dev.web.app/release-notes/3.7.0