### PR TITLE
Fix video URL variable not included

### DIFF
--- a/src/apprentice-giveaway/index.md
+++ b/src/apprentice-giveaway/index.md
@@ -4,6 +4,8 @@ toc: false
 description: This event is ended.
 ---
 
+{% include docs/yt_shims.liquid %}
+
 {{site.alert.info}}
   The Flutter Apprentice event has ended.
   Thanks to all who participated!<br>

--- a/src/codelabs/index.md
+++ b/src/codelabs/index.md
@@ -4,6 +4,8 @@ description: >-
   Codelabs to help you quickly get started programming Flutter.
 ---
 
+{% include docs/yt_shims.liquid %}
+
 The Flutter codelabs provide a guided,
 hands-on coding experience. Some codelabs
 run in DartPad&mdash;no downloads required!

--- a/src/cookbook/effects/download-button.md
+++ b/src/cookbook/effects/download-button.md
@@ -6,6 +6,8 @@ js:
     url: https://dartpad.dev/inject_embed.dart.js
 ---
 
+{% include docs/yt_shims.liquid %}
+
 <?code-excerpt path-base="cookbook/effects/download_button"?>
 
 Apps are filled with buttons that execute long-running behaviors.

--- a/src/perf/best-practices.md
+++ b/src/perf/best-practices.md
@@ -4,6 +4,8 @@ short-title: Best practices
 description: How to ensure that your Flutter app is performant.
 ---
 
+{% include docs/yt_shims.liquid %}
+
 {% include docs/performance.md %}
 
 Generally, Flutter applications are performant by default,

--- a/src/perf/ui-performance.md
+++ b/src/perf/ui-performance.md
@@ -4,6 +4,8 @@ subtitle: Where to look when your Flutter app drops frames in the UI.
 description: Diagnosing UI performance issues in Flutter.
 ---
 
+{% include docs/yt_shims.liquid %}
+
 {% include docs/performance.md %}
 
 {{site.alert.secondary}}

--- a/src/resources/architectural-overview.md
+++ b/src/resources/architectural-overview.md
@@ -3,6 +3,8 @@ title: Flutter architectural overview
 description: A high-level overview of the architecture of Flutter, including the core principles and concepts that form its design.
 ---
 
+{% include docs/yt_shims.liquid %}
+
 <?code-excerpt path-base="resources/architectural_overview/"?>
 
 This article is intended to provide a high-level overview of the architecture of

--- a/src/resources/news-toolkit.md
+++ b/src/resources/news-toolkit.md
@@ -3,6 +3,8 @@ title: Flutter News Toolkit
 description: Learn more about creating a newsfeed app in Flutter.
 ---
 
+{% include docs/yt_shims.liquid %}
+
 The Flutter News Toolkit enables you to accelerate
 development of a mobile news app.
 The toolkit assists you in building a customized

--- a/src/tools/devtools/memory.md
+++ b/src/tools/devtools/memory.md
@@ -3,6 +3,8 @@ title: Using the Memory view
 description: Learn how to use the DevTools memory view.
 ---
 
+{% include docs/yt_shims.liquid %}
+
 The memory view provides insights into details
 of the application's memory allocation and
 tools to detect and debug specific issues.

--- a/src/tools/flutter-fix.md
+++ b/src/tools/flutter-fix.md
@@ -3,6 +3,8 @@ title: Flutter fix
 description: Keep your code up to date with the help of the Flutter Fix feature.
 ---
 
+{% include docs/yt_shims.liquid %}
+
 As Flutter continues to evolve, we provide a tool to help you clean up
 deprecated APIs from your codebase. The tool ships as part of Flutter, and
 suggests changes that you might want to make to your code. The tool is available

--- a/src/ui/interactivity/index.md
+++ b/src/ui/interactivity/index.md
@@ -5,6 +5,8 @@ short-title: Interactivity
 diff2html: true
 ---
 
+{% include docs/yt_shims.liquid %}
+
 {% capture examples -%} {{site.repo.this}}/tree/{{site.branch}}/examples {%- endcapture -%}
 
 {{site.alert.secondary}}


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Fixes like this:
Video link for `"Building your first Flutter app (workshop)…………"`
(https://docs.flutter.dev/codelabs#good-for-beginners)
- ❌ Video link: https://docs.flutter.dev/codelabs?v=8sAyPDLorek
- ✅ Video link: https://www.youtube.com/watch?v=8sAyPDLorek

_Issues fixed by this PR (if any):_ none.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
