### PR TITLE
Fix migration guide for "deprecated gradle plugin apply"

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -351,6 +351,7 @@
       { "source": "/go/flutter-engine-clocks", "destination": "https://docs.google.com/document/d/1Sx8QA1qXgJGw5r4ESviDnU2LSShNHiq_LjbRWPgSvXQ/edit?usp=sharing&resourcekey=0-BoBvLxgqf_nc_rwLc0zmTw", "type": 301 },
       { "source": "/go/flutter-engine-extensions", "destination": "https://docs.google.com/document/d/1xG7jR4FserdW7TdwnklF3_lXUGmt4myPQjDGF3LFtCQ/edit?resourcekey=0-Iug4D2mWuyQI6suvC_2itw#", "type": 301 },
       { "source": "/go/flutter-for-embedded-linux", "destination": "https://docs.google.com/document/d/1n4NXCk0QlGz16gUCtywR79H0Z1fzPqB2iNL8oxuexuk/edit?usp=sharing", "type": 301 },
+      { "source": "/go/flutter-gradle-plugin-apply", "destination": "/release/breaking-changes/flutter-gradle-plugin-apply", "type": 301 },
       { "source": "/go/flutter-iap-migrate-pblv2", "destination": "https://docs.google.com/document/d/1XM16UsLE_aPWoZnheE9waO06mhxLkkWjpPf9jtI1AdY/edit", "type": 301 },
       { "source": "/go/flutter-ios-system-font", "destination": "https://docs.google.com/document/d/1FG9ONkG-sLuFkb9vUAL2i7oeUtUqm8qiQJe_poK754w/edit", "type": 301 },
       { "source": "/go/flutter-lints", "destination": "https://docs.google.com/document/d/1b0X0HOzvFY3WxI363U8BXx6Am13qFm96KlbS72mmFAk/edit", "type": 301 },

--- a/src/release/breaking-changes/flutter-gradle-plugin-apply.md
+++ b/src/release/breaking-changes/flutter-gradle-plugin-apply.md
@@ -33,7 +33,7 @@ buildscripts.
 ### android/settings.gradle
 
 Replace the contents of `<app-src>/android/settings.gradle` with the below,
-remembering to replace `{{agpVersion}}` and `{{kotlinVersion}}` with previously
+remembering to replace `{agpVersion}` and `{kotlinVersion}` with previously
 used values:
 
 ```gradle
@@ -58,8 +58,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "{{agpVersion}}" apply false
-    id "org.jetbrains.kotlin.android" version "{{kotlinVersion}}" apply false
+    id "com.android.application" version "{agpVersion}" apply false
+    id "org.jetbrains.kotlin.android" version "{kotlinVersion}" apply false
 }
 
 include ":app"
@@ -75,7 +75,7 @@ Remove the whole `buildscript` block from `<app-src/android/build.gradle`:
 
 ```diff
 -buildscript {
--    ext.kotlin_version = '{{kotlinVersion}}'
+-    ext.kotlin_version = '{kotlinVersion}'
 -    repositories {
 -        google()
 -        mavenCentral()
@@ -176,15 +176,14 @@ the following lines to `<app-src>/android/settings.gradle`:
 ```diff
  plugins {
      id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-     id "com.android.application" version "{{agpVersion}}" apply false
-     id "org.jetbrains.kotlin.android" version "{{kotlinVersion}}" apply false
+     id "com.android.application" version "{agpVersion}" apply false
+     id "org.jetbrains.kotlin.android" version "{kotlinVersion}" apply false
 +    id "com.google.gms.google-services" version "4.4.0" apply false
 +    id "com.google.firebase.crashlytics" version "2.9.9" apply false
  }
 ```
 
-and the following lines to `<app-src>/android/app/build.gradle` (remembering to
-replace `{{agpVersion}}` and `{{kotlinVersion}}` with previously used values):
+and the following lines to `<app-src>/android/app/build.gradle`:
 
 ```diff
  plugins {

--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -41,7 +41,7 @@ release, and listed in alphabetical order:
 [Deprecate `TextField.canRequestFocus`]: {{site.url}}/release/breaking-changes/can-request-focus
 [Accessibility traversal order of tooltip changed]: {{site.url}}/release/breaking-changes/tooltip-semantics-order
 [Default multitouch scrolling]: {{site.url}}/release/breaking-changes/multi-touch-scrolling
-[Deprecate imperative apply of Flutter's Gradle plugins]: ${{ site.url }}/release/breaking-changes/flutter-gradle-plugin-apply
+[Deprecate imperative apply of Flutter's Gradle plugins]: {{site.url}}/release/breaking-changes/flutter-gradle-plugin-apply
 
 ### Released in Flutter 3.16
 

--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -35,6 +35,7 @@ release, and listed in alphabetical order:
 * [Deprecate `TextField.canRequestFocus`][]
 * [Accessibility traversal order of tooltip changed][]
 * [Default multitouch scrolling][]
+* [Deprecate imperative apply of Flutter's Gradle plugins][]
 
 [Migrate RawKeyEvent/RawKeyboard system to KeyEvent/HardwareKeyboard system]: {{site.url}}/release/breaking-changes/key-event-migration
 [Deprecate `TextField.canRequestFocus`]: {{site.url}}/release/breaking-changes/can-request-focus


### PR DESCRIPTION
This PR fixes errors in the migration guide:
- missing entry for this guide from _index_ ([link](https://docs.flutter.dev/release/breaking-changes#not-yet-released-to-stable))
- {agpVersion} and {kotlinVersion} not displaying ([link](https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply))

Original PR #9857

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.

## Preview

[here](https://flutter-docs-prod--pr9907-fix-migration-guide-gradle-p-f53g480f.web.app/release/breaking-changes/flutter-gradle-plugin-apply#google-mobile-services-and-crashlytics)
