### PR TITLE
[add2app] update android fragment instructions

### DIFF
--- a/src/add-to-app/android/add-flutter-fragment.md
+++ b/src/add-to-app/android/add-flutter-fragment.md
@@ -184,6 +184,20 @@ public class MyActivity extends FragmentActivity {
     }
 
     @Override
+    public void onActivityResult(
+        int requestCode,
+        int resultCode,
+        @Nullable Intent data
+    ) {
+        super.onActivityResult(requestCode, resultCode, data);
+        flutterFragment.onActivityResult(
+            requestCode,
+            resultCode,
+            data
+      );
+    }
+
+    @Override
     public void onUserLeaveHint() {
         flutterFragment.onUserLeaveHint();
     }
@@ -221,6 +235,19 @@ class MyActivity : FragmentActivity() {
       requestCode,
       permissions,
       grantResults
+    )
+  }
+
+  override fun onActivityResult(
+    requestCode: Int,
+    resultCode: Int,
+    data: Intent?
+  ) {
+    super.onActivityResult(requestCode, resultCode, data)
+    flutterFragment!!.onActivityResult(
+      requestCode,
+      resultCode,
+      data
     )
   }
 

--- a/src/add-to-app/android/add-flutter-fragment.md
+++ b/src/add-to-app/android/add-flutter-fragment.md
@@ -194,7 +194,7 @@ public class MyActivity extends FragmentActivity {
             requestCode,
             resultCode,
             data
-      );
+        );
     }
 
     @Override


### PR DESCRIPTION
Include the `onActivityResult` call forwarding instruction in the add to app Android Fragment guideline.

Related to https://github.com/flutter/flutter/issues/100366 (fixes?)

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
