### PR TITLE
Drawer cookbook recipe with navigation

### DIFF
--- a/examples/cookbook/design/drawer/lib/drawer.dart
+++ b/examples/cookbook/design/drawer/lib/drawer.dart
@@ -55,21 +55,25 @@ void drawerListview() {
 }
 
 void drawerClose() {
-  Drawer(
-    child: ListView(
-      children: [
-        // #docregion CloseDrawer
-        ListTile(
-          title: const Text('Item 1'),
-          onTap: () {
-            // Update the state of the app
-            // ...
-            // Then close the drawer
-            Navigator.pop(context);
-          },
+  Builder(
+    builder: (context) {
+      return Drawer(
+        child: ListView(
+          children: [
+            // #docregion CloseDrawer
+            ListTile(
+              title: const Text('Item 1'),
+              onTap: () {
+                // Update the state of the app
+                // ...
+                // Then close the drawer
+                Navigator.pop(context);
+              },
+            ),
+            // #enddocregion CloseDrawer
+          ],
         ),
-        // #enddocregion CloseDrawer
-      ],
-    ),
+      );
+    },
   );
 }

--- a/examples/cookbook/design/drawer/lib/drawer.dart
+++ b/examples/cookbook/design/drawer/lib/drawer.dart
@@ -53,3 +53,23 @@ void drawerListview() {
   );
   // #enddocregion DrawerListView
 }
+
+void drawerClose() {
+  Drawer(
+    child: ListView(
+      children: [
+        // #docregion CloseDrawer
+        ListTile(
+          title: const Text('Item 1'),
+          onTap: () {
+            // Update the state of the app
+            // ...
+            // Then close the drawer
+            Navigator.pop(context);
+          },
+        ),
+        // #enddocregion CloseDrawer
+      ],
+    ),
+  );
+}

--- a/examples/cookbook/design/drawer/lib/main.dart
+++ b/examples/cookbook/design/drawer/lib/main.dart
@@ -16,17 +16,46 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class MyHomePage extends StatelessWidget {
+class MyHomePage extends StatefulWidget {
   const MyHomePage({super.key, required this.title});
 
   final String title;
 
   @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  int _selectedIndex = 0;
+  static const TextStyle optionStyle =
+      TextStyle(fontSize: 30, fontWeight: FontWeight.bold);
+  static const List<Widget> _widgetOptions = <Widget>[
+    Text(
+      'Index 0: Home',
+      style: optionStyle,
+    ),
+    Text(
+      'Index 1: Business',
+      style: optionStyle,
+    ),
+    Text(
+      'Index 2: School',
+      style: optionStyle,
+    ),
+  ];
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(title)),
-      body: const Center(
-        child: Text('My Page!'),
+      appBar: AppBar(title: Text(widget.title)),
+      body: Center(
+        child: _widgetOptions[_selectedIndex],
       ),
       drawer: Drawer(
         // Add a ListView to the drawer. This ensures the user can scroll
@@ -42,22 +71,32 @@ class MyHomePage extends StatelessWidget {
               ),
               child: Text('Drawer Header'),
             ),
-            // #docregion CloseDrawer
             ListTile(
-              title: const Text('Item 1'),
+              title: const Text('Home'),
+              selected: _selectedIndex == 0,
               onTap: () {
                 // Update the state of the app
-                // ...
+                _onItemTapped(0);
                 // Then close the drawer
                 Navigator.pop(context);
               },
             ),
-            // #enddocregion CloseDrawer
             ListTile(
-              title: const Text('Item 2'),
+              title: const Text('Business'),
+              selected: _selectedIndex == 1,
               onTap: () {
                 // Update the state of the app
-                // ...
+                _onItemTapped(1);
+                // Then close the drawer
+                Navigator.pop(context);
+              },
+            ),
+            ListTile(
+              title: const Text('School'),
+              selected: _selectedIndex == 2,
+              onTap: () {
+                // Update the state of the app
+                _onItemTapped(2);
                 // Then close the drawer
                 Navigator.pop(context);
               },

--- a/src/cookbook/design/drawer.md
+++ b/src/cookbook/design/drawer.md
@@ -136,11 +136,11 @@ ListTile(
 This example shows a [`Drawer`][] as it is used within a [`Scaffold`][] widget.
 The [`Drawer`][] has three [`ListTile`][] items.
 The `_onItemTapped` function changes the selected item's index
-and displays the corresponding text in the center of the Scaffold.
+and displays the corresponding text in the center of the `Scaffold`.
 
 {{site.alert.note}}
   For more information on implementing navigation,
-  see the [Navigation][] section of the cookbook.
+  check out the [Navigation][] section of the cookbook.
 {{site.alert.end}}
 
 <?code-excerpt "lib/main.dart"?>

--- a/src/cookbook/design/drawer.md
+++ b/src/cookbook/design/drawer.md
@@ -118,7 +118,7 @@ You can do this by using the [`Navigator`][].
 When a user opens the drawer, Flutter adds the drawer to the navigation
 stack. Therefore, to close the drawer, call `Navigator.pop(context)`.
 
-<?code-excerpt "lib/main.dart (CloseDrawer)"?>
+<?code-excerpt "lib/drawer.dart (CloseDrawer)"?>
 ```dart
 ListTile(
   title: const Text('Item 1'),

--- a/src/cookbook/design/drawer.md
+++ b/src/cookbook/design/drawer.md
@@ -134,7 +134,7 @@ ListTile(
 ## Interactive example
 
 This example shows a [`Drawer`][] as it is used within a [`Scaffold`][] widget.
-The [`Drawer`][] has three [`ListTile][] items.
+The [`Drawer`][] has three [`ListTile`][] items.
 The `_onItemTapped` function changes the selected item's index
 and displays the corresponding text in the center of the Scaffold.
 

--- a/src/cookbook/design/drawer.md
+++ b/src/cookbook/design/drawer.md
@@ -133,6 +133,16 @@ ListTile(
 
 ## Interactive example
 
+This example shows a [`Drawer`][] as it is used within a [`Scaffold`][] widget.
+The [`Drawer`][] has three [`ListTile][] items.
+The `_onItemTapped` function changes the selected item's index
+and displays the corresponding text in the center of the Scaffold.
+
+{{site.alert.note}}
+  For more information on implementing navigation,
+  see the [Navigation][] section of the cookbook.
+{{site.alert.end}}
+
 <?code-excerpt "lib/main.dart"?>
 ```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
 import 'package:flutter/material.dart';
@@ -153,17 +163,46 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class MyHomePage extends StatelessWidget {
+class MyHomePage extends StatefulWidget {
   const MyHomePage({super.key, required this.title});
 
   final String title;
 
   @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  int _selectedIndex = 0;
+  static const TextStyle optionStyle =
+      TextStyle(fontSize: 30, fontWeight: FontWeight.bold);
+  static const List<Widget> _widgetOptions = <Widget>[
+    Text(
+      'Index 0: Home',
+      style: optionStyle,
+    ),
+    Text(
+      'Index 1: Business',
+      style: optionStyle,
+    ),
+    Text(
+      'Index 2: School',
+      style: optionStyle,
+    ),
+  ];
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(title)),
-      body: const Center(
-        child: Text('My Page!'),
+      appBar: AppBar(title: Text(widget.title)),
+      body: Center(
+        child: _widgetOptions[_selectedIndex],
       ),
       drawer: Drawer(
         // Add a ListView to the drawer. This ensures the user can scroll
@@ -180,19 +219,31 @@ class MyHomePage extends StatelessWidget {
               child: Text('Drawer Header'),
             ),
             ListTile(
-              title: const Text('Item 1'),
+              title: const Text('Home'),
+              selected: _selectedIndex == 0,
               onTap: () {
                 // Update the state of the app
-                // ...
+                _onItemTapped(0);
                 // Then close the drawer
                 Navigator.pop(context);
               },
             ),
             ListTile(
-              title: const Text('Item 2'),
+              title: const Text('Business'),
+              selected: _selectedIndex == 1,
               onTap: () {
                 // Update the state of the app
-                // ...
+                _onItemTapped(1);
+                // Then close the drawer
+                Navigator.pop(context);
+              },
+            ),
+            ListTile(
+              title: const Text('School'),
+              selected: _selectedIndex == 2,
+              onTap: () {
+                // Update the state of the app
+                _onItemTapped(2);
                 // Then close the drawer
                 Navigator.pop(context);
               },
@@ -218,3 +269,4 @@ class MyHomePage extends StatelessWidget {
 [material library]: {{site.api}}/flutter/material/material-library.html
 [`Navigator`]: {{site.api}}/flutter/widgets/Navigator-class.html
 [`Scaffold`]: {{site.api}}/flutter/material/Scaffold-class.html
+[Navigation]: {{site.url}}/cookbook#navigation


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

In this PR I extend the example found in the cookbook recipe for the Drawer, as proposed in the ticket issue #1518.

I used the documentation for the BottomNavigationBar as starting point and modified it a bit to fit a Drawer. From https://api.flutter.dev/flutter/material/BottomNavigationBar-class.html

I've also added a short explanation and an alert note that recommends the reader to check the navigation cookbook recipes for more information on how to implement navigation.

I hosted a working example here: https://mb-flutter-dev-1.web.app/cookbook/design/drawer

Video recording:

https://github.com/flutter/website/assets/2494376/48e4cc68-0b2d-4551-8414-2923684bc317

_Issues fixed by this PR (if any):_

- Fixes #1518

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
