### PR TITLE
Fix typos in vs-code.md

### DIFF
--- a/src/tools/vs-code.md
+++ b/src/tools/vs-code.md
@@ -285,8 +285,9 @@ can assist in correcting it.
 Snippets can be used to speed up entering typical code structures.
 They are invoked by typing their prefix,
 and then selecting from the code completion window:
-![Snippets]({{site.url}}/assets/images/docs/tools/vs-code/snippets.png){:width="100%"}-
--he Flutter extension includes the following -nippets:
+![Snippets]({{site.url}}/assets/images/docs/tools/vs-code/snippets.png){:width="100%"}
+
+The Flutter extension includes the following snippets:
 
 - Prefix `stless`: Create a new subclass of -StatelessWidget`.
 - Prefix `stful`: Create a new subclass of `StatefulWidget`


### PR DESCRIPTION
Fixing the highlighted text below the code screenshot (i.e. replace `-` with the proper letter)

<img width="972" alt="Screen Shot 2024-01-01 at 2 17 05 PM" src="https://github.com/flutter/website/assets/46427323/8e09e5da-2e8d-4392-9fc2-143ea8ddb4b4">



## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
