### PR TITLE
Fix wrong link to staggered animations example

### DIFF
--- a/src/ui/animations/staggered-animations.md
+++ b/src/ui/animations/staggered-animations.md
@@ -359,6 +359,6 @@ class _StaggerDemoState extends State<StaggerDemo>
 [staggered_pic_selection]: {{site.repo.this}}/tree/{{site.branch}}/examples/_animation/staggered_pic_selection
 [`CurvedAnimation`]: {{site.api}}/flutter/animation/CurvedAnimation-class.html
 [`Curves`]: {{site.api}}/flutter/animation/Curves-class.html
-[Full code for basic_staggered_animation's main.dart]: {{site.repo.this}}/tree/{{site.branch}}/examples/_animation/basic_staggered_animation/main.dart
+[Full code for basic_staggered_animation's main.dart]: {{site.repo.this}}/tree/{{site.branch}}/examples/_animation/basic_staggered_animation/lib/main.dart
 [`Interval`]: {{site.api}}/flutter/animation/Interval-class.html
 [`Tween`]: {{site.api}}/flutter/animation/Tween-class.html


### PR DESCRIPTION
Fixes https://github.com/flutter/website/issues/10073
