### PR TITLE
Re-add Build Tools for Visual Studio 2022

### DIFF
--- a/src/_includes/docs/install/reqs/windows/software.md
+++ b/src/_includes/docs/install/reqs/windows/software.md
@@ -17,11 +17,10 @@
 
 {% else -%}
 
-* [Visual Studio 2022][] with the the **Desktop development with C++**
-  workload or [Build Tools for Visual Studio 2022][]. This enables
-  building Windows app including all of its default components.
-  **Visual Studio** is an IDE separate from
-  **[Visual Studio _Code_][]**.
+* [Visual Studio 2022][] with the the **Desktop development with C++** workload
+  or [Build Tools for Visual Studio 2022][].
+  This enables building Windows app including all of its default components.
+  **Visual Studio** is an IDE separate from **[Visual Studio _Code_][]**.
 * [Android Studio][] {{site.appmin.android_studio}} to debug and compile
   Java or Kotlin code for Android.
   Flutter requires the full version of Android Studio.

--- a/src/_includes/docs/install/reqs/windows/software.md
+++ b/src/_includes/docs/install/reqs/windows/software.md
@@ -17,10 +17,11 @@
 
 {% else -%}
 
-* [Visual Studio 2022][] to debug and compile native C++ Windows code.
-  Make sure to install the **Desktop development with C++** workload.
-  This enables building Windows app including all of its default components.
-  **Visual Studio** is an IDE separate from **[Visual Studio _Code_][]**.
+* [Visual Studio 2022][] with the the **Desktop development with C++**
+  workload or [Build Tools for Visual Studio 2022][]. This enables
+  building Windows app including all of its default components.
+  **Visual Studio** is an IDE separate from
+  **[Visual Studio _Code_][]**.
 * [Android Studio][] {{site.appmin.android_studio}} to debug and compile
   Java or Kotlin code for Android.
   Flutter requires the full version of Android Studio.
@@ -30,5 +31,6 @@
 
 [Android Studio]: https://developer.android.com/studio/install#windows
 [Visual Studio 2022]: https://learn.microsoft.com/visualstudio/install/install-visual-studio?view=vs-2022
+[Build Tools for Visual Studio 2022]: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022
 [Google Chrome]: https://www.google.com/chrome/dr/download/
 [Visual Studio _Code_]: https://code.visualstudio.com/


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Re-add the Build Tools for Visual Studio 2022 option. This is a significantly smaller download than a full Visual Studio installation.

This was originally added by https://github.com/flutter/website/pull/7484 but was removed by https://github.com/flutter/website/pull/9238.

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
