### PR TITLE
style(flutter for react native devs): add trailing comma to code example

### DIFF
--- a/examples/get-started/flutter-for/react_native_devs/lib/components.dart
+++ b/examples/get-started/flutter-for/react_native_devs/lib/components.dart
@@ -16,15 +16,16 @@ class CustomCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-        child: Column(
-      children: <Widget>[
-        Text('Card $index'),
-        TextButton(
-          onPressed: onPress,
-          child: const Text('Press'),
-        ),
-      ],
-    ));
+      child: Column(
+        children: <Widget>[
+          Text('Card $index'),
+          TextButton(
+            onPressed: onPress,
+            child: const Text('Press'),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/src/get-started/flutter-for/react-native-devs.md
+++ b/src/get-started/flutter-for/react-native-devs.md
@@ -576,15 +576,16 @@ class CustomCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-        child: Column(
-      children: <Widget>[
-        Text('Card $index'),
-        TextButton(
-          onPressed: onPress,
-          child: const Text('Press'),
-        ),
-      ],
-    ));
+      child: Column(
+        children: <Widget>[
+          Text('Card $index'),
+          TextButton(
+            onPressed: onPress,
+            child: const Text('Press'),
+          ),
+        ],
+      ),
+    );
   }
 }
 
@@ -1514,15 +1515,16 @@ class CustomCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-        child: Column(
-      children: <Widget>[
-        Text('Card $index'),
-        TextButton(
-          onPressed: onPress,
-          child: const Text('Press'),
-        ),
-      ],
-    ));
+      child: Column(
+        children: <Widget>[
+          Text('Card $index'),
+          TextButton(
+            onPressed: onPress,
+            child: const Text('Press'),
+          ),
+        ],
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
In some code example on the docs for react native developers, the code was not well formatted as shown in the table below:

| Before the changes  |  After the changes |
|---|---|
| <img width="200" alt="Capture d’écran 2023-10-16 à 13 08 55" src="https://github.com/flutter/website/assets/51904486/1db377a8-23ff-41f3-b0bd-4551d7625619"> |  <img width="200" alt="Capture d’écran 2023-10-16 à 13 07 50" src="https://github.com/flutter/website/assets/51904486/fb36db36-96d3-47bf-abb0-21a7a9f226d8"> |

This PR aims to fix this issue.

_Issues fixed by this PR (if any):_ None

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
