### PR TITLE
Update project-setup.md

### DIFF
--- a/src/add-to-app/android/project-setup.md
+++ b/src/add-to-app/android/project-setup.md
@@ -173,8 +173,8 @@ app's `build.gradle` file, under the `android { }` block.
 android {
   //...
   compileOptions {
-    sourceCompatibility 11 # The minimum value
-    targetCompatibility 11 # The minimum value
+    sourceCompatibility 11 // The minimum value
+    targetCompatibility 11 // The minimum value
   }
 }
 ```


### PR DESCRIPTION
Fix the comment style to be compatible with `build.gradle`s format.

Copy pasting in the `#` comments leads to the file not being parsed in Android Studio.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
