### PR TITLE
Fix indentation in flutter integration test example

### DIFF
--- a/examples/testing/integration_tests/how_to/integration_test/counter_test.dart
+++ b/examples/testing/integration_tests/how_to/integration_test/counter_test.dart
@@ -1,10 +1,13 @@
+// #docregion initial
 import 'package:flutter_test/flutter_test.dart';
 import 'package:how_to/main.dart';
 import 'package:integration_test/integration_test.dart';
 
 void main() {
+  // #enddocregion initial
   IntegrationTestWidgetsFlutterBinding.ensureInitialized(); // NEW
 
+  // #docregion initial
   testWidgets('tap on the floating action button, verify counter',
       (tester) async {
     // Load app widget.
@@ -27,3 +30,4 @@ void main() {
     expect(find.text('1'), findsOneWidget);
   });
 }
+// #enddocregion initial

--- a/src/testing/integration-tests/index.md
+++ b/src/testing/integration-tests/index.md
@@ -95,7 +95,7 @@ import 'package:how_to/main.dart';
 import 'package:integration_test/integration_test.dart';
 
 void main() {
-    testWidgets('tap on the floating action button, verify counter',
+  testWidgets('tap on the floating action button, verify counter',
       (tester) async {
     // Load app widget.
     await tester.pumpWidget(const MyApp());

--- a/src/testing/integration-tests/index.md
+++ b/src/testing/integration-tests/index.md
@@ -88,7 +88,7 @@ Changed 9 dependencies!
 In your project, create a new directory
 `integration_test` with a new file, `<name>_test.dart`:
 
-<?code-excerpt "integration_test/counter_test.dart" replace="/IntegrationTestWidgetsFlutterBinding\.ensureInitialized\(\); \/\/ NEW\n\n//g"?>
+<?code-excerpt "integration_test/counter_test.dart (initial)" plaster="none"?>
 ```dart
 import 'package:flutter_test/flutter_test.dart';
 import 'package:how_to/main.dart';


### PR DESCRIPTION
## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
