### PR TITLE
Add the focus management design doc link

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -369,6 +369,7 @@
       { "source": "/go/flutter-support-multi-architecture", "destination": "https://docs.google.com/document/d/19tzWySgtgtTA99XQsjx5Pg0SFJeZKXyUlYavR0EXv8c/edit?usp=sharing", "type": 301 },
       { "source": "/go/flutter-tool-extension-api", "destination": "https://docs.google.com/document/d/12iXm23TP6e6qS1Ntx-i-azcBWByiUl_kWjRxRC2YTz8/edit?usp=sharing&resourcekey=0-pVl2giJzGAHqOYEaZagVow", "type": 301 },
       { "source": "/go/flutter-web-scenelets", "destination": "https://docs.google.com/document/d/1GUAx3aqdtEoaBMTNpsS1-i59QZlwTi6vUCASbaanPCo", "type": 301 },
+      { "source": "/go/focus-management", "destination": "https://docs.google.com/document/d/1-NS3NJFd2j9kzKj5GOPoWq-G0B6jrpiCL892EX5Nxgk/edit", "type": 301 },
       { "source": "/go/form-field-autovalidation", "destination": "https://docs.google.com/document/d/16HAURcOtYAoHntDOEtdGy9KkKSItulG9Ldyjzdaosqo/edit", "type": 301 },
       { "source": "/go/fragment-program-support", "destination": "https://docs.google.com/document/d/1R0qx3znTe_wcKZoeWwkMlgxs1MtrdiPJ_1xiuExZuH0/edit", "type": 301 },
       { "source": "/go/games-revenue", "destination": "https://services.google.com/fh/files/blogs/gaming_ux_and_revenue_optimizations.pdf", "type": 301 },


### PR DESCRIPTION
This change should result in pointing https://flutter.dev/go/focus-management to https://docs.google.com/document/d/1-NS3NJFd2j9kzKj5GOPoWq-G0B6jrpiCL892EX5Nxgk/edit?tab=t.0