### PR TITLE
Adjust 'Widget catalog' card name on homepage

### DIFF
--- a/src/_data/docs_cards.yml
+++ b/src/_data/docs_cards.yml
@@ -1,7 +1,7 @@
 - name: Get started
   description: Set up your environment and start building.
   url: /get-started/install
-- name: Widgets catalog
+- name: Widget catalog
   description: Dip into the rich set of Flutter widgets available in the SDK.
   url: /ui/widgets
 - name: API docs


### PR DESCRIPTION
This makes it consistent with the naming elsewhere.
