### PR TITLE
Adding link to home screen widget codelab

### DIFF
--- a/src/platform-integration/ios/app-extensions.md
+++ b/src/platform-integration/ios/app-extensions.md
@@ -213,6 +213,4 @@ Flutter iOS app, check out the
 [read and write files]: {{site.url}}/cookbook/persistence/reading-writing-files
 [example from the community on GitHub]: {{site.github}}/flutter/engine/pull/39941
 [Deep Linking]:{{site.url}}/ui/navigation/deep-linking
-
-<!--  TO DO: add links when published -->
-[Adding Home Screen Widgets to your Flutter app]: {{site.codelabs}}/?product=flutter
+[Adding Home Screen Widgets to your Flutter app]: {{site.codelabs}}/flutter-home-screen-widgets#0


### PR DESCRIPTION
_Issues fixed by this PR (if any):_ https://github.com/flutter/website/issues/9043

## Presubmit checklist

- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
