### PR TITLE
Add note about missing web support in profiling.md

### DIFF
--- a/src/cookbook/testing/integration/profiling.md
+++ b/src/cookbook/testing/integration/profiling.md
@@ -22,7 +22,7 @@ timeline while performing a specific task and saves a summary of the
 results to a local file.
 
 {{site.alert.note}}
-  Note that recording performance timelines is not supported on web.
+  Recording performance timelines isn't supported on web.
   For performance profiling on web, see
   [Debugging performance for web apps][]
 {{site.alert.end}}

--- a/src/cookbook/testing/integration/profiling.md
+++ b/src/cookbook/testing/integration/profiling.md
@@ -21,6 +21,12 @@ In this recipe, learn how to write a test that records a performance
 timeline while performing a specific task and saves a summary of the
 results to a local file.
 
+{{site.alert.note}}
+  Note that recording performance timelines is not supported on web.
+  For performance profiling on web, see
+  [Debugging performance for web apps][]
+{{site.alert.end}}
+
 This recipe uses the following steps:
 
   1. Write a test that scrolls through a list of items.
@@ -268,3 +274,4 @@ Future<void> main() {
 [`Timeline`]: {{site.api}}/flutter/flutter_driver/Timeline-class.html
 [`TimelineSummary`]: {{site.api}}/flutter/flutter_driver/TimelineSummary-class.html
 [`traceAction()`]: {{site.api}}/flutter/flutter_driver/FlutterDriver/traceAction.html
+[Debugging performance for web apps]: {{site.url}}/perf/web-performance


### PR DESCRIPTION
Adds a note that tracing performance in integration tests is not supported on web.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
