### PR TITLE
Temporarily remove cookbook recipe prev->next links

### DIFF
--- a/src/cookbook/animation/animated-container.md
+++ b/src/cookbook/animation/animated-container.md
@@ -1,12 +1,6 @@
 ---
 title: Animate the properties of a container
 description: How to animate properties of a container using implicit animations.
-prev:
-  title: Animate a widget using a physics simulation
-  path: /cookbook/animation/physics-simulation
-next:
-  title: Fade a widget in and out
-  path: /cookbook/animation/opacity-animation
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/animation/opacity-animation.md
+++ b/src/cookbook/animation/opacity-animation.md
@@ -1,12 +1,6 @@
 ---
 title: Fade a widget in and out
 description: How to fade a widget in and out.
-prev:
-  title: Animate the properties of a container
-  path: /cookbook/animation/animated-container
-next:
-  title: Add a drawer to a screen
-  path: /cookbook/design/drawer
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/animation/page-route-animation.md
+++ b/src/cookbook/animation/page-route-animation.md
@@ -1,9 +1,6 @@
 ---
 title: Animate a page route transition
 description: How to animate from one page to another.
-next:
-  title: Animate a widget using a physics simulation
-  path: /cookbook/animation/physics-simulation
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/animation/physics-simulation.md
+++ b/src/cookbook/animation/physics-simulation.md
@@ -2,12 +2,6 @@
 title: Animate a widget using a physics simulation
 description: How to implement a physics animation.
 diff2html: true
-prev:
-  title: Animate a page route transition
-  path: /cookbook/animation/page-route-animation
-next:
-  title: Animate the properties of a container
-  path: /cookbook/animation/animated-container
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/design/drawer.md
+++ b/src/cookbook/design/drawer.md
@@ -1,12 +1,6 @@
 ---
 title: Add a drawer to a screen
 description: How to implement a Material Drawer.
-prev:
-  title: Fade a widget in and out
-  path: /cookbook/animation/opacity-animation
-next:
-  title: Display a snackbar
-  path: /cookbook/design/snackbars
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/design/fonts.md
+++ b/src/cookbook/design/fonts.md
@@ -1,12 +1,6 @@
 ---
 title: Use a custom font
 description: How to use custom fonts.
-prev:
-  title: Update the UI based on orientation
-  path: /cookbook/design/orientation
-next:
-  title: Use themes to share colors and font styles
-  path: /cookbook/design/themes
 ---
 
 <?code-excerpt path-base="cookbook/design/fonts/"?>

--- a/src/cookbook/design/orientation.md
+++ b/src/cookbook/design/orientation.md
@@ -1,12 +1,6 @@
 ---
 title: Update the UI based on orientation
 description: Respond to a change in the screen's orientation.
-prev:
-  title: Export fonts from a package
-  path: /cookbook/design/package-fonts
-next:
-  title: Use a custom font
-  path: /cookbook/design/fonts
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/design/package-fonts.md
+++ b/src/cookbook/design/package-fonts.md
@@ -1,12 +1,6 @@
 ---
 title: Export fonts from a package
 description: How to export fonts from a package.
-prev:
-  title: Display a snackbar
-  path: /cookbook/design/snackbars
-next:
-  title: Update the UI based on orientation
-  path: /cookbook/design/orientation
 ---
 
 <?code-excerpt path-base="cookbook/design/package_fonts"?>

--- a/src/cookbook/design/snackbars.md
+++ b/src/cookbook/design/snackbars.md
@@ -1,12 +1,6 @@
 ---
 title: Display a snackbar
 description: How to implement a snackbar to display messages.
-prev:
-  title: Add a drawer to a screen
-  path: /cookbook/design/drawer
-next:
-  title: Export fonts from a package
-  path: /cookbook/design/package-fonts
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/design/tabs.md
+++ b/src/cookbook/design/tabs.md
@@ -1,12 +1,6 @@
 ---
 title: Work with tabs
 description: How to implement tabs in a layout.
