### PR TITLE
fix grammar in layout-basics.md

### DIFF
--- a/src/codelabs/layout-basics.md
+++ b/src/codelabs/layout-basics.md
@@ -621,7 +621,7 @@ the widget becomes the `Flexible` widget's child
 and is considered *flexible*.
 After inflexible widgets are laid out,
 the widgets are resized according to their
-`flex` and `fit` properties.:
+`flex` and `fit` properties:
 
 `flex`
 : Compares itself against other `flex`


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Current sentence including a full stop after colon is incorrect. To fix it the colon can be used without a full stop or the sentence can be rephrased, which doesn't seem necessary to me.

_Issues fixed by this PR (if any):_

Incorrect grammar

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
