### PR TITLE
Fix links to iOS API docs

### DIFF
--- a/src/_includes/docs/platform-view-perf.md
+++ b/src/_includes/docs/platform-view-perf.md
@@ -39,6 +39,6 @@ For more information, see:
 * [`FlutterImageView`][]
 
 [`FlutterImageView`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterImageView.html
-[`FlutterTextureRegistry`]: {{site.api}}/objcdoc/Protocols/FlutterTextureRegistry.html
+[`FlutterTextureRegistry`]: {{site.api}}/ios-embedder/protocol_flutter_texture_registry-p.html
 [`TextureLayer`]: {{site.api}}/flutter/rendering/TextureLayer-class.html
 [`TextureRegistry`]: {{site.api}}/javadoc/io/flutter/view/TextureRegistry.html

--- a/src/add-to-app/index.md
+++ b/src/add-to-app/index.md
@@ -130,11 +130,11 @@ see our API usage guides at the following links:
 [Flutter plugins]: {{site.pub}}/flutter
 [`FlutterActivity`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterActivity.html
 [java-engine]: {{site.api}}/javadoc/io/flutter/embedding/engine/FlutterEngine.html
-[ios-engine]: {{site.api}}/objcdoc/Classes/FlutterEngine.html
+[ios-engine]: {{site.api}}/ios-embedder/interface_flutter_engine.html
 [FlutterFire]: {{site.github}}/firebase/flutterfire/tree/master/packages
 [`FlutterFragment`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterFragment.html
 [`FlutterPlugin`]: {{site.api}}/javadoc/io/flutter/embedding/engine/plugins/FlutterPlugin.html
-[`FlutterViewController`]: {{site.api}}/objcdoc/Classes/FlutterViewController.html
+[`FlutterViewController`]: {{site.api}}/ios-embedder/interface_flutter_view_controller.html
 [iOS Framework]: {{site.apple-dev}}/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/WhatAreFrameworks.html
 [maintained by the Flutter team]: {{site.repo.packages}}/tree/main/packages
 [multiple Flutters]: {{site.url}}/add-to-app/multiple-flutters

--- a/src/add-to-app/ios/add-flutter-screen.md
+++ b/src/add-to-app/ios/add-flutter-screen.md
@@ -738,8 +738,8 @@ in any way you'd like, before presenting the Flutter UI using a
 `FlutterViewController`.
 
 
-[`FlutterEngine`]: {{site.api}}/objcdoc/Classes/FlutterEngine.html
-[`FlutterViewController`]: {{site.api}}/objcdoc/Classes/FlutterViewController.html
+[`FlutterEngine`]: {{site.api}}/ios-embedder/interface_flutter_engine.html
+[`FlutterViewController`]: {{site.api}}/ios-embedder/interface_flutter_view_controller.html
 [Loading sequence and performance]: {{site.url}}/add-to-app/performance
 [local_auth]: {{site.pub}}/packages/local_auth
 [Navigation and routing]: {{site.url}}/ui/navigation
@@ -747,10 +747,10 @@ in any way you'd like, before presenting the Flutter UI using a
 [`NavigatorState`]: {{site.api}}/flutter/widgets/NavigatorState-class.html
 [`openURL`]: {{site.apple-dev}}/documentation/uikit/uiapplicationdelegate/1623112-application
 [platform channels]: {{site.url}}/platform-integration/platform-channels
-[`popRoute()`]: {{site.api}}/objcdoc/Classes/FlutterViewController.html#/c:objc(cs)FlutterViewController(im)popRoute
-[`pushRoute()`]: {{site.api}}/objcdoc/Classes/FlutterViewController.html#/c:objc(cs)FlutterViewController(im)pushRoute:
+[`popRoute()`]: {{site.api}}/ios-embedder/interface_flutter_view_controller.html#ac89c8010fbf7a39f7aaab64f68c013d2
+[`pushRoute()`]: {{site.api}}/ios-embedder/interface_flutter_view_controller.html#ac7cffbf03f9c8c0b28d1f0dafddece4e
 [`runApp`]: {{site.api}}/flutter/widgets/runApp.html
-[`runWithEntrypoint`]: {{site.api}}/objcdoc/Classes/FlutterEngine.html#/c:objc(cs)FlutterEngine(im)runWithEntrypoint:
+[`runWithEntrypoint`]: {{site.api}}/ios-embedder/interface_flutter_engine.html#a019d6b3037eff6cfd584fb2eb8e9035e
 [`SystemNavigator.pop()`]: {{site.api}}/flutter/services/SystemNavigator/pop.html
 [tree-shaken]: https://en.wikipedia.org/wiki/Tree_shaking
 [`WidgetsApp`]: {{site.api}}/flutter/widgets/WidgetsApp-class.html

--- a/src/add-to-app/multiple-flutters.md
+++ b/src/add-to-app/multiple-flutters.md
@@ -84,7 +84,7 @@ on both Android and iOS on [GitHub][].
 
 [GitHub]: {{site.repo.samples}}/tree/main/add_to_app/multiple_flutters
 [`FlutterActivity`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterActivity.html
-[`FlutterViewController`]: {{site.api}}/objcdoc/Classes/FlutterViewController.html
+[`FlutterViewController`]: {{site.api}}/ios-embedder/interface_flutter_view_controller.html
 [performance characteristics]: {{site.url}}/add-to-app/performance
 [flutter.dev/go/multiple-flutters]: {{site.url}}/go/multiple-flutters
 [Issue 72009]: {{site.repo.flutter}}/issues/72009

--- a/src/add-to-app/performance.md
+++ b/src/add-to-app/performance.md
@@ -207,15 +207,15 @@ see [multiple Flutters][].
 [`DartExecutor.executeDartEntrypoint()`]: {{site.api}}/javadoc/io/flutter/embedding/engine/dart/DartExecutor.html#executeDartEntrypoint-io.flutter.embedding.engine.dart.DartExecutor.DartEntrypoint-
 [`FlutterActivity.createDefaultIntent()`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterActivity.html#createDefaultIntent-android.content.Context-
 [`FlutterActivity.withCachedEngine()`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterActivity.html#withCachedEngine-java.lang.String-
-[`FlutterViewController`]: {{site.api}}/objcdoc/Classes/FlutterViewController.html
-[`FlutterViewController initWithProject: nibName: bundle:`]: {{site.api}}/objcdoc/Classes/FlutterViewController.html#/c:objc(cs)FlutterViewController(im)initWithProject:nibName:bundle:
-[`initWithEngine: nibName: bundle:`]: {{site.api}}/objcdoc/Classes/FlutterViewController.html#/c:objc(cs)FlutterViewController(im)initWithEngine:nibName:bundle:
+[`FlutterViewController`]: {{site.api}}/ios-embedder/interface_flutter_view_controller.html
+[`FlutterViewController initWithProject: nibName: bundle:`]: {{site.api}}/ios-embedder/interface_flutter_view_controller.html#aa3aabfb89e958602ce6a6690c919f655
+[`initWithEngine: nibName: bundle:`]: {{site.api}}/ios-embedder/interface_flutter_view_controller.html#a0aeea9525c569d5efbd359e2d95a7b31
 [`Intent`]: {{site.android-dev}}/reference/android/content/Intent.html
-[ios-engine]: {{site.api}}/objcdoc/Classes/FlutterEngine.html
+[ios-engine]: {{site.api}}/ios-embedder/interface_flutter_engine.html
 [`Layer`]: {{site.api}}/flutter/rendering/Layer-class.html
 [multiple Flutters]: {{site.url}}/add-to-app/multiple-flutters
 [`runApp()`]: {{site.api}}/flutter/widgets/runApp.html
-[`runWithEntrypoint:`]: {{site.api}}/objcdoc/Classes/FlutterEngine.html#/c:objc(cs)FlutterEngine(im)runWithEntrypoint:
+[`runWithEntrypoint:`]: {{site.api}}/ios-embedder/interface_flutter_engine.html#a019d6b3037eff6cfd584fb2eb8e9035e
 [snapshot]: {{site.github}}/dart-lang/sdk/wiki/Snapshots
 [`startActivity()`]: {{site.android-dev}}/reference/android/content/Context.html#startActivity(android.content.Intent
 [`Surface`]: {{site.android-dev}}/reference/android/view/Surface

--- a/src/platform-integration/android/restore-state-android.md
+++ b/src/platform-integration/android/restore-state-android.md
@@ -128,7 +128,6 @@ check out [Testing state restoration][] on the
 {{site.alert.end}}
 
 [Testing state restoration]: {{site.api}}/flutter/services/RestorationManager-class.html#testing-state-restoration
-[`FlutterViewController`]: {{site.api}}/objcdoc/Classes/FlutterViewController.html
 [`RestorationBucket`]: {{site.api}}/flutter/services/RestorationBucket-class.html
 [`RestorationManager`]: {{site.api}}/flutter/services/RestorationManager-class.html
 [services]: {{site.api}}/flutter/services/services-library.html

--- a/src/platform-integration/ios/platform-views.md
+++ b/src/platform-integration/ios/platform-views.md
@@ -336,8 +336,8 @@ For more information, see the API docs for:
 * [`FlutterPlatformView`][]
 * [`PlatformView`][]
 
-[`FlutterPlatformView`]: {{site.api}}/objcdoc/Protocols/FlutterPlatformView.html
-[`FlutterPlatformViewFactory`]: {{site.api}}/objcdoc/Protocols/FlutterPlatformViewFactory.html
+[`FlutterPlatformView`]: {{site.api}}/ios-embedder/protocol_flutter_platform_view-p.html
+[`FlutterPlatformViewFactory`]: {{site.api}}/ios-embedder/protocol_flutter_platform_view_factory-p.html
 [`PlatformView`]: {{site.api}}/javadoc/io/flutter/plugin/platform/PlatformView.html
 
 ## Putting it together

--- a/src/platform-integration/platform-channels.md
+++ b/src/platform-integration/platform-channels.md
@@ -1404,7 +1404,7 @@ DispatchQueue.main.async {
 [`JSONMessageCodec`]: {{site.api}}/flutter/services/JSONMessageCodec-class.html
 [`MethodChannel`]: {{site.api}}/flutter/services/MethodChannel-class.html
 [`MethodChannelAndroid`]: {{site.api}}/javadoc/io/flutter/plugin/common/MethodChannel.html
-[`MethodChanneliOS`]: {{site.api}}/objcdoc/Classes/FlutterMethodChannel.html
+[`MethodChanneliOS`]: {{site.api}}/ios-embedder/interface_flutter_method_channel.html
 [Platform adaptations]: {{site.url}}/platform-integration/platform-adaptations
 [publishing packages]: {{site.url}}/packages-and-plugins/developing-packages#publish
 [`quick_actions`]: {{site.pub}}/packages/quick_actions

--- a/src/ui/assets/assets-and-images.md
+++ b/src/ui/assets/assets-and-images.md
@@ -485,9 +485,9 @@ For more details, see
 [device pixel ratio]: {{site.api}}/flutter/dart-ui/FlutterView/devicePixelRatio.html
 [Device pixel ratio]: {{site.api}}/flutter/dart-ui/FlutterView/devicePixelRatio.html
 [drawables]: {{site.android-dev}}/guide/topics/resources/drawable-resource
-[`FlutterPluginRegistrar`]: {{site.api}}/objcdoc/Protocols/FlutterPluginRegistrar.html
+[`FlutterPluginRegistrar`]: {{site.api}}/ios-embedder/protocol_flutter_plugin_registrar-p.html
 [`FlutterView`]: {{site.api}}/javadoc/io/flutter/view/FlutterView.html
-[`FlutterViewController`]: {{site.api}}/objcdoc/Classes/FlutterViewController.html
+[`FlutterViewController`]: {{site.api}}/ios-embedder/interface_flutter_view_controller.html
 [Human Interface Guidelines]: {{site.apple-dev}}/design/human-interface-guidelines/app-icons
 [`ios_platform_images`]: {{site.pub}}/packages/ios_platform_images
 [layer list drawable]: {{site.android-dev}}/guide/topics/resources/drawable-resource#LayerList


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_  The iOS API doc paths were changed, update from `objcdoc` to the new `ios-embedder` format.  

_Issues fixed by this PR (if any):_ https://github.com/flutter/website/issues/9984

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