-prev:
-  title: Use themes to share colors and font styles
-  path: /cookbook/design/themes
-next:
-  title: Create a download button
-  path: /cookbook/effects/download-button
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/design/themes.md
+++ b/src/cookbook/design/themes.md
@@ -2,12 +2,6 @@
 title: Use themes to share colors and font styles
 short-title: Themes
 description: How to share colors and font styles throughout an app using Themes.
-prev:
-  title: Use a custom font
-  path: /cookbook/design/fonts
-next:
-  title: Work with tabs
-  path: /cookbook/design/tabs
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/effects/download-button.md
+++ b/src/cookbook/effects/download-button.md
@@ -1,12 +1,6 @@
 ---
 title: Create a download button
 description: How to implement a download button.
-prev:
-  title: Work with tabs
-  path: /cookbook/design/tabs
-next:
-  title: Create a nested navigation flow
-  path: /cookbook/effects/nested-nav
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/effects/drag-a-widget.md
+++ b/src/cookbook/effects/drag-a-widget.md
@@ -1,12 +1,6 @@
 ---
 title: Drag a UI element
 description: How to implement a draggable UI element.
-prev:
-  title: Create gradient chat bubbles
-  path: /cookbook/effects/gradient-bubbles
-next:
-  title: Build a form with validation
-  path: /cookbook/forms/validation
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/effects/expandable-fab.md
+++ b/src/cookbook/effects/expandable-fab.md
@@ -1,12 +1,6 @@
 ---
 title: Create an expandable FAB
 description: How to implement a FAB that expands to multiple buttons when tapped.
-prev:
-  title: Create a typing indicator
-  path: /cookbook/effects/typing-indicator
-next:
-  title: Create gradient chat bubbles
-  path: /cookbook/effects/gradient-bubbles
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/effects/gradient-bubbles.md
+++ b/src/cookbook/effects/gradient-bubbles.md
@@ -1,12 +1,6 @@
 ---
 title: Create gradient chat bubbles
 description: How to implement gradient chat bubbles.
-prev:
-  title: Create an expandable FAB
-  path: /cookbook/effects/expandable-fab
-next:
-  title: Drag a UI element
-  path: /cookbook/effects/drag-a-widget
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/effects/nested-nav.md
+++ b/src/cookbook/effects/nested-nav.md
@@ -1,12 +1,6 @@
 ---
 title: Create a nested navigation flow
 description: How to implement a flow with nested navigation.
-prev:
-  title: Create a download button
-  path: /cookbook/effects/download-button
-next:
-  title: Create a photo filter carousel
-  path: /cookbook/effects/photo-filter-carousel
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/effects/parallax-scrolling.md
+++ b/src/cookbook/effects/parallax-scrolling.md
@@ -1,12 +1,6 @@
 ---
 title: Create a scrolling parallax effect
 description: How to implement a scrolling parallax effect.
-prev:
-  title: Create a photo filter carousel
-  path: /cookbook/effects/photo-filter-carousel
-next:
-  title: Create a shimmer loading effect
-  path: /cookbook/effects/shimmer-loading
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/effects/photo-filter-carousel.md
+++ b/src/cookbook/effects/photo-filter-carousel.md
@@ -1,12 +1,6 @@
 ---
 title: Create a photo filter carousel
 description: How to implement a photo filter carousel.
-prev:
-  title: Create a nested navigation flow
-  path: /cookbook/effects/nested-nav
-next:
-  title: Create a scrolling parallax effect
-  path: /cookbook/effects/parallax-scrolling
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/effects/shimmer-loading.md
+++ b/src/cookbook/effects/shimmer-loading.md
@@ -1,12 +1,6 @@
 ---
 title: Create a shimmer loading effect
 description: How to implement a shimmer loading effect.
