### PR TITLE
Clean and speed up test CI setup a bit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
       lsof \
       make \
       unzip \
-      vim-nox \
       xdg-user-dirs \
     && rm -rf /var/lib/apt/lists/*
 
@@ -32,7 +31,7 @@ ENV FLUTTER_ROOT=flutter
 ENV FLUTTER_BIN=flutter/bin
 ENV PATH="/flutter/bin:$PATH"
 
-RUN git clone --branch $FLUTTER_BUILD_BRANCH --single-branch https://github.com/flutter/flutter /flutter/
+RUN git clone --branch $FLUTTER_BUILD_BRANCH --single-branch --filter=tree:0 https://github.com/flutter/flutter /flutter/
 VOLUME /flutter
 
 # Set up Flutter

--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,12 @@ emulate:
 # WARNING this can take a while to run!
 # Usage: `FLUTTER_BUILD_BRANCH=<channel> make test`
 test:
+	@echo "::group::Setting up container"
 	DOCKER_BUILDKIT=1 docker build --rm \
 	    --target tests \
 	    -t flt-test \
 	    --build-arg FLUTTER_BUILD_BRANCH=${FLUTTER_BUILD_BRANCH} .
+	@echo "::endgroup::"
 	docker run --rm --name flt-tests -t flt-test
 
 # Stop long running tests

--- a/build.excerpt.yaml
+++ b/build.excerpt.yaml
@@ -10,8 +10,11 @@ targets:
       exclude:
         - '**/.*/**'
         - '**/android/**'
-        - '**/build/**'
         - '**/ios/**'
+        - '**/linux/**'
+        - '**/macos/**'
+        - '**/windows/**'
+        - '**/build/**'
         - '**/node_modules/**'
         - '**/*.jar'
         - '**/codelab_rebuild.yaml'


### PR DESCRIPTION
- Don't download `vim-nox` as part of container setup. It adds time to the container setup and occasionally has warnings. If someone has a use case for it, they can always download it themselves.
- Use a partial treeless clone for cloning Flutter since we only need the blobs of the latest commit on the branch.
- Prevent the code excerpter from descending into all generated platform specific folders for generating fragments.
- In `make test`, group the setup in the GitHub actions output to make it easier to visually parse.