### PR TITLE
Update android setup device requirements

### DIFF
--- a/src/get-started/install/_android-setup-chromeos.md
+++ b/src/get-started/install/_android-setup-chromeos.md
@@ -35,7 +35,7 @@ To deploy apps directly to your Chromebook, you need to do the following:
 ### Set up your Android device
 
 To prepare to run and test your Flutter app on an attached device,
-you need an Android device running Android 4.1 (API level 16) or higher.
+you need an Android device running Android 5.0 (API level 21) or higher.
 
  1. Enable **Developer options** and **USB debugging** on your device.
     Detailed instructions are available in the

--- a/src/get-started/install/_android-setup.md
+++ b/src/get-started/install/_android-setup.md
@@ -25,7 +25,7 @@
 {% include_relative _help-link.md location='android-device' section='#android-setup' %}
 
 To prepare to run and test your Flutter app on an Android device,
-you need an Android device running Android 4.1 (API level 16) or higher.
+you need an Android device running Android 5.0 (API level 21) or higher.
 
  1. Enable **Developer options** and **USB debugging** on your device.
     Detailed instructions are available in the


### PR DESCRIPTION
To match the "Supported" column on [Supported deployment platforms](https://docs.flutter.dev/reference/supported-platforms). We could technically use the "Best effort" versions but Google play services is dropping support for those and 19/20 devices count for <= 0.5% of all active Android devices. This prevents any potential confusion and is more future proof.
