### PR TITLE
Revert HTML changes from "Update template HTML with a11y fixes (#8819)"

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -7,25 +7,19 @@ permalink: /404.html
 ---
 
 <div class="not-found__wrapper">
-  <header>
-    <h1>404</h1>
-    <p>Sorry, we couldn’t find that page…</p>
-  </header>
-
-  <main>
-    <img src='/assets/images/404/dash_nest.png' class='not-found__illo' alt="Dash pointing you in the right direction">
-    <p>But Dash is here to help - maybe one of these will point you in the right direction?</p>
-
-    <ul class="not-found__link-list">
-      <li><a href="{{site.main-url}}/">Homepage</a></li>
-      <li><a href="{{site.pub}}/">Package site</a></li>
-      <li><a href="{{site.api}}/">API reference</a></li>
-      <li><a href="{{site.url}}/">Documentation</a></li>
-      <li><a href="https://flutter.github.io/samples">Samples</a></li>
-      <li><a href="{{site.main-url}}/community">Community</a></li>
-      <li><a href="{{site.medium}}/flutter">Medium</a></li>
-      <li><a href="{{site.social.twitter}}/">Twitter</a></li>
-      <li><a href="{{site.url}}/resources/faq">FAQ</a></li>
-    </ul>
-  </main>
+  <h1>404</h1>
+  <p>Sorry, we couldn’t find that page…</p>
+  <img src='/assets/images/404/dash_nest.png' class='not-found__illo' alt="Dash pointing you in the right direction">
+  <p>But Dash is here to help - maybe one of these will point you in the right direction?</p>
+  <ul class="not-found__link-list">
+    <li><a href="{{site.main-url}}/">Homepage</a></li>
+    <li><a href="{{site.pub}}/">Package site</a></li>
+    <li><a href="{{site.api}}/">API reference</a></li>
+    <li><a href="{{site.url}}/">Documentation</a></li>
+    <li><a href="https://flutter.github.io/samples">Samples</a></li>
+    <li><a href="{{site.main-url}}/community">Community</a></li>
+    <li><a href="{{site.medium}}/flutter">Medium</a></li>
+    <li><a href="{{site.social.twitter}}/">Twitter</a></li>
+    <li><a href="{{site.url}}/resources/faq">FAQ</a></li>
+  </ul>
 </div>

--- a/src/_includes/cookie-notice.html
+++ b/src/_includes/cookie-notice.html
@@ -1,13 +1,10 @@
-<article id="cookie-notice">
+<section id="cookie-notice">
   <div class="container">
-    <p>Google uses cookies to deliver its services, to personalize ads, and to
-      analyze traffic. You can adjust your privacy controls anytime in your
-      <a href="https://myaccount.google.com/data-and-personalization" target="_blank" rel="noopener" title="Go to Google settings">Google settings</a>.
-      <a href="https://policies.google.com/technologies/cookies" target="_blank" rel="noopener" title="Learn more about cookies">Learn more</a>.
+    <p>Google uses cookies to deliver its services, to personalize ads, and to 
+      analyze traffic. You can adjust your privacy controls anytime in your 
+      <a href="https://myaccount.google.com/data-and-personalization" target="_blank" rel="noopener">Google settings</a>. 
+      <a href="https://policies.google.com/technologies/cookies" target="_blank" rel="noopener">Learn more</a>.
     </p>
-    <form>
-      <label for="cookie-consent">I agree to the use of cookies:</label>
-      <button id="cookie-consent" class="btn btn-primary">Okay</button>
-    </form>
+    <button id="cookie-consent" class="btn btn-primary">Okay</button>
   </div>
-</article>
+</section>

