### PR TITLE
Reference sheet for post-3.16 deprecation clean up

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -302,6 +302,7 @@
       { "source": "/go/deprecations-removed-after-3-7", "destination": "https://docs.google.com/spreadsheets/d/1WCQmKobsgslfhqf6uL7I2BKk5KKhGX-n_xfk9g3CTEE/edit?usp=sharing", "type": 301 },
       { "source": "/go/deprecations-removed-after-3-10", "destination": "https://docs.google.com/spreadsheets/d/1gs2tvYBuwycP1XAZsDbMuqP5jUa6gWH1a0ZQGrzjXvw/edit?usp=sharing", "type": 301 },
       { "source": "/go/deprecations-removed-after-3-13", "destination": "https://docs.google.com/spreadsheets/d/1zzyBRdIkqiEcpv_njEQA7pyG7X8PcNhvXFYrEAB8P78/edit?usp=sharing", "type": 301 },
+      { "source": "/go/deprecations-removed-after-3-16", "destination": "https://docs.google.com/spreadsheets/d/1ei3UmfvhmGGuwAGgLaQo1k_pgdu9Mu06tHPuSaS4TI4/edit?usp=sharing", "type": 301 },
       { "source": "/go/desktop-multi-window-support", "destination": "https://docs.google.com/document/d/11_4wntz_9IJTQOo_Qhp7QF4RfpIMTfVygtOTxQ4OGHY/edit", "type": 301 },
       { "source": "/go/desktop-multi-view-runner-apis", "destination": "https://docs.google.com/document/d/1WkJuzifgJXyceaSoCCu8qTETYmYBOYKoz7Qaxtsore4/edit?usp=sharing", "type": 301 },
       { "source": "/go/desktop-release-conductor", "destination": "https://docs.google.com/document/d/15AwPXNd5FvItAqM0wa2VK0tRrqtRTgM8vR5LQeT2Mag/edit?usp=sharing&resourcekey=0-yZ2FAN-wEKwKT-ymdisetA", "type": 301 },


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/139243
With the release of 3.16, these APIs are next to be removed from the framework.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
