### PR TITLE
Add /ui exception for mini-toc generation

### DIFF
--- a/src/_layouts/toc.html
+++ b/src/_layouts/toc.html
@@ -17,7 +17,7 @@ toc: false
   {% else -%}
     {% assign path = path | append: '/' | append: path_part -%}
   {% endif -%}
-  {% if forloop.index0 > 0 -%}
+  {% if forloop.index0 > 0 and path != '/ui' -%}
     {% assign topics = topics | where: "permalink", path -%}
     {% assign topics = topics[0].children | where_exp:"item", "item != 'divider'" -%}
   {% endif -%}

--- a/src/_layouts/toc.html
+++ b/src/_layouts/toc.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 toc: false
+sitemap: false
 ---
 
 {% assign url = page.url | regex_replace: '/index$|/index.html$|/$' -%}

--- a/src/ui/design/index.md
+++ b/src/ui/design/index.md
@@ -1,6 +1,6 @@
 ---
 layout: toc
-title: Design
+title: Design & theming
 description: Content covering designing Flutter apps.
 sitemap: false
 ---

--- a/src/ui/index.md
+++ b/src/ui/index.md
@@ -1,5 +1,4 @@
 ---
-layout: toc
 title: Building user interfaces with Flutter
 short-title: UI
 description: Introduction to user interface development in Flutter.

--- a/src/ui/interactivity/gestures/index.md
+++ b/src/ui/interactivity/gestures/index.md
@@ -1,5 +1,6 @@
 ---
 title: Taps, drags, and other gestures
+short-title: Gestures
 description: How gestures, such as taps and drags, work in Flutter.
 ---
 


### PR DESCRIPTION
This allows index pages linked to from the breadcrumbs to be generated properly, such as the text index page. They were empty since the generation didn't account for `/ui` having multiple entries in the sidenav.

**Before:** https://docs.flutter.dev/ui/design/text

**After:** https://flutter-docs-prod--pr9164-fix-9156-yw9b52uw.web.app/ui/design/text
