### PR TITLE
Add migration guide for `AppLifecycleState.hidden`

### DIFF
--- a/src/release/breaking-changes/add-applifecyclestate-hidden.md
+++ b/src/release/breaking-changes/add-applifecyclestate-hidden.md
@@ -1,0 +1,87 @@
+---
+title: Migration guide for adding AppLifecycleState.hidden
+description: AppLifecycleState had an additional hidden state added.
+---
+
+## Summary
+
+A new `hidden` state was added to the [`AppLifecycleState`][] enum to denote when
+the application is not visible.
+
+## Context
+
+The `AppLifecycleState` enum is used to indicate which lifecycle state the
+application is in when [`WidgetsBindingObserver.didChangeAppLifecycleState`][] is
+called.
+
+## Description of change
+
+The new state `AppLifecycleState.hidden` was added to the `AppLifecycleState`
+enum in the `dart:ui` package.
+
+The `hidden` state is entered when all of the application views are no longer
+visible to the user. On Android and iOS, this state is entered briefly whenever
+the state machine traverses from inactive to paused, or from paused to inactive.
+It doesn't change when paused or inactive are entered. On other platforms, it
+will be in this state while the application is not visible.
+
+## Migration guide
+
+If code has switch statements that handle all cases of the `AppLifecycleState`
+enum, a new case will need to be added to handle the `AppLifecycleState.hidden`
+state.
+
+Code before migration:
+
+```dart
+void didChangeAppLifecycleState(AppLifecycleState state) {
+  switch (state) {
+    case AppLifecycleState.resumed:
+    case AppLifecycleState.inactive:
+      // Do something when the app is visible...
+      break;
+    case AppLifecycleState.paused:
+    case AppLifecycleState.detached:
+      // Do something when the app is not visible...
+      break;
+  }
+}
+```
+
+Code after migration:
+
+```dart
+void didChangeAppLifecycleState(AppLifecycleState state) {
+  switch (state) {
+    case AppLifecycleState.resumed:
+    case AppLifecycleState.inactive:
+      // Do something when the app is visible...
+      break;
+    case AppLifecycleState.hidden:  // <-- This is the new state.
+    case AppLifecycleState.paused:
+    case AppLifecycleState.detached:
+      // Do something when the app is not visible...
+      break;
+  }
+}
+```
+
+If there is already a `default:` case in the switch statement, or the code uses
+conditionals instead, then the code will compile without changes, but the
+default case or conditional will still need to be evaluated to decide if the
+`hidden` state should also be handled.
+
+## Timeline
+
+Landed in version: v3.11.0-15.0.pre
+In stable release: TBD
+
+## References
+
+Relevant PRs:
+
+* [PR 42418][]: Adds `AppLifecycleState.hidden` enum value.
+
+[PR 42418]: {{site.repo.engine}}/pull/42418
+[`WidgetsBindingObserver.didChangeAppLifecycleState`]: {{site.api}}/flutter/widgets/WidgetsBindingObserver/didChangeAppLifecycleState.html
+[`AppLifecycleState`]: {{site.api}}/flutter/dart-ui/AppLifecycleState.html

--- a/src/release/breaking-changes/add-applifecyclestate-hidden.md
+++ b/src/release/breaking-changes/add-applifecyclestate-hidden.md
@@ -5,14 +5,14 @@ description: AppLifecycleState had an additional hidden state added.
 
 ## Summary
 
-A new `hidden` state was added to the [`AppLifecycleState`][] enum to denote when
-the application is not visible.
+A new `hidden` state was added to the [`AppLifecycleState`][] enum to denote
+when the application is not visible.
 
 ## Context
 
 The `AppLifecycleState` enum is used to indicate which lifecycle state the
-application is in when [`WidgetsBindingObserver.didChangeAppLifecycleState`][] is
-called.
+application is in when [`WidgetsBindingObserver.didChangeAppLifecycleState`][]
+is called.
 
 ## Description of change
 
@@ -73,7 +73,7 @@ default case or conditional will still need to be evaluated to decide if the
 
 ## Timeline
 
-Landed in version: v3.11.0-15.0.pre
+Landed in version: 3.11.0-16.0.pre
 In stable release: TBD
 
 ## References

--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -30,10 +30,12 @@ release, and listed in alphabetical order:
 
 ### Not yet released to stable
 
+* [Added AppLifecycleState.hidden][] enum value
 * [Moved ReorderableListView's localized strings][]  from material to widgets localizations
 * [Removed `ignoringSemantics`][] properties
 * [Deprecated `RouteInformation.location`][] and its related APIs
 
+[Added AppLifecycleState.hidden]: {{site.url}}/release/breaking-changes/add=applifecyclestate-hidden
 [Moved ReorderableListView's localized strings]: {{site.url}}/release/breaking-changes/material-localized-strings
 [Removed `ignoringSemantics`]: {{site.url}}/release/breaking-changes/ignoringsemantics-migration
 [Deprecated `RouteInformation.location`]: {{site.url}}/release/breaking-changes/route-information-uri

--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -35,7 +35,7 @@ release, and listed in alphabetical order:
 * [Removed `ignoringSemantics`][] properties
 * [Deprecated `RouteInformation.location`][] and its related APIs
 
-[Added AppLifecycleState.hidden]: {{site.url}}/release/breaking-changes/add=applifecyclestate-hidden
+[Added AppLifecycleState.hidden]: {{site.url}}/release/breaking-changes/add-applifecyclestate-hidden
 [Moved ReorderableListView's localized strings]: {{site.url}}/release/breaking-changes/material-localized-strings
 [Removed `ignoringSemantics`]: {{site.url}}/release/breaking-changes/ignoringsemantics-migration
 [Deprecated `RouteInformation.location`]: {{site.url}}/release/breaking-changes/route-information-uri


### PR DESCRIPTION
This PR adds a migration guide for addition of `AppLIfecycleState.hidden`, which is a breaking change.

## Presubmit checklist

- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.


