### PR TITLE
Remove survey metadata redirect

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -49,7 +49,6 @@
       { "source": "/development/:rest*", "destination": "/:rest*", "type": 301 },
       { "source": "/devtools/:rest*", "destination": "/tools/devtools/:rest*", "type": 301 },
       { "source": "/downloads/:resource*", "destination": "/resources/:resource*", "type": 301 },
-      { "source": "/f/dart-devtools-survey-metadata.json", "destination": "https://storage.googleapis.com/flutter-uxr/surveys/devtools-survey-metadata.json", "type": 301 },
       { "source": "/f/flutter-survey-metadata.json", "destination": "https://storage.googleapis.com/flutter-uxr/surveys/flutter-survey-metadata.json", "type": 301 },
       { "source": "/faq", "destination": "/resources/faq", "type": 301 },
       { "source": "/fastlane-cd", "destination": "/deployment/cd#fastlane", "type": 301 },


### PR DESCRIPTION
this redirect was accidentally committed.
related: https://github.com/flutter/website/commit/919cb746459fb46a80ea69244557e0ffebf55388

The goal is to land https://github.com/flutter/website/pull/9942, but we need to confirm the redirects are working even on master. I was noticing some strange behavior there with trying to access the cloud storage urls but I have not had time to dig into it.

This redirect is causing some failures on master so we need to land this asap. Once this is green and approved, feel free to land as I'm going to be away from my computer starting tomorrow.