### PR TITLE
Explicit mention of git as a dependency for linux env

### DIFF
--- a/src/_includes/docs/linux-requirements-command.md
+++ b/src/_includes/docs/linux-requirements-command.md
@@ -7,5 +7,5 @@
 {% endcomment -%}
 
 ```terminal
-$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev
+$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev git
 ```

--- a/src/_includes/docs/linux-requirements-command.md
+++ b/src/_includes/docs/linux-requirements-command.md
@@ -7,5 +7,5 @@
 {% endcomment -%}
 
 ```terminal
-$ sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev git
+$ sudo apt-get install clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev
 ```

--- a/src/_includes/docs/linux-requirements-list.md
+++ b/src/_includes/docs/linux-requirements-list.md
@@ -8,6 +8,7 @@
 
 * [Clang][]
 * [CMake][]
+* [git][]
 * [GTK development headers][]
 * [Ninja build][]
 * [pkg-config][]
@@ -16,6 +17,7 @@
 
 [Clang]: https://clang.llvm.org/
 [CMake]: https://cmake.org/
+[git]: https://git-scm.com/
 [GTK development headers]: https://www.gtk.org/docs/installations/linux#installing-gtk3-from-packages
 [Ninja build]: https://ninja-build.org/
 [pkg-config]: https://www.freedesktop.org/wiki/Software/pkg-config/


### PR DESCRIPTION
## Change

Had a problem installing flutter on a clean Ubuntu due to missing `git`. Since instructions are Ubuntu-oriented it might be useful to some with fresh install.

## Testing

Bulding the following docker image 

```dockerfile
FROM ubuntu:jammy-20231004 as base

# Install dependencies
RUN apt-get update
RUN apt-get install -y clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev  # PR change

# Download and install Flutter SDK
WORKDIR /usr/local
RUN apt-get install curl
RUN curl -L -o flutter.tar.xz https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.13.7-stable.tar.xz
RUN tar xf flutter.tar.xz
RUN rm flutter.tar.xz
ENV PATH="/usr/local/flutter/bin:${PATH}"
RUN flutter precache
```

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
