### PR TITLE
fix: Not working YouTube movie redirection to a Widget of the week

### DIFF
--- a/src/testing/common-errors.md
+++ b/src/testing/common-errors.md
@@ -137,7 +137,7 @@ The resources linked below provide further information about this error.
 * [Understanding constraints][]
 
 [its source code]: {{site.repo.flutter}}/blob/c8e42b47f5ea8b5ff7bf2f2b0a2a8e765f1aa51d/packages/flutter/lib/src/widgets/basic.dart#L5166-L5174
-[flexible-video]: ({{site.youtube-site}}/watch?v=CI7x0mAZiY0)
+[flexible-video]: {{site.youtube-site}}/watch?v=CI7x0mAZiY0
 [medium-article]: {{site.flutter-medium}}/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db#738b
 [Understanding constraints]: {{site.url}}/ui/layout/constraints
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
It fixes YouTube video syntax errors, leading to a page not found error (404).

_Issues fixed by this PR (if any):_
Fixes the syntax so the redirect works and opens the intended Youtube video (https://www.youtube.com/watch?v=CI7x0mAZiY0).

## Presubmit checklist

- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
