### PR TITLE
Fix CanvasKit link

### DIFF
--- a/src/resources/architectural-overview.md
+++ b/src/resources/architectural-overview.md
@@ -1018,7 +1018,7 @@ rendering Flutter content on the web: HTML and WebGL.
 In HTML mode, Flutter uses HTML, CSS, Canvas, and SVG.
 To render to WebGL, Flutter uses a version of Skia
 compiled to WebAssembly called
-[CanvasKit](https://skia.org/user/modules/canvaskit).
+[CanvasKit](https://skia.org/docs/user/modules/canvaskit/).
 While HTML mode offers the best code size characteristics,
 `CanvasKit` provides the fastest path to the
 browser's graphics stack,


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
The link for CanvasKit library is broken. Replacing it with the correct link.
_Issues fixed by this PR (if any):_

## Presubmit checklist

- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
