### PR TITLE
Fix typo in platform-integration/web/wasm.md

### DIFF
--- a/src/platform-integration/web/wasm.md
+++ b/src/platform-integration/web/wasm.md
@@ -92,7 +92,7 @@ If you don't have a local HTTP server installed, you can use the
 Server started on port 8080
 ```
 
-#### Load it an a browser
+#### Load it in a browser
 
 As of {{page.last-update}}, only Chromium-based browsers can run Flutter web
 apps compiled to Wasm. Your Chromium-based browser should meet the following


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
The header “Load it an a browser” was changed to “Load it in a browser”

_Issues fixed by this PR (if any):_ Typo

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