-prev:
-  title: Create a scrolling parallax effect
-  path: /cookbook/effects/parallax-scrolling
-next:
-  title: Create a staggered menu animation
-  path: /cookbook/effects/staggered-menu-animation
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/effects/staggered-menu-animation.md
+++ b/src/cookbook/effects/staggered-menu-animation.md
@@ -1,12 +1,6 @@
 ---
 title: Create a staggered menu animation
 description: How to implement a staggered menu animation.
-prev:
-  title: Create a shimmer loading effect
-  path: /cookbook/effects/shimmer-loading
-next:
-  title: Create a typing indicator
-  path: /cookbook/effects/typing-indicator
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/effects/typing-indicator.md
+++ b/src/cookbook/effects/typing-indicator.md
@@ -1,12 +1,6 @@
 ---
 title: Create a typing indicator
 description: How to implement a typing indicator.
-prev:
-  title: Create a staggered menu animation
-  path: /cookbook/effects/staggered-menu-animation
-next:
-  title: Create an expandable FAB
-  path: /cookbook/effects/expandable-fab
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/forms/focus.md
+++ b/src/cookbook/forms/focus.md
@@ -1,12 +1,6 @@
 ---
 title: Focus and text fields
 description: How focus works with text fields.
-prev:
-  title: Retrieve the value of a text field
-  path: /cookbook/forms/retrieve-input
-next:
-  title: Add Material touch ripples
-  path: /cookbook/gestures/ripples
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/forms/retrieve-input.md
+++ b/src/cookbook/forms/retrieve-input.md
@@ -1,24 +1,12 @@
 ---
 title: Retrieve the value of a text field
 description: How to retrieve text from a text field.
-prev:
-  title: Create an expandable FAB
-  path: /cookbook/effects/expandable-fab
-next:
-  title: Focus and text fields
-  path: /cookbook/forms/focus
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js
 ---
 
 <?code-excerpt path-base="cookbook/forms/retrieve_input"?>
-
-{% comment %}
-prev:
-  title: Handle changes to a text field
-  path: /cookbook/forms/text-field-changes
-{% endcomment %}
 
 In this recipe,
 learn how to retrieve the text a user has entered into a text field

--- a/src/cookbook/forms/text-field-changes.md
+++ b/src/cookbook/forms/text-field-changes.md
@@ -1,12 +1,6 @@
 ---
 title: Handle changes to a text field
 description: How to detect changes to a text field.
-prev:
-  title: Create and style a text field
-  path: /cookbook/forms/text-input
-next:
-  title: Retrieve the value of a text field
-  path: /cookbook/forms/retrieve-input
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/forms/text-input.md
+++ b/src/cookbook/forms/text-input.md
@@ -1,12 +1,6 @@
 ---
 title: Create and style a text field
 description: How to implement a text field.
-prev:
-  title: Build a form with validation
-  path: /cookbook/forms/validation
-next:
-  title: Handle changes to a text field
-  path: /cookbook/forms/text-field-changes
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/forms/validation.md
+++ b/src/cookbook/forms/validation.md
@@ -1,12 +1,6 @@
 ---
 title: Build a form with validation
 description: How to build a form that validates input.
-prev:
-  title: Drag a UI element
-  path: /cookbook/effects/drag-a-widget
-next:
-  title: Create and style a text field
-  path: /cookbook/forms/text-input
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/gestures/dismissible.md
+++ b/src/cookbook/gestures/dismissible.md
@@ -2,12 +2,6 @@
 title: Implement swipe to dismiss
 description: How to implement swiping to dismiss or delete.
 diff2html: true
-prev:
-  title: Handle taps
-  path: /cookbook/gestures/handling-taps
-next:
-  title: Display images from the internet
-  path: /cookbook/images/network-image
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/gestures/handling-taps.md
+++ b/src/cookbook/gestures/handling-taps.md
@@ -1,12 +1,6 @@
 ---
 title: Handle taps
 description: How to handle tapping and dragging.
