### PR TITLE
Bump supported Android version to 33

### DIFF
--- a/src/reference/supported-platforms.md
+++ b/src/reference/supported-platforms.md
@@ -39,7 +39,7 @@ following table:
 <div class="table-wrapper" markdown="1">
 |Platform version|Supported|Best effort|Unsupported|
 |----------------|---------|-----------|-----------|
-| Android SDK    |21-31|19-20|18-|
+| Android SDK    |21-33|19-20|18-|
 | iOS            |16|11-15|10-, arm7v 32-bit|
 | Linux Debian   |10-11|9-|any 32-bit|
 | Linux Ubuntu   |18.04 LTS|20.04-22.04|any 32-bit|


### PR DESCRIPTION
Bumps the supported Android version from 31 to 33 since we support 32 & 33 now 🥳 

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
