### PR TITLE
Update macOS install for security settings change

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -15,6 +15,8 @@ $(function () {
   setupTabs($('#editor-setup'), 'io.flutter.tool-id');
   setupTabs($('.sample-code-tabs'), 'io.flutter.tool-id');
 
+  setupTabs($('#ios-versions'), 'dev.flutter.ios-versions');
+
   prettyPrint();
 });
 

--- a/src/get-started/install/_ios-setup.md
+++ b/src/get-started/install/_ios-setup.md
@@ -87,25 +87,26 @@ you need to do the following:
 
 - Create an [Apple Developer][] account.
 - Set up physical device deployment in Xcode.
-- Provision your Flutter app.
+- Create a development provisioning profile to self-sign certificates.
 - Install the third-party CocoaPods dependency manager
   if your app uses Flutter plugins.
 
 #### Create your Apple ID and Apple Developer account
 
-To test deploy to a physical iOS device, you need an Apple ID.
+To test deploying to a physical iOS device, you need an Apple ID.
 
 To distribute your app to the App Store,
 you must enroll in the Apple Developer Program.
 
-If you only need to test your app, complete the first step and move on
-to the next section.
+If you only need to test deploying your app,
+complete the first step and move on to the next section.
 
 1. If you don't have an [Apple ID][], create one.
 
 1. If you haven't enrolled in the [Apple Developer][] program, enroll now.
 
-   To learn more about membership types, see [Choosing a Membership][].
+   To learn more about membership types,
+   check out [Choosing a Membership][].
 
 [Apple ID]: https://support.apple.com/en-us/HT204316
 
@@ -116,7 +117,7 @@ Configure your physical iOS device to connect to Xcode.
 1. Attach your iOS device to the USB port on your Mac.
 
 1. On first connecting your iOS device to your Mac,
-   your iOS device displays the **Trust this computer?** modal.
+   your iOS device displays the **Trust this computer?** dialog.
 
 1. Click **Trust**.
 
@@ -127,7 +128,8 @@ Configure your physical iOS device to connect to Xcode.
 To deploy to a physical iOS device, you need to establish trust with your
 Mac and the iOS device.
 This requires you to load signed developer certificates to your iOS device.
-To sign an app in Xcode, you need to create a development provisioning profile.
+To sign an app in Xcode,
+you need to create a development provisioning profile.
 
 Follow the Xcode signing flow to provision your project.
 

--- a/src/get-started/install/_ios-setup.md
+++ b/src/get-started/install/_ios-setup.md
@@ -7,127 +7,296 @@ To develop Flutter apps for iOS, you need a Mac with Xcode installed.
  1. Install the latest stable version of Xcode
     (using [web download][] or the [Mac App Store][]).
 
- 1. Configure the Xcode command-line tools to use the
-    newly-installed version of Xcode by
-    running the following from the command line:
+ 1. To configure the Xcode command-line tools to use the
+    installed version, run the following commands.
 
     ```terminal
-    $ sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+    $ sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
     $ sudo xcodebuild -runFirstLaunch
     ```
 
-    This is the correct path for most cases,
-    when you want to use the latest version of Xcode.
-    If you need to use a different version,
-    specify that path instead.
+    To use the latest version of Xcode, use this path.
+    If you need to use a different version, specify that path instead.
 
- 1. Make sure the Xcode license agreement is signed by
-    either opening Xcode once and confirming or running
-    `sudo xcodebuild --license` from the command line.
+ 1. Sign the Xcode license agreement.
+    To sign the SLA, either open Xcode once and confirm or run:
+
+    ```terminal
+    $ sudo xcodebuild --license
+    ```
 
 Versions older than the latest stable version might still work,
 but are not recommended for Flutter development.
 
-With Xcode, you’ll be able to run Flutter apps on
-an iOS device or on the simulator.
+With Xcode, you can run Flutter apps on an iOS device or on the simulator.
 
 ### Set up the iOS simulator
 
 To prepare to run and test your Flutter app on the iOS simulator,
-follow these steps:
+follow this procedure.
 
- 1. On your Mac, find the Simulator via Spotlight or
-    by using the following command:
+ 1. To start the Simulator, run the following command:
 
     ```terminal
     $ open -a Simulator
     ```
 
- 2. Make sure your simulator is using a 64-bit device
-    (iPhone 5s or later).  You can check the device by viewing the settings in
-    the simulator's **Hardware > Device** or **File > Open Simulator** menus.
+ 2. Set your Simulator to use a 64-bit device (iPhone 5s or later).
 
