### PR TITLE
Reduce stage expiration time

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -31,5 +31,5 @@ jobs:
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.SERVICE_KEY }}
-          expires: 14d
+          expires: 7d
           projectId: flutter-docs-prod


### PR DESCRIPTION
There's a limit on the amount of channels active at one time which we passed twice over the past week. 7 days should prevent this from happening while still being sufficient for review time. Staging can be manually retriggered in the GitHub actions UI if a link expired already or by merging in `main`.