### PR TITLE
Disable TOC on 'Write your first app' step

### DIFF
--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -8,6 +8,7 @@ prev:
 next:
   title: Learn more
   path: /get-started/learn-more
+toc: false
 ---
 
 You are now ready to start the “First Flutter app” codelab.


### PR DESCRIPTION
Currently the page generates an empty TOC when it doesn't need one. This removes the TOC to match steps 2-3.

Before: https://docs.flutter.dev/get-started/codelab
After: https://flutter-docs-prod--pr8790-feature-write-first-kowjpan3.web.app/get-started/codelab