### PR TITLE
Test staging forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
     if: |
       github.event_name == 'push'
       && github.ref == 'refs/heads/main'
+      && github.repository == 'flutter/website'
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,6 @@ jobs:
     if: |
       github.event_name == 'push'
       && github.ref == 'refs/heads/main'
-      && github.repository == 'flutter/website'
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
         with:

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -24,6 +24,8 @@ jobs:
         run: make build BUILD_CONFIGS=_config.yml,_config_stage.yml
       - name: Stage site on Firebase
         if: ${{
+          github.repository == 'flutter/website' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
           github.event.pull_request.user.login != 'dependabot[bot]'
           }}
         uses: FirebaseExtended/action-hosting-deploy@120e124148ab7016bec2374e5050f15051255ba2

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -24,7 +24,9 @@ jobs:
         run: make build BUILD_CONFIGS=_config.yml,_config_stage.yml
       - name: Stage site on Firebase
         if: ${{
-          github.event.pull_request.user.login != 'dependabot[bot]' }}
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.event.pull_request.user.login != 'dependabot[bot]'
+          }}
         uses: FirebaseExtended/action-hosting-deploy@120e124148ab7016bec2374e5050f15051255ba2
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -24,8 +24,6 @@ jobs:
         run: make build BUILD_CONFIGS=_config.yml,_config_stage.yml
       - name: Stage site on Firebase
         if: ${{
-          github.repository == 'flutter/website' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
           github.event.pull_request.user.login != 'dependabot[bot]'
           }}
         uses: FirebaseExtended/action-hosting-deploy@120e124148ab7016bec2374e5050f15051255ba2

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -24,8 +24,6 @@ jobs:
         run: make build BUILD_CONFIGS=_config.yml,_config_stage.yml
       - name: Stage site on Firebase
         if: ${{
-          github.repository == 'flutter/website' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
           github.event.pull_request.user.login != 'dependabot[bot]' }}
         uses: FirebaseExtended/action-hosting-deploy@120e124148ab7016bec2374e5050f15051255ba2
         with:

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -24,7 +24,6 @@ jobs:
         run: make build BUILD_CONFIGS=_config.yml,_config_stage.yml
       - name: Stage site on Firebase
         if: ${{
-          github.event.pull_request.head.repo.full_name == github.repository &&
           github.event.pull_request.user.login != 'dependabot[bot]'
           }}
         uses: FirebaseExtended/action-hosting-deploy@120e124148ab7016bec2374e5050f15051255ba2


### PR DESCRIPTION
Testing staging from a fork.

According to GitHub docs on [Approving workflow runs on a pull request from a public fork](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks#approving-workflow-runs-on-a-pull-request-from-a-public-fork) and [Controlling changes from forks to workflows in public repositories](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#controlling-changes-from-forks-to-workflows-in-public-repositories), GitHub should allow forks to stage. Our code must be the distinguishing factor.
