### PR TITLE
[Docs] [Dart Doc Tool] rename `dartdoc` executable to `dart doc`

### DIFF
--- a/src/development/packages-and-plugins/developing-packages.md
+++ b/src/development/packages-and-plugins/developing-packages.md
@@ -799,7 +799,7 @@ cd ~/dev/mypackage
 ```
 </li>
 
-<li markdown="1">Run the `dartdoc` tool
+<li markdown="1">Run the `dart doc` tool
     (included as part of the Flutter SDK), as follows:
 
 ```terminal

--- a/src/development/packages-and-plugins/developing-packages.md
+++ b/src/development/packages-and-plugins/developing-packages.md
@@ -803,9 +803,9 @@ cd ~/dev/mypackage
     (included as part of the Flutter SDK), as follows:
 
 ```terminal
-   $FLUTTER_ROOT/bin/cache/dart-sdk/bin/dartdoc   # on macOS or Linux
+   $FLUTTER_ROOT/bin/cache/dart-sdk/bin/dart doc   # on macOS or Linux
 
-   %FLUTTER_ROOT%\bin\cache\dart-sdk\bin\dartdoc  # on Windows
+   %FLUTTER_ROOT%\bin\cache\dart-sdk\bin\dart doc  # on Windows
 ```
 </li>
 </ol>


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ rename `dartdoc` executable to `dart doc`

_Issues fixed by this PR (if any):_ Fixes #8560 

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
