### PR TITLE
Add 'characters' example to text field changes cookbook recipe

### DIFF
--- a/examples/cookbook/forms/text_field_changes/lib/main.dart
+++ b/examples/cookbook/forms/text_field_changes/lib/main.dart
@@ -51,7 +51,8 @@ class _MyCustomFormState extends State<MyCustomForm> {
 
   // #docregion printLatestValue
   void _printLatestValue() {
-    print('Second text field: ${myController.text}');
+    final text = myController.text;
+    print('Second text field: $text (${text.characters.length})');
   }
   // #enddocregion printLatestValue
 
@@ -68,7 +69,7 @@ class _MyCustomFormState extends State<MyCustomForm> {
             // #docregion TextField1
             TextField(
               onChanged: (text) {
-                print('First text field: $text');
+                print('First text field: $text (${text.characters.length})');
               },
             ),
             // #enddocregion TextField1

--- a/src/cookbook/forms/text-field-changes.md
+++ b/src/cookbook/forms/text-field-changes.md
@@ -25,14 +25,19 @@ The simplest approach is to supply an [`onChanged()`][] callback to a
 [`TextField`][] or a [`TextFormField`][].
 Whenever the text changes, the callback is invoked.
 
-In this example, print the current value of the text field to the
-console every time the text changes.
+In this example, print the current value and length of the text field 
+to the console every time the text changes.
+
+It's important to use [characters][] when dealing with user input,
+as text may contain complex characters.
+This ensures that every character is counted correctly
+as they appear to the user.
 
 <?code-excerpt "lib/main.dart (TextField1)"?>
 ```dart
 TextField(
   onChanged: (text) {
-    print('First text field: $text');
+    print('First text field: $text (${text.characters.length})');
   },
 ),
 ```
@@ -115,7 +120,8 @@ out the current value of the text field.
 <?code-excerpt "lib/main.dart (printLatestValue)"?>
 ```dart
 void _printLatestValue() {
-  print('Second text field: ${myController.text}');
+  final text = myController.text;
+  print('Second text field: $text (${text.characters.length})');
 }
 ```
 
@@ -203,7 +209,8 @@ class _MyCustomFormState extends State<MyCustomForm> {
   }
 
   void _printLatestValue() {
-    print('Second text field: ${myController.text}');
+    final text = myController.text;
+    print('Second text field: $text (${text.characters.length})');
   }
 
   @override
@@ -218,7 +225,7 @@ class _MyCustomFormState extends State<MyCustomForm> {
           children: [
             TextField(
               onChanged: (text) {
-                print('First text field: $text');
+                print('First text field: $text (${text.characters.length})');
               },
             ),
             TextField(
@@ -232,10 +239,10 @@ class _MyCustomFormState extends State<MyCustomForm> {
 }
 ```
 
-
 [`addListener()`]: {{site.api}}/flutter/foundation/ChangeNotifier/addListener.html
 [`controller`]: {{site.api}}/flutter/material/TextField/controller.html
 [`onChanged()`]: {{site.api}}/flutter/material/TextField/onChanged.html
 [`TextField`]: {{site.api}}/flutter/material/TextField-class.html
 [`TextEditingController`]: {{site.api}}/flutter/widgets/TextEditingController-class.html
 [`TextFormField`]: {{site.api}}/flutter/material/TextFormField-class.html
+[characters]: {{site.pub}}/packages/characters


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

As proposed in https://github.com/flutter/website/issues/4834#issuecomment-1673187300
adds an example of use of `characters` text fields input and links to documentation.

_Issues fixed by this PR (if any):_

Closes #4834

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
