### PR TITLE
Drop "Building a Cupertino app with Flutter" codelab

### DIFF
--- a/src/codelabs/index.md
+++ b/src/codelabs/index.md
@@ -273,13 +273,6 @@ Learn how to test your Flutter application.
 Learn how to write code that's targeted for specific platforms,
 like iOS, Android, desktop, or the web.
 
-* [Building a Cupertino app with Flutter][]<br>
-  Build a version of the Shrine shopping app
-  (used in the Material Design codelabs) using the
-  Cupertino package to create an iOS style look and feel.
-  Create multiple tabs and navigate between them.
-  Use the [provider][] package to manage state between screens.
-
 * [How to write a Flutter plugin][]<br>
   Learn how to write a plugin by creating a music plugin
   for iOS and Android that processes audio on the host platform.
@@ -303,7 +296,6 @@ like iOS, Android, desktop, or the web.
   on iOS. This applies to your home screen, lock screen, or the
   today view.
 
-[Building a Cupertino app with Flutter]: {{site.codelabs}}/codelabs/flutter-cupertino
 [home-screen]: {{site.codelabs}}/flutter-home-screen-widgets
 [How to write a Flutter plugin]: {{site.codelabs}}/codelabs/write-flutter-plugin
 [provider]: {{site.pub-pkg}}/provider

--- a/src/cookbook/design/tabs.md
+++ b/src/cookbook/design/tabs.md
@@ -13,11 +13,6 @@ Material Design guidelines.
 Flutter includes a convenient way to create tab layouts as part of
 the [material library][].
 
-{{site.alert.note}}
-  To create tabs in a Cupertino app, see the
-  [Building a Cupertino app with Flutter][] codelab.
-{{site.alert.end}}
-
 This recipe creates a tabbed example using the following steps;
 
   1. Create a `TabController`.
@@ -147,7 +142,6 @@ class TabBarDemo extends StatelessWidget {
 
 
 [`AppBar`]: {{site.api}}/flutter/material/AppBar-class.html
-[Building a Cupertino app with Flutter]: {{site.codelabs}}/codelabs/flutter-cupertino
 [`DefaultTabController`]: {{site.api}}/flutter/material/DefaultTabController-class.html
 [material library]: {{site.api}}/flutter/material/material-library.html
 [`Tab`]: {{site.api}}/flutter/material/Tab-class.html


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Drop the "Building a Cupertino app with Flutter" codelab

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
