### PR TITLE
Fix broken API doc links in old release notes

### DIFF
--- a/src/release/release-notes/release-notes-0.0.21-1.0.0.md
+++ b/src/release/release-notes/release-notes-0.0.21-1.0.0.md
@@ -85,7 +85,7 @@ _This page is a dump of the old Changelog page from the Flutter wiki up until
 
 ### v0.9.2
 
-* [#21540](https://github.com/flutter/flutter/pull/21540) added a `transform()` method to [`Animatable`](https://docs.flutter.io/flutter/animation/Animatable-class.html). It is implemented by `Tween` (the main subclass of `Animatable`) but classes that subclass `Animatable` directly will need to implement it. Typically the existing `evaluate()` method can be changed to implement `transform()` instead, using the value given by the argument to `transform()` rather than the current value of the animation provided to `evaluate()`. `evaluate()` now has a default implementation that defers to `transform()`.
+* [#21540](https://github.com/flutter/flutter/pull/21540) added a `transform()` method to [`Animatable`](https://api.flutter.dev/flutter/animation/Animatable-class.html). It is implemented by `Tween` (the main subclass of `Animatable`) but classes that subclass `Animatable` directly will need to implement it. Typically the existing `evaluate()` method can be changed to implement `transform()` instead, using the value given by the argument to `transform()` rather than the current value of the animation provided to `evaluate()`. `evaluate()` now has a default implementation that defers to `transform()`.
 
 ## Changes in v0.8.2 (since v0.7.3) - beta 8
 
@@ -225,7 +225,7 @@ To follow our investigation, see [Dart issue 32936](https://github.com/dart-lang
 
 * [#15416](https://github.com/flutter/flutter/pull/15416) removed `package:http` from Flutter and replaced all usages with the `HttpClient` from `dart:io`. If you use `package:http` you must add it as a dependency in your `pubspec.yaml` to continue using it.
 
-  `createHttpClient()` was also removed after being marked deprecated. To change how the framework creates http clients, you can use [HttpOverrides](https://docs.flutter.io/flutter/dart-io/HttpOverrides-class.html) from `dart:io` to provide your own `createHttpClient()` callback globally or per zone.
+  `createHttpClient()` was also removed after being marked deprecated. To change how the framework creates http clients, you can use [HttpOverrides](https://api.flutter.dev/flutter/dart-io/HttpOverrides-class.html) from `dart:io` to provide your own `createHttpClient()` callback globally or per zone.
 
   More details are available [in the announcement](https://groups.google.com/forum/#!topic/flutter-dev/AnqDqgQ6vus).
 
@@ -297,7 +297,7 @@ To follow our investigation, see [Dart issue 32936](https://github.com/dart-lang
 
 ### v0.1.9
 
-* [#14901](https://github.com/flutter/flutter/pull/14901) A [Slider](https://docs.flutter.io/flutter/material/Slider-class.html) visual update changed the colors, opacities, and the value indicator shape and behavior. It also removed the "`thumbOpenAtMin`" flag from the Slider class, which is no longer needed, and can be emulated by the custom thumb shape support.
+* [#14901](https://github.com/flutter/flutter/pull/14901) A [Slider](https://api.flutter.dev/flutter/material/Slider-class.html) visual update changed the colors, opacities, and the value indicator shape and behavior. It also removed the "`thumbOpenAtMin`" flag from the Slider class, which is no longer needed, and can be emulated by the custom thumb shape support.
 
 ## Changes in v0.1.5 (since v0.1.4) - beta 1.1
 

--- a/src/release/release-notes/release-notes-1.2.1.md
+++ b/src/release/release-notes/release-notes-1.2.1.md
@@ -58,7 +58,7 @@ To integrate more fully with desktop form-factors like Android tablets and Chrom
 
 [#24830](https://github.com/flutter/flutter/pull/24830) Implement hover support for mouse pointers
 
-As widgets are the core way to interact with users in Flutter, this release continues to add features and fixes to the Flutter widget set with particular attention paid to the [SliverAppBar](https://docs.flutter.io/flutter/material/SliverAppBar-class.html):
+As widgets are the core way to interact with users in Flutter, this release continues to add features and fixes to the Flutter widget set with particular attention paid to the [SliverAppBar](https://api.flutter.dev/flutter/material/SliverAppBar-class.html):
 
 [#26021](https://github.com/flutter/flutter/pull/26021) Fix SliverAppBar title opacity and test all cases
 


### PR DESCRIPTION
The old links were 404ing on the marketing page.