### PR TITLE
Update to firebase-tools v13 to resolve deprecation warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install Firebase CLI
-        run: npm install -g firebase-tools@12.9.1
+        run: npm install -g firebase-tools@13.0.2
       - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
         with:
           sdk: stable
@@ -82,7 +82,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install Firebase CLI
-        run: npm install -g firebase-tools@12.9.1
+        run: npm install -g firebase-tools@13.0.2
       - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
         with:
           sdk: stable


### PR DESCRIPTION
Also reduces installation time of the tool and compatibility with Node 20 (which we are using).