-prev:
-  title: Add Material touch ripples
-  path: /cookbook/gestures/ripples
-next:
-  title: Implement swipe to dismiss
-  path: /cookbook/gestures/dismissible
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/gestures/ripples.md
+++ b/src/cookbook/gestures/ripples.md
@@ -1,24 +1,12 @@
 ---
 title: Add Material touch ripples
 description: How to implement ripple animations.
-prev:
-  title: Retrieve the value of a text field
-  path: /cookbook/forms/retrieve-input
-next:
-  title: Handle taps
-  path: /cookbook/gestures/handling-taps
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js
 ---
 
 <?code-excerpt path-base="cookbook/gestures/ripples/"?>
-
-{% comment %}
-prev:
-  title: Focus and text fields
-  path: /cookbook/forms/focus
-{% endcomment %}
 
 Widgets that follow the Material Design guidelines display
 a ripple animation when tapped.

--- a/src/cookbook/images/cached-images.md
+++ b/src/cookbook/images/cached-images.md
@@ -1,12 +1,6 @@
 ---
 title: Work with cached images
 description: How to work with cached images.
-prev:
-  title: Fade in images with a placeholder
-  path: /cookbook/images/fading-in-images
-next:
-  title: Use lists
-  path: /cookbook/lists/basic-list
 ---
 
 <?code-excerpt path-base="cookbook/images/cached_images"?>

--- a/src/cookbook/images/fading-in-images.md
+++ b/src/cookbook/images/fading-in-images.md
@@ -1,12 +1,6 @@
 ---
 title: Fade in images with a placeholder
 description: How to fade images into view.
-prev:
-  title: Display images from the internet
-  path: /cookbook/images/network-image
-next:
-  title: Work with cached images
-  path: /cookbook/images/cached-images
 ---
 
 <?code-excerpt path-base="cookbook/images/fading_in_images"?>

--- a/src/cookbook/images/network-image.md
+++ b/src/cookbook/images/network-image.md
@@ -1,12 +1,6 @@
 ---
 title: Display images from the internet
 description: How to display images from the internet.
-prev:
-  title: Implement swipe to dismiss
-  path: /cookbook/gestures/dismissible
-next:
-  title: Fade in images with a placeholder
-  path: /cookbook/images/fading-in-images
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/lists/basic-list.md
+++ b/src/cookbook/lists/basic-list.md
@@ -1,12 +1,6 @@
 ---
 title: Use lists
 description: How to implement a list.
-prev:
-  title: Work with cached images
-  path: /cookbook/images/cached-images
-next:
-  title: Create a horizontal list
-  path: /cookbook/lists/horizontal-list
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/lists/floating-app-bar.md
+++ b/src/cookbook/lists/floating-app-bar.md
@@ -1,12 +1,6 @@
 ---
 title: Place a floating app bar above a list
 description: How to place a floating app bar above a list.
-prev:
-  title: Create lists with different types of items
-  path: /cookbook/lists/mixed-list
-next:
-  title: Work with long lists
-  path: /cookbook/lists/long-lists
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/lists/grid-lists.md
+++ b/src/cookbook/lists/grid-lists.md
@@ -1,12 +1,6 @@
 ---
 title: Create a grid list
 description: How to implement a grid list.
-prev:
-  title: Create a horizontal list
-  path: /cookbook/lists/horizontal-list
-next:
-  title: Create lists with different types of items
-  path: /cookbook/lists/mixed-list
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/lists/horizontal-list.md
+++ b/src/cookbook/lists/horizontal-list.md
@@ -1,12 +1,6 @@
 ---
 title: Create a horizontal list
 description: How to implement a horizontal list.
-prev:
-  title: Use lists
-  path: /cookbook/lists/basic-list
-next:
-  title: Create a grid list
-  path: /cookbook/lists/grid-lists
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/lists/long-lists.md
+++ b/src/cookbook/lists/long-lists.md
@@ -1,12 +1,6 @@
 ---
 title: Work with long lists
 description: Use ListView.builder to implement a long or infinite list.
