### PR TITLE
Fix RiverPod getting started url

### DIFF
--- a/src/data-and-backend/state-mgmt/options.md
+++ b/src/data-and-backend/state-mgmt/options.md
@@ -49,7 +49,7 @@ It offers compile safety and testing without depending on the Flutter SDK.
 * [Getting started with Riverpod][]
 
 
-[Getting started with Riverpod]: https://riverpod.dev/docs/getting_started
+[Getting started with Riverpod]: https://riverpod.dev/docs/introduction/getting_started
 [Riverpod]: https://riverpod.dev/
 
 ## setState


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
https://riverpod.dev/docs/getting_started is page not found.
Fix the link to https://riverpod.dev/docs/introduction/getting_started

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
