### PR TITLE
Propose another default install path for Windows

### DIFF
--- a/src/get-started/install/_get-sdk-win.md
+++ b/src/get-started/install/_get-sdk-win.md
@@ -13,7 +13,7 @@
     check out the [SDK archive][].
  1. Extract the zip file and place the contained `flutter`
     in the desired installation location for the Flutter SDK
-    (for example, `C:\src\flutter`).
+    (for example, `%USERPROFILE%\flutter`, `D:\dev\flutter`).
 
 {{site.alert.warning}}
   Do not install Flutter to a path that contains special


### PR DESCRIPTION
There are many file access exception issues with Flutter that are caused by the inaccessible path for the Flutter installation on Windows. The PR changes the default path which should be available for users most of the time.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
