### PR TITLE
Fix link to blog post on 'Creating responsive and adaptive apps' page

### DIFF
--- a/src/ui/layout/responsive/adaptive-responsive.md
+++ b/src/ui/layout/responsive/adaptive-responsive.md
@@ -150,7 +150,8 @@ You can learn more about creating platform adaptive apps
 in the following resources:
 
 * [Platform-specific behaviors and adaptations][], a page on this site.
-* [Designing truly adaptive user interfaces][] a blog post and video by Aloïs Deniel, presented at Flutter Viking 2020 conference.
+* [Designing truly adaptive user interfaces][] a blog post and video by
+  Aloïs Deniel, presented at Flutter Viking 2020 conference.
 * The [Flutter gallery app][] ([repo][]) has been written as an
   adaptive app.
 

--- a/src/ui/layout/responsive/adaptive-responsive.md
+++ b/src/ui/layout/responsive/adaptive-responsive.md
@@ -151,7 +151,7 @@ in the following resources:
 
 * [Platform-specific behaviors and adaptations][], a page on this site.
 * [Designing truly adaptive user interfaces][] a blog post and video by
-  Aloïs Deniel, presented at Flutter Viking 2020 conference.
+  Aloïs Deniel, presented at the Flutter Vikings 2020 conference.
 * The [Flutter gallery app][] ([repo][]) has been written as an
   adaptive app.
 

--- a/src/ui/layout/responsive/adaptive-responsive.md
+++ b/src/ui/layout/responsive/adaptive-responsive.md
@@ -150,8 +150,7 @@ You can learn more about creating platform adaptive apps
 in the following resources:
 
 * [Platform-specific behaviors and adaptations][], a page on this site.
-* [Designing truly adaptive user interfaces][] a blog post and video
-  by Aloïs Deniel, presented at this year's FlutterViking conference.
+* [Designing truly adaptive user interfaces][] a blog post and video by Aloïs Deniel, presented at Flutter Viking 2020 conference.
 * The [Flutter gallery app][] ([repo][]) has been written as an
   adaptive app.
 
@@ -159,7 +158,7 @@ in the following resources:
 [Adaptive layouts, part 2]: {{site.youtube-site}}/watch?v=eikOZzfc0l4&t=11s
 [Building adaptive apps]: {{site.url}}/ui/layout/responsive/building-adaptive-apps
 
-[Designing truly adaptive user interfaces]: https://aloisdeniel.com/#/posts/adaptative-ui
+[Designing truly adaptive user interfaces]: https://www.aloisdeniel.com/blog/designing-truly-adaptative-user-interfaces
 [Flutter gallery app]: {{site.gallery}}
 [Folio source code]: {{site.github}}/gskinnerTeam/flutter-folio
 [gskinner blog]: https://blog.gskinner.com/


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
[Designing truly adaptive user interfaces](https://www.aloisdeniel.com/#/posts/adaptative-ui) is changed to [Designing truly adaptive user interfaces](https://www.aloisdeniel.com/blog/designing-truly-adaptative-user-interfaces) at https://docs.flutter.dev/ui/layout/responsive/adaptive-responsive#other-resources-1

_Issues fixed by this PR (if any):_
#9467

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
