### PR TITLE
Missed '()' on platform-views.md

### DIFF
--- a/src/development/platform-integration/ios/platform-views.md
+++ b/src/development/platform-integration/ios/platform-views.md
@@ -184,7 +184,7 @@ import UIKit
 
 class FLPlugin: NSObject, FlutterPlugin {
     public static func register(with registrar: FlutterPluginRegistrar) {
-        let factory = FLNativeViewFactory(messenger: registrar.messenger)
+        let factory = FLNativeViewFactory(messenger: registrar.messenger())
         registrar.register(factory, withId: "<platform-view-type>")
     }
 }


### PR DESCRIPTION
Fixed error message: 
`Function produces expected type 'any FlutterBinaryMessenger'; did you mean to call it with '()'?`

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
