### PR TITLE
Update android-devs.md

### DIFF
--- a/examples/get-started/flutter-for/android_devs/l10n.yaml
+++ b/examples/get-started/flutter-for/android_devs/l10n.yaml
@@ -1,0 +1,3 @@
+arb-dir: lib
+template-arb-file: arb_examples.arb
+output-localization-file: app_localizations.dart

--- a/examples/get-started/flutter-for/android_devs/lib/arb_examples.arb
+++ b/examples/get-started/flutter-for/android_devs/lib/arb_examples.arb
@@ -1,0 +1,12 @@
+{
+   "hello":"Hello {userName}",
+   "@hello":{
+      "description":"A message with a single parameter",
+      "placeholders":{
+         "userName":{
+            "type":"String",
+            "example":"Bob"
+         }
+      }
+   }
+}

--- a/examples/get-started/flutter-for/android_devs/lib/arb_examples.arb
+++ b/examples/get-started/flutter-for/android_devs/lib/arb_examples.arb
@@ -1,4 +1,5 @@
 {
+   "@@locale": "en",
    "hello":"Hello {userName}",
    "@hello":{
       "description":"A message with a single parameter",

--- a/examples/get-started/flutter-for/android_devs/lib/localization_examples.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/localization_examples.dart
@@ -1,3 +1,6 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 class MyWidget extends StatelessWidget {
   const MyWidget({super.key});
 

--- a/examples/get-started/flutter-for/android_devs/lib/localization_examples.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/localization_examples.dart
@@ -9,6 +9,6 @@ class MyWidget extends StatelessWidget {
     return
         // #docregion AccessString
         Text(AppLocalizations.of(context)!.hello('John'));
-    // #enddocregion AccessString
+        // #enddocregion AccessString
   }
 }

--- a/examples/get-started/flutter-for/android_devs/lib/localization_examples.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/localization_examples.dart
@@ -1,0 +1,11 @@
+class MyWidget extends StatelessWidget {
+  const MyWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return
+        // #docregion AccessString
+        Text(AppLocalizations.of(context)!.hello('John'));
+    // #enddocregion AccessString
+  }
+}

--- a/examples/get-started/flutter-for/android_devs/pubspec.yaml
+++ b/examples/get-started/flutter-for/android_devs/pubspec.yaml
@@ -11,10 +11,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
     
   cupertino_icons: ^1.0.6
   http: ^1.1.0
   shared_preferences: ^2.2.0
+  intl: any
 
 dev_dependencies:
   example_utils:
@@ -23,4 +26,5 @@ dev_dependencies:
     sdk: flutter
 
 flutter:
+  generate: true
   uses-material-design: true

--- a/src/get-started/flutter-for/android-devs.md
+++ b/src/get-started/flutter-for/android-devs.md
@@ -1314,7 +1314,7 @@ Widget build(BuildContext context) {
 Flutter currently doesn't have a dedicated resources-like system for strings.
 The best and recommended practice is to hold your strings in a `.arb` file as key-value pairs For example:
 
-<?code-excerpt "lib/arb_examples.dart (Strings)"?>
+<?code-excerpt "lib/arb_examples.dart"?>
 ```arb
 {
    "hello":"Hello {userName}",

--- a/src/get-started/flutter-for/android-devs.md
+++ b/src/get-started/flutter-for/android-devs.md
@@ -1330,13 +1330,9 @@ The best and recommended practice is to hold your strings in a `.arb` file as ke
 
 Then in your code, you can access your strings as such:
 
+<?code-excerpt "lib/localization_examples.dart (AccessString)"?>
 ```dart
-return Column(
-  children: <Widget>[
-    // Returns 'Hello John'
-    Text(AppLocalizations.of(context)!.hello('John')),
-  ],
-);
+Text(AppLocalizations.of(context)!.hello('John'));
 ```
 
 Flutter has basic support for accessibility on Android,

--- a/src/get-started/flutter-for/android-devs.md
+++ b/src/get-started/flutter-for/android-devs.md
@@ -1314,7 +1314,7 @@ Widget build(BuildContext context) {
 Flutter currently doesn't have a dedicated resources-like system for strings.
 The best and recommended practice is to hold your strings in a `.arb` file as key-value pairs For example:
 
-<?code-excerpt "lib/arb_examples.dart"?>
+<?code-excerpt "lib/arb_examples.arb"?>
 ```arb
 {
    "hello":"Hello {userName}",

--- a/src/get-started/flutter-for/android-devs.md
+++ b/src/get-started/flutter-for/android-devs.md
@@ -1317,6 +1317,7 @@ The best and recommended practice is to hold your strings in a `.arb` file as ke
 <?code-excerpt "lib/arb_examples.arb"?>
 ```arb
 {
+   "@@locale": "en",
    "hello":"Hello {userName}",
    "@hello":{
       "description":"A message with a single parameter",

--- a/src/get-started/flutter-for/android-devs.md
+++ b/src/get-started/flutter-for/android-devs.md
@@ -1314,17 +1314,19 @@ Widget build(BuildContext context) {
 Flutter currently doesn't have a dedicated resources-like system for strings.
 The best and recommended practice is to hold your strings in a `.arb` file as key-value pairs For example:
 
-<?code-excerpt "lib/string_examples.dart (Strings)"?>
+<?code-excerpt "lib/arb_examples.dart (Strings)"?>
 ```arb
-"hello": "Hello {userName}",
-"@hello": {
-  "description": "A message with a single parameter",
-  "placeholders": {
-    "userName": {
-      "type": "String",
-      "example": "Bob"
-    }
-  }
+{
+   "hello":"Hello {userName}",
+   "@hello":{
+      "description":"A message with a single parameter",
+      "placeholders":{
+         "userName":{
+            "type":"String",
+            "example":"Bob"
+         }
+      }
+   }
 }
 ```
 

--- a/src/get-started/flutter-for/android-devs.md
+++ b/src/get-started/flutter-for/android-devs.md
@@ -1312,28 +1312,37 @@ Widget build(BuildContext context) {
 ### Where do I store strings? How do I handle localization?
 
 Flutter currently doesn't have a dedicated resources-like system for strings.
-At the moment, the best practice is to hold your copy text in a class as
-static fields and accessing them from there. For example:
+The best and recommended practice is to hold your strings in a `.arb` file as key-value pairs For example:
 
 <?code-excerpt "lib/string_examples.dart (Strings)"?>
-```dart
-class Strings {
-  static String welcomeMessage = 'Welcome To Flutter';
+```arb
+"hello": "Hello {userName}",
+"@hello": {
+  "description": "A message with a single parameter",
+  "placeholders": {
+    "userName": {
+      "type": "String",
+      "example": "Bob"
+    }
+  }
 }
 ```
 
 Then in your code, you can access your strings as such:
 
-<?code-excerpt "lib/string_examples.dart (AccessString)"?>
 ```dart
-Text(Strings.welcomeMessage);
+return Column(
+  children: <Widget>[
+    // Returns 'Hello John'
+    Text(AppLocalizations.of(context)!.hello('John')),
+  ],
+);
 ```
 
 Flutter has basic support for accessibility on Android,
 though this feature is a work in progress.
 
-Flutter developers are encouraged to use the
-[intl package][] for internationalization and localization.
+See [Internationalizing Flutter apps][] for more information on this.
 
 ### What is the equivalent of a Gradle file? How do I add dependencies?
 
@@ -2413,3 +2422,4 @@ see the [`firebase_messaging`][] plugin documentation.
 [SQFlite]: {{site.pub}}/packages/sqflite
 [StackOverflow]: {{site.so}}/questions/44396075/equivalent-of-relativelayout-in-flutter
 [widget catalog]: {{site.url}}/ui/widgets/layout
+[Internationalizing Flutter apps]: {{site.url}}/ui/accessibility-and-internationalization/internationalization


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Updated https://github.com/flutter/website/tree/main/src/get-started/flutter-for/android-devs.md page as it is containing some outdated information.

_Issues fixed by this PR (if any):_
https://github.com/flutter/website/issues/10101

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
