### PR TITLE
Update android.md for windows

### DIFF
--- a/src/deployment/android.md
+++ b/src/deployment/android.md
@@ -170,7 +170,7 @@ storeFile=<keystore-file-location>
 
 The `storeFile` might be located at
 `/Users/<user name>/upload-keystore.jks` on macOS
-or `C:\\Users\\<user name>\\upload-keystore.jks` on Windows.
+or `C:/Users/<user name>/upload-keystore.jks` on Windows.
 
 {{site.alert.warning}}
   Keep the `key.properties` file private;


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

While preparing my app for release on the Play Store, I encountered the error message `Malformed \uxxxx encoding.` This error was related to the file path specified.

I made changes to the documentation regarding the creation of the keystore file because the path `C:\\Users\\<user name>\\upload-keystore.jks` was causing an error. I corrected it to `C:/Users/<user name>/upload-keystore.jks`.

For additional reference, please visit: [Stack Overflow - Flutter buildAppBundle error](https://stackoverflow.com/questions/67471948/flutter-build-appbundle-error-what-went-wrong-a-problem-occurred-evaluating-p).