### PR TITLE
Run column and sidenav adjustments on page resize

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -95,6 +95,7 @@ function initFixedColumns() {
 
     // listen for scroll and execute once
     $(window).scroll(adjustFixedColumns);
+    $(window).resize(adjustFixedColumns);
     adjustFixedColumns();
   }
 }


### PR DESCRIPTION
We currently ran the adjustments on scrolling, but they need to be made when resizing the browser window as well.

This fixes a few issues, including one where when resizing with the mobile sidenav caused the top items of the sidenav to be inaccessible.