### PR TITLE
Increase consistency between sidenav styles and increase density

### DIFF
--- a/src/_sass/base/_variables.scss
+++ b/src/_sass/base/_variables.scss
@@ -29,7 +29,8 @@ $site-header-height: 66px;
 $site-footer-md-default-height: 140px;
 $site-content-top-padding: 40px;
 $site-content-max-width: 960px;
-$site-sidebar-side-padding: 16px;
+$site-sidebar-top-padding: 24px;
+$site-sidebar-side-padding: 20px;
 $site-nav-mobile-side-padding: 20px;
 $site-snackbar-padding: 20px;
 

--- a/src/_sass/base/_variables.scss
+++ b/src/_sass/base/_variables.scss
@@ -30,7 +30,7 @@ $site-footer-md-default-height: 140px;
 $site-content-top-padding: 40px;
 $site-content-max-width: 960px;
 $site-sidebar-top-padding: 24px;
-$site-sidebar-side-padding: 20px;
+$site-sidebar-side-padding: 16px;
 $site-nav-mobile-side-padding: 20px;
 $site-snackbar-padding: 20px;
 

--- a/src/_sass/components/_cookie-notice.scss
+++ b/src/_sass/components/_cookie-notice.scss
@@ -8,7 +8,7 @@
   box-shadow: -1px 1px 4px rgba(0, 0, 0, 0.3);
   opacity: 0;
   display: none;
-  z-index: 999;
+  z-index: $zindex-popover;
 
   @keyframes fadein {
       0% { opacity: 0; }

--- a/src/_sass/components/_footer.scss
+++ b/src/_sass/components/_footer.scss
@@ -3,7 +3,7 @@
   color: $site-color-white;
   padding: bs-spacer(5) 0;
   position: relative;
-  z-index: $site-z-footer;
+  z-index: $zindex-sticky;
 
   &__wrapper {
     align-items: center;

--- a/src/_sass/components/_header.scss
+++ b/src/_sass/components/_header.scss
@@ -39,6 +39,10 @@ header.site-header {
         margin-bottom: 1.5rem;
       }
     }
+
+    .site-header__sheet > * {
+      margin: 0;
+    }
   }
 
   @include media-breakpoint-down(md) {

--- a/src/_sass/components/_sidebar.scss
+++ b/src/_sass/components/_sidebar.scss
@@ -66,7 +66,7 @@
 
   // Top-level nav item
   > .nav {
-    > .nav-item, > .nav-header {
+    > .nav-item {
       padding: 0 $site-sidebar-side-padding;
     }
 

--- a/src/_sass/components/_sidebar.scss
+++ b/src/_sass/components/_sidebar.scss
@@ -1,11 +1,10 @@
 .site-sidebar {
-  padding: $site-content-top-padding $site-sidebar-side-padding;
+  font-family: $site-font-family-alt;
+  padding: $site-sidebar-top-padding 0 ($site-sidebar-top-padding * 2);
 
   // Customization for sidebar in mobile nav
   &.site-sidebar--header {
-    padding-left: bs-spacer(2);
-    padding-top: 0;
-    padding-bottom: 0;
+    padding: 0;
 
     > .nav > .nav-item {
       font-size: $font-size-base;
@@ -40,6 +39,10 @@
     color: inherit;
     &.disabled { opacity: 0.5; }
 
+    &.active {
+      font-weight: $font-weight-bold;
+    }
+
     @include nav-link-not-active-hover;
   }
 
@@ -62,25 +65,33 @@
   }
 
   // Top-level nav item
-  > .nav > .nav-item {
-    font-family: $site-font-family-alt;
-
-    &:first-child {
-      > .nav-link {
-        padding-top: 0;
-      }
+  > .nav {
+    > .nav-item, > .nav-header {
+      padding: 0 $site-sidebar-side-padding;
     }
 
-    > .nav-link {
-      padding: bs-spacer(3) 0;
+    > .nav-item {
+      &:first-child {
+        > .nav-link {
+          padding-top: 0;
+        }
+      }
 
-      @include collapsable();
+      > .nav-link {
+        padding: bs-spacer(2) 0;
+        color: $site-color-body;
+
+        @include collapsable();
+
+        @include nav-link-not-active-hover;
+      }
     }
   }
 
   // Sub navs
   > .nav .nav {
     padding-left: bs-spacer(4);
+    margin-bottom: bs-spacer(1);
 
     .nav-item {
       font-size: $font-size-sm;
@@ -89,7 +100,6 @@
         color: $site-color-body-light;
 
         &.active {
-          font-weight: $font-weight-bold;
           &:not(.collapsable) {
             color: $site-color-primary;
 


### PR DESCRIPTION
This PR better standardizes styles between the two sidenavs, fixes some padding issues, properly indicates active entries, and increases density. This can land now but will be even more important as we add new top-level entries with future IA work.

- Increase consistency between the mobile (thin) and normal (wide) sidenav.
  - Fix font and text styles on mobile sidenav to match the normal side
  - Highlight active top-level entry on both, not just mobile sidenav
- Prevent sidenav text overlapping footer on scroll
- Slightly reduce vertical padding between top-level entries to improve density

**Staged:** https://parlough-style-flutter-dev.web.app/