### PR TITLE
Add docs on how to add a macOS release to TestFlight

### DIFF
--- a/src/deployment/macos.md
+++ b/src/deployment/macos.md
@@ -414,10 +414,24 @@ keychain use-login
 </li>
 </ol>
 
+## Release your app on TestFlight
+
+[TestFlight][] allows developers to push their apps
+to internal and external testers. This optional step
+covers releasing your build on TestFlight.
+
+1. Navigate to the TestFlight tab of your app's application
+   details page on [App Store Connect][appstoreconnect_login].
+1. Select **Internal Testing** in the sidebar.
+1. Select the build to publish to testers, then click **Save**.
+1. Add the email addresses of any internal testers.
+   You can add additional internal users in the **Users and Roles**
+   page of App Store Connect,
+   available from the dropdown menu at the top of the page.
+
 ## Distribute to registered devices
 
-[TestFlight][] is not available for distributing macOS apps
-to internal and external testers. See [distribution guide][distributionguide_macos] 
+See [distribution guide][distributionguide_macos] 
 to prepare an archive for distribution to designated Mac computers.
 
 ## Release your app to the App Store


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

The current says that TestFlight is not available for macOS. As in #8015 pointed out, is this wrong:

> TestFlight supports apps for iOS, iPadOS, macOS, tvOS, watchOS, and iMessage, as well as automatic updates to ensure that testers always test the latest available build

See https://developer.apple.com/testflight/

<img src="https://user-images.githubusercontent.com/24459435/266362659-3f53569b-5ab9-46e1-b727-f802c810de4f.png" />

I just copied the text from the iOS docs: https://docs.flutter.dev/deployment/ios#release-your-app-on-testflight

_Issues fixed by this PR (if any):_ Fixes #8015

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
