### PR TITLE
Fix highlighting of navigation entries in sidenav

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -62,6 +62,7 @@
 
 - title: User interface
   permalink: /ui
+  match-page-url-exactly: true
   children:
     - title: Introduction to widgets
       permalink: /ui/widgets-intro


### PR DESCRIPTION
Since the navigation docs are within `/ui`, they were causing the earlier UI section to be indicated as active incorrectly in the sidenav, rather than the navigation docs.

**Before:**

<img width="425" alt="Example of UI being highlighted instead of navigation" src="https://github.com/flutter/website/assets/18372958/bdf38b28-26d5-4022-975d-14ea471a66fe">
