### PR TITLE
Adding macOS impeller info

### DIFF
--- a/src/perf/impeller.md
+++ b/src/perf/impeller.md
@@ -106,7 +106,7 @@ submitting an issue for Impeller on macOS:
 
 - The device you are running on, including the chip information.
 - Screenshots or recordings of any visible issues.
-- An [export of the performance trace]. Please add it to the Github issue by zipping the file.
+- An [export of the performance trace][]. Please add it to the Github issue by zipping the file.
 
 
 [file-issue]: {{site.github}}/flutter/flutter/issues/new/choose

--- a/src/perf/impeller.md
+++ b/src/perf/impeller.md
@@ -74,6 +74,44 @@ include a small reproducible test case.
 
 [file-issue]: {{site.github}}/flutter/flutter/issues/new/choose
 
+### macOS
+
+Impeller is available for macOS in preview as of the 
+Flutter 3.13 stable release.
+
+* To _enable_ Impeller on iOS when debugging,
+  pass `--enable-impeller` to the `flutter run` command.
+
+  ```terminal
+  $ flutter run --enable-impeller
+  ```
+
+* To _enable_ Impeller on iOS when deploying your app,
+  add the following tags under the top-level `<dict>` tag in your
+  app's `Info.plist` file.
+
+  ```xml
+    <key>FLTEnableImpeller</key>
+    <true />
+  ```
+
+The team continues to improve macOS support.
+If you encounter performance or fidelity issues
+with Impeller on macOS, file an issue in the [GitHub tracker][file-issue].
+Prefix the issue title with `[Impeller]` and
+include a small reproducible test case.
+
+It's helpful to include the following information when 
+submitting an issue for Impeller on macOS:
+
+- The device you are running on, including the chip information.
+- Screenshots or recordings of any visible issues.
+- An [export of the performance trace]. Please add it to the Github issue by zipping the file.
+
+
+[file-issue]: {{site.github}}/flutter/flutter/issues/new/choose
+[export of the performance trace]:{{site.url}}/tools/devtools/performance#import-and-export
+
 ### Android
 
 Android development continues but it's not ready for preview.

--- a/src/perf/impeller.md
+++ b/src/perf/impeller.md
@@ -101,12 +101,13 @@ with Impeller on macOS, file an issue in the [GitHub tracker][file-issue].
 Prefix the issue title with `[Impeller]` and
 include a small reproducible test case.
 
-It's helpful to include the following information when 
+Please include the following information when 
 submitting an issue for Impeller on macOS:
 
 - The device you are running on, including the chip information.
 - Screenshots or recordings of any visible issues.
-- An [export of the performance trace][]. Please add it to the Github issue by zipping the file.
+- An [export of the performance trace][].
+  Zip the file and attach it to the GitHub issue.
 
 
 [file-issue]: {{site.github}}/flutter/flutter/issues/new/choose

--- a/src/perf/impeller.md
+++ b/src/perf/impeller.md
@@ -79,14 +79,14 @@ include a small reproducible test case.
 Impeller is available for macOS in preview as of the 
 Flutter 3.13 stable release.
 
-* To _enable_ Impeller on iOS when debugging,
+* To _enable_ Impeller on macOS when debugging,
   pass `--enable-impeller` to the `flutter run` command.
 
   ```terminal
   $ flutter run --enable-impeller
   ```
 
-* To _enable_ Impeller on iOS when deploying your app,
+* To _enable_ Impeller on macOS when deploying your app,
   add the following tags under the top-level `<dict>` tag in your
   app's `Info.plist` file.
 


### PR DESCRIPTION
Note that this should go live for 3.13

_Issues fixed by this PR (if any):_ https://github.com/flutter/website/issues/8908

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
