### PR TITLE
Provide different IDs to the two different sidenav entries

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -36,7 +36,7 @@
       <div class="site-header__sheet">
         <ul class="navbar-nav">
           <div class="site-sidebar site-sidebar--header d-md-none">
-            {% include_cached sidenav-level-1.html nav=site.data.sidenav page_url_path=route %}
+            {% include sidenav-level-1.html nav=site.data.sidenav page_url_path=route base_id="header" %}
           </div>
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" id="platform-navbar-dropdown"

--- a/src/_includes/sidenav-level-1.html
+++ b/src/_includes/sidenav-level-1.html
@@ -7,7 +7,7 @@
     {% elsif entry contains 'header' -%}
       <li class="nav-header">{{entry.header}}</li>
     {% else -%}
-      {% assign id = 'sidenav-' | append: forloop.index -%}
+      {% assign id = include.base_id | append: '-sidenav-' | append: forloop.index -%}
       {% if forloop.index == active_entries[0] -%}
         {% assign isActive = true -%}
         {% assign class = 'active' -%}

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -14,7 +14,7 @@ layout: base
   <div class="row flex-xl-nowrap">
     <div class="fixed-col site-sidebar site-sidebar--fixed {{sidebar-col}} d-none d-md-block" data-fixed-column>
       {% assign route = page.url | regex_replace:'/index$|/index\.html$|\.html$|/$' %}
-      {% include_cached sidenav-level-1.html nav=site.data.sidenav page_url_path=route %}
+      {% include sidenav-level-1.html nav=site.data.sidenav page_url_path=route base_id="fixed" %}
     </div>
 
     {% if page.toc and layout.toc != false -%}


### PR DESCRIPTION
Prepends each sidenav button ID used for labeling with the sidenav type (left/desktop vs header/mobile).

Fixes https://github.com/flutter/website/issues/9708
