### PR TITLE
Simplify test setup and fix inaccessible Dart/Flutter in container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,9 @@ jobs:
         with:
           submodules: recursive
       - name: Test
-        run: make test FLUTTER_TEST_BRANCH=${{ matrix.branch }}
+        env:
+          FLUTTER_BUILD_BRANCH: ${{ matrix.branch }}
+        run: make test
         continue-on-error: ${{ matrix.experimental }}
 
   deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,6 @@ WORKDIR /app
 
 
 # ============== INSTALL FLUTTER ==============
-# NOTE that this will fail if you have not cloned the repo with --recurse-submodules
-# or run `git submodule update --init --recursive` after cloning.
 FROM base AS flutter
 
 COPY ./site-shared ./site-shared
@@ -66,13 +64,8 @@ FROM flutter AS tests
 
 COPY ./ ./
 
-ARG FLUTTER_TEST_BRANCH=stable
-ENV FLUTTER_TEST_BRANCH=$FLUTTER_TEST_BRANCH
-
 # Only test the code here, checking links is purely for site deployment
-# NOTE bash scripts will switch the Flutter branch based on $FLUTTER_TEST_BRANCH
 ENTRYPOINT ["tool/test.sh"]
-
 
 
 # ============== DEV / JEKYLL SETUP ==============

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,10 @@ ARG FLUTTER_BUILD_BRANCH=stable
 ENV FLUTTER_BUILD_BRANCH=$FLUTTER_BUILD_BRANCH
 ENV FLUTTER_ROOT=flutter
 ENV FLUTTER_BIN=flutter/bin
-ENV PATH="/app/flutter/bin:$PATH"
+ENV PATH="/flutter/bin:$PATH"
 
-RUN git clone --branch $FLUTTER_BUILD_BRANCH --single-branch https://github.com/flutter/flutter ./flutter
+RUN git clone --branch $FLUTTER_BUILD_BRANCH --single-branch https://github.com/flutter/flutter /flutter/
+VOLUME /flutter
 
 # Set up Flutter
 # NOTE You will get a warning "Woah! You appear to be trying to run flutter as root."

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ BUILD_NAME = tmpbuild
 BUILD_TAG = "fltbuild:${BUILD_COMMIT}"
 FIREBASE_ALIAS ?= default
 FLUTTER_BUILD_BRANCH ?= stable
-FLUTTER_TEST_BRANCH ?= stable
 JEKYLL_SITE_HOST ?= 0.0.0.0
 JEKYLL_SITE_PORT ?= 4002
 STAGE_NAME ?= docs
@@ -85,12 +84,15 @@ emulate:
 # =================== Build / Test / Deploy Commands ==================
 
 # Run all tests that would be run inside the container for the 
-# given target channel on the Github action `test` job.
+# given target channel on the GitHub action `test` job.
 # WARNING this can take a while to run!
-# Usage: `make test FLUTTER_TEST_BRANCH=<channel>`
+# Usage: `FLUTTER_BUILD_BRANCH=<channel> make test`
 test:
-	DOCKER_BUILDKIT=1 docker build --rm --target tests -t flt-test .
-	docker run --rm --name flt-tests -t flt-test --target ${FLUTTER_TEST_BRANCH}
+	DOCKER_BUILDKIT=1 docker build --rm \
+	    --target tests \
+	    -t flt-test \
+	    --build-arg FLUTTER_BUILD_BRANCH=${FLUTTER_BUILD_BRANCH} .
+	docker run --rm --name flt-tests -t flt-test
 
 # Stop long running tests
 # Usage `make stop-tests`

--- a/tool/test.sh
+++ b/tool/test.sh
@@ -2,68 +2,9 @@
 
 set -e # Fail fast
 
-ROOT=$(pwd)
-TARGET=${FLUTTER_TEST_BRANCH:-stable} # default to stable
-
-while [[ "$1" == -* ]]; do
-  case "$1" in
-    --target)   shift; TARGET=$1; shift;;
-    --help|-h)  echo ""
-                echo "Refresh, analyze and test code examples"
-                echo ""
-                echo "Usage: $(basename $0) [options]";
-                echo ""
-                echo "      --target Flutter channel target [stable]"
-                echo "  -h, --help   Print this usage information"
-                echo ""
-                exit 0;;
-    *)          echo "Unrecognized option: $1. Use --help for usage."; exit 0;;
-  esac
-done
-
-# We use different Flutter SDKs on different tasks. The flutter
-# submodule has a pinned commit that will be checkout out. The checkout 
-# is a shallow, single-branch (depth=1) checkout so to get to other 
-# versions of flutter without doing a full checkout we need to tell 
-# git about the remote branch, fetch it, and then check it out. To know
-# its version, the flutter tool relies on the tags. Those need to be 
-# pulled separately with a shallow fetch to avoid fetching all of them.
-BETA=beta                     # Beta channel
-STABLE=stable                 # Stable channel
-
-# TODO(rearch) indentify usage of this target, whether locally when 
-# testing a particular commit or on a github action deploy
-SUBMODULE=submodule-commit    # Pinned flutter submodule commit
-
-if [[ -z "$TARGET" || ! "$TARGET" =~ ^($BETA|$STABLE)$ ]]; then
-  echo $'\nA valid Flutter branch target is required!\n'
-  exit 0
-fi
-
-function switch_flutter_channel() {
-  pushd flutter
-  git remote set-branches origin $1
-  git fetch --depth 1 origin $1
-  git checkout $1 --
-  git pull
-  popd
-  flutter doctor
-}
-
 echo $'\n================== Running Tests =================='
 
 rm -rf **/*.log tmp example.g .dart_tool
-current_branch=$(cd flutter && git rev-parse --abbrev-ref HEAD)
-
-echo "=> Current branch = $current_branch, target = $TARGET"
-
-# NOTE when fresh the submodule will always be a pull of stable
-if [[ "$current_branch" != "$TARGET" ]]; then
-  echo $'\n---------------------------------------------------'
-  echo "=> Switching from \"$current_branch\" to \"$TARGET\" branch"
-  echo $'---------------------------------------------------\n'
-  switch_flutter_channel $TARGET
-fi
 
 time tool/check-code.sh --refresh
 


### PR DESCRIPTION
https://github.com/flutter/website/pull/9307 caused `dart` and `flutter` to not be accessible when running inside the container. This PR attaches the cloned Flutter repository as a volume to allow it to persist and be accessible.

To be compatible with these changes, also modifies the `test.sh` script to be simpler, not allowing switching branches separately from the container. When it's ran from GitHub actions, a new container is created anyway.