### PR TITLE
Update iOS minimum version documentation to 12.0

### DIFF
--- a/src/add-to-app/ios/project-setup.md
+++ b/src/add-to-app/ios/project-setup.md
@@ -35,7 +35,7 @@ For an example using SwiftUI, see the iOS directory in [News Feed App][].
 Your development environment must meet the
 [macOS system requirements for Flutter][]
 with [Xcode installed][].
-Flutter supports iOS 11 and later.
+Flutter supports iOS 12 and later.
 Additionally, you will need [CocoaPods][]
 version 1.10 or later.
 

--- a/src/deployment/ios.md
+++ b/src/deployment/ios.md
@@ -118,9 +118,9 @@ In the **Deployment** section of the **Build Settings** tab:
 
 `iOS Deployment Target`
 : The minimum iOS version that your app supports.
-  Flutter supports iOS 11 and later. If your app or plugins
+  Flutter supports iOS 12 and later. If your app or plugins
   include Objective-C or Swift code that makes use of APIs newer
-  than iOS 11, update this setting to the highest required version.
+  than iOS 12, update this setting to the highest required version.
 
 The **General** tab of your project settings should resemble
 the following:

--- a/src/platform-integration/ios/ios-app-clip.md
+++ b/src/platform-integration/ios/ios-app-clip.md
@@ -333,7 +333,7 @@ target '<name of your App Clip target>'
 ```
 
 At the top of the file,
-also uncomment `platform :ios, '11.0'` and set the
+also uncomment `platform :ios, '12.0'` and set the
 version to the lowest of the two target's iOS
 Deployment Target.
 

--- a/src/reference/supported-platforms.md
+++ b/src/reference/supported-platforms.md
@@ -40,7 +40,7 @@ following table:
 |Platform version|Supported|Best effort|Unsupported|
 |----------------|---------|-----------|-----------|
 | Android SDK    |21-34|19-20|18-|
-| iOS            |16|11-15, 17|10-, arm7v 32-bit|
+| iOS            |16|12-15, 17|11-, arm7v 32-bit|
 | Linux Debian   |10-12|9-|any 32-bit|
 | Linux Ubuntu   |20.04 LTS|20.10-23.04|any 32-bit|
 | macOS          |Ventura (13)|Mojave (10.14) to Monterey (12), Sonoma (14)|High Sierra (10.13-) |


### PR DESCRIPTION
Move iOS 11 to the unsupported tier.  

**This should not be merged until https://github.com/flutter/flutter/issues/140923 is cherry-picked to stable and released.**

Part of https://github.com/flutter/flutter/issues/140474
