### PR TITLE
Eliminate `CRLF` from the copied `flutter` directory for Docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ env:
 jobs:
 
   test:
+    runs-on: windows-latest
     if: github.repository == 'flutter/website'
     strategy:
       fail-fast: false
@@ -31,8 +32,6 @@ jobs:
           - name: "Stable channel"
             branch: stable
             experimental: false
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
     steps:
       - run: git config --global core.autocrlf true
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ env:
 jobs:
 
   test:
-    runs-on: ${{ matrix.os }}
     if: github.repository == 'flutter/website'
     strategy:
       fail-fast: false
@@ -33,6 +32,7 @@ jobs:
             branch: stable
             experimental: false
         os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - run: git config --global core.autocrlf true
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ env:
 jobs:
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     if: github.repository == 'flutter/website'
     strategy:
       fail-fast: false
@@ -32,7 +32,9 @@ jobs:
           - name: "Stable channel"
             branch: stable
             experimental: false
+        os: [ubuntu-latest, windows-latest]
     steps:
+      - run: git config --global core.autocrlf true
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           submodules: recursive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,6 @@ jobs:
             branch: stable
             experimental: false
     steps:
-      - run: git config --global core.autocrlf true
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           submodules: recursive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ env:
 jobs:
 
   test:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     if: github.repository == 'flutter/website'
     strategy:
       fail-fast: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 WORKDIR /app
 
 # Replace all files from CRLF to LF in case they are copied from the Windows environment.
-ENV REPLACE_CRLF find . -type f -not -name "*.bat" -not -path "*/.git/*" -not -path "*/flutter/bin/internal/shared.sh" -exec sed -i 's/\r$//' {} \;
+ENV REPLACE_CRLF find . -type f -not -name "*.bat" -not -path "*/.git/*" -exec sed -i 's/\r$//' {} \;
 
 
 # ============== INSTALL FLUTTER ==============

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 WORKDIR /app
 
 
-ENV REPLACE_CRLF="find . -not \( -name .git -prune \) -type f -exec perl -pi -e 's/\r\n|\n|\r/\n/g' {} \;"
+RUN alias REPLACE_CRLF='find . -not \( -name .git -prune \) -type f -exec perl -pi -e "s/\r\n|\n|\r/\n/g" {} \;'
 # ============== INSTALL FLUTTER ==============
 # NOTE that this will fail if you have not cloned the repo with --recurse-submodules
 # or run `git submodule update --init --recursive` after cloning.

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,10 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 
 WORKDIR /app
 
+# Replace all files from CRLF to LF in case they are copied from the Windows environment.
+ENV REPLACE_CRLF find . -type f -exec sed -i 's/\r$//' {} \;
 
-RUN alias REPLACE_CRLF='find . -not \( -name .git -prune \) -type f -exec perl -pi -e "s/\r\n|\n|\r/\n/g" {} \;'
+
 # ============== INSTALL FLUTTER ==============
 # NOTE that this will fail if you have not cloned the repo with --recurse-submodules
 # or run `git submodule update --init --recursive` after cloning.

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 WORKDIR /app
 
 # Replace all files from CRLF to LF in case they are copied from the Windows environment.
-ENV REPLACE_CRLF find . -type f -not -name "*.bat" -not -path "*/.git/*" -exec sed -i 's/\r$//' {} \;
+ENV REPLACE_CRLF find . -type f -not -name "*.bat" -not -path "*/.git/*" -not -path "*/flutter/bin/internal/shared.sh" -exec sed -i 's/\r$//' {} \;
 
 
 # ============== INSTALL FLUTTER ==============

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 WORKDIR /app
 
 # Replace all files from CRLF to LF in case they are copied from the Windows environment.
-ENV REPLACE_CRLF find . -type f -not -name "*.bat" -exec sed -i 's/\r$//' {} \;
+ENV REPLACE_CRLF find . -type f -not -name "*.bat" -not -path "*/.git/*" -exec sed -i 's/\r$//' {} \;
 
 
 # ============== INSTALL FLUTTER ==============

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ FROM base AS flutter
 
 # This Flutter install uses/requires the local ./flutter submodule
 COPY ./flutter ./flutter
+RUN find . -not \( -name .git -prune \) -type f -exec perl -pi -e 's/\r\n|\n|\r/\n/g' {} \;
 COPY ./site-shared ./site-shared
 COPY pubspec.yaml ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,6 @@ RUN npm install -g firebase-tools@12.4.0
 FROM flutter AS tests
 
 COPY ./ ./
-RUN $REPLACE_CRLF
 
 ARG FLUTTER_TEST_BRANCH=stable
 ENV FLUTTER_TEST_BRANCH=$FLUTTER_TEST_BRANCH
@@ -104,7 +103,6 @@ COPY package.json package-lock.json ./
 RUN npm install
 
 COPY ./ ./
