### PR TITLE
Tiny fix outdated link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ but two of the primary repos are the
 [Flutter SDK](https://github.com/flutter/flutter), and this repo, the
 [Flutter website](https://github.com/flutter/website).
 To contribute a fix to a repo, submit a [pull request
-(PR)](https://services.github.com/on-demand/github-cli/open-pull-request-github).
+(PR)](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
 
 For information on contributing code or API docs to the Flutter SDK, see
 [Contributing to


### PR DESCRIPTION
The old link seems 404:

![image](https://github.com/flutter/website/assets/5236035/5c53561d-9401-40ce-ae50-4f5860e3e07d)

New link:

![image](https://github.com/flutter/website/assets/5236035/d944e363-2099-473b-939c-5a236238185b)


## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
