### PR TITLE
Remove Fabric from the error tracking services listed in error-reporting.md

### DIFF
--- a/src/cookbook/maintenance/error-reporting.md
+++ b/src/cookbook/maintenance/error-reporting.md
@@ -17,7 +17,7 @@ How can you determine how often your users experiences bugs?
 Whenever an error occurs, create a report containing the
 error that occurred and the associated stacktrace.
 You can then send the report to an error tracking
-service, such as [Bugsnag][], [Datadog][], Fabric, 
+service, such as [Bugsnag][], [Datadog][],
 [Firebase Crashlytics][], [Rollbar][], or Sentry.
 
 The error tracking service aggregates all of the crashes your users


### PR DESCRIPTION
Removes Fabric from the error tracking services listed in error-reporting.md.
Fabric seems to be completely replaced with Firebase Crashlytics, and is no longer available.

No issues will be fixed.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
