### PR TITLE
Add /go/match-xcode-deployment-range doc redirect

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -441,6 +441,7 @@
       { "source": "/go/mac-voiceover-text-editing", "destination": "https://docs.google.com/document/d/19YP1o4Shba6NzQTBH_EWC8y1GUhKAbo9dan4digFbZs", "type": 301 },
       { "source": "/go/macros-for-leak-tracker", "destination": "https://docs.google.com/document/d/1ireWmX4J5Jc6oDO1PmAXPlLdiAlCHvTz8SVC_Sg9KM8/edit?usp=sharing&resourcekey=0-yODb_SAStMgMefYpQeX8uQ", "type": 301 },
       { "source": "/go/make-dropdownmenuitem-value-param-required", "destination": "https://docs.google.com/document/d/1x5jsgnLxI3wSDwXRzO0n5hdXKn2a_XTJcsXdjFZLX44/edit", "type": 301 },
+      { "source": "/go/match-xcode-deployment-range", "destination": "https://docs.google.com/document/d/1Y1WpbQPMOL3GvL8ow_OTD_-ENG3uuhS46CGRhLt12I8/edit?usp=sharing", "type": 301 },
       { "source": "/go/material-banner-updates", "destination": "https://docs.google.com/document/d/12Jet1gW2B_QFxig5B4K7f_lrpGhkbjR3LYpsKd4ZtJs/edit?usp=sharing&resourcekey=0-CfFoZ-0oqWPtz2WH0Jj0aw", "type": 301 },
       { "source": "/go/material-button-migration-guide", "destination": "https://docs.google.com/document/d/1yohSuYrvyya5V1hB6j9pJskavCdVq9sVeTqSoEPsWH0", "type": 301 },
       { "source": "/go/material-button-system-updates", "destination": "https://docs.google.com/document/d/10Fbn59hiHkppqJ6y_1Rjwl7klN-OvJXQU3SFEqicpME/edit", "type": 301 },


### PR DESCRIPTION
Add go link redirect to design doc "Match Xcode iOS and macOS Deployment Versions"

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
