### PR TITLE
Use the official way to upgrade Gradle

### DIFF
--- a/src/release/breaking-changes/android-java-gradle-migration-guide.md
+++ b/src/release/breaking-changes/android-java-gradle-migration-guide.md
@@ -56,32 +56,32 @@ using one of the following approaches.**
 Upgrade the Gradle version in Android Studio Flamingo
 as follows:
 
-**Step 1**: In Android Studio Flamingo, open the `android` folder,
-  which should bring up the following dialog: 
+1. In Android Studio, open the `android` folder.
+   This should bring up the following dialog: 
 
-![Dialog prompting you to upgrade Gradle]({{site.url}}/assets/images/docs/releaseguide/android-studio-flamingo-upgrade-alert.png){:width="50%"}
+   ![Dialog prompting you to upgrade Gradle]({{site.url}}/assets/images/docs/releaseguide/android-studio-flamingo-upgrade-alert.png){:width="50%"}
 
-Update to a Gradle release between 7.3 through 7.6.1, inclusive.
+   Update to a Gradle release between 7.3 through 7.6.1, inclusive.
 
-**Step 2**: Follow the guided workflow to update Gradle:
+1. Follow the guided workflow to update Gradle.
 
-![Workflow to upgrade Gradle]({{site.url}}/assets/images/docs/releaseguide/android-studio-flamingo-gradle-upgrade.png){:width="85%"}
+   ![Workflow to upgrade Gradle]({{site.url}}/assets/images/docs/releaseguide/android-studio-flamingo-gradle-upgrade.png){:width="85%"}
 
 ## Solution #2: Manual fix at the command line
 
 Do the following from the top of your Flutter project.
 
-**Step 1**: Go to the android directory for your project:
+1. Go to the Android directory for your project.
 
-```sh
-cd android
-```
+   ```terminal
+   $ cd android
+   ```
 
-**Step 2**: Update Gradle to the preferred version (7.3 through 7.6.1, inclusive):
+1. Update Gradle to the preferred version. Choose between 7.3 through 7.6.1, inclusive.
 
-```sh
-./gradlew wrapper --gradle-version=7.6.1
-```
+   ```terminal
+   $ ./gradlew wrapper --gradle-version=7.6.1
+   ```
 
 ## Notes
 

--- a/src/release/breaking-changes/android-java-gradle-migration-guide.md
+++ b/src/release/breaking-changes/android-java-gradle-migration-guide.md
@@ -71,18 +71,16 @@ Update to a Gradle release between 7.3 through 7.6.1, inclusive.
 
 Do the following from the top of your Flutter project.
 
-**Step 1**: Go to the gradle directory for your project:
+**Step 1**: Go to the android directory for your project:
 
 ```sh
-cd android/gradle/wrapper
+cd android
 ```
 
-**Step 2**: Edit the `gradle-wrapper.properties` file to
-  change the `distributionUrl` field to the preferred
-  Gradle version (7.3 through 7.6.1, inclusive):
+**Step 2**: Update Gradle to the preferred version (7.3 through 7.6.1, inclusive):
 
-```properties
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip 
+```sh
+./gradlew wrapper --gradle-version=7.6.1
 ```
 
 ## Notes


### PR DESCRIPTION
This pull request changes the way to upgrade Gradle from manually modifying `gradle-wrapper.properties` to running `./gradlew wrapper --gradle-version=<version>` as instructed in [the official Gradle documentation](https://docs.gradle.org/7.6.1/release-notes.html?_gl=1*96lisb*_ga*MTQ0MzIyNzczMi4xNjk4MTUxMTEy*_ga_7W7NC6YNPT*MTY5ODE1MTExMi4xLjEuMTY5ODE1MTczMi42MC4wLjA.#upgrade-instructions
).

This command updates not only Gradle, but also `gradlew` and `gradle.bat`.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
