### PR TITLE
Update to Ruby 3.2.2 and update gems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2-1-slim-bullseye@sha256:0b2fb4813f79de93a6fc1d1caf37c1be54f4b09385ee1b5dfb7ff34d8e864140 AS base
+FROM ruby:3.2-2-slim-bullseye@sha256:d8e5caa21b5ebc425828af1eb43a678afceaca80681cac26b457063a18488e10 AS base
 
 ENV TZ=US/Pacific
 RUN apt-get update && apt-get install -yq --no-install-recommends \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.1)
+    addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     colorator (1.1.0)
     concurrent-ruby (1.2.2)
@@ -18,9 +18,9 @@ GEM
       forwardable-extended (~> 2.5)
     ffi (1.15.5)
     forwardable-extended (2.6.0)
-    google-protobuf (3.22.2)
-    google-protobuf (3.22.2-aarch64-linux)
-    google-protobuf (3.22.2-x86_64-linux)
+    google-protobuf (3.22.3)
+    google-protobuf (3.22.3-aarch64-linux)
+    google-protobuf (3.22.3-x86_64-linux)
     http_parser.rb (0.8.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -81,12 +81,12 @@ GEM
     rexml (3.2.5)
     rouge (4.1.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.59.2)
+    sass-embedded (1.62.0)
       google-protobuf (~> 3.21)
       rake (>= 10.0.0)
-    sass-embedded (1.59.2-aarch64-linux-gnu)
+    sass-embedded (1.62.0-aarch64-linux-gnu)
       google-protobuf (~> 3.21)
-    sass-embedded (1.59.2-x86_64-linux-gnu)
+    sass-embedded (1.62.0-x86_64-linux-gnu)
       google-protobuf (~> 3.21)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -110,4 +110,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.4.8
+   2.4.12


### PR DESCRIPTION
[Ruby 3.2.2](https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-2-2-released/) includes a few security fixes.