### PR TITLE
[Desktop] [Linux] add missing dependency in apt-get install

### DIFF
--- a/src/development/platform-integration/desktop.md
+++ b/src/development/platform-integration/desktop.md
@@ -109,7 +109,7 @@ Alternatively, if you prefer not to use `snapd`,
 you can use the following command:
 
 ```terminal
-$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
+$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev
 ```
 
 [Clang]: https://clang.llvm.org/


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ add missing dependency `libstdc++-12-dev` in `apt-get install` (requirements) command which is for setting up Flutter for Linux Desktop environment.

_Issues fixed by this PR (if any):_ Fixes #8016

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
