### PR TITLE
Adjust tools in sidenav

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -266,55 +266,6 @@
     - title: Package site
       permalink: https://pub.dev/flutter
 
-- title: Tools & features
-  permalink: /tools
-  children:
-    - title: Android Studio & IntelliJ
-      permalink: /tools/android-studio
-    - title: Visual Studio Code
-      permalink: /tools/vs-code
-    - title: DevTools
-      permalink: /tools/devtools
-      children:
-        - title: Overview
-          permalink: /tools/devtools/overview
-        - title: Install from Android Studio & IntelliJ
-          permalink: /tools/devtools/android-studio
-        - title: Install from VS Code
-          permalink: /tools/devtools/vscode
-        - title: Install from command line
-          permalink: /tools/devtools/cli
-        - title: Flutter inspector
-          permalink: /tools/devtools/inspector
-        - title: Performance view
-          permalink: /tools/devtools/performance
-        - title: CPU Profiler view
-          permalink: /tools/devtools/cpu-profiler
-        - title: Memory view
-          permalink: /tools/devtools/memory
-        - title: Debug console view
-          permalink: /tools/devtools/console
-        - title: Network view
-          permalink: /tools/devtools/network
-        - title: Debugger
-          permalink: /tools/devtools/debugger
-        - title: Logging view
-          permalink: /tools/devtools/logging
-        - title: App size tool
-          permalink: /tools/devtools/app-size
-        - title: Release notes
-          permalink: /tools/devtools/release-notes
-    - title: SDK overview
-      permalink: /tools/sdk
-    - title: Flutter and the pubspec file
-      permalink: /tools/pubspec
-    - title: Hot reload
-      permalink: /tools/hot-reload
-    - title: Flutter Fix
-      permalink: /tools/flutter-fix
-    - title: Code formatting
-      permalink: /tools/formatting
-
 - title: Testing & debugging
   permalink: /testing
   children:
@@ -424,6 +375,55 @@
       permalink: /add-to-app/performance
     - title: Multiple Flutter instances
       permalink: /add-to-app/multiple-flutters
+
+- title: Tools & features
+  permalink: /tools
+  children:
+    - title: Android Studio & IntelliJ
+      permalink: /tools/android-studio
+    - title: Visual Studio Code
+      permalink: /tools/vs-code
+    - title: DevTools
+      permalink: /tools/devtools
+      children:
+        - title: Overview
+          permalink: /tools/devtools/overview
+        - title: Install from Android Studio & IntelliJ
+          permalink: /tools/devtools/android-studio
+        - title: Install from VS Code
+          permalink: /tools/devtools/vscode
+        - title: Install from command line
+          permalink: /tools/devtools/cli
+        - title: Flutter inspector
+          permalink: /tools/devtools/inspector
+        - title: Performance view
+          permalink: /tools/devtools/performance
+        - title: CPU Profiler view
+          permalink: /tools/devtools/cpu-profiler
+        - title: Memory view
+          permalink: /tools/devtools/memory
+        - title: Debug console view
+          permalink: /tools/devtools/console
+        - title: Network view
+          permalink: /tools/devtools/network
+        - title: Debugger
+          permalink: /tools/devtools/debugger
+        - title: Logging view
+          permalink: /tools/devtools/logging
+        - title: App size tool
+          permalink: /tools/devtools/app-size
+        - title: Release notes
+          permalink: /tools/devtools/release-notes
+    - title: SDK overview
+      permalink: /tools/sdk
+    - title: Flutter's pubspec options
+      permalink: /tools/pubspec
+    - title: Hot reload
+      permalink: /tools/hot-reload
+    - title: Automated fixes
+      permalink: /tools/flutter-fix
+    - title: Code formatting
+      permalink: /tools/formatting
 
 - divider
 

--- a/src/tools/android-studio.md
+++ b/src/tools/android-studio.md
@@ -1,6 +1,7 @@
 ---
 title: Android Studio and IntelliJ
-description: How to develop Flutter apps in Android Studio or other IntelliJ products.
+description: >
+  How to develop Flutter apps in Android Studio or other IntelliJ products.
 ---
 
 <ul class="nav nav-tabs" id="ide" role="tablist">

--- a/src/tools/flutter-fix.md
+++ b/src/tools/flutter-fix.md
@@ -1,5 +1,5 @@
 ---
-title: Flutter Fix
+title: Flutter fix
 description: Keep your code up to date with the help of the Flutter Fix feature.
 ---
 
@@ -7,13 +7,12 @@ As Flutter continues to evolve, we provide a tool to help you clean up
 deprecated APIs from your codebase. The tool ships as part of Flutter, and
 suggests changes that you might want to make to your code. The tool is available
 from the command line, and is also integrated into the IDE plugins for Android
-Studio and Visual Studio Code. 
+Studio and Visual Studio Code.
 
 {{site.alert.tip}}
   These automated updates are called _quick-fixes_ in IntelliJ and Android
   Studio, and _code actions_ in VS Code.
 {{site.alert.end}}
-
 
 ## Applying individual fixes
 

--- a/src/tools/formatting.md
+++ b/src/tools/formatting.md
@@ -1,6 +1,8 @@
 ---
 title: Code formatting
-description: Flutter's code formatter formats your code along recommended style guidelines.
+description: >
+    Flutter's code formatter formats your code
+    following recommended style guidelines.
 ---
 
 


### PR DESCRIPTION
Primarily lower "Tools" down, since most of it is reference content.

Also renames "Flutter Fix" to "Automated fixes" in the sidenav to make it more clear what the doc actually covers.