### PR TITLE
Update shaders.md

### DIFF
--- a/src/development/ui/advanced/shaders.md
+++ b/src/development/ui/advanced/shaders.md
@@ -67,7 +67,7 @@ The available uniforms depends on how the shader was defined.
 
 ```dart
 void updateShader(Canvas canvas, Rect rect, FragmentProgram program) {
-  var shader = program.createShader();
+  var shader = program.fragmentShader();
   shader.setFloat(0, 42.0);
   canvas.drawRect(rect, Paint()..shader = shader);
 }


### PR DESCRIPTION
FragmentProgram does not have createShader() method but it does have fragmentShader() method

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
