### PR TITLE
Standardize extra anchor targets

### DIFF
--- a/src/accessibility-and-localization/internationalization.md
+++ b/src/accessibility-and-localization/internationalization.md
@@ -142,7 +142,7 @@ structured, is covered in this page.
 
 [113 languages]: {{site.api}}/flutter/flutter_localizations/GlobalMaterialLocalizations-class.html
 
-<a name="overriding-locale"></a>
+<a id="overriding-locale"></a>
 ### Overriding the locale
 
 `Localizations.override` is a factory constructor
@@ -194,7 +194,7 @@ Widget build(BuildContext context) {
 Hot reload the app and the `CalendarDatePicker`
 widget should re-render in Spanish.
 
-<a name="adding-localized-messages"></a>
+<a id="adding-localized-messages"></a>
 ### Adding your own localized messages
 
 After adding the `flutter_localizations` package,
@@ -633,7 +633,7 @@ AppLocalizations.of(context).helloWorldOn(DateTime.utc(1959, 7, 9))
 
 [`DateFormat`]: {{site.api}}/flutter/intl/DateFormat-class.html
 
-<a name="ios-specifics"></a>
+<a id="ios-specifics"></a>
 ### Localizing for iOS: Updating the iOS app bundle
 
 Typically, iOS applications define key application metadata,
@@ -660,13 +660,13 @@ use the following instructions:
 
 5. Once all supported locales have been added, save the file.
 
-<a name="advanced-customization">
+<a id="advanced-customization">
 ## Advanced topics for further customization
 
 This section covers additional ways to customize a
 localized Flutter application.
 
-<a name="advanced-locale"></a>
+<a id="advanced-locale"></a>
 ### Advanced locale definition
 
 Some languages with multiple variants require more than just a
@@ -725,7 +725,7 @@ should also be fully differentiated for more nuanced localization.
 
 [`Localizations`]: {{site.api}}/flutter/widgets/WidgetsApp/supportedLocales.html
 
-<a name="tracking-locale"></a>
+<a id="tracking-locale"></a>
 ### Tracking the locale: The Locale class and the Localizations widget
 
 The [`Locale`][] class identifies the user's language.
@@ -753,7 +753,7 @@ Locale myLocale = Localizations.localeOf(context);
 [`WidgetsApp`]: {{site.api}}/flutter/widgets/WidgetsApp-class.html
 [widgets-global]: {{site.api}}/flutter/flutter_localizations/GlobalWidgetsLocalizations-class.html
 
-<a name="specifying-supportedlocales"></a>
+<a id="specifying-supportedlocales"></a>
 ### Specifying the app's supported&shy;Locales parameter
 
 Although the `flutter_localizations` library currently supports
@@ -835,7 +835,7 @@ in Flutter. If you're planning on supporting your own set of localized
 messages, the following content would be helpful.
 Otherwise, you can skip this section.
 
-<a name="loading-and-retrieving"></a>
+<a id="loading-and-retrieving"></a>
 ### Loading and retrieving localized values
 
 The `Localizations` widget is used to load and
@@ -897,7 +897,7 @@ tooltip: MaterialLocalizations.of(context).backButtonTooltip,
 [`MaterialApp`]: {{site.api}}/flutter/material/MaterialApp-class.html
 [`MaterialLocalizations`]: {{site.api}}/flutter/material/MaterialLocalizations-class.html
 
-<a name="defining-class"></a>
+<a id="defining-class"></a>
 ### Defining a class for the app's localized resources
 
 Putting together an internationalized Flutter app usually
@@ -965,7 +965,7 @@ In this case that would just be the `DemoLocalizations` class.
 [`intl`]: {{site.pub-pkg}}/intl
 [`Intl.message()`]: {{site.pub-api}}/intl/latest/intl/Intl/message.html
 
-<a name="adding-language"></a>
+<a id="adding-language"></a>
 ### Adding support for a new language
 
 An app that needs to support a language that's not included in
@@ -1152,13 +1152,13 @@ const MaterialApp(
 [flutter_localizations README]: {{site.repo.flutter}}/blob/master/packages/flutter_localizations/lib/src/l10n/README.md
 [`GlobalMaterialLocalizations`]: {{site.api}}/flutter/flutter_localizations/GlobalMaterialLocalizations-class.html
 
-<a name="alternative-internationalization-workflows">
+<a id="alternative-internationalization-workflows">
 ## Alternative internationalization workflows
 
 This section describes different approaches to internationalize
 your Flutter application.
 
-<a name="alternative-class"></a>
+<a id="alternative-class"></a>
 ### An alternative class for the app's localized resources
 
 The previous example was defined in terms of the Dart `intl`
@@ -1228,7 +1228,7 @@ class DemoLocalizationsDelegate
 
 [`SynchronousFuture`]: {{site.api}}/flutter/foundation/SynchronousFuture-class.html
 
-<a name="dart-tools"></a>
+<a id="dart-tools"></a>
 ### Using the Dart intl tools
 
 Before building an API using the Dart [`intl`][] package,

--- a/src/apprentice-giveaway/index.md
+++ b/src/apprentice-giveaway/index.md
@@ -19,10 +19,9 @@ description: This event is ended.
 
 ---
 
-<a name="videos"></a>
+<a id="videos"></a>
 ## Book club replay videos
 
-<a name="videos"></a>
 You can find replays of the book club videos on YouTube.
 
 <div class="table-wrapper" markdown="1">

--- a/src/data-and-backend/serialization/json.md
+++ b/src/data-and-backend/serialization/json.md
@@ -99,7 +99,7 @@ based on code generation instead. This
 approach is covered in more detail in the
 [code generation libraries][] section.
 
-<a name="manual-encoding"></a>
+<a id="manual-encoding"></a>
 ## Serializing JSON manually using dart:convert
 
 Basic JSON serialization in Flutter is very simple. Flutter has a built-in
@@ -221,7 +221,7 @@ class.
 It would be nice if there were something that handled the JSON encoding
 and decoding for you.  Luckily, there is!
 
-<a name="code-generation"></a>
+<a id="code-generation"></a>
 ## Serializing JSON using code generation libraries
 
 Although there are other libraries available, this guide uses

--- a/src/perf/deferred-components.md
+++ b/src/perf/deferred-components.md
@@ -314,7 +314,7 @@ any issues and guides you through suggested changes to fix them.
 {{site.alert.end}}
 
 <ol markdown="1">
-<li markdown="1"><a name="step-3.1"></a>The
+<li markdown="1"><a id="step-3.1"></a>The
     `flutter build appbundle` command
     runs the validator and attempts to build the app with
     `gen_snapshot` instructed to produce split AOT shared libraries
@@ -413,7 +413,7 @@ validator passes.
     changes to your `android/` directory automatically.
 </li>
 
-<li markdown="1"><a name="step-3.3"></a>Once the available
+<li markdown="1"><a id="step-3.3"></a>Once the available
     loading units are generated and logged in
     `<projectDirectory>/deferred_components_loading_units.yaml`,
     it is possible to fully configure the pubspec’s

--- a/src/platform-integration/ios/ios-app-clip.md
+++ b/src/platform-integration/ios/ios-app-clip.md
@@ -74,7 +74,7 @@ activate the new scheme for the new target.
 {% include docs/app-figure.md
 image="development/platform-integration/ios-app-clip/activate-scheme.png" %}
 
-<a name="step-3"></a>
+<a id="step-3"></a>
 ## Step 3 - Remove unneeded files
 
 **3.1**

--- a/src/platform-integration/web/index.md
+++ b/src/platform-integration/web/index.md
@@ -56,7 +56,7 @@ the following video:
 
 <iframe width="560" height="315" src="{{site.youtube-site}}/embed/HAstl_NkXl0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<a name="web"></a>
+<a id="web"></a>
 ## Resources
 
 The following resources can help you get started:

--- a/src/resources/architectural-overview.md
+++ b/src/resources/architectural-overview.md
@@ -1059,23 +1059,23 @@ provides a useful guide to the framework’s design philosophy.
 
 **Footnotes:**
 
-<sup><a name="a1">1</a></sup> While the `build` function returns a fresh tree,
+<sup><a id="a1">1</a></sup> While the `build` function returns a fresh tree,
 you only need to return something _different_ if there's some new
 configuration to incorporate. If the configuration is in fact the same, you can
 just return the same widget.
 
-<sup><a name="a2">2</a></sup> This is a slight simplification for ease of
+<sup><a id="a2">2</a></sup> This is a slight simplification for ease of
 reading. In practice, the tree might be more complex.
 
-<sup><a name="a3">3</a></sup> While work is underway on Linux and Windows,
+<sup><a id="a3">3</a></sup> While work is underway on Linux and Windows,
 examples for those platforms can be found in the [Flutter desktop embedding
 repository]({{site.github}}/google/flutter-desktop-embedding/tree/master/plugins).
 As development on those platforms reaches maturity, this content will be
 gradually migrated into the main Flutter repository.
 
-<sup><a name="a4">4</a></sup> There are some limitations with this approach, for
+<sup><a id="a4">4</a></sup> There are some limitations with this approach, for
 example, transparency doesn’t composite the same way for a platform view as it
 would for other Flutter widgets.
 
-<sup><a name="a5">5</a></sup> One example is shadows, which have to be
+<sup><a id="a5">5</a></sup> One example is shadows, which have to be
 approximated with DOM-equivalent primitives at the cost of some fidelity.

--- a/src/resources/inside-flutter.md
+++ b/src/resources/inside-flutter.md
@@ -624,11 +624,11 @@ widgets on demand when they become visible.
 ---
 **Footnotes:**
 
-<sup><a name="a1">1</a></sup> For layout, at least. It might be revisited
+<sup><a id="a1">1</a></sup> For layout, at least. It might be revisited
   for painting, for building the accessibility tree if necessary,
   and for hit testing if necessary.
 
-<sup><a name="a2">2</a></sup> Reality, of course, is a bit more
+<sup><a id="a2">2</a></sup> Reality, of course, is a bit more
   complicated. Some layouts involve intrinsic dimensions or baseline
   measurements, which do involve an additional walk of the relevant subtree
   (aggressive caching is used to mitigate the potential for quadratic
@@ -636,7 +636,7 @@ widgets on demand when they become visible.
   rare. In particular, intrinsic dimensions are not required for the
   common case of shrink-wrapping.
 
-<sup><a name="a3">3</a></sup> Technically, the child's position is not
+<sup><a id="a3">3</a></sup> Technically, the child's position is not
   part of its RenderBox geometry and therefore need not actually be
   calculated during layout. Many render objects implicitly position
   their single child at 0,0 relative to their own origin, which
@@ -645,7 +645,7 @@ widgets on demand when they become visible.
   possible moment (for example, during the paint phase), to avoid
   the computation entirely if they are not subsequently painted.
 
-<sup><a name="a4">4</a></sup>  There exists one exception to this rule.
+<sup><a id="a4">4</a></sup>  There exists one exception to this rule.
   As discussed in the [Building widgets on demand](#building-widgets-on-demand)
   section, some widgets can be rebuilt as a result of a change in layout
   constraints. If a widget marked itself dirty for unrelated reasons in
@@ -653,19 +653,19 @@ widgets on demand when they become visible.
   it will be updated twice. This redundant build is limited to the
   widget itself and does not impact its descendants.
 
-<sup><a name="a5">5</a></sup> A key is an opaque object optionally
+<sup><a id="a5">5</a></sup> A key is an opaque object optionally
   associated with a widget whose equality operator is used to influence
   the reconciliation algorithm.
 
-<sup><a name="a6">6</a></sup>  For accessibility, and to give applications
+<sup><a id="a6">6</a></sup>  For accessibility, and to give applications
   a few extra milliseconds between when a widget is built and when it
   appears on the screen, the viewport creates (but does not paint)
   widgets for a few hundred pixels before and after the visible widgets.
 
-<sup><a name="a7">7</a></sup>  This approach was first made popular by
+<sup><a id="a7">7</a></sup>  This approach was first made popular by
   Facebook's React library.
 
-<sup><a name="a8">8</a></sup>  In practice, the _t_ value is allowed
+<sup><a id="a8">8</a></sup>  In practice, the _t_ value is allowed
   to extend past the 0.0-1.0 range, and does so for some curves. For
   example, the "elastic" curves overshoot briefly in order to represent
   a bouncing effect. The interpolation logic typically can extrapolate

--- a/src/tools/android-studio.md
+++ b/src/tools/android-studio.md
@@ -18,7 +18,7 @@ description: >
 Follow the [Set up an editor]({{site.url}}/get-started/editor?tab=androidstudio)
 instructions to install the Dart and Flutter plugins.
 
-### Updating the plugins<a name="updating"/>
+### Updating the plugins {#updating}
 
 Updates to the plugins are shipped on a regular basis.
 You should be prompted in the IDE when an update is available.

--- a/src/tools/devtools/overview.md
+++ b/src/tools/devtools/overview.md
@@ -29,7 +29,7 @@ Here are some of the things you can do with DevTools:
 We expect you to use DevTools in conjunction with
 your existing IDE or command-line based development workflow.
 
-<a name="install-devtools"></a>
+<a id="install-devtools"></a>
 ## How do I install DevTools?
 
 See the [VS Code][], [Android Studio/IntelliJ][], or

--- a/src/ui/animations/hero-animations.md
+++ b/src/ui/animations/hero-animations.md
@@ -105,7 +105,7 @@ to learn how to structure hero animation code,
 and [behind the scenes](#behind-the-scenes) to understand
 how Flutter performs a hero animation.
 
-<a name="basic-structure"></a>
+<a id="basic-structure"></a>
 ## Basic structure of a hero animation
 
 {{site.alert.secondary}}
@@ -269,7 +269,7 @@ implement hero animations:
     image in a layout widget. These examples use `Container`.
 {{site.alert.end}}
 
-<a name="standard-hero-animation-code"></a>
+<a id="standard-hero-animation-code"></a>
 {{site.alert.secondary}}
   **Standard hero animation code**
 
@@ -460,7 +460,7 @@ in the Material motion spec.
 This animation might seem complex (and it is), but you can **customize the
 provided example to your needs.** The heavy lifting is done for you.
 
-<a name="radial-hero-animation-code"></a>
+<a id="radial-hero-animation-code"></a>
 {{site.alert.secondary}}
   **Radial hero animation code**
 

--- a/src/ui/animations/tutorial.md
+++ b/src/ui/animations/tutorial.md
@@ -31,7 +31,7 @@ triggered by setting a beginning and ending point.
 They are simpler to implement
 than custom explicit animations, which are described here.
 
-<a name="concepts"></a>
+<a id="concepts"></a>
 ## Essential animation concepts and classes
 
 {{site.alert.secondary}}
@@ -61,7 +61,7 @@ changes or they can use the animations as the basis of
 more elaborate animations that they pass along to
 other widgets.
 
-<a name="animation-class"></a>
+<a id="animation-class"></a>
 ### Animation<wbr>\<double>
 
 In Flutter, an `Animation` object knows nothing about what
@@ -543,7 +543,7 @@ and it passes the `Animation` object to `AnimatedLogo`:
 
 **App source:** [animate2][]
 
-<a name="monitoring"></a>
+<a id="monitoring"></a>
 ### Monitoring the progress of the animation
 
 {{site.alert.secondary}}

--- a/src/ui/interactivity/index.md
+++ b/src/ui/interactivity/index.md
@@ -126,7 +126,7 @@ or you've launched the [iOS simulator][]
 [Android emulator][] (part of the Android Studio
 install), you are good to go!
 
-<a name="step-1"></a>
+<a id="step-1"></a>
 ### Step 1: Decide which object manages the widget's state
 
 A widget's state can be managed in several ways,
@@ -139,7 +139,7 @@ the UI, so the widget can handle its state internally.
 Learn more about the separation of widget and state,
 and how state might be managed, in [Managing state][].
 
-<a name="step-2"></a>
+<a id="step-2"></a>
 ### Step 2: Subclass StatefulWidget
 
 The `FavoriteWidget` class manages its own state,
@@ -168,7 +168,7 @@ class FavoriteWidget extends StatefulWidget {
   [Dart language documentation][].
 {{site.alert.end}}
 
-<a name="step-3"></a>
+<a id="step-3"></a>
 ### Step 3: Subclass State
 
 The `_FavoriteWidgetState` class stores the mutable data
@@ -261,7 +261,7 @@ void _toggleFavorite() {
 }
 ```
 
-<a name="step-4"></a>
+<a id="step-4"></a>
 ### Step 4: Plug the stateful widget into the widget tree
 
 Add your custom stateful widget to the widget tree in
@@ -371,7 +371,7 @@ color: green for active or grey for inactive.
 These examples use [`GestureDetector`][] to capture activity
 on the `Container`.
 
-<a name="self-managed"></a>
+<a id="self-managed"></a>
 ### The widget manages its own state
 
 Sometimes it makes the most sense for the widget
@@ -462,7 +462,7 @@ class MyApp extends StatelessWidget {
 
 <hr>
 
-<a name="parent-managed"></a>
+<a id="parent-managed"></a>
 ### The parent widget manages the widget's state
 
 Often it makes the most sense for the parent widget
@@ -565,7 +565,7 @@ class TapboxB extends StatelessWidget {
 
 <hr>
 
-<a name="mix-and-match"></a>
+<a id="mix-and-match"></a>
 ### A mix-and-match approach
 
 For some widgets, a mix-and-match approach makes


### PR DESCRIPTION
In HTML4 both `id` and `name` were allowed, but technically only `id` is allowed for anchors now.