--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -1,27 +1,29 @@
 <footer class="site-footer">
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-12 site-footer__wrapper">
-                <div class="site-footer__logo">
-                    <img src="/assets/images/shared/brand/flutter/logo/flutter-mono-81x100.png" alt="Flutter Logo" width="81" height="100">
-                </div>
-                <div class="site-footer__content">
-                    <ul class="site-footer__link-list">
-                        <li><a href="/tos">Terms</a></li>
-                        <li><a href="/brand">Brand Usage</a></li>
-                        <li><a href="/security">Security</a></li>
-                        <li><a href="https://www.google.com/intl/en/policies/privacy">Privacy</a></li>
-                        <li><a href="https://esflutter.dev/">Español</a></li>
-                        <li><a href="https://flutter.cn" class="text-nowrap" target="_blank">Flutter Community in Chinese</a></li>
-                        <li><a href="https://blog.google/inside-google/company-announcements/standing-with-black-community">Important Announcement: Standing with the Black Community</a></li>
-                    </ul>
-                    <p class="licenses">
-                        Except as otherwise noted, this work is licensed under a
-                        <a rel="license" href="https://creativecommons.org/licenses/by/4.0">Creative Commons Attribution 4.0 International License</a>,
-                        and code samples are licensed under the BSD License.
-                    </p>
-                </div>
-            </div>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12 site-footer__wrapper">
+        <div class="site-footer__logo">
+          <img src="/assets/images/shared/brand/flutter/logo/flutter-mono-81x100.png" alt="Flutter Logo" width="81" height="100">
         </div>
+        <div class="site-footer__content">
+          <ul class="site-footer__link-list">
+              <li><a href="/tos">terms</a></li>
+              <li><a href="/brand">brand usage</a></li>
+              <li><a href="/security">security</a></li>
+              <li><a href="https://www.google.com/intl/en/policies/privacy">privacy</a></li>
+              <li><a href="https://esflutter.dev/">español</a></li>
+              <li><a href="https://flutter.cn" class="text-nowrap">社区中文资源</a></li> 
+              <li><a href="https://blog.google/inside-google/company-announcements/standing-with-black-community">We stand in solidarity with the Black community. Black Lives Matter.</a></li>
+          </ul>
+          <p class="licenses">
+            Except as otherwise noted,
+            this work is licensed under a
+            <a rel="license" href="https://creativecommons.org/licenses/by/4.0">Creative
+            Commons Attribution 4.0 International License</a>,
+            and code samples are licensed under the BSD License.
+          </p>
+        </div>
+      </div>
     </div>
+  </div>
 </footer>

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -1,29 +1,38 @@
-{% assign route = page.url | regex_replace:'/index$|/index\.html$|\.html$|/$' %}
+{% assign route = page.url|regex_replace:'/index$|/index\.html$|\.html$|/$' %}
 
 <header class="site-header">
-  <nav class="navbar navbar-expand-md justify-content-between">
-    <button
-            class="navbar-toggler"
-            type="button"
-            data-toggle="collapse"
-            data-target="#navbarSupportedContent"
-            aria-controls="navbarSupportedContent"
-            aria-expanded="false"
-            aria-label="Toggle navigation">
+  <nav class="navbar navbar-expand-md justify-content-start justify-content-md-between">
+    <button 
+      class="navbar-toggler" 
+      type="button" 
+      data-toggle="collapse" 
+      data-target="#navbarSupportedContent" 
+      aria-controls="navbarSupportedContent" 
+      aria-expanded="false" 
+      aria-label="Toggle navigation">
       <i class="material-icons">menu</i>
     </button>
 
-    <a class="navbar-brand" href="{{ site.url }}">
-      <img
-              src='/assets/images/shared/brand/flutter/logo/flutter-lockup.png'
-              alt='Flutter logo'
-              height="37"
-              width="129"
-              class="align-middle">
+    <a class="navbar-brand" href="{{site.url}}">
+      <img 
+        src='/assets/images/shared/brand/flutter/logo/flutter-lockup.png' 
+        alt='Flutter logo' 
+        height="37" 
+        width="129" 
+        class="align-middle">
     </a>
 
-    <div id="navbarSupportedContent" class="collapse navbar-collapse flex-grow-0">
-      <div class="site-header__sheet-bg"></div>
+    <div 
+      id="navbarSupportedContent"
+      class="collapse navbar-collapse flex-grow-0">
+      <div 
+        class="site-header__sheet-bg" 
+        data-toggle="collapse" 
+        data-target="#navbarSupportedContent" 
+        aria-controls="navbarSupportedContent" 
+        aria-expanded="false" 
+        aria-label="Toggle navigation">
+      </div>
       <div class="site-header__sheet">
         <ul class="navbar-nav">
           <div class="site-sidebar site-sidebar--header d-md-none">
