### PR TITLE
Reduce margin below page headers

### DIFF
--- a/src/_sass/components/_content.scss
+++ b/src/_sass/components/_content.scss
@@ -50,7 +50,7 @@
   }
 
   &__title {
-    margin-bottom: bootstrap.bs-spacer(12);
+    margin-bottom: bootstrap.bs-spacer(8);
 
     @at-root {
       #page-github-links {


### PR DESCRIPTION
Slightly reduces the margin below h1 headers and breadcrumbs to get to the content faster. This makes it not as small as dart.dev's, but still smaller than we have now.