### PR TITLE
Give online courses its own page

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -604,8 +604,10 @@
     - header: Learning
     - title: Books
       permalink: /resources/books
-    - title: Videos and online courses
+    - title: Videos
       permalink: /resources/videos
+    - title: Courses
+      permalink: /resources/courses
     - title: Learn Dart
       permalink: /resources/bootstrap-into-dart
     - header: Contributing

--- a/src/resources/courses.md
+++ b/src/resources/courses.md
@@ -1,0 +1,29 @@
+---
+title: Online courses
+description: An index of online courses teaching Flutter development.
+---
+
+Learn how to build Flutter apps with these video courses.
+Before signing up for a course, verify that it includes
+up-to-date information, such as null-safe Dart code.
+These courses are listed alphabetically.
+To include your course, [submit a PR][]:
+
+* [Flutter & Dart - The Complete Guide, 2023 Edition][]
+* [The Complete 2021 Flutter Development Bootcamp Using Dart][] by App Brewery
+* [Flutter Crash Course][] by Nick Manning
+* [Flutter leicht gemacht 2022 - Zero to Mastery!][] by Max Berktold (German)
+* [Flutter Zero to Hero][] by Veli Bacik (Turkish)
+* [Flutter Bootcamp][] by Rubens de Melo (Portuguese)
+* [Flutter para iniciantes][] by Rubens de Melo (Portuguese)
+* [Dart & Flutter - Zero to Mastery 2023 + Clean Architecture][] by Max Berktold & Max Steffen
+
+[Flutter & Dart - The Complete Guide, 2023 Edition]: https://www.udemy.com/course/learn-flutter-dart-to-build-ios-android-apps/
+[The Complete 2021 Flutter Development Bootcamp Using Dart]: https://www.appbrewery.co/p/flutter-development-bootcamp-with-dart/
+[Flutter Crash Course]: https://fluttercrashcourse.com/
+[Flutter leicht gemacht 2022 - Zero to Mastery!]: https://www.udemy.com/course/dart-flutter-leicht-gemacht/
+[Flutter Zero to Hero]: {{site.youtube-site}}/watch?v=lpvuM9lo3HU&list=PL1k5oWAuBhgXdw1BbxVGxxWRmkGB1C11l
+[Flutter Bootcamp]: https://flutterbootcamp.com.br
+[Flutter para iniciantes]: {{site.youtube-site}}/playlist?list=PLS4cqF1_X2syzBpkoSwtmKoREgnp1MhTn
+[Dart & Flutter - Zero to Mastery 2023 + Clean Architecture]: https://www.udemy.com/course/flutter-made-easy-zero-to-mastery/?referralCode=CCBFCD16CC71F359EE3C
+[submit a PR]: {{site.repo.this}}/pulls

--- a/src/resources/videos.md
+++ b/src/resources/videos.md
@@ -1,6 +1,7 @@
 ---
-title: Videos and online courses
-description: Available videos and online courses on various aspects of developing in Flutter.
+title: Videos
+description: >
+  Available videos on various aspects of developing in Flutter.
 ---
 
 These Flutter videos, produced both internally
@@ -183,31 +184,3 @@ millions of downloads.
 [Flutter developer stories playlist][]
 
 [Flutter developer stories playlist]: {{site.youtube-site}}/playlist?list=PLjxrf2q8roU33POuWi4bK0zvDpAHK6759
-
-## Online courses
-
-Learn how to build Flutter apps with these video courses.
-Before signing up for a course, verify that it includes
-up-to-date information, such as null safe Dart code.
-These courses are listed alphabetically.
-To include your course, [submit a PR][]:
-
-* [Flutter & Dart - The Complete Guide, 2023 Edition][]
-* [The Complete 2021 Flutter Development Bootcamp Using Dart][] by App Brewery
-* [Flutter Crash Course][] by Nick Manning
-* [Flutter leicht gemacht 2022 - Zero to Mastery!][] by Max Berktold (German)
-* [Flutter Zero to Hero][] by Veli Bacik (Turkish)
-* [Flutter Bootcamp][] by Rubens de Melo (Portuguese)
-* [Flutter para iniciantes][] by Rubens de Melo (Portuguese)
-* [Dart & Flutter - Zero to Mastery 2023 + Clean Architecture][] by Max Berktold & Max Steffen
-
-[Flutter & Dart - The Complete Guide, 2023 Edition]: https://www.udemy.com/course/learn-flutter-dart-to-build-ios-android-apps/
-[The Complete 2021 Flutter Development Bootcamp Using Dart]: https://www.appbrewery.co/p/flutter-development-bootcamp-with-dart/
-[Flutter Crash Course]: https://fluttercrashcourse.com/
-[Flutter leicht gemacht 2022 - Zero to Mastery!]: https://www.udemy.com/course/dart-flutter-leicht-gemacht/
-[Flutter Zero to Hero]: {{site.youtube-site}}/watch?v=lpvuM9lo3HU&list=PL1k5oWAuBhgXdw1BbxVGxxWRmkGB1C11l
-[Flutter Bootcamp]: https://flutterbootcamp.com.br
-[Flutter para iniciantes]: {{site.youtube-site}}/playlist?list=PLS4cqF1_X2syzBpkoSwtmKoREgnp1MhTn
-[Dart & Flutter - Zero to Mastery 2023 + Clean Architecture]: https://www.udemy.com/course/flutter-made-easy-zero-to-mastery/?referralCode=CCBFCD16CC71F359EE3C
-[submit a PR]: {{site.repo.this}}/pulls
-


### PR DESCRIPTION
The new page is relatively empty, but it provides a better experience for users looking for Flutter videos or courses through search.

Closes https://github.com/flutter/website/issues/9017