### PR TITLE
Improve SEO of error on Gradle migration page

### DIFF
--- a/src/release/breaking-changes/android-java-gradle-migration-guide.md
+++ b/src/release/breaking-changes/android-java-gradle-migration-guide.md
@@ -9,7 +9,7 @@ If you've recently upgraded Android Studio to the Flamingo
 release and have either run or built an existing Android app,
 you might have run into an error similar to the following:
 
-![Error dialog in Android Studio Flamingo]({{site.url}}/assets/images/docs/releaseguide/android-studio-flamingo-error.png){:width="80%"}
+![Error dialog in Android Studio Flamingo: MultipleCompilationErrorsException]({{site.url}}/assets/images/docs/releaseguide/android-studio-flamingo-error.png){:width="80%"}
 
 The terminal output for this error is
 similar to the following:


### PR DESCRIPTION
I have a feeling developers will search for MultipleCompilationErrorsException, so I'm adding it to the page source (till now, it was only in the screenshot).

Small change, no biggie if this gets swallowed by bigger priorities.