### PR TITLE
Update samples repo URLs to point to main instead of master

### DIFF
--- a/src/add-to-app/android/add-flutter-view.md
+++ b/src/add-to-app/android/add-flutter-view.md
@@ -50,7 +50,7 @@ in this case is being added to an Activity or Fragment in your application,
 you must recreate the connections manually. Otherwise, the [FlutterView]({{site.api}}/javadoc/io/flutter/embedding/android/FlutterView.html)
 will not render anything or have other missing functionalities.
 
-A sample [FlutterViewEngine]({{site.repo.samples}}/blob/master/add_to_app/android_view/android_view/app/src/main/java/dev/flutter/example/androidView/FlutterViewEngine.kt)
+A sample [FlutterViewEngine]({{site.repo.samples}}/blob/main/add_to_app/android_view/android_view/app/src/main/java/dev/flutter/example/androidView/FlutterViewEngine.kt)
 class shows one such possible implementation of an application-specific
 connection between an Activity, a [FlutterView]({{site.api}}/javadoc/io/flutter/embedding/android/FlutterView.html)
 and a [FlutterEngine]({{site.api}}/javadoc/io/flutter/embedding/engine/FlutterEngine.html).

--- a/src/platform-integration/ios/ios-app-clip.md
+++ b/src/platform-integration/ios/ios-app-clip.md
@@ -23,7 +23,7 @@ existing Flutter project or [add-to-app][] project.
 
 To see a working sample, see the [App Clip sample][] on GitHub.
 
-[App Clip sample]: {{site.repo.samples}}/tree/master/ios_app_clip
+[App Clip sample]: {{site.repo.samples}}/tree/main/ios_app_clip
 
 ## Step 1 - Open project
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
The default branch in the samples repo is main, not master.  Update the URLs to avoid master_archived

Example https://github.com/flutter/samples/tree/master/ios_app_clip
<img width="246" alt="Screenshot 2024-02-13 at 2 47 31 PM" src="https://github.com/flutter/website/assets/682784/5ef6f5e4-022a-4179-bb61-cb926a89e608">

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
