### PR TITLE
Update long link in content

### DIFF
--- a/src/ui/accessibility-and-internationalization/accessibility.md
+++ b/src/ui/accessibility-and-internationalization/accessibility.md
@@ -248,8 +248,7 @@ widgets to offer a dramatically more accessible experience.
 
 ## Testing accessibility on mobile
 
-Test your app using Flutter's
-<a href="https://api.flutter.dev/flutter/flutter_test/AccessibilityGuideline-class.html">Accessibility Guideline API</a>.
+Test your app using Flutter's [Accessibility Guideline API][].
 This API checks if your app's UI meets Flutter's accessibility recommendations.
 These cover recommendations for text contrast, target size, and target labels.
 
@@ -287,6 +286,7 @@ You can add Guideline API tests
 in `test/widget_test.dart` of your app directory, or as a separate test
 file (such as `test/a11y_test.dart` in the case of the Name Generator).
 
+[Accessibility Guideline API]: https://api.flutter.dev/flutter/flutter_test/AccessibilityGuideline-class.html
 
 ## Testing accessibility on web
 

--- a/src/ui/accessibility-and-internationalization/accessibility.md
+++ b/src/ui/accessibility-and-internationalization/accessibility.md
@@ -286,7 +286,7 @@ You can add Guideline API tests
 in `test/widget_test.dart` of your app directory, or as a separate test
 file (such as `test/a11y_test.dart` in the case of the Name Generator).
 
-[Accessibility Guideline API]: https://api.flutter.dev/flutter/flutter_test/AccessibilityGuideline-class.html
+[Accessibility Guideline API]: {{site.api}}/flutter/flutter_test/AccessibilityGuideline-class.html
 
 ## Testing accessibility on web
 


### PR DESCRIPTION
```diff
-Test your app using Flutter's
-<a href="https://api.flutter.dev/flutter/flutter_test/AccessibilityGuideline-class.html">Accessibility Guideline API</a>.
-......

+Test your app using Flutter's [Accessibility Guideline API][].
+......
+[Accessibility Guideline API]: {{site.api}}/flutter/flutter_test/AccessibilityGuideline-class.html
```

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
