### PR TITLE
Fix small typos/updates in key-event-migration.md

### DIFF
--- a/src/release/breaking-changes/key-event-migration.md
+++ b/src/release/breaking-changes/key-event-migration.md
@@ -101,7 +101,7 @@ longer supported. One exception is that [`RawKeyEventDataAndroid.eventSource`][]
 information is accessible now as [`KeyEvent.deviceType`][] in a more
 platform independent form.
 
-#### Migrating `IsKeyPressed` and related functions
+#### Migrating `isKeyPressed` and related functions
 
 If the legacy code used the [`RawKeyEvent.isKeyPressed`][],
 [`RawKeyEvent.isControlPressed`][], [`RawKeyEvent.isShiftPressed`][],
@@ -151,6 +151,8 @@ If the legacy code was using the [`Focus.onKey`][], [`FocusScope.onKey`][],
 an equivalent [`Focus.onKeyEvent`][], [`FocusScope.onKeyEvent`][],
 [`FocusNode.onKeyEvent`][], or [`FocusScopeNode.onKeyEvent`][] parameter that
 supplies `KeyEvent`s instead of `RawKeyEvent`s.
+
+Before:
 
 ```dart
 Widget build(BuildContext context) {
@@ -213,7 +215,7 @@ both `KeyDownEvent` and `KeyRepeatEvent` need to be checked.
 
 ## Timeline
 
-Landed in version: 3.18.0-2.0.pre<br>
+Landed in version: 3.18.0-7.0.pre<br>
 In stable release: not yet (Not in 3.18)
 
 ## References


### PR DESCRIPTION
I fixed a couple of small typos, and bumped the version it was released in to the actual version.

## Presubmit checklist

- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
