### PR TITLE
Add go-router v7 and v8 breaking change redirects

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -323,6 +323,8 @@
       { "source": "/go/go-router-v5-breaking-changes", "destination": "https://docs.google.com/document/d/10l22o4ml4Ss83UyzqUC8_xYOv_QjZEi80lJDNE4q7wM/edit?pli=1&resourcekey=0-U-BXBQzNfkk4v241Ow-vZg", "type": 301 },
       { "source": "/go/go-router-v5-1-2-breaking-changes", "destination": "https://docs.google.com/document/d/1HMUZA-lgeGFZ5JyU4g5jOFhbYAbk9ysfz9Ok1tGvqRw/edit?resourcekey=0-7otvjyBeefkQ9xQP9S2-9w#", "type": 301 },
       { "source": "/go/go-router-v6-breaking-changes", "destination": "https://docs.google.com/document/d/1CMJwd5Moq_scvHf-trRldy9RW5MU7_Y8IB1aTrny-6s/edit", "type": 301 },
+      { "source": "/go/go-router-v7-breaking-changes", "destination": "https://docs.google.com/document/d/10Xbpifbs4E-zh6YE5akIO8raJq_m3FIXs6nUGdOspOg/edit?usp=sharing", "type": 301 },
+      { "source": "/go/go-router-v8-breaking-changes", "destination": "https://docs.google.com/document/d/1VCuB85D5kYxPR3qYOjVmw8boAGKb7k62heFyfFHTOvw/edit?usp=sharing", "type": 301 },
       { "source": "/go/handling-synchronous-keyboard-events", "destination": "https://docs.google.com/document/d/1rWXSjkb2ZKv-cpg26lVK0aZi4cVeXJ8j7YmSJdq2TOM/edit", "type": 301 },
       { "source": "/go/hermetic-xcode-installation", "destination": "https://docs.google.com/document/d/1EcXm4Woq48GR_ky07mEJka6NfV1vFBN2OHDEeGfPk34/edit?resourcekey=0-0Gjtt1I66mGJ8AwiCTlFNw", "type": 301 },
       { "source": "/go/hero-refactor", "destination": "https://docs.google.com/document/d/1JZVqykFjhDXcJyj_Ep5gfTmF-Eu4pQXXNRcLCN04tls/edit?usp=sharing", "type": 301 },


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
