### PR TITLE
Add a link to the `testing_app` for the integration tests

### DIFF
--- a/src/testing/integration-tests/index.md
+++ b/src/testing/integration-tests/index.md
@@ -126,6 +126,9 @@ void main() {
   be reported correctly.
 {{site.alert.end}}
 
+If you are looking for more examples, take a look at the [testing_app][] of
+the [samples][] repository.
+
 ### Directory structure
 
 ```yaml
@@ -323,4 +326,6 @@ from the command line.
 [iOS Device Testing]: {{site.repo.flutter}}/tree/main/packages/integration_test#ios-device-testing
 [Migrating from flutter_drive]: {{site.url}}/release/breaking-changes/flutter-driver-migration
 [Running Flutter driver tests with web]: {{site.repo.flutter}}/wiki/Running-Flutter-Driver-tests-with-Web
+[samples]: {{site.repo.samples}}
+[testing_app]: {{site.repo.samples}}/tree/main/testing_app/integration_test
 [widget tests]: {{site.url}}/testing/overview#widget-tests


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

When I started to learn about integration tests, I was a little lost in Flutter documentation because there were only 1 or 2 poor examples in the docs: https://flutter.dev/docs/testing/integration-tests. Later, I discovered the [testing_app](https://github.com/flutter/samples/tree/main/testing_app/integration_test) which contains multiple examples which would have helped me if I discovered them earlier.

Therefore, I think it's a good idea to add a simple link in the docs.

_Issues fixed by this PR (if any):_ Fixes https://github.com/flutter/flutter/issues/87437

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
