### PR TITLE
Fix typo in Impeller page

### DIFF
--- a/src/perf/impeller.md
+++ b/src/perf/impeller.md
@@ -117,7 +117,7 @@ flutter run --enable-impeller
 ```
 
 Or, you can add the following setting to your project’s
-`AndroidManiest.xml` file under the `<application>` tag:
+`AndroidManifest.xml` file under the `<application>` tag:
 
 ```xml
 <meta-data


### PR DESCRIPTION
Fix a small typo in Impeller docs page.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
