### PR TITLE
Cleanup and adjust install help links

### DIFF
--- a/src/_sass/base/_base.scss
+++ b/src/_sass/base/_base.scss
@@ -226,6 +226,24 @@ dd {
   }
 }
 
+.install-help {
+  text-align: right;
+
+  a {
+    display: inline-flex;
+    align-items: center;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  .material-icons {
+    font-size: 20px;
+    margin-right: 0.125rem;
+  }
+}
+
 blockquote {
   background-color: $site-color-codeblock-bg;
   padding: bs-spacer(3) bs-spacer(4);

--- a/src/get-started/install/_help-link.md
+++ b/src/get-started/install/_help-link.md
@@ -1,5 +1,6 @@
-<p style='text-align: right;'>
-    <a id='{{ include.location }}' class='install-help' href='help/{{ include.section }}'>
-    <i class='fas fa-question-circle'></i> Help
+<p class="install-help">
+    <a id='{{ include.location }}' href='{{site.url}}/get-started/install/help{{ include.section }}'>
+    <span class='material-icons'>help</span>
+    <span>Help</span>
     </a>
 </p>


### PR DESCRIPTION
- Don't use relative links (which break when staging and on some translated versions of the site)
- Don't use inline styles
- Use material icons instead of Font Awesome (https://github.com/flutter/website/issues/8983)

**Staged example:** https://flutter-docs-prod--pr9059-misc-cleanup-install-jrqqvfer.web.app/get-started/install/windows#get-the-flutter-sdk
