### PR TITLE
Extend local caching to more file types

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -518,9 +518,9 @@
         ]
       },
       {
-        "source": "**/*.@(jpg|jpeg|gif|png|md)",
+        "source": "**/*.@(jpg|jpeg|gif|png|webp|webm|svg|md|json|css|js)",
         "headers": [
-          { "key": "Cache-Control", "value": "max-age=3600" },
+          { "key": "Cache-Control", "value": "max-age=86400" },
           { "key": "Access-Control-Allow-Origin", "value": "*" }
         ]
       }

--- a/firebase.json
+++ b/firebase.json
@@ -520,7 +520,7 @@
       {
         "source": "**/*.@(jpg|jpeg|gif|png|webp|webm|svg|md|json|css|js)",
         "headers": [
-          { "key": "Cache-Control", "value": "max-age=86400" },
+          { "key": "Cache-Control", "value": "max-age=3600" },
           { "key": "Access-Control-Allow-Origin", "value": "*" }
         ]
       }

--- a/firebase.json
+++ b/firebase.json
@@ -518,7 +518,7 @@
         ]
       },
       {
-        "source": "**/*.@(jpg|jpeg|gif|png|webp|webm|svg|md|json|css|js)",
+        "source": "**/*.@(jpg|jpeg|gif|png|webp|webm|svg|md|css|js)",
         "headers": [
           { "key": "Cache-Control", "value": "max-age=3600" },
           { "key": "Access-Control-Allow-Origin", "value": "*" }


### PR DESCRIPTION
This expands local caching to also cache `webp` images, `webm` videos, `svg` images, as well as `css` and `js` files. We append cache busts to our styles and scripts on build, so those won't get out of date.