@@ -31,114 +40,114 @@
           </div>
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" id="platform-navbar-dropdown"
-               href="{{ site.main-url }}/multi-platform"
-               role="button" data-toggle="dropdown"
+               href="{{site.main-url}}/multi-platform" 
+               role="button" data-toggle="dropdown" 
                aria-haspopup="true" aria-expanded="false">
-              Multi-Platform
+               Multi-Platform
             </a>
             <div class="dropdown-menu" aria-labelledby="platform-navbar-dropdown">
-              <a class="dropdown-item" href="{{ site.main-url }}/multi-platform/mobile">Mobile</a>
-              <a class="dropdown-item" href="{{ site.main-url }}/multi-platform/web">Web</a>
-              <a class="dropdown-item" href="{{ site.main-url }}/multi-platform/desktop">Desktop</a>
-              <a class="dropdown-item" href="{{ site.main-url }}/multi-platform/embedded">Embedded</a>
+              <a class="dropdown-item" href="{{site.main-url}}/multi-platform/mobile">Mobile</a>
+              <a class="dropdown-item" href="{{site.main-url}}/multi-platform/web">Web</a>
+              <a class="dropdown-item" href="{{site.main-url}}/multi-platform/desktop">Desktop</a>
+              <a class="dropdown-item" href="{{site.main-url}}/multi-platform/embedded">Embedded</a>
             </div>
           </li>
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" id="dev-navbar-dropdown"
-               href="{{ site.main-url }}/"
-               role="button" data-toggle="dropdown"
+               href="{{site.main-url}}/"
+               role="button" data-toggle="dropdown" 
                aria-haspopup="true" aria-expanded="false">
-              Development
+               Development
             </a>
             <div class="dropdown-menu" aria-labelledby="dev-navbar-dropdown">
-              <a class="dropdown-item" href="{{ site.main-url }}/learn">Learn</a>
+              <a class="dropdown-item" href="{{site.main-url}}/learn">Learn</a>
               <a class="dropdown-item" href="https://pub.dev/flutter/favorites" target="_blank">Flutter Favorites</a>
               <a class="dropdown-item" href="https://pub.dev/" target="_blank">Packages</a>
             </div>
           </li>
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" id="ecosystem-navbar-dropdown"
-               href="{{ site.main-url }}/ecosystem"
-               role="button" data-toggle="dropdown"
+               href="{{site.main-url}}/ecosystem"
+               role="button" data-toggle="dropdown" 
                aria-haspopup="true" aria-expanded="false">
-              Ecosystem
+               Ecosystem
             </a>
             <div class="dropdown-menu" aria-labelledby="ecosystem-navbar-dropdown">
-              <a class="dropdown-item" href="{{ site.main-url }}/community">Community</a>
-              <a class="dropdown-item" href="{{ site.main-url }}/events">Events</a>
-              <a class="dropdown-item" href="{{ site.main-url }}/monetization">Monetization</a>
+              <a class="dropdown-item" href="{{site.main-url}}/community">Community</a>
+              <a class="dropdown-item" href="{{site.main-url}}/events">Events</a>
+              <a class="dropdown-item" href="{{site.main-url}}/monetization">Monetization</a>
             </div>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="{{ site.main-url }}/showcase">Showcase</a>
+            <a class="nav-link" href="{{site.main-url}}/showcase">Showcase</a>
           </li>
           <li class="nav-item dropdown docs-item">
             <a class="nav-link dropdown-toggle{% if route == '/' %} active{% endif %}"
                id="docs-navbar-dropdown"
                href="/"
-               role="button" data-toggle="dropdown"
+               role="button" data-toggle="dropdown" 
                aria-haspopup="true" aria-expanded="false">
