### PR TITLE
Reintroduce titles to code snippets without excerpts

### DIFF
--- a/src/add-to-app/android/_initial-route-cached-engine.md
+++ b/src/add-to-app/android/_initial-route-cached-engine.md
@@ -14,7 +14,7 @@ demonstrates the use of an initial route with a cached engine:
 
 {% samplecode cached-engine-with-initial-route %}
 {% sample Java %}
-<!--code-excerpt "MyApplication.java" title-->
+<?code-excerpt title="MyApplication.java"?>
 ```java
 public class MyApplication extends Application {
   @Override
@@ -36,7 +36,7 @@ public class MyApplication extends Application {
 }
 ```
 {% sample Kotlin %}
-<!--code-excerpt "MyApplication.kt" title-->
+<?code-excerpt title="MyApplication.kt"?>
 ```kotlin
 class MyApplication : Application() {
   lateinit var flutterEngine : FlutterEngine

--- a/src/add-to-app/android/add-flutter-fragment.md
+++ b/src/add-to-app/android/add-flutter-fragment.md
@@ -47,7 +47,7 @@ attach an instance of `FlutterFragment` in `onCreate()` within the
 
 {% samplecode add-fragment %}
 {% sample Java %}
-<!--code-excerpt "MyActivity.java" title-->
+<?code-excerpt title="MyActivity.java"?>
 ```java
 public class MyActivity extends FragmentActivity {
     // Define a tag String to represent the FlutterFragment within this
@@ -93,7 +93,7 @@ public class MyActivity extends FragmentActivity {
 }
 ```
 {% sample Kotlin %}
-<!--code-excerpt "MyActivity.kt" title-->
+<?code-excerpt title="MyActivity.kt"?>
 ```kotlin
 class MyActivity : FragmentActivity() {
   companion object {
@@ -151,7 +151,7 @@ These calls are shown in the following example:
 
 {% samplecode forward-activity-calls %}
 {% sample Java %}
-<!--code-excerpt "MyActivity.java" title-->
+<?code-excerpt title="MyActivity.java"?>
 ```java
 public class MyActivity extends FragmentActivity {
     @Override
@@ -196,7 +196,7 @@ public class MyActivity extends FragmentActivity {
 }
 ```
 {% sample Kotlin %}
-<!--code-excerpt "MyActivity.kt" title-->
+<?code-excerpt title="MyActivity.kt"?>
 ```kotlin
 class MyActivity : FragmentActivity() {
   override fun onPostResume() {
@@ -261,7 +261,7 @@ factory method.
 
 {% samplecode use-prewarmed-engine %}
 {% sample Java %}
-<!--code-excerpt "MyApplication.java" title-->
+<?code-excerpt title="MyApplication.java"?>
 ```java
 // Somewhere in your app, before your FlutterFragment is needed,
 // like in the Application class ...
@@ -279,12 +279,12 @@ FlutterEngineCache
   .put("my_engine_id", flutterEngine);
 ```
 
-<!--code-excerpt "MyActivity.java" title-->
+<?code-excerpt title="MyActivity.java"?>
 ```java
 FlutterFragment.withCachedEngine("my_engine_id").build();
 ```
 {% sample Kotlin %}
-<!--code-excerpt "MyApplication.kt" title-->
+<?code-excerpt title="MyApplication.kt"?>
 ```kotlin
 // Somewhere in your app, before your FlutterFragment is needed,
 // like in the Application class ...
@@ -302,7 +302,7 @@ FlutterEngineCache
   .put("my_engine_id", flutterEngine)
 ```
 
-<!--code-excerpt "MyActivity.kt" title-->
+<?code-excerpt title="MyActivity.java"?>
 ```kotlin
 FlutterFragment.withCachedEngine("my_engine_id").build()
 ```
@@ -342,7 +342,7 @@ allows you to specify a desired initial route, as shown:
 
 {% samplecode launch-with-initial-route %}
 {% sample Java %}
-<!--code-excerpt "MyActivity.java" title-->
+<?code-excerpt title="MyActivity.java"?>
 ```java
 // With a new FlutterEngine.
 FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
@@ -350,7 +350,7 @@ FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
     .build();
 ```
 {% sample Kotlin %}
-<!--code-excerpt "MyActivity.kt" title-->
+<?code-excerpt title="MyActivity.kt"?>
 ```kotlin
 // With a new FlutterEngine.
 val flutterFragment = FlutterFragment.withNewEngine()
@@ -379,14 +379,14 @@ To specify an entrypoint, build `FlutterFragment`, as shown:
 
 {% samplecode launch-with-custom-entrypoint %}
 {% sample Java %}
-<!--code-excerpt "MyActivity.java" title-->
+<?code-excerpt title="MyActivity.java"?>
 ```java
 FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
     .dartEntrypoint("mySpecialEntrypoint")
     .build();
 ```
 {% sample Kotlin %}
-<!--code-excerpt "MyActivity.kt" title-->
+<?code-excerpt title="MyActivity.kt"?>
 ```kotlin
 val flutterFragment = FlutterFragment.withNewEngine()
     .dartEntrypoint("mySpecialEntrypoint")
@@ -426,7 +426,7 @@ Select a `TextureView` by building a `FlutterFragment` with a
 
 {% samplecode launch-with-rendermode %}
 {% sample Java %}
-<!--code-excerpt "MyActivity.java" title-->
+<?code-excerpt title="MyActivity.java"?>
 ```java
 // With a new FlutterEngine.
 FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
@@ -439,7 +439,7 @@ FlutterFragment flutterFragment = FlutterFragment.withCachedEngine("my_engine_id
     .build();
 ```
 {% sample Kotlin %}
-<!--code-excerpt "MyActivity.kt" title-->
+<?code-excerpt title="MyActivity.kt"?>
 ```kotlin
 // With a new FlutterEngine.
 val flutterFragment = FlutterFragment.withNewEngine()
@@ -490,7 +490,7 @@ build it with the following configuration:
 
 {% samplecode launch-with-transparency %}
 {% sample Java %}
-<!--code-excerpt "MyActivity.java" title-->
+<?code-excerpt title="MyActivity.java"?>
 ```java
 // Using a new FlutterEngine.
 FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
@@ -503,7 +503,7 @@ FlutterFragment flutterFragment = FlutterFragment.withCachedEngine("my_engine_id
     .build();
 ```
 {% sample Kotlin %}
-<!--code-excerpt "MyActivity.kt" title-->
+<?code-excerpt title="MyActivity.kt"?>
 ```kotlin
 // Using a new FlutterEngine.
 val flutterFragment = FlutterFragment.withNewEngine()
@@ -550,7 +550,7 @@ use the `shouldAttachEngineToActivity()` method in
 
 {% samplecode attach-to-activity %}
 {% sample Java %}
-<!--code-excerpt "MyActivity.java" title-->
+<?code-excerpt title="MyActivity.java"?>
 ```java
 // Using a new FlutterEngine.
 FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
@@ -563,7 +563,7 @@ FlutterFragment flutterFragment = FlutterFragment.withCachedEngine("my_engine_id
     .build();
 ```
 {% sample Kotlin %}
-<!--code-excerpt "MyActivity.kt" title-->
+<?code-excerpt title="MyActivity.kt"?>
 ```kotlin
 // Using a new FlutterEngine.
 val flutterFragment = FlutterFragment.withNewEngine()

--- a/src/add-to-app/android/add-flutter-screen.md
+++ b/src/add-to-app/android/add-flutter-screen.md
@@ -57,7 +57,7 @@ import io.flutter.embedding.android.FlutterActivity;
 
 {% samplecode default-activity-launch %}
 {% sample Java %}
-<!--code-excerpt "ExistingActivity.java" title-->
+<?code-excerpt title="ExistingActivity.java"?>
 ```java
 myButton.setOnClickListener(new OnClickListener() {
   @Override
@@ -69,7 +69,7 @@ myButton.setOnClickListener(new OnClickListener() {
 });
 ```
 {% sample Kotlin %}
-<!--code-excerpt "ExistingActivity.kt" title-->
+<?code-excerpt title="ExistingActivity.kt"?>
 ```kotlin
 myButton.setOnClickListener {
   startActivity(
@@ -89,7 +89,7 @@ route in Flutter.
 
 {% samplecode custom-activity-launch %}
 {% sample Java %}
-<!--code-excerpt "ExistingActivity.java" title-->
+<?code-excerpt title="ExistingActivity.java"?>
 ```java
 myButton.addOnClickListener(new OnClickListener() {
   @Override
@@ -104,7 +104,7 @@ myButton.addOnClickListener(new OnClickListener() {
 });
 ```
 {% sample Kotlin %}
-<!--code-excerpt "ExistingActivity.kt" title-->
+<?code-excerpt title="ExistingActivity.kt"?>
 ```kotlin
 myButton.setOnClickListener {
   startActivity(
@@ -145,7 +145,7 @@ The following example arbitrarily pre-warms a
 
 {% samplecode prewarm-engine %}
 {% sample Java %}
-<!--code-excerpt "MyApplication.java" title-->
+<?code-excerpt title="MyApplication.java"?>
 ```java
 public class MyApplication extends Application {
   public FlutterEngine flutterEngine;
@@ -169,7 +169,7 @@ public class MyApplication extends Application {
 }
 ```
 {% sample Kotlin %}
-<!--code-excerpt "MyApplication.kt" title-->
+<?code-excerpt title="MyApplication.kt"?>
 ```kotlin
 class MyApplication : Application() {
   lateinit var flutterEngine : FlutterEngine
@@ -222,7 +222,7 @@ builder:
 
 {% samplecode cached-engine-activity-launch %}
 {% sample Java %}
-<!--code-excerpt "ExistingActivity.java" title-->
+<?code-excerpt title="ExistingActivity.java"?>
 ```java
 myButton.addOnClickListener(new OnClickListener() {
   @Override
@@ -236,7 +236,7 @@ myButton.addOnClickListener(new OnClickListener() {
 });
 ```
 {% sample Kotlin %}
-<!--code-excerpt "ExistingActivity.kt" title-->
+<?code-excerpt title="ExistingActivity.kt"?>
 ```kotlin
 myButton.setOnClickListener {
   startActivity(
@@ -339,7 +339,7 @@ pass the appropriate `BackgroundMode` to the `IntentBuilder`:
 
 {% samplecode transparent-activity-launch %}
 {% sample Java %}
-<!--code-excerpt "ExistingActivity.java" title-->
+<?code-excerpt title="ExistingActivity.java"?>
 ```java
 // Using a new FlutterEngine.
 startActivity(
@@ -359,7 +359,7 @@ startActivity(
 ```
 
 {% sample Kotlin %}
-<!--code-excerpt "ExistingActivity.kt" title-->
+<?code-excerpt title="ExistingActivity.kt"?>
 ```kotlin
 // Using a new FlutterEngine.
 startActivity(

--- a/src/add-to-app/android/plugin-setup.md
+++ b/src/add-to-app/android/plugin-setup.md
@@ -75,7 +75,7 @@ does (transitively via a plugin).
 
 For instance, your existing app's Gradle may already have:
 
-<!--code-excerpt "<existing app>/app/build.gradle" title-->
+<?code-excerpt title="ExistingApp/app/build.gradle"?>
 ```gradle
 …
 dependencies {
@@ -87,9 +87,9 @@ dependencies {
 ```
 
 And your Flutter module also depends on
-[firebase_crashlytics][] via pubspec.yaml:
+[firebase_crashlytics][] via `pubspec.yaml`:
 
-<!--code-excerpt "<Flutter module>/pubspec.yaml" title-->
+<?code-excerpt title="flutter_module/pubspec.yaml"?>
 ```yaml
 …
 dependencies:
@@ -102,7 +102,7 @@ dependencies:
 This plugin usage transitively adds a Gradle dependency again via
 firebase_crashlytics v0.1.3's own [Gradle file][]:
 
-<!--code-excerpt "<firebase_crashlytics via pub>/android/build.gradle" title-->
+<?code-excerpt title="firebase_crashlytics_via_pub/android/build.gradle"?>
 ```gradle
 …
 dependencies {
@@ -127,7 +127,7 @@ or implementation breaking changes between the versions.
 For example, you might use the new Crashlytics library
 in your existing app as follows:
 
-<!--code-excerpt "<existing app>/app/build.gradle" title-->
+<?code-excerpt title="<existing app>/app/build.gradle">
 ```gradle
 …
 dependencies {

--- a/src/add-to-app/android/plugin-setup.md
+++ b/src/add-to-app/android/plugin-setup.md
@@ -127,7 +127,7 @@ or implementation breaking changes between the versions.
 For example, you might use the new Crashlytics library
 in your existing app as follows:
 
-<?code-excerpt title="ExistingApp/app/build.gradle">
+<?code-excerpt title="ExistingApp/app/build.gradle"?>
 ```gradle
 …
 dependencies {

--- a/src/add-to-app/android/plugin-setup.md
+++ b/src/add-to-app/android/plugin-setup.md
@@ -127,7 +127,7 @@ or implementation breaking changes between the versions.
 For example, you might use the new Crashlytics library
 in your existing app as follows:
 
-<?code-excerpt title="<existing app>/app/build.gradle">
+<?code-excerpt title="ExistingApp/app/build.gradle">
 ```gradle
 …
 dependencies {

--- a/src/add-to-app/android/project-setup.md
+++ b/src/add-to-app/android/project-setup.md
@@ -285,7 +285,7 @@ Flutter SDK to build the host app.
 Include the Flutter module as a subproject in the host app's
 `settings.gradle`:
 
-<?code-excerpt title="MyApp/app/build.gradle"?>
+<?code-excerpt title="MyApp/settings.gradle"?>
 ```groovy
 // Include the host app project.
 include ':app'                                    // assumed existing content

--- a/src/add-to-app/android/project-setup.md
+++ b/src/add-to-app/android/project-setup.md
@@ -22,7 +22,7 @@ IDE with the [Flutter plugin][] or manually.
   Doing this avoids a missing `libflutter.so` runtime crash,
   for example:
 
-<!--code-excerpt "MyApp/app/build.gradle" title-->
+<?code-excerpt title="MyApp/app/build.gradle"?>
 ```gradle
 android {
   //...
@@ -146,7 +146,7 @@ app declares the following source compatibility within your
 app's `build.gradle` file, under the `android { }`
 block, such as:
 
-<!--code-excerpt "MyApp/app/build.gradle" title-->
+<?code-excerpt title="MyApp/app/build.gradle"?>
 ```gradle
 android {
   //...
@@ -223,7 +223,7 @@ to find these files.
 To do that, edit `app/build.gradle` in your host app
 so that it includes the local repository and the dependency:
 
-<!--code-excerpt "MyApp/app/build.gradle" title-->
+<?code-excerpt title="MyApp/app/build.gradle"?>
 ```gradle
 android {
   // ...
@@ -285,7 +285,7 @@ Flutter SDK to build the host app.
 Include the Flutter module as a subproject in the host app's
 `settings.gradle`:
 
-<!--code-excerpt "MyApp/settings.gradle" title-->
+<?code-excerpt title="MyApp/app/build.gradle"?>
 ```groovy
 // Include the host app project.
 include ':app'                                    // assumed existing content
@@ -307,7 +307,7 @@ your `settings.gradle`.
 Introduce an `implementation` dependency on the Flutter
 module from your app:
 
-<!--code-excerpt "MyApp/app/build.gradle" title-->
+<?code-excerpt title="MyApp/app/build.gradle"?>
 ```groovy
 dependencies {
   implementation project(':flutter')

--- a/src/add-to-app/ios/add-flutter-screen.md
+++ b/src/add-to-app/ios/add-flutter-screen.md
@@ -46,8 +46,7 @@ In this example, we create a `FlutterEngine` object inside a SwiftUI `Observable
 We then pass this `FlutterEngine` into a `ContentView` using the 
  `environmentObject()` property. 
 
- **In `MyApp.swift`:**
- <!--code-excerpt "MyApp.swift" title-->
+ <?code-excerpt title="MyApp.swift"?>
  ```swift
 import SwiftUI
 import Flutter
@@ -81,9 +80,7 @@ As an example, we demonstrate creating a
 `FlutterEngine`, exposed as a property, on app startup in
 the app delegate.
 
-**In `AppDelegate.swift`:**
-
-<!--code-excerpt "AppDelegate.swift" title-->
+<?code-excerpt title="AppDelegate.swift"?>
 ```swift
 import UIKit
 import Flutter
@@ -108,11 +105,9 @@ class AppDelegate: FlutterAppDelegate { // More on the FlutterAppDelegate.
 In this example, we create a `FlutterEngine` 
 object inside a SwiftUI `ObservableObject`. 
 We then pass this `FlutterEngine` into a 
-`ContentView` using the `environmentObject()` property. 
+`ContentView` using the `environmentObject()` property.
 
-**In `AppDelegate.h`:**
-
-<!--code-excerpt "AppDelegate.h" title-->
+<?code-excerpt title="AppDelegate.h"?>
 ```objectivec
 @import UIKit;
 @import Flutter;
@@ -122,9 +117,7 @@ We then pass this `FlutterEngine` into a
 @end
 ```
 
-**In `AppDelegate.m`:**
-
-<!--code-excerpt "AppDelegate.m" title-->
+<?code-excerpt title="AppDelegate.m"?>
 ```objectivec
 // The following library connects plugins with iOS platform code to this app.
 #import <FlutterPluginRegistrant/GeneratedPluginRegistrant.h>
@@ -158,7 +151,7 @@ The `FlutterViewController` constructor takes the pre-warmed
 `FlutterEngine` as an argument. `FlutterEngine` is passed in 
 as an `EnvironmentObject` via `flutterDependencies`.
 
-<!--code-excerpt "ContentView.swift" title-->
+<?code-excerpt title="ContentView.swift"?>
 ```swift
 import SwiftUI
 import Flutter
@@ -201,7 +194,8 @@ The following example shows a generic `ViewController` with a
 `UIButton` hooked to present a [`FlutterViewController`][].
 The `FlutterViewController` uses the `FlutterEngine` instance
 created in the `AppDelegate`.
-<!--code-excerpt "ViewController.swift" title-->
+
+<?code-excerpt title="ViewController.swift"?>
 ```swift
 import UIKit
 import Flutter
@@ -233,7 +227,8 @@ The following example shows a generic `ViewController` with a
 `UIButton` hooked to present a [`FlutterViewController`][].
 The `FlutterViewController` uses the `FlutterEngine` instance
 created in the `AppDelegate`.
-<!--code-excerpt "ViewController.m" title-->
+
+<?code-excerpt title="ViewController.m"?>
 ```objectivec
 @import Flutter;
 #import "AppDelegate.h"
@@ -327,7 +322,7 @@ func openFlutterApp() {
 }
 ```
 {% sample UIKit-Swift %}
-<!--code-excerpt "ViewController.swift" title-->
+<?code-excerpt title="ViewController.swift"?>
 ```swift
 // Existing code omitted.
 func showFlutter() {
@@ -336,7 +331,7 @@ func showFlutter() {
 }
 ```
 {% sample UIKit-ObjC %}
-<!--code-excerpt "ViewController.m" title-->
+<?code-excerpt title="ViewController.m"?>
 ```objectivec
 // Existing code omitted.
 - (void)showFlutter {
@@ -452,6 +447,7 @@ For instance:
 
 {% samplecode app-delegate %}
 {% sample Swift %}
+<?code-excerpt title="AppDelegate.swift"?>
 ```swift
 import Foundation
 import Flutter
@@ -511,7 +507,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FlutterAppLifeCycleProvid
 ```
 
 {% sample Objective-C %}
-<!--code-excerpt "AppDelegate.h" title-->
+<?code-excerpt title="AppDelegate.h"?>
 ```objectivec
 @import Flutter;
 @import UIKit;
@@ -526,7 +522,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FlutterAppLifeCycleProvid
 The implementation should delegate mostly to a
 `FlutterPluginAppLifeCycleDelegate`:
 
-<!--code-excerpt "AppDelegate.m" title-->
+<?code-excerpt title="AppDelegate.m"?>
 ```objectivec
 @interface AppDelegate ()
 @property (nonatomic, strong) FlutterPluginAppLifeCycleDelegate* lifeCycleDelegate;
@@ -665,12 +661,10 @@ in `lib/other_file.dart` instead of `main()` in `lib/main.dart`:
 
 {% samplecode entrypoint-library %}
 {% sample Swift %}
-<!--code-excerpt "Swift" title-->
 ```swift
 flutterEngine.run(withEntrypoint: "myOtherEntrypoint", libraryURI: "other_file.dart")
 ```
 {% sample Objective-C %}
-<!--code-excerpt "Objective-C" title-->
 ```objectivec
 [flutterEngine runWithEntrypoint:@"myOtherEntrypoint" libraryURI:@"other_file.dart"];
 ```
@@ -685,7 +679,6 @@ FlutterViewController.
 
 {% samplecode initial-route %}
 {% sample Swift %}
-<!--code-excerpt "Creating engine" title-->
 ```swift
 let flutterEngine = FlutterEngine()
 // FlutterDefaultDartEntrypoint is the same as nil, which will run main().
@@ -693,7 +686,6 @@ engine.run(
   withEntrypoint: "main", initialRoute: "/onboarding")
 ```
 {% sample Objective-C %}
-<!--code-excerpt "Creating engine" title-->
 ```objectivec
 FlutterEngine *flutterEngine = [[FlutterEngine alloc] init];
 // FlutterDefaultDartEntrypoint is the same as nil, which will run main().
@@ -710,13 +702,11 @@ a FlutterEngine:
 
 {% samplecode initial-route-without-pre-warming %}
 {% sample Swift %}
-<!--code-excerpt "Creating view controller" title-->
 ```swift
 let flutterViewController = FlutterViewController(
       project: nil, initialRoute: "/onboarding", nibName: nil, bundle: nil)
 ```
 {% sample Objective-C %}
-<!--code-excerpt "Creating view controller" title-->
 ```objectivec
 FlutterViewController* flutterViewController =
       [[FlutterViewController alloc] initWithProject:nil

--- a/src/add-to-app/ios/project-setup.md
+++ b/src/add-to-app/ios/project-setup.md
@@ -163,7 +163,7 @@ CocoaPods in the [CocoaPods getting started guide][].
 
 Add the following lines to your `Podfile`:
 
-<!--code-excerpt "MyApp/Podfile" title-->
+<?code-excerpt title="MyApp/Podfile"?>
 ```ruby
 flutter_application_path = '../my_flutter'
 load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
@@ -176,7 +176,7 @@ load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
 For each [Podfile target][] that needs to
 embed Flutter, call `install_all_flutter_pods(flutter_application_path)`.
 
-<!--code-excerpt "MyApp/Podfile" title-->
+<?code-excerpt title="MyApp/Podfile"?>
 ```ruby
 target 'MyApp' do
   install_all_flutter_pods(flutter_application_path)
@@ -189,7 +189,7 @@ end
 
 In the `Podfile`'s `post_install` block, call `flutter_post_install(installer)`.
 
-<!--code-excerpt "MyApp/Podfile" title-->
+<?code-excerpt title="MyApp/Podfile"?>
 ```ruby
 post_install do |installer|
   flutter_post_install(installer) if defined?(flutter_post_install)
@@ -379,10 +379,11 @@ some/path/MyApp/
 
 Host apps using CocoaPods can add Flutter to their Podfile:
 
-<!--code-excerpt "MyApp/Podfile" title-->
+<?code-excerpt title="MyApp/Podfile"?>
 ```ruby
 pod 'Flutter', :podspec => 'some/path/MyApp/Flutter/[build mode]/Flutter.podspec'
 ```
+
 {{site.alert.note}}
   You must hard code the `[build mode]` value.
   For example, use `Debug` if you need to use

--- a/src/platform-integration/android/splash-screen.md
+++ b/src/platform-integration/android/splash-screen.md
@@ -146,7 +146,7 @@ Android APIs might be helpful:
 
 {% samplecode android-splash-alignment %}
 {% sample Java %}
-<!--code-excerpt "MainActivity.java" title-->
+<?code-excerpt title="MainActivity.java"?>
 ```java
 import android.os.Build;
 import android.os.Bundle;
@@ -176,7 +176,7 @@ public class MainActivity extends FlutterActivity {
 ```
 
 {% sample Kotlin %}
-<!--code-excerpt "MainActivity.kt" title-->
+<?code-excerpt title="MainActivity.kt"?>
 ```kotlin
 import android.os.Build
 import android.os.Bundle

--- a/src/platform-integration/platform-channels.md
+++ b/src/platform-integration/platform-channels.md
@@ -349,7 +349,7 @@ Inside the `configureFlutterEngine()` method, create a `MethodChannel` and call
 `setMethodCallHandler()`. Make sure to use the same channel name as
 was used on the Flutter client side.
 
-<!--code-excerpt "MyActivity.kt" title-->
+<?code-excerpt title="MyActivity.kt"?>
 ```kotlin
 import androidx.annotation.NonNull
 import io.flutter.embedding.android.FlutterActivity
@@ -376,7 +376,7 @@ would write in a native Android app.
 
 First, add the needed imports at the top of the file:
 
-<!--code-excerpt "MyActivity.kt" title-->
+<?code-excerpt title="MyActivity.kt"?>
 ```kotlin
 import android.content.Context
 import android.content.ContextWrapper
@@ -390,7 +390,7 @@ import android.os.Build.VERSION_CODES
 Next, add the following method in the `MainActivity` class,
 below the `configureFlutterEngine()` method:
 
-<!--code-excerpt "MyActivity.kt" title-->
+<?code-excerpt title="MyActivity.kt"?>
 ```kotlin
   private fun getBatteryLevel(): Int {
     val batteryLevel: Int
@@ -416,7 +416,7 @@ If an unknown method is called, report that instead.
 
 Remove the following code:
 
-<!--code-excerpt "MyActivity.kt" title-->
+<?code-excerpt title="MyActivity.kt"?>
 ```kotlin
     MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
       call, result ->
@@ -427,7 +427,7 @@ Remove the following code:
 
 And replace with the following:
 
-<!--code-excerpt "MyActivity.kt" title-->
+<?code-excerpt title="MyActivity.kt"?>
 ```kotlin
     MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
       // This method is invoked on the main thread.
@@ -465,7 +465,7 @@ inside the `configureFlutterEngine()` method.
 Make sure to use the same channel name as was used on the
 Flutter client side.
 
-<!--code-excerpt "MainActivity.java" title-->
+<?code-excerpt title="MainActivity.java"?>
 ```java
 import androidx.annotation.NonNull;
 import io.flutter.embedding.android.FlutterActivity;
@@ -495,7 +495,7 @@ would write in a native Android app.
 
 First, add the needed imports at the top of the file:
 
-<!--code-excerpt "MainActivity.java" title-->
+<?code-excerpt title="MainActivity.java"?>
 ```java
 import android.content.ContextWrapper;
 import android.content.Intent;
@@ -509,7 +509,7 @@ import android.os.Bundle;
 Then add the following as a new method in the activity class,
 below the `configureFlutterEngine()` method:
 
-<!--code-excerpt "MainActivity.java" title-->
+<?code-excerpt title="MainActivity.java"?>
 ```java
   private int getBatteryLevel() {
     int batteryLevel = -1;
@@ -537,7 +537,7 @@ If an unknown method is called, report that instead.
 
 Remove the following code:
 
-<!--code-excerpt "MainActivity.java" title-->
+<?code-excerpt title="MainActivity.java"?>
 ```java
           (call, result) -> {
             // This method is invoked on the main thread.
@@ -547,7 +547,7 @@ Remove the following code:
 
 And replace with the following:
 
-<!--code-excerpt "MainActivity.java" title-->
+<?code-excerpt title="MainActivity.java"?>
 ```java
           (call, result) -> {
             // This method is invoked on the main thread.
@@ -594,7 +594,7 @@ Override the `application:didFinishLaunchingWithOptions:` function and create
 a `FlutterMethodChannel` tied to the channel name
 `samples.flutter.dev/battery`:
 
-<!--code-excerpt "AppDelegate.swift" title-->
+<?code-excerpt title="AppDelegate.swift"?>
 ```swift
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
@@ -623,7 +623,7 @@ would write in a native iOS app.
 
 Add the following as a new method at the bottom of `AppDelegate.swift`:
 
-<!--code-excerpt "AppDelegate.swift" title-->
+<?code-excerpt title="AppDelegate.swift"?>
 ```swift
 private func receiveBatteryLevel(result: FlutterResult) {
   let device = UIDevice.current
@@ -645,7 +645,7 @@ The implementation of this platform method calls
 the iOS code written in the previous step. If an unknown method
 is called, report that instead.
 
-<!--code-excerpt "AppDelegate.swift" title-->
+<?code-excerpt title="AppDelegate.swift"?>
 ```swift
 batteryChannel.setMethodCallHandler({
   [weak self] (call: FlutterMethodCall, result: FlutterResult) -> Void in
@@ -678,7 +678,7 @@ didFinishLaunchingWithOptions:` method.
 Make sure to use the same channel name
 as was used on the Flutter client side.
 
-<!--code-excerpt "AppDelegate.m" title-->
+<?code-excerpt title="AppDelegate.m"?>
 ```objectivec
 #import <Flutter/Flutter.h>
 #import "GeneratedPluginRegistrant.h"
@@ -707,7 +707,7 @@ would write in a native iOS app.
 
 Add the following method in the `AppDelegate` class, just before `@end`:
 
-<!--code-excerpt "AppDelegate.m" title-->
+<?code-excerpt title="AppDelegate.m"?>
 ```objectivec
 - (int)getBatteryLevel {
   UIDevice* device = UIDevice.currentDevice;
@@ -727,7 +727,7 @@ this platform method calls the iOS code written in the previous step,
 and returns a response for both the success and error cases using
 the `result` argument. If an unknown method is called, report that instead.
 
-<!--code-excerpt "AppDelegate.m" title-->
+<?code-excerpt title="AppDelegate.m"?>
 ```objectivec
 __weak typeof(self) weakSelf = self;
 [batteryChannel setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
@@ -778,7 +778,7 @@ Add the C++ implementation of the platform channel method:
 First, add the necessary includes to the top of the file, just
 after `#include "flutter_window.h"`:
 
-<!--code-excerpt "flutter_window.cpp" title-->
+<?code-excerpt title="flutter_window.cpp"?>
 ```cpp
 #include <flutter/event_channel.h>
 #include <flutter/event_sink.h>
@@ -794,7 +794,7 @@ Edit the `FlutterWindow::OnCreate` method and create
 a `flutter::MethodChannel` tied to the channel name
 `samples.flutter.dev/battery`:
 
-<!--code-excerpt "flutter_window.cpp" title-->
+<?code-excerpt title="flutter_window.cpp"?>
 ```cpp
 bool FlutterWindow::OnCreate() {
   // ...
@@ -821,7 +821,7 @@ you would write in a native Windows application.
 Add the following as a new function at the top of
 `flutter_window.cpp` just after the `#include` section:
 
-<!--code-excerpt "flutter_window.cpp" title-->
+<?code-excerpt title="flutter_window.cpp"?>
 ```cpp
 static int GetBatteryLevel() {
   SYSTEM_POWER_STATUS status;
@@ -841,7 +841,7 @@ is called, report that instead.
   
 Remove the following code:
 
-<!--code-excerpt "flutter_window.cpp" title-->
+<?code-excerpt title="flutter_window.cpp"?>
 ```cpp
   channel.SetMethodCallHandler(
       [](const flutter::MethodCall<>& call,
@@ -852,7 +852,7 @@ Remove the following code:
 
 And replace with the following:
 
-<!--code-excerpt "flutter_window.cpp" title-->
+<?code-excerpt title="flutter_window.cpp"?>
 ```cpp
   channel.SetMethodCallHandler(
       [](const flutter::MethodCall<>& call,
@@ -895,7 +895,7 @@ Add the Swift implementation of the platform channel method:
 First, add the necessary import to the top of the file, just after
 `import FlutterMacOS`:
 
-<!--code-excerpt "MainFlutterWindow.swift" title-->
+<?code-excerpt title="MainFlutterWindow.swift"?>
 ```swift
 import IOKit.ps
 ```
@@ -903,7 +903,7 @@ import IOKit.ps
 Create a `FlutterMethodChannel` tied to the channel name
 `samples.flutter.dev/battery` in the `awakeFromNib` method:
 
-<!--code-excerpt "MainFlutterWindow.swift" title-->
+<?code-excerpt title="MainFlutterWindow.swift"?>
 ```swift
   override func awakeFromNib() {
     // ...
@@ -930,7 +930,7 @@ would write in a native macOS app.
 
 Add the following as a new method at the bottom of `MainFlutterWindow.swift`:
 
-<!--code-excerpt "MainFlutterWindow.swift" title-->
+<?code-excerpt title="MainFlutterWindow.swift"?>
 ```swift
 private func getBatteryLevel() -> Int? {
   let info = IOPSCopyPowerSourcesInfo().takeRetainedValue()
@@ -953,7 +953,7 @@ The implementation of this platform method calls
 the macOS code written in the previous step. If an unknown method
 is called, report that instead.
 
-<!--code-excerpt "MainFlutterWindow.swift" title-->
+<?code-excerpt title="MainFlutterWindow.swift"?>
 ```swift
 batteryChannel.setMethodCallHandler { (call, result) in
   switch call.method {
@@ -1001,7 +1001,7 @@ of your choice. The instructions below are for Visual Studio Code with the
 First, add the necessary includes to the top of the file, just
 after `#include <flutter_linux/flutter_linux.h`:
 
-<!--code-excerpt "my_application.cc" title-->
+<?code-excerpt title="my_application.cc"?>
 ```c
 #include <math.h>
 #include <upower.h>
@@ -1009,7 +1009,7 @@ after `#include <flutter_linux/flutter_linux.h`:
 
 Add an `FlMethodChannel` to the `_MyApplication` struct:
 
-<!--code-excerpt "my_application.cc" title-->
+<?code-excerpt title="my_application.cc"?>
 ```c
 struct _MyApplication {
   GtkApplication parent_instance;
@@ -1020,7 +1020,7 @@ struct _MyApplication {
 
 Make sure to clean it up in `my_application_dispose`:
 
-<!--code-excerpt "my_application.cc" title-->
+<?code-excerpt title="my_application.cc"?>
 ```c
 static void my_application_dispose(GObject* object) {
   MyApplication* self = MY_APPLICATION(object);
@@ -1035,7 +1035,7 @@ Edit the `my_application_activate` method and initialize
 `samples.flutter.dev/battery`, just after the call to
 `fl_register_plugins`:
 
-<!--code-excerpt "my_application.cc" title-->
+<?code-excerpt title="my_application.cc"?>
 ```c
 static void my_application_activate(GApplication* application) {
   // ...
@@ -1059,7 +1059,7 @@ you would write in a native Linux application.
 Add the following as a new function at the top of
 `my_application.cc` just after the `G_DEFINE_TYPE` line:
 
-<!--code-excerpt "my_application.cc" title-->
+<?code-excerpt title="my_application.cc"?>
 ```c
 static FlMethodResponse* get_battery_level() {
   // Find the first available battery and report that.
@@ -1090,7 +1090,7 @@ is called, report that instead.
   
 Add the following code after the `get_battery_level` function:
 
-<!--code-excerpt "flutter_window.cpp" title-->
+<?code-excerpt title="flutter_window.cpp"?>
 ```c
 static void battery_method_call_handler(FlMethodChannel* channel,
                                         FlMethodCall* method_call,

--- a/src/release/breaking-changes/plugin-api-migration.md
+++ b/src/release/breaking-changes/plugin-api-migration.md
@@ -73,7 +73,7 @@ The following instructions outline the steps for supporting the new API:
    You might have to make a public constructor for your plugin class
    if one didn't exist already. For example:
 
-   <!--code-excerpt "MainActivity.java" title-->
+   <?code-excerpt title="MainActivity.java"?>
    ```java
     package io.flutter.plugins.firebasecoreexample;
 
@@ -92,7 +92,7 @@ The following instructions outline the steps for supporting the new API:
    to use `io.flutter.embedding.android.FlutterActivity`.
    For example:
 
-    <!--code-excerpt "AndroidManifest.xml" title-->
+    <?code-excerpt title="AndroidManifest.xml"?>
     ```xml
      <activity android:name="io.flutter.embedding.android.FlutterActivity"
             android:theme="@style/LaunchTheme"
@@ -118,7 +118,7 @@ The following instructions outline the steps for supporting the new API:
    register all the plugins instead of using
    `GeneratedPluginRegistrant`.  For example:
 
-    <!--code-excerpt "EmbeddingV1Activity.java" title-->
+    <?code-excerpt title="EmbeddingV1Activity.java"?>
     ```java
     package io.flutter.plugins.batteryexample;
 
@@ -144,7 +144,7 @@ The following instructions outline the steps for supporting the new API:
    `<plugin_name>/example/android/app/src/main/AndroidManifest.xml` file.
    For example:
 
-    <!--code-excerpt "AndroidManifest.xml" title-->
+    <?code-excerpt title="AndroidManifest.xml"?>
     ```xml
     <activity
         android:name=".EmbeddingV1Activity"
@@ -164,7 +164,7 @@ but aren't required.
 1. Update `<plugin_name>/example/android/app/build.gradle`
    to replace references to `android.support.test` with `androidx.test`:
 
-    <!--code-excerpt "build.gradle" title-->
+    <?code-excerpt title="build.gradle"?>
     ```groovy
     defaultConfig {
       ...
@@ -173,7 +173,7 @@ but aren't required.
     }
     ```
 
-    <!--code-excerpt "build.gradle" title-->
+    <?code-excerpt title="build.gradle"?>
     ```groovy
     dependencies {
     ...
@@ -188,7 +188,7 @@ but aren't required.
    in `<plugin_name>/example/android/app/src/androidTest/java/<plugin_path>/`.
    You will need to create these directories. For example:
 
-    <!--code-excerpt "MainActivityTest.java" title-->
+    <?code-excerpt title="MainActivityTest.java"?>
     ```java
     package io.flutter.plugins.firebase.core;
 
@@ -204,7 +204,7 @@ but aren't required.
     }
     ```
 
-    <!--code-excerpt "EmbeddingV1ActivityTest.java" title-->
+    <?code-excerpt title="EmbeddingV1ActivityTest.java"?>
     ```java
     package io.flutter.plugins.firebase.core;
 
@@ -225,7 +225,7 @@ but aren't required.
    `<plugin_name>/pubspec.yaml` and
    `<plugin_name>/example/pubspec.yaml`.
 
-    <!--code-excerpt "pubspec.yaml" title-->
+    <?code-excerpt title="pubspec.yaml"?>
     ```yaml
     integration_test:
       sdk: flutter
@@ -239,7 +239,7 @@ but aren't required.
    which is the minimum version for which we can guarantee support.
    For example:
 
-    <!--code-excerpt "pubspec.yaml" title-->
+    <?code-excerpt title="pubspec.yaml"?>
     ```yaml
     environment:
       sdk: ">=2.16.1 <3.0.0"


### PR DESCRIPTION
These were all commented out because at some point the code excerpt tool was changed breaking them. This reenables all usages by specifying a specific title instead of a source file so the excerpt tool won't fail because it can't find them.

In review, please check out a few locations to verify the filename properly shows up above the code snippet :)  

Closes https://github.com/flutter/website/issues/4018
