### PR TITLE
Update example created pubspec for latest changes

### DIFF
--- a/src/tools/pubspec.md
+++ b/src/tools/pubspec.md
@@ -64,7 +64,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   [[highlight]]flutter:[[/highlight]]       # Required for every Flutter project
@@ -77,6 +77,8 @@ dependencies:
 dev_dependencies:
   [[highlight]]flutter_test:[[/highlight]]
     [[highlight]]sdk: flutter[[/highlight]] # Required for a Flutter project that includes tests
+
+  [[highlight]]flutter_lints: ^2.0.0[[/highlight]] # Contains a set of recommended lints for Flutter code
 
 [[highlight]]flutter:[[/highlight]]
 


### PR DESCRIPTION
Changes to support Dart 3 and includes `flutter_lints` which is included by the default `flutter create` command.
