### PR TITLE
Update site security page to match current flutter security policy

### DIFF
--- a/src/security/index.md
+++ b/src/security/index.md
@@ -86,13 +86,12 @@ Contributing teams are welcome to include Flutter within the scope
 of their bug bounty programs. To have your program listed, please
 contact `security@flutter.dev`.
 
-Google considers Flutter to be in scope for the [Google Open Source
-Software Vulnerability Reward Program][]. For expediency, we ask that
-reporters please contact `security@flutter.dev` before using Google's
-vulnerability reporting flow.
+Google considers Flutter to be in scope for the
+[Google Open Source Software Vulnerability Reward Program][google-oss-vrp].
+For expediency, we ask that reporters please contact `security@flutter.dev`
+before using Google's vulnerability reporting flow.
 
-[Google Open Source Software Vulnerability Reward Program]:
-https://bughunters.google.com/open-source-security
+[google-oss-vrp]: https://bughunters.google.com/open-source-security
 
 ## Receiving security updates
 

--- a/src/security/index.md
+++ b/src/security/index.md
@@ -80,7 +80,15 @@ Any vulnerability reported for flutter websites like
 docs.flutter.dev doesn't require a release and will be
 fixed in the website itself.
 
-Flutter doesn't have a bug bounty program.
+## Bug Bounty programs
+
+Contributing teams are welcome to include Flutter within the scope of their bug bounty programs.
+To have your program listed, please contact `security@flutter.dev`.
+
+Google considers Flutter to be in scope for the [Google Open Source Software Vulnerability Reward Program][].
+For expediency we ask that reporters please contact `security@flutter.dev` before using Google's vulnerability reporting flow.
+
+[Google Open Source Software Vulnerability Reward Program]: https://bughunters.google.com/open-source-security
 
 ## Receiving security updates
 

--- a/src/security/index.md
+++ b/src/security/index.md
@@ -82,13 +82,17 @@ fixed in the website itself.
 
 ## Bug Bounty programs
 
-Contributing teams are welcome to include Flutter within the scope of their bug bounty programs.
-To have your program listed, please contact `security@flutter.dev`.
+Contributing teams are welcome to include Flutter within the scope
+of their bug bounty programs. To have your program listed, please
+contact `security@flutter.dev`.
 
-Google considers Flutter to be in scope for the [Google Open Source Software Vulnerability Reward Program][].
-For expediency we ask that reporters please contact `security@flutter.dev` before using Google's vulnerability reporting flow.
+Google considers Flutter to be in scope for the [Google Open Source
+Software Vulnerability Reward Program][]. For expediency, we ask that
+reporters please contact `security@flutter.dev` before using Google's
+vulnerability reporting flow.
 
-[Google Open Source Software Vulnerability Reward Program]: https://bughunters.google.com/open-source-security
+[Google Open Source Software Vulnerability Reward Program]:
+https://bughunters.google.com/open-source-security
 
 ## Receiving security updates
 

--- a/src/security/index.md
+++ b/src/security/index.md
@@ -82,13 +82,13 @@ fixed in the website itself.
 
 ## Bug Bounty programs
 
-Contributing teams are welcome to include Flutter within the scope
-of their bug bounty programs. To have your program listed, please
+Contributing teams can include Flutter within the scope
+of their bug bounty programs. To have your program listed,
 contact `security@flutter.dev`.
 
 Google considers Flutter to be in scope for the
 [Google Open Source Software Vulnerability Reward Program][google-oss-vrp].
-For expediency, we ask that reporters please contact `security@flutter.dev`
+For expediency, reporters should contact `security@flutter.dev`
 before using Google's vulnerability reporting flow.
 
 [google-oss-vrp]: https://bughunters.google.com/open-source-security


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Match [security page](https://flutter.dev/security) with current [flutter security policy](https://github.com/flutter/flutter/security/policy).

also refer to this [PR](https://github.com/flutter/.github/pull/30)

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
