### PR TITLE
Add DartPad to Chat Bubbles cookbook recipe

### DIFF
--- a/examples/cookbook/effects/gradient_bubbles/lib/bubble_background.dart
+++ b/examples/cookbook/effects/gradient_bubbles/lib/bubble_background.dart
@@ -1,0 +1,113 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+@immutable
+class BubbleBackground extends StatelessWidget {
+  const BubbleBackground({
+    super.key,
+    required this.colors,
+    this.child,
+  });
+
+  final List<Color> colors;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: BubblePainter(
+        colors: colors,
+        bubbleContext: context,
+        scrollable: ScrollableState(),
+      ),
+      child: child,
+    );
+  }
+}
+
+// #docregion BubblePainter
+class BubblePainter extends CustomPainter {
+  BubblePainter({
+    required ScrollableState scrollable,
+    required BuildContext bubbleContext,
+    required List<Color> colors,
+  })  : _scrollable = scrollable,
+        _bubbleContext = bubbleContext,
+        _colors = colors;
+
+  final ScrollableState _scrollable;
+  final BuildContext _bubbleContext;
+  final List<Color> _colors;
+
+  @override
+  bool shouldRepaint(BubblePainter oldDelegate) {
+    return oldDelegate._scrollable != _scrollable ||
+        oldDelegate._bubbleContext != _bubbleContext ||
+        oldDelegate._colors != _colors;
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final scrollableBox = _scrollable.context.findRenderObject() as RenderBox;
+    final scrollableRect = Offset.zero & scrollableBox.size;
+    final bubbleBox = _bubbleContext.findRenderObject() as RenderBox;
+
+    final origin =
+        bubbleBox.localToGlobal(Offset.zero, ancestor: scrollableBox);
+    final paint = Paint()
+      ..shader = ui.Gradient.linear(
+        scrollableRect.topCenter,
+        scrollableRect.bottomCenter,
+        _colors,
+        [0.0, 1.0],
+        TileMode.clamp,
+        Matrix4.translationValues(-origin.dx, -origin.dy, 0.0).storage,
+      );
+    canvas.drawRect(Offset.zero & size, paint);
+  }
+}
+// #enddocregion BubblePainter
+
+class Message {
+  Message();
+
+  bool isMine = true;
+  String text = 'The quick brown fox jumps over the lazy dog';
+  String from = 'Flutter Dev';
+}
+
+class MyChat extends StatefulWidget {
+  const MyChat({super.key});
+
+  @override
+  State<MyChat> createState() => _MyChatState();
+}
+
+class _MyChatState extends State<MyChat> {
+  Message message = Message();
+
+  @override
+  Widget build(BuildContext context) {
+    // #docregion BubbleBackground
+    return BubbleBackground(
+      // The colors of the gradient, which are different
+      // depending on which user sent this message.
+      colors: message.isMine
+          ? const [Color(0xFF6C7689), Color(0xFF3A364B)]
+          : const [Color(0xFF19B7FF), Color(0xFF491CCB)],
+      // The content within the bubble.
+      child: DefaultTextStyle.merge(
+        style: const TextStyle(
+          fontSize: 18.0,
+          color: Colors.white,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Text(message.text),
+        ),
+      ),
+    );
+    // #enddocregion BubbleBackground
+  }
+}

