### PR TITLE
Remove JAVA_HOME instructions from Android Licenses

### DIFF
--- a/src/get-started/install/_android-setup.md
+++ b/src/get-started/install/_android-setup.md
@@ -77,11 +77,6 @@ Before you can use Flutter, you must agree to the
 licenses of the Android SDK platform. This step should be done after
 you have installed the tools listed above.
 
- 1. Make sure that you have a version of Java 11 installed and that your 
-    `JAVA_HOME` environment variable is set to the JDK's folder.
-    
-    Android Studio versions 2.2 and higher come with a JDK, so this should
-    already be done.
  1. Open an elevated console window and run the following command to begin
     signing licenses.
     ```terminal


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Removed JAVA_HOME instructions from the "Agree to Android Licences" section.

_Issues fixed by this PR (if any):_ Fixes #8691

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
