### PR TITLE
Add go link for go_router 11.0.0 migration guide 

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -373,6 +373,7 @@
       { "source": "/go/go-router-v8-breaking-changes", "destination": "https://docs.google.com/document/d/1VCuB85D5kYxPR3qYOjVmw8boAGKb7k62heFyfFHTOvw/edit?usp=sharing", "type": 301 },
       { "source": "/go/go-router-v9-breaking-changes", "destination": "https://docs.google.com/document/d/16plvWc9ablQsUs7w6bWDpTZ7PwMP4YUhV-qMQ3iljE0/edit?usp=sharing", "type": 301 },
       { "source": "/go/go-router-v10-breaking-changes", "destination": "https://docs.google.com/document/d/1vjupshmFJtfGSOppZxp7Tzkq7dotcLxCcpdluuNYe1o/edit?usp=sharing&resourcekey=0-aS66t4OcDTjJW50s-veSzQ", "type": 301 },
+      { "source": "/go/go-router-v11-breaking-changes", "destination": "https://docs.google.com/document/d/1L2LPM_DBqKQx1pTRRfG7pi33P88iAypBju65rcMW_dU/edit?usp=sharing", "type": 301 },
       { "source": "/go/handling-synchronous-keyboard-events", "destination": "https://docs.google.com/document/d/1rWXSjkb2ZKv-cpg26lVK0aZi4cVeXJ8j7YmSJdq2TOM/edit", "type": 301 },
       { "source": "/go/hermetic-xcode-installation", "destination": "https://docs.google.com/document/d/1EcXm4Woq48GR_ky07mEJka6NfV1vFBN2OHDEeGfPk34/edit?resourcekey=0-0Gjtt1I66mGJ8AwiCTlFNw", "type": 301 },
       { "source": "/go/hero-refactor", "destination": "https://docs.google.com/document/d/1JZVqykFjhDXcJyj_Ep5gfTmF-Eu4pQXXNRcLCN04tls/edit?usp=sharing", "type": 301 },


### PR DESCRIPTION
breaking change for https://github.com/flutter/packages/pull/4723

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
