### PR TITLE
pin logging dependency version temporarily

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,3 +11,6 @@ dev_dependencies:
     path: site-shared/packages/code_excerpter
   linkcheck: ^3.0.0
   path: ^1.8.3
+
+dependency_overrides:
+  logging: 1.1.1


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ tool/refresh_code_excerpts.sh is [broken](https://github.com/flutter/website/actions/runs/5062554416/jobs/9088203605) as it depends on build_runner. See [BuildForInputLogger needs to be updated for latest pkg:logger](https://github.com/dart-lang/build/issues/3514) Pinning the logging version will fix it until logging package gets updated with a fix. 

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
