### PR TITLE
Document Windows build path breaking change

### DIFF
--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -37,6 +37,7 @@ release, and listed in alphabetical order:
 * [Deprecate `describeEnum` and update `EnumProperty` to be type strict][]
 * [Deprecated just-in-time navigation pop APIs for Android Predictive Back][]
 * [Updated default text styles for menus][]
+* [Windows build path changed to add the target architecture][]
 
 [Customize tabs alignment using the new `TabBar.tabAlignment` property]: {{site.url}}/release/breaking-changes/tab-alignment
 [Deprecate `textScaleFactor` in favor of `TextScaler`]: {{site.url}}/release/breaking-changes/deprecate-textscalefactor
@@ -44,6 +45,7 @@ release, and listed in alphabetical order:
 [Deprecate `describeEnum` and update `EnumProperty` to be type strict]: {{site.url}}/release/breaking-changes/describe-enum
 [Deprecated just-in-time navigation pop APIs for Android Predictive Back]: {{site.url}}/release/breaking-changes/android-predictive-back
 [Updated default text styles for menus]: {{site.url}}/release/breaking-changes/menus-text-style
+[Windows build path changed to add the target architecture]: {{site.url}}/release/breaking-changes/windows-build-architecture
 
 ### Released in Flutter 3.13
 

--- a/src/release/breaking-changes/windows-build-architecture.md
+++ b/src/release/breaking-changes/windows-build-architecture.md
@@ -7,14 +7,15 @@ description: >
 
 ## Summary
 
-Flutter Window's build path was updated to include the target architecture.
+Built executables for Flutter Windows apps are now located in architecture
+dependent folders
 
 ## Context
 
 In preparation for supporting Windows Arm64, the Windows build path was
 updated to add the build's target architecture.
 
-Previously, Flutter Windows build assumed an x64 target architecture.
+Previously, Flutter builds for Windows assumed an x64 target architecture.
 
 ## Migration guide
 
@@ -26,7 +27,6 @@ Example build path before the migration:
 ```
 build\windows\runner\Release\hello_world.exe
 ```
-
 
 Example build path after the migration if targeting x64:
 

--- a/src/release/breaking-changes/windows-build-architecture.md
+++ b/src/release/breaking-changes/windows-build-architecture.md
@@ -6,39 +6,57 @@ description: >
 ---
 
 ## Summary
+
 Flutter Window's build path was updated to include the target architecture.
 
 ## Context
+
 In preparation for supporting Windows Arm64, the Windows build path was
 updated to add the build's target architecture.
 
 Previously, Flutter Windows build assumed an x64 target architecture.
 
 ## Migration guide
+
 You may need to update your infrastructure to use the new Flutter Windows
 build path.
 
 Example build path before the migration:
-`build\windows\runner\Release\hello_world.exe`
 
-Example build path after the migration:
-`build\windows\x64\runner\Release\hello_world.exe`
+```
+build\windows\runner\Release\hello_world.exe
+```
+
+
+Example build path after the migration if targeting x64:
+
+```
+build\windows\x64\runner\Release\hello_world.exe
+```
+
+Example build path after the migration if targeting Arm64:
+
+```
+build\windows\arm64\runner\Release\hello_world.exe
+```
 
 If you use [`package:msix`][], update to version 3.15.0 or newer.
 
-[`package:msix`]: https://pub.dev/packages/msix
+[`package:msix`]: {{site.pub-pkg}}/msix
 
 ## Timeline
+
 Landed in version: TBD
 
 In stable release: TBD
 
 ## References
+
 Design document:
 *  [https://flutter.dev/go/windows-arm64][]
 
 Relevant pull requests:
 * [Introduce architecture subdirectory for Windows build][]
 
-[https://flutter.dev/go/windows-arm64]: {{site.url}}/go/windows-arm64
+[https://flutter.dev/go/windows-arm64]: {{site.main-url}}/go/windows-arm64
 [Introduce architecture subdirectory for Windows build]: {{site.github}}/flutter/flutter/pull/131843

--- a/src/release/breaking-changes/windows-build-architecture.md
+++ b/src/release/breaking-changes/windows-build-architecture.md
@@ -1,0 +1,44 @@
+---
+title: Windows build path changed to add the target architecture
+description: >
+  In preparation for supporting Windows Arm64, 
+  the Windows build path was updated to include the target architecture.
+---
+
+## Summary
+Flutter Window's build path was updated to include the target architecture.
+
+## Context
+In preparation for supporting Windows Arm64, the Windows build path was
+updated to add the build's target architecture.
+
+Previously, Flutter Windows build assumed an x64 target architecture.
+
+## Migration guide
+You may need to update your infrastructure to use the new Flutter Windows
+build path.
+
+Example build path before the migration:
+`build\windows\runner\Release\hello_world.exe`
+
+Example build path after the migration:
+`build\windows\x64\runner\Release\hello_world.exe`
+
+If you use [`package:msix`][], update to version 3.15.0 or newer.
+
+[`package:msix`]: https://pub.dev/packages/msix
+
+## Timeline
+Landed in version: TBD
+
+In stable release: TBD
+
+## References
+Design document:
+*  [https://flutter.dev/go/windows-arm64][]
+
+Relevant pull requests:
+* [Introduce architecture subdirectory for Windows build][]
+
+[https://flutter.dev/go/windows-arm64]: {{site.url}}/go/windows-arm64
+[Introduce architecture subdirectory for Windows build]: {{site.github}}/flutter/flutter/pull/131843


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
To support Windows Arm64, we updated the Windows's build directory to include the target architecture. Previously, the Windows build assumed an x64 build.

Example build path before: `build/windows/runner/Release/hello_world.exe`
Example build path after: `build/windows/x64/runner/Release/hello_world.exe`

Tooling that depends on this build path will need to be updated. For example, `package:msix` takes your app's executable and bundles for the Microsoft Store. It needed to be updated: https://github.com/YehudaKremer/msix/issues/205

_Issues fixed by this PR (if any):_
https://github.com/flutter/flutter/issues/129804

/cc @pbo-linaro Who implemented this.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