-prev:
-  title: Place a floating app bar above a list
-  path: /cookbook/lists/floating-app-bar
-next:
-  title: Report errors to a service
-  path: /cookbook/maintenance/error-reporting
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/lists/mixed-list.md
+++ b/src/cookbook/lists/mixed-list.md
@@ -1,12 +1,6 @@
 ---
 title: Create lists with different types of items
 description: How to implement a list that contains different types of assets.
-prev:
-  title: Create a grid list
-  path: /cookbook/lists/grid-lists
-next:
-  title: Place a floating app bar above a list
-  path: /cookbook/lists/floating-app-bar
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/maintenance/error-reporting.md
+++ b/src/cookbook/maintenance/error-reporting.md
@@ -1,12 +1,6 @@
 ---
 title: Report errors to a service
 description: How to keep track of errors that users encounter.
-prev:
-  title: Work with long lists
-  path: /cookbook/lists/long-lists
-next:
-  title: Animate a widget across screens
-  path: /cookbook/navigation/hero-animations
 ---
 
 <?code-excerpt path-base="cookbook/maintenance/error_reporting/"?>

--- a/src/cookbook/navigation/hero-animations.md
+++ b/src/cookbook/navigation/hero-animations.md
@@ -1,12 +1,6 @@
 ---
 title: Animate a widget across screens
 description: How to animate a widget from one screen to another
-prev:
-  title: Report errors to a service
-  path: /cookbook/maintenance/error-reporting
-next:
-  title: Navigate to a new screen and back
-  path: /cookbook/navigation/navigation-basics
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/navigation/named-routes.md
+++ b/src/cookbook/navigation/named-routes.md
@@ -1,12 +1,6 @@
 ---
 title: Navigate with named routes
 description: How to implement named routes for navigating between screens.
-prev:
-  title: Navigate to a new screen and back
-  path: /cookbook/navigation/navigation-basics
-next:
-  title: Pass arguments to a named route
-  path: /cookbook/navigation/navigate-with-arguments
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/navigation/navigate-with-arguments.md
+++ b/src/cookbook/navigation/navigate-with-arguments.md
@@ -1,12 +1,6 @@
 ---
 title: Pass arguments to a named route
 description: How to pass arguments to a named route.
-prev:
-  title: Navigate with named routes
-  path: /cookbook/navigation/named-routes
-next:
-  title: Set up app links for Android
-  path: /cookbook/navigation/set-up-app-links
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/navigation/navigation-basics.md
+++ b/src/cookbook/navigation/navigation-basics.md
@@ -1,12 +1,6 @@
 ---
 title: Navigate to a new screen and back
 description: How to navigate between routes.
-prev:
-  title: Animate a widget across screens
-  path: /cookbook/navigation/hero-animations
-next:
-  title: Navigate with named routes
-  path: /cookbook/navigation/named-routes
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/navigation/passing-data.md
+++ b/src/cookbook/navigation/passing-data.md
@@ -1,12 +1,6 @@
 ---
 title: Send data to a new screen
 description: How to pass data to a new route.
-prev:
-  title: Return data from a screen
-  path: /cookbook/navigation/returning-data
-next:
-  title: Delete data on the internet
-  path: /cookbook/networking/delete-data
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/navigation/returning-data.md
+++ b/src/cookbook/navigation/returning-data.md
@@ -1,12 +1,6 @@
 ---
 title: Return data from a screen
 description: How to return data from a new screen.
-prev:
-  title: Set up universal links for iOS
-  path: /cookbook/navigation/set-up-universal-links
-next:
-  title: Send data to a new screen
-  path: /cookbook/navigation/passing-data
 js:
   - defer: true
     url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/navigation/set-up-app-links.md
+++ b/src/cookbook/navigation/set-up-app-links.md
@@ -1,12 +1,6 @@
 ---
 title: Set up app links for Android
 description: How set up universal links for an iOS application built with Flutter
