### PR TITLE
Announce deprecation of AssetManifest.json

### DIFF
--- a/src/release/breaking-changes/asset-manifest-dot-json.md
+++ b/src/release/breaking-changes/asset-manifest-dot-json.md
@@ -1,0 +1,58 @@
+---
+title: Removal of AssetManifest.json
+description: >-
+    Built Flutter apps will no longer include an AssetManifest.json asset file.
+---
+
+## Summary
+
+Flutter apps currently include an asset file named AssetManifest.json, which
+effectively contains a list of assets. This file could be read using the
+[AssetBundle][] API. This is useful in the scenario that application/plugin
+code needs to determine what assets are available at runtime.
+
+The AssetManifest.json file is an undocumented implementation detail.
+It's also no longer used by the framework, so it will stop being created in a
+future release.
+To get a list of available assets, use the [AssetManifest][] API instead.
+
+## Migration guide
+
+Before:
+
+```dart
+import 'dart:convert';
+import 'package:flutter/services.dart';
+
+final String assetManifestContent = await rootBundle.loadString('AssetManifest.json');
+final Map<Object?, Object?> decodedAssetManifest = 
+    json.decode(assetManifestContent) as Map<String, Object?>;
+final List<String> assets = decodedAssetManifest.keys.toList().cast();
+```
+
+After:
+
+```dart
+import 'package:flutter/services.dart';
+
+final AssetManifest assetManifest = await AssetManifest.loadFromAssetBundle(rootBundle);
+final List<String> assets = assetManifest.listAssets();
+```
+
+## Timeline
+
+AssetManifest.json will no longer be generated started with the third stable
+release after 3.20.
+
+Landed in version: Not yet
+Landed in stable: Not yet
+
+## References
+
+Relevant issues:
+
+* [When building a Flutter app, the flutter tool still generates an AssetManifest.json file that is unused by the framework (Issue #143577)][]
+
+[AssetBundle]: {{site.api}}/flutter/services/AssetBundle-class.html
+[AssetManifest]: {{site.api}}/flutter/services/AssetManifest-class.html
+[When building a Flutter app, the flutter tool still generates an AssetManifest.json file that is unused by the framework (Issue #143577)]: {{site.repo.flutter}}/issues/143577

--- a/src/release/breaking-changes/asset-manifest-dot-json.md
+++ b/src/release/breaking-changes/asset-manifest-dot-json.md
@@ -74,10 +74,8 @@ format of the file may change in a future release without announcement.
 
 ## Timeline
 
-AssetManifest.json will no longer be generated started with the third stable
-release after 3.19.
-
-Landed in version: Not yet
+AssetManifest.json will no longer be generated starting with the fourth stable
+release after 3.19 or one year after the release of 3.19, whichever comes last.
 
 ## References
 

--- a/src/release/breaking-changes/asset-manifest-dot-json.md
+++ b/src/release/breaking-changes/asset-manifest-dot-json.md
@@ -18,6 +18,8 @@ the [AssetManifest][] API instead.
 
 ## Migration guide
 
+### Reading asset manifest from Flutter application code
+
 Before:
 
 ```dart
@@ -27,7 +29,7 @@ import 'package:flutter/services.dart';
 final String assetManifestContent = await rootBundle.loadString('AssetManifest.json');
 final Map<Object?, Object?> decodedAssetManifest = 
     json.decode(assetManifestContent) as Map<String, Object?>;
-final List<String> assets = decodedAssetManifest.keys.toList().cast();
+final List<String> assets = decodedAssetManifest.keys.toList().cast<String>();
 ```
 
 After:
@@ -39,14 +41,41 @@ final AssetManifest assetManifest = await AssetManifest.loadFromAssetBundle(root
 final List<String> assets = assetManifest.listAssets();
 ```
 
+### Reading asset manifest information from Dart code outside of a Flutter app
+
+The tool generates a new file, AssetManifest.bin. This replaces AssetManifest.json.
+This file contains the same information of AssetManifest.json, but in a different format.
+If you need to be able to read this file from code that is not part of a Flutter app
+(and therefore cannot use the [AssetManifest][] API), you can still parse the file yourself.
+
+The [standard_message_codec][] package can be used to parse the contents.
+
+```dart
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:standard_message_codec/standard_message_codec.dart';
+
+void main() {
+  // The path to AssetManifest.bin depends on the target platform.
+  final String pathToAssetManifest = './build/web/assets/AssetManifest.bin';
+  final Uint8List manifest = File(pathToAssetManifest).readAsBytesSync();
+  final Map<Object?, Object?> decoded = const StandardMessageCodec()
+      .decodeMessage(ByteData.sublistView(manifest));
+  final List<String> assets = decoded.keys.cast<String>().toList();
+}
+```
+
+Keep in mind that AssetManifest.bin is an implementation detail of Flutter.
+Reading this file is not an officially supported workflow. The contents or
+format of the file may change in a future release without announcement.
+
 ## Timeline
 
 AssetManifest.json will no longer be generated started with the third stable
-release after 3.20.
+release after 3.19.
 
 Landed in version: Not yet
-
-Landed in stable: Not yet
 
 ## References
 
@@ -57,3 +86,4 @@ Relevant issues:
 [AssetBundle]: {{site.api}}/flutter/services/AssetBundle-class.html
 [AssetManifest]: {{site.api}}/flutter/services/AssetManifest-class.html
 [(Issue #143577)]: {{site.repo.flutter}}/issues/143577
+[standard_message_codec]: {{site.pub}}/packages/standard_message_codec

--- a/src/release/breaking-changes/asset-manifest-dot-json.md
+++ b/src/release/breaking-changes/asset-manifest-dot-json.md
@@ -6,15 +6,16 @@ description: >-
 
 ## Summary
 
-Flutter apps currently include an asset file named AssetManifest.json, which
+Flutter apps currently include an asset file named AssetManifest.json. This file
 effectively contains a list of assets. This file could be read using the
-[AssetBundle][] API. This is useful in the scenario that application/plugin
-code needs to determine what assets are available at runtime.
+[AssetBundle][] API, allowing application code to determine what assets are
+available at runtime.
 
 The AssetManifest.json file is an undocumented implementation detail.
-It's also no longer used by the framework, so it will stop being created in a
+It's also no longer used by the framework, so it will stop being generated in a
 future release.
-To get a list of available assets, use the [AssetManifest][] API instead.
+If your application code needs to get a list of available assets, use
+the [AssetManifest][] API instead.
 
 ## Migration guide
 
@@ -45,6 +46,7 @@ AssetManifest.json will no longer be generated started with the third stable
 release after 3.20.
 
 Landed in version: Not yet
+
 Landed in stable: Not yet
 
 ## References

--- a/src/release/breaking-changes/asset-manifest-dot-json.md
+++ b/src/release/breaking-changes/asset-manifest-dot-json.md
@@ -11,8 +11,8 @@ effectively contains a list of assets. Application code can read it using the
 [AssetBundle][] API determine what assets are available at runtime.
 
 The AssetManifest.json file is an undocumented implementation detail.
-It's also no longer used by the framework, so it will stop being generated in a
-future release.
+It's no longer used by the framework, so it will no longer be
+generated in a future release.
 If your application code needs to get a list of available assets, use
 the [AssetManifest][] API instead.
 

--- a/src/release/breaking-changes/asset-manifest-dot-json.md
+++ b/src/release/breaking-changes/asset-manifest-dot-json.md
@@ -43,10 +43,12 @@ final List<String> assets = assetManifest.listAssets();
 
 ### Reading asset manifest information from Dart code outside of a Flutter app
 
-The tool generates a new file, AssetManifest.bin. This replaces AssetManifest.json.
+The `flutter` CLI tool generates a new file, AssetManifest.bin.
+This replaces AssetManifest.json.
 This file contains the same information of AssetManifest.json, but in a different format.
-If you need to be able to read this file from code that is not part of a Flutter app
-(and therefore cannot use the [AssetManifest][] API), you can still parse the file yourself.
+If you need to be able to read this file from code that is not part of a
+Flutter app(and therefore cannot use the [AssetManifest][] API), you can
+still parse the file yourself.
 
 The [standard_message_codec][] package can be used to parse the contents.
 

--- a/src/release/breaking-changes/asset-manifest-dot-json.md
+++ b/src/release/breaking-changes/asset-manifest-dot-json.md
@@ -52,8 +52,8 @@ Landed in stable: Not yet
 
 Relevant issues:
 
-* [When building a Flutter app, the flutter tool still generates an AssetManifest.json file that is unused by the framework (Issue #143577)][]
+* When building a Flutter app, the flutter tool generates an AssetManifest.json file that is unused by the framework [(Issue #143577)][]
 
 [AssetBundle]: {{site.api}}/flutter/services/AssetBundle-class.html
 [AssetManifest]: {{site.api}}/flutter/services/AssetManifest-class.html
-[When building a Flutter app, the flutter tool still generates an AssetManifest.json file that is unused by the framework (Issue #143577)]: {{site.repo.flutter}}/issues/143577
+[(Issue #143577)]: {{site.repo.flutter}}/issues/143577

--- a/src/release/breaking-changes/asset-manifest-dot-json.md
+++ b/src/release/breaking-changes/asset-manifest-dot-json.md
@@ -7,9 +7,8 @@ description: >-
 ## Summary
 
 Flutter apps currently include an asset file named AssetManifest.json. This file
-effectively contains a list of assets. This file could be read using the
-[AssetBundle][] API, allowing application code to determine what assets are
-available at runtime.
+effectively contains a list of assets. Application code can read it using the
+[AssetBundle][] API determine what assets are available at runtime.
 
 The AssetManifest.json file is an undocumented implementation detail.
 It's also no longer used by the framework, so it will stop being generated in a

--- a/src/release/breaking-changes/asset-manifest-dot-json.md
+++ b/src/release/breaking-changes/asset-manifest-dot-json.md
@@ -8,7 +8,7 @@ description: >-
 
 Flutter apps currently include an asset file named AssetManifest.json. This file
 effectively contains a list of assets. Application code can read it using the
-[AssetBundle][] API determine what assets are available at runtime.
+[AssetBundle][] API to determine what assets are available at runtime.
 
 The AssetManifest.json file is an undocumented implementation detail.
 It's no longer used by the framework, so it will no longer be

--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -31,10 +31,12 @@ release, and listed in alphabetical order:
 
 ### Not yet released to stable
 
+* [Stop generating AssetManifest.json][]
 * [Rename `MemoryAllocations` to `FlutterMemoryAllocations`][]
 * [Deprecate `TextField.canRequestFocus`][]
 * [Nullable PageView.controller][]
 
+[Stop generating AssetManifest.json]: {{site.url}}/release/breaking-changes/asset-manifest-dot-json
 [Rename `MemoryAllocations` to `FlutterMemoryAllocations`]: {{site.url}}/release/breaking-changes/flutter-memory-allocations
 [Deprecate `TextField.canRequestFocus`]: {{site.url}}/release/breaking-changes/can-request-focus
 [Nullable PageView.controller]: {{site.url}}/release/breaking-changes/pageview-controller


### PR DESCRIPTION
Announces a change to `flutter` planned in a later release that might break (a small number of) Flutter apps.

See https://github.com/flutter/flutter/issues/143577 for the relevant issue on flutter/flutter.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
