### PR TITLE
Introduce a new top-level sidenav category for toolkit content

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -254,6 +254,29 @@
 - divider
 - header: Beyond UI
 
+- title: Build by category
+  children:
+    - title: Games
+      children:
+        - title: Create a casual game
+          permalink: /resources/games-toolkit
+        - title: Build a game with Flame
+          permalink: https://codelabs.developers.google.com/codelabs/flutter-flame-game
+    - title: News
+      children:
+        - title: Build a news app
+          permalink: /resources/news-toolkit
+    - title: Monetization
+      children:
+        - title: Overview
+          permalink: https://flutter.dev/monetization
+        - title: Add in-app purchases
+          permalink: https://codelabs.developers.google.com/codelabs/flutter-in-app-purchases#0
+    - title: Maps & navigation
+      children:
+        - title: Add maps to your app
+          permalink: https://developers.google.com/maps/flutter-package
+
 - title: Data & backend
   permalink: /data-and-backend
   children:
@@ -620,11 +643,6 @@
       permalink: https://github.com/flutter/flutter/blob/main/CONTRIBUTING.md
     - title: Design documents
       permalink: /resources/design-docs
-    - header: Toolkits
-    - title: Casual Games Toolkit
-      permalink: /resources/games-toolkit
-    - title: Flutter News Toolkit
-      permalink: /resources/news-toolkit
 
 - title: Reference
   permalink: /reference

--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -61,6 +61,29 @@
     - title: Codelabs
       permalink: /codelabs
 
+- title: App solutions
+  children:
+    - title: Games
+      children:
+        - title: Create a casual game
+          permalink: /resources/games-toolkit
+        - title: Build a game with Flame
+          permalink: https://codelabs.developers.google.com/codelabs/flutter-flame-game
+    - title: News
+      children:
+        - title: Build a news app
+          permalink: /resources/news-toolkit
+    - title: Monetization
+      children:
+        - title: Overview
+          permalink: https://flutter.dev/monetization
+        - title: Add in-app purchases
+          permalink: https://codelabs.developers.google.com/codelabs/flutter-in-app-purchases#0
+    - title: Maps
+      children:
+        - title: Add maps to your app
+          permalink: https://developers.google.com/maps/flutter-package
+
 - divider
 - header: User interface
 - title: Introduction
@@ -253,29 +276,6 @@
 
 - divider
 - header: Beyond UI
-
-- title: Build by category
-  children:
-    - title: Games
-      children:
-        - title: Create a casual game
-          permalink: /resources/games-toolkit
-        - title: Build a game with Flame
-          permalink: https://codelabs.developers.google.com/codelabs/flutter-flame-game
-    - title: News
-      children:
-        - title: Build a news app
-          permalink: /resources/news-toolkit
-    - title: Monetization
-      children:
-        - title: Overview
-          permalink: https://flutter.dev/monetization
-        - title: Add in-app purchases
-          permalink: https://codelabs.developers.google.com/codelabs/flutter-in-app-purchases#0
-    - title: Maps & navigation
-      children:
-        - title: Add maps to your app
-          permalink: https://developers.google.com/maps/flutter-package
 
 - title: Data & backend
   permalink: /data-and-backend


### PR DESCRIPTION
This work is primarily to introduce a new top-level sidenav category for toolkits so we can more prominently link to the corresponding cookbook recipes.

However, the two toolkits we have are not the only unique goals/app categories we should cover and I doubt anyone would look under "Toolkits" for this kind of content. So I am proposing a new top-level entry called "Build by category". To showcase what could live here, I also added Monetization and Maps. While we don't have content on the docs website for these areas yet we have great content elsewhere that's currently not as discoverable from the site. Perhaps this will give it a chance to shine!

Note that this doesn't change the file structure, at least not yet, so we can easily make adjustments by removing or adding links.

**Looking for feedback:**

- Does the name make sense to you?
  - Would something like "Use cases", "Toolkits", or something else be better?
- Does the location in the sidenav make sense?
  - Should it instead be at the bottom of "Beyond UI", under "Resources", next to "Samples", etc?
- Does the initial content I added seem worthwhile, despite much of it being external?
  - Would it be better to just have the toolkits?
  - What other subcategories make sense to add that we have content for?
  - Am I missing any high quality content to link to?
- How are the names of the individual entries?

**Staged:** https://flutter-docs-prod--pr9744-feature-build-by-cat-pbqz0954.web.app/resources/games-toolkit

_To find the changes on the staged site, scroll down in the left sidenav. The new category is currently directly under "Beyond UI"._

Fixes https://github.com/flutter/website/issues/9743