### PR TITLE
Document android multithreaded platform view constraints

### DIFF
--- a/src/platform-integration/android/platform-views.md
+++ b/src/platform-integration/android/platform-views.md
@@ -406,6 +406,10 @@ android {
 }
 ```
 
+#### Multi threaded draw calls
+
+Android's PlatformView implementation requires that the view is manually invalidated when the Android View draws using a separate thread. 
+
 [`AndroidViewSurface`]: {{site.api}}/flutter/widgets/AndroidViewSurface-class.html
 
 {% include docs/platform-view-perf.md %}

--- a/src/platform-integration/android/platform-views.md
+++ b/src/platform-integration/android/platform-views.md
@@ -406,11 +406,15 @@ android {
 }
 ```
 
-#### Multi threaded draw calls
+#### Multithreaded draw calls
 
-When the Android View draws using a separate thread,
-you must invalidate the view according to 
-Android's PlatformView implementation. 
+Certain Android Views do not invalidate themselves when their content changes.
+Some example views include `SurfaceView` and `SurfaceTexture`.
+When your Platform View includes these views you are required to
+manually invalidate the viewafter they have been drawn to
+(or more specifically: after the swap chain is flipped).
+Manual view invalidation is done by calling `invalidate` on the View 
+or one of its parent views.
 
 [`AndroidViewSurface`]: {{site.api}}/flutter/widgets/AndroidViewSurface-class.html
 

--- a/src/platform-integration/android/platform-views.md
+++ b/src/platform-integration/android/platform-views.md
@@ -406,7 +406,7 @@ android {
 }
 ```
 
-#### Multithreaded draw calls
+#### Manual view invalidation
 
 Certain Android Views do not invalidate themselves when their content changes.
 Some example views include `SurfaceView` and `SurfaceTexture`.

--- a/src/platform-integration/android/platform-views.md
+++ b/src/platform-integration/android/platform-views.md
@@ -411,7 +411,7 @@ android {
 Certain Android Views do not invalidate themselves when their content changes.
 Some example views include `SurfaceView` and `SurfaceTexture`.
 When your Platform View includes these views you are required to
-manually invalidate the viewafter they have been drawn to
+manually invalidate the view after they have been drawn to
 (or more specifically: after the swap chain is flipped).
 Manual view invalidation is done by calling `invalidate` on the View 
 or one of its parent views.

--- a/src/platform-integration/android/platform-views.md
+++ b/src/platform-integration/android/platform-views.md
@@ -408,7 +408,9 @@ android {
 
 #### Multi threaded draw calls
 
-Android's PlatformView implementation requires that the view is manually invalidated when the Android View draws using a separate thread. 
+When the Android View draws using a separate thread,
+you must invalidate the view according to 
+Android's PlatformView implementation. 
 
 [`AndroidViewSurface`]: {{site.api}}/flutter/widgets/AndroidViewSurface-class.html
 


### PR DESCRIPTION
Update documentation based on the investigation done in 
https://b.corp.google.com/issues/299285351

This constraint is not listed in the places plugin authors were looking for it. 

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
