### PR TITLE
Replace Webby mention with I/O in banner

### DIFF
--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -2,12 +2,7 @@
   For headings use <h3> elements.
 {% endcomment -%}
 <div class="site-banner site-banner--default" role="alert">
-{% comment %}
-Remove for now...
   Flutter is back at Google I/O on May 10th!
   <a href="https://io.google/2023/?utm_source=flutter&utm_medium=embedded_marketing&utm_campaign=hpp_banner&utm_content=">Register now</a><br>
-{% endcomment %}
-  <a href="https://medium.com/flutter/wonderous-nominated-for-webby-award-8e00e2a648c2">Wonderous has been nominated for a Webby award for best user interface!</a>
-  <a href="https://vote.webbyawards.com/PublicVoting#/2023/apps-dapps-and-software/app-features/best-user-interface">Vote here.</a><br>
   <a href="/release/breaking-changes/android-java-gradle-migration-guide">Android Java Gradle migration guide.</a>
 </div>


### PR DESCRIPTION
The Webby voting has ended. This PR removes the Webby mention and reintroduces the I/O call to action.

<img width="559" alt="Screenshot of banner" src="https://user-images.githubusercontent.com/18372958/234385170-785d7be7-9b39-4752-b398-95a7e7f987a7.png">