### PR TITLE
Triple State Pattern broken link fix

### DIFF
--- a/src/data-and-backend/state-mgmt/options.md
+++ b/src/data-and-backend/state-mgmt/options.md
@@ -259,7 +259,7 @@ For more information, refer to the following resources:
 
 [Triple documentation]: https://triple.flutterando.com.br/
 [Flutter Triple package]: {{site.pub-pkg}}/flutter_triple
-[Segmented State pattern]: https://triple.flutterando.com.br/docs/intro/
+[Segmented State pattern]: https://triple.flutterando.com.br/docs/intro/overview#-segmented-state-pattern-ssp
 [Triple Pattern: A new pattern for state management in Flutter]: https://blog.flutterando.com.br/triple-pattern-um-novo-padr%C3%A3o-para-ger%C3%AAncia-de-estado-no-flutter-2e693a0f4c3e
 [VIDEO: Flutter Triple Pattern by Kevlin Ossada]: {{yt-watch}}?v=dXc3tR15AoA
 


### PR DESCRIPTION
In the "Triple Pattern" section of the page "List of state management approaches" of the Flutter documentation there's a link for the "Segmented State Pattern" that is broken.

The link has been changed to a working one referencing the pattern on the official documentation of the package.
This link doesn't work: [https://triple.flutterando.com.br/docs/intro/](https://triple.flutterando.com.br/docs/intro/)
This link does work: [https://triple.flutterando.com.br/docs/intro/overview#-segmented-state-pattern-ssp](https://triple.flutterando.com.br/docs/intro/overview#-segmented-state-pattern-ssp)

A broken link in the "List of state management approaches" of the Flutter documentation gets fixed.