### PR TITLE
Add max-width of 100% default to images in primary content

### DIFF
--- a/src/_sass/components/_content.scss
+++ b/src/_sass/components/_content.scss
@@ -35,6 +35,10 @@
 
   .container {
     max-width: $site-content-max-width;
+
+    img {
+      max-width: 100%;
+    }
   }
 
   @include media-breakpoint-up(md) {


### PR DESCRIPTION
This matches what is used in dart-lang/site-www.