- 3. Depending on your development machine's screen size,
-    simulated high-screen-density iOS devices
-    might overflow your screen. Grab the corner of the
-    simulator and drag it to change the scale. You can also
-    use the **Window > Physical Size** or **Window > Pixel Accurate**
-    options if your computer's resolution is high enough.
+    - From Xcode, choose a simulator device type. Go to
+      **Product** <span aria-label="and then">></span>
+      **Destination** <span aria-label="and then">></span>
+      Choose your target device.
 
-### Deploy to iOS devices
+    - From the Simulator app, go to
+      **File** <span aria-label="and then">></span>
+      **Open Simulator** <span aria-label="and then">></span>
+      Choose your target iOS device
 
-To deploy your Flutter app to a physical iPhone or iPad
-you'll need to set up physical device deployment in Xcode
-and an Apple Developer account. If your app is using Flutter plugins,
-you will also need the third-party CocoaPods dependency manager.
+    - To check the device version in the Simulator,
+      open the **Settings** app <span aria-label="and then">></span>
+      **General** <span aria-label="and then">></span>
+      **About**.
 
-<ol markdown="1">
-<li markdown="1">
-<a name="connect"></a>
-To set up physical device deployment in Xcode,
-connect your device to the USB port on your
-computer.
-</li>
-<li markdown="1">
-<a name="wireless"></a>
-[Optional] To leverage wireless debugging, ensure that
-your device is on the same network as your computer
-and that the device has a set passcode.
+ 3. The simulated high-screen density iOS devices might overflow your screen.
+    If that appears true on your Mac, change the presented size in the
+    Simulator app
 
