### PR TITLE
Add two developer tool design doc go links

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -346,6 +346,8 @@
       { "source": "/go/floating-snackbar-offset", "destination": "https://docs.google.com/document/d/1elP-y83PtvfAZHNcpHCtnOFhZO9VnnlobwfQ33QO4hg/edit", "type": 301 },
       { "source": "/go/floating-widgetspans", "destination": "https://docs.google.com/document/d/1I-VqCxvszXGAas_6EE9b6ZIzyMY3HjxDxGW9_DWWd7M/edit", "type": 301 },
       { "source": "/go/flutter-developer-tooling-plugins", "destination": "https://docs.google.com/document/d/189A-T-pcHPuds8pOtbzLS8Wl6Hr0AIAIl0aRTPvLKec/", "type": 301 },
+      { "source": "/go/flutter-devtools-extensions", "destination": "https://docs.google.com/document/d/189A-T-pcHPuds8pOtbzLS8Wl6Hr0AIAIl0aRTPvLKec/", "type": 301 },
+      { "source": "/go/flutter-devtools-static-extensions", "destination": "https://docs.google.com/document/d/1MQUPUe2Gs93g_Mbh6aDCMflQcr0Kv0PUEWZXHGF19fo/", "type": 301 },
       { "source": "/go/flutter-drop-android-jellybean-2023", "destination": "https://docs.google.com/document/d/1wWNly2SZRDqupSsHkBWDI_lS2MohBGEwPSXF6W05NOc/edit?usp=sharing", "type": 301 },
       { "source": "/go/flutter-doctor-app-folder", "destination": "https://docs.google.com/document/d/1_N70oh5rl0pMlz-epE_3fIr7gqE94dgoV-DHq5OlF2I/edit", "type": 301 },
       { "source": "/go/flutter-drop-macOS-10.13-2022-q4", "destination": "https://docs.google.com/document/d/1wHqr2cob78VfUKhOFEKjaUM_mnV4gL-mg3gSQCFhF7Y/edit", "type": 301 },

--- a/firebase.json
+++ b/firebase.json
@@ -347,7 +347,7 @@
       { "source": "/go/floating-widgetspans", "destination": "https://docs.google.com/document/d/1I-VqCxvszXGAas_6EE9b6ZIzyMY3HjxDxGW9_DWWd7M/edit", "type": 301 },
       { "source": "/go/flutter-developer-tooling-plugins", "destination": "https://docs.google.com/document/d/189A-T-pcHPuds8pOtbzLS8Wl6Hr0AIAIl0aRTPvLKec/", "type": 301 },
       { "source": "/go/flutter-devtools-extensions", "destination": "https://docs.google.com/document/d/189A-T-pcHPuds8pOtbzLS8Wl6Hr0AIAIl0aRTPvLKec/", "type": 301 },
-      { "source": "/go/flutter-devtools-static-extensions", "destination": "https://docs.google.com/document/d/1MQUPUe2Gs93g_Mbh6aDCMflQcr0Kv0PUEWZXHGF19fo/", "type": 301 },
+      { "source": "/go/flutter-devtools-static-extensions", "destination": "https://docs.google.com/document/d/11J4h1oEfB9wBoRYUy4KzclnKITBY-234jKpU3kq4V4w/edit?resourcekey=0-pPo85Svkb9lKdtlrhMCTbw", "type": 301 },
       { "source": "/go/flutter-drop-android-jellybean-2023", "destination": "https://docs.google.com/document/d/1wWNly2SZRDqupSsHkBWDI_lS2MohBGEwPSXF6W05NOc/edit?usp=sharing", "type": 301 },
       { "source": "/go/flutter-doctor-app-folder", "destination": "https://docs.google.com/document/d/1_N70oh5rl0pMlz-epE_3fIr7gqE94dgoV-DHq5OlF2I/edit", "type": 301 },
       { "source": "/go/flutter-drop-macOS-10.13-2022-q4", "destination": "https://docs.google.com/document/d/1wHqr2cob78VfUKhOFEKjaUM_mnV4gL-mg3gSQCFhF7Y/edit", "type": 301 },


### PR DESCRIPTION
This adds an alias for go/flutter-developer-tooling-plugins (go/flutter-devtools-extensions) to more accurately reflect the content, and adds a new go link go/static-flutter-devtools-extensions.
