### PR TITLE
Minor standardization and cleanup in `archive.js`

### DIFF
--- a/src/assets/js/archive.js
+++ b/src/assets/js/archive.js
@@ -70,7 +70,7 @@ let macOSArm64ArchiveFilename = '';
 
 // Listen for the macOS arm64 download link to be clicked and update
 // the example unzip command with correct arm64 filename
-$(".download-latest-link-macos-arm64").click(function() {
+$('.download-latest-link-macos-arm64').click(function() {
   // Update inlined filenames in <code> element text nodes with arm64 filename:
   const fileNamePrefix = 'flutter_';
   const code = $(`code:contains("${fileNamePrefix}")`);
@@ -88,7 +88,7 @@ os: macos, windows, or linux
 [optional] arch: Only specify if there's additional architecture, such as arm64
 */
 function updateReleaseDownloadButton(releases, base_url, os, arch = '') {
-  const archString = !arch.length ? '': '-' + arch;
+  const archString = !arch.length ? '': `-${arch}`;
 
   const release = releases[0];
   const linkSegments = release.archive.split('/');
@@ -120,7 +120,7 @@ function updateReleaseDownloadButton(releases, base_url, os, arch = '') {
 }
 
 function updateDownloadLink(releases, os, arch) {
-  const channel = "stable";
+  const channel = 'stable';
   const releasesForChannel = releases.releases.filter(function (release) {
     return release.channel === channel;
   });
@@ -143,7 +143,7 @@ function updateDownloadLink(releases, os, arch) {
 
     // If no arm64 releases available, delete all apple silicon elements
     if (!releasesForArm64.length) {
-      $(".apple-silicon").each(function(){
+      $('.apple-silicon').each(function(){
         this.remove();
       })
       
@@ -170,7 +170,7 @@ function getProvenanceLink(os, release, date, channel) {
     return $('<span />').text('-');
   }
   const extension = os === 'linux' ? 'tar.xz' : 'zip';
-  return $("<a />").attr('href',
+  return $('<a />').attr('href',
     `${baseUrl}${channel}/${os}/flutter_${os}_${release.version}-${channel}`+
     `.${extension}.intoto.jsonl`
   ).text(`${release.version} file`)
@@ -178,15 +178,15 @@ function getProvenanceLink(os, release, date, channel) {
 
 // Send requests to render the tables.
 $(function () {
-  if ($("#sdk-archives").length) {
+  if ($('#sdk-archives').length) {
     fetchFlutterReleases('windows', updateTable, updateTableFailed);
     fetchFlutterReleases('macos', updateTable, updateTableFailed);
     fetchFlutterReleases('linux', updateTable, updateTableFailed);
   }
-  if ($(".download-latest-link-windows").length)
+  if ($('.download-latest-link-windows').length)
     fetchFlutterReleases('windows', updateDownloadLink, updateDownloadLinkFailed);
-  if ($(".download-latest-link-macos").length)
+  if ($('.download-latest-link-macos').length)
     fetchFlutterReleases('macos', updateDownloadLink, updateDownloadLinkFailed);
-  if ($(".download-latest-link-linux").length)
+  if ($('.download-latest-link-linux').length)
     fetchFlutterReleases('linux', updateDownloadLink, updateDownloadLinkFailed);
 });

--- a/src/assets/js/archive.js
+++ b/src/assets/js/archive.js
@@ -1,16 +1,14 @@
-// TODO(chalin): package archive.js as its own top-level js so that it can be loaded independently
-
 // Number of releases to show by default (rest will be behind a "show all" link).
-var releasesToShow = 99999;
+const releasesToShow = 99999;
 
 // Fetches Flutter release JSON for the given OS and calls the callback once the data is available.
-var fetchFlutterReleases = function (os, callback, errorCallback) {
+function fetchFlutterReleases(os, callback, errorCallback) {
   // OS: windows, macos, linux
-  var url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_" + os + ".json";
+  const url = `https://storage.googleapis.com/flutter_infra_release/releases/releases_${os}.json`;
   $.ajax({
-    type: "GET",
+    type: 'GET',
     url: url,
-    dataType: "json",
+    dataType: 'json',
     success: function (data) { callback(data, os); },
     error: function (xhr, textStatus, errorThrown) {
       if (errorCallback) errorCallback(os);
@@ -19,73 +17,68 @@ var fetchFlutterReleases = function (os, callback, errorCallback) {
 }
 
 function updateTable(releases, os) {
-  var releaseData = releases.releases;
+  const releaseData = releases.releases;
 
-  for (var channel in releases.current_release) {
-    var table = $("#downloads-" + os + "-" + channel);
-    table.addClass("collapsed").find(".loading").remove();
+  for (const channel in releases.current_release) {
+    const table = $(`#downloads-${os}-${channel}`);
+    table.addClass('collapsed').find('.loading').remove();
 
-    var releasesForChannel = releaseData.filter(function (release) {
-      return release.channel == channel;
+    const releasesForChannel = releaseData.filter(function (release) {
+      return release.channel === channel;
     });
 
     releasesForChannel.forEach(function (release, index) {
       // If this is the first row after the cut-off, insert the "Show more..." link.
       if (index === releasesToShow) {
-        var showAll = $("<a />").text("Show all...").attr("href", "#").click(function (event) {
-          $(this).closest("table").removeClass("collapsed");
-          $(this).closest("tr").remove();
+        const showAll = $('<a />').text('Show all...').attr('href', '#').click(function (event) {
+          $(this).closest('table').removeClass('collapsed');
+          $(this).closest('tr').remove();
           event.preventDefault();
         });
-        $("<tr>").append($("<td colspan=\"6\"></td></tr>").append(showAll)).appendTo(table);
+        $('<tr>').append($('<td colspan="6"></td></tr>').append(showAll)).appendTo(table);
       }
 
-      var className = index >= releasesToShow ? "overflow" : "";
-      var url = releases.base_url + "/" + release.archive;
-      var row = $("<tr />").addClass(className).appendTo(table);
-      var hashLabel = $("<span />").text(release.hash.substr(0, 7)).addClass("git-hash");
-      var downloadLink = $("<a />").attr("href", url).text(release.version);
-      var dartSdkVersion = $("<span />").text(
+      const className = index >= releasesToShow ? 'overflow' : '';
+      const url = releases.base_url + '/' + release.archive;
+      const row = $('<tr />').addClass(className).appendTo(table);
+      const hashLabel = $('<span />').text(release.hash.substr(0, 7)).addClass('git-hash');
+      const downloadLink = $('<a />').attr('href', url).text(release.version);
+      const dartSdkVersion = $('<span />').text(
         release.dart_sdk_version ? release.dart_sdk_version.split(' ')[0] : '-',
       );
-      var dartSdkArch = $("<span />").text(
+      const dartSdkArch = $('<span />').text(
         release.dart_sdk_arch ? release.dart_sdk_arch : 'x64',
       );
-      var date = new Date(Date.parse(release.release_date));
-      var provenance = getProvenanceLink(os, release, date, channel);
-      $("<td />").append(downloadLink).appendTo(row);
-      $("<td />").append(dartSdkArch).appendTo(row);
-      $("<td />").append(hashLabel).appendTo(row);
-      $("<td />").addClass("date").text(date.toLocaleDateString()).appendTo(row);
-      $("<td />").append(dartSdkVersion).appendTo(row);
-      $("<td />").append(provenance).appendTo(row);
+      const date = new Date(Date.parse(release.release_date));
+      const provenance = getProvenanceLink(os, release, date, channel);
+      $('<td />').append(downloadLink).appendTo(row);
+      $('<td />').append(dartSdkArch).appendTo(row);
+      $('<td />').append(hashLabel).appendTo(row);
+      $('<td />').addClass('date').text(date.toLocaleDateString()).appendTo(row);
+      $('<td />').append(dartSdkVersion).appendTo(row);
+      $('<td />').append(provenance).appendTo(row);
     });
   }
 }
 
 function updateTableFailed(os) {
-  var tab = $("#tab-os-" + os);
-  tab.find(".loading").text("Failed to load releases. Refresh page to try again.");
+  const tab = $(`#tab-os-${os}`);
+  tab.find('.loading').text('Failed to load releases. Refresh page to try again.');
 }
 
-
-var macOSArm64ArchiveFilename = '';
+let macOSArm64ArchiveFilename = '';
 
 // Listen for the macOS arm64 download link to be clicked and update
 // the example unzip command with correct arm64 filename
 $(".download-latest-link-macos-arm64").click(function() {
-  macOSArch = 'arm64';
-
   // Update inlined filenames in <code> element text nodes with arm64 filename:
-  var fileNamePrefix = 'flutter_';
-  var code = $('code:contains("' + fileNamePrefix + '")');
-  var textNode = $(code).contents().filter(function() {
-    return this.nodeType == 3 && this.textContent.includes(fileNamePrefix);
+  const fileNamePrefix = 'flutter_';
+  const code = $(`code:contains("${fileNamePrefix}")`);
+  const textNode = $(code).contents().filter(function() {
+    return this.nodeType === 3 && this.textContent.includes(fileNamePrefix);
   });
-  var text = $(textNode).text();
-  //var newText = text.replace(new RegExp('^(.*?)\\b' + fileNamePrefix + '\\w+_v.*'), '$1' + macOSArm64ArchiveFilename);
-  $(textNode).replaceWith(`unzip ~/Downloads/${macOSArm64ArchiveFilename}`);
 
+  $(textNode).replaceWith(`unzip ~/Downloads/${macOSArm64ArchiveFilename}`);
 });
 
 /*
@@ -95,58 +88,57 @@ os: macos, windows, or linux
 [optional] arch: Only specify if there's additional architecture, such as arm64
 */
 function updateReleaseDownloadButton(releases, base_url, os, arch = '') {
-  var archString = !arch.length ? archString = '': archString = '-' + arch;
+  const archString = !arch.length ? '': '-' + arch;
 
-  var release = releases[0];
-  var linkSegments = release.archive.split("/");
-  var archiveFilename = linkSegments[linkSegments.length - 1]; // Just the filename part of url
-  var downloadLink = $(".download-latest-link-" + os + archString);
+  const release = releases[0];
+  const linkSegments = release.archive.split('/');
+  const archiveFilename = linkSegments[linkSegments.length - 1]; // Just the filename part of url
+  const downloadLink = $(`.download-latest-link-${os}${archString}`);
 
-  if (os == "macos" && arch == "arm64") {
+  if (os === 'macos' && arch === 'arm64') {
     macOSArm64ArchiveFilename = archiveFilename;
   }
   
   downloadLink
     .text(archiveFilename)
-    .attr("href", base_url + "/" + release.archive);
+    .attr('href', `${base_url}/${release.archive}`);
 
 
   //Update download-filename placeholders:
-  $(".download-latest-link-filename-" + os + archString).text(archiveFilename);
-  $(".download-latest-link-filename").text(archiveFilename);
+  $(`.download-latest-link-filename-${os}${archString}`).text(archiveFilename);
+  $('.download-latest-link-filename').text(archiveFilename);
 
   // Update inlined filenames in <code> element text nodes:
-  var fileNamePrefix = 'flutter_';
-  var code = $('code:contains("' + fileNamePrefix + '")');
-  var textNode = $(code).contents().filter(function() {
-    return this.nodeType == 3 && this.textContent.includes(fileNamePrefix);
+  const fileNamePrefix = 'flutter_';
+  const code = $(`code:contains("${fileNamePrefix}")`);
+  const textNode = $(code).contents().filter(function() {
+    return this.nodeType === 3 && this.textContent.includes(fileNamePrefix);
   });
-  var text = $(textNode).text();
-  var newText = text.replace(new RegExp('^(.*?)\\b' + fileNamePrefix + '\\w+_v.*'), '$1' + archiveFilename);
+  const text = $(textNode).text();
+  const newText = text.replace(new RegExp(`^(.*?)\\b${fileNamePrefix}\\w+_v.*`), `$1${archiveFilename}`);
   $(textNode).replaceWith(newText);
-  
 }
 
 function updateDownloadLink(releases, os, arch) {
-  var channel = "stable";
-  var releasesForChannel = releases.releases.filter(function (release) {
-    return release.channel == channel;
+  const channel = "stable";
+  const releasesForChannel = releases.releases.filter(function (release) {
+    return release.channel === channel;
   });
   if (!releasesForChannel.length)
     return;
 
   // On macOS, update the download buttons for both architectures, x64 and arm64
-  if (os == 'macos') {
+  if (os === 'macos') {
     // Filter releases by x64 architecture 
-    var releasesForX64 = releasesForChannel.filter(function (release) {
-      return release.dart_sdk_arch == 'x64';
+    const releasesForX64 = releasesForChannel.filter(function (release) {
+      return release.dart_sdk_arch === 'x64';
     });
 
     updateReleaseDownloadButton(releasesForX64, releases.base_url, os);
 
     // Filter releases by arm64 architecture 
-    var releasesForArm64 = releasesForChannel.filter(function (release) {
-      return release.dart_sdk_arch == 'arm64';
+    const releasesForArm64 = releasesForChannel.filter(function (release) {
+      return release.dart_sdk_arch === 'arm64';
     });
 
     // If no arm64 releases available, delete all apple silicon elements
@@ -159,27 +151,26 @@ function updateDownloadLink(releases, os, arch) {
     }
     
     updateReleaseDownloadButton(releasesForArm64, releases.base_url, os, 'arm64');
-  }
-  else {
+  } else {
     updateReleaseDownloadButton(releasesForChannel, releases.base_url, os);
   }
 }
 
 function updateDownloadLinkFailed(os) {
-  $(".download-latest-link-" + os).text("(failed)");
+  $(`.download-latest-link-${os}`).text('(failed)');
 }
 
 function getProvenanceLink(os, release, date, channel) {
-  var baseUrl = 'https://storage.googleapis.com/flutter_infra_release/releases/'
-  if (os == 'windows' && date < new Date(Date.parse('4/3/2023'))) {
+  const baseUrl = 'https://storage.googleapis.com/flutter_infra_release/releases/'
+  if (os === 'windows' && date < new Date(Date.parse('4/3/2023'))) {
     // provenance not available before 4/3/2023 for Windows
-    return $("<span />").text('-');
+    return $('<span />').text('-');
   } else if (date < new Date(Date.parse('12/15/2022'))) {
     // provenance not available before 12/15/2022 for macOS and Linux
-    return $("<span />").text('-');
+    return $('<span />').text('-');
   }
-  var extension = os == "linux" ? "tar.xz" : "zip";
-  return $("<a />").attr("href",
+  const extension = os === 'linux' ? 'tar.xz' : 'zip';
+  return $("<a />").attr('href',
     `${baseUrl}${channel}/${os}/flutter_${os}_${release.version}-${channel}`+
     `.${extension}.intoto.jsonl`
   ).text(`${release.version} file`)
@@ -188,15 +179,14 @@ function getProvenanceLink(os, release, date, channel) {
 // Send requests to render the tables.
 $(function () {
   if ($("#sdk-archives").length) {
-    fetchFlutterReleases("windows", updateTable, updateTableFailed);
-    fetchFlutterReleases("macos", updateTable, updateTableFailed);
-    fetchFlutterReleases("linux", updateTable, updateTableFailed);
+    fetchFlutterReleases('windows', updateTable, updateTableFailed);
+    fetchFlutterReleases('macos', updateTable, updateTableFailed);
+    fetchFlutterReleases('linux', updateTable, updateTableFailed);
   }
   if ($(".download-latest-link-windows").length)
-    fetchFlutterReleases("windows", updateDownloadLink, updateDownloadLinkFailed);
+    fetchFlutterReleases('windows', updateDownloadLink, updateDownloadLinkFailed);
   if ($(".download-latest-link-macos").length)
-    fetchFlutterReleases("macos", updateDownloadLink, updateDownloadLinkFailed);
+    fetchFlutterReleases('macos', updateDownloadLink, updateDownloadLinkFailed);
   if ($(".download-latest-link-linux").length)
-    fetchFlutterReleases("linux", updateDownloadLink, updateDownloadLinkFailed);
+    fetchFlutterReleases('linux', updateDownloadLink, updateDownloadLinkFailed);
 });
-


### PR DESCRIPTION
To make future review of new and updated code easier, this PR slightly cleans up and standardizes `archive.js`:

- Use `const` and `let` instead of `var`
- Use template strings where it makes sense
- Standardize to single quotes (to be consistent across the file and with our Dart style)
- Standardize function syntax
- Removes some dead/unused code and comments
- Other minor cleanup

**Staged site to verify functionality:**
https://parlough-docs-flutter-dev.web.app/release/archive
