### PR TITLE
Updated committee member list and removed paused notice.

### DIFF
--- a/src/packages-and-plugins/favorites.md
+++ b/src/packages-and-plugins/favorites.md
@@ -5,14 +5,6 @@ description: Guidelines for identifying a plugin or package as a Flutter Favorit
 
 ![The Flutter Favorite program logo]({{site.url}}/assets/images/docs/development/packages-and-plugins/FlutterFavoriteLogo.png){:width="20%"}
 
-{{site.alert.note}}
-  Due to limited staffing resources,
-  we are pausing the
-  Flutter Favorites and Happy Path programs.
-  We will update (and possibly combine)
-  these programs as soon as possible.
-{{site.alert.end}}
-
 The aim of the **Flutter Favorite** program is to identify
 packages and plugins that you should first consider when
 building your app.
@@ -70,7 +62,7 @@ are as follows:
 * Lara Martín
 * John Ryan
 * Diego Velasquez
-* Kyle Wang
+* Ander Dobo
 
 If you'd like to nominate a package or plugin as a
 potential future Flutter Favorite, or would like


### PR DESCRIPTION
Updated the list of Flutter Ecosystem Committee members and removed the banner notifying that the program is paused.

_Description of what this PR is changing or adding, and why:_ Updated the list of Flutter Ecosystem Committee members and removed the notification that the program is paused.

_Issues fixed by this PR (if any):_ N/A

## Presubmit checklist

- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
