### PR TITLE
Remove closing parentheses in Common Errors

### DIFF
--- a/src/testing/common-errors.md
+++ b/src/testing/common-errors.md
@@ -504,6 +504,6 @@ To learn more about how to debug errors,
 especially layout errors in Flutter, 
 check out the following resources: 
 
-* [How to debug layout issues with the Flutter Inspector][medium-article]]
+* [How to debug layout issues with the Flutter Inspector][medium-article]
 * [Understanding constraints][]
 * [Flutter architectural overview]({{site.url}}/resources/architectural-overview#layout-and-rendering)


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
