### PR TITLE
🔥 Use `flutter pub get` instead of `flutter packages get`

### DIFF
--- a/tool/check-code.sh
+++ b/tool/check-code.sh
@@ -42,10 +42,10 @@ flutter --version
 if [[ $REFRESH ]]; then
   echo "=> Refreshing code excerpts..."
   (
-    set -x;
+    set -x
     tool/refresh-code-excerpts.sh --keep-dart-tool
   ) || (
-    echo "=> ERROR: some code excerpts were not refreshed!";
+    echo "=> ERROR: some code excerpts were not refreshed!"
     exit 1
   )
 fi
@@ -97,12 +97,12 @@ for sample in $EXAMPLE_ROOT/*/*{,/*}; do
     # Does it match our filter?
     if [[ -n "$FILTER" && ! $sample =~ $FILTER ]]; then
       echo "=> Example: $sample - skipped because of filter"
-      continue;
+      continue
     
     # Skip submodules
-    elif [[ "$(cd $sample ; git rev-parse --show-superproject-working-tree)" ]]; then
+    elif [[ "$(cd $sample; git rev-parse --show-superproject-working-tree)" ]]; then
       echo "=> Example: $sample - skipped because it's in a submodule."
-      continue;
+      continue
     
     else
       echo "=> Example: $sample"
@@ -111,24 +111,24 @@ for sample in $EXAMPLE_ROOT/*/*{,/*}; do
     # Only hydrate the sample if we're going to test it.
     if [[ -n $TEST && -d "$sample/test" ]]; then
       (
-        set -x;
-        cd $ROOT;
+        set -x
+        cd $ROOT
         flutter create --no-overwrite $sample
         rm -rf $sample/integration_test # Remove unneeded integration test stubs.
       )
     fi
 
     (
-      set -x;
+      set -x
       cd $sample
-      flutter packages get;
-      flutter analyze .;
+      flutter pub get
+      flutter analyze .
     )
 
     if [[ -n $TEST && -d "$sample/test" ]]; then
       (
-        cd $sample;
-        set -x;
+        cd $sample
+        set -x
         echo "=> Running tests..."
         flutter test
       )

--- a/tool/refresh-code-excerpts.sh
+++ b/tool/refresh-code-excerpts.sh
@@ -37,8 +37,8 @@ if [[ ${diffVersion:0:1} != "3" ]]; then
 fi
 
 if [[ -e "$FRAG" ]]; then 
-  echo "=> Deleting old $FRAG"; 
-  rm -Rf "$FRAG"; 
+  echo "=> Deleting old $FRAG"
+  rm -Rf "$FRAG"
 fi
 
 # Ensure package_config.json is generated


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
- Replace the outdated command in `check-code.sh`.
- Remove redundant semicolons in bash scripts (suggested by ChatGPT).

_Issues fixed by this PR (if any): none._

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
