### PR TITLE
Fix footer being above opened sidenav menu

### DIFF
--- a/src/_sass/base/_variables.scss
+++ b/src/_sass/base/_variables.scss
@@ -32,15 +32,3 @@ $site-sidebar-top-padding: 24px;
 $site-sidebar-side-padding: 16px;
 $site-nav-mobile-side-padding: 20px;
 $site-snackbar-padding: 20px;
-
-// Layer stack
-$site-z-header: 100;
-$site-z-footer: 99;
-$site-z-snackbar: 150;
-$hero-layer-1-z: 40;
-$hero-layer-2-z: 41;
-$hero-layer-3-z: 42;
-$hero-layer-4-z: 43;
-$hero-layer-5-z: 44;
-$hero-phone-z: 50;
-$hero-text-z: 60;

--- a/src/_sass/components/_banner.scss
+++ b/src/_sass/components/_banner.scss
@@ -6,7 +6,7 @@
   padding: bs-spacer(5);
   position: relative;
   text-align: center;
-  z-index: 50;
+  z-index: $zindex-sticky;
 
   p {
     margin-bottom: bs-spacer(3);

--- a/src/_sass/components/_header.scss
+++ b/src/_sass/components/_header.scss
@@ -4,7 +4,7 @@
   font-family: $site-font-family-alt;
   position: sticky;
   top: 0;
-  z-index: $site-z-header;
+  z-index: $zindex-fixed;
 
   .navbar {
     font-size: $font-size-lg;
@@ -66,7 +66,7 @@
     right: 0;
     top: 0;
     transition-duration: 0s;
-    z-index: $site-z-header;
+    z-index: $zindex-fixed;
 
     @include media-breakpoint-down(sm) {
       pointer-events: none;
@@ -90,6 +90,7 @@
       .navbar-nav {
         margin-bottom: bs-spacer(5);
         overflow-y: auto;
+        overscroll-behavior: contain;
       }
     }
 
@@ -100,6 +101,7 @@
 
   &__sheet {
     display: flex;
+    z-index: $zindex-modal;
 
     @include media-breakpoint-down(sm) {
       background: $site-color-white;
@@ -125,6 +127,7 @@
 
   &__sheet-bg {
     cursor: pointer; // needed for iOS to recognize the div as clickable
+    z-index: $zindex-modal-backdrop;
 
     @include media-breakpoint-down(sm) {
       background: rgba(0, 0, 0, .4);
@@ -178,10 +181,10 @@
     font-size: $font-size-sm;
     padding-left: bs-spacer(8);
 
-    @include media-breakpoint-down(sm) {
+    @include media-breakpoint-down(md) {
       font-size: $font-size-lg;
       height: 66px;
-      width: 100%;
+      width: 100% !important;
     }
 
     @include media-breakpoint-up(md) {

--- a/src/_sass/components/_snackbar.scss
+++ b/src/_sass/components/_snackbar.scss
@@ -6,7 +6,7 @@
   left: $site-snackbar-padding;
   position: fixed;
   right: $site-snackbar-padding;
-  z-index: $site-z-snackbar;
+  z-index: $zindex-popover;
 
   &__container {
     align-items: center;


### PR DESCRIPTION
Also makes some other related fixes and cleanup. Overall completes:

**1. Primary:** Fix footer being above opened sidenav menu
2. Don't scroll the behind page when done scrolling the open sidenav menu
3. Standardize z-index usages to bootstrap defined variables to avoid incompatibilities
4. Removes previously and newly unused z-index variables
5. Fixes the width style specifier for the search bar in the opened sidenav menu

Fixes https://github.com/flutter/website/issues/8900