### PR TITLE
Fix broken links in DevTools release notes

### DIFF
--- a/src/tools/devtools/release-notes/release-notes-2.10.0-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.10.0-src.md
@@ -18,6 +18,6 @@ Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 ## Logging View Updates
 * Fix a fatal error that occurred when filtering logs more than once - [#3588](https://github.com/flutter/devtools/pull/3588)
 
-## Changelog
-More details about changes and fixes are available in our
-[changelog](https://github.com/flutter/devtools/blob/master/CHANGELOG.md).
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).

--- a/src/tools/devtools/release-notes/release-notes-2.11.2-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.11.2-src.md
@@ -17,6 +17,6 @@ Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 
 ![debugger file explorer scrolling]({{site.url}}/tools/devtools/release-notes/images-2.11.2/image2.gif "debugger file explorer scrolling")
 
-## Changelog
-More details about changes and fixes are available in our
-[changelog](https://github.com/flutter/devtools/blob/master/CHANGELOG.md).
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).

--- a/src/tools/devtools/release-notes/release-notes-2.12.1-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.12.1-src.md
@@ -17,6 +17,6 @@ learn more about these features - [#3934](https://github.com/flutter/devtools/pu
 
 ![enhance tracing documentation links]({{site.url}}/tools/devtools/release-notes/images-2.12.1/image1.png "enhance tracing documentation links")
 
-## Changelog
-More details about changes and fixes are available in our
-[changelog](https://github.com/flutter/devtools/blob/master/CHANGELOG.md).
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).

--- a/src/tools/devtools/release-notes/release-notes-2.13.1-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.13.1-src.md
@@ -33,6 +33,6 @@ your code only or in all code - [#4010](https://github.com/flutter/devtools/pull
 ## Flutter Inspector Updates
 * Add support for displaying flex values larger than 5 in the Layout Explorer - [#4055](https://github.com/flutter/devtools/pull/4055)
 
-## Changelog
-More details about changes and fixes are available in our
-[changelog](https://github.com/flutter/devtools/blob/master/CHANGELOG.md).
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).

--- a/src/tools/devtools/release-notes/release-notes-2.14.0-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.14.0-src.md
@@ -36,6 +36,6 @@ hover card - [#4090](https://github.com/flutter/devtools/pull/4090)
 * Warn users that the rendering layer toggles in the "More Debugging Options" menu are not available for profile mode 
 apps - [#4075](https://github.com/flutter/devtools/pull/4075)
 
-## Changelog
-More details about changes and fixes are available in our
-[changelog](https://github.com/flutter/devtools/blob/master/CHANGELOG.md).
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).

--- a/src/tools/devtools/release-notes/release-notes-2.15.0-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.15.0-src.md
@@ -25,6 +25,6 @@ See [#4175](https://github.com/flutter/devtools/pull/4175)
 ## CPU Profiler
 * Stop manually truncating source URIs in the profiler tables - [#4166](https://github.com/flutter/devtools/pull/4166)
 
-## Changelog
-More details about changes and fixes are available in our
-[changelog](https://github.com/flutter/devtools/blob/master/CHANGELOG.md).
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).

--- a/src/tools/devtools/release-notes/release-notes-2.16.0-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.16.0-src.md
@@ -8,6 +8,6 @@ towards some new features that are coming soon!
 See the full list of commits for DevTools 2.16.0
 [in the changelog](https://github.com/flutter/devtools/blob/master/CHANGELOG.md#2160).
 
-## Changelog
-More details about changes and fixes are available in the DevTools
-[changelog](https://github.com/flutter/devtools/blob/master/CHANGELOG.md).
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).

--- a/src/tools/devtools/release-notes/release-notes-2.17.0-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.17.0-src.md
@@ -30,6 +30,6 @@ Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 
 ![frame_analysis]({{site.url}}/tools/devtools/release-notes/images-2.17.0/frame_analysis.png "frame analysis")
 
-## Changelog
-More details about changes and fixes are available in the DevTools
-[changelog](https://github.com/flutter/devtools/blob/master/CHANGELOG.md).
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).

--- a/src/tools/devtools/release-notes/release-notes-2.18.0-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.18.0-src.md
@@ -61,7 +61,7 @@ Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 - Log messages from non-stdout sources are now shown -
   [#4487](https://github.com/flutter/devtools/pull/4487)
 
-## Changelog
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).
 
-More details about changes and fixes are available in the DevTools
-[changelog](https://github.com/flutter/devtools/blob/master/CHANGELOG.md).

--- a/src/tools/devtools/release-notes/release-notes-2.19.0-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.19.0-src.md
@@ -34,7 +34,7 @@ for Dart and Flutter
   (thanks to @netos23) -
   [#4509](https://github.com/flutter/devtools/pull/4509) 
 
-## Changelog
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).
 
-More details about changes and fixes are available in the DevTools
-[changelog](https://github.com/flutter/devtools/blob/master/CHANGELOG.md).

--- a/src/tools/devtools/release-notes/release-notes-2.20.0-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.20.0-src.md
@@ -55,7 +55,7 @@ for Dart and Flutter
   (thanks to leungpuikuen@!) -
   [#4602](https://github.com/flutter/devtools/pull/4602)
 
-## Changelog
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).
 
-More details about changes and fixes are available in the DevTools
-[changelog](https://github.com/flutter/devtools/blob/master/CHANGELOG.md).

--- a/src/tools/devtools/release-notes/release-notes-2.21.1-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.21.1-src.md
@@ -33,7 +33,7 @@ Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 * Add a link to the DevTools [CONTRIBUTING](https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md) guide to the About menu, and fixed the Discord link - [#4926](https://github.com/flutter/devtools/pull/4926)
 * Fix conflicting colors in light theme - [5067](https://github.com/flutter/devtools/pull/5067)
 
-## Changelog
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).
 
-More details about changes and fixes are available in the DevTools
-[changelog](https://github.com/flutter/devtools/blob/master/CHANGELOG.md).

--- a/src/tools/devtools/release-notes/release-notes-2.22.2-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.22.2-src.md
@@ -41,6 +41,6 @@ in deeply nested trees - [#5181](https://github.com/flutter/devtools/pull/5181)
 ## Network profiler updates
 - Improve reliability and performance of the Network tab - [#5056](https://github.com/flutter/devtools/pull/5056)
 
-## Changelog
-More details about changes and fixes are available in the DevTools
-[changelog](https://github.com/flutter/devtools/blob/master/CHANGELOG.md).
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).

--- a/src/tools/devtools/release-notes/release-notes-2.23.1-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.23.1-src.md
@@ -54,6 +54,6 @@ Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 * Fix a bug where JSON requests were shown in plain text, instead of the formatted JSON viewer. [#5463](https://github.com/flutter/devtools/pull/5463)
 * Fix a UI issue where the copy button on the response or request tab would let you copy while still loading the data. [#5476](https://github.com/flutter/devtools/pull/5476)
 
-## Changelog
-More details about changes and fixes are available in the DevTools
-[changelog](https://github.com/flutter/devtools/blob/master/CHANGELOG.md).
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).

--- a/src/tools/devtools/release-notes/release-notes-2.7.0-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.7.0-src.md
@@ -53,8 +53,6 @@ in the list of available user tags.
 
 ![Class names]({{site.url}}/tools/devtools/release-notes/images-2.7.0/image6.png "Class names")
 
-## Changelog
-
-More details about changes and fixes are available in our [changelog][].
-
-[changelog]: https://github.com/flutter/devtools/blob/master/CHANGELOG.md
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).

--- a/src/tools/devtools/release-notes/release-notes-2.8.0-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.8.0-src.md
@@ -85,7 +85,6 @@ The expected workflow is as such:
 * UI polish - [#3421](https://github.com/flutter/devtools/pull/3421),
   [#3449](https://github.com/flutter/devtools/pull/3449)
 
-## Changelog
-More details about changes and fixes are available in our [changelog][].
-
-[changelog]: https://github.com/flutter/devtools/blob/master/CHANGELOG.md
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).

--- a/src/tools/devtools/release-notes/release-notes-2.9.1-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.9.1-src.md
@@ -25,9 +25,7 @@ Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter.
 
 ![alt_text]({{site.url}}/tools/devtools/release-notes/images-2.9.1/image3.png "Flutter frame tooltips")
 
-## Changelog
-
-More details about changes and fixes are available in our [changelog][].
-
-[changelog]: https://github.com/flutter/devtools/blob/master/CHANGELOG.md
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).
 

--- a/src/tools/devtools/release-notes/release-notes-2.9.2-src.md
+++ b/src/tools/devtools/release-notes/release-notes-2.9.2-src.md
@@ -34,6 +34,6 @@ are on Flutter 2.10, this bug will still be present._
   after a hot restart -
   [#3527](https://github.com/flutter/devtools/pull/3527)
 
-## Changelog
-More details about changes and fixes are available in our
-[changelog](https://github.com/flutter/devtools/blob/master/CHANGELOG.md).
+## Full commit history
+More details about changes and fixes are available from the
+[DevTools git log.](https://github.com/flutter/devtools/commits/master).


### PR DESCRIPTION
The links to the DevTools CHANGELOG are no longer valid. This PR replaces all these links with the commit history, like we used in the latest release notes and what we will continue to use in release notes from here on out.