### PR TITLE
Remind users enum names are not obfuscated at all

### DIFF
--- a/src/deployment/obfuscate.md
+++ b/src/deployment/obfuscate.md
@@ -149,3 +149,5 @@ eventually be an obfuscated binary.
 ```dart
 expect(foo.runtimeType.toString(), equals('Foo'));
 ```
+
+* Enum names are not obfuscated currently.


### PR DESCRIPTION
It is surprising for me, since I did expect everything is obfuscated, and thus I expect enum names will not be in the production code. 

Related: https://github.com/flutter/flutter/issues/94751

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