-              Docs
+               Docs
             </a>
             <div class="dropdown-menu" aria-labelledby="docs-navbar-dropdown">
-              <a class="dropdown-item{% if route == '/release/whats-new' %} active{% endif %}"
+              <a class="dropdown-item {% if route == '/release/whats-new' %} active{% endif %}"
                  href="/release/whats-new">What's new</a>
-              <a class="dropdown-item{% if route contains '/get-started/editor' %} active{% endif %}"
+              <a class="dropdown-item {% if route contains '/get-started/editor' %} active{% endif %}"
                  href="/get-started/editor">Editor support</a>
-              <a class="dropdown-item{% if route contains '/tools/hot-reload' %} active{% endif %}"
+              <a class="dropdown-item {% if route contains '/tools/hot-reload' %} active{% endif %}"
                  href="/tools/hot-reload">Hot reload</a>
-              <a class="dropdown-item{% if route contains '/perf/ui-performance' %} active{% endif %}"
+              <a class="dropdown-item {% if route contains '/perf/ui-performance' %} active{% endif %}"
                  href="/perf/ui-performance">Profiling</a>
-              <a class="dropdown-item{% if route contains '/get-started/install' %} active{% endif %}"
+              <a class="dropdown-item {% if route contains '/get-started/install' %} active{% endif %}"
                  href="/get-started/install">Install Flutter</a>
-              <a class="dropdown-item{% if route contains '/tools/devtools' %} active{% endif %}"
+              <a class="dropdown-item {% if route contains '/tools/devtools' %} active{% endif %}"
                  href="/tools/devtools/overview">DevTools</a>
-              <a class="dropdown-item{% if route contains '/cookbook' %} active{% endif %}"
+              <a class="dropdown-item {% if route contains '/cookbook' %} active{% endif %}"
                  href="/cookbook">Cookbook</a>
-              <a class="dropdown-item{% if route contains '/reference/tutorials' %} active{% endif %}"
+              <a class="dropdown-item {% if route contains '/reference/tutorials' %} active{% endif %}"
                  href="/reference/tutorials">Tutorials</a>
             </div>
           </li>
         </ul>
         <form action="/search/" class="site-header__search form-inline">
-          <input
-                  class="site-header__searchfield form-control"
-                  type="search" name="q" id="q" autocomplete="off"
-                  placeholder="Search" aria-label="Search">
+          <input 
+            class="site-header__searchfield form-control" 
+            type="search" name="q" id="q" autocomplete="off" 
+            placeholder="Search" aria-label="Search">
         </form>
       </div>
     </div>
     <div class="site-header__social navbar-nav flex-row">
-      <a
-              class="nav-item nav-link nav-icon"
-              href="{{ site.social.twitter }}"
-              aria-label="Twitter">
+      <a 
+        class="nav-item nav-link nav-icon"
+        href="{{site.social.twitter}}" 
+        aria-label="Twitter">
         <i class="fab fa-twitter fa-lg"></i>
       </a>
-      <a
-              class="nav-item nav-link nav-icon"
-              href="{{ site.social.youtube }}"
-              aria-label="YouTube">
+      <a 
+        class="nav-item nav-link nav-icon"
+        href="{{site.social.youtube}}" 
+        aria-label="YouTube">
         <i class="fab fa-youtube fa-lg"></i>
       </a>
       <a
-              class="nav-item nav-link nav-icon"
-              href="{{ site.flutter-medium }}"
-              aria-label="Medium blog">
+        class="nav-item nav-link nav-icon"
+        href="{{site.flutter-medium}}"
+        aria-label="Medium blog">
         <i class="fab fa-medium fa-lg"></i>
       </a>
-      <a
-              class="nav-item nav-link nav-icon"
-              href="{{ site.repo.organization }}"
-              aria-label="GitHub">
+      <a 
+        class="nav-item nav-link nav-icon"
+        href="{{site.repo.organization}}" 
+        aria-label="GitHub">
         <i class="fab fa-github fa-lg"></i>
       </a>
     </div>
     {% if page.show-nav-get-started-button -%}
