### PR TITLE
Switch body text font to 'Google Sans Text'

### DIFF
--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -56,7 +56,7 @@
 
     {% unless page.strip_fonts == true -%}
     <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Text:wght@400;500;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Mono:wght@400;500;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap" rel="stylesheet">
     <script

--- a/src/_sass/base/_variables.scss
+++ b/src/_sass/base/_variables.scss
@@ -17,8 +17,8 @@ $site-color-primary: $flutter-color-blue-500;
 $twitter-color: #60CAF6;
 
 // Fonts
-$site-font-family-base: 'Roboto', sans-serif;
-$site-font-family-alt: 'Google Sans', 'Roboto', sans-serif;
+$site-font-family-base: 'Google Sans Text', 'Roboto', sans-serif;
+$site-font-family-alt: 'Google Sans', 'Google Sans Text', 'Roboto', sans-serif;
 $site-font-family-icon: 'Material Icons';
 $site-font-family-monospace: 'Google Sans Mono', 'Roboto Mono', monospace;
 $site-font-icon: 24px/1 $site-font-family-icon;

--- a/src/_sass/pages/_clock.scss
+++ b/src/_sass/pages/_clock.scss
@@ -661,7 +661,7 @@
     .title {
       font-family: $site-font-family-base;
       font-size: 14px;
-      font-weight: 600;
+      font-weight: 500;
       margin: 40px 0 16px;
     }
 


### PR DESCRIPTION
Updates body text font to 'Google Sans Text' to match Flutter's brand guidelines.

Fixes https://github.com/flutter/website/issues/8982