### PR TITLE
Fix import in android platform views

### DIFF
--- a/src/platform-integration/android/platform-views.md
+++ b/src/platform-integration/android/platform-views.md
@@ -174,6 +174,7 @@ package dev.flutter.example
 
 import android.content.Context
 import android.graphics.Color
+import android.view.View
 import android.widget.TextView
 import io.flutter.plugin.platform.PlatformView
 
@@ -203,7 +204,6 @@ Create a factory class that creates an instance of the
 package dev.flutter.example
 
 import android.content.Context
-import android.view.View
 import io.flutter.plugin.common.StandardMessageCodec
 import io.flutter.plugin.platform.PlatformView
 import io.flutter.plugin.platform.PlatformViewFactory


### PR DESCRIPTION
In the android platform views documentation page there is an import error. The `android.view.View` library is imported in the wrong file.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
