### PR TITLE
Fixed the tab name Signing & Capabilities

### DIFF
--- a/src/cookbook/navigation/set-up-universal-links.md
+++ b/src/cookbook/navigation/set-up-universal-links.md
@@ -99,7 +99,7 @@ It provides a simple API to handle complex routing scenarios.
    {{site.alert.end}}
 
 7. Click the top-level **Runner**.
-8. Click **Sign & Signature**.
+8. Click **Signing & Capabilities**.
 9. Click **+ Capability** to add a new domain.
 10. Click **Associated Domains**.
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Fixes a tab name in xcode

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
