### PR TITLE
Rename the multi-view sync APIs design doc

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -464,6 +464,7 @@
       { "source": "/go/multi-view-embedder-apis", "destination": "https://docs.google.com/document/d/1kegGJ235y1778-vzyyv90MgSHmYQcROTupMuLtEDBq0/edit?usp=sharing", "type": 301 },
       { "source": "/go/multi-view-pipeline-and-rasterizer", "destination": "https://docs.google.com/document/d/1xoD02qOxt2OSe3eN1ARsBUUWNFawdrxC2JXUURx7218/edit?usp=sharing", "type": 301 },
       { "source": "/go/multi-view-sync-embedder-apis", "destination": "https://docs.google.com/document/d/14z-e-x6M3P53ZMD6qBh4UaJ3nJdG_VdMNqGKERv31hw/edit?usp=sharing", "type": 301 },
+      { "source": "/go/multi-view-sync-over-async", "destination": "https://docs.google.com/document/d/14z-e-x6M3P53ZMD6qBh4UaJ3nJdG_VdMNqGKERv31hw/edit?usp=sharing", "type": 301 },
       { "source": "/go/multi-window-single-isolate", "destination": "https://docs.google.com/document/d/1Wdqs79TY3b1VkOZMDmt12psg5AhO-q9k5-Uv28Snr8M/edit?resourcekey=0-qvOf6jo8bR9W4ozLrbLMcQ", "type": 301 },
       { "source": "/go/navigator-with-router", "destination": "https://docs.google.com/document/d/1Q0jx0l4-xymph9O6zLaOY4d_f7YFpNWX_eGbzYxr9wY/edit", "type": 301 },
       { "source": "/go/nshc", "destination": "https://docs.google.com/document/d/1uwHQ3ZEGN2cH6bFwa3CCXTTXCeDfOWw-kUa_B6oTMuA/edit", "type": 301 },


### PR DESCRIPTION
Hello, I'd like to update a design doc's URL:

* Old: [flutter.dev/go/multi-view-sync-embedder-apis](flutter.dev/go/multi-view-sync-embedder-apis)
* New: [flutter.dev/go/multi-view-sync-over-async](flutter.dev/go/multi-view-sync-over-async)

Context: after peer review, we decided to pivot the design. The previous name is no longer relevant. I've kept the old URL so that existing links aren't broken, but please let me know if you'd rather I remove the old URL instead.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
