### PR TITLE
Fix stretching images after recent figure style change

### DIFF
--- a/src/_sass/base/_base.scss
+++ b/src/_sass/base/_base.scss
@@ -170,7 +170,7 @@ dd {
 
   .site-figure-container {
     flex: 0 1 auto;
-    width: 100%;
+    max-width: 100%;
 
     img { width: 100%; }
 

--- a/src/platform-integration/ios/app-extensions.md
+++ b/src/platform-integration/ios/app-extensions.md
@@ -1,6 +1,6 @@
 ---
 title: Adding iOS app extensions
-description: Learn how to add app extensions to your Flutter apps
+description: Learn how to add app extensions to your Flutter apps.
 ---
 
 iOS app extensions allow you to expand functionality


### PR DESCRIPTION
https://github.com/flutter/website/commit/d93a46c6d8c749dcb73d1a9d8bd5bcf3c5e9db22 changed the styles of figure images to stretch to a width of 100%, but this causes images to stretch when a height is specified. Adjust to `max-width`. 