### PR TITLE
Switch monospace font to 'Google Sans Mono'

### DIFF
--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -57,7 +57,7 @@
     {% unless page.strip_fonts == true -%}
     <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Mono:wght@400;500;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap" rel="stylesheet">
     <script
       src="https://use.fontawesome.com/releases/v5.15.4/js/all.js"

--- a/src/_sass/base/_variables.scss
+++ b/src/_sass/base/_variables.scss
@@ -20,8 +20,7 @@ $twitter-color: #60CAF6;
 $site-font-family-base: 'Roboto', sans-serif;
 $site-font-family-alt: 'Google Sans', 'Roboto', sans-serif;
 $site-font-family-icon: 'Material Icons';
-$site-font-family-monospace: 'Roboto Mono', monospace;
-$site-font-family-courier: 'Courier', monospace;
+$site-font-family-monospace: 'Google Sans Mono', 'Roboto Mono', monospace;
 $site-font-icon: 24px/1 $site-font-family-icon;
 
 // Layout

--- a/src/_sass/pages/_clock.scss
+++ b/src/_sass/pages/_clock.scss
@@ -667,7 +667,7 @@
 
     .code-font {
       color: $color-code-block;
-      font-family: $site-font-family-courier;
+      font-family: $site-font-family-monospace;
     }
 
     @include media-breakpoint-up(sm) {
@@ -785,7 +785,7 @@
 
   .code-font {
     color: $color-code-block;
-    font-family: $site-font-family-courier;
+    font-family: $site-font-family-monospace;
   }
 
   .dropdown__button[aria-expanded="true"] {


### PR DESCRIPTION
Also makes monospace fonts consistently use it as the only monospace font.

Closes https://github.com/flutter/website/issues/8981

Contributes to aligning with Flutter branding guidelines