### PR TITLE
Replace primarySwatch with ColorScheme.fromSeed in the examples.

### DIFF
--- a/examples/cookbook/gestures/dismissible/lib/main.dart
+++ b/examples/cookbook/gestures/dismissible/lib/main.dart
@@ -27,7 +27,7 @@ class MyAppState extends State<MyApp> {
     return MaterialApp(
       title: title,
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Scaffold(
         appBar: AppBar(

--- a/examples/cookbook/gestures/dismissible/lib/step1.dart
+++ b/examples/cookbook/gestures/dismissible/lib/step1.dart
@@ -25,7 +25,7 @@ class MyAppState extends State<MyApp> {
     return MaterialApp(
       title: title,
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Scaffold(
         appBar: AppBar(

--- a/examples/cookbook/gestures/dismissible/lib/step2.dart
+++ b/examples/cookbook/gestures/dismissible/lib/step2.dart
@@ -25,7 +25,7 @@ class MyAppState extends State<MyApp> {
     return MaterialApp(
       title: title,
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Scaffold(
         appBar: AppBar(

--- a/examples/cookbook/networking/delete_data/lib/main.dart
+++ b/examples/cookbook/networking/delete_data/lib/main.dart
@@ -85,7 +85,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'Delete Data Example',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Scaffold(
         appBar: AppBar(

--- a/examples/cookbook/networking/fetch_data/lib/main.dart
+++ b/examples/cookbook/networking/fetch_data/lib/main.dart
@@ -70,7 +70,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'Fetch Data Example',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Scaffold(
         appBar: AppBar(

--- a/examples/cookbook/networking/send_data/lib/main.dart
+++ b/examples/cookbook/networking/send_data/lib/main.dart
@@ -68,7 +68,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'Create Data Example',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Scaffold(
         appBar: AppBar(

--- a/examples/cookbook/networking/update_data/lib/main.dart
+++ b/examples/cookbook/networking/update_data/lib/main.dart
@@ -92,7 +92,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'Update Data Example',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Scaffold(
         appBar: AppBar(

--- a/examples/cookbook/networking/update_data/lib/main_step5.dart
+++ b/examples/cookbook/networking/update_data/lib/main_step5.dart
@@ -84,7 +84,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'Update Data Example',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Scaffold(
         appBar: AppBar(

--- a/examples/cookbook/testing/unit/mocking/lib/main.dart
+++ b/examples/cookbook/testing/unit/mocking/lib/main.dart
@@ -60,7 +60,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'Fetch Data Example',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Scaffold(
         appBar: AppBar(

--- a/examples/get-started/flutter-for/android_devs/lib/animation.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/animation.dart
@@ -12,7 +12,7 @@ class FadeAppTest extends StatelessWidget {
     return MaterialApp(
       title: 'Fade Demo',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const MyFadeTest(title: 'Fade Demo'),
     );

--- a/examples/get-started/flutter-for/android_devs/lib/async.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/async.dart
@@ -14,7 +14,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );

--- a/examples/get-started/flutter-for/android_devs/lib/isolates.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/isolates.dart
@@ -17,7 +17,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );

--- a/examples/get-started/flutter-for/android_devs/lib/layout.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/layout.dart
@@ -14,7 +14,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );

--- a/examples/get-started/flutter-for/android_devs/lib/list_item_tapped.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/list_item_tapped.dart
@@ -14,7 +14,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );

--- a/examples/get-started/flutter-for/android_devs/lib/listview.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/listview.dart
@@ -12,7 +12,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );

--- a/examples/get-started/flutter-for/android_devs/lib/listview_builder.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/listview_builder.dart
@@ -14,7 +14,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );

--- a/examples/get-started/flutter-for/android_devs/lib/listview_dynamic.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/listview_dynamic.dart
@@ -14,7 +14,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );

--- a/examples/get-started/flutter-for/android_devs/lib/progress.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/progress.dart
@@ -15,7 +15,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );

--- a/examples/get-started/flutter-for/android_devs/lib/request_data.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/request_data.dart
@@ -14,7 +14,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample Shared App Handler',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );

--- a/examples/get-started/flutter-for/android_devs/lib/text_widget.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/text_widget.dart
@@ -13,7 +13,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );

--- a/examples/get-started/flutter-for/android_devs/lib/theme.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/theme.dart
@@ -9,7 +9,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         textSelectionTheme:
             const TextSelectionThemeData(selectionColor: Colors.red),
       ),

--- a/examples/get-started/flutter-for/android_devs/lib/validation_errors.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/validation_errors.dart
@@ -12,7 +12,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );

--- a/examples/get-started/flutter-for/declarative/lib/main.dart
+++ b/examples/get-started/flutter-for/declarative/lib/main.dart
@@ -12,7 +12,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const MyHomePage(),
     );

--- a/examples/get-started/flutter-for/ios_devs/lib/request_data.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/request_data.dart
@@ -13,7 +13,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample Shared App Handler',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );

--- a/examples/get-started/flutter-for/ios_devs/lib/theme.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/theme.dart
@@ -9,7 +9,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         dividerColor: Colors.grey,
       ),
       home: const SampleAppPage(),

--- a/examples/get-started/flutter-for/react_native_devs/lib/examples.dart
+++ b/examples/get-started/flutter-for/react_native_devs/lib/examples.dart
@@ -144,7 +144,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-          primarySwatch: Colors.blue,
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
           textSelectionTheme:
               const TextSelectionThemeData(selectionColor: Colors.red)),
       home: const SampleAppPage(),

--- a/examples/get-started/flutter-for/xamarin_devs/lib/theme.dart
+++ b/examples/get-started/flutter-for/xamarin_devs/lib/theme.dart
@@ -10,7 +10,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         textSelectionTheme:
             const TextSelectionThemeData(selectionColor: Colors.red),
       ),

--- a/examples/integration_test/lib/main.dart
+++ b/examples/integration_test/lib/main.dart
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );

--- a/examples/integration_test_migration/lib/main.dart
+++ b/examples/integration_test_migration/lib/main.dart
@@ -23,7 +23,7 @@ class PlantsApp extends StatelessWidget {
     return MaterialApp(
       title: 'Plants by common name',
       theme: ThemeData(
-        primarySwatch: Colors.lightGreen,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.lightGreen),
       ),
       home: const HomePage(title: 'Plants by common name'),
     );

--- a/examples/testing/code_debugging/lib/performance_overlay.dart
+++ b/examples/testing/code_debugging/lib/performance_overlay.dart
@@ -10,7 +10,7 @@ class MyApp extends StatelessWidget {
       showPerformanceOverlay: true,
       title: 'My Awesome App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const MyHomePage(title: 'My Awesome App'),
     );

--- a/examples/ui/advanced/actions_and_shortcuts/lib/copyable_text.dart
+++ b/examples/ui/advanced/actions_and_shortcuts/lib/copyable_text.dart
@@ -171,7 +171,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: title,
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Shortcuts(
         shortcuts: <LogicalKeySet, Intent>{

--- a/src/cookbook/gestures/dismissible.md
+++ b/src/cookbook/gestures/dismissible.md
@@ -155,7 +155,7 @@ class MyAppState extends State<MyApp> {
     return MaterialApp(
       title: title,
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Scaffold(
         appBar: AppBar(

--- a/src/cookbook/networking/delete-data.md
+++ b/src/cookbook/networking/delete-data.md
@@ -222,7 +222,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'Delete Data Example',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Scaffold(
         appBar: AppBar(

--- a/src/cookbook/networking/fetch-data.md
+++ b/src/cookbook/networking/fetch-data.md
@@ -304,7 +304,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'Fetch Data Example',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Scaffold(
         appBar: AppBar(

--- a/src/cookbook/networking/send-data.md
+++ b/src/cookbook/networking/send-data.md
@@ -303,7 +303,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'Create Data Example',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Scaffold(
         appBar: AppBar(

--- a/src/cookbook/networking/update-data.md
+++ b/src/cookbook/networking/update-data.md
@@ -336,7 +336,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'Update Data Example',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Scaffold(
         appBar: AppBar(

--- a/src/cookbook/testing/unit/mocking.md
+++ b/src/cookbook/testing/unit/mocking.md
@@ -263,7 +263,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'Fetch Data Example',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Scaffold(
         appBar: AppBar(

--- a/src/get-started/flutter-for/android-devs.md
+++ b/src/get-started/flutter-for/android-devs.md
@@ -2271,7 +2271,7 @@ same functionality, but is not as rich as `MaterialApp`.
 
 To customize the colors and styles of any child components, pass a
 `ThemeData` object to the `MaterialApp` widget. For example, in the code below,
-the primary swatch is set to blue and text selection color is red.
+the color scheme from seed is set to deepPurple and text selection color is red.
 
 <?code-excerpt "lib/theme.dart (Theme)"?>
 ```dart

--- a/src/get-started/flutter-for/android-devs.md
+++ b/src/get-started/flutter-for/android-devs.md
@@ -135,7 +135,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );
@@ -237,7 +237,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );
@@ -331,7 +331,7 @@ class FadeAppTest extends StatelessWidget {
     return MaterialApp(
       title: 'Fade Demo',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const MyFadeTest(title: 'Fade Demo'),
     );
@@ -689,7 +689,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample Shared App Handler',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );
@@ -807,7 +807,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );
@@ -991,7 +991,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );
@@ -1160,7 +1160,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );
@@ -1737,7 +1737,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );
@@ -1799,7 +1799,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );
@@ -1878,7 +1878,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );
@@ -1955,7 +1955,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );
@@ -2128,7 +2128,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const SampleAppPage(),
     );
@@ -2285,7 +2285,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         textSelectionTheme:
             const TextSelectionThemeData(selectionColor: Colors.red),
       ),

--- a/src/get-started/flutter-for/react-native-devs.md
+++ b/src/get-started/flutter-for/react-native-devs.md
@@ -1136,7 +1136,7 @@ Set the theme property in `MaterialApp` to the `ThemeData` object.
 The [`Colors`][] class provides colors
 from the Material Design [color palette][].
 
-The following example sets the primary swatch to `blue`
+The following example sets the color scheme from seed to `deepPurple`
 and the text selection to `red`.
 
 <?code-excerpt "lib/examples.dart (Swatch)"?>

--- a/src/get-started/flutter-for/react-native-devs.md
+++ b/src/get-started/flutter-for/react-native-devs.md
@@ -1149,7 +1149,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-          primarySwatch: Colors.blue,
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
           textSelectionTheme:
               const TextSelectionThemeData(selectionColor: Colors.red)),
       home: const SampleAppPage(),

--- a/src/get-started/flutter-for/uikit-devs.md
+++ b/src/get-started/flutter-for/uikit-devs.md
@@ -1367,7 +1367,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         dividerColor: Colors.grey,
       ),
       home: const SampleAppPage(),

--- a/src/get-started/flutter-for/uikit-devs.md
+++ b/src/get-started/flutter-for/uikit-devs.md
@@ -1353,7 +1353,7 @@ but is not as rich as `MaterialApp`.
 To customize the colors and styles of any child components,
 pass a `ThemeData` object to the `MaterialApp` widget.
 For example, in the code below,
-the primary swatch is set to blue and divider color is grey.
+the color scheme from seed is set to deepPurple and divider color is grey.
 
 <?code-excerpt "lib/theme.dart (Theme)"?>
 ```dart

--- a/src/get-started/flutter-for/xamarin-forms-devs.md
+++ b/src/get-started/flutter-for/xamarin-forms-devs.md
@@ -2487,7 +2487,7 @@ class SampleApp extends StatelessWidget {
     return MaterialApp(
       title: 'Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         textSelectionTheme:
             const TextSelectionThemeData(selectionColor: Colors.red),
       ),

--- a/src/get-started/flutter-for/xamarin-forms-devs.md
+++ b/src/get-started/flutter-for/xamarin-forms-devs.md
@@ -2474,7 +2474,7 @@ but is not as rich as `MaterialApp`.
 To customize the colors and styles of any child components,
 pass a `ThemeData` object to the `MaterialApp` widget.
 For example, in the following code,
-the primary swatch is set to blue and text selection color is red.
+the color scheme from seed is set to deepPurple and text selection color is red.
 
 <?code-excerpt "lib/theme.dart (Theme)"?>
 ```dart

--- a/src/release/breaking-changes/layout-builder-optimization.md
+++ b/src/release/breaking-changes/layout-builder-optimization.md
@@ -82,7 +82,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Counter(),
     );
@@ -179,7 +179,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Counter(),
     );

--- a/src/release/breaking-changes/page-transition-replaced-by-ZoomPageTransitionBuilder.md
+++ b/src/release/breaking-changes/page-transition-replaced-by-ZoomPageTransitionBuilder.md
@@ -50,7 +50,7 @@ Code before migration:
 
 ```dart
 MaterialApp(
-  theme: ThemeData(primarySwatch: Colors.blue),
+  theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple)),
 )
 ```
 

--- a/src/testing/code-debugging.md
+++ b/src/testing/code-debugging.md
@@ -982,7 +982,7 @@ class MyApp extends StatelessWidget {
       [[highlight]]showPerformanceOverlay: true,[[/highlight]]
       title: 'My Awesome App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const MyHomePage(title: 'My Awesome App'),
     );

--- a/src/ui/interactivity/actions-and-shortcuts.md
+++ b/src/ui/interactivity/actions-and-shortcuts.md
@@ -591,7 +591,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: title,
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: Shortcuts(
         shortcuts: <LogicalKeySet, Intent>{


### PR DESCRIPTION
### Description

Fixes #9713 
this PR updates and replace all instances of `primarySwatch` with `ColorScheme.fromSeed` in the `examples/cookbook` and in remaining code. 


## Presubmit checklist

- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
