### PR TITLE
Adjust style for page source and bug report icons

### DIFF
--- a/src/_sass/components/_content.scss
+++ b/src/_sass/components/_content.scss
@@ -52,7 +52,23 @@
     @at-root {
       #page-github-links {
         float: right;
-        .btn { padding: 0 ($btn-padding-x * 0.5); }
+        .btn {
+          padding: 0 ($btn-padding-x * 0.5);
+          border: none;
+          box-shadow: none;
+
+          &:hover, &:focus-visible {
+            color: $site-color-primary;
+          }
+
+          &:active {
+            color: $flutter-color-dark-blue;
+          }
+        }
+
+        .material-icons {
+          font-size: 18px;
+        }
       }
     }
 


### PR DESCRIPTION
- (from site-shared) Switches to Material Icons to work towards removing Font Awesome which slows down site loading (https://github.com/dart-lang/site-www/issues/3790)
- Adds hover and active styles
- Replaces focus style which comes from the underlying bootstrap button but doesn't match the rest of the site.

<img width="192" alt="Example with page source focused" src="https://github.com/flutter/website/assets/18372958/957b32c8-0698-4eb2-b810-c53393dcb35a">