-prev:
-  title: Pass arguments to a named route
-  path: /cookbook/navigation/navigate-with-arguments
-next:
-  title: Set up universal links for iOS
-  path: /cookbook/navigation/set-up-universal-links
 js:
 - defer: true
   url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/navigation/set-up-universal-links.md
+++ b/src/cookbook/navigation/set-up-universal-links.md
@@ -1,12 +1,6 @@
 ---
 title: Set up universal links for iOS
 description: How set up universal links for an iOS application built with Flutter
-prev:
-  title: Set up app links for Android
-  path: /cookbook/navigation/set-up-app-links
-next:
-  title: Return data from a screen
-  path: /cookbook/navigation/returning-data
 js:
 - defer: true
   url: https://dartpad.dev/inject_embed.dart.js

--- a/src/cookbook/networking/authenticated-requests.md
+++ b/src/cookbook/networking/authenticated-requests.md
@@ -1,12 +1,6 @@
 ---
 title: Make authenticated requests
 description: How to fetch authorized data from a web service.
-prev:
-  title: Fetch data from the internet
-  path: /cookbook/networking/fetch-data
-next:
-  title: Parse JSON in the background
-  path: /cookbook/networking/background-parsing
 ---
 
 <?code-excerpt path-base="cookbook/networking/authenticated_requests/"?>

--- a/src/cookbook/networking/background-parsing.md
+++ b/src/cookbook/networking/background-parsing.md
@@ -1,12 +1,6 @@
 ---
 title: Parse JSON in the background
 description: How to perform a task in the background.
-prev:
-  title: Make authenticated requests
-  path: /cookbook/networking/authenticated-requests
-next:
-  title: Send data to the internet
-  path: /cookbook/networking/send-data
 ---
 
 <?code-excerpt path-base="cookbook/networking/background_parsing/"?>

--- a/src/cookbook/networking/delete-data.md
+++ b/src/cookbook/networking/delete-data.md
@@ -1,12 +1,6 @@
 ---
 title: Delete data on the internet
 description: How to use the http package to delete data on the internet.
-prev:
-  title: Send data to a new screen
-  path: /cookbook/navigation/passing-data
-next:
-  title: Fetch data from the internet
-  path: /cookbook/networking/fetch-data
 ---
 
 <?code-excerpt path-base="cookbook/networking/delete_data/"?>

--- a/src/cookbook/networking/fetch-data.md
+++ b/src/cookbook/networking/fetch-data.md
@@ -1,12 +1,6 @@
 ---
 title: Fetch data from the internet
 description: How to fetch data over the internet using the http package.
-prev:
-  title: Delete data on the internet
-  path: /cookbook/networking/delete-data
-next:
-  title: Make authenticated requests
-  path: /cookbook/networking/authenticated-requests
 ---
 
 <?code-excerpt path-base="cookbook/networking/fetch_data/"?>

--- a/src/cookbook/networking/send-data.md
+++ b/src/cookbook/networking/send-data.md
@@ -1,12 +1,6 @@
 ---
 title: Send data to the internet
 description: How to use the http package to send data over the internet.
-prev:
-  title: Parse JSON in the background
-  path: /cookbook/networking/background-parsing
-next:
-  title: Update data over the internet
-  path: /cookbook/networking/update-data
 ---
 
 <?code-excerpt path-base="cookbook/networking/send_data/"?>

--- a/src/cookbook/networking/update-data.md
+++ b/src/cookbook/networking/update-data.md
@@ -1,12 +1,6 @@
 ---
 title: Update data over the internet
 description: How to use the http package to update data over the internet.
-prev:
-  title: Send data to the internet
-  path: /cookbook/networking/send-data
-next:
-  title: Work with WebSockets
-  path: /cookbook/networking/web-sockets
 ---
 
 <?code-excerpt path-base="cookbook/networking/update_data/"?>

