### PR TITLE
Update. pigeon platform & lang support.

### DIFF
--- a/src/platform-integration/platform-channels.md
+++ b/src/platform-integration/platform-channels.md
@@ -1127,7 +1127,7 @@ structured, typesafe manner.
 
 With [Pigeon][pigeon], the messaging protocol is defined
 in a subset of Dart that then generates messaging
-code for Android or iOS. You can find a more complete
+code for Android, iOS, macOS or Windows. You can find a more complete
 example and more information on the [`pigeon`][pigeon]
 page on pub.dev.
 
@@ -1140,7 +1140,7 @@ asynchronous wrapper code and sending messages
 in either direction. The generated code is readable
 and guarantees there are no conflicts between
 multiple clients of different versions.
-Supported languages are Objective-C, Java, Kotlin,
+Supported languages are Objective-C, Java, Kotlin, C++
 and Swift (with Objective-C interop).
 
 ### Pigeon example

--- a/src/platform-integration/platform-channels.md
+++ b/src/platform-integration/platform-channels.md
@@ -1140,7 +1140,7 @@ asynchronous wrapper code and sending messages
 in either direction. The generated code is readable
 and guarantees there are no conflicts between
 multiple clients of different versions.
-Supported languages are Objective-C, Java, Kotlin, C++
+Supported languages are Objective-C, Java, Kotlin, C++,
 and Swift (with Objective-C interop).
 
 ### Pigeon example

--- a/src/platform-integration/platform-channels.md
+++ b/src/platform-integration/platform-channels.md
@@ -1127,7 +1127,7 @@ structured, typesafe manner.
 
 With [Pigeon][pigeon], the messaging protocol is defined
 in a subset of Dart that then generates messaging
-code for Android, iOS, macOS or Windows. You can find a more complete
+code for Android, iOS, macOS, or Windows. You can find a more complete
 example and more information on the [`pigeon`][pigeon]
 page on pub.dev.
 


### PR DESCRIPTION

### Description
As a part of Issue: #9672 this PR updates pigeon section documentation of 
https://docs.flutter.dev/platform-integration/platform-channels page

Task done:
- Adding platform support of Windows and macOS.
- Adding language support of C++. 

_Closes: #9672_

## Presubmit checklist

- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
