### PR TITLE
Add redirecting scripts for broken get-started fragments

### DIFF
--- a/src/assets/js/temp/macos-install-redirector.js
+++ b/src/assets/js/temp/macos-install-redirector.js
@@ -1,0 +1,56 @@
+const oldToNew = {
+  'ios-setup': '/get-started/install/macos/mobile-ios',
+  'set-up-the-ios-simulator': '/get-started/install/macos/mobile-ios#configure-your-target-ios-device',
+  'deploy-to-physical-ios-devices': '/deployment/ios',
+  'deploy-to-ios-devices': '/deployment/ios',
+
+  'macos-setup': '/get-started/install/macos/desktop',
+
+  'android-setup': '/get-started/install/macos/mobile-android#configure-android-development',
+  'set-up-your-android-device': '/get-started/install/macos/mobile-android#configure-your-target-android-device',
+  'set-up-the-android-emulator': '/get-started/install/macos/mobile-android#configure-your-target-android-device',
+  'agree-to-android-licenses': '/get-started/install/macos/mobile-android#agree-to-android-licenses',
+};
+
+function handleRedirect() {
+  const rawOldFragment = window.location.hash;
+
+  // If no fragment was specified, don't do anything.
+  if (!rawOldFragment) {
+    return;
+  }
+
+  const oldFragmentWithHash = rawOldFragment.trim().toLowerCase();
+
+  // If the fragment is empty, don't do anything.
+  if (oldFragmentWithHash.length === 0) {
+    return;
+  }
+
+  const oldFragment = oldFragmentWithHash.substring(1);
+
+  // If the fragment did not exist, don't do anything.
+  if (!(oldFragment in oldToNew)) {
+    return;
+  }
+
+  const newDestination = oldToNew[oldFragment];
+
+  // If the desired destination exists, go there.
+  // Otherwise, don't go anywhere.
+  fetch(newDestination)
+      .then((response) => {
+        if (response.status === 200) {
+          window.location.replace(newDestination);
+        }
+      }).catch((_) => {
+  });
+}
+
+const currentLocation = window.location.pathname;
+
+if (currentLocation.includes('/get-started/install/macos') &&
+    currentLocation.split('/')
+        .filter(value => value.trim().length !== 0).length === 3) {
+  handleRedirect();
+}

--- a/src/assets/js/temp/windows-install-redirector.js
+++ b/src/assets/js/temp/windows-install-redirector.js
@@ -1,0 +1,51 @@
+const oldToNew = {
+  'windows-setup': '/get-started/install/windows/desktop',
+
+  'set-up-your-android-device': '/get-started/install/windows/mobile#configure-your-target-android-device',
+  'set-up-the-android-emulator': '/get-started/install/windows/mobile#configure-your-target-android-device',
+  'agree-to-android-licenses': '/get-started/install/windows/mobile#agree-to-android-licenses',
+  'android-setup': '/get-started/install/windows/mobile#configure-android-development',
+};
+
+function handleRedirect() {
+  const rawOldFragment = window.location.hash;
+
+  // If no fragment was specified, don't do anything.
+  if (!rawOldFragment) {
+    return;
+  }
+
+  const oldFragmentWithHash = rawOldFragment.trim().toLowerCase();
+
+  // If the fragment is empty, don't do anything.
+  if (oldFragmentWithHash.length === 0) {
+    return;
+  }
+
+  const oldFragment = oldFragmentWithHash.substring(1);
+
+  // If the fragment did not exist, don't do anything.
+  if (!(oldFragment in oldToNew)) {
+    return;
+  }
+
+  const newDestination = oldToNew[oldFragment];
+
+  // If the desired destination exists, go there.
+  // Otherwise, don't go anywhere.
+  fetch(newDestination)
+      .then((response) => {
+        if (response.status === 200) {
+          window.location.replace(newDestination);
+        }
+      }).catch((_) => {});
+}
+
+const currentLocation = window.location.pathname;
+
+// Only handle redirects in the parent directory, not any subdirectories.
+if (currentLocation.includes('/get-started/install/windows') &&
+    currentLocation.split('/')
+        .filter(value => value.trim().length !== 0).length === 3) {
+  handleRedirect();
+}

--- a/src/get-started/install/macos/index.md
+++ b/src/get-started/install/macos/index.md
@@ -3,6 +3,7 @@ title: Choose your first type of app
 description: Configure your system to develop Flutter on macOS.
 short-title: macOS
 target-list: [Desktop, Mobile-iOS, Mobile-Android, Web]
+js: [{url: '/assets/js/temp/macos-install-redirector.js'}]
 ---
 
 {% assign os = 'macos' -%}

--- a/src/get-started/install/windows/index.md
+++ b/src/get-started/install/windows/index.md
@@ -3,6 +3,7 @@ title: Choose your first type of app
 description: Configure your system to develop Flutter on Windows.
 short-title: Windows
 target-list: [Desktop, Mobile, Web]
+js: [{url: '/assets/js/temp/windows-install-redirector.js'}]
 ---
 
 {% assign os = 'windows' -%}


### PR DESCRIPTION
This will ensure links to these fragments from past releases of the Flutter SDK still lead to relevant content.

Fixes https://github.com/flutter/flutter/issues/141772