### PR TITLE
Remove hanging `<`

### DIFF
--- a/src/cookbook/games/achievements-leaderboard.md
+++ b/src/cookbook/games/achievements-leaderboard.md
@@ -143,7 +143,6 @@ have your achievement & leaderboard IDs ready, it's finally Dart time.
       // ... deal with failures ...
     }
     ```
-    <
 
 The sign in happens in the background. It takes several seconds, so
 don't call `signIn()` before `runApp()` or the players will be forced to


### PR DESCRIPTION
I seem to have forgotten this `<` during my latest PR.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
