### PR TITLE
Remove unnecessary version requirement specification

### DIFF
--- a/src/packages-and-plugins/developing-packages.md
+++ b/src/packages-and-plugins/developing-packages.md
@@ -214,12 +214,6 @@ flutter:
         pluginClass: HelloPlugin
       ios:
         pluginClass: HelloPlugin
-
-environment:
-  sdk: ">=2.1.0 <3.0.0"
-  # Flutter versions prior to 1.12 did not support the
-  # flutter.plugin.platforms map.
-  flutter: ">=1.12.0"
 ```
 
 When adding plugin implementations for more platforms,
@@ -242,12 +236,6 @@ flutter:
       web:
         pluginClass: HelloPlugin
         fileName: hello_web.dart
-
-environment:
-  sdk: ">=2.1.0 <3.0.0"
-  # Flutter versions prior to 1.12 did not support the
-  # flutter.plugin.platforms map.
-  flutter: ">=1.12.0"
 ```
 
 #### Federated platform packages

--- a/src/packages-and-plugins/favorites.md
+++ b/src/packages-and-plugins/favorites.md
@@ -111,8 +111,8 @@ As the Flutter ecosystem grows,
 we’ll be looking at expanding the set of metrics,
 which might include the following:
 
-* Use of the new [pubspec.yaml format][] that clearly
-  indicates which platforms are supported.
+* Use of the [pubspec.yaml format][] that clearly
+  indicates which platforms a plugin supports.
 * Support for the latest stable version of Flutter.
 * Support for AndroidX.
 * Support for multiple platforms, such as web, macOS,


### PR DESCRIPTION
There is no value in specifying this version requirement, as 1.12 is a long time ago.