--- a/src/cookbook/networking/web-sockets.md
+++ b/src/cookbook/networking/web-sockets.md
@@ -1,12 +1,6 @@
 ---
 title: Work with WebSockets
 description: How to connect to a web socket.
-prev:
-  title: Update data over the internet
-  path: /cookbook/networking/update-data
-next:
-  title: Persist data with SQLite
-  path: /cookbook/persistence/sqlite
 ---
 
 <?code-excerpt path-base="cookbook/networking/web_sockets/"?>

--- a/src/cookbook/persistence/key-value.md
+++ b/src/cookbook/persistence/key-value.md
@@ -1,12 +1,6 @@
 ---
 title: Store key-value data on disk
 description: How to use the shared_preferences package to store key-value data.
-prev:
-  title: Read and write files
-  path: /cookbook/persistence/reading-writing-files
-next:
-  title: Play and pause a video
-  path: /cookbook/plugins/play-video
 ---
 
 <?code-excerpt path-base="cookbook/persistence/key_value/"?>

--- a/src/cookbook/persistence/reading-writing-files.md
+++ b/src/cookbook/persistence/reading-writing-files.md
@@ -1,12 +1,6 @@
 ---
 title: Read and write files
 description: How to read from and write to files on disk.
-prev:
-  title: Persist data with SQLite
-  path: /cookbook/persistence/sqlite
-next:
-  title: Store key-value data on disk
-  path: /cookbook/persistence/key-value
 ---
 
 <?code-excerpt path-base="cookbook/persistence/reading_writing_files/"?>

--- a/src/cookbook/persistence/sqlite.md
+++ b/src/cookbook/persistence/sqlite.md
@@ -1,12 +1,6 @@
 ---
 title: Persist data with SQLite
 description: How to use SQLite to store and retrieve data.
-prev:
-  title: Work with WebSockets
-  path: /cookbook/networking/web-sockets
-next:
-  title: Read and write files
-  path: /cookbook/persistence/reading-writing-files
 ---
 
 <?code-excerpt path-base="cookbook/persistence/sqlite/"?>

--- a/src/cookbook/plugins/picture-using-camera.md
+++ b/src/cookbook/plugins/picture-using-camera.md
@@ -1,12 +1,6 @@
 ---
 title: Take a picture using the camera
 description: How to use a camera plugin on mobile.
-prev:
-  title: Play and pause a video
-  path: /cookbook/plugins/play-video
-next:
-  title: An introduction to integration testing
-  path: /cookbook/testing/integration/introduction
 ---
 
 <?code-excerpt path-base="cookbook/plugins/picture_using_camera/"?>

--- a/src/cookbook/plugins/play-video.md
+++ b/src/cookbook/plugins/play-video.md
@@ -1,12 +1,6 @@
 ---
 title: Play and pause a video
 description: How to use the video_player plugin.
-prev:
-  title: Store key-value data on disk
-  path: /cookbook/persistence/key-value
-next:
-  title: Take a picture using the camera
-  path: /cookbook/plugins/picture-using-camera
 ---
 
 <?code-excerpt path-base="cookbook/plugins/play_video/"?>

--- a/src/cookbook/testing/integration/introduction.md
+++ b/src/cookbook/testing/integration/introduction.md
@@ -2,12 +2,6 @@
 title: An introduction to integration testing
 description: Learn about integration testing in Flutter.
 short-title: Introduction
-prev:
-  title: Take a picture using the camera
-  path: /cookbook/plugins/picture-using-camera
-next:
-  title: Performance profiling
-  path: /cookbook/testing/integration/profiling
 ---
 
 <?code-excerpt path-base="cookbook/testing/integration/introduction/"?>

--- a/src/cookbook/testing/integration/profiling.md
+++ b/src/cookbook/testing/integration/profiling.md
@@ -1,12 +1,6 @@
 ---
 title: Performance profiling
 description: How to profile performance for a Flutter app.