-While the device is attached, open **Xcode > Window > Devices and Simulators**.
-Select your phone, and check **Connect via Network.**
-For more details, check out
-[Apple's documentation on pairing a wireless device with Xcode][].
+    - To display the Simulator at a small size, go to
+      **Window** <span aria-label="and then">></span>
+      **Physical Size** or<br>press <kbd>Command</kbd> + <kbd>1</kbd>.
 
-Once the network icon appears next to the device name,
-you can unplug your device from USB.
+    - To display the Simulator at a moderate size, go to
+      **Window** <span aria-label="and then">></span>
+      **Point Accurate** or<br>press <kbd>Command</kbd> + <kbd>2</kbd>.
 
-Sometimes it takes longer to find network devices.
+    - To display the Simulator at an HD representation, go to
+      **Window** <span aria-label="and then">></span>
+      **Pixel Accurate** or<br>press <kbd>Command</kbd> + <kbd>3</kbd>.
+      _The Simulator defaults to this size._
+
+    - The Simulator defaults to **Fit Screen**.
+      If you need to return to that size, go to
+      **Window** <span aria-label="and then">></span>
+      **Fit Screen** or press <kbd>Command</kbd> + <kbd>4</kbd>.
+
+### Deploy to physical iOS devices
+
+To deploy your Flutter app to a physical iPhone or iPad,
+you need to do the following:
+
+- Create an [Apple Developer][] account.
+- Set up physical device deployment in Xcode.
+- Provision your Flutter app.
+- Install the third-party CocoaPods dependency manager
+  if your app uses Flutter plugins.
+
+#### Create your Apple ID and Apple Developer account
+
+To test deploy to a physical iOS device, you need an Apple ID.
+
+To distribute your app to the App Store,
+you must enroll in the Apple Developer Program.
+
+If you only need to test your app, complete the first step and move on
+to the next section.
+
+1. If you don't have an [Apple ID][], create one.
+
+1. If you haven't enrolled in the [Apple Developer][] program, enroll now.
+
+   To learn more about membership types, see [Choosing a Membership][].
+
+[Apple ID]: https://support.apple.com/en-us/HT204316
+
+#### Attach your physical iOS device to your Mac {#attach}
+
+Configure your physical iOS device to connect to Xcode.
+
+1. Attach your iOS device to the USB port on your Mac.
+
+1. On first connecting your iOS device to your Mac,
+   your iOS device displays the **Trust this computer?** modal.
+
+1. Click **Trust**.
+
+   ![Trust Mac][]{:.mw-100}
+
+#### Enable developer code signing certificates
+
+To deploy to a physical iOS device, you need to establish trust with your
+Mac and the iOS device.
+This requires you to load signed developer certificates to your iOS device.
+To sign an app in Xcode, you need to create a development provisioning profile.
+
+Follow the Xcode signing flow to provision your project.
+
+1. Open Xcode.
+
+1. Sign in to Xcode with your Apple ID. ![Xcode account add][]{:.mw-100}
+   Development and testing supports any Apple ID.
+
+1. Go to **File** <span aria-label="and then">></span> **Open...**
+
+   You can also press <kbd>Command</kbd> + <kbd>O</kbd>.
+
+1. Navigate to your Flutter project directory.
+
+1. Open the default Xcode workspace in your project: `ios/Runner.xcworkspace`.
+
+1. Select the physical iOS device you intend to deploy to in the device
+   drop-down menu to the right of the run button.
+
+1. In the left navigation panel under **Targets**, select **Runner**.
+
+1. In the **Runner** settings pane, click **Signing & Capabilities**.
+
+1. Select **All** at the top.
+
+1. Select **Automatically manage signing**.
+
+1. Select a team from the **Team** dropdown menu.
+
+   Teams are created in the **App Store Connect** section of your
+   [Apple Developer Account][] page.
+   If you have not created a team, you can choose a _personal team_.
+
+   The **Team** dropdown displays that option as **Your Name (Personal Team)**.
+
+   After you select a team, Xcode performs the following tasks:
+
+   {: type="a"}
+   1. Creates and downloads a Development Certificate
+   1. Registers your device with your account,
+   1. Creates and downloads a provisioning profile if needed
+
+If automatic signing fails in Xcode, verify that the project's
+**General** <span aria-label="and then">></span>
+**Identity** <span aria-label="and then">></span>
+**Bundle Identifier** value is unique.
+
+![Check the app's Bundle ID][]{:.mw-100}
+
+#### Enable trust of your Mac and iOS device {#trust}
+
+When you attach your physical iOS device for the first time,
+enable trust for both your Mac and the Development Certificate
+on the iOS device.
+
+##### Agree to trust your Mac
+
+You should enabled trust of your Mac on your iOS device when
+you [attached the device to your Mac](#attach).
+
+##### Enable developer certificate for your iOS devices
+
+Enabling certificates varies in different versions of iOS.
+
+{% comment %} Nav tabs {% endcomment -%}
+<ul class="nav nav-tabs" id="ios-versions" role="tablist">
+    <li class="nav-item">
+        <a class="nav-link" id="ios14-tab" href="#ios14" role="tab" aria-controls="ios14" aria-selected="true">iOS 14</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" id="ios15-tab" href="#ios15" role="tab" aria-controls="ios15" aria-selected="false">iOS 15</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link active" id="ios16-tab" href="#ios16" role="tab" aria-controls="ios16" aria-selected="false">iOS 16</a>
+    </li>
+</ul>
+
+{% comment %} Tab panes {% endcomment -%}
+<div class="tab-content">
+
+<div class="tab-pane" id="ios14" role="tabpanel" aria-labelledby="ios14-tab" markdown="1">
+
+1. Open the **Settings** app on the iOS device.
+
+1. Go to **General** <span aria-label="and then">></span>
+   **Profiles & Device Management**.
+
+1. Toggle your Certificate to **Enable**
+
+</div>
+
+<div class="tab-pane" id="ios15" role="tabpanel" aria-labelledby="ios15-tab" markdown="1">
+
+1. Open the **Settings** app on the iOS device.
+
+1. Go to **General** <span aria-label="and then">></span>
+    **VPN & Device Management**.
+
+1. Toggle your Certificate to **Enable**.
+
+</div>
+
+<div class="tab-pane active" id="ios16" role="tabpanel" aria-labelledby="ios16-tab" markdown="1">
+
+1. Open the **Settings** app on the iOS device.
+
+1. Go to **Privacy & Security** <span aria-label="and then">></span>
+    **Developer Mode**.
+
+1. Toggle **Developer Mode** to on.
+    iOS displays a prompt to restart your device.
+
+1. Click **Restart**.
+
+1. After your device restarts and you unlock your device,
+    iOS asks if you want to **Turn On Developer Mode?**
+    Click **Turn On**.
+
+1. Go to **General** <span aria-label="and then">></span>
+    **Device Management**.
+
+</div>
+</div>{% comment %} End: Tab panes. {% endcomment -%}
+
+#### Optional deployment procedures
+
+You can skip these procedures. They enable additional debugging features.
+
+##### Set up wireless debugging on your iOS device
+
+Follow this procedure to debug your device using a Wi-Fi connection.
+
+To use wireless debugging:
+
+- Connect your iOS device to the same network as your macOS device.
+- Set a passcode for your iOS device.
+
+After you connect your iOS device to your Mac:
+
+1. Go to
+   **Xcode** <span aria-label="and then">></span>
+   **Window** <span aria-label="and then">></span>
+   **Devices and Simulators**.
+1. Select your iOS device.
+1. Check **Connect via Network**.
+1. Once the network icon appears next to the device name,
+   unplug your iOS device from your Mac.
+
 If you don't see your device listed when using `flutter run`,
-try extending the timeout: `flutter run --device-timeout 10`.
+extend the timeout. The timeout defaults to 10 seconds.
+To extend the timeout, change the value to an integer greater than 10.
 
-For additional help troubleshooting,
-check out [Apple's Developer Forums][]. For setting up
-wireless debugging with `flutter attach`,
-checkout [Debugging your add-to-app module][].
-</li>
-<li markdown="1">
+```terminal
+flutter run --device-timeout 60
+```
 
-<a name="trust"></a>
-The first time you attach a physical device for iOS development,
-you need to trust both your Mac and the Development Certificate
-on that device.
-On iOS 16 and later, you must also enable [Developer Mode][].
+###### Learn more about wireless debugging
 
-Select **Trust** in the dialog prompt when
-first connecting the iOS device to your Mac.
+- To learn more, check out
+  [Apple's documentation on pairing a wireless device with Xcode][].
+- To troubleshoot, check out [Apple's Developer Forums][].
+- To learn how to configure wireless debugging with `flutter attach`,
+  check out [Debugging your add-to-app module][].
 
-![Trust Mac][]{:.mw-100}
-</li>
 
-<li markdown="1">
+##### Install CocoaPods
 
-a. Open the **Settings** app on the iOS device.
-
-b. Go to **General** > **Device Management**.
-
-c. Trust your Certificate.
-
-**First time users:** You might need to go to
-**General** > **Profiles** > **Device Management**.
-
-**iOS 16 and later**
-
-a. Open the **Settings** app
-b. Select **Privacy & Security** > **Developer Mode**,
-c. Toggle **Developer Mode** to on.
-
-</li>
-
-<li markdown="1">
-
-If your apps do not depend on [Flutter plugins][] with native iOS code,
-skip this step.
+Follow this procedure if your apps depend on [Flutter plugins][]
+with native iOS code.
 
 To [Install and set up CocoaPods][], run the following commands:
 
@@ -141,55 +310,11 @@ $ sudo gem install cocoapods
 
   Additionally, if you are installing on an [Apple Silicon Mac][],
   run the command:
+
   ```terminal
   $ sudo gem uninstall ffi && sudo gem install ffi -- --enable-libffi-alloc
   ```
 {{site.alert.end}}
-
-</li>
-
-<li markdown="1">
-
-Follow the Xcode signing flow to provision your project:
-
-   {: type="a"}
-   1. To open the default Xcode workspace in your project,
-      run `open ios/Runner.xcworkspace` in a terminal
-      window from your Flutter project directory.
-   1. Select the device you intend to deploy to in the device
-      drop-down menu next to the run button.
-   1. Select the `Runner` project in the left navigation panel.
-   1. In the `Runner` target settings page,
-      make sure your Development Team is selected
-      under **Signing & Capabilities > Team**.
-
-      When you select a team,
-      Xcode creates and downloads a Development Certificate,
-      registers your device with your account,
-      and creates and downloads a provisioning profile (if needed).
-
-      * To start your first iOS development project,
-        you might need to sign into
-        Xcode with your Apple ID. ![Xcode account add][]{:.mw-100}
-        Development and testing is supported for any Apple ID.
-        Enrolling in the Apple Developer Program is required to
-        distribute your app to the App Store.
-        For details about membership types,
-        see [Choosing a Membership][].
-
-      * If automatic signing fails in Xcode, verify that the project's
-        **General > Identity > Bundle Identifier** value is unique.
-        ![Check the app's Bundle ID][]{:.mw-100}
-
-</li>
-
-<li markdown="1">
-
-Start your app by running `flutter run`
-or clicking the Run button in Xcode.
-
-</li>
-</ol>
 
 [Check the app's Bundle ID]: {{site.url}}/assets/images/docs/setup/xcode-unique-bundle-id.png
 [Choosing a Membership]: {{site.apple-dev}}/support/compare-memberships
@@ -204,3 +329,5 @@ or clicking the Run button in Xcode.
 [Apple's Developer Forums]: {{site.apple-dev}}/forums/
 [Debugging your add-to-app module]: {{site.url}}/add-to-app/debugging/#wireless-debugging
 [Apple's documentation on pairing a wireless device with Xcode]: https://help.apple.com/xcode/mac/9.0/index.html?localePath=en.lproj#/devbc48d1bad
+[Apple Developer]: {{site.apple-dev}}/programs/
+[Apple Developer Account]: {{site.apple-dev}}/account

--- a/src/get-started/install/_ios-setup.md
+++ b/src/get-started/install/_ios-setup.md
@@ -123,6 +123,46 @@ Configure your physical iOS device to connect to Xcode.
 
    ![Trust Mac][]{:.mw-100}
 
+1. When prompted, unlock your iOS device.
+
+#### Enable Developer Mode on iOS 16 or later
+{:.no_toc}
+
+Starting with iOS 16, Apple requires you to enable **[Developer Mode][]**
+to protect against malicious software.
+Enable Developer Mode before deploying to a device running iOS 16 or later.
+
+1. Tap on **Settings** <span aria-label="and then">></span>
+   **Privacy & Security** <span aria-label="and then">></span>
+   **Developer Mode**.
+
+1. Tap to toggle **Developer Mode** to **On**.
+
+1. Tap **Restart**.
+
+1. After the iOS device restarts, unlock your iOS device.
+
+1. When the **Turn on Developer Mode?** dialog appears, tap **Turn On**.
+
+   The dialog explains that Developer Mode requires reducing the security
+   of the iOS device.
+
+1. Unlock your iOS device.
+
+1. Go to **Privacy & Security** <span aria-label="and then">></span>
+    **Developer Mode**.
+
+1. Tap to toggle **Developer Mode** to on.
+   iOS displays a prompt to restart your device.
+
+1. Click **Restart**.
+
+1. After your device restarts and you unlock your device,
+   iOS asks if you want to **Turn On Developer Mode?**
+   Tap **Turn On**.
+
+1. Unlock your iOS device.
+
 #### Enable developer code signing certificates
 
 To deploy to a physical iOS device, you need to establish trust with your
@@ -135,7 +175,17 @@ Follow the Xcode signing flow to provision your project.
 
 1. Open Xcode.
 
-1. Sign in to Xcode with your Apple ID. ![Xcode account add][]{:.mw-100}
+1. Sign in to Xcode with your Apple ID.
+
+   {: type="a"}
+   1. Go to **Xcode** <span aria-label="and then">></span>
+      **Settings...*
+   1. Click **Accounts**.
+   1. Click **+**.
+   1. Select **Apple ID** and click **Continue**.
+   1. When prompted, enter your **Apple ID** and **Password**.
+   1. Close the **Settings** dialog.
+
    Development and testing supports any Apple ID.
 
 1. Go to **File** <span aria-label="and then">></span> **Open...**
@@ -148,6 +198,8 @@ Follow the Xcode signing flow to provision your project.
 
 1. Select the physical iOS device you intend to deploy to in the device
    drop-down menu to the right of the run button.
+
+   It should appear under the **iOS devices** heading.
 
 1. In the left navigation panel under **Targets**, select **Runner**.
 
@@ -164,6 +216,8 @@ Follow the Xcode signing flow to provision your project.
    If you have not created a team, you can choose a _personal team_.
 
    The **Team** dropdown displays that option as **Your Name (Personal Team)**.
+
+   ![Xcode account add][]{:.mw-100}
 
    After you select a team, Xcode performs the following tasks:
 
@@ -214,10 +268,10 @@ Enabling certificates varies in different versions of iOS.
 
 1. Open the **Settings** app on the iOS device.
 
-1. Go to **General** <span aria-label="and then">></span>
+1. Tap on **General** <span aria-label="and then">></span>
    **Profiles & Device Management**.
 
-1. Toggle your Certificate to **Enable**
+1. Tap to toggle your Certificate to **Enable**
 
 </div>
 
@@ -225,10 +279,10 @@ Enabling certificates varies in different versions of iOS.
 
 1. Open the **Settings** app on the iOS device.
 
-1. Go to **General** <span aria-label="and then">></span>
+1. Tap on **General** <span aria-label="and then">></span>
     **VPN & Device Management**.
 
-1. Toggle your Certificate to **Enable**.
+1. Tap to toggle your Certificate to **Enable**.
 
 </div>
 
@@ -236,23 +290,22 @@ Enabling certificates varies in different versions of iOS.
 
 1. Open the **Settings** app on the iOS device.
 
-1. Go to **Privacy & Security** <span aria-label="and then">></span>
-    **Developer Mode**.
+1. Tap on **General** <span aria-label="and then">></span>
+    **VPN and Device Management**.
 
-1. Toggle **Developer Mode** to on.
-    iOS displays a prompt to restart your device.
+1. Under the **Developer App** heading, you should find your certificate.
 
-1. Click **Restart**.
+1. Tap your Certificate.
 
-1. After your device restarts and you unlock your device,
-    iOS asks if you want to **Turn On Developer Mode?**
-    Click **Turn On**.
+1. Tap **Trust "\<certificate\>"**.
 
-1. Go to **General** <span aria-label="and then">></span>
-    **Device Management**.
+1. When the dialog displays, tap **Trust**.
 
 </div>
 </div>{% comment %} End: Tab panes. {% endcomment -%}
+
+If prompted, enter your Mac password into the
+**codesign wants to access key...** dialog and tap **Always Allow**.
 
 #### Optional deployment procedures
 
@@ -269,12 +322,17 @@ To use wireless debugging:
 
 After you connect your iOS device to your Mac:
 
-1. Go to
-   **Xcode** <span aria-label="and then">></span>
-   **Window** <span aria-label="and then">></span>
+1. Open **Xcode**.
+
+1. Go to **Window** <span aria-label="and then">></span>
    **Devices and Simulators**.
+
+   You can also press <kbd>Shift</kbd> + <kbd>Command</kbd> + <kbd>2</kbd>.
+
 1. Select your iOS device.
-1. Check **Connect via Network**.
+
+1. Select **Connect via Network**.
+
 1. Once the network icon appears next to the device name,
    unplug your iOS device from your Mac.
 
@@ -327,7 +385,7 @@ $ sudo gem install cocoapods
 [web download]: {{site.apple-dev}}/xcode/
 [Xcode account add]: {{site.url}}/assets/images/docs/setup/xcode-account.png
 [Apple Silicon Mac]: https://support.apple.com/en-us/HT211814
-[Developer Mode]: https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device
+[Developer Mode]: {{site.apple-dev}}/documentation/xcode/enabling-developer-mode-on-a-device
 [Apple's Developer Forums]: {{site.apple-dev}}/forums/
 [Debugging your add-to-app module]: {{site.url}}/add-to-app/debugging/#wireless-debugging
 [Apple's documentation on pairing a wireless device with Xcode]: https://help.apple.com/xcode/mac/9.0/index.html?localePath=en.lproj#/devbc48d1bad

--- a/src/get-started/install/_ios-setup.md
+++ b/src/get-started/install/_ios-setup.md
@@ -6,6 +6,7 @@ To develop Flutter apps for iOS, you need a Mac with Xcode installed.
 
  1. Install the latest stable version of Xcode
     (using [web download][] or the [Mac App Store][]).
+
  1. Configure the Xcode command-line tools to use the
     newly-installed version of Xcode by
     running the following from the command line:
@@ -22,7 +23,7 @@ To develop Flutter apps for iOS, you need a Mac with Xcode installed.
 
  1. Make sure the Xcode license agreement is signed by
     either opening Xcode once and confirming or running
-    `sudo xcodebuild -license` from the command line.
+    `sudo xcodebuild --license` from the command line.
 
 Versions older than the latest stable version might still work,
 but are not recommended for Flutter development.
@@ -45,6 +46,7 @@ follow these steps:
  2. Make sure your simulator is using a 64-bit device
     (iPhone 5s or later).  You can check the device by viewing the settings in
     the simulator's **Hardware > Device** or **File > Open Simulator** menus.
+
  3. Depending on your development machine's screen size,
     simulated high-screen-density iOS devices
     might overflow your screen. Grab the corner of the
@@ -62,66 +64,77 @@ you will also need the third-party CocoaPods dependency manager.
 <ol markdown="1">
 <li markdown="1">
 <a name="connect"></a>
-To set up physical device deployment in Xcode, 
-connect your device to the USB port on your 
-computer. 
+To set up physical device deployment in Xcode,
+connect your device to the USB port on your
+computer.
 </li>
 <li markdown="1">
 <a name="wireless"></a>
-[Optional] To leverage wireless debugging, ensure that 
-your device is on the same network as your computer 
-and that the device has a set passcode.  
+[Optional] To leverage wireless debugging, ensure that
+your device is on the same network as your computer
+and that the device has a set passcode.
 
-While the device is attached, open **Xcode > Window > Devices and Simulators**. 
-Select your phone, and check **Connect via Network.** 
-For more details, check out 
+While the device is attached, open **Xcode > Window > Devices and Simulators**.
+Select your phone, and check **Connect via Network.**
+For more details, check out
 [Apple's documentation on pairing a wireless device with Xcode][].
 
-Once the network icon appears next to the device name, 
-you can unplug your device from USB. 
+Once the network icon appears next to the device name,
+you can unplug your device from USB.
 
-Sometimes it takes longer to find network devices. 
-If you don't see your device listed when using `flutter run`, 
+Sometimes it takes longer to find network devices.
+If you don't see your device listed when using `flutter run`,
 try extending the timeout: `flutter run --device-timeout 10`.
 
-For additional help troubleshooting, 
-check out [Apple's Developer Forums][]. For setting up 
-wireless debugging with `flutter attach`, 
+For additional help troubleshooting,
+check out [Apple's Developer Forums][]. For setting up
+wireless debugging with `flutter attach`,
 checkout [Debugging your add-to-app module][].
 </li>
 <li markdown="1">
 
 <a name="trust"></a>
-The first time you use an attached physical device for iOS
-development, you need to trust both your Mac and the
-Development Certificate on that device.
-On iOS 16 and higher you must also enable [Developer Mode][].
+The first time you attach a physical device for iOS development,
+you need to trust both your Mac and the Development Certificate
+on that device.
+On iOS 16 and later, you must also enable [Developer Mode][].
 
 Select **Trust** in the dialog prompt when
 first connecting the iOS device to your Mac.
 
 ![Trust Mac][]{:.mw-100}
+</li>
 
-Then, go to the Settings app on the iOS device,
-select **General > Device Management**
-and trust your Certificate.
-For first time users, you might need to select
-**General > Profiles > Device Management** instead.
-On iOS 16 and higher, navigate back to the top level
-of the Settings app, select **Privacy & Security > Developer Mode**,
-and toggle Developer Mode on.
+<li markdown="1">
+
+a. Open the **Settings** app on the iOS device.
+
+b. Go to **General** > **Device Management**.
+
+c. Trust your Certificate.
+
+**First time users:** You might need to go to
+**General** > **Profiles** > **Device Management**.
+
+**iOS 16 and later**
+
+a. Open the **Settings** app
+b. Select **Privacy & Security** > **Developer Mode**,
+c. Toggle **Developer Mode** to on.
 
 </li>
 
 <li markdown="1">
 
-You can skip this step if your apps do not depend on
-[Flutter plugins][] with native iOS code.
-[Install and set up CocoaPods][] by running the following commands:
+If your apps do not depend on [Flutter plugins][] with native iOS code,
+skip this step.
+
+To [Install and set up CocoaPods][], run the following commands:
 
 ```terminal
 $ sudo gem install cocoapods
 ```
+
 {{site.alert.note}}
   The default version of Ruby requires `sudo` to install the CocoaPods gem.
   If you are using a Ruby Version manager, you might need to run without `sudo`.
@@ -140,8 +153,8 @@ $ sudo gem install cocoapods
 Follow the Xcode signing flow to provision your project:
 
    {: type="a"}
-   1. Open the default Xcode workspace in your project by
-      running `open ios/Runner.xcworkspace` in a terminal
+   1. To open the default Xcode workspace in your project,
+      run `open ios/Runner.xcworkspace` in a terminal
       window from your Flutter project directory.
    1. Select the device you intend to deploy to in the device
       drop-down menu next to the run button.


### PR DESCRIPTION
Fixes #8990

Staged: https://tony-flutter-site--fix-8890-1j1r8fre.web.app/get-started/install/macos#ios-setup

This revises the iOS physical deployment section of the Getting Started page for macOS. (This should be extracted at a later date.)

Need verification that this process is in the correct order and the iOS version instructions are correct.