### PR TITLE
Add "Declarative extension style" to declarative.md

### DIFF
--- a/src/get-started/flutter-for/declarative.md
+++ b/src/get-started/flutter-for/declarative.md
@@ -80,12 +80,11 @@ their constructor just like in the declarative style shown above.
 
 ```dart
 // Declarative extension style
-return ViewB().offset(x: 10);
+return ViewB().center();
 
 extension on Widget {
-  Widget offset({double x = 0, double y = 0}) {
-    return Transform.translate(
-      offset: Offset(x, y),
+  Widget center() {
+    return Center(
       child: this,
     );
   }

--- a/src/get-started/flutter-for/declarative.md
+++ b/src/get-started/flutter-for/declarative.md
@@ -68,3 +68,28 @@ RenderObjects persist between frames and Flutter’s lightweight Widgets
 tell the framework to mutate the RenderObjects between states.
 The Flutter framework handles the rest.
 
+## Declarative extension style
+
+There is a new declarative pattern that has emerged as a result of Dart 
+adding the `extension` language feature. While this pattern is not currently 
+in use in the Flutter framework, it is actively in use within the community.
+
+This declarative style does appear at first glance to be similar to the imperative
+style shown above, but the underlying operation is composing widgets through
+their constructor just like in the declarative style shown above.
+
+```dart
+// Declarative extension style
+return ViewB().offset(x: 10);
+
+extension on Widget {
+  Widget offset({double x = 0, double y = 0}) {
+    return Transform.translate(
+      offset: Offset(x, y),
+      child: this,
+    );
+  }
+}
+```
+
+


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

There is some confusion in the community over the declarative nature of the Widget extension pattern that is becoming more commonly used. Folks are pointing to this article saying that they are imperative because they are using method calls.

_Issues fixed by this PR (if any):_

Confusion in the community

_How reviewers can help:_

I would appreciate suggestions to improve the technical writing

_Notes:_

I did not reuse the ViewB/ViewC example because it's not a pattern that I recommend for extension Widget composition and in my experience people will use this as an indication of patterns to follow

_Community context:_

- https://twitter.com/luke_pighetti/status/1667909336088170498
- https://twitter.com/_incendial/status/1667911906936455169
- https://twitter.com/BrandoTrautmann/status/1667914597108535296
- https://twitter.com/TheKnaecke/status/1667906454295117824
- https://twitter.com/caseycrogers/status/1667894024848674817

_Industry context:_

- https://developer.apple.com/xcode/swiftui/ "Declarative syntax" section

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
