### PR TITLE
Fix analysis error from incorrect const usage

### DIFF
--- a/examples/basics/lib/main.dart
+++ b/examples/basics/lib/main.dart
@@ -23,7 +23,7 @@ class MyApp extends StatelessWidget {
         appBar: AppBar(
           title: const Text('Nullable Fields Demo'),
         ),
-        body: const Center(
+        body: Center(
           child: Column(
             children: [
               Text('anInt is $anInt.'),


### PR DESCRIPTION
@atsansone This will fix the error you're seeing. It's surfaced in today's stable build because of a fix to the analyzer that was allowing `const` when it shouldn't have.  