### PR TITLE
Be explicit about how to invoke `ensureSemantics()`

### DIFF
--- a/src/accessibility-and-localization/accessibility.md
+++ b/src/accessibility-and-localization/accessibility.md
@@ -163,7 +163,14 @@ Users can skip this step if you programmatically auto-enable
 accessibility for your app using this API:
 
 ```dart
-SemanticsBinding.instance.ensureSemantics();
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  SemanticsBinding.instance.ensureSemantics();
+  runApp(const MyApp());
+}
 ```
 
 </div>

--- a/src/accessibility-and-localization/accessibility.md
+++ b/src/accessibility-and-localization/accessibility.md
@@ -167,9 +167,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 
 void main() {
-  WidgetsFlutterBinding.ensureInitialized();
-  SemanticsBinding.instance.ensureSemantics();
   runApp(const MyApp());
+  SemanticsBinding.instance.ensureSemantics();
 }
 ```
 


### PR DESCRIPTION
I spent a good while figuring out how to call `SemanticsBinding.instance.ensureSemantics()` without causing a error in the JavaScript console.

@kevmoo is this a recommended approach to invoking `ensureSemantics()` or should it be installed in an app in another way?

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
