### PR TITLE
Ads tweaks

### DIFF
--- a/src/cookbook/plugins/google-mobile-ads.md
+++ b/src/cookbook/plugins/google-mobile-ads.md
@@ -137,19 +137,17 @@ $ flutter pub add google_mobile_ads
 
 ## 4. Initialize the Mobile Ads SDK
 
-You need to initialize the Mobile Ads SDK before loading ads.
+You need to initialize the Mobile Ads SDK before loading ads. 
+Call `MobileAds.instance.initialize()` to initialize the Mobile Ads SDK.
 
-1.  Call `MobileAds.instance.initialize()` to initialize the Mobile Ads
-    SDK.
+```dart
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  MobileAds.instance.initialize();
 
-    ```dart
-    void main() {
-      WidgetsFlutterBinding.ensureInitialized();
-      MobileAds.instance.initialize();
-    
-      runApp(MyApp());
-    }
-    ```
+  runApp(MyApp());
+}
+```
 
 Run the initialization step at startup, as shown above, 
 so that the AdMob SDK has enough time to initialize before it is needed.

--- a/src/cookbook/plugins/google-mobile-ads.md
+++ b/src/cookbook/plugins/google-mobile-ads.md
@@ -138,7 +138,9 @@ $ flutter pub add google_mobile_ads
 ## 4. Initialize the Mobile Ads SDK
 
 You need to initialize the Mobile Ads SDK before loading ads. 
-Call `MobileAds.instance.initialize()` to initialize the Mobile Ads SDK.
+Call 
+[`MobileAds.instance.initialize()`](https://pub.dev/documentation/google_mobile_ads/latest/google_mobile_ads/MobileAds/initialize.html)
+to initialize the Mobile Ads SDK.
 
 ```dart
 void main() {

--- a/src/cookbook/plugins/google-mobile-ads.md
+++ b/src/cookbook/plugins/google-mobile-ads.md
@@ -145,7 +145,7 @@ You need to initialize the Mobile Ads SDK before loading ads.
     ```dart
     void main() {
       WidgetsFlutterBinding.ensureInitialized();
-      unawaited(MobileAds.instance.initialize());
+      MobileAds.instance.initialize();
     
       runApp(MyApp());
     }

--- a/src/cookbook/plugins/google-mobile-ads.md
+++ b/src/cookbook/plugins/google-mobile-ads.md
@@ -167,8 +167,9 @@ so that the AdMob SDK has enough time to initialize before it is needed.
 
 To show an ad, you need to request it from AdMob.
 
-To load a banner ad, construct a `BannerAd` instance, and
-call `load()` on it.
+To load a banner ad, construct a 
+[`BannerAd`](https://pub.dev/documentation/google_mobile_ads/latest/google_mobile_ads/BannerAd-class.html)
+instance, and call `load()` on it.
 
 {{site.alert.note}}
   In the following code snippet, `adSize` and `adUnitId` have not been


### PR DESCRIPTION
Leftover tweaks to the new ads codelab.

I merged https://github.com/flutter/website/pull/9730 before adding the changes suggested by @parlough. The ones I forgot are tweaks such as two instances of linking classes to their API docs.

The one change that needs explanation is removing `unawaited` from the initialization code after it was suggested and added by @parlough. Here's the commit description:

> I belatedly realized that `unawaited()` requires an additional import. For simplicity, I’m going to omit `unawaited` for this recipe. I’m going to assume that people who know `await_futures` (because they turned it on), know how to deal with the lint warning.

It's not ideal, but in my opinion, it's better than complicating the recipe with yet another small step that just adds `import 'dart:async';` — which is something that is irrelevant to ads.
 

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
