### PR TITLE
Fix wrong file name in developing-packages.md 

### DIFF
--- a/src/packages-and-plugins/developing-packages.md
+++ b/src/packages-and-plugins/developing-packages.md
@@ -679,7 +679,7 @@ folder with the following specialized content:
 **lib**: The Dart code that defines the API of the plugin,
   and which calls into the native code using `dart:ffi`.
 
-**src**: The native source code, and a `CmakeFile.txt`
+**src**: The native source code, and a `CMakeLists.txt`
   file for building that source code into a dynamic library.
 
 **platform folders** (`android`, `ios`, `windows`, etc.): The


### PR DESCRIPTION
Fix #8769 

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
