### PR TITLE
Updates ignoreSemantics migration guide

### DIFF
--- a/src/release/breaking-changes/ignoringsemantics-migration.md
+++ b/src/release/breaking-changes/ignoringsemantics-migration.md
@@ -14,10 +14,10 @@ The `ignoringSemantics` properties are removed in [`IgnorePointer`][],
 The `ignoreSemantics` was introduced as a workaround to mitigate the result of
 `IgnorePointer` and its related widgets dropping entire semantics subtrees.
 Setting `ignoreSemantics` to false was the only way to preserve the semantics
-subtree while using the `IgnorePointer`.
+subtree while using the `IgnorePointer` widget.
 
-After v3.10.0-2.0.pre, the `IgnorePointer` no longer drops the entire semantics
-subtree but only removing the pointer related semantics actions. Therefore, this
+After v3.10.0-2.0.pre, the `IgnorePointer` widget no longer drops the entire semantics
+subtree but only removes the pointer-related semantics actions. Therefore, this
 workaround is no longer needed.
 
 ## Description of change
@@ -70,7 +70,7 @@ SliverIgnorePointer(
 );
 ```
 
-The behaviors of setting `ignoringSemantics` to false are no longer supported.
+Setting `ignoringSemantics` to false is no longer supported.
 Consider creating your own custom widgets.
 
 ```dart
@@ -93,7 +93,7 @@ class _RenderIgnorePointerWithSemantics extends RenderProxyBox {
   bool hitTest(BoxHitTestResult result, { required Offset position }) => false;
 }
 
