### PR TITLE
Change the default entry point to a string for Swift

### DIFF
--- a/src/add-to-app/ios/add-flutter-screen.md
+++ b/src/add-to-app/ios/add-flutter-screen.md
@@ -690,7 +690,7 @@ FlutterViewController.
 let flutterEngine = FlutterEngine()
 // FlutterDefaultDartEntrypoint is the same as nil, which will run main().
 engine.run(
-  withEntrypoint: FlutterDefaultDartEntrypoint, initialRoute: "/onboarding")
+  withEntrypoint: "main", initialRoute: "/onboarding")
 ```
 {% sample Objective-C %}
 <!--code-excerpt "Creating engine" title-->


### PR DESCRIPTION
_Issues fixed by this PR (if any):_ https://github.com/flutter/website/issues/8756

## Presubmit checklist

- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.


