### PR TITLE
Add medium blog icon link to header

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -119,23 +119,29 @@
     </div>
     <div class="site-header__social navbar-nav flex-row">
       <a 
-        class="nav-item nav-link" 
+        class="nav-item nav-link nav-icon"
         href="{{site.social.twitter}}" 
         aria-label="Twitter">
         <i class="fab fa-twitter fa-lg"></i>
       </a>
       <a 
-        class="nav-item nav-link" 
+        class="nav-item nav-link nav-icon"
         href="{{site.social.youtube}}" 
         aria-label="YouTube">
         <i class="fab fa-youtube fa-lg"></i>
-    </a>
+      </a>
+      <a
+        class="nav-item nav-link nav-icon"
+        href="{{site.flutter-medium}}"
+        aria-label="Medium blog">
+        <i class="fab fa-medium fa-lg"></i>
+      </a>
       <a 
-        class="nav-item nav-link" 
+        class="nav-item nav-link nav-icon"
         href="{{site.repo.organization}}" 
         aria-label="GitHub">
         <i class="fab fa-github fa-lg"></i>
-    </a>
+      </a>
     </div>
     {% if page.show-nav-get-started-button -%}
       <a 

--- a/src/_sass/components/_header.scss
+++ b/src/_sass/components/_header.scss
@@ -52,4 +52,10 @@ header.site-header {
       display: none;
     }
   }
+
+  .nav-icon {
+    &:hover {
+      color: $site-color-body-light;
+    }
+  }
 }


### PR DESCRIPTION
The blog has become an integral part of Flutter releases and docs, and deserves a spot with the other social entries.

This PR introduces a "Medium blog" entry to the top navbar alongside Youtube and Twitter. It also adds a hover style to make interaction with the icons/links more apparent.

**Updated top navbar (with GitHub currently hovered):**
<img width="306" alt="Screenshot of updated navbar" src="https://user-images.githubusercontent.com/18372958/230702036-94d34436-0056-419f-aba1-987096d651e3.png">
