### PR TITLE
Remove unnecessary redirect and remove dividers from generated TOC

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -140,7 +140,6 @@
       { "source": "/get-started/flutter-for/ios-devs", "destination": "/get-started/flutter-for/swiftui-devs", "type": 301 },
       { "source": "/get-started/install/null", "destination": "/get-started/install", "type": 301 },
       { "source": "/get-started/web", "destination": "/development/platform-integration/web/building", "type": 301 },
-      { "source": "/release", "destination": "/release/whats-new", "type": 301 },
       { "source": "/release/release-notes/changelogs/changelog-1.17.0", "destination": "/release/release-notes/release-notes-1.17.0", "type": 301 },
       { "source": "/release-notes", "destination": "/release/release-notes", "type": 301 },
       { "source": "/release-notes/:version*", "destination": "/release/release-notes/release-notes-:version*", "type": 301 },

--- a/src/_layouts/toc.html
+++ b/src/_layouts/toc.html
@@ -19,7 +19,7 @@ toc: false
   {% endif -%}
   {% if forloop.index0 > 0 -%}
     {% assign topics = topics | where: "permalink", path -%}
-    {% assign topics = topics[0].children -%}
+    {% assign topics = topics[0].children | where_exp:"item", "item != 'divider'" -%}
   {% endif -%}
 {% endfor -%}
 

--- a/src/release/index.md
+++ b/src/release/index.md
@@ -3,6 +3,4 @@ title: Stay up to date
 description: Flutter archive, releases, and breaking changes.
 layout: toc
 sitemap: false
-# This is a placeholder page used to enable accurate breadcrumbs.
-# Firebase redirects this page's URL to `/release/whats-new`.
 ---


### PR DESCRIPTION
This removes a redirect from `/release` to `/release/whats-new` since it's causing some breadcrumbs issues.

Since `/release` has a divider in the sidenav, it was showing up as an entry in the generated TOC on the new page. This adds an exception for dividers to remove them. 

_Example of generated TOC with empty entry because of divider before:_
<img width="310" alt="Example with empty entry" src="https://user-images.githubusercontent.com/18372958/231006761-7b1238ef-51e7-496a-baf6-2ae4a3c1139a.png">

