### PR TITLE
add locking device orientation section to orientation cookbook recipe

### DIFF
--- a/examples/cookbook/design/orientation/lib/orientation.dart
+++ b/examples/cookbook/design/orientation/lib/orientation.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'main.dart';
+
+// #docregion PreferredOrientations
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  SystemChrome.setPreferredOrientations([
+    DeviceOrientation.portraitUp,
+  ]);
+  runApp(const MyApp());
+}
+// #enddocregion PreferredOrientations

--- a/src/cookbook/design/orientation.md
+++ b/src/cookbook/design/orientation.md
@@ -135,7 +135,41 @@ class OrientationList extends StatelessWidget {
   <img src="/assets/images/docs/cookbook/orientation.gif" alt="Orientation Demo" class="site-mobile-screenshot" />
 </noscript>
 
+## Locking device orientation
+
+In the previous section you have learned 
+how to adapt the app UI to device orientation changes.
+
+However, Flutter also allows you define the specific preferred orientations
+that your app will support.
+This allows you to lock the app to single orientation 
+(e.g. only portrait up position)
+or to allow multiple orientations 
+(e.g. both portrait up and down, but not lanscape).
+
+In the application `main()` method,
+call to [`SystemChrome.setPreferredOrientations()`]
+with the list of preferred orientations that your app supports.
+
+You can also pass a list with a single item
+to lock the device to that specific device orientation.
+
+Check [`DeviceOrientation`] for a list of all the possible values.
+
+<?code-excerpt "lib/orientation.dart (PreferredOrientations)"?>
+```dart
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  SystemChrome.setPreferredOrientations([
+    DeviceOrientation.portraitUp,
+  ]);
+  runApp(const MyApp());
+}
+```
+
 
 [Creating a grid list]: {{site.url}}/cookbook/lists/grid-lists
-[`Orientation`]: {{site.api}}/flutter/widgets/Orientation.html
+[`DeviceOrientation`]: {{site.api}}/flutter/services/DeviceOrientation.html
 [`OrientationBuilder`]: {{site.api}}/flutter/widgets/OrientationBuilder-class.html
+[`Orientation`]: {{site.api}}/flutter/widgets/Orientation.html
+[`SystemChrome.setPreferredOrientations()`]: {{site.api}}/flutter/services/SystemChrome/setPreferredOrientations.html


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

This PR adds a section explaining how to device orientation lock in the "Update the UI based on orientation" cookbook recipe.

This section has been added at the bottom of the page after the interactive example.
I decided to put it after because, although it is related to the topic, it is not part of the code steps.

_Issues fixed by this PR (if any):_

- Closes #1757

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
