### PR TITLE
Add Q3 DevIntel report go-link

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -309,6 +309,7 @@
       { "source": "/go/desktop-resize", "destination": "https://docs.google.com/document/d/1OTy-qCGdP7tYfrEKCNX9A24sgnx5vshfK6FupfniyxA", "type": 301 },
       { "source": "/go/detect-memory-leaks", "destination": "https://docs.google.com/document/d/1hvRVpULPnwGjBc5nw52iSaDfB8hjIzbaQuECHmKvDrY/edit", "type": 301 },
       { "source": "/go/developing-plugins", "destination": "/packages-and-plugins/developing-packages#plugin", "type": 301 },
+      { "source": "/go/devintel-q3-2023", "destination": "https://docs.google.com/document/d/1VGux5IxePO8lN_7kUuzYJtcJ76fkldr_TJv4R0tciYk", "type": 301 },
       { "source": "/go/dirty-region-management", "destination": "https://docs.google.com/document/d/19WDvGJql1bmnECTdEzJFeH9Ixw4AP2R7JlgujBSbDbk/edit?usp=sharing", "type": 301 },
       { "source": "/go/disable-dropdownmenuitem", "destination": "https://docs.google.com/document/d/13W6PupVZUt6TenoE3NaTP9OCYsKBIYg9YgdurKe1XKs/edit?usp=sharing&resourcekey=0-6n8D5zSLjWs2ZncIyG6HUw", "type": 301 },
       { "source": "/go/docs-nnbd-migration-guide", "destination": "https://docs.google.com/document/d/1U8blxmkArsd09C-IGe3cQbJ5SvDLhwn0rWWsY2SthZ4/edit?usp=sharing&resourcekey=0-0CviWT1D47VGxK-Li4_NIw", "type": 301 },


### PR DESCRIPTION
I'm adding a golink to the following DevIntel report: https://docs.google.com/document/d/1VGux5IxePO8lN_7kUuzYJtcJ76fkldr_TJv4R0tciYk/edit

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
