### PR TITLE
Removes `time` measurement from the `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ emulate:
 # WARNING this can take a while to run!
 # Usage: `make test FLUTTER_TEST_BRANCH=<channel>`
 test:
-	DOCKER_BUILDKIT=1 time docker build --rm --target tests -t flt-test .
+	DOCKER_BUILDKIT=1 docker build --rm --target tests -t flt-test .
 	docker run --rm --name flt-tests -t flt-test --target ${FLUTTER_TEST_BRANCH}
 
 # Stop long running tests
@@ -110,13 +110,13 @@ debug-tests:
 # those will be run on the Github action.
 # Usage: `make build-image`
 build-image:
-	DOCKER_BUILDKIT=1 time docker build --rm --no-cache --target build \
+	DOCKER_BUILDKIT=1 docker build --rm --no-cache --target build \
 		--build-arg BUILD_CONFIGS=${BUILD_CONFIGS} -t ${BUILD_TAG} .
 
 # Build the production site & Run the link checker
 # Usage: `make check-links`
 build-image-and-check-links:
-	DOCKER_BUILDKIT=1 time docker build --rm --no-cache --target checklinks \
+	DOCKER_BUILDKIT=1 docker build --rm --no-cache --target checklinks \
 		--build-arg BUILD_CONFIGS=${BUILD_CONFIGS} -t ${BUILD_TAG} .
 	docker run --rm -t ${BUILD_TAG}
 


### PR DESCRIPTION
`time` is not a valid command on Windows. This helps to setup the environment on the Windows platform. We currently not monitoring the built time so we can add it back once we have requests.

_Issues fixed (partially) by this PR (if any)_:
- https://github.com/flutter/website/issues/6443
- https://github.com/flutter/website/issues/8272

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
