### PR TITLE
Fix broken iphone icon

### DIFF
--- a/src/get-started/install/macos/index.md
+++ b/src/get-started/install/macos/index.md
@@ -17,7 +17,7 @@ target-list: [Desktop, Mobile-iOS, Mobile-Android, Web]
           {% if icon == 'desktop' -%}
             <span class="material-symbols">laptop_mac</span>
           {% elsif icon == 'mobile-ios' -%}
-            <span class="symbols">phone_iphone</span>
+            <span class="material-symbols">phone_iphone</span>
           {% elsif icon == 'mobile-android' -%}
             <span class="material-symbols">phone_android</span>
           {% else -%}


### PR DESCRIPTION
**Staged:** https://flutter-docs-prod--pr10108-fix-broken-iphone-icon-fgiaua19.web.app/get-started/install/macos