### PR TITLE
Add arb-editor reference to i18n docs

### DIFF
--- a/src/ui/accessibility-and-localization/internationalization.md
+++ b/src/ui/accessibility-and-localization/internationalization.md
@@ -346,7 +346,9 @@ return MaterialApp(
 
 ### Placeholders, plurals, and selects
 {{site.alert.note}}
-  When using VS Code, the [arb-editor](https://marketplace.visualstudio.com/items?itemName=Google.arb-editor) extension can help with editing `.arb` templates file through syntax hightlighting, snippets, diagnostics, and quick fixes.
+  When using VS Code, the [arb-editor](https://marketplace.visualstudio.com/items?itemName=Google.arb-editor)
+  extension can help with editing `.arb` templates file through syntax
+  hightlighting, snippets, diagnostics, and quick fixes.
 {{site.alert.end}}
 
 You can also include application values in a message with

--- a/src/ui/accessibility-and-localization/internationalization.md
+++ b/src/ui/accessibility-and-localization/internationalization.md
@@ -345,6 +345,9 @@ return MaterialApp(
 [`MaterialApp.onGenerateTitle`]: {{site.api}}/flutter/material/MaterialApp/onGenerateTitle.html
 
 ### Placeholders, plurals, and selects
+{{site.alert.note}}
+  When using VS Code, the [arb-editor](https://marketplace.visualstudio.com/items?itemName=Google.arb-editor) extension can help with editing `.arb` templates file through syntax hightlighting, snippets, diagnostics, and quick fixes.
+{{site.alert.end}}
 
 You can also include application values in a message with
 special syntax that uses a _placeholder_ to generate a method

--- a/src/ui/accessibility-and-localization/internationalization.md
+++ b/src/ui/accessibility-and-localization/internationalization.md
@@ -346,10 +346,10 @@ return MaterialApp(
 
 ### Placeholders, plurals, and selects
 
-{{site.alert.note}}
+{{site.alert.tip}}
   When using VS Code, add the [arb-editor extension][].
-  This extension adds syntax hightlighting, snippets, diagnostics, and quick fixes.
-  to help edit `.arb` template files.
+  This extension adds syntax highlighting, snippets, 
+  diagnostics, and quick fixes to help edit `.arb` template files.
 {{site.alert.end}}
 
 [arb-editor extension]: https://marketplace.visualstudio.com/items?itemName=Google.arb-editor

--- a/src/ui/accessibility-and-localization/internationalization.md
+++ b/src/ui/accessibility-and-localization/internationalization.md
@@ -345,11 +345,14 @@ return MaterialApp(
 [`MaterialApp.onGenerateTitle`]: {{site.api}}/flutter/material/MaterialApp/onGenerateTitle.html
 
 ### Placeholders, plurals, and selects
+
 {{site.alert.note}}
-  When using VS Code, the [arb-editor](https://marketplace.visualstudio.com/items?itemName=Google.arb-editor)
-  extension can help with editing `.arb` templates file through syntax
-  hightlighting, snippets, diagnostics, and quick fixes.
+  When using VS Code, add the [arb-editor extension][].
+  This extension adds syntax hightlighting, snippets, diagnostics, and quick fixes.
+  to help edit `.arb` template files.
 {{site.alert.end}}
+
+[arb-editor extension]: https://marketplace.visualstudio.com/items?itemName=Google.arb-editor
 
 You can also include application values in a message with
 special syntax that uses a _placeholder_ to generate a method


### PR DESCRIPTION
Add arb-editor reference to i18n documentation.

Fix #9286.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
