### PR TITLE
Update flutter_reactive_widget -> flutter_reactive_value

### DIFF
--- a/src/data-and-backend/state-mgmt/options.md
+++ b/src/data-and-backend/state-mgmt/options.md
@@ -287,16 +287,14 @@ A simple but powerful state management solution inspired by SolidJS.
 
 ## flutter_reactive_value
 
-`flutter_reactive_value` is probably the simplest possible solution for state
-management in Flutter, and may be a good starting point for newcomers
-to Flutter who need a simple way to add reactivity to their UI, without
-the complexity of the mechanisms described above.
-`flutter_reactive_value` defines the `reactiveValue(BuildContext)`
-extension method on `ValueNotifier`, which allows a `Widget` to
-fetch the current value of the `ValueNotifier`, while also
-subscribing the `Widget` to changes in the value of the `ValueNotifier`,
-so that the `Widget` is rebuilt automatically if the value
-of the `ValueNotifier` changes.
+The `flutter_reactive_value` library might offer the least complex solution for state
+management in Flutter. It might help Flutter newcomers add reactivity to their UI,
+without the complexity of the mechanisms described before.
+The `flutter_reactive_value` library defines the `reactiveValue(BuildContext)`
+extension method on `ValueNotifier`. This extension allows a `Widget` to
+fetch the current value of the `ValueNotifier` and 
+subscribe the `Widget` to changes in the value of the `ValueNotifier`.
+If the value of the `ValueNotifier` changes, `Widget` rebuilds.
 
 * [`flutter_reactive_value`][] source and documentation
 

--- a/src/data-and-backend/state-mgmt/options.md
+++ b/src/data-and-backend/state-mgmt/options.md
@@ -285,19 +285,20 @@ A simple but powerful state management solution inspired by SolidJS.
 [solidart package]: {{site.pub-pkg}}/solidart
 [flutter_solidart package]: {{site.pub-pkg}}/flutter_solidart
 
-## flutter_reactive_widget
+## flutter_reactive_value
 
-An ultra-low-boilerplate solution for state management,
-flutter_reactive_widget defines
-`ReactiveWidget` and `ReactiveValue`. Any read of a `ReactiveValue`'s
-value within a `ReactiveWidget` definition automatically causes the
-`ReactiveWidget` to listen for changes on the `ReactiveValue`.
+`flutter_reactive_value` is probably the simplest possible solution for state
+management in Flutter, and may be a good starting point for newcomers
+to Flutter who need a simple way to add reactivity to their UI, without
+the complexity of the mechanisms described above.
+`flutter_reactive_value` defines the `reactiveValue(BuildContext)`
+extension method on `ValueNotifier`, which allows a `Widget` to
+fetch the current value of the `ValueNotifier`, while also
+subscribing the `Widget` to changes in the value of the `ValueNotifier`,
+so that the `Widget` is rebuilt automatically if the value
+of the `ValueNotifier` changes.
 
-Also includes a definition for `PersistentReactiveValue`, a subclass
-of `ReactiveValue` whose latest value persists, surviving app
-restarts.
+* [`flutter_reactive_value`][] source and documentation
 
-* [`flutter_reactive_widget`][] source and documentation
-
-[`flutter_reactive_widget`]: {{site.github}}/lukehutch/flutter_reactive_widget
+[`flutter_reactive_value`]: {{site.github}}/lukehutch/flutter_reactive_value
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

I deprecated `flutter_reactive_widget` and created a new library `flutter_reactive_value`, because I found a dramatically simpler (and better) way to add reactivity to Flutter UIs. I don't believe it's possible to build a simpler state management solution for Flutter than this.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
