### PR TITLE
Add link to RFC to drop support for Windows 7

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -347,6 +347,7 @@
       { "source": "/go/flutter-drop-android-jellybean-2023", "destination": "https://docs.google.com/document/d/1wWNly2SZRDqupSsHkBWDI_lS2MohBGEwPSXF6W05NOc/edit?usp=sharing", "type": 301 },
       { "source": "/go/flutter-doctor-app-folder", "destination": "https://docs.google.com/document/d/1_N70oh5rl0pMlz-epE_3fIr7gqE94dgoV-DHq5OlF2I/edit", "type": 301 },
       { "source": "/go/flutter-drop-macOS-10.13-2022-q4", "destination": "https://docs.google.com/document/d/1wHqr2cob78VfUKhOFEKjaUM_mnV4gL-mg3gSQCFhF7Y/edit", "type": 301 },
+      { "source": "/go/flutter-drop-win7-2024", "destination": "https://docs.google.com/document/d/18gfRT8klo0zEvn6fIpders7ghoWIBKO22cNYS22WLhc/edit", "type": 301 },
       { "source": "/go/flutter-android-emulator-testing", "destination": "https://docs.google.com/document/d/10wYUcLcSTF4Epg2EUGoBqOkkOe4zxKHvYKjXFZAOgGs/edit?usp=sharing&resourcekey=0-pltjPvEtVezXDADMbUwFHQ", "type": 301 },
       { "source": "/go/flutter-engine-clocks", "destination": "https://docs.google.com/document/d/1Sx8QA1qXgJGw5r4ESviDnU2LSShNHiq_LjbRWPgSvXQ/edit?usp=sharing&resourcekey=0-BoBvLxgqf_nc_rwLc0zmTw", "type": 301 },
       { "source": "/go/flutter-engine-extensions", "destination": "https://docs.google.com/document/d/1xG7jR4FserdW7TdwnklF3_lXUGmt4myPQjDGF3LFtCQ/edit?resourcekey=0-Iug4D2mWuyQI6suvC_2itw#", "type": 301 },


### PR DESCRIPTION
Adds a link to an RFC proposing to bump the minimum supported Windows deployment platform from Windows 7 to Windows 10.

Link: https://flutter.dev/go/flutter-drop-win7-2024
Linked document: https://docs.google.com/document/d/18gfRT8klo0zEvn6fIpders7ghoWIBKO22cNYS22WLhc/edit

Issue: https://github.com/flutter/flutter/issues/140830

## Presubmit checklist

- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
