### PR TITLE
Remove security@flutter.dev workaround

### DIFF
--- a/src/security/index.md
+++ b/src/security/index.md
@@ -27,13 +27,6 @@ Flutter security strategy is based on five key pillars:
 
 ## Reporting vulnerabilities
 
-{{site.alert.warning}}
-  We are currently experiencing technical difficulties with the
-  `security@flutter.dev` e-mail alias. To ensure prompt attention
-  we ask that you cc `ian@hixie.ch` on such e-mails for the time
-  being. Thanks for your understanding.
-{{site.alert.end}}
-
 Before reporting a security vulnerability found
 by a static analysis tool,
 consider checking our list of [known false positives][].


### PR DESCRIPTION
The alias works again.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