-prev:
-  title: An introduction to integration testing
-  path: /cookbook/testing/integration/introduction
-next:
-  title: An introduction to unit testing
-  path: /cookbook/testing/unit/introduction
 ---
 
 <?code-excerpt path-base="cookbook/testing/integration/profiling/"?>

--- a/src/cookbook/testing/unit/introduction.md
+++ b/src/cookbook/testing/unit/introduction.md
@@ -2,12 +2,6 @@
 title: An introduction to unit testing
 description: How to write unit tests.
 short-title: Introduction
-prev:
-  title: Performance profiling
-  path: /cookbook/testing/integration/profiling
-next:
-  title: Mock dependencies using Mockito
-  path: /cookbook/testing/unit/mocking
 ---
 
 <?code-excerpt path-base="cookbook/testing/unit/counter_app"?>

--- a/src/cookbook/testing/unit/mocking.md
+++ b/src/cookbook/testing/unit/mocking.md
@@ -1,13 +1,8 @@
 ---
 title: Mock dependencies using Mockito
-description: Use the Mockito package to mimic the behavior of services for testing.
+description: >
+  Use the Mockito package to mimic the behavior of services for testing.
 short-title: Mocking
-prev:
-  title: An introduction to unit testing
-  path: /cookbook/testing/unit/introduction
-next:
-  title: An introduction to widget testing
-  path: /cookbook/testing/widget/introduction
 ---
 
 <?code-excerpt path-base="cookbook/testing/unit/mocking"?>

--- a/src/cookbook/testing/widget/finders.md
+++ b/src/cookbook/testing/widget/finders.md
@@ -1,12 +1,6 @@
 ---
 title: Find widgets
 description: How to use the Finder classes for testing widgets.
-prev:
-  title: An introduction to widget testing
-  path: /cookbook/testing/widget/introduction
-next:
-  title: Handle scrolling
-  path: /cookbook/testing/widget/scrolling
 ---
 
 <?code-excerpt path-base="cookbook/testing/widget/finders/"?>

--- a/src/cookbook/testing/widget/introduction.md
+++ b/src/cookbook/testing/widget/introduction.md
@@ -2,12 +2,6 @@
 title: An introduction to widget testing
 description: Learn more about widget testing in Flutter.
 short-title: Introduction
-prev:
-  title: Mock dependencies using Mockito
-  path: /cookbook/testing/unit/mocking
-next:
-  title: Find widgets
-  path: /cookbook/testing/widget/finders
 ---
 
 <?code-excerpt path-base="cookbook/testing/widget/introduction/"?>

--- a/src/cookbook/testing/widget/scrolling.md
+++ b/src/cookbook/testing/widget/scrolling.md
@@ -1,12 +1,6 @@
 ---
 title: Handle scrolling
 description: How to handle scrolling in a widget test.
-prev:
-  title: Find widgets
-  path: /cookbook/testing/widget/finders
-next:
-  title: Tap, drag, and enter text
-  path: /cookbook/testing/widget/tap-drag
 ---
 
 <?code-excerpt path-base="cookbook/testing/widget/scrolling/"?>

--- a/src/cookbook/testing/widget/tap-drag.md
+++ b/src/cookbook/testing/widget/tap-drag.md
@@ -1,9 +1,6 @@
 ---
 title: Tap, drag, and enter text
 description: How to test widgets for user interaction.
-prev:
-  title: Handle scrolling
-  path: /cookbook/testing/widget/scrolling
 ---
 
 <?code-excerpt path-base="cookbook/testing/widget/tap_drag/"?>


### PR DESCRIPTION
After reviewing them, many of the orders don't necessarily make sense. Beyond that, the cookbook recipes are most useful when learning a specific thing rather than a sequential order of experiences, hence the idea of them being standalone recipes.

Anyway, maintaining them will make the next phase of Information Architecture work much more challenging to implement and review with extra changes and consideration surrounding them.

This PR removes them, with the option to revisit when the IA work is done, so we can more thoughtfully approach a prev->next order.
