### PR TITLE
Remove duplicated words on deployment page

### DIFF
--- a/src/deployment/android.md
+++ b/src/deployment/android.md
@@ -345,7 +345,7 @@ to verify that the values are correct.
   Defaults to `flutter.minSdkVersion`.
 
 `targetSdkVersion`
-: Specify the target API level on which on which you designed the app to run.
+: Specify the target API level on which you designed the app to run.
   Defaults to `flutter.targetSdkVersion`.
   
 `versionCode`


### PR DESCRIPTION
Removes duplicated words on the deployment page.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
