### PR TITLE
Add wildcard

### DIFF
--- a/src/data-and-backend/networking.md
+++ b/src/data-and-backend/networking.md
@@ -15,7 +15,7 @@ Some platforms require additional steps, as detailed below.
 ### Android
 
 Android apps must [declare their use of the internet][declare] in the Android
-manifest (`AndroidManifest.xml `):
+manifest (`AndroidManifest.xml`):
 
 ```
 <manifest xmlns:android...>

--- a/src/data-and-backend/networking.md
+++ b/src/data-and-backend/networking.md
@@ -27,7 +27,7 @@ manifest (`AndroidManifest.xml `):
 
 ### macOS
 
-macOS apps must allow network access in the relevant `.entitlements` files. 
+macOS apps must allow network access in the relevant `*.entitlements` files. 
 
 ```
 <key>com.apple.security.network.client</key>


### PR DESCRIPTION
The current wording makes it look as if there are literally `.entitlements` files (i.e. hidden files, such as `.gitignore`).

But in fact, they are files like "DebugProfile.entitlements" and "Release.entitlements". I think the wildcard makes it clearer what is meant.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
