### PR TITLE
Remove games cookbook index redirect

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -103,7 +103,6 @@
       { "source": "/add-to-app/android/add-splash-screen", "destination": "/platform-integration/android/splash-screen", "type": 301 },
       { "source": "/codelabs/layout-basics", "destination": "/ui/layout", "type": 301 },
       { "source": "/codelabs/explicit-animations", "destination": "/ui/animations/tutorial", "type": 301 },
-      { "source": "/cookbook/games", "destination": "https://flutter.dev/games", "type": 301 },
       { "source": "/cookbook/games/google-mobile-ads", "destination": "/cookbook/plugins/google-mobile-ads", "type": 301 },
       { "source": "/cookbook/networking/named-routes", "destination": "/cookbook/navigation/named-routes", "type": 301 },
       { "source": "/cookbook/testing/integration-test-introduction", "destination": "/cookbook/testing/integration", "type": 301 },


### PR DESCRIPTION
We now have an index to place at this location with links to the recipes, so we don't need the redirect anymore.
