### PR TITLE
Add link to next batch of deprecations

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -244,6 +244,7 @@
       { "source": "/go/deprecations-removed-after-2-10", "destination": "https://docs.google.com/spreadsheets/d/12krawYCu6X_g_5wLGpmiAIi-VcTRV6xG7RGbRovuatQ/edit?usp=sharing", "type": 301 },
       { "source": "/go/deprecations-removed-after-3-3", "destination": "https://docs.google.com/spreadsheets/d/13cZzXz3_yMhnMH3Fyv2TKR_3974el103xlZuNWdevZM/edit?usp=sharing", "type": 301 },
       { "source": "/go/deprecations-removed-after-3-7", "destination": "https://docs.google.com/spreadsheets/d/1WCQmKobsgslfhqf6uL7I2BKk5KKhGX-n_xfk9g3CTEE/edit?usp=sharing", "type": 301 },
+      { "source": "/go/deprecations-removed-after-3-10", "destination": "https://docs.google.com/spreadsheets/d/1gs2tvYBuwycP1XAZsDbMuqP5jUa6gWH1a0ZQGrzjXvw/edit?usp=sharing", "type": 301 },
       { "source": "/go/desktop-multi-window-support", "destination": "https://docs.google.com/document/d/11_4wntz_9IJTQOo_Qhp7QF4RfpIMTfVygtOTxQ4OGHY/edit", "type": 301 },
       { "source": "/go/desktop-release-conductor", "destination": "https://docs.google.com/document/d/15AwPXNd5FvItAqM0wa2VK0tRrqtRTgM8vR5LQeT2Mag/edit?usp=sharing&resourcekey=0-yZ2FAN-wEKwKT-ymdisetA", "type": 301 },
       { "source": "/go/desktop-resize-macos", "destination": "https://docs.google.com/document/d/1slGllp1Jhde7wkF6snqGhdrZwHV1VVmXeIF3f0t24JU/edit?usp=sharing", "type": 301 },


### PR DESCRIPTION
This adds a link to the [quick reference](https://docs.google.com/spreadsheets/d/1gs2tvYBuwycP1XAZsDbMuqP5jUa6gWH1a0ZQGrzjXvw/edit?usp=sharing) for the next batch of deprecations we are announcing to remove from the framework.

Part of https://github.com/flutter/flutter/issues/127042

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
