### PR TITLE
[WEB] fix wrong name of a variable in print statement

### DIFF
--- a/src/release/breaking-changes/window-singleton.md
+++ b/src/release/breaking-changes/window-singleton.md
@@ -96,7 +96,7 @@ Code before migration:
 Widget build(BuildContext context) {
   final double dpr = WidgetsBinding.instance.window.devicePixelRatio;
   final Locale locale = WidgetsBinding.instance.window.locale;
-  return Text('The device pixel ratio is $pdr and the locale is $locale.');
+  return Text('The device pixel ratio is $dpr and the locale is $locale.');
 }
 ```
 
@@ -106,7 +106,7 @@ Code after migration:
 Widget build(BuildContext context) {
   final double dpr = View.of(context).devicePixelRatio;
   final Locale locale = View.of(context).platformDispatcher.locale;
-  return Text('The device pixel ratio is $pdr and the locale is $locale.');
+  return Text('The device pixel ratio is $dpr and the locale is $locale.');
 }
 ```
 


### PR DESCRIPTION
`dpr` stands for `devicePixelRatio`, but the print statement is `pdr`

## Presubmit checklist

- [Y] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [Y] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [N] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
