### PR TITLE
Avoid git usage in code excerpt diff functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
       gnupg \
       lsof \
       make \
+      rsync \
       unzip \
       xdg-user-dirs \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The diff setup in https://github.com/flutter/website/commit/e11bcec690cc189feab8e01149c4de78db7e912b was causing some errors in CI and also could end up adding local changes to the staging area if not desired. This changes the refresh code excerpt check to:

- Store a copy of the content files in `/src` in a temporary location
- Run the code excerpt updater
- Diff the the modified `/src` location with the backed-up temporary one
  - Output the diff results with file names and -2 +2 content diff using color
- Remove the temporary folder

New example output:

<img width="500" alt="Example of diff output" src="https://github.com/flutter/website/assets/18372958/e1378842-22b3-4f48-9d16-2d2a80efbd5b">
