### PR TITLE
Update "Customizing tabs alignment using the new TabBar.tabAlignment property"

### DIFF
--- a/src/release/breaking-changes/tab-alignment.md
+++ b/src/release/breaking-changes/tab-alignment.md
@@ -86,7 +86,7 @@ TabBar(
 
 ## Timeline
 
-Landed in version: 3.11.0-0.0.pre<br>
+Landed in version: 3.13.0-17.0.pre<br>
 In stable release: TBD
 
 ## References
@@ -107,4 +107,4 @@ Relevant PRs:
 [`TabAlignment`]: {{site.api}}/flutter/material/TabAlignment.html
 
 [Introduce `TabBar.tabAlignment`]: {{site.repo.flutter}}/pull/125036
-[Fix Material 3 Scrollable `TabBar`]: {{site.repo.flutter}}/pull/125974
+[Fix Material 3 Scrollable `TabBar`]: {{site.repo.flutter}}/pull/131409


### PR DESCRIPTION
fixes https://github.com/flutter/website/issues/9228

Timeline and PR reference in [Customizing tabs alignment using the new TabBar.tabAlignment property](https://docs.flutter.dev/release/breaking-changes/tab-alignment) are outdated

https://github.com/flutter/flutter/pull/131409 landed recently and the breaking change page needs to reflect that.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
