### PR TITLE
[Docs] [Install] [Linux] remove confusing instruction

### DIFF
--- a/src/get-started/install/_get-sdk-linux.md
+++ b/src/get-started/install/_get-sdk-linux.md
@@ -54,22 +54,6 @@ install Flutter using the following steps.
     $ tar xf ~/Downloads/flutter_{{os}}_vX.X.X-{{site.sdk.channel}}.tar.xz
     ```
     
-    If you don't want to install a fixed version of the installation bundle, 
-    you can skip steps 1 and 2. 
-    Instead, get the source code from the [Flutter repo][]
-    on GitHub with the following command:
-    
-    ```terminal
-    $ git clone https://github.com/flutter/flutter.git
-    ```
-    
-    You can also change branches or tags as needed.
-    For example, to get just the stable version:
-    
-    ```terminal
-    $ git clone https://github.com/flutter/flutter.git -b stable
-    ```
-    
  1. Add the `flutter` tool to your path:
 
     ```terminal


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Fixes an issue in flutter SDK install guide for Linux which is similar to the issue #8321 which fixed by PR #8562.

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
