### PR TITLE
Fix typo in native-debugging.md

### DIFF
--- a/src/testing/native-debugging.md
+++ b/src/testing/native-debugging.md
@@ -23,7 +23,7 @@ that portion of your code with a native debugger.
 
 - To debug iOS or macOS code written in Swift or Objective-C,
   you can use Xcode.
-- To debug Android code written in Java or Kotlin, you can use Gradle.
+- To debug Android code written in Java or Kotlin, you can use Android Studio.
 - To debug Windows code written in C++, you can use Visual Studio.
 
 This guide shows you how you can connect _two_


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

There is a typo in the debugging docs for Android, which mention Gradle to debug, instead of Android Studio.
In the section below, it correctly mentions Android Studio for debugging.

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
