### PR TITLE
fix broken link

### DIFF
--- a/src/release/breaking-changes/form-field-autovalidation-api.md
+++ b/src/release/breaking-changes/form-field-autovalidation-api.md
@@ -81,7 +81,7 @@ In stable release: 1.22
 
 API documentation:
 
-* [`AutovalidateMode`]({{site.api}}/flutter/widgets/AutovalidateMode-class.html)
+* [`AutovalidateMode`]({{site.api}}/flutter/widgets/AutovalidateMode.html)
 
 Relevant issues:
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
 Fixed a broken link to AutoValidateMode docs
 
_Issues fixed by this PR (if any):_

## Presubmit checklist

- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
