### PR TITLE
Remove Font Awesome from the site

### DIFF
--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -12,7 +12,6 @@
     <meta name="theme-color" content="#ffffff">
     {% unless page.strip_fonts == true -%}
     <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preload" href="https://use.fontawesome.com/releases/v5.15.4/js/all.js" as="script">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     {% endunless -%}
 
@@ -59,10 +58,6 @@
     <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Text:wght@400;500;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Mono:wght@400;500;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap" rel="stylesheet">
-    <script
-      src="https://use.fontawesome.com/releases/v5.15.4/js/all.js"
-      data-auto-replace-svg="nest">
-    </script>
     {% endunless -%}
 
     {% include shared/head-diff2html.html -%}

--- a/src/_sass/base/_base.scss
+++ b/src/_sass/base/_base.scss
@@ -212,13 +212,6 @@ dd {
   }
 }
 
-.fa-external-link-alt:before {
-  font-size: 0.25rem;
-  margin-left: 3px;
-  opacity: 0.5;
-  vertical-align: top;
-}
-
 .table-wrapper {
   overflow-x: auto;
 }


### PR DESCRIPTION
This reduces page load and render time, as it was the largest file download when loading the site, and it ran JS on load. When running Lighthouse with the mobile report, the first contentful paint takes around half the time with this removed 🥳! The gains on a desktop report were not as large, but around 25% faster on average.

Closes https://github.com/flutter/website/issues/8983