--- a/examples/cookbook/effects/gradient_bubbles/lib/main.dart
+++ b/examples/cookbook/effects/gradient_bubbles/lib/main.dart
@@ -1,6 +1,132 @@
+// Copyright 2020, the Flutter project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:math';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const App(
+    home: ExampleGradientBubbles(),
+  ));
+}
+
+@immutable
+class App extends StatelessWidget {
+  const App({super.key, this.home});
+
+  final Widget? home;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      title: 'Flutter Chat',
+      theme: ThemeData.dark(useMaterial3: true),
+      home: home,
+    );
+  }
+}
+
+@immutable
+class ExampleGradientBubbles extends StatefulWidget {
+  const ExampleGradientBubbles({super.key});
+
+  @override
+  State<ExampleGradientBubbles> createState() => _ExampleGradientBubblesState();
+}
+
+class _ExampleGradientBubblesState extends State<ExampleGradientBubbles> {
+  late final List<Message> data;
+
+  @override
+  void initState() {
+    super.initState();
+    data = MessageGenerator.generate(60, 1337);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Theme(
+      data: ThemeData(
+        brightness: Brightness.dark,
+        primaryColor: const Color(0xFF4F4F4F),
+      ),
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Flutter Chat'),
+        ),
+        body: ListView.builder(
+          padding: const EdgeInsets.symmetric(vertical: 16.0),
+          reverse: true,
+          itemCount: data.length,
+          itemBuilder: (context, index) {
+            final message = data[index];
+            return MessageBubble(
+              message: message,
+              child: Text(message.text),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+@immutable
+class MessageBubble extends StatelessWidget {
+  const MessageBubble({
+    super.key,
+    required this.message,
+    required this.child,
+  });
+
+  final Message message;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final messageAlignment =
+        message.isMine ? Alignment.topLeft : Alignment.topRight;
+
+    return FractionallySizedBox(
+      alignment: messageAlignment,
+      widthFactor: 0.8,
+      child: Align(
+        alignment: messageAlignment,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 6.0, horizontal: 20.0),
+          child: ClipRRect(
+            borderRadius: const BorderRadius.all(Radius.circular(16.0)),
+            child: BubbleBackground(
+              colors: [
+                if (message.isMine) ...const [
+                  Color(0xFF6C7689),
+                  Color(0xFF3A364B),
+                ] else ...const [
+                  Color(0xFF19B7FF),
+                  Color(0xFF491CCB),
+                ],
+              ],
+              child: DefaultTextStyle.merge(
+                style: const TextStyle(
+                  fontSize: 18.0,
+                  color: Colors.white,
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(12.0),
+                  child: child,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
 
 @immutable
 class BubbleBackground extends StatelessWidget {
@@ -17,16 +143,15 @@ class BubbleBackground extends StatelessWidget {
   Widget build(BuildContext context) {
     return CustomPaint(
       painter: BubblePainter(
-        colors: colors,
+        scrollable: Scrollable.of(context),
         bubbleContext: context,
-        scrollable: ScrollableState(),
+        colors: colors,
       ),
       child: child,
     );
   }
 }
 
-// #docregion BubblePainter
 class BubblePainter extends CustomPainter {
   BubblePainter({
     required ScrollableState scrollable,
@@ -34,18 +159,12 @@ class BubblePainter extends CustomPainter {
     required List<Color> colors,
   })  : _scrollable = scrollable,
         _bubbleContext = bubbleContext,
-        _colors = colors;
+        _colors = colors,
+        super(repaint: scrollable.position);
 
   final ScrollableState _scrollable;
   final BuildContext _bubbleContext;
   final List<Color> _colors;
-
-  @override
-  bool shouldRepaint(BubblePainter oldDelegate) {
-    return oldDelegate._scrollable != _scrollable ||
-        oldDelegate._bubbleContext != _bubbleContext ||
-        oldDelegate._colors != _colors;
-  }
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -66,48 +185,68 @@ class BubblePainter extends CustomPainter {
       );
     canvas.drawRect(Offset.zero & size, paint);
   }
-}
-// #enddocregion BubblePainter
-
-class Message {
-  Message();
-
-  bool isMine = true;
-  String text = 'The quick brown fox jumps over the lazy dog';
-  String from = 'Flutter Dev';
-}
-
-class MyChat extends StatefulWidget {
-  const MyChat({super.key});
 
   @override
-  State<MyChat> createState() => _MyChatState();
-}
-
-class _MyChatState extends State<MyChat> {
-  Message message = Message();
-
-  @override
-  Widget build(BuildContext context) {
-    // #docregion BubbleBackground
-    return BubbleBackground(
-      // The colors of the gradient, which are different
-      // depending on which user sent this message.
-      colors: message.isMine
-          ? const [Color(0xFF6C7689), Color(0xFF3A364B)]
-          : const [Color(0xFF19B7FF), Color(0xFF491CCB)],
-      // The content within the bubble.
-      child: DefaultTextStyle.merge(
-        style: const TextStyle(
-          fontSize: 18.0,
-          color: Colors.white,
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(12),
-          child: Text(message.text),
-        ),
-      ),
-    );
-    // #enddocregion BubbleBackground
+  bool shouldRepaint(BubblePainter oldDelegate) {
+    return oldDelegate._scrollable != _scrollable ||
+        oldDelegate._bubbleContext != _bubbleContext ||
+        oldDelegate._colors != _colors;
   }
+}
+
+enum MessageOwner { myself, other }
+
+@immutable
+class Message {
+  const Message({
+    required this.owner,
+    required this.text,
+  });
+
+  final MessageOwner owner;
+  final String text;
+
+  bool get isMine => owner == MessageOwner.myself;
+}
+
+class MessageGenerator {
+  static List<Message> generate(int count, [int? seed]) {
+    final random = Random(seed);
+    return List.unmodifiable(List<Message>.generate(count, (index) {
+      return Message(
+        owner: random.nextBool() ? MessageOwner.myself : MessageOwner.other,
+        text: _exampleData[random.nextInt(_exampleData.length)],
+      );
+    }));
+  }
+
+  static final _exampleData = [
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    'In tempus mauris at velit egestas, sed blandit felis ultrices.',
+    'Ut molestie mauris et ligula finibus iaculis.',
+    'Sed a tempor ligula.',
+    'Test',
+    'Phasellus ullamcorper, mi ut imperdiet consequat, nibh augue condimentum nunc, vitae molestie massa augue nec erat.',
+    'Donec scelerisque, erat vel placerat facilisis, eros turpis egestas nulla, a sodales elit nibh et enim.',
+    'Mauris quis dignissim neque. In a odio leo. Aliquam egestas egestas tempor. Etiam at tortor metus.',
+    'Quisque lacinia imperdiet faucibus.',
+    'Proin egestas arcu non nisl laoreet, vitae iaculis enim volutpat. In vehicula convallis magna.',
+    'Phasellus at diam a sapien laoreet gravida.',
+    'Fusce maximus fermentum sem a scelerisque.',
+    'Nam convallis sapien augue, malesuada aliquam dui bibendum nec.',
+    'Quisque dictum tincidunt ex non lobortis.',
+    'In hac habitasse platea dictumst.',
+    'Ut pharetra ligula libero, sit amet imperdiet lorem luctus sit amet.',
+    'Sed ex lorem, lacinia et varius vitae, sagittis eget libero.',
+    'Vestibulum scelerisque velit sed augue ultricies, ut vestibulum lorem luctus.',
+    'Pellentesque et risus pretium, egestas ipsum at, facilisis lectus.',
+    'Praesent id eleifend lacus.',
+    'Fusce convallis eu tortor sit amet mattis.',
+    'Vivamus lacinia magna ut urna feugiat tincidunt.',
+    'Sed in diam ut dolor imperdiet vehicula non ac turpis.',
+    'Praesent at est hendrerit, laoreet tortor sed, varius mi.',
+    'Nunc in odio leo.',
+    'Praesent placerat semper libero, ut aliquet dolor.',
+    'Vestibulum elementum leo metus, vitae auctor lorem tincidunt ut.',
+  ];
 }

--- a/examples/cookbook/effects/gradient_bubbles/lib/main.dart
+++ b/examples/cookbook/effects/gradient_bubbles/lib/main.dart
@@ -1,16 +1,10 @@
-// Copyright 2020, the Flutter project authors. Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
-
 import 'dart:math';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(const App(
-    home: ExampleGradientBubbles(),
-  ));
+  runApp(const App(home: ExampleGradientBubbles()));
 }
 
 @immutable

--- a/src/cookbook/effects/gradient-bubbles.md
+++ b/src/cookbook/effects/gradient-bubbles.md
@@ -243,15 +243,6 @@ class BubblePainter extends CustomPainter {
 Congratulations! You now have a modern, chat bubble UI.
 
 {{site.alert.note}}
-  The recipe doesn’t yet work on the web because
-  Flutter doesn’t yet support `Paint` shaders.
-  {% comment %}
-    For more information, see [Issue xxx][].
-    [I can't find the issue on GitHub, I've asked the web team]
-  {% endcomment %}
-{{site.alert.end}}
-
-{{site.alert.note}}
   Each bubble’s gradient changes as the user
   scrolls because the `BubbleBackground` widget
   invokes `Scrollable.of(context)`. This method 
@@ -261,6 +252,265 @@ Congratulations! You now have a modern, chat bubble UI.
   up or down. See the [`InheritedWidget`][] documentation
   for more information about these types of dependencies.
 {{site.alert.end}}
+
+## Interactive example
+
+Run the app:
+
+* Scroll up and down to observe the gradient effect.
+* Chat bubbles located at the bottom of the screen
+have a darker gradient color than the ones at the top.
+
+<!-- start dartpad -->
+<?code-excerpt "lib/main.dart"?>
+```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+import 'dart:math';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const App(home: ExampleGradientBubbles()));
+}
+
+@immutable
+class App extends StatelessWidget {
+  const App({super.key, this.home});
+
+  final Widget? home;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      title: 'Flutter Chat',
+      theme: ThemeData.dark(useMaterial3: true),
+      home: home,
+    );
+  }
+}
+
+@immutable
+class ExampleGradientBubbles extends StatefulWidget {
+  const ExampleGradientBubbles({super.key});
+
+  @override
+  State<ExampleGradientBubbles> createState() => _ExampleGradientBubblesState();
+}
+
+class _ExampleGradientBubblesState extends State<ExampleGradientBubbles> {
+  late final List<Message> data;
+
+  @override
+  void initState() {
+    super.initState();
+    data = MessageGenerator.generate(60, 1337);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Theme(
+      data: ThemeData(
+        brightness: Brightness.dark,
+        primaryColor: const Color(0xFF4F4F4F),
+      ),
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Flutter Chat'),
+        ),
+        body: ListView.builder(
+          padding: const EdgeInsets.symmetric(vertical: 16.0),
+          reverse: true,
+          itemCount: data.length,
+          itemBuilder: (context, index) {
+            final message = data[index];
+            return MessageBubble(
+              message: message,
+              child: Text(message.text),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+@immutable
+class MessageBubble extends StatelessWidget {
+  const MessageBubble({
+    super.key,
+    required this.message,
+    required this.child,
+  });
+
+  final Message message;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final messageAlignment =
+        message.isMine ? Alignment.topLeft : Alignment.topRight;
+
+    return FractionallySizedBox(
+      alignment: messageAlignment,
+      widthFactor: 0.8,
+      child: Align(
+        alignment: messageAlignment,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 6.0, horizontal: 20.0),
+          child: ClipRRect(
+            borderRadius: const BorderRadius.all(Radius.circular(16.0)),
+            child: BubbleBackground(
+              colors: [
+                if (message.isMine) ...const [
+                  Color(0xFF6C7689),
+                  Color(0xFF3A364B),
+                ] else ...const [
+                  Color(0xFF19B7FF),
+                  Color(0xFF491CCB),
+                ],
+              ],
+              child: DefaultTextStyle.merge(
+                style: const TextStyle(
+                  fontSize: 18.0,
+                  color: Colors.white,
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(12.0),
+                  child: child,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+@immutable
+class BubbleBackground extends StatelessWidget {
+  const BubbleBackground({
+    super.key,
+    required this.colors,
+    this.child,
+  });
+
+  final List<Color> colors;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: BubblePainter(
+        scrollable: Scrollable.of(context),
+        bubbleContext: context,
+        colors: colors,
+      ),
+      child: child,
+    );
+  }
+}
+
+class BubblePainter extends CustomPainter {
+  BubblePainter({
+    required ScrollableState scrollable,
+    required BuildContext bubbleContext,
+    required List<Color> colors,
+  })  : _scrollable = scrollable,
+        _bubbleContext = bubbleContext,
+        _colors = colors,
+        super(repaint: scrollable.position);
+
+  final ScrollableState _scrollable;
+  final BuildContext _bubbleContext;
+  final List<Color> _colors;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final scrollableBox = _scrollable.context.findRenderObject() as RenderBox;
+    final scrollableRect = Offset.zero & scrollableBox.size;
+    final bubbleBox = _bubbleContext.findRenderObject() as RenderBox;
+
+    final origin =
+        bubbleBox.localToGlobal(Offset.zero, ancestor: scrollableBox);
+    final paint = Paint()
+      ..shader = ui.Gradient.linear(
+        scrollableRect.topCenter,
+        scrollableRect.bottomCenter,
+        _colors,
+        [0.0, 1.0],
+        TileMode.clamp,
+        Matrix4.translationValues(-origin.dx, -origin.dy, 0.0).storage,
+      );
+    canvas.drawRect(Offset.zero & size, paint);
+  }
+
+  @override
+  bool shouldRepaint(BubblePainter oldDelegate) {
+    return oldDelegate._scrollable != _scrollable ||
+        oldDelegate._bubbleContext != _bubbleContext ||
+        oldDelegate._colors != _colors;
+  }
+}
+
+enum MessageOwner { myself, other }
+
+@immutable
+class Message {
+  const Message({
+    required this.owner,
+    required this.text,
+  });
+
+  final MessageOwner owner;
+  final String text;
+
+  bool get isMine => owner == MessageOwner.myself;
+}
+
+class MessageGenerator {
+  static List<Message> generate(int count, [int? seed]) {
+    final random = Random(seed);
+    return List.unmodifiable(List<Message>.generate(count, (index) {
+      return Message(
+        owner: random.nextBool() ? MessageOwner.myself : MessageOwner.other,
+        text: _exampleData[random.nextInt(_exampleData.length)],
+      );
+    }));
+  }
+
+  static final _exampleData = [
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    'In tempus mauris at velit egestas, sed blandit felis ultrices.',
+    'Ut molestie mauris et ligula finibus iaculis.',
+    'Sed a tempor ligula.',
+    'Test',
+    'Phasellus ullamcorper, mi ut imperdiet consequat, nibh augue condimentum nunc, vitae molestie massa augue nec erat.',
+    'Donec scelerisque, erat vel placerat facilisis, eros turpis egestas nulla, a sodales elit nibh et enim.',
+    'Mauris quis dignissim neque. In a odio leo. Aliquam egestas egestas tempor. Etiam at tortor metus.',
+    'Quisque lacinia imperdiet faucibus.',
+    'Proin egestas arcu non nisl laoreet, vitae iaculis enim volutpat. In vehicula convallis magna.',
+    'Phasellus at diam a sapien laoreet gravida.',
+    'Fusce maximus fermentum sem a scelerisque.',
+    'Nam convallis sapien augue, malesuada aliquam dui bibendum nec.',
+    'Quisque dictum tincidunt ex non lobortis.',
+    'In hac habitasse platea dictumst.',
+    'Ut pharetra ligula libero, sit amet imperdiet lorem luctus sit amet.',
+    'Sed ex lorem, lacinia et varius vitae, sagittis eget libero.',
+    'Vestibulum scelerisque velit sed augue ultricies, ut vestibulum lorem luctus.',
+    'Pellentesque et risus pretium, egestas ipsum at, facilisis lectus.',
+    'Praesent id eleifend lacus.',
+    'Fusce convallis eu tortor sit amet mattis.',
+    'Vivamus lacinia magna ut urna feugiat tincidunt.',
+    'Sed in diam ut dolor imperdiet vehicula non ac turpis.',
+    'Praesent at est hendrerit, laoreet tortor sed, varius mi.',
+    'Nunc in odio leo.',
+    'Praesent placerat semper libero, ut aliquet dolor.',
+    'Vestibulum elementum leo metus, vitae auctor lorem tincidunt ut.',
+  ];
+}
+```
 
 ## Recap
 
@@ -275,19 +525,9 @@ then you can base your painting decisions on the layout
 information, such as the position of the `CustomPaint`
 widget within a `Scrollable` or within the screen.
 
-{{site.alert.note}}
-  This recipe doesn't provide an interactive DartPad because
-  `Paint` shaders have not yet been implemented for the web.
-  You can run this recipe on a mobile or desktop device by
-  [cloning the example code][]. See the "Gradient Bubbles"
-  example under the “cookbook” directory.
-{{site.alert.end}}
-
-
 [cloning the example code]: {{site.github}}/flutter/codelabs
 [`CustomPainter`]: {{site.api}}/flutter/rendering/CustomPainter-class.html
 [`Flow`]: {{site.api}}/flutter/widgets/Flow-class.html
 [`InheritedWidget`]: {{site.api}}/flutter/widgets/InheritedWidget-class.html
 [Issue 44152]: {{site.repo.flutter}}/issues/44152
 [`RenderBox`]: {{site.api}}/flutter/rendering/RenderBox-class.html
-

--- a/src/cookbook/effects/gradient-bubbles.md
+++ b/src/cookbook/effects/gradient-bubbles.md
@@ -67,7 +67,7 @@ background with a new stateless widget called
 represent the full-screen gradient that should be
 applied to the bubble.
 
-<?code-excerpt "lib/main.dart (BubbleBackground)" replace="/return //g"?>
+<?code-excerpt "lib/bubble_background.dart (BubbleBackground)" replace="/return //g"?>
 ```dart
 BubbleBackground(
   // The colors of the gradient, which are different
@@ -196,7 +196,7 @@ of the bubble, configure a shader with the given colors,
 and then use a matrix translation to offset the shader
 based on the bubble’s position within the `Scrollable`.
 
-<?code-excerpt "lib/main.dart (BubblePainter)"?>
+<?code-excerpt "lib/bubble_background.dart (BubblePainter)"?>
 ```dart
 class BubblePainter extends CustomPainter {
   BubblePainter({


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

- Adds the interactive example to the Bubble gradient chat example as defined in #8971
- Old `main.dart` file was renamed to `bubble_background.dart`.
- Copied the `main.dart` from the codelabs repo into the website example.
- Load the `main.dart` as a DartPad.
- Update the documentation, removed outdated text.

_Issues fixed by this PR (if any):_

- Fix #8971

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
