### PR TITLE
Use `flutter pub add` for dependencies in networking cookbooks

### DIFF
--- a/src/cookbook/networking/background-parsing.md
+++ b/src/cookbook/networking/background-parsing.md
@@ -38,9 +38,8 @@ First, add the [`http`][] package to your project.
 The `http` package makes it easier to perform network
 requests, such as fetching data from a JSON endpoint.
 
-To install the `http` package,
-add it to the dependencies section of the `pubspec.yaml` file
-by running `flutter pub add`:
+To add the `http` package as a dependency,
+run `flutter pub add`:
 
 ```terminal
 $ flutter pub add http

--- a/src/cookbook/networking/background-parsing.md
+++ b/src/cookbook/networking/background-parsing.md
@@ -38,6 +38,10 @@ First, add the [`http`][] package to your project.
 The `http` package makes it easier to perform network
 requests, such as fetching data from a JSON endpoint.
 
+To install the `http` package,
+add it to the dependencies section of the `pubspec.yaml` file
+by running `flutter pub add`:
+
 ```terminal
 $ flutter pub add http
 ```

--- a/src/cookbook/networking/background-parsing.md
+++ b/src/cookbook/networking/background-parsing.md
@@ -38,9 +38,8 @@ First, add the [`http`][] package to your project.
 The `http` package makes it easier to perform network
 requests, such as fetching data from a JSON endpoint.
 
-```yaml
-dependencies:
-  http: <latest_version>
+```terminal
+$ flutter pub add http
 ```
 
 ## 2. Make a network request

--- a/src/cookbook/networking/delete-data.md
+++ b/src/cookbook/networking/delete-data.md
@@ -23,13 +23,11 @@ This recipe uses the following steps:
 ## 1. Add the `http` package
 
 To install the `http` package,
-add it to the dependencies section of the `pubspec.yaml` file.
-You can find the latest version of the
-[`http` package][] on pub.dev.
+add it to the dependencies section of the `pubspec.yaml` file
+by running `flutter pub add`:
 
-```yaml
-dependencies:
-  http: <latest_version>
+```terminal
+$ flutter pub add http
 ```
 
 Import the `http` package.

--- a/src/cookbook/networking/delete-data.md
+++ b/src/cookbook/networking/delete-data.md
@@ -22,9 +22,8 @@ This recipe uses the following steps:
 
 ## 1. Add the `http` package
 
-To install the `http` package,
-add it to the dependencies section of the `pubspec.yaml` file
-by running `flutter pub add`:
+To add the `http` package as a dependency,
+run `flutter pub add`:
 
 ```terminal
 $ flutter pub add http

--- a/src/cookbook/networking/fetch-data.md
+++ b/src/cookbook/networking/fetch-data.md
@@ -27,9 +27,8 @@ This recipe uses the following steps:
 The [`http`][] package provides the
 simplest way to fetch data from the internet.
 
-To install the `http` package,
-add it to the dependencies section of the `pubspec.yaml` file
-by running `flutter pub add`:
+To add the `http` package as a dependency,
+run `flutter pub add`:
 
 ```terminal
 $ flutter pub add http

--- a/src/cookbook/networking/fetch-data.md
+++ b/src/cookbook/networking/fetch-data.md
@@ -27,14 +27,12 @@ This recipe uses the following steps:
 The [`http`][] package provides the
 simplest way to fetch data from the internet.
 
-To install the `http` package, add it to the
-dependencies section of the `pubspec.yaml` file.
-You can find the latest version of the
-[`http` package][] the pub.dev.
+To install the `http` package,
+add it to the dependencies section of the `pubspec.yaml` file
+by running `flutter pub add`:
 
-```yaml
-dependencies:
-  http: <latest_version>
+```terminal
+$ flutter pub add http
 ```
 
 Import the http package.

--- a/src/cookbook/networking/send-data.md
+++ b/src/cookbook/networking/send-data.md
@@ -24,13 +24,12 @@ This recipe uses the following steps:
 
 ## 1. Add the `http` package
 
-To install the [`http`][] package, add it to the dependencies section
-of the `pubspec.yaml` file. You can find the latest version of the
-[`http` package][] on pub.dev.
+To install the `http` package,
+add it to the dependencies section of the `pubspec.yaml` file
+by running `flutter pub add`:
 
-```yaml
-dependencies:
-  http: <latest_version>
+```terminal
+$ flutter pub add http
 ```
 
 Import the `http` package.

--- a/src/cookbook/networking/send-data.md
+++ b/src/cookbook/networking/send-data.md
@@ -24,9 +24,8 @@ This recipe uses the following steps:
 
 ## 1. Add the `http` package
 
-To install the `http` package,
-add it to the dependencies section of the `pubspec.yaml` file
-by running `flutter pub add`:
+To add the `http` package as a dependency,
+run `flutter pub add`:
 
 ```terminal
 $ flutter pub add http

--- a/src/cookbook/networking/update-data.md
+++ b/src/cookbook/networking/update-data.md
@@ -26,14 +26,11 @@ This recipe uses the following steps:
 ## 1. Add the `http` package
 
 To install the `http` package,
-add it to the dependencies section
-of the `pubspec.yaml` file.
-You can find the latest version of the
-[`http` package][] on pub.dev.
+add it to the dependencies section of the `pubspec.yaml` file
+by running `flutter pub add`:
 
-```yaml
-dependencies:
-  http: <latest_version>
+```terminal
+$ flutter pub add http
 ```
 
 Import the `http` package.

--- a/src/cookbook/networking/update-data.md
+++ b/src/cookbook/networking/update-data.md
@@ -25,9 +25,8 @@ This recipe uses the following steps:
 
 ## 1. Add the `http` package
 
-To install the `http` package,
-add it to the dependencies section of the `pubspec.yaml` file
-by running `flutter pub add`:
+To add the `http` package as a dependency,
+run `flutter pub add`:
 
 ```terminal
 $ flutter pub add http


### PR DESCRIPTION
This way users don't need to find the latest version themselves.