### PR TITLE
Replace instructions to modify pubspec.yaml with `flutter pub add` command in multiple pages

### DIFF
--- a/src/add-to-app/android/plugin-setup.md
+++ b/src/add-to-app/android/plugin-setup.md
@@ -89,11 +89,14 @@ dependencies {
 And your Flutter module also depends on
 [firebase_crashlytics][] via `pubspec.yaml`:
 
-To add the `firebase_crashlytics` package as a dependency,
-run `flutter pub add`:
-
-```terminal
-$ flutter pub add firebase_crashlytics
+<?code-excerpt title="flutter_module/pubspec.yaml"?>
+```yaml
+…
+dependencies:
+  …
+  firebase_crashlytics: ^0.1.3
+  …
+…
 ```
 
 This plugin usage transitively adds a Gradle dependency again via

--- a/src/add-to-app/android/plugin-setup.md
+++ b/src/add-to-app/android/plugin-setup.md
@@ -89,14 +89,11 @@ dependencies {
 And your Flutter module also depends on
 [firebase_crashlytics][] via `pubspec.yaml`:
 
-<?code-excerpt title="flutter_module/pubspec.yaml"?>
-```yaml
-…
-dependencies:
-  …
-  firebase_crashlytics: ^0.1.3
-  …
-…
+To add the `firebase_crashlytics` package as a dependency,
+run `flutter pub add`:
+
+```terminal
+$ flutter pub add firebase_crashlytics
 ```
 
 This plugin usage transitively adds a Gradle dependency again via

--- a/src/cookbook/design/package-fonts.md
+++ b/src/cookbook/design/package-fonts.md
@@ -52,9 +52,11 @@ updating the `pubspec.yaml` in the *app's* root directory.
 
 ### Add the package to the app
 
-```yaml
-dependencies:
-  awesome_package: <latest_version>
+To add the `awesome_package` package as a dependency,
+run `flutter pub add`:
+
+```terminal
+$ flutter pub add awesome_package
 ```
 
 ### Declare the font assets

--- a/src/cookbook/maintenance/error-reporting.md
+++ b/src/cookbook/maintenance/error-reporting.md
@@ -57,9 +57,11 @@ Import the [`sentry_flutter`][] package into the app.
 The sentry package makes it easier to send
 error reports to the Sentry error tracking service.
 
-```yaml
-dependencies:
-  sentry_flutter: <latest_version>
+To add the `sentry_flutter` package as a dependency,
+run `flutter pub add`:
+
+```terminal
+$ flutter pub add sentry_flutter
 ```
 
 ## 3. Initialize the Sentry SDK

--- a/src/cookbook/navigation/set-up-app-links.md
+++ b/src/cookbook/navigation/set-up-app-links.md
@@ -40,13 +40,13 @@ It provides a simple API to handle complex routing scenarios.
     ```
 
 2. To include `go_router` package in your app, add a dependency for
-`go_router` in the `pubspec.yaml` file.
+`go_router` to the project.
 
-    ```yaml
-    dependencies:
-      flutter:
-        sdk: flutter
-      go_router: ^6.0.9
+    To add the `go_router` package as a dependency,
+    run `flutter pub add`:
+
+    ```terminal
+    $ flutter pub add go_router
     ```
 
 3. To handle the routing, create a `GoRouter` object in the `main.dart` file:

--- a/src/cookbook/navigation/set-up-universal-links.md
+++ b/src/cookbook/navigation/set-up-universal-links.md
@@ -39,14 +39,10 @@ It provides a simple API to handle complex routing scenarios.
     $ flutter create deeplink_cookbook
     ```
 
-2. To include `go_router` package in your app, add a dependency for
-`go_router` in the `pubspec.yaml` file.
+2. To include `go_router` package in your app, run `flutter pub add`:
 
-    ```yaml
-    dependencies:
-      flutter:
-        sdk: flutter
-      go_router: ^6.0.9
+    ```terminal
+    $ flutter pub add go_router
     ```
 
 3. To handle the routing, create a `GoRouter` object in the `main.dart` file:

--- a/src/cookbook/navigation/set-up-universal-links.md
+++ b/src/cookbook/navigation/set-up-universal-links.md
@@ -39,7 +39,8 @@ It provides a simple API to handle complex routing scenarios.
     $ flutter create deeplink_cookbook
     ```
 
-2. To include `go_router` package in your app, run `flutter pub add`:
+2. To include the `go_router` package as a dependency, 
+   run `flutter pub add`:
 
     ```terminal
     $ flutter pub add go_router

--- a/src/cookbook/persistence/key-value.md
+++ b/src/cookbook/persistence/key-value.md
@@ -37,14 +37,13 @@ This recipe uses the following steps:
 
 ## 1. Add the dependency
 
-Before starting, add the [`shared_preferences`][]
-plugin to the `pubspec.yaml` file:
+Before starting, add the [`shared_preferences`][] dependecy to your project.
 
-```yaml
-dependencies:
-  flutter:
-    sdk: flutter
-  shared_preferences: "<newest version>"
+To add the `shared_preferences` package as a dependency,
+run `flutter pub add`:
+
+```terminal
+$ flutter pub add shared_preferences
 ```
 
 ## 2. Save data

--- a/src/cookbook/persistence/key-value.md
+++ b/src/cookbook/persistence/key-value.md
@@ -37,7 +37,7 @@ This recipe uses the following steps:
 
 ## 1. Add the dependency
 
-Before starting, add the [`shared_preferences`][] dependecy to your project.
+Before starting, add the [`shared_preferences`][] package as a dependency.
 
 To add the `shared_preferences` package as a dependency,
 run `flutter pub add`:

--- a/src/cookbook/persistence/sqlite.md
+++ b/src/cookbook/persistence/sqlite.md
@@ -45,12 +45,11 @@ To work with SQLite databases, import the `sqflite` and `path` packages.
   * The `path` package provides functions to
     define the location for storing the database on disk.
 
-```yaml
-dependencies:
-  flutter:
-    sdk: flutter
-  sqflite:
-  path:
+To add the packages as a dependency,
+run `flutter pub add`:
+
+```terminal
+$ flutter pub add sqflite path
 ```
 
 Make sure to import the packages in the file you'll be working in.

--- a/src/cookbook/plugins/picture-using-camera.md
+++ b/src/cookbook/plugins/picture-using-camera.md
@@ -40,14 +40,12 @@ To complete this recipe, you need to add three dependencies to your app:
 [`path`][]
 : Creates paths that work on any platform.
 
-```yaml
-dependencies:
-  flutter:
-    sdk: flutter
-  camera:
-  path_provider:
-  path:
+To add the packages as dependencies, run `flutter pub add`:
+
+```terminal
+$ flutter pub add camera path_provider path
 ```
+
 {{site.alert.tip}}
   - For android, You must update `minSdkVersion` to 21 (or higher).
   - On iOS, lines below have to be added inside `ios/Runner/Info.plist` in order the access the camera and microphone.

--- a/src/cookbook/plugins/play-video.md
+++ b/src/cookbook/plugins/play-video.md
@@ -34,13 +34,12 @@ the following steps:
 ## 1. Add the `video_player` dependency
 
 This recipe depends on one Flutter plugin: `video_player`. First, add this
-dependency to your `pubspec.yaml`.
+dependency to your project.
 
-```yaml
-dependencies:
-  flutter:
-    sdk: flutter
-  video_player:
+To add the `video_player` package as a dev dependency, run `flutter pub add`:
+
+```terminal
+$ flutter pub add video_player
 ```
 
 ## 2. Add permissions to your app

--- a/src/cookbook/testing/unit/introduction.md
+++ b/src/cookbook/testing/unit/introduction.md
@@ -40,9 +40,11 @@ The `test` package provides the core functionality for
 writing tests in Dart. This is the best approach when
 writing packages consumed by web, server, and Flutter apps.
 
-```yaml
-dev_dependencies:
-  test: <latest_version>
+To add the `test` package as a dev dependency,
+run `flutter pub add`:
+
+```terminal
+$ flutter pub add dev:test
 ```
 
 ## 2. Create a test file

--- a/src/cookbook/testing/unit/mocking.md
+++ b/src/cookbook/testing/unit/mocking.md
@@ -54,14 +54,10 @@ so define that dependency in the `dependencies` section.
 To run the required code generation, add the `build_runner` dependency
 in the `dev_dependencies` section.
 
-```yaml
-dependencies:
-  http: <newest_version>
-dev_dependencies:
-  flutter_test:
-    sdk: flutter
-  mockito: <newest_version>
-  build_runner: <newest_version>
+To add the packages, run `flutter pub add`:
+
+```terminal
+$ flutter pub add http dev:mockito dev:build_runner
 ```
 
 ## 2. Create a function to test

--- a/src/cookbook/testing/unit/mocking.md
+++ b/src/cookbook/testing/unit/mocking.md
@@ -54,7 +54,7 @@ so define that dependency in the `dependencies` section.
 To run the required code generation, add the `build_runner` dependency
 in the `dev_dependencies` section.
 
-To add the packages, run `flutter pub add`:
+To add the dependencies, run `flutter pub add`:
 
 ```terminal
 $ flutter pub add http dev:mockito dev:build_runner

--- a/src/data-and-backend/json.md
+++ b/src/data-and-backend/json.md
@@ -251,20 +251,10 @@ dependency, and two _dev dependencies_. In short, _dev dependencies_
 are dependencies that are not included in our app source code&mdash;they
 are only used in the development environment.
 
-The latest versions of these required dependencies can be seen by
-following the [pubspec file][] in the JSON serializable example.
+To add the packages run `flutter pub add`:
 
-**pubspec.yaml**
-
-```yaml
-dependencies:
-  # Your other regular dependencies here
-  json_annotation: <latest_version>
-
-dev_dependencies:
-  # Your other dev_dependencies here
-  build_runner: <latest_version>
-  json_serializable: <latest_version>
+```terminal
+$ flutter pub add json_annotation dev:build_runner dev:json_serializable
 ```
 
 Run `flutter pub get` inside your project root folder

--- a/src/data-and-backend/json.md
+++ b/src/data-and-backend/json.md
@@ -251,7 +251,7 @@ dependency, and two _dev dependencies_. In short, _dev dependencies_
 are dependencies that are not included in our app source code&mdash;they
 are only used in the development environment.
 
-To add the packages run `flutter pub add`:
+To add the dependencies, run `flutter pub add`:
 
 ```terminal
 $ flutter pub add json_annotation dev:build_runner dev:json_serializable

--- a/src/data-and-backend/state-mgmt/simple.md
+++ b/src/data-and-backend/state-mgmt/simple.md
@@ -190,20 +190,10 @@ widgets but is simple to use. It's called `provider`.
 Before working with `provider`,
 don't forget to add the dependency on it to your `pubspec.yaml`.
 
-```yaml
-name: my_name
-description: Blah blah blah.
+To add the `provider` package as a dependency, run `flutter pub add`:
 
-# ...
-
-dependencies:
-  flutter:
-    sdk: flutter
-
-  provider: ^6.0.0
-
-dev_dependencies:
-  # ...
+```terminal
+$ flutter pub add provider
 ```
 
 Now you can `import 'package:provider/provider.dart';`

--- a/src/get-started/flutter-for/android-devs.md
+++ b/src/get-started/flutter-for/android-devs.md
@@ -1106,12 +1106,10 @@ While the http package doesn't have every feature found in OkHttp,
 it abstracts away much of the networking that you would normally implement
 yourself, making it a simple way to make network calls.
 
-To use the `http` package, add it to your dependencies in `pubspec.yaml`:
+To add the `http` package as a dependency, run `flutter pub add`:
 
-```yaml
-dependencies:
-  ...
-  http: ^1.0.0
+```terminal
+$ flutter pub add http
 ```
 
 To make a network call, call `await` on the `async` function `http.get()`:

--- a/src/get-started/flutter-for/react-native-devs.md
+++ b/src/get-started/flutter-for/react-native-devs.md
@@ -750,16 +750,10 @@ from the command line.
 
 In Flutter, install a package using the following instructions:
 
-1. Add the package name and version to the `pubspec.yaml` dependencies section.
-   The example below shows how to add the `google_sign_in` Dart package to the
-   `pubspec.yaml` file. Check your spaces when working in the YAML file because
-   **white space matters**!
+1. To add the `google_sign_in` package as a dependency, run `flutter pub add`:
 
-```yaml
-dependencies:
-  flutter:
-    sdk: flutter
-  google_sign_in: ^3.0.3
+```terminal
+$ flutter pub add google_sign_in
 ```
 
 2. Install the package from the command line by using `flutter pub get`.
@@ -1582,15 +1576,11 @@ store and retrieve key-value data that is persistent and global
 to the app. The `shared_preferences` plugin wraps
 `NSUserDefaults` on iOS and `SharedPreferences` on Android,
 providing a persistent store for simple data.
-To use the plugin,
-add `shared_preferences` as a dependency in the `pubspec.yaml`
-file then import the package in your Dart file.
 
-```yaml
-dependencies:
-  flutter:
-    sdk: flutter
-  shared_preferences: ^2.0.13
+To add the `shared_preferences` package as a dependency, run `flutter pub add`:
+
+```terminal
+$ flutter pub add shared_preferences
 ```
 
 <?code-excerpt "lib/examples.dart (SharedPrefs)"?>
@@ -2056,14 +2046,12 @@ const _getIPAddress = () => {
 };
 ```
 
-Flutter uses the `http` package. To install the `http` package,
-add it to the dependencies' section of our pubspec.yaml.
+Flutter uses the `http` package. 
 
-```yaml
-dependencies:
-  flutter:
-    sdk: flutter
-  http: <latest_version>
+To add the `http` package as a dependency, run `flutter pub add`:
+
+```terminal
+$ flutter pub add http
 ```
 
 Flutter uses the [`dart:io`][] core HTTP support client.

--- a/src/get-started/flutter-for/uikit-devs.md
+++ b/src/get-started/flutter-for/uikit-devs.md
@@ -2021,11 +2021,10 @@ use the popular [`http` package][]. This abstracts
 away a lot of the networking that you might normally
 implement yourself, making it simple to make network calls.
 
-To use the `http` package, add it to your dependencies in `pubspec.yaml`:
+To add the `http` package as a dependency, run `flutter pub add`:
 
-```yaml
-dependencies:
-  http: ^1.0.0
+```terminal
+$ flutter pub add http
 ```
 
 To make a network call,


### PR DESCRIPTION
Following the proposal in #3340

I have replaced many cases in which the documentation asked developers to modify the pubspec.yaml to add a dependency, with a call to `flutter pub add`. This also required modifying a bit the description text.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
