### PR TITLE
Follow-up CODEOWNERS adjustments

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,10 +11,10 @@
 /src/_sass/ @khanhnwin @parlough @sfshaza2 @atsansone
 
 # Covers website tooling
-/tool/      @atsansone @parlough
+/tool/      @atsansone @parlough @khanhnwin
 
 # Covers examples in files
 /examples/  @domesticmouse @johnpryan @khanhnwin @parlough
 
 # Covers all configuration files for the website
-/*          @atsansone @parlough @sfshaza2
+/*          @atsansone @parlough @sfshaza2 @khanhnwin

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,6 +4,12 @@
 # Covers all web content
 /src/       @sfshaza2 @atsansone @parlough
 
+# Covers Jekyll plugins
+/src/_plugins/ @khanhnwin @parlough @sfshaza2 @atsansone
+
+# Covers website styles
+/src/_sass/ @khanhnwin @parlough @sfshaza2 @atsansone
+
 # Covers website tooling
 /tool/      @atsansone @parlough
 
@@ -11,4 +17,4 @@
 /examples/  @domesticmouse @johnpryan @khanhnwin @parlough
 
 # Covers all configuration files for the website
-/*          @atsansone @parlough
+/*          @atsansone @parlough @sfshaza2


### PR DESCRIPTION
It seems like later rules from https://github.com/flutter/website/commit/23583e6e068d1e47e91392084eae83f85dd65b21 override the default declared at the top, preventing Shams from approving configuration and root repository files. She needs that access. This PR adjusts the file to return that access.

Also adds Khanh as a code owner for Jekyll plugins and sass files, which aren't often updated, but often need a technical review.