### PR TITLE
Fix recently introduced bottom margin in sidenav

### DIFF
--- a/src/_sass/base/_base.scss
+++ b/src/_sass/base/_base.scss
@@ -286,8 +286,11 @@ summary {
   margin-bottom: 1rem;
 }
 
-ol + img, ul + img, ol + p, ul + p, p + p + img, li:last-child, ul + p:last-child {
-  margin-bottom: 1rem;
+main {
+  ol + img, ul + img, ol + p, ul + p,
+  p + p + img, li:last-child, ul + p:last-child {
+    margin-bottom: 1rem;
+  }
 }
 
 td ol, td ul, td dl, td p {


### PR DESCRIPTION
https://github.com/flutter/website/commit/83a10b544738aaf36ad280fc7213cf20d9b51ac7 added some styles to the last child of list items, but this ended up affecting the sidenav and TOC as well, resulting in awkward margins. Fix this by only applying these styles to the main body of each page.