-    <a
-            class="site-header__cta btn btn-primary"
-            href="/get-started/install/">Get started
-    </a>
+      <a 
+        class="site-header__cta btn btn-primary" 
+        href="/get-started/install/">Get started
+      </a>
     {% endif -%}
   </nav>
 </header>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -2,34 +2,31 @@
 layout: base
 ---
 
-{% assign sidebarColumnClass = 'col-12 col-md-3 col-xl-2' -%}
+{% assign sidebar-col = 'col-12 col-md-3 col-xl-2' -%}
 {% if page.toc -%}
-  {% assign mainColumnClass = 'col-12 col-md-9 offset-md-3 col-xl-8 offset-xl-2 col-xxl-8 offset-xxl-2' -%}
+  {% assign main-col = 'col-12 col-md-9 offset-md-3 col-xl-8 offset-xl-2 col-xxl-8 offset-xxl-2' -%}
   {% comment %}Side toc is col-xl-2{% endcomment -%}
 {% else -%}
-  {% assign mainColumnClass = 'col-12 col-md-9 offset-md-3 col-xl-10 offset-xl-2 col-xxl-8 offset-xxl-2' -%}
+  {% assign main-col = 'col-12 col-md-9 offset-md-3 col-xl-10 offset-xl-2 col-xxl-8 offset-xxl-2' -%}
 {% endif -%}
 
 <div class="container-fluid position-relative">
   <div class="row flex-xl-nowrap">
-    <div class="fixed-col site-sidebar site-sidebar--fixed {{ sidebarColumnClass }} d-none d-md-block" data-fixed-column>
+    <div class="fixed-col site-sidebar site-sidebar--fixed {{sidebar-col}} d-none d-md-block" data-fixed-column>
       {% assign route = page.url | regex_replace:'/index$|/index\.html$|\.html$|/$' %}
       {% include_cached sidenav-level-1.html nav=site.data.sidenav page_url_path=route %}
     </div>
 
     {% if page.toc and layout.toc != false -%}
-      {% assign showToc = true -%}
-    {% endif -%}
-    {% if showToc -%}
-    {% assign tocContent = content | toc_only -%}
-    {% include side-toc.html toc_content=tocContent -%}
+      {% assign toc_content = content | toc_only -%}
+      {% include side-toc.html toc_content=toc_content -%}
     {% endif -%}
 
-    <main class="site-content {{ mainColumnClass }}">
+    <main class="site-content {{main-col}}">
       <div class="container">
 
         {% if page.deprecated %}
-        {% include snackbar.html class="snackbar--dismissible" label="This page is deprecated and its content may be out of date." action="Dismiss" %}
+          {% include snackbar.html class="snackbar--dismissible" label="This page is deprecated and its content may be out of date." action="Dismiss" %}
         {% endif %}
 
         {% include_cached next-prev-nav.html prev=page.prev next=page.next %}
@@ -38,12 +35,12 @@ layout: base
           {% include shared/page-github-links.html %}
           <h1>{{ page.title }}</h1>
           {% if page.show_breadcrumbs -%}
-          {% include shared/breadcrumbs.html %}
+            {% include shared/breadcrumbs.html %}
           {% endif -%}
         </header>
-
-        {% if showToc -%}
-        {% include inline-toc.html toc_content=tocContent -%}
+        
+        {% if page.toc and layout.toc != false -%}
+          {% include inline-toc.html toc_content=toc_content -%}
         {% endif -%}
         {{ content | inject_anchors }}
 


### PR DESCRIPTION
Reverts the HTML/template changes from #8819.

It introduced some issues, primarily not being able to close the side menu on mobile/small screens. 

There are a few minor formatting and semantic issues as well, such as incorrect line breaking in the cookie notice, some less direct text in the footer, multiple `<main>` elements on the 404 page, and not following our style in a few cases.

To fix the issues quickly, this PR reverts the changes. Improvements from the original PR can be revisited as follow-up, and should be done isolated, rather than in one big PR.

This PR does not revert the JS changes from the PR as there are conflicts due to other recent changes made and they seem to be working fine.
