### PR TITLE
Update site to use Ruby 3.3, yjit, and latest gems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2.2-slim-bookworm@sha256:75f884a28c1337d744a42b006d864d3ba161c6b1980d2414910e660d2034b14e AS base
+FROM ruby:3.3-slim-bookworm@sha256:763422273a15e307b044fcb3ad6b1ef6c290d2043ac73596842aba5659dc7318 as base
 
 ENV TZ=US/Pacific
 RUN apt-get update && apt-get install -yq --no-install-recommends \
@@ -70,6 +70,7 @@ ENTRYPOINT ["tool/test.sh"]
 FROM node AS dev
 
 ENV JEKYLL_ENV=development
+ENV RUBY_YJIT_ENABLE=1
 RUN gem install bundler
 COPY Gemfile Gemfile.lock ./
 RUN bundle config set force_ruby_platform true
@@ -96,6 +97,7 @@ EXPOSE 5502
 FROM node AS build
 
 ENV JEKYLL_ENV=production
+ENV RUBY_YJIT_ENABLE=1
 RUN gem install bundler
 COPY Gemfile Gemfile.lock ./
 RUN bundle config set force_ruby_platform true

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '4.3.2'
+gem 'jekyll', '4.3.3'
 gem 'jekyll-sass-converter', '~> 3.0.0'
 gem 'webrick'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,10 +11,10 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     base64 (0.2.0)
-    bigdecimal (3.1.4)
+    bigdecimal (3.1.5)
     colorator (1.1.0)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
@@ -28,11 +28,11 @@ GEM
       forwardable-extended (~> 2.5)
     ffi (1.16.3)
     forwardable-extended (2.6.0)
-    google-protobuf (3.25.0)
+    google-protobuf (3.25.1)
     http_parser.rb (0.8.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.2)
+    jekyll (4.3.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -72,12 +72,12 @@ GEM
     mini_portile2 (2.8.5)
     minitest (5.20.0)
     mutex_m (0.2.0)
-    nokogiri (1.15.4)
+    nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.0.3)
+    public_suffix (5.0.4)
     racc (1.7.3)
     rake (13.1.0)
     rb-fsevent (0.11.2)
@@ -102,7 +102,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 7.1.2)
-  jekyll (= 4.3.2)
+  jekyll (= 4.3.3)
   jekyll-include-cache (~> 0.2.1)
   jekyll-sass-converter (~> 3.0.0)
   jekyll-toc (~> 0.18.0)
@@ -110,4 +110,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.4.21
+   2.5.3


### PR DESCRIPTION
- Updates to Ruby 3.3 for latest bug fixes and performance improvements.
- Updates to use the YJIT compiler as suggested by Ruby and Shopify.
- Update Jekyll for compatibility with Ruby 3.3.
- Update to latest bundler and gems.