### PR TITLE
Remove unused 'toc' ID from table of contents

### DIFF
--- a/src/_includes/inline-toc.html
+++ b/src/_includes/inline-toc.html
@@ -15,6 +15,7 @@
 {% endcomment -%}
 
 {% if toc contains "<li" -%}
+  {% assign toc = toc | replace: 'id="toc" ', '' %}
   <div
     id="site-toc--inline"
     class="site-toc site-toc--inline {{include.class}}"

--- a/src/_includes/side-toc.html
+++ b/src/_includes/side-toc.html
@@ -15,6 +15,7 @@
 {% endcomment -%}
 
 {% if toc contains "<li" -%}
+  {% assign toc = toc | replace: 'id="toc" ', '' %}
   {% assign toc = toc | replace: '<ul>', '<ul class="nav">' %}
   {% assign toc = toc | replace: '<ul class="section-nav">', '<ul class="section-nav nav">' %}
   {% assign toc = toc | replace: 'class="toc-entry', 'class="toc-entry nav-item' %}


### PR DESCRIPTION
We use a TOC generated from a plugin, so we need to do the replacement manually.

Fixes https://github.com/flutter/website/issues/9707
