### PR TITLE
Rename tools category and locate with other reference docs

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -373,7 +373,9 @@
     - title: Loading sequence and performance
       permalink: /add-to-app/performance
 
-- title: Tools & features
+- divider
+
+- title: Tools & editors
   permalink: /tools
   children:
     - title: Android Studio & IntelliJ
@@ -421,8 +423,6 @@
       permalink: /tools/flutter-fix
     - title: Code formatting
       permalink: /tools/formatting
-
-- divider
 
 - title: Resources
   permalink: /resources


### PR DESCRIPTION
I decided to rename the category to "Tools & editors", but let me know if you think just "Tools" or "Tooling" is better :) 

Closes https://github.com/flutter/website/issues/9108