### PR TITLE
Update broken link to Flutter Interact event

### DIFF
--- a/src/dash/index.md
+++ b/src/dash/index.md
@@ -129,30 +129,37 @@ Dash 2.0 and 2.1
 * Dash has a **straight** beak. 
   **Please, don't depict Dash with a curved beak.**
 * We also have Mega-Dash, a life-sized mascot
-  who is currently resting in a locked-down Google office.<br>
-![Mega-Dash in the office]({{site.url}}/assets/images/dash/MegaDashChilling.png){:width="50%"}<br>
+  who is currently resting in a Google office.
+  
+  ![Mega-Dash in the office]({{site.url}}/assets/images/dash/MegaDashChilling.png){:width="50%"}
+  
   Mega-Dash made her
   first appearance at the [Flutter Interact][] event
-  in Brooklyn, New York, on December 11, 2019.<br>
-<iframe width="560" height="315" src="{{site.youtube-site}}/embed/EgBMGDtHZhE" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  in Brooklyn, New York, on December 11, 2019.
+  
+  <iframe width="560" height="315" src="{{site.youtube-site}}/embed/EgBMGDtHZhE" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  
 * We also have a Dash puppet that Shams made from
   one of the first plushies.
-![Nilay and the Dash puppet]({{site.url}}/assets/images/dash/NilayDashPuppet.png){:width="50%"}<br>
+  
+  ![Nilay and the Dash puppet]({{site.url}}/assets/images/dash/NilayDashPuppet.png){:width="50%"}
+  
   A number of our YouTube videos feature the Dash puppet,
-  voiced by Emily Fortuna, one of our early (and much loved)
+  voiced by Emily Fortuna, one of the early (and much loved)
   Flutter Developer Advocates.
-<iframe width="560" height="315" src="{{site.youtube-site}}/embed/dsiLVNDJ3t0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-<iframe width="560" height="315" src="{{site.youtube-site}}/embed/oyy_1CjNdBU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  
+  <iframe width="560" height="315" src="{{site.youtube-site}}/embed/dsiLVNDJ3t0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="{{site.youtube-site}}/embed/oyy_1CjNdBU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 {% comment %}
 I haven't been able to figure out how to play the mp4 file...
 * Here is a sound recording of Dash's chirp, by Kathy Walrath,
   the Dart writer.
 ![Dash's chirp]({{site.url}}/assets/images/dash/DartDartDarrrrrrt.mp4){:width="50%"}<br>
 {% endcomment %}
-
+<br>
 !["Born to Hot Reload" jacket]({{site.url}}/assets/images/dash/ShamsDashJacket.png){:width="35%"}<br>
 
-[Flutter Interact]: {{site.developers}}/events/flutter-interact
+[Flutter Interact]: {{site.youtube-site}}/playlist?list=PLjxrf2q8roU0o0wKRJTjyN0pSUA6TI8lg
 [Instagram account]: https://www.instagram.com/dash_the_dartlang_plushy/
 
 {% comment %}


### PR DESCRIPTION
Updates the link to the Youtube playlist, since the event page no longer exists.

Also fixes some spacing and nesting issues on the page.

Closes https://github.com/flutter/website/issues/9497