### PR TITLE
Adjust provenance download link text on archive to avoid confusion

### DIFF
--- a/src/assets/js/archive.js
+++ b/src/assets/js/archive.js
@@ -276,7 +276,7 @@ function getProvenanceLink(os, release, date, channel) {
   const extension = os === 'linux' ? 'tar.xz' : 'zip';
   const provenanceAnchor = document.createElement('a');
   provenanceAnchor.href = `${baseUrl}${channel}/${os}/flutter_${os}_${release.version}-${channel}.${extension}.intoto.jsonl`;
-  provenanceAnchor.textContent = `${release.version} file`;
+  provenanceAnchor.textContent = `Attestation bundle`;
   provenanceAnchor.target = '_blank';
   return provenanceAnchor;
 }


### PR DESCRIPTION
The text "<version> file" was easily mistaken as a download link and was repetitive of the first column anyway. Instead have the text just be "Attestation bundle". With archive improvements in the future we will solve this concern more thoroughly. 

Fixes https://github.com/flutter/website/issues/10014

**Staged:** https://flutter-docs-prod--pr10027-misc-avoid-download-link-co-ca3jdgm2.web.app/release/archive