### PR TITLE
Simplify 'Samples & tutorials' top-level category

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -47,11 +47,9 @@
 
 - title: Samples & tutorials
   children:
-    - title: Flutter Gallery [running app]
+    - title: Flutter Gallery
       permalink: https://gallery.flutter.dev
-    - title: Flutter Gallery [repo]
-      permalink: https://github.com/flutter/gallery
-    - title: Sample apps on GitHub
+    - title: Samples and demos
       permalink: https://flutter.github.io/samples/
     - title: Cookbook
       permalink: /cookbook


### PR DESCRIPTION
The Flutter Gallery shows a lot of the relevant code within the app and has links to the source, so I think linking to the app should be sufficient and reduce unnecessary choices.

As for the "Samples apps on GitHub", it leads to a standalone site, so the "on GitHub" is a little confusing and a bit unnecessary. Especially since not all of the demos are actually hosted on the flutter/samples repo.