### PR TITLE
Update test-drive/vscode.md.

### DIFF
--- a/src/_includes/docs/install/test-drive/vscode.md
+++ b/src/_includes/docs/install/test-drive/vscode.md
@@ -30,14 +30,8 @@ contains a simple demo app that uses [Material Components][].
 
 ### Run your sample Flutter app
 
-Run your example application on your desktop platform, in Chrome, in an iOS simulator, or
+Run your example application on your desktop platform, in the Chrome web browser, in an iOS simulator, or
 Android emulator.
-
-{{site.alert.secondary}}
-  Though you can deploy your app to the web,
-  don't choose that target for this tutorial.
-  The web target doesn't support hot reload at this time.
-{{site.alert.end}}
 
 1. Open the Command Palette.
 

--- a/src/_includes/docs/install/test-drive/vscode.md
+++ b/src/_includes/docs/install/test-drive/vscode.md
@@ -30,7 +30,7 @@ contains a simple demo app that uses [Material Components][].
 
 ### Run your sample Flutter app
 
-Run your example application on your desktop platform or in an iOS simulator or
+Run your example application on your desktop platform, in Chrome, in an iOS simulator, or
 Android emulator.
 
 {{site.alert.secondary}}

--- a/src/_includes/docs/install/test-drive/vscode.md
+++ b/src/_includes/docs/install/test-drive/vscode.md
@@ -33,6 +33,12 @@ contains a simple demo app that uses [Material Components][].
 Run your example application on your desktop platform, in the Chrome web browser, in an iOS simulator, or
 Android emulator.
 
+{{site.alert.secondary}}
+  Though you can deploy your app to the web,
+  note that the web target doesn't support
+  hot reload at this time.
+{{site.alert.end}}
+
 1. Open the Command Palette.
 
    Go to **View** <span aria-label="and then">></span> **Command Palette** or


### PR DESCRIPTION
This seems like a minor change, but this caused me some (perhaps self-inflicted) confusion.  I'm an experienced developer, with many years of React experience.

If you start from [here](https://docs.flutter.dev/get-started/install/macos) (which is where the "Beginner" track takes you) this asks you to choose your first kind of app.  If you pick "Web", this brings you to instructions for how to install and configure Flutter for web development.

At the bottom of this page is a link to [Create a Test App](https://docs.flutter.dev/get-started/test-drive), which is styled to make it look like this is the next page of the tutorial.  The problem here is that I picked "Web" as my app, and then I went looking for instructions on this page about how to launch a browser.  I got to "Run your example application on your desktop platform or in an iOS simulator or Android emulator," but none of these are "browser", so I stopped reading and searched for "browser" (which doesn't appear on this page) or "Chrome" (which doesn't appear on this page).  So at this point I was a bit stuck, as this seemed to only have instructions for how to launch the app in an emulator, and I didn't bother installing Android or xcode.

But, of course, these instructions work just fine for web, you just have to keep going.  :P

I also removed the warning that hot reloading doesn't work for web, because it certainly seems to work fine for me.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
