### PR TITLE
fix provenance link on linux

### DIFF
--- a/src/assets/js/archive.js
+++ b/src/assets/js/archive.js
@@ -178,8 +178,8 @@ function getProvenanceLink(os, release, date, channel) {
     // provenance not available before 12/15/2022 for macOS and Linux
     return $("<span />").text('-');
   }
-  var extension = os == "linux" ? "xz" : "zip";
-  return $("<a />").attr("href", 
+  var extension = os == "linux" ? "tar.xz" : "zip";
+  return $("<a />").attr("href",
     `${baseUrl}${channel}/${os}/flutter_${os}_${release.version}-${channel}`+
     `.${extension}.intoto.jsonl`
   ).text(`${release.version} file`)

--- a/src/assets/js/archive.js
+++ b/src/assets/js/archive.js
@@ -178,9 +178,10 @@ function getProvenanceLink(os, release, date, channel) {
     // provenance not available before 12/15/2022 for macOS and Linux
     return $("<span />").text('-');
   }
+  var extension = os == "linux" ? "xz" : "zip";
   return $("<a />").attr("href", 
     `${baseUrl}${channel}/${os}/flutter_${os}_${release.version}-${channel}`+
-    `.zip.intoto.jsonl`
+    `.${extension}.intoto.jsonl`
   ).text(`${release.version} file`)
 }
 


### PR DESCRIPTION
This is fixing the provenance link on the website for linux releases (which today will give a 404 error).

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
