### PR TITLE
[Docs] [Install] [Windows] remove confusing instruction

### DIFF
--- a/src/get-started/install/_get-sdk-win.md
+++ b/src/get-started/install/_get-sdk-win.md
@@ -21,15 +21,6 @@
   `C:\Program Files\` that requires elevated privileges.
 {{site.alert.end}}
 
-If you don't want to install a fixed version of the installation 
-bundle, you can skip steps 1 and 2. Instead, get the source code 
-from the [Flutter repo][] on 
-GitHub, and change branches or tags as needed. For example:
-
-```batchfile
-C:\src>git clone https://github.com/flutter/flutter.git -b stable
-```
-
 You are now ready to run Flutter commands in the Flutter Console.
 
 [Flutter repo]: {{site.repo.flutter}}


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Removes following paragraph & the `git clone` command:

> If you don’t want to install a fixed version of the installation bundle, you can skip steps 1 and 2. Instead, get the source code from the Flutter repo on GitHub, and change branches or tags as needed.

Because, (👇 explanation from the issue description)

> This instruction might lead to misunderstanding that once you download an installation bundle, you're stuck with a particular version or channel of Flutter, which is not true.
>
> This instruction seems to be redundant, since there's a link to https://docs.flutter.dev/development/tools/sdk/releases above it.

_Issues fixed by this PR (if any):_ Fixes: #8321

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
