### PR TITLE
Updates colors for a11y contrast requirements

### DIFF
--- a/src/_sass/base/_variables.scss
+++ b/src/_sass/base/_variables.scss
@@ -12,7 +12,7 @@ $site-color-white: #FFF;
 $site-color-codeblock-bg: #F8F9FA;
 $site-color-light-grey: #F1F3F4;
 $site-color-nav-links: #6E7274;
-$site-color-body: #4A4A4A; // Poor contrast with links
+$site-color-body: #212121; // Poor contrast with links
 $site-color-body-light: rgba(0, 0, 0, .8);
 $site-color-footer: #303c42;
 $site-color-primary: $flutter-color-blue-500;

--- a/src/_sass/base/_variables.scss
+++ b/src/_sass/base/_variables.scss
@@ -10,7 +10,7 @@ $flutter-dark-blue-texture: #232C33;
 $site-color-black: #000;
 $site-color-white: #FFF;
 $site-color-codeblock-bg: #F8F9FA;
-$site-color-light-grey: #F1F3F4;
+$site-color-light-grey: #DADCE0;
 $site-color-nav-links: #6E7274;
 $site-color-body: #212121; // Poor contrast with links
 $site-color-body-light: rgba(0, 0, 0, .8);

--- a/src/_sass/base/_variables.scss
+++ b/src/_sass/base/_variables.scss
@@ -1,16 +1,18 @@
 // Colors
-$flutter-color-teal: #60caf6;
-$flutter-color-blue-500: #1389FD;
-$flutter-color-dark-blue: #075b9a;
-$flutter-color-fuchsia: #FF2B5B;
+$flutter-color-blue: #043875;
+$flutter-color-teal: #158477;
+$flutter-color-blue-on-dark: #B8EAFE;
+$flutter-color-blue-500: #0468D7;
+$flutter-color-dark-blue: #042B59;
+$flutter-color-fuchsia: #E64637;
 $flutter-color-light-blue: #E7F8FF;
 $flutter-dark-blue-texture: #232C33;
 $site-color-black: #000;
 $site-color-white: #FFF;
 $site-color-codeblock-bg: #F8F9FA;
-$site-color-light-grey: #D8D8D8;
+$site-color-light-grey: #F1F3F4;
 $site-color-nav-links: #6E7274;
-$site-color-body: #4A4A4A;
+$site-color-body: #4A4A4A; // Poor contrast with links
 $site-color-body-light: rgba(0, 0, 0, .8);
 $site-color-footer: #303c42;
 $site-color-primary: $flutter-color-blue-500;

--- a/src/_sass/components/_banner.scss
+++ b/src/_sass/components/_banner.scss
@@ -2,7 +2,7 @@
 @use '../vendor/bootstrap';
 
 .site-banner {
-  background-color: $flutter-color-dark-blue;
+  background-color: $flutter-color-blue;
   color: $site-color-white;
   font-family: $site-font-family-alt;
   font-size: bootstrap.$font-size-lg;

--- a/src/_sass/components/_banner.scss
+++ b/src/_sass/components/_banner.scss
@@ -20,10 +20,10 @@
   }
 
   a {
-    color: $flutter-color-teal;
+    color: $flutter-color-blue-on-dark;
 
     &:hover {
-      color: $flutter-color-teal;
+      color: $flutter-color-blue-on-dark;
     }
   }
 

--- a/src/_sass/components/_code.scss
+++ b/src/_sass/components/_code.scss
@@ -93,7 +93,7 @@ pre.console-output {
 }
 
 code {
-  color: #008f83;
+  color: #10675d; /* 10% darker than Flutter green */
 }
 
 pre {

--- a/src/_sass/vendor/_bootstrap.scss
+++ b/src/_sass/vendor/_bootstrap.scss
@@ -12,9 +12,6 @@
   $font-weight-bold: 500,
   $headings-font-family: $site-font-family-alt,
   $headings-font-weight: $font-size-base-weight,
-  $h1-font-size: 3rem,
-  $h2-font-size: 2.5rem,
-  $h3-font-size: 2rem,
   $dt-font-weight: $font-size-base-weight,
 
   // Layout config


### PR DESCRIPTION
Fixes #9427

Staged: https://tony-flutter-site--docs-6warcibu.web.app

This doesn't cover updates to the lexer colors. That will happen later.

These changes:

- Darkened text color to create the required contrast between body background. (Current 3.49:1, Needs 4.5:1)
- Darkened background color of button to contrast with link text. (Current 3.79:1, Needs 4.5:1)
- Darkened text color of code text to contrast with the background. (Current 3.99:1, Needs 4.5:1)
- Darkened text color of copy to contrast with the link text. (Current 2.54, Needs 3:1)
- Change heading font settings to Design Standards.

Current:

![image](https://github.com/flutter/website/assets/706219/bf85e141-b2e8-4b21-a6fd-0c78f2c67f10)

Changed:

![image](https://github.com/flutter/website/assets/706219/515d454e-e39f-4d1b-875d-0026373db12a)

