### PR TITLE
Fix Android Studio and IntelliJ editor code format command for Mac

### DIFF
--- a/src/tools/formatting.md
+++ b/src/tools/formatting.md
@@ -32,7 +32,7 @@ Install the `Dart` plugin (see
 [Editor setup]({{site.url}}/get-started/editor))
 to get automatic formatting of code in Android Studio and IntelliJ.
 To automatically format your code in the current source code window,
-use `Cmd+Alt+L` (on Mac) or `Ctrl+Alt+L` (on Windows and Linux).
+use `Cmd+Option+L` (on Mac) or `Ctrl+Alt+L` (on Windows and Linux).
 Android Studio and IntelliJ also provide a check box named
 **Format code on save** on the Flutter page in Preferences
 (on Mac) or Settings (on Windows and Linux)


### PR DESCRIPTION
fixes https://github.com/flutter/website/issues/8726

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