-/// A widget absorbs pointer event but still keeps semantics actions.
+/// A widget absorbs pointer events but still keeps semantics actions.
 class _AbsorbPointerWithSemantics extends SingleChildRenderObjectWidget {
   const _AbsorbPointerWithSemantics({
     super.child,
@@ -114,7 +114,7 @@ class _RenderAbsorbPointerWithSemantics extends RenderProxyBox {
   }
 }
 
-/// A sliver ignores pointer event but still keeps semantics actions.
+/// A sliver ignores pointer events but still keeps semantics actions.
 class _SliverIgnorePointerWithSemantics extends SingleChildRenderObjectWidget {
   const _SliverIgnorePointerWithSemantics({
     super.child,

--- a/src/release/breaking-changes/ignoringsemantics-migration.md
+++ b/src/release/breaking-changes/ignoringsemantics-migration.md
@@ -74,7 +74,7 @@ Setting `ignoringSemantics` to false is no longer supported.
 Consider creating your own custom widgets.
 
 ```dart
-/// A widget ignores pointer event but still keeps semantics actions.
+/// A widget ignores pointer event without modifying the semantics tree.
 class _IgnorePointerWithSemantics extends SingleChildRenderObjectWidget {
   const _IgnorePointerWithSemantics({
     super.child,
@@ -93,7 +93,7 @@ class _RenderIgnorePointerWithSemantics extends RenderProxyBox {
   bool hitTest(BoxHitTestResult result, { required Offset position }) => false;
 }
 
-/// A widget absorbs pointer events but still keeps semantics actions.
+/// A widget absorbs pointer events without modifying the semantics tree.
 class _AbsorbPointerWithSemantics extends SingleChildRenderObjectWidget {
   const _AbsorbPointerWithSemantics({
     super.child,
@@ -114,7 +114,7 @@ class _RenderAbsorbPointerWithSemantics extends RenderProxyBox {
   }
 }
 
-/// A sliver ignores pointer events but still keeps semantics actions.
+/// A sliver ignores pointer events without modifying the semantics tree.
 class _SliverIgnorePointerWithSemantics extends SingleChildRenderObjectWidget {
   const _SliverIgnorePointerWithSemantics({
     super.child,

--- a/src/release/breaking-changes/ignoringsemantics-migration.md
+++ b/src/release/breaking-changes/ignoringsemantics-migration.md
@@ -13,7 +13,12 @@ The `ignoringSemantics` properties are removed in [`IgnorePointer`][],
 
 The `ignoreSemantics` was introduced as a workaround to mitigate the result of
 `IgnorePointer` and its related widgets dropping entire semantics subtrees.
-Therefore, this workaround is no longer needed.
+Setting `ignoreSemantics` to false was the only way to preserve the semantics
+subtree while using the `IgnorePointer`.
+
+After v3.10.0-2.0.pre, the `IgnorePointer` no longer drops the entire semantics
+subtree but only removing the pointer related semantics actions. Therefore, this
+workaround is no longer needed.
 
 ## Description of change
 

--- a/src/release/breaking-changes/ignoringsemantics-migration.md
+++ b/src/release/breaking-changes/ignoringsemantics-migration.md
@@ -27,7 +27,17 @@ If you set this parameter to true in these widgets, consider using
 Code before migration:
 
 ```dart
-IgnorePointer(``
+IgnorePointer(
+  ignoringSemantics: true,
+  child: const PlaceHolder(),
+);
+
+AbsorbPointer(
+  ignoringSemantics: true,
+  child: const PlaceHolder(),
+);
+
+SliverIgnorePointer(
   ignoringSemantics: true,
   child: const PlaceHolder(),
 );
@@ -41,10 +51,22 @@ ExcludeSemantics(
     child: const PlaceHolder(),
   ),
 );
+
+ExcludeSemantics(
+  child: AbsorbPointer(
+    child: const PlaceHolder(),
+  ),
+);
+
+SliverIgnorePointer(
+  child: ExcludeSemantics(
+    child: const PlaceHolder(),
+  ),
+);
 ```
 
-The behavior of setting `ignoringSemantics` to false is no longer supported.
-Consider creating your own custom widget.
+The behaviors of setting `ignoringSemantics` to false are no longer supported.
+Consider creating your own custom widgets.
 
 ```dart
 /// A widget ignores pointer event but still keeps semantics actions.
@@ -61,6 +83,46 @@ class _IgnorePointerWithSemantics extends SingleChildRenderObjectWidget {
 
 class _RenderIgnorePointerWithSemantics extends RenderProxyBox {
   _RenderIgnorePointerWithSemantics();
+
+  @override
+  bool hitTest(BoxHitTestResult result, { required Offset position }) => false;
+}
+
+/// A widget absorbs pointer event but still keeps semantics actions.
+class _AbsorbPointerWithSemantics extends SingleChildRenderObjectWidget {
+  const _AbsorbPointerWithSemantics({
+    super.child,
+  });
+
+  @override
+  _RenderAbsorbPointerWithSemantics createRenderObject(BuildContext context) {
+    return _RenderAbsorbPointerWithSemantics();
+  }
+}
+
+class _RenderAbsorbPointerWithSemantics extends RenderProxyBox {
+  _RenderAbsorbPointerWithSemantics();
+
+  @override
+  bool hitTest(BoxHitTestResult result, { required Offset position }) {
+    return size.contains(position);
+  }
+}
+
+/// A sliver ignores pointer event but still keeps semantics actions.
+class _SliverIgnorePointerWithSemantics extends SingleChildRenderObjectWidget {
+  const _SliverIgnorePointerWithSemantics({
+    super.child,
+  });
+
+  @override
+  _RenderSliverIgnorePointerWithSemantics createRenderObject(BuildContext context) {
+    return _RenderSliverIgnorePointerWithSemantics();
+  }
+}
+
+class _RenderSliverIgnorePointerWithSemantics extends RenderProxySliver {
+  _RenderSliverIgnorePointerWithSemantics();
 
   @override
   bool hitTest(BoxHitTestResult result, { required Offset position }) => false;

--- a/src/release/breaking-changes/ignoringsemantics-migration.md
+++ b/src/release/breaking-changes/ignoringsemantics-migration.md
@@ -14,7 +14,7 @@ dropped its subtree from the semantics tree. The `ignoreSemantics` parameter
 was introduced as a workaround to preserve the semantics tree when using
 `IgnorePointer`s.
 
-The `IgnorePointer` behavior has changed that it no longer drops
+The `IgnorePointer` behavior has changed in that it no longer drops
 the entire semantics subtree but merely blocks semantics actions in the 
 subtree. The `ignoringSemantics` workaround is no longer needed and is
 deprecated.
@@ -73,7 +73,7 @@ SliverIgnorePointer(
 ```
 
 If you are previously using `IgnorePointer`s with `ignoringSemantics` set to `false`,
-you can achieve the same behvavior by copying the follow widgets directly into your
+you can achieve the same behavior by copying the follow widgets directly into your
 code and use.
 
 ```dart

--- a/src/release/breaking-changes/ignoringsemantics-migration.md
+++ b/src/release/breaking-changes/ignoringsemantics-migration.md
@@ -5,20 +5,22 @@ description: Removal of ignoringSemantics in IgnorePointer and related classes.
 
 ## Summary
 
-The `ignoringSemantics` properties are removed in [`IgnorePointer`][],
-[`AbsorbPointer`][], [`SliverIgnorePointer`][], [`RenderSliverIgnorePointer`][],
-[`RenderIgnorePointer`][], and [`RenderAbsorbPointer`][].
+The `IgnoringPointer` widget allows you to designate an area of the UI
+where you don't want to accept pointer events, for example, when
+you don't want to allow the user to enter text in a text field.
 
-## Context
+Previously, the `IgnorePointer` not only blocked pointer events but also
+dropped its subtree from the semantics tree. The `ignoreSemantics` parameter
+was introduced as a workaround to preserve the semantics tree when using
+`IgnorePointer`s.
 
-The `ignoreSemantics` was introduced as a workaround to mitigate the result of
-`IgnorePointer` and its related widgets dropping entire semantics subtrees.
-Setting `ignoreSemantics` to false was the only way to preserve the semantics
-subtree while using the `IgnorePointer` widget.
+The `IgnorePointer` behavior has changed that it no longer drops
+the entire semantics subtree but merely blocks semantics actions in the 
+subtree. The `ignoringSemantics` workaround is no longer needed and is
+deprecated.
 
-After v3.10.0-2.0.pre, the `IgnorePointer` widget no longer drops the entire semantics
-subtree but only removes the pointer-related semantics actions. Therefore, this
-workaround is no longer needed.
+This change also applies to the AbsorbPointer and
+SliverIgnorePointer widgets.
 
 ## Description of change
 
@@ -70,11 +72,12 @@ SliverIgnorePointer(
 );
 ```
 
-Setting `ignoringSemantics` to false is no longer supported.
-Consider creating your own custom widgets.
+If you are previously using `IgnorePointer`s with `ignoringSemantics` set to `false`,
+you can achieve the same behvavior by copying the follow widgets directly into your
+code and use.
 
 ```dart
-/// A widget ignores pointer event without modifying the semantics tree.
+/// A widget ignores pointer events without modifying the semantics tree.
 class _IgnorePointerWithSemantics extends SingleChildRenderObjectWidget {
   const _IgnorePointerWithSemantics({
     super.child,


### PR DESCRIPTION
relevant https://github.com/flutter/flutter/pull/131287

## Presubmit checklist

- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
