### PR TITLE
Fix links to `dart` tool documentation

### DIFF
--- a/src/_includes/docs/dart-tool-win.md
+++ b/src/_includes/docs/dart-tool-win.md
@@ -49,4 +49,4 @@
   from the command line, or see the [dart tool][] page.
 {{site.alert.end}}
 
-[dart tool]: {{site.dart-site}}/tools/dart-vm
+[dart tool]: {{site.dart-site}}/tools/dart-tool

--- a/src/_includes/docs/dart-tool.md
+++ b/src/_includes/docs/dart-tool.md
@@ -33,4 +33,4 @@
   from the command line, or see the [dart tool][] page.
 {{site.alert.end}}
 
-[dart tool]: {{site.dart-site}}/tools/dart-vm
+[dart tool]: {{site.dart-site}}/tools/dart-tool


### PR DESCRIPTION
The existing link was redirecting to the `dart run` page, but the text on these pages is referring to the entire `dart` tool.