### PR TITLE
Add redirect for gallery to redirect to

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -20,6 +20,7 @@
 
       { "source": "/ads", "destination": "https://flutter.dev/monetization", "type": 301 },
       { "source": "/community", "destination": "https://flutter.dev/community", "type": 301 },
+      { "source": "/gallery", "destination": "https://github.com/flutter/gallery#flutter-gallery", "type": 301 },
       { "source": "/showcase", "destination": "https://flutter.dev/showcase", "type": 301 },
       { "source": "/support", "destination": "https://flutter.dev/community", "type": 301 },
       { "source": "/docs/:rest*", "destination": "/:rest*", "type": 301 },


### PR DESCRIPTION
Add a redirect that gallery.flutter.dev can redirect to that we can easily adjust in the future. For now redirect to the repository's README.

Reference: https://github.com/flutter/gallery/issues/1072#issuecomment-1885341465
