### PR TITLE
Remove last usage of testing from embedded DartPads

### DIFF
--- a/examples/get-started/codelab_web/lib/starter.dart
+++ b/examples/get-started/codelab_web/lib/starter.dart
@@ -98,5 +98,3 @@ class _SignUpFormState extends State<SignUpForm> {
     );
   }
 }
-
-// ignore_for_file: prefer_final_fields

--- a/examples/get-started/codelab_web/lib/starter.dart
+++ b/examples/get-started/codelab_web/lib/starter.dart
@@ -1,4 +1,3 @@
-/* {$ begin main.dart $} */
 import 'package:flutter/material.dart';
 
 void main() => runApp(const SignUpApp());
@@ -99,8 +98,5 @@ class _SignUpFormState extends State<SignUpForm> {
     );
   }
 }
-/* {$ end main.dart $} */
-/* {$ begin test.dart $} */
-// Avoid warning on "double _formProgress = 0;"
-//_ignore_for_file: prefer_final_fields
-/* {$ end test.dart $} */
+
+// ignore_for_file: prefer_final_fields

--- a/src/get-started/codelab-web.md
+++ b/src/get-started/codelab-web.md
@@ -231,8 +231,6 @@ class _SignUpFormState extends State<SignUpForm> {
     );
   }
 }
-
-// ignore_for_file: prefer_final_fields
 ```
 
 {{site.alert.important}}

--- a/src/get-started/codelab-web.md
+++ b/src/get-started/codelab-web.md
@@ -129,9 +129,8 @@ of the Flutter DevTools tooling.
 
 <li markdown="1">The starting app is displayed in the following DartPad.
 
-<?code-excerpt "lib/starter.dart" replace="/\/\* //g;/ \*\///g;/_ignore_for_file/ignore_for_file/g"?>
+<?code-excerpt "lib/starter.dart"?>
 ```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-starting_code
-{$ begin main.dart $}
 import 'package:flutter/material.dart';
 
 void main() => runApp(const SignUpApp());
@@ -232,11 +231,8 @@ class _SignUpFormState extends State<SignUpForm> {
     );
   }
 }
-{$ end main.dart $}
-{$ begin test.dart $}
-// Avoid warning on "double _formProgress = 0;"
-//ignore_for_file: prefer_final_fields
-{$ end test.dart $}
+
+// ignore_for_file: prefer_final_fields
 ```
 
 {{site.alert.important}}


### PR DESCRIPTION
Support for multifile is going away, so remove the final usage.

It's okay a lint shows up in this step, as it will be fixed in a following step.