### PR TITLE
[Windows] Document the show window migration

### DIFF
--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -51,6 +51,7 @@ release, and listed in alphabetical order:
 * [Removed `ignoringSemantics`][] properties
 * [Deprecated `RouteInformation.location`][] and its related APIs
 * [Updated EditableText scroll into view behavior][]
+* [Migrate a Windows project to ensure the window is shown][]
 
 [Deprecated API removed after v3.10]: {{site.url}}/release/breaking-changes/3-10-deprecations
 [Added AppLifecycleState.hidden]: {{site.url}}/release/breaking-changes/add-applifecyclestate-hidden
@@ -58,6 +59,7 @@ release, and listed in alphabetical order:
 [Removed `ignoringSemantics`]: {{site.url}}/release/breaking-changes/ignoringsemantics-migration
 [Deprecated `RouteInformation.location`]: {{site.url}}/release/breaking-changes/route-information-uri
 [Updated EditableText scroll into view behavior]: {{site.url}}/release/breaking-changes/editable-text-scroll-into-view
+[Migrate a Windows project to ensure the window is shown]: {{site.url}}/release/breaking-changes/windows-show-window-migration
 
 ### Released in Flutter 3.10
 

--- a/src/release/breaking-changes/windows-show-window-migration.md
+++ b/src/release/breaking-changes/windows-show-window-migration.md
@@ -3,9 +3,11 @@ title: Migrate a Windows project to ensure the window is shown
 description: How to update a Windows project to ensure the window is shown
 ---
 
-Flutter 3.13 fixed an issue that could result in the window not being shown.
+Flutter 3.13 fixed a [bug][] that could result in the window not being shown.
 Windows projects created using Flutter 3.7 or Flutter 3.10 need to be migrated
 to fix this issue.
+
+[bug]: {{site.github}}/flutter/flutter/issues/119415
 
 ## Migration steps
 

--- a/src/release/breaking-changes/windows-show-window-migration.md
+++ b/src/release/breaking-changes/windows-show-window-migration.md
@@ -1,0 +1,49 @@
+---
+title: Migrate a Windows project to ensure the window is shown
+description: How to update a Windows project to ensure the window is shown
+---
+
+Flutter 3.13 fixed an issue that could result in the window not being shown.
+Windows projects created using Flutter 3.7 or Flutter 3.10 need to be migrated
+to fix this issue.
+
+## Migration steps
+
+Verify you are on Flutter version 3.13 or newer using `flutter --version`.
+If needed, use `flutter upgrade` to update to the latest version of the
+Flutter SDK.
+
+Projects that have not modified their `windows/runner/flutter_window.cpp` file
+will be migrated automatically by `flutter run` or `flutter build windows`.
+
+Projects that have modified their `windows/runner/flutter_window.cpp` file might
+need to migrate manually.
+
+Code before migration:
+
+```cpp
+flutter_controller_->engine()->SetNextFrameCallback([&]() {
+  this->Show();
+});
+```
+
+Code after migration:
+
+```cpp
+flutter_controller_->engine()->SetNextFrameCallback([&]() {
+  this->Show();
+});
+
+// Flutter can complete the first frame before the "show window" callback is
+// registered. The following call ensures a frame is pending to ensure the
+// window is shown. It is a no-op if the first frame hasn't completed yet.
+flutter_controller_->ForceRedraw();
+```
+
+## Example
+
+[PR 995][] shows the migration work for the
+[Flutter Gallery][] app.
+
+[PR 995]: {{site.github}}/flutter/gallery/pull/995/files
+[Flutter Gallery]: https://gallery.flutter.dev/


### PR DESCRIPTION
Flutter 3.7 and 3.10 has a race condition that can result in the window not being shown (see https://github.com/flutter/flutter/issues/119415). Projects need to be migrated to fix this bug.

Most Windows projects will be migrated automatically by running `flutter windows build` or `flutter run` unless they've done significant changes to their `windows/runner/flutter_window.cpp` file.

This documents how to migrate a Windows project manually. Note that this fix depends on an API that was added in Flutter 3.13. In other words, projects that are still using Flutter 3.7 or 3.10 should not do this migration.

_Issues fixed by this PR (if any):_ https://github.com/flutter/flutter/issues/127695

![image](https://github.com/flutter/website/assets/737941/a9ed95bf-91be-4a23-9857-fb888fee244a)

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
