### PR TITLE
Remove Android bits and add limitations on ios platform views

### DIFF
--- a/src/platform-integration/ios/platform-views.md
+++ b/src/platform-integration/ios/platform-views.md
@@ -56,7 +56,7 @@ import 'package:flutter/services.dart';
 <?code-excerpt "lib/platform_views/native_view_example_3.dart (iOSCompositionWidget)"?>
 ```dart
 Widget build(BuildContext context) {
-  // Use this on the platform side to register the view.
+  // This is used in the platform side to register the view.
   const String viewType = '<platform-view-type>';
   // Pass parameters to the platform side.
   final Map<String, dynamic> creationParams = <String, dynamic>{};
@@ -339,7 +339,7 @@ to detect the platform, and decide which widget to use:
 <?code-excerpt "lib/platform_views/native_view_example_3.dart (TogetherWidget)"?>
 ```dart
 Widget build(BuildContext context) {
-  // Use this on the platform side to register the view.
+  // This is used in the platform side to register the view.
   const String viewType = '<platform-view-type>';
   // Pass parameters to the platform side.
   final Map<String, dynamic> creationParams = <String, dynamic>{};

--- a/src/platform-integration/ios/platform-views.md
+++ b/src/platform-integration/ios/platform-views.md
@@ -35,11 +35,11 @@ use the following instructions:
 ### On the Dart side
 
 On the Dart side, create a `Widget`
-and add the following build implementation,
+and add the build implementation,
 as shown in the following steps.
 
-In your Dart file, for example
-do the following in `native_view_example.dart`:
+In the Dart widget file, make changes similar to those 
+shown in `native_view_example.dart`:
 
 <ol markdown="1">
 <li markdown="1">Add the following imports:
@@ -56,7 +56,7 @@ import 'package:flutter/services.dart';
 <?code-excerpt "lib/platform_views/native_view_example_3.dart (iOSCompositionWidget)"?>
 ```dart
 Widget build(BuildContext context) {
-  // This is used in the platform side to register the view.
+  // Use this on the platform side to register the view.
   const String viewType = '<platform-view-type>';
   // Pass parameters to the platform side.
   final Map<String, dynamic> creationParams = <String, dynamic>{};
@@ -79,7 +79,7 @@ For more information, see the API docs for:
 
 ### On the platform side
 
-On the platform side, you use the either Swift or Objective-C:
+On the platform side, use either Swift or Objective-C:
 
 {% samplecode ios-platform-views %}
 {% sample Swift %}
@@ -192,8 +192,8 @@ class FLPlugin: NSObject, FlutterPlugin {
 
 {% sample Objective-C %}
 
-Add the headers for the factory and the platform view.
-For example, `FLNativeView.h`:
+In Objective-C, add the headers for the factory and the platform view.
+For example, as shown in `FLNativeView.swift`:
 
 ```objc
 #import <Flutter/Flutter.h>
@@ -334,12 +334,12 @@ For more information, see the API docs for:
 
 When implementing the `build()` method in Dart,
 you can use [`defaultTargetPlatform`][]
-to detect the platform, and decide what widget to use:
+to detect the platform, and decide which widget to use:
 
 <?code-excerpt "lib/platform_views/native_view_example_3.dart (TogetherWidget)"?>
 ```dart
 Widget build(BuildContext context) {
-  // This is used in the platform side to register the view.
+  // Use this on the platform side to register the view.
   const String viewType = '<platform-view-type>';
   // Pass parameters to the platform side.
   final Map<String, dynamic> creationParams = <String, dynamic>{};
@@ -355,7 +355,41 @@ Widget build(BuildContext context) {
 }
 ```
 
-[`defaultTargetPlatform`]: {{site.api}}/flutter/foundation/defaultTargetPlatform.html
+## Performance
+Platform views in Flutter come with performance trade-offs.
 
-{% include docs/platform-view-perf.md %}
+For example, in a typical Flutter app, the Flutter UI is 
+composed on a dedicated raster thread. 
+This allows Flutter apps to be fast, 
+as the main platform thread is rarely blocked.
+
+When a platform view is rendered with hybrid composition, 
+the Flutter UI is composed from the platform thread. 
+The platform thread competes with other tasks 
+like handling OS or plugin messages.
+
+When an iOS PlatformView is on screen, the screen refresh rate is 
+capped at 80fps to avoid rendering janks.
+
+For complex cases, there are some techniques that can be used 
+to mitigate performance issues.
+
+For example, you could use a placeholder texture while an 
+animation is happening in Dart. 
+In other words, if an animation is slow while a platform view is rendered, 
+then consider taking a screenshot of the native view and rendering it as a texture.
+
+## Composition limitations
+There are some limitations when composing iOS Platform Views.
+
+- The [`ShaderMask`][] and [`ColorFiltered`][] widgets are not supported.
+- The [`BackdropFilter`][] widget is supported, 
+but there are some limitations on how it can be used. 
+See the [iOS Platform View Backdrop Filter Blur design doc] for details.
+
+[`ShaderMask`]: {{site.api}}/flutter/foundation/ShaderMask.html
+[`ColorFiltered`]: {{site.api}}/flutter/foundation/ColorFiltered.html
+[`BackdropFilter`]: {{site.api}}/flutter/foundation/BackdropFilter.html
+[`defaultTargetPlatform`]: {{site.api}}/flutter/foundation/defaultTargetPlatform.html
+[iOS Platform View Backdrop Filter Blur design doc]: flutter.dev/go/ios-platformview-backdrop-filter-blur
 

--- a/src/platform-integration/ios/platform-views.md
+++ b/src/platform-integration/ios/platform-views.md
@@ -193,7 +193,7 @@ class FLPlugin: NSObject, FlutterPlugin {
 {% sample Objective-C %}
 
 In Objective-C, add the headers for the factory and the platform view.
-For example, as shown in `FLNativeView.swift`:
+For example, as shown in `FLNativeView.h`:
 
 ```objc
 #import <Flutter/Flutter.h>


### PR DESCRIPTION
Moving from previous PR: https://github.com/flutter/website/pull/8793

Fixes https://github.com/flutter/website/issues/8741

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