-RUN $REPLACE_CRLF
 
 # Jekyl ports
 EXPOSE 35730

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 WORKDIR /app
 
 
-ENV REPLACE_CRLF='find . -not \( -name .git -prune \) -type f -exec perl -pi -e 's/\r\n|\n|\r/\n/g' {} \;'
+ENV REPLACE_CRLF="find . -not \( -name .git -prune \) -type f -exec perl -pi -e 's/\r\n|\n|\r/\n/g' {} \;"
 # ============== INSTALL FLUTTER ==============
 # NOTE that this will fail if you have not cloned the repo with --recurse-submodules
 # or run `git submodule update --init --recursive` after cloning.

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 WORKDIR /app
 
 
+
 # ============== INSTALL FLUTTER ==============
 # NOTE that this will fail if you have not cloned the repo with --recurse-submodules
 # or run `git submodule update --init --recursive` after cloning.

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,6 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 
 WORKDIR /app
 
-# Replace all files from CRLF to LF in case they are copied from the Windows environment.
-ENV REPLACE_CRLF find . -type f -not -name "*.bat" -not -path "*/.git/*" -exec sed -i 's/\r$//' {} \;
-
 
 # ============== INSTALL FLUTTER ==============
 # NOTE that this will fail if you have not cloned the repo with --recurse-submodules
@@ -30,7 +27,8 @@ FROM base AS flutter
 COPY ./flutter ./flutter
 COPY ./site-shared ./site-shared
 COPY pubspec.yaml ./
-RUN $REPLACE_CRLF
+# Replace files from CRLF to LF (*.bat and .git directories are excluded) in case they are copied from the Windows environment.
+RUN find . -type f -not -name "*.bat" -not -path "*/.git/*" -exec sed -i 's/\r$//' {} \;
 
 ARG FLUTTER_BUILD_BRANCH
 ENV FLUTTER_BUILD_BRANCH=$FLUTTER_BUILD_BRANCH
@@ -128,7 +126,6 @@ COPY package.json package-lock.json ./
 RUN npm ci
 
 COPY ./ ./
-RUN $REPLACE_CRLF
 
 RUN echo 'User-agent: *\nDisallow:\n\nSitemap: https://docs.flutter.dev/sitemap.xml' > src/robots.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 WORKDIR /app
 
 
-
+ENV REPLACE_CRLF='find . -not \( -name .git -prune \) -type f -exec perl -pi -e 's/\r\n|\n|\r/\n/g' {} \;'
 # ============== INSTALL FLUTTER ==============
 # NOTE that this will fail if you have not cloned the repo with --recurse-submodules
 # or run `git submodule update --init --recursive` after cloning.
@@ -26,9 +26,9 @@ FROM base AS flutter
 
 # This Flutter install uses/requires the local ./flutter submodule
 COPY ./flutter ./flutter
-RUN find . -not \( -name .git -prune \) -type f -exec perl -pi -e 's/\r\n|\n|\r/\n/g' {} \;
 COPY ./site-shared ./site-shared
 COPY pubspec.yaml ./
+RUN $REPLACE_CRLF
 
 ARG FLUTTER_BUILD_BRANCH
 ENV FLUTTER_BUILD_BRANCH=$FLUTTER_BUILD_BRANCH
@@ -76,6 +76,7 @@ RUN npm install -g firebase-tools@12.4.0
 FROM flutter AS tests
 
 COPY ./ ./
+RUN $REPLACE_CRLF
 
 ARG FLUTTER_TEST_BRANCH=stable
 ENV FLUTTER_TEST_BRANCH=$FLUTTER_TEST_BRANCH
@@ -101,6 +102,7 @@ COPY package.json package-lock.json ./
 RUN npm install
 
 COPY ./ ./
+RUN $REPLACE_CRLF
 
 # Jekyl ports
 EXPOSE 35730
@@ -126,6 +128,7 @@ COPY package.json package-lock.json ./
 RUN npm ci
 
 COPY ./ ./
+RUN $REPLACE_CRLF
 
 RUN echo 'User-agent: *\nDisallow:\n\nSitemap: https://docs.flutter.dev/sitemap.xml' > src/robots.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
 WORKDIR /app
 
 # Replace all files from CRLF to LF in case they are copied from the Windows environment.
-ENV REPLACE_CRLF find . -type f -exec sed -i 's/\r$//' {} \;
+ENV REPLACE_CRLF find . -type f -not -name "*.bat" -exec sed -i 's/\r$//' {} \;
 
 
 # ============== INSTALL FLUTTER ==============


### PR DESCRIPTION
Force eliminate `CRLF` from the copied `flutter` directory.

_Issues fixed (partially) by this PR (if any)_:
- https://github.com/flutter/website/issues/6443#issuecomment-971186295
- https://github.com/flutter/website/issues/8272#issuecomment-1432645530

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
