### PR TITLE
Eliminate y-axis overscroll on overall page

### DIFF
--- a/src/_sass/base/_base.scss
+++ b/src/_sass/base/_base.scss
@@ -1,7 +1,12 @@
+html {
+  overscroll-behavior-y: none;
+}
+
 body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   overflow-x: hidden;
+  overscroll-behavior-y: none;
 }
 
 .container main {


### PR DESCRIPTION
I needed to disable the behavior on both `html` and `body` to get it to work consistently across browsers.

Tested on:

macOS:
- Chrome
- Safari
- Firefox

TODO: Windows:
- TODO: Chrome
- TODO: Edge