### PR TITLE
[Docs] [Install] [Android Emulator] Update Instruction Terms

### DIFF
--- a/src/get-started/install/_android-setup.md
+++ b/src/get-started/install/_android-setup.md
@@ -51,7 +51,7 @@ follow these steps:
     launch **Android Studio > Tools > Android > AVD Manager** and select
     **Create Virtual Device...**. (The **Android** submenu is only present
     when inside an Android project.)
-    * If you do not have a project open, you can choose
+    * If you do not have a project open, you can choose 
     **3-Dot Menu / More Actions > Virtual Device Manager** and select **Create Device...**
  1. Choose a device definition and select **Next**.
  1. Select one or more system images for the Android versions you want

--- a/src/get-started/install/_android-setup.md
+++ b/src/get-started/install/_android-setup.md
@@ -45,14 +45,14 @@ follow these steps:
  1. Enable
     [VM acceleration]({{site.android-dev}}/studio/run/emulator-acceleration#accel-vm)
     on your machine.
- 1. Launch **Android Studio**, click the **AVD Manager**
-    icon, and select **Create Virtual Device...**
+ 1. Launch **Android Studio**, click the **Device Manager**
+    icon, and select **Create Device** under **Virtual** tab...
     * In older versions of Android Studio, you should instead
     launch **Android Studio > Tools > Android > AVD Manager** and select
     **Create Virtual Device...**. (The **Android** submenu is only present
     when inside an Android project.)
-    * If you do not have a project open, you can choose 
-    **Configure > AVD Manager** and select **Create Virtual Device...**
+    * If you do not have a project open, you can choose
+    **3-Dot Menu / More Actions > Virtual Device Manager** and select **Create Device...**
  1. Choose a device definition and select **Next**.
  1. Select one or more system images for the Android versions you want
     to emulate, and select **Next**.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Replace some of the terms in the instructions of Android emulator.

Fixes: #8561 

- "**AVD Manager**" is now "**Device Manager**"
- "**Create Virtual Device...**" is now "**Create Device** under **Virtual** tab..."

![screenshot_2023-04-16_at_5 18 57_pm](https://user-images.githubusercontent.com/13456345/232308361-85dd3a81-e80e-45fa-ae84-1dcc054e3fb6.png)

![screenshot_2023-04-16_at_4 58 45_pm](https://user-images.githubusercontent.com/13456345/232306889-32ecac09-cc31-49ad-8f4f-345444ddf36d.png)

---

- "**Configure > AVD Manager** and select **Create Virtual Device...**" is now "**3-Dot Menu / More Actions > Virtual Device Manager** and select **Create Device...**"

![screenshot_2023-04-16_at_4 54 20_pm](https://user-images.githubusercontent.com/13456345/232306885-2b45d541-588a-445b-b4ba-ab65c240fd08.png)

![screenshot_2023-04-16_at_4 54 28_pm](https://user-images.githubusercontent.com/13456345/232306890-3b0c0c71-fc85-4a07-9ca6-4a8a1a4dfb7b.png)

https://user-images.githubusercontent.com/13456345/232308433-b877b6eb-422c-4849-9b58-ccecde0f3b9e.mp4

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
