### PR TITLE
Clean up yt_shims before migration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,6 +56,13 @@ firebase: https://firebase.google.com
 wonderous: https://wonderous.app/
 youtube-site: https://youtube.com
 
+yt:
+  set = 'frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen loading="lazy"'
+  set-short = 'frameborder="0" allowfullscreen loading="lazy"'
+  watch = 'https://www.youtube.com/watch'
+  embed = 'https://www.youtube.com/embed'
+  playlist = 'https://www.youtube.com/playlist?list='
+
 ## Software minimum versions
 
 appmin:

--- a/_config.yml
+++ b/_config.yml
@@ -57,11 +57,11 @@ wonderous: https://wonderous.app/
 youtube-site: https://youtube.com
 
 yt:
-  set = 'frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen loading="lazy"'
-  set-short = 'frameborder="0" allowfullscreen loading="lazy"'
-  watch = 'https://www.youtube.com/watch'
-  embed = 'https://www.youtube.com/embed'
-  playlist = 'https://www.youtube.com/playlist?list='
+  set: 'frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen loading="lazy"'
+  set-short: 'frameborder="0" allowfullscreen loading="lazy"'
+  watch: 'https://www.youtube.com/watch'
+  embed: 'https://www.youtube.com/embed'
+  playlist: 'https://www.youtube.com/playlist?list='
 
 ## Software minimum versions
 

--- a/src/_data/yt.yml
+++ b/src/_data/yt.yml
@@ -1,0 +1,5 @@
+set = 'frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen loading="lazy"'
+set-short = 'frameborder="0" allowfullscreen loading="lazy"'
+watch = 'https://www.youtube.com/watch'
+embed = 'https://www.youtube.com/embed'
+playlist = 'https://www.youtube.com/playlist?list='

--- a/src/_data/yt.yml
+++ b/src/_data/yt.yml
@@ -1,5 +1,0 @@
-set = 'frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen loading="lazy"'
-set-short = 'frameborder="0" allowfullscreen loading="lazy"'
-watch = 'https://www.youtube.com/watch'
-embed = 'https://www.youtube.com/embed'
-playlist = 'https://www.youtube.com/playlist?list='

--- a/src/_includes/docs/resource-links/ffi-video-resources.md
+++ b/src/_includes/docs/resource-links/ffi-video-resources.md
@@ -6,5 +6,5 @@ To learn more about C interoperability, check out these videos:
 - [C interoperability with Dart FFI]
 - [How to Use Dart FFI to Build a Retro Audio Player]
 
-[C interoperability with Dart FFI]: {{yt-watch}}?v=2MMK7YoFgaA
-[How to Use Dart FFI to Build a Retro Audio Player]: {{yt-watch}}?v=05Wn2oM_nWw
+[C interoperability with Dart FFI]: {{site.yt.watch}}?v=2MMK7YoFgaA
+[How to Use Dart FFI to Build a Retro Audio Player]: {{site.yt.watch}}?v=05Wn2oM_nWw

--- a/src/_includes/docs/yt_shims.liquid
+++ b/src/_includes/docs/yt_shims.liquid
@@ -1,5 +1,0 @@
-{% assign yt-set = 'frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen loading="lazy"' %}
-{% assign yt-set-short = 'frameborder="0" allowfullscreen loading="lazy"' %}
-{% assign yt-watch = 'https://www.youtube.com/watch' %}
-{% assign yt-embed = 'https://www.youtube.com/embed' %}
-{% assign yt-playlist = 'https://www.youtube.com/playlist?list=' %}

--- a/src/apprentice-giveaway/index.md
+++ b/src/apprentice-giveaway/index.md
@@ -4,8 +4,6 @@ toc: false
 description: This event is ended.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 {{site.alert.info}}
   The Flutter Apprentice event has ended.
   Thanks to all who participated!<br>
@@ -43,14 +41,14 @@ You can find replays of the book club videos on YouTube.
 
 
 [book club replay videos]: #videos
-[week 1 replay]: {{yt-watch}}?v=FFZkjw1PVrY
-[week 2 replay]: {{yt-watch}}?v=Llnq61KyOPg
-[week 3 replay]: {{yt-watch}}?v=4Ea1mhkQRxQ
-[week 4 replay]: {{yt-watch}}?v=jJ1W52f6CiM
-[week 5 replay]: {{yt-watch}}?v=Vqs9qbbTeQ0
-[week 6 replay]: {{yt-watch}}?v=vDOsMxTbfoI
-[week 7 replay]: {{yt-watch}}?v=lBS5a1hVxPM
-[week 8 replay]: {{yt-watch}}?v=R39i_xTXhpY
-[week 9 replay]: {{yt-watch}}?v=xy-H1d2L78c
-[week 10 replay]: {{yt-watch}}?v=rg5dYnCO2vo
+[week 1 replay]: {{site.yt.watch}}?v=FFZkjw1PVrY
+[week 2 replay]: {{site.yt.watch}}?v=Llnq61KyOPg
+[week 3 replay]: {{site.yt.watch}}?v=4Ea1mhkQRxQ
+[week 4 replay]: {{site.yt.watch}}?v=jJ1W52f6CiM
+[week 5 replay]: {{site.yt.watch}}?v=Vqs9qbbTeQ0
+[week 6 replay]: {{site.yt.watch}}?v=vDOsMxTbfoI
+[week 7 replay]: {{site.yt.watch}}?v=lBS5a1hVxPM
+[week 8 replay]: {{site.yt.watch}}?v=R39i_xTXhpY
+[week 9 replay]: {{site.yt.watch}}?v=xy-H1d2L78c
+[week 10 replay]: {{site.yt.watch}}?v=rg5dYnCO2vo
 [raywenderlich.com]: https://www.raywenderlich.com/books/flutter-apprentice/v1.0.ea2

--- a/src/codelabs/index.md
+++ b/src/codelabs/index.md
@@ -4,8 +4,6 @@ description: >-
   Codelabs to help you quickly get started programming Flutter.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 The Flutter codelabs provide a guided,
 hands-on coding experience. Some codelabs
 run in DartPad&mdash;no downloads required!
@@ -37,7 +35,7 @@ one of the following codelabs:
   Android and iOS tooling, the completed app
   works on Android and iOS devices, as well.
 
-[Building your first Flutter app]: {{yt-watch}}?v=8sAyPDLorek
+[Building your first Flutter app]: {{site.yt.watch}}?v=8sAyPDLorek
 [Your first Flutter app]: {{site.codelabs}}/codelabs/flutter-codelab-first
 [Write your first Flutter app on the web]: {{site.url}}/get-started/codelab-web
 
@@ -64,8 +62,8 @@ one of the following codelabs:
   by Flutter.
 
 [Records and Patterns in Dart 3]: {{site.codelabs}}/codelabs/dart-patterns-records
-[Dart null safety in Action]: {{yt-watch}}?v=HdKwuHQvArY
-[inherited-widget-ws]: {{yt-watch}}?v=LFcGPS6cGrY
+[Dart null safety in Action]: {{site.yt.watch}}?v=HdKwuHQvArY
+[inherited-widget-ws]: {{site.yt.watch}}?v=LFcGPS6cGrY
 [low-level state management]: {{site.url}}/data-and-backend/state-mgmt/options#inheritedwidget--inheritedmodel
 
 ## Designing a Flutter UI
@@ -130,7 +128,7 @@ like layout and animations:
 [Adaptive Apps in Flutter]: {{site.codelabs}}/codelabs/flutter-adaptive-app
 [animations]: {{site.pub}}/packages/animations
 [Building Beautiful Transitions with Material Motion for Flutter]: {{site.codelabs}}/codelabs/material-motion-flutter
-[Building scrolling experiences in Flutter]: {{yt-watch}}?v=YY-_yrZdjGc
+[Building scrolling experiences in Flutter]: {{site.yt.watch}}?v=YY-_yrZdjGc
 [How to debug layout issues with the Flutter Inspector]: {{site.flutter-medium}}/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db
 [Implicit animations]: {{site.url}}/codelabs/implicit-animations
 [MDC-101 Flutter: Material Components (MDC) Basics]: {{site.codelabs}}/codelabs/mdc-101-flutter
@@ -191,7 +189,7 @@ Learn how to use Flutter with other technologies.
   the Auth and Firestore emulators.
 
 [Add a user authentication flow to a Flutter app using FirebaseUI]: {{site.firebase}}/codelabs/firebase-auth-in-flutter-apps
-[firebase-ws]: {{yt-watch}}?v=wUSkeTaBonA
+[firebase-ws]: {{site.yt.watch}}?v=wUSkeTaBonA
 [Get to know Firebase for Flutter]: {{site.firebase}}/codelabs/firebase-get-to-know-flutter
 [Local development for your Flutter apps using the Firebase Emulator Suite]: {{site.firebase}}/codelabs/get-started-firebase-emulators-and-flutter
 
@@ -252,7 +250,7 @@ Learn how to use Flutter with other technologies.
 [Adding Google Maps to a Flutter app]: {{site.codelabs}}/codelabs/google-maps-in-flutter
 [Adding WebView to your Flutter app]: {{site.codelabs}}/codelabs/flutter-webview
 [Build voice bots for Android with Dialogflow and Flutter]: {{site.codelabs}}/codelabs/dialogflow-flutter
-[Build voice bots for mobile with Dialogflow and Flutter]: {{yt-watch}}?v=O7JfSF3CJ84
+[Build voice bots for mobile with Dialogflow and Flutter]: {{site.yt.watch}}?v=O7JfSF3CJ84
 [Introduction to Flame with Flutter]: {{site.codelabs}}/codelabs/flutter-flame-brick-breaker
 [Using FFI in a Flutter plugin]: {{site.codelabs}}/codelabs/flutter-ffigen
 [Create haikus about Google products with the PaLM API and Flutter]: {{site.codelabs}}/haiku-generator

--- a/src/cookbook/design/fonts.md
+++ b/src/cookbook/design/fonts.md
@@ -3,8 +3,6 @@ title: Use a custom font
 description: How to use custom fonts.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="cookbook/design/fonts/"?>
 
 {{site.alert.secondary}}
@@ -102,7 +100,7 @@ Choose the typeface or font family that meets the design needs of your app.
   To learn how to get direct access to over 1,000 open-sourced font families,
   check out the [google_fonts][] package.
 
-  <iframe class="full-width" src="{{yt-embed}}/8Vzv2CdbEY0" title="Learn about the google_fonts Flutter Package" {{yt-set}}></iframe>
+  <iframe class="full-width" src="{{site.yt.embed}}/8Vzv2CdbEY0" title="Learn about the google_fonts Flutter Package" {{site.yt.set}}></iframe>
 
   To learn about another approach to using custom fonts that allows you to
   re-use one font over multiple projects,

--- a/src/cookbook/design/snackbars.md
+++ b/src/cookbook/design/snackbars.md
@@ -6,8 +6,6 @@ js:
     url: https://old-dartpad-3ce3f.web.app/inject_embed.dart.js
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="cookbook/design/snackbars/"?>
 
 It can be useful to briefly inform your users when certain actions
@@ -66,7 +64,7 @@ ScaffoldMessenger.of(context).showSnackBar(snackBar);
 {{site.alert.note}}
   To learn more, watch this short Widget of the Week video on the ScaffoldMessenger widget:
 
-  <iframe class="full-width" src="{{yt-embed}}/lytQi-slT5Y" title="Learn about the ScaffoldMessenger Flutter Widget" {{yt-set}}></iframe>
+  <iframe class="full-width" src="{{site.yt.embed}}/lytQi-slT5Y" title="Learn about the ScaffoldMessenger Flutter Widget" {{site.yt.set}}></iframe>
 {{site.alert.end}}
 
 ## 3. Provide an optional action

--- a/src/cookbook/design/themes.md
+++ b/src/cookbook/design/themes.md
@@ -7,8 +7,6 @@ js:
     url: https://old-dartpad-3ce3f.web.app/inject_embed.dart.js
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="cookbook/design/themes"?>
 
 {{site.alert.note}}
@@ -185,7 +183,7 @@ Theme(
 
 To learn more, watch this short Widget of the Week video on the `Theme` widget:
 
-<iframe class="full-width" src="{{yt-embed}}/oTvQDJOBXmM" title="Learn about the Theme Flutter Widget" {{yt-set}}></iframe>
+<iframe class="full-width" src="{{site.yt.embed}}/oTvQDJOBXmM" title="Learn about the Theme Flutter Widget" {{site.yt.set}}></iframe>
 
 ## Try an interactive example
 

--- a/src/cookbook/effects/download-button.md
+++ b/src/cookbook/effects/download-button.md
@@ -6,8 +6,6 @@ js:
     url: https://old-dartpad-3ce3f.web.app/inject_embed.dart.js
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="cookbook/effects/download_button"?>
 
 Apps are filled with buttons that execute long-running behaviors.
@@ -125,7 +123,7 @@ that follow. Instead of creating a function to return a widget,
 like `Widget _buildSomething() {}`, always prefer creating a
 `StatelessWidget` or a `StatefulWidget` which is more performant. More
 considerations on this can be found in the [documentation]({{site.api}}/flutter/widgets/StatelessWidget-class.html)
-or in a dedicated video in the Flutter [YouTube channel]({{yt-watch}}?v=IOyq-eTRhvo).
+or in a dedicated video in the Flutter [YouTube channel]({{site.yt.watch}}?v=IOyq-eTRhvo).
 
 For now, the `AnimatedContainer` child is just a `SizedBox` because we will come back at it in another step.
 

--- a/src/cookbook/effects/parallax-scrolling.md
+++ b/src/cookbook/effects/parallax-scrolling.md
@@ -6,8 +6,6 @@ js:
     url: https://old-dartpad-3ce3f.web.app/inject_embed.dart.js
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="cookbook/effects/parallax_scrolling"?>
 
 When you scroll a list of cards (containing images,
@@ -218,7 +216,7 @@ to reposition your child widgets however you want.
 {{site.alert.note}}
   To learn more, watch this short Widget of the Week video on the Flow widget:
 
-  <iframe class="full-width" src="{{yt-embed}}/NG6pvXpnIso" title="Learn about the Flow Flutter Widget" {{yt-set}}></iframe>
+  <iframe class="full-width" src="{{site.yt.embed}}/NG6pvXpnIso" title="Learn about the Flow Flutter Widget" {{site.yt.set}}></iframe>
 {{site.alert.end}}
 
 {{site.alert.note}}

--- a/src/cookbook/games/firestore-multiplayer.md
+++ b/src/cookbook/games/firestore-multiplayer.md
@@ -5,8 +5,6 @@ description: >
   in your game.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="cookbook/games/firestore_multiplayer"?>
 
 Multiplayer games need a way to synchronize game states between players.
@@ -97,7 +95,7 @@ so every player sees the same state.
 If you want a quick, 15-minute primer on Cloud Firestore,
 check out the following video:
 
-<iframe width="560" height="315" src="{{yt-embed}}/v_hR4K4auoQ" title="What is a NoSQL Database? Learn about Cloud Firestore" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/v_hR4K4auoQ" title="What is a NoSQL Database? Learn about Cloud Firestore" {{site.yt.set}}></iframe>
 
 To add Firestore to your Flutter project,
 follow the first two steps of the

--- a/src/cookbook/gestures/handling-taps.md
+++ b/src/cookbook/gestures/handling-taps.md
@@ -6,8 +6,6 @@ js:
     url: https://old-dartpad-3ce3f.web.app/inject_embed.dart.js
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="cookbook/gestures/handling_taps/"?>
 
 You not only want to display information to users,
@@ -18,7 +16,7 @@ to fundamental actions, such as tapping and dragging.
 {{site.alert.note}}
   To learn more, watch this short Widget of the Week video on the GestureDetector widget:
 
-  <iframe class="full-width" src="{{yt-embed}}/WhVXkCFPmK4" title="Learn about the GestureDetector Flutter Widget" {{yt-set}}></iframe>
+  <iframe class="full-width" src="{{site.yt.embed}}/WhVXkCFPmK4" title="Learn about the GestureDetector Flutter Widget" {{site.yt.set}}></iframe>
 {{site.alert.end}}
 
 This recipe shows how to make a custom button that shows

--- a/src/cookbook/persistence/key-value.md
+++ b/src/cookbook/persistence/key-value.md
@@ -4,8 +4,6 @@ description: >-
   Learn how to use the shared_preferences package to store key-value data.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="cookbook/persistence/key_value/"?>
 
 If you have a relatively small collection of key-values
@@ -27,7 +25,7 @@ This recipe uses the following steps:
   To learn more, watch this short Package of the Week video
   on the `shared_preferences` package:
 
-  <iframe class="full-width" src="{{yt-embed}}/sa_U0jffQII" title="Learn about the shared_preferences Flutter package" {{yt-set}}></iframe>
+  <iframe class="full-width" src="{{site.yt.embed}}/sa_U0jffQII" title="Learn about the shared_preferences Flutter package" {{site.yt.set}}></iframe>
 {{site.alert.end}}
 
 ## 1. Add the dependency

--- a/src/cookbook/persistence/reading-writing-files.md
+++ b/src/cookbook/persistence/reading-writing-files.md
@@ -3,8 +3,6 @@ title: Read and write files
 description: How to read from and write to files on disk.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="cookbook/persistence/reading_writing_files/"?>
 
 In some cases, you need to read and write files to disk.
@@ -24,7 +22,7 @@ This recipe uses the following steps:
 To learn more, watch this Package of the Week video
 on the `path_provider` package:
 
-<iframe class="full-width" src="{{yt-embed}}/Ci4t-NkOY3I" title="Learn about the path_provider Flutter Package" {{yt-set}}></iframe>
+<iframe class="full-width" src="{{site.yt.embed}}/Ci4t-NkOY3I" title="Learn about the path_provider Flutter Package" {{site.yt.set}}></iframe>
 
 {{site.alert.note}}
   This recipe doesn't work with web apps at this time.

--- a/src/dash/index.md
+++ b/src/dash/index.md
@@ -3,8 +3,6 @@ title: Who is Dash?
 description: Learn more about the Flutter and Dart mascot, Dash.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 This is Dash:
 
 ![Dash by herself]({{site.url}}/assets/images/dash/Dash.png){:width="50%"}<br>
@@ -87,7 +85,7 @@ manufacturers who returned the prototypes some weeks later.
 ![The first Dash prototypes]({{site.url}}/assets/images/dash/dash-prototypes.jpg){:width="35%"} ![The first Dash prototypes]({{site.url}}/assets/images/dash/dash-prototypes2.jpg){:width="35%"}<br>
 
 Introducing Dash at the January 2018 Dart Conference.
-<iframe width="541" height="350" src="{{yt-embed}}/R5vIUjRZaZA" title="Introducing Dash at the January 2018 Dart Conference" {{yt-set}}></iframe>
+<iframe width="541" height="350" src="{{site.yt.embed}}/R5vIUjRZaZA" title="Introducing Dash at the January 2018 Dart Conference" {{site.yt.set}}></iframe>
 
 While the manufacturing process was proceeding,
 Shams chose a name for the plushy: Dash,
@@ -136,7 +134,7 @@ Dash 2.0 and 2.1
   first appearance at the [Flutter Interact][] event
   in Brooklyn, New York, on December 11, 2019.
   
-  <iframe width="560" height="315" src="{{yt-embed}}/EgBMGDtHZhE" title="Watch the Flutter Interact 2019 highlights" {{yt-set}}></iframe>
+  <iframe width="560" height="315" src="{{site.yt.embed}}/EgBMGDtHZhE" title="Watch the Flutter Interact 2019 highlights" {{site.yt.set}}></iframe>
   
 * We also have a Dash puppet that Shams made from
   one of the first plushies.
@@ -147,11 +145,11 @@ Dash 2.0 and 2.1
   voiced by Emily Fortuna, one of the early (and much loved)
   Flutter Developer Advocates.
   
-  <iframe width="560" height="315" src="{{yt-embed}}/oyy_1CjNdBU" title="Building DashCast, a Flutter-based podcast app" {{yt-set}}></iframe>
-  <iframe width="560" height="315" src="{{yt-embed}}/dsiLVNDJ3t0" title="Revisiting DashCast, a Flutter-based podcast app" {{yt-set}}></iframe>
+  <iframe width="560" height="315" src="{{site.yt.embed}}/oyy_1CjNdBU" title="Building DashCast, a Flutter-based podcast app" {{site.yt.set}}></iframe>
+  <iframe width="560" height="315" src="{{site.yt.embed}}/dsiLVNDJ3t0" title="Revisiting DashCast, a Flutter-based podcast app" {{site.yt.set}}></iframe>
 
 <br>
 !["Born to Hot Reload" jacket]({{site.url}}/assets/images/dash/ShamsDashJacket.png){:width="35%"}<br>
 
-[Flutter Interact]: {{yt-playlist}}PLjxrf2q8roU0o0wKRJTjyN0pSUA6TI8lg
+[Flutter Interact]: {{site.yt.playlist}}PLjxrf2q8roU0o0wKRJTjyN0pSUA6TI8lg
 [Instagram account]: https://www.instagram.com/dash_the_dartlang_plushy/

--- a/src/data-and-backend/firebase.md
+++ b/src/data-and-backend/firebase.md
@@ -3,8 +3,6 @@ title: Firebase
 description: How to use Firebase and Firestore with Flutter.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 ## Introduction
 
 Firebase is a Backend-as-a-Service (BaaS) app development platform
@@ -52,8 +50,8 @@ The Flutter community created the following useful resources.
 [codelab1]: {{site.codelabs}}/codelabs/firebase-get-to-know-flutter
 [Firebase plugins]: {{site.firebase}}/docs/flutter/setup#available-plugins
 [started]: {{site.firebase}}/docs/flutter/setup
-[video]: {{yt-watch}}/DqJ_KjFzL9I&t#38s
-[video2]: {{yt-watch}}/OlcYP6UXlm8
-[video3]: {{yt-watch}}/u_Lyx8KJWpg
-[video4]: {{yt-watch}}/13-jNF984C0
-[workshop]: {{yt-watch}}/4wunbF29Kkg
+[video]: {{site.yt.watch}}/DqJ_KjFzL9I&t#38s
+[video2]: {{site.yt.watch}}/OlcYP6UXlm8
+[video3]: {{site.yt.watch}}/u_Lyx8KJWpg
+[video4]: {{site.yt.watch}}/13-jNF984C0
+[workshop]: {{site.yt.watch}}/4wunbF29Kkg

--- a/src/data-and-backend/state-mgmt/options.md
+++ b/src/data-and-backend/state-mgmt/options.md
@@ -6,8 +6,6 @@ prev:
   path: /development/data-and-backend/state-mgmt/simple
 ---
 
-{% include docs/yt_shims.liquid %}
-
 State management is a complex topic.
 If you feel that some of your questions haven't been answered,
 or that the approach described on these pages
@@ -30,7 +28,7 @@ Things to review before selecting an approach.
 
 [Flutter Architecture Samples]: https://fluttersamples.com/
 [Introduction to state management]: {{site.url}}/data-and-backend/state-mgmt/intro
-[Pragmatic State Management in Flutter]: {{yt-watch}}?v=d_m5csmrf7I
+[Pragmatic State Management in Flutter]: {{site.yt.watch}}?v=d_m5csmrf7I
 
 ## Provider
 
@@ -70,7 +68,7 @@ use under the hood.
 The following instructor-led video workshop covers how to
 use `InheritedWidget`:
 
-<iframe width="560" height="315" src="{{yt-embed}}/LFcGPS6cGrY" title="How to manage application states using inherited widgets" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/LFcGPS6cGrY" title="How to manage application states using inherited widgets" {{site.yt.set}}></iframe>
 
 Other useful docs include:
 
@@ -112,10 +110,10 @@ A state container approach familiar to many web developers.
 * [Flutter_Redux_Gen - VS Code Plugin to generate boiler plate code][], by Balamurugan Muthusamy (BalaDhruv)
 
 [Accompanying article on Medium]: {{site.flutter-medium}}/animation-management-with-flutter-and-flux-redux-94729e6585fa
-[Animation Management with Redux and Flutter]: {{yt-watch}}?v=9ZkLtr0Fbgk
+[Animation Management with Redux and Flutter]: {{site.yt.watch}}?v=9ZkLtr0Fbgk
 [Async Redux–Redux without boilerplate. Allows for both sync and async reducers]: {{site.pub}}/packages/async_redux
 [Building a (large) Flutter app with Redux]: https://hillelcoren.com/2018/06/01/building-a-large-flutter-app-with-redux/
-[Building a TODO application (CRUD) in Flutter with Redux&mdash;Part 1]: {{yt-watch}}?v=Wj216eSBBWs
+[Building a TODO application (CRUD) in Flutter with Redux&mdash;Part 1]: {{site.yt.watch}}?v=Wj216eSBBWs
 [Fish-Redux–An assembled flutter application framework based on Redux]: {{site.github}}/alibaba/fish-redux/
 [Flutter Redux Thunk, an example]: {{site.medium}}/flutterpub/flutter-redux-thunk-27c2f2b80a3b
 [Flutter meets Redux: The Redux way of managing Flutter applications state]: {{site.medium}}/@thisisamir98/flutter-meets-redux-the-redux-way-of-managing-flutter-applications-state-f60ef693b509
@@ -172,7 +170,7 @@ doesn't need a `BuildContext`.
 {{site.alert.note}}
   To learn more, watch this short Package of the Week video on the GetIt package:
 
-  <iframe class="full-width" src="{{yt-embed}}/f9XQD5mf6FY" title="Learn about the GetIt Flutter Package" {{yt-set}}></iframe>
+  <iframe class="full-width" src="{{site.yt.embed}}/f9XQD5mf6FY" title="Learn about the GetIt Flutter Package" {{site.yt.set}}></iframe>
 {{site.alert.end}}
 
 [Flutter state management for minimalists]: {{site.medium}}/flutter-community/flutter-state-management-for-minimalists-4c71a2f2f0c1?sk=6f9cedfb550ca9cc7f88317e2e7055a0
@@ -188,7 +186,7 @@ A popular library based on observables and reactions.
 * [Getting started with MobX.dart][]
 * [Flutter: State Management with Mobx][], a video by Paul Halliday
 
-[Flutter: State Management with Mobx]: {{yt-watch}}?v=p-MUBLOEkCs
+[Flutter: State Management with Mobx]: {{site.yt.watch}}?v=p-MUBLOEkCs
 [Getting started with MobX.dart]: https://mobx.netlify.com/getting-started
 [MobX.dart, Hassle free state-management for your Dart and Flutter apps]: {{site.github}}/mobxjs/mobx.dart
 
@@ -261,7 +259,7 @@ For more information, refer to the following resources:
 [Flutter Triple package]: {{site.pub-pkg}}/flutter_triple
 [Segmented State pattern]: https://triple.flutterando.com.br/docs/intro/overview#-segmented-state-pattern-ssp
 [Triple Pattern: A new pattern for state management in Flutter]: https://blog.flutterando.com.br/triple-pattern-um-novo-padr%C3%A3o-para-ger%C3%AAncia-de-estado-no-flutter-2e693a0f4c3e
-[VIDEO: Flutter Triple Pattern by Kevlin Ossada]: {{yt-watch}}?v=dXc3tR15AoA
+[VIDEO: Flutter Triple Pattern by Kevlin Ossada]: {{site.yt.watch}}?v=dXc3tR15AoA
 
 ## solidart
 

--- a/src/deployment/ios.md
+++ b/src/deployment/ios.md
@@ -4,8 +4,6 @@ description: How to release a Flutter app to the App Store.
 short-title: iOS
 ---
 
-{% include docs/yt_shims.liquid %}
-
 This guide provides a step-by-step walkthrough of releasing a
 Flutter app to the [App Store][appstore] and [TestFlight][].
 
@@ -26,9 +24,9 @@ You can read more about the various membership options in Apple's
 
 For those who prefer video over text,
 the following video covers the same material as this guide.
-<iframe width="560" height="315" src="{{yt-embed}}/iE2bpP56QKc?si=tHqWYKNTN1H8H9mC" title="Release an iOS app with Flutter in 7 steps" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/iE2bpP56QKc?si=tHqWYKNTN1H8H9mC" title="Release an iOS app with Flutter in 7 steps" {{site.yt.set}}></iframe>
 
-[Release an iOS app with Flutter in 7 steps]({{yt-watch}}?v=iE2bpP56QKc)
+[Release an iOS app with Flutter in 7 steps]({{site.yt.watch}}?v=iE2bpP56QKc)
 
 ## Register your app on App Store Connect
 

--- a/src/get-started/codelab.md
+++ b/src/get-started/codelab.md
@@ -11,8 +11,6 @@ next:
 toc: false
 ---
 
-{% include docs/yt_shims.liquid %}
-
 You are now ready to start the "First Flutter app" codelab.
 In about an hour and a half,
 you will learn the basics of Flutter
@@ -47,4 +45,4 @@ that works on mobile, desktop, and web.
 If you prefer an instructor-led version of this codelab,
 check out the following workshop:
 
-<iframe width="560" height="315" src="{{yt-embed}}/8sAyPDLorek" title="Learn how to build your first Flutter app" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/8sAyPDLorek" title="Learn how to build your first Flutter app" {{site.yt.set}}></iframe>

--- a/src/get-started/flutter-for/swiftui-devs.md
+++ b/src/get-started/flutter-for/swiftui-devs.md
@@ -3,8 +3,6 @@ title: Flutter for SwiftUI Developers
 description: Learn how to apply SwiftUI developer knowledge when building Flutter apps.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="get-started/flutter-for/ios_devs"?>
 
 {% assign sample_path = "blob/main/examples/get-started/flutter-for/ios_devs" %}
@@ -50,7 +48,7 @@ You can test full working examples on DartPad or view them on GitHub.
 As an introduction, watch the following video.
 It outlines how Flutter works on iOS and how to use Flutter to build iOS apps.
 
-<iframe class="full-width" src="{{yt-embed}}/ceMsPBbcEGg" title="Learn how to develop with Flutter as an iOS developer" {{yt-set}}></iframe>
+<iframe class="full-width" src="{{site.yt.embed}}/ceMsPBbcEGg" title="Learn how to develop with Flutter as an iOS developer" {{site.yt.set}}></iframe>
 
 Flutter and SwiftUI code describes how the UI looks and works.
 Developers call this type of code a _declarative framework_.
@@ -166,7 +164,7 @@ your Flutter app can use many different design systems:
 - Your own custom widgets
 - [Cupertino widgets][] that follow Apple's Human Interface Guidelines
 
-<iframe width="560" height="315" src="{{yt-embed}}/3PdUaidHc-E?rel=0" title="Learn about the Cupertino Flutter Package" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/3PdUaidHc-E?rel=0" title="Learn about the Cupertino Flutter Package" {{site.yt.set}}></iframe>
 
 If you're looking for a great reference app that features a
 custom design system, check out [Wonderous][].

--- a/src/get-started/flutter-for/uikit-devs.md
+++ b/src/get-started/flutter-for/uikit-devs.md
@@ -3,8 +3,6 @@ title: Flutter for UIKit developers
 description: Learn how to apply iOS and UIKit developer knowledge when building Flutter apps.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="get-started/flutter-for/ios_devs"?>
 
 iOS developers with experience using UIKit
@@ -47,7 +45,7 @@ Jump around and find questions that address your most relevant needs.
 As an introduction, watch the following video.
 It outlines how Flutter works on iOS and how to use Flutter to build iOS apps.
 
-<iframe class="full-width" src="{{yt-embed}}/ceMsPBbcEGg" title="Learn how to develop with Flutter as an iOS developer" {{yt-set}}></iframe>
+<iframe class="full-width" src="{{site.yt.embed}}/ceMsPBbcEGg" title="Learn how to develop with Flutter as an iOS developer" {{site.yt.set}}></iframe>
 
 ### Views vs. Widgets
 

--- a/src/index.md
+++ b/src/index.md
@@ -4,8 +4,6 @@ short-title: Docs
 description: Get started with Flutter. Widgets, examples, updates, and API docs to help you write your first Flutter app.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 {% for card in site.data.docs_cards -%}
   {% capture index0Modulo3 -%}{{ forloop.index0 | modulo:3 }}{% endcapture -%}
   {% capture indexModulo3 -%}{{ forloop.index | modulo:3 }}{% endcapture -%}
@@ -81,24 +79,24 @@ widgets in [What is State?][]
 <div class="card-deck card-deck--responsive">
     <div class="video-card">
         <div class="card-body">
-            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{yt-embed}}/xWV71C2kp38" title="Create your first Flutter app" {{yt-set}}></iframe>
+            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{site.yt.embed}}/xWV71C2kp38" title="Create your first Flutter app" {{site.yt.set}}></iframe>
         </div>
     </div>
     <div class="video-card">
         <div class="card-body">
-            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{yt-embed}}/QlwiL_yLh6E" title="What is state?" {{yt-set}}></iframe>
+            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{site.yt.embed}}/QlwiL_yLh6E" title="What is state?" {{site.yt.set}}></iframe>
         </div>
     </div>
 </div>
 
-[first-app]: {{yt-watch}}?v=xWV71C2kp38
-[What is State?]: {{yt-watch}}?v=QlwiL_yLh6E
+[first-app]: {{site.yt.watch}}?v=xWV71C2kp38
+[What is State?]: {{site.yt.watch}}?v=QlwiL_yLh6E
 
 {:.text-center}
 **Only have 60 seconds? Learn how to build and deploy a Flutter App!**
 
 <div style="display: flex; align-items: center; justify-content: center; flex-direction: column;">
-  <iframe style="max-width: 100%" width="560" height="315" src="{{yt-embed}}/ZnufaryH43s" title="Learn how to build and deploy a Flutter app in 60 seconds" {{yt-set}}></iframe>
+  <iframe style="max-width: 100%" width="560" height="315" src="{{site.yt.embed}}/ZnufaryH43s" title="Learn how to build and deploy a Flutter app in 60 seconds" {{site.yt.set}}></iframe>
 </div>
 
 ## Want to skill up?
@@ -111,18 +109,18 @@ using helper methods][standalone-widgets] or
 <div class="card-deck card-deck--responsive">
     <div class="video-card">
         <div class="card-body">
-            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{yt-embed}}/IOyq-eTRhvo" title="Learn the difference between Widgets and Helper Methods" {{yt-set}}></iframe>
+            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{site.yt.embed}}/IOyq-eTRhvo" title="Learn the difference between Widgets and Helper Methods" {{site.yt.set}}></iframe>
         </div>
     </div>
     <div class="video-card">
         <div class="card-body">
-            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{yt-embed}}/rIaaH87z1-g" title="Learn how to demystify BuildContext" {{yt-set}}></iframe>
+            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{site.yt.embed}}/rIaaH87z1-g" title="Learn how to demystify BuildContext" {{site.yt.set}}></iframe>
         </div>
     </div>
 </div>
 
-[standalone-widgets]: {{yt-watch}}?v=IOyq-eTRhvo
-[buildcontext]: {{yt-watch}}?v=rIaaH87z1-g
+[standalone-widgets]: {{site.yt.watch}}?v=IOyq-eTRhvo
+[buildcontext]: {{site.yt.watch}}?v=rIaaH87z1-g
 
 To learn about all of the Flutter video series,
 see our [videos][] page.

--- a/src/packages-and-plugins/using-packages.md
+++ b/src/packages-and-plugins/using-packages.md
@@ -3,8 +3,6 @@ title: Using packages
 description: How to use packages in your Flutter app.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="development/plugin_api_migration"?>
 
 Flutter supports using shared packages contributed by other developers
@@ -36,7 +34,7 @@ an app without having to develop everything from scratch.
     For example, a plugin might provide Flutter apps
     with the ability to use a device's camera.
 
-  <iframe width="560" height="315" src="{{yt-embed}}/Y9WifT8aN6o?start=1" title="Learn the difference between a package and a plugin" {{yt-set}}></iframe>
+  <iframe width="560" height="315" src="{{site.yt.embed}}/Y9WifT8aN6o?start=1" title="Learn the difference between a package and a plugin" {{site.yt.set}}></iframe>
 {{site.alert.end}}
 
 Existing packages enable many use cases—for example,

--- a/src/perf/best-practices.md
+++ b/src/perf/best-practices.md
@@ -4,8 +4,6 @@ short-title: Best practices
 description: How to ensure that your Flutter app is performant.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 {% include docs/performance.md %}
 
 Generally, Flutter applications are performant by default,
@@ -104,7 +102,7 @@ For more information, check out:
 [`StatefulWidget`]: {{site.api}}/flutter/widgets/StatefulWidget-class.html
 [`StatelessWidget`]: {{site.api}}/flutter/widgets/StatelessWidget-class.html
 [`TransitionBuilder`]: {{site.api}}/flutter/widgets/TransitionBuilder.html
-[Widgets vs helper methods]: {{yt-watch}}?v=IOyq-eTRhvo
+[Widgets vs helper methods]: {{site.yt.watch}}?v=IOyq-eTRhvo
 
 ---
 
@@ -372,7 +370,7 @@ If you are wondering why 60fps leads to a smooth visual experience,
 check out the video [Why 60fps?][]
 
 [profile mode]: {{site.url}}/testing/build-modes#profile
-[Why 60fps?]: {{yt-watch}}?v=CaMTIgxCSqU
+[Why 60fps?]: {{site.yt.watch}}?v=CaMTIgxCSqU
 
 ## Pitfalls
 

--- a/src/perf/impeller.md
+++ b/src/perf/impeller.md
@@ -3,8 +3,6 @@ title: Impeller rendering engine
 description: What is Impeller and how to enable it?
 ---
 
-{% include docs/yt_shims.liquid %}
-
 ## What is Impeller?
 
 Impeller provides a new rendering runtime for Flutter.
@@ -19,8 +17,8 @@ at Engine build time so they don't compile at runtime.
 For a video introduction to Impeller, check out the following
 talk from Google I/O 2023.
 
-<iframe width="560" height="315" src="{{yt-embed}}/vd5NqS01rlA" title="YouTube video player - Introducing Impeller - Flutter's new rendering engine" {{yt-set}}></iframe>
-[Introducing Impeller - Flutter's new rendering engine]({{yt-watch}}?v=vd5NqS01rlA)
+<iframe width="560" height="315" src="{{site.yt.embed}}/vd5NqS01rlA" title="YouTube video player - Introducing Impeller - Flutter's new rendering engine" {{site.yt.set}}></iframe>
+[Introducing Impeller - Flutter's new rendering engine]({{site.yt.watch}}?v=vd5NqS01rlA)
 
 Impeller has the following objectives:
 

--- a/src/perf/index.md
+++ b/src/perf/index.md
@@ -3,10 +3,8 @@ title: Performance
 description: Evaluating the performance of your app from several angles.
 ---
 
-{% include docs/yt_shims.liquid %}
-
-<iframe width="560" height="315" src="{{yt-embed}}/PKGguGUwSYE" title="Learn tips to boost Flutter's performance" {{yt-set}}></iframe>
-[Flutter performance basics]({{yt-watch}}?v=PKGguGUwSYE)
+<iframe width="560" height="315" src="{{site.yt.embed}}/PKGguGUwSYE" title="Learn tips to boost Flutter's performance" {{site.yt.set}}></iframe>
+[Flutter performance basics]({{site.yt.watch}}?v=PKGguGUwSYE)
 
 {{site.alert.note}}
   If your app has a performance issue and you are

--- a/src/perf/isolates.md
+++ b/src/perf/isolates.md
@@ -3,8 +3,6 @@ title: Concurrency and isolates
 description: Multithreading in Flutter using Dart isolates.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="development/concurrency/isolates/"?>
 
 All Dart code runs in [isolates]({{site.dart-site}}/language/concurrency),
@@ -66,7 +64,7 @@ documentation.
 
 [concurrency page]: {{site.dart-site}}/language/concurrency
 
-<iframe width="560" height="315" src="{{yt-embed}}/vl_AaCgudcY" title="Learn about Isolates and Loop Events in Flutter" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/vl_AaCgudcY" title="Learn about Isolates and Loop Events in Flutter" {{site.yt.set}}></iframe>
 
 ## Common use cases for isolates
 

--- a/src/perf/ui-performance.md
+++ b/src/perf/ui-performance.md
@@ -4,8 +4,6 @@ subtitle: Where to look when your Flutter app drops frames in the UI.
 description: Diagnosing UI performance issues in Flutter.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 {% include docs/performance.md %}
 
 {{site.alert.secondary}}
@@ -453,7 +451,7 @@ Flutter's tools and debugging in Flutter:
 [devtools]: {{site.url}}/tools/devtools
 [Flutter API]: {{site.api}}
 [Flutter inspector]: {{site.url}}/tools/devtools/inspector
-[Flutter inspector talk]: {{yt-watch}}?v=JIcmJNT9DNI
+[Flutter inspector talk]: {{site.yt.watch}}?v=JIcmJNT9DNI
 [`PerformanceOverlay`]: {{site.api}}/flutter/widgets/PerformanceOverlay-class.html
-[video]: {{yt-watch}}?v=5F-6n_2XWR8
+[video]: {{site.yt.watch}}?v=5F-6n_2XWR8
 [Why Flutter Uses Dart]: https://hackernoon.com/why-flutter-uses-dart-dd635a054ebf

--- a/src/platform-integration/web/index.md
+++ b/src/platform-integration/web/index.md
@@ -4,8 +4,6 @@ short-title: Web
 description: Details of how Flutter supports the creation of web experiences.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 Flutter's web support delivers the same experiences on the web as on mobile.
 Building on the portability of Dart, the power of the web platform and the
 flexibility of the Flutter framework, you can now build apps for iOS, Android,
@@ -56,7 +54,7 @@ experiences into these websites.
 For a glimpse into how to migrate your mobile app to web, see
 the following video:
 
-<iframe width="560" height="315" src="{{yt-embed}}/HAstl_NkXl0" title="Learn how to move from a Mobile App to a Web App using Flutter" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/HAstl_NkXl0" title="Learn how to move from a Mobile App to a Web App using Flutter" {{site.yt.set}}></iframe>
 
 <a id="web"></a>
 

--- a/src/reference/widgets.md
+++ b/src/reference/widgets.md
@@ -5,8 +5,6 @@ short-title: Widgets
 show_breadcrumbs: false
 ---
 
-{% include docs/yt_shims.liquid %}
-
 {% assign sorted = site.data.catalog.widgets | sort:'name' -%}
 
 This is an alphabetical list of nearly every widget that is bundled with
@@ -17,8 +15,8 @@ on the [Flutter YouTube channel]({{site.social.youtube}}). Each short
 episode features a different Flutter widget. For more video series, see
 our [videos]({{site.url}}/resources/videos) page.
 
-<iframe width="560" height="315" src="{{yt-embed}}/b_sQ9bMltGU" title="Introducing the Flutter Widget of the Week" {{yt-set}}></iframe>
-[Widget of the Week playlist]({{yt-playlist}}PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG)
+<iframe width="560" height="315" src="{{site.yt.embed}}/b_sQ9bMltGU" title="Introducing the Flutter Widget of the Week" {{site.yt.set}}></iframe>
+[Widget of the Week playlist]({{site.yt.playlist}}PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG)
 
 <div class="card-deck card-deck--responsive">
 {% for comp in sorted %}

--- a/src/release/archive-whats-new.md
+++ b/src/release/archive-whats-new.md
@@ -5,8 +5,6 @@ description: >-
   and related documentation sites.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 This page contains of archived announcements of
 what's new on the Flutter website and blog.
 For information on the latest releases,
@@ -617,7 +615,7 @@ For more information, see
 and [What's new in Flutter 2.10][],
 free articles on Medium.
 
-<iframe width="560" height="315" src="{{yt-embed}}/g-0B_Vfc9qM" title="Learn how Flutter can develop Windows native apps" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/g-0B_Vfc9qM" title="Learn how Flutter can develop Windows native apps" {{site.yt.set}}></iframe>
 
 [Announcing Flutter for Windows]: {{site.flutter-medium}}/announcing-flutter-for-windows-6979d0d01fed
 [What's new in Flutter 2.10]: {{site.flutter-medium}}/whats-new-in-flutter-2-10-5aafb0314b12
@@ -750,21 +748,21 @@ publication since the last stable release:
 [Announcing Flutter 2.2]: {{site.flutter-medium}}/announcing-flutter-2-2-at-google-i-o-2021-92f0fcbd7ef9
 [Building adaptive apps]: {{site.url}}/ui/layout/responsive/building-adaptive-apps
 [Build Voice Bots for Android with Dialogflow Essentials & Flutter]: {{site.codelabs}}/codelabs/dialogflow-flutter
-[Building your first Flutter app]: {{yt-watch}}?v=Z6KZ3cTGBWw
+[Building your first Flutter app]: {{site.yt.watch}}?v=Z6KZ3cTGBWw
 [DartPad Sharing Guide (using a Gist file)]: {{site.github}}/dart-lang/dart-pad/wiki/Sharing-Guide
 [DartPad Workshop Authoring Guide]: {{site.github}}/dart-lang/dart-pad/wiki/Workshop-Authoring-Guide
 [Deferred components]: {{site.url}}/perf/deferred-components
 [Embedded Support for Flutter]: {{site.url}}/embedded
 [Embedding DartPad in your web page]: {{site.github}}/dart-lang/dart-pad/wiki/Embedding-Guide
-[Firebase for Flutter]: {{yt-watch}}?v=4wunbF29Kkg
-[Flutter and Dialogflow voice bots]: {{yt-watch}}?v=O7JfSF3CJ84
+[Firebase for Flutter]: {{site.yt.watch}}?v=4wunbF29Kkg
+[Flutter and Dialogflow voice bots]: {{site.yt.watch}}?v=O7JfSF3CJ84
 [Get to know Firebase for Flutter]: {{site.firebase}}/codelabs/firebase-get-to-know-flutter#0
 [Google APIs]: {{site.url}}/data-and-backend/google-apis
 [How It's Made: I/O Photo Booth]: {{site.flutter-medium}}/how-its-made-i-o-photo-booth-3b8355d35883
-[Inherited widgets]: {{yt-watch}}?v=LFcGPS6cGrY
+[Inherited widgets]: {{site.yt.watch}}?v=LFcGPS6cGrY
 [Memory view page]: {{site.url}}/tools/devtools/memory
-[Null safety]: {{yt-watch}}?v=HdKwuHQvArY
-[Slivers]: {{yt-watch}}?v=YY-_yrZdjGc
+[Null safety]: {{site.yt.watch}}?v=HdKwuHQvArY
+[Slivers]: {{site.yt.watch}}?v=YY-_yrZdjGc
 [Q1 2021 survey]: {{site.flutter-medium}}/which-factors-affected-users-decisions-to-adopt-flutter-q1-2021-user-survey-results-563e61fc68c9
 [What's New in Flutter 2.2]: {{site.flutter-medium}}/whats-new-in-flutter-2-2-fd00c65e2039
 

--- a/src/release/whats-new.md
+++ b/src/release/whats-new.md
@@ -4,8 +4,6 @@ description: >-
   A list of what's new on docs.flutter.dev and related documentation sites.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 This page contains current and recent announcements
 of what's new on the Flutter website and blog.
 Find past what's new information on the

--- a/src/resources/architectural-overview.md
+++ b/src/resources/architectural-overview.md
@@ -3,8 +3,6 @@ title: Flutter architectural overview
 description: A high-level overview of the architecture of Flutter, including the core principles and concepts that form its design.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="resources/architectural_overview/"?>
 
 This article is intended to provide a high-level overview of the architecture of
@@ -198,7 +196,7 @@ when the application state changes. This model is inspired by
 which includes a rethinking of many traditional design principles.
 
 [faq]: {{site.url}}/resources/faq#what-programming-paradigm-does-flutters-framework-use
-[fb]: {{yt-watch}}?time_continue=2&v=x7cQ3mrcKaY&feature=emb_logo
+[fb]: {{site.yt.watch}}?time_continue=2&v=x7cQ3mrcKaY&feature=emb_logo
 
 In most traditional UI frameworks, the user interface's initial state is
 described once and then separately updated by user code at runtime, in response
@@ -753,7 +751,7 @@ GPU to render it.
 Further details of the composition and rasterization stages of the pipeline are
 beyond the scope of this high-level article, but more information can be found
 [in this talk on the Flutter rendering
-pipeline]({{yt-watch}}?v=UUfXWzp0-DU).
+pipeline]({{site.yt.watch}}?v=UUfXWzp0-DU).
 
 ## Platform embedding
 

--- a/src/resources/courses.md
+++ b/src/resources/courses.md
@@ -3,8 +3,6 @@ title: Online courses
 description: An index of online courses teaching Flutter development.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 Learn how to build Flutter apps with these video courses.
 Before signing up for a course, verify that it includes
 up-to-date information, such as null-safe Dart code.
@@ -26,9 +24,9 @@ To include your course, [submit a PR][]:
 [The Complete 2021 Flutter Development Bootcamp Using Dart]: https://www.appbrewery.co/p/flutter-development-bootcamp-with-dart/
 [Flutter Crash Course]: https://fluttercrashcourse.com/
 [Flutter leicht gemacht 2022 - Zero to Mastery!]: https://www.udemy.com/course/dart-flutter-leicht-gemacht/
-[Flutter Zero to Hero]: {{yt-playlist}}PL1k5oWAuBhgXdw1BbxVGxxWRmkGB1C11l
+[Flutter Zero to Hero]: {{site.yt.playlist}}PL1k5oWAuBhgXdw1BbxVGxxWRmkGB1C11l
 [Flutter Bootcamp]: https://flutterbootcamp.com.br
-[Flutter para iniciantes]: {{yt-playlist}}PLS4cqF1_X2syzBpkoSwtmKoREgnp1MhTn
+[Flutter para iniciantes]: {{site.yt.playlist}}PLS4cqF1_X2syzBpkoSwtmKoREgnp1MhTn
 [Dart & Flutter - Zero to Mastery 2023 + Clean Architecture]: https://www.udemy.com/course/flutter-made-easy-zero-to-mastery/?referralCode=CCBFCD16CC71F359EE3C
 [Dart & Flutter - Zero to Mastery 2023 - Keiko Corp. Food Reviews App]: https://academy.zerotomastery.io/courses/2092303/lectures/47623876
 [Sticky Grouped Headers in Flutter]: https://academy.droidcon.com/course/sticky-grouped-headers-in-flutter

--- a/src/resources/news-toolkit.md
+++ b/src/resources/news-toolkit.md
@@ -3,8 +3,6 @@ title: Flutter News Toolkit
 description: Learn more about creating a newsfeed app in Flutter.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 The Flutter News Toolkit enables you to accelerate
 development of a mobile news app.
 The toolkit assists you in building a customized
@@ -57,5 +55,5 @@ You might also check out:
 
 [toolkit]: https://flutter.github.io/news_toolkit/
 [blog]: {{site.flutter-medium}}/announcing-the-flutter-news-toolkit-180a0d32c012
-[video]: {{yt-watch}}?v=dukRAS-OUMM
+[video]: {{site.yt.watch}}?v=dukRAS-OUMM
 [file an issue]: {{site.repo.flutter}}/issues

--- a/src/resources/videos.md
+++ b/src/resources/videos.md
@@ -4,8 +4,6 @@ description: >
   Available videos on various aspects of developing in Flutter.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 These Flutter videos, produced both internally
 at Google and by the Flutter community,
 might help if you are a visual learner.
@@ -24,11 +22,11 @@ some in different languages.
 Even if you couldn't make it to Nairobi for the in-person
 event, you can enjoy the content created for Flutter Forward!
 
-<iframe width="560" height="315" src="{{yt-embed}}/zKQYGKAe5W8?start=2778" title="Watch the livestream from Flutter Forward in Nairobi Kenya from 2023" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/zKQYGKAe5W8?start=2778" title="Watch the livestream from Flutter Forward in Nairobi Kenya from 2023" {{site.yt.set}}></iframe>
 Flutter Forward livestream<br>
 [Flutter Forward playlist][]
 
-[Flutter Forward playlist]: {{yt-playlist}}PLjxrf2q8roU3LvrdR8Hv_phLrTj0xmjnD
+[Flutter Forward playlist]: {{site.yt.playlist}}PLjxrf2q8roU3LvrdR8Hv_phLrTj0xmjnD
 
 ### Get ready for Flutter Forward
 
@@ -38,11 +36,11 @@ featuring new content and activities leading up to the event.
 This playlist contains these and other pre-event videos relating to
 Flutter Forward.
 
-<iframe width="560" height="315" src="{{yt-embed}}/hpgkrUPRBjc?start=6" title="Watch the videos to prepare you for Flutter Forward 2023" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/hpgkrUPRBjc?start=6" title="Watch the videos to prepare you for Flutter Forward 2023" {{site.yt.set}}></iframe>
 17 Days of Flutter!<br>
 [Get ready for Flutter Forward playlist][]
 
-[Get ready for Flutter Forward playlist]: {{yt-playlist}}PLjxrf2q8roU3PUEaM4yYXqvFMEwOluBNl
+[Get ready for Flutter Forward playlist]: {{site.yt.playlist}}PLjxrf2q8roU3PUEaM4yYXqvFMEwOluBNl
 
 ### Learning to Fly
 
@@ -53,7 +51,7 @@ Flutter Forward.
   game, DoodleDash, using the Flame engine.
 {{site.alert.end}}
 
-[Season 2]: {{yt-watch}}?v=ILTx1Wa33Z0
+[Season 2]: {{site.yt.watch}}?v=ILTx1Wa33Z0
 
 Follow along with Khanh's journey as she learns Flutter.
 From ideation down to the moments of confusion,
@@ -61,11 +59,11 @@ learn alongside her as she asks important questions like:
 "What is the best way to build out a theme? How to approach using fonts?"
 And more!
 
-<iframe width="560" height="315" src="{{yt-embed}}/CkcvVZZEsJE" title="Learn how to build your first Flutter app" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/CkcvVZZEsJE" title="Learn how to build your first Flutter app" {{site.yt.set}}></iframe>
 Building my first Flutter app | Learning to Fly<br>
 [Learning to Fly playlist][]
 
-[Learning to Fly playlist]: {{yt-playlist}}PLjxrf2q8roU3X18pAQWLyCJaa79RpqWnn
+[Learning to Fly playlist]: {{site.yt.playlist}}PLjxrf2q8roU3X18pAQWLyCJaa79RpqWnn
 
 Here are some of the series offered on the
 [flutterdev YouTube channel][].
@@ -82,33 +80,33 @@ and general advice on getting the most out of Flutter.
 In the comments section for this series,
 you can submit suggestions future episodes.
 
-<iframe width="560" height="315" src="{{yt-embed}}/QIW35-vcA2o" title="Watch this series on best practices for Flutter: Decoding Flutter" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/QIW35-vcA2o" title="Watch this series on best practices for Flutter: Decoding Flutter" {{site.yt.set}}></iframe>
 Introducing Decoding Flutter
 [Decoding Flutter playlist][]
 
-[Decoding Flutter playlist]: {{yt-playlist}}PLjxrf2q8roU1fRV40Ec8200rX6OuQkmnl
+[Decoding Flutter playlist]: {{site.yt.playlist}}PLjxrf2q8roU1fRV40Ec8200rX6OuQkmnl
 
 ### Flutter widget of the week
 
 Do you have 60 seconds?
 Each one-minute video highlights a Flutter widget.
 
-<iframe width="560" height="315" src="{{yt-embed}}/b_sQ9bMltGU" title="Watch this series on different Flutter Widgets: Widget of the Week" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/b_sQ9bMltGU" title="Watch this series on different Flutter Widgets: Widget of the Week" {{site.yt.set}}></iframe>
 Introducing widget of the week<br>
 [Flutter widget of the week playlist][]
 
-[Flutter widget of the week playlist]: {{yt-playlist}}PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG
+[Flutter widget of the week playlist]: {{site.yt.playlist}}PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG
 
 ### Flutter package of the week
 
 If you have another minute (or two),
 each of these videos highlights a Flutter package.
 
-<iframe width="560" height="315" src="{{yt-embed}}/QFcFEpFmNJ8" title="Watch this series on different Flutter Packages: Package of the Week" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/QFcFEpFmNJ8" title="Watch this series on different Flutter Packages: Package of the Week" {{site.yt.set}}></iframe>
 `flutter_slidable` package
 [Flutter package of the week playlist][]
 
-[Flutter package of the week playlist]: {{yt-playlist}}PLjxrf2q8roU1quF6ny8oFHJ2gBdrYN_AK
+[Flutter package of the week playlist]: {{site.yt.playlist}}PLjxrf2q8roU1quF6ny8oFHJ2gBdrYN_AK
 
 ### The Boring Flutter show
 
@@ -116,21 +114,21 @@ This series features Flutter programmers coding,
 unscripted and in real time. Mistakes, solutions
 (some of them correct), and snazzy intro music included.
 
-<iframe width="560" height="315" src="{{yt-embed}}/vqPG1tU6-c0" title="Watch this live Flutter coding series: The Boring Show" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/vqPG1tU6-c0" title="Watch this live Flutter coding series: The Boring Show" {{site.yt.set}}></iframe>
 Introducing the Boring Flutter show<br>
 [The Boring Flutter show playlist][]
 
-[The Boring Flutter show playlist]: {{yt-playlist}}PLjxrf2q8roU3ahJVrSgAnPjzkpGmL9Czl
+[The Boring Flutter show playlist]: {{site.yt.playlist}}PLjxrf2q8roU3ahJVrSgAnPjzkpGmL9Czl
 
 ### Flutter at Google I/O 2022
 
 Google I/O 2022 is over, but you can still catch
 the great Flutter content!
 
-<iframe width="560" height="315" src="{{yt-embed}}/w_ezWG1yKQQ" title="Watch highlights about Flutter from Google I/O 2022" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/w_ezWG1yKQQ" title="Watch highlights about Flutter from Google I/O 2022" {{site.yt.set}}></iframe>
 [Flutter at Google I/O playlist][]
 
-[Flutter at Google I/O playlist]: {{yt-playlist}}PLjxrf2q8roU1kHjuHoFGBLCxjy4h2WOcP
+[Flutter at Google I/O playlist]: {{site.yt.playlist}}PLjxrf2q8roU1kHjuHoFGBLCxjy4h2WOcP
 
 ### Flutter Engage 2021
 
@@ -141,40 +139,40 @@ officially launched Flutter 2.
 
 Check out the Flutter Engage 2021 highlights reel.
 
-<iframe width="560" height="315" src="{{yt-embed}}/IdrCyS7EF8M" title="Watch highlights about Flutter from Flutter Engage 2021" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/IdrCyS7EF8M" title="Watch highlights about Flutter from Flutter Engage 2021" {{site.yt.set}}></iframe>
 
 Watch recordings of the sessions on the Flutter YouTube channel.
 
-<iframe width="560" height="315" src="{{yt-embed}}/zSbsIiluixw" title="Watch the Flutter sessions from Flutter Engage 2021" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/zSbsIiluixw" title="Watch the Flutter sessions from Flutter Engage 2021" {{site.yt.set}}></iframe>
 Keynote<br>
 [Flutter Engage 2021 playlist][]
 
 Watch recordings of the sessions offered by the Flutter community.
 
-<iframe width="560" height="315" src="{{yt-embed}}/-_de6IfY2RU" title="Watch the Flutter community sessions from Flutter Engage 2021" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/-_de6IfY2RU" title="Watch the Flutter community sessions from Flutter Engage 2021" {{site.yt.set}}></iframe>
 [Flutter Engage community talks playlist][]
 
-[Flutter Engage 2021 playlist]: {{yt-playlist}}PLjxrf2q8roU21cXt24HLm-ZODXmr4Jw0C
-[Flutter Engage community talks playlist]: {{yt-playlist}}PLjxrf2q8roU1ln3WoiGTUvLr7ZrPPFvXv
+[Flutter Engage 2021 playlist]: {{site.yt.playlist}}PLjxrf2q8roU21cXt24HLm-ZODXmr4Jw0C
+[Flutter Engage community talks playlist]: {{site.yt.playlist}}PLjxrf2q8roU1ln3WoiGTUvLr7ZrPPFvXv
 
 ### Flutter in focus
 
 Five-to-ten minute tutorials (more or less) on using Flutter.
 
-<iframe width="560" height="315" src="{{yt-embed}}/wgTBLj7rMPM" title="Watch this series on Flutter tutorials: Flutter in Focus" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/wgTBLj7rMPM" title="Watch this series on Flutter tutorials: Flutter in Focus" {{site.yt.set}}></iframe>
 Introducing Flutter in focus<br>
 [Flutter in focus playlist][]
 
-[Flutter in focus playlist]: {{yt-playlist}}PLjxrf2q8roU2HdJQDjJzOeO6J3FoFLWr2
+[Flutter in focus playlist]: {{site.yt.playlist}}PLjxrf2q8roU2HdJQDjJzOeO6J3FoFLWr2
 
 ## Conference talks
 
 Here are a some Flutter talks given at various conferences.
 
-<iframe width="560" height="315" src="{{yt-embed}}/d_m5csmrf7I" title="Watch this series on Flutter talks given at other conferences" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/d_m5csmrf7I" title="Watch this series on Flutter talks given at other conferences" {{site.yt.set}}></iframe>
 [Conference talks playlist][]
 
-[Conference talks playlist]: {{yt-playlist}}PLjxrf2q8roU1UJ0OEpANodVMVm1GeE7Ti
+[Conference talks playlist]: {{site.yt.playlist}}PLjxrf2q8roU1UJ0OEpANodVMVm1GeE7Ti
 
 ## Flutter developer stories
 
@@ -182,7 +180,7 @@ Videos showing how various customers, such as Abbey Road Studio, Hamilton,
 and Alibaba, have used Flutter to create beautiful compelling apps with
 millions of downloads.
 
-<iframe width="560" height="315" src="{{yt-embed}}/_ACWeGGBP4E" title="Watch this series on Flutter developer stories" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/_ACWeGGBP4E" title="Watch this series on Flutter developer stories" {{site.yt.set}}></iframe>
 [Flutter developer stories playlist][]
 
-[Flutter developer stories playlist]: {{yt-playlist}}PLjxrf2q8roU33POuWi4bK0zvDpAHK6759
+[Flutter developer stories playlist]: {{site.yt.playlist}}PLjxrf2q8roU33POuWi4bK0zvDpAHK6759

--- a/src/testing/common-errors.md
+++ b/src/testing/common-errors.md
@@ -3,8 +3,6 @@ title: Common Flutter errors
 description: How to recognize and resolve common Flutter framework errors.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="testing/common_errors"?>
 
 ## Introduction
@@ -140,7 +138,7 @@ The resources linked below provide further information about this error.
 * [Understanding constraints][]
 
 [its source code]: {{site.repo.flutter}}/blob/c8e42b47f5ea8b5ff7bf2f2b0a2a8e765f1aa51d/packages/flutter/lib/src/widgets/basic.dart#L5166-L5174
-[flexible-video]: {{yt-watch}}?v=CI7x0mAZiY0
+[flexible-video]: {{site.yt.watch}}?v=CI7x0mAZiY0
 [medium-article]: {{site.flutter-medium}}/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db#738b
 [Understanding constraints]: {{site.url}}/ui/layout/constraints
 
@@ -507,7 +505,7 @@ For more information and to learn how to fix,
 check out the following video on
 [`PrimaryScrollController`][controller-video]:
 
-<iframe width="560" height="315" src="{{yt-embed}}/33_0ABjFJUU" title="Learn about the PrimaryScrollController Flutter Widget" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/33_0ABjFJUU" title="Learn about the PrimaryScrollController Flutter Widget" {{site.yt.set}}></iframe>
 
 [controller-video]: {{site.api}}/flutter/widgets/PrimaryScrollController-class.html
 

--- a/src/tools/devtools/inspector.md
+++ b/src/tools/devtools/inspector.md
@@ -3,8 +3,6 @@ title: Using the Flutter inspector
 description: Learn how to use the Flutter inspector to explore a Flutter app's widget tree.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="../examples/visual_debugging/"?>
 
 {{site.alert.note}}
@@ -98,7 +96,7 @@ Flutter layouts.
 For an overview of what you can do with this tool, see
 the Flutter Explorer video:
 
-<iframe width="560" height="315" src="{{yt-embed}}/Jakrc3Tn_y4" title="Learn about the Layout Explorer in Flutter DevTools" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/Jakrc3Tn_y4" title="Learn about the Layout Explorer in Flutter DevTools" {{site.yt.set}}></iframe>
 
 You might also find the following step-by-step article useful:
 
@@ -573,7 +571,7 @@ using DevTools, check out a guided
 [`Column`]: {{site.api}}/flutter/widgets/Column-class.html
 [common problems when debugging]: {{site.url}}/testing/debugging#common-problems
 [`crossAxisAlignment`]: {{site.api}}/flutter/widgets/Flex/crossAxisAlignment.html
-[DartConf 2018 talk]: {{yt-watch}}?v=JIcmJNT9DNI
+[DartConf 2018 talk]: {{site.yt.watch}}?v=JIcmJNT9DNI
 [debug mode]: {{site.url}}/testing/build-modes#debug
 [`Flex`]: {{site.api}}/flutter/widgets/Flex-class.html
 [flex layouts]: {{site.api}}/flutter/widgets/Flex-class.html

--- a/src/tools/devtools/memory.md
+++ b/src/tools/devtools/memory.md
@@ -3,8 +3,6 @@ title: Using the Memory view
 description: Learn how to use the DevTools memory view.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 The memory view provides insights into details
 of the application's memory allocation and
 tools to detect and debug specific issues.
@@ -383,7 +381,7 @@ The quantities plotted on the y-axis are as follows:
 [DevTools Performance view]: {{site.url}}/tools/devtools/performance
 [Flutter architectural overview]: {{site.url}}/resources/architectural-overview
 [frog]: https://dartfrog.vgv.dev/
-[heroku]: {{yt-watch}}?v=nkTUMVNelXA
+[heroku]: {{site.yt.watch}}?v=nkTUMVNelXA
 
 ### Profile Memory tab
 

--- a/src/tools/devtools/overview.md
+++ b/src/tools/devtools/overview.md
@@ -3,8 +3,6 @@ title: DevTools
 description: How to use the DevTools with Flutter.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 ## What is DevTools?
 
 DevTools is a suite of performance and debugging tools
@@ -15,8 +13,8 @@ for Dart and Flutter.
 For a video introduction to DevTools, check out
 the following deep dive and use case walkthrough:
 
-<iframe width="560" height="315" src="{{yt-embed}}/_EYk-E29edo" title="Dive in to Flutter DevTools" {{yt-set}}></iframe>
-[Dive in to DevTools]({{yt-watch}}?v=_EYk-E29edo)
+<iframe width="560" height="315" src="{{site.yt.embed}}/_EYk-E29edo" title="Dive in to Flutter DevTools" {{site.yt.set}}></iframe>
+[Dive in to DevTools]({{site.yt.watch}}?v=_EYk-E29edo)
 
 ## What can I do with DevTools?
 

--- a/src/tools/devtools/performance.md
+++ b/src/tools/devtools/performance.md
@@ -3,8 +3,6 @@ title: Using the Performance view
 description: Learn how to use the DevTools performance view.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 {{site.alert.note}}
   The DevTools performance view works for Flutter mobile and desktop apps.
   For web apps, Flutter adds timeline events to the
@@ -296,6 +294,6 @@ detect jank using DevTools, check out a guided
 [Reduce shader compilation jank on mobile]: {{site.url}}/perf/shader
 [Import and export]: #import-and-export
 [performance-tutorial]: {{site.medium}}/@fluttergems/mastering-dart-flutter-devtools-performance-view-part-8-of-8-4ae762f91230
-[track-widgets]: {{yt-watch}}/_EYk-E29edo?t=623
-[track-layouts]: {{yt-watch}}/_EYk-E29edo?t=676
-[track-paints]: {{yt-watch}}/_EYk-E29edo?t=748
+[track-widgets]: {{site.yt.watch}}/_EYk-E29edo?t=623
+[track-layouts]: {{site.yt.watch}}/_EYk-E29edo?t=676
+[track-paints]: {{site.yt.watch}}/_EYk-E29edo?t=748

--- a/src/tools/flutter-fix.md
+++ b/src/tools/flutter-fix.md
@@ -3,8 +3,6 @@ title: Flutter fix
 description: Keep your code up to date with the help of the Flutter Fix feature.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 As Flutter continues to evolve, we provide a tool to help you clean up
 deprecated APIs from your codebase. The tool ships as part of Flutter, and
 suggests changes that you might want to make to your code. The tool is available
@@ -87,4 +85,4 @@ on Flutter's Medium publication.
 
 [Deprecation lifetime in Flutter]: {{site.flutter-medium}}/deprecation-lifetime-in-flutter-e4d76ee738ad
 [`dart fix`]: {{site.dart-site}}/tools/dart-fix
-[dart fix Decoding Flutter]: {{yt-watch}}?v=OBIuSrg_Quo
+[dart fix Decoding Flutter]: {{site.yt.watch}}?v=OBIuSrg_Quo

--- a/src/ui/accessibility-and-internationalization/accessibility.md
+++ b/src/ui/accessibility-and-internationalization/accessibility.md
@@ -3,8 +3,6 @@ title: Accessibility
 description: Information on Flutter's accessibility support.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 Ensuring apps are accessible to a broad range of users is an essential
 part of building a high-quality app. Applications that are poorly
 designed create barriers to people of all ages. The [UN Convention on
@@ -129,7 +127,7 @@ navigate around your app.
 To learn how to find and customize Android's
 accessibility features, view the following video.
 
-<iframe width="560" height="315" src="{{yt-embed}}/FQyj_XTl01w" title="Learn about the accessibility features on the Google Pixel" {{yt-set}}>
+<iframe width="560" height="315" src="{{site.yt.embed}}/FQyj_XTl01w" title="Learn about the accessibility features on the Google Pixel" {{site.yt.set}}>
 </iframe>
 
 </div>
@@ -142,7 +140,7 @@ accessibility features, view the following video.
 To learn how to find and customize iOS
 accessibility features, view the following video.
 
-<iframe width="560" height="315" src="{{yt-embed}}/qDm7GiKra28" title="Learn how to navigate your iPhone or iPad with VoiceOver" {{yt-set}}>
+<iframe width="560" height="315" src="{{site.yt.embed}}/qDm7GiKra28" title="Learn how to navigate your iPhone or iPad with VoiceOver" {{site.yt.set}}>
 </iframe>
 
 </div>
@@ -191,7 +189,7 @@ Windows apps, check out
 On a Mac, you can use the desktop version of VoiceOver,
 which is included in macOS.
 
-<iframe width="560" height="315" src="{{yt-embed}}/5R-6WvAihms" title="Learn about the macOS VoiceOver screen reader" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/5R-6WvAihms" title="Learn about the macOS VoiceOver screen reader" {{site.yt.set}}></iframe>
 
 On Linux, a popular screen reader is called Orca.
 It comes pre-installed with some distributions
@@ -247,7 +245,7 @@ In the video below, two of our engineers take a mobile app from a dire
 accessibility state to one that takes advantage of Flutter's built-in
 widgets to offer a dramatically more accessible experience.
 
-<iframe width="560" height="315" src="{{yt-embed}}/bWbBgbmAdQs" title="Learn about building Flutter apps with Accessibility in mind" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/bWbBgbmAdQs" title="Learn about building Flutter apps with Accessibility in mind" {{site.yt.set}}></iframe>
 
 ## Testing accessibility on mobile
 
@@ -356,5 +354,5 @@ the following articles written by community members:
 [TalkBack]: https://support.google.com/accessibility/android/answer/6283677?hl=en
 [W3C recommends]: https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html
 [VoiceOver]: https://www.apple.com/lae/accessibility/iphone/vision/
-[video demo]: {{yt-watch}}?v=A6Sx0lBP8PI
+[video demo]: {{site.yt.watch}}?v=A6Sx0lBP8PI
 [file a bug report]: https://goo.gle/flutter_web_issue

--- a/src/ui/animations/hero-animations.md
+++ b/src/ui/animations/hero-animations.md
@@ -4,8 +4,6 @@ description: How to animate a widget to fly between two screens.
 short-title: Hero
 ---
 
-{% include docs/yt_shims.liquid %}
-
 {{site.alert.secondary}}
   <h4 class="no_toc">What you'll learn</h4>
 
@@ -27,7 +25,7 @@ motion is sometimes referred to as a _shared element transition_.
 
 You might want to watch this one-minute video introducing the Hero widget:
 
-<iframe width="560" height="315" src="{{yt-embed}}/Be9UH1kXFDw" title="Learn about the Hero Flutter Widget" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/Be9UH1kXFDw" title="Learn about the Hero Flutter Widget" {{site.yt.set}}></iframe>
 
 This guide demonstrates how to build standard hero animations, and hero
 animations that transform the image from a circular shape to a square shape
@@ -73,7 +71,7 @@ Tapping the flippers in the blue route (or using the device's
 back-to-previous-route gesture) flies the flippers back to
 the original route.
 
-<iframe width="560" height="315" src="{{yt-embed}}/CEcFnqRDfgw" title="Watch this example of a standard hero animation in Flutter" {{yt-set-short}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/CEcFnqRDfgw" title="Watch this example of a standard hero animation in Flutter" {{site.yt.set-short}}></iframe>
 
 <br>**Radial hero animations**<br>
 
@@ -88,7 +86,7 @@ that displays it with a square shape.
 Tapping the square image flies the hero back to
 the original route, displayed with a circular shape.
 
-<iframe width="560" height="315" src="{{yt-embed}}/LWKENpwDKiM" title="Watch this example of a radial hero animation in Flutter" {{yt-set-short}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/LWKENpwDKiM" title="Watch this example of a radial hero animation in Flutter" {{site.yt.set-short}}></iframe>
 
 <br>Before moving to the sections specific to
 [standard](#standard-hero-animations)

--- a/src/ui/animations/implicit-animations.md
+++ b/src/ui/animations/implicit-animations.md
@@ -3,8 +3,6 @@ title: Implicit animations
 description: Where to find more information on using implicit animations in Flutter.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 With Flutter's [animation library][],
 you can add motion and create visual effects
 for the widgets in your UI.
@@ -40,11 +38,11 @@ that every Flutter dev needs to know from top to bottom.
 The following videos cover topics
 that are relevant to implicit animations.
 
-<iframe width="560" height="315" src="{{yt-embed}}/IVTjpW3W33s" title="Learn about basic Flutter animation with implicit animations" {{yt-set}}></iframe>
-[Learn about Animation Basics with Implicit Animations]({{yt-watch}}/IVTjpW3W33s)
+<iframe width="560" height="315" src="{{site.yt.embed}}/IVTjpW3W33s" title="Learn about basic Flutter animation with implicit animations" {{site.yt.set}}></iframe>
+[Learn about Animation Basics with Implicit Animations]({{site.yt.watch}}/IVTjpW3W33s)
 
-<iframe width="560" height="315" src="{{yt-embed}}/6KiPEqzJIKQ" title="Learn about building Custom Implicit Animations with TweenAnimationBuilder" {{yt-set}}></iframe>
-[Learn about building Custom Implicit Animations with TweenAnimationBuilder]({{yt-watch}}/6KiPEqzJIKQ)
+<iframe width="560" height="315" src="{{site.yt.embed}}/6KiPEqzJIKQ" title="Learn about building Custom Implicit Animations with TweenAnimationBuilder" {{site.yt.set}}></iframe>
+[Learn about building Custom Implicit Animations with TweenAnimationBuilder]({{site.yt.watch}}/6KiPEqzJIKQ)
 
 ## The Boring Show
 
@@ -52,8 +50,8 @@ Watch the Boring Show to follow Google Engineers build apps
 from scratch in Flutter. The following episode covers
 using implicit animations in a news aggregator app.
 
-<iframe width="560" height="315" src="{{yt-embed}}/8ehlWchLVlQ" title="about implicitly animating the Hacker News app" {{yt-set}}></iframe>
-[Learn about implicitly animating the Hacker News app]({{yt-watch}}/8ehlWchLVlQ)
+<iframe width="560" height="315" src="{{site.yt.embed}}/8ehlWchLVlQ" title="about implicitly animating the Hacker News app" {{site.yt.set}}></iframe>
+[Learn about implicitly animating the Hacker News app]({{site.yt.watch}}/8ehlWchLVlQ)
 
 ## Widget of the Week videos
 
@@ -70,8 +68,8 @@ implicitly animated widgets:
 {% for widget in animated-widgets %}
 {% assign video-url = animated-urls[forloop.index0] %}
 
-<iframe width="560" height="315" src="{{yt-embed}}/{{video-url}}" title="Learn about the {{widget}} Flutter Widget" {{yt-set}}></iframe>
-[Learn about the {{widget}} Flutter Widget]({{yt-watch}}/{{video-url}})
+<iframe width="560" height="315" src="{{site.yt.embed}}/{{video-url}}" title="Learn about the {{widget}} Flutter Widget" {{site.yt.set}}></iframe>
+[Learn about the {{widget}} Flutter Widget]({{site.yt.watch}}/{{video-url}})
 
 {% endfor -%}
 

--- a/src/ui/animations/index.md
+++ b/src/ui/animations/index.md
@@ -4,8 +4,6 @@ short-title: Animations
 description: How to perform animations in Flutter.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 Well-designed animations make a UI feel more intuitive,
 contribute to the slick look and feel of a polished app,
 and improve the user experience.
@@ -22,7 +20,7 @@ To help you decide, check out the video,
 [How to choose which Flutter Animation Widget is right for you?][]
 (Also published as a [_companion article_][article1].)
 
-<iframe width="560" height="315" src="{{yt-embed}}/GXIJJkq_H8g" title="Learn how to choose the Flutter Animation Widget for your use case" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/GXIJJkq_H8g" title="Learn how to choose the Flutter Animation Widget for your use case" {{site.yt.set}}></iframe>
 
 (To dive deeper into the decision process,
 watch the [Animations in Flutter done right][] video,
@@ -40,15 +38,15 @@ to implement) suits your needs, watch
 [Animation basics with implicit animations][].
 (Also published as a [_companion article_][article2].)
 
-<iframe width="560" height="315" src="{{yt-embed}}/IVTjpW3W33s" title="Learn about basic Flutter animation with implicit animations" {{yt-set}}></iframe>
-[Learn about Animation Basics with Implicit Animations]({{yt-watch}}/IVTjpW3W33s)
+<iframe width="560" height="315" src="{{site.yt.embed}}/IVTjpW3W33s" title="Learn about basic Flutter animation with implicit animations" {{site.yt.set}}></iframe>
+[Learn about Animation Basics with Implicit Animations]({{site.yt.watch}}/IVTjpW3W33s)
 
 To create a custom implicit animation, watch
 [Creating your own custom implicit animations with TweenAnimationBuilder][].
 (Also published as a [_companion article_][article3].)
 
-<iframe width="560" height="315" src="{{yt-embed}}/6KiPEqzJIKQ" title="Learn about building Custom Implicit Animations with TweenAnimationBuilder" {{yt-set}}></iframe>
-[Learn about building Custom Implicit Animations with TweenAnimationBuilder]({{yt-watch}}/6KiPEqzJIKQ)
+<iframe width="560" height="315" src="{{site.yt.embed}}/6KiPEqzJIKQ" title="Learn about building Custom Implicit Animations with TweenAnimationBuilder" {{site.yt.set}}></iframe>
+[Learn about building Custom Implicit Animations with TweenAnimationBuilder]({{site.yt.watch}}/6KiPEqzJIKQ)
 
 To create an explicit animation (where you control the animation,
 rather than letting the framework control it), perhaps
@@ -58,20 +56,20 @@ For more information, watch
 built-in explicit animations][].
 (Also published as a [_companion article_][article4].)
 
-<iframe width="560" height="315" src="{{yt-embed}}/CunyH6unILQ" title="Learn about the built-in explicit animations in Flutter" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/CunyH6unILQ" title="Learn about the built-in explicit animations in Flutter" {{site.yt.set}}></iframe>
 
 If you need to build an explicit animation from scratch, watch
 [Creating custom explicit animations with
 AnimatedBuilder and AnimatedWidget][].
 (Also published as a [_companion article_][article5].)
 
-<iframe width="560" height="315" src="{{yt-embed}}/fneC7t4R_B0" title="Learn about building Custom Explicit Animations with the AnimatedBuilder and AnimatedWidget Flutter Widgets" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/fneC7t4R_B0" title="Learn about building Custom Explicit Animations with the AnimatedBuilder and AnimatedWidget Flutter Widgets" {{site.yt.set}}></iframe>
 
 For a deeper understanding of just how animations work in Flutter, watch
 [Animation deep dive][].
 (Also published as a [_companion article_][article6].)
 
-<iframe width="560" height="315" src="{{yt-embed}}/PbcILiN8rbo" title="Take a deep dive into Flutter animation" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/PbcILiN8rbo" title="Take a deep dive into Flutter animation" {{site.yt.set}}></iframe>
 
 ## Codelabs, tutorials, and articles
 
@@ -215,13 +213,13 @@ Learn more about Flutter animations at the following links:
 [Animate a widget using a physics simulation]: {{site.url}}/cookbook/animation/physics-simulation
 [`AnimatedList` example]: https://flutter.github.io/samples/animations.html
 [Animation and motion widgets]: {{site.url}}/ui/widgets/animation
-[Animation basics with implicit animations]: {{yt-watch}}?v=IVTjpW3W33s&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=1
-[Animation deep dive]: {{yt-watch}}?v=PbcILiN8rbo&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=5
+[Animation basics with implicit animations]: {{site.yt.watch}}?v=IVTjpW3W33s&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=1
+[Animation deep dive]: {{site.yt.watch}}?v=PbcILiN8rbo&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=5
 [animation library]: {{site.api}}/flutter/animation/animation-library.html
 [Animation recipes]: {{site.url}}/cookbook/animation
 [Animation samples]: {{site.repo.samples}}/tree/main/animations#animation-samples
 [Animation videos]: {{site.social.youtube}}/search?query=animation
-[Animations in Flutter done right]: {{yt-watch}}?v=wnARLByOtKA&t=3s
+[Animations in Flutter done right]: {{site.yt.watch}}?v=wnARLByOtKA&t=3s
 [Animations: overview]: {{site.url}}/ui/animations/overview
 [animations package]: {{site.pub}}/packages/animations
 [Animations tutorial]: {{site.url}}/ui/animations/tutorial
@@ -232,14 +230,14 @@ Learn more about Flutter animations at the following links:
 [article4]: {{site.flutter-medium}}/directional-animations-with-built-in-explicit-animations-3e7c5e6fbbd7
 [article5]: {{site.flutter-medium}}/when-should-i-useanimatedbuilder-or-animatedwidget-57ecae0959e8
 [article6]: {{site.flutter-medium}}/animation-deep-dive-39d3ffea111f
-[Creating your own custom implicit animations with TweenAnimationBuilder]: {{yt-watch}}?v=6KiPEqzJIKQ&feature=youtu.be
-[Creating custom explicit animations with AnimatedBuilder and AnimatedWidget]: {{yt-watch}}?v=fneC7t4R_B0&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=4
+[Creating your own custom implicit animations with TweenAnimationBuilder]: {{site.yt.watch}}?v=6KiPEqzJIKQ&feature=youtu.be
+[Creating custom explicit animations with AnimatedBuilder and AnimatedWidget]: {{site.yt.watch}}?v=fneC7t4R_B0&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=4
 [Flutter API documentation]: {{site.api}}
 [`Hero`]: {{site.api}}/flutter/widgets/Hero-class.html
 [Hero animations]: {{site.url}}/ui/animations/hero-animations
-[How to choose which Flutter Animation Widget is right for you?]: {{yt-watch}}?v=GXIJJkq_H8g
+[How to choose which Flutter Animation Widget is right for you?]: {{site.yt.watch}}?v=GXIJJkq_H8g
 [Implicit animations codelab]: {{site.url}}/codelabs/implicit-animations
-[Making your first directional animations with built-in explicit animations]: {{yt-watch}}?v=CunyH6unILQ&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=3
+[Making your first directional animations with built-in explicit animations]: {{site.yt.watch}}?v=CunyH6unILQ&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=3
 [Material widgets]: {{site.url}}/ui/widgets/material
 [`Navigator`]: {{site.api}}/flutter/widgets/Navigator-class.html
 [`PageRoute`]: {{site.api}}/flutter/widgets/PageRoute-class.html

--- a/src/ui/animations/staggered-animations.md
+++ b/src/ui/animations/staggered-animations.md
@@ -4,8 +4,6 @@ description: How to write a staggered animation in Flutter.
 short-title: Staggered
 ---
 
-{% include docs/yt_shims.liquid %}
-
 {{site.alert.secondary}}
   <h4 class="no_toc">What you'll learn</h4>
 
@@ -63,7 +61,7 @@ This guide shows how to build a staggered animation in Flutter.
 The following video demonstrates the animation performed by
 basic_staggered_animation:
 
-<iframe width="560" height="315" src="{{yt-embed}}/0fFvnZemmh8" title="Watch this example of a staggered animation in Flutter" {{yt-set-short}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/0fFvnZemmh8" title="Watch this example of a staggered animation in Flutter" {{site.yt.set-short}}></iframe>
 
 In the video, you see the following animation of a single widget,
 which begins as a bordered blue square with slightly rounded corners.

--- a/src/ui/design/material/index.md
+++ b/src/ui/design/material/index.md
@@ -3,8 +3,6 @@ title: Material Design for Flutter
 description: Learn about Material Design for Flutter.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 Material Design is an open-source design system built
 and supported by Google designers and developers.
 

--- a/src/ui/design/text/typography.md
+++ b/src/ui/design/text/typography.md
@@ -3,8 +3,6 @@ title: Flutter's fonts and typography
 description: Learn about Flutter's support for typography.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 [_Typography_][] covers the style and appearance of
 type or fonts: it specifies how heavy the font is,
 the slant of the font, the spacing between
@@ -126,7 +124,7 @@ of Flutter's typography and combines it with the Material
 _and_ Cupertino look and feel (depending on the platform
 the app runs on), animation, and custom fragment shaders:
 
-<iframe width="560" height="315" src="{{yt-embed}}/sA5MRFFUuOU" title="Learn how to prototype beautiful designs with Flutter" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/sA5MRFFUuOU" title="Learn how to prototype beautiful designs with Flutter" {{site.yt.set}}></iframe>
 <b>Prototyping beautiful designs with Flutter</b>
 
 To read one engineer's experience

--- a/src/ui/interactivity/focus.md
+++ b/src/ui/interactivity/focus.md
@@ -3,8 +3,6 @@ title: Understanding Flutter's keyboard focus system
 description: How to use the focus system in your Flutter app.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 This article explains how to control where keyboard input is directed. If you
 are implementing an application that uses a physical keyboard, such as most
 desktop and web applications, this page is for you. If your app won't be used
@@ -421,7 +419,7 @@ your custom controls.
 {{site.alert.note}}
   To learn more, watch this short Widget of the Week video on the FocusableActionDetector widget:
 
-  <iframe class="full-width" src="{{yt-embed}}/R84AGg0lKs8" title="Learn about the FocusableActionDetector Flutter Widget" {{yt-set}}></iframe>
+  <iframe class="full-width" src="{{site.yt.embed}}/R84AGg0lKs8" title="Learn about the FocusableActionDetector Flutter Widget" {{site.yt.set}}></iframe>
 {{site.alert.end}}
 
 ## Controlling focus traversal

--- a/src/ui/interactivity/gestures/index.md
+++ b/src/ui/interactivity/gestures/index.md
@@ -4,8 +4,6 @@ short-title: Gestures
 description: How gestures, such as taps and drags, work in Flutter.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 This document explains how to listen for, and respond to,
 _gestures_ in Flutter.
 Examples of gestures include taps, drags, and scaling.
@@ -155,7 +153,7 @@ use a [`GestureDetector`][].
   To learn more, watch this short
   Widget of the Week video on the `GestureDetector` widget:
 
-  <iframe class="full-width" src="{{yt-embed}}/WhVXkCFPmK4" title="Learn about the GestureDetector Flutter Widget" {{yt-set}}></iframe>
+  <iframe class="full-width" src="{{site.yt.embed}}/WhVXkCFPmK4" title="Learn about the GestureDetector Flutter Widget" {{site.yt.set}}></iframe>
 {{site.alert.end}}
 
 If you're using Material Components,

--- a/src/ui/interactivity/index.md
+++ b/src/ui/interactivity/index.md
@@ -5,8 +5,6 @@ short-title: Interactivity
 diff2html: true
 ---
 
-{% include docs/yt_shims.liquid %}
-
 {% capture examples -%} {{site.repo.this}}/tree/{{site.branch}}/examples {%- endcapture -%}
 
 {{site.alert.secondary}}
@@ -792,7 +790,7 @@ Wonderous app [running app][wonderous-app], [repo][wonderous-repo]
 [`FloatingActionButton`]: {{site.api}}/flutter/material/FloatingActionButton-class.html
 [Flutter API documentation]: {{site.api}}
 [Flutter cookbook]: {{site.url}}/cookbook
-[Flutter's Layered Design]: {{yt-watch}}?v=dkyY9WCGMi0
+[Flutter's Layered Design]: {{site.yt.watch}}?v=dkyY9WCGMi0
 [`FormField`]: {{site.api}}/flutter/widgets/FormField-class.html
 [`Form`]: {{site.api}}/flutter/widgets/Form-class.html
 [`GestureDetector`]: {{site.api}}/flutter/widgets/GestureDetector-class.html

--- a/src/ui/layout/constraints.md
+++ b/src/ui/layout/constraints.md
@@ -7,8 +7,6 @@ js:
     url: https://old-dartpad-3ce3f.web.app/inject_embed.dart.js
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="layout/constraints/"?>
 
 <img src='/assets/images/docs/ui/layout/article-hero-image.png'
@@ -2202,6 +2200,6 @@ header image at the top of the article.
 {{site.alert.note}}
   To better understand how Flutter implements layout
   constraints, check out the following 5-minute video:
-  <iframe width="560" height="315" src="{{yt-embed}}/jckqXR5CrPI" title="Learn how Flutter implements layout constraints" {{yt-set}}></iframe>
+  <iframe width="560" height="315" src="{{site.yt.embed}}/jckqXR5CrPI" title="Learn how Flutter implements layout constraints" {{site.yt.set}}></iframe>
   <p>Decoding Flutter: Unbounded height and width</p>
 {{site.alert.end}}

--- a/src/ui/layout/index.md
+++ b/src/ui/layout/index.md
@@ -5,8 +5,6 @@ description: Learn how Flutter's layout mechanism works and how to build a layou
 diff2html: true
 ---
 
-{% include docs/yt_shims.liquid %}
-
 {% assign api = site.api | append: '/flutter' -%}
 {% capture examples -%} {{site.repo.this}}/tree/{{site.branch}}/examples {%- endcapture -%}
 
@@ -1255,18 +1253,18 @@ The following videos, part of the
 [Flutter in Focus][] series,
 explain `Stateless` and `Stateful` widgets.
 
-<iframe width="560" height="315" src="{{yt-embed}}/wE7khGHVkYY?rel=0" title="Learn how to create stateless widgets" {{yt-set}}></iframe>
-<iframe width="560" height="315" src="{{yt-embed}}/AqCMFXEmf3w?rel=0" title="Learn the best times to use stateful widgets" {{yt-set}}></iframe>
-[Flutter in Focus playlist]({{yt-playlist}}PLjxrf2q8roU2HdJQDjJzOeO6J3FoFLWr2)
+<iframe width="560" height="315" src="{{site.yt.embed}}/wE7khGHVkYY?rel=0" title="Learn how to create stateless widgets" {{site.yt.set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/AqCMFXEmf3w?rel=0" title="Learn the best times to use stateful widgets" {{site.yt.set}}></iframe>
+[Flutter in Focus playlist]({{site.yt.playlist}}PLjxrf2q8roU2HdJQDjJzOeO6J3FoFLWr2)
 
 ---
 
 Each episode of the
-[Widget of the Week series]({{yt-playlist}}PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG)
+[Widget of the Week series]({{site.yt.playlist}}PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG)
 focuses on a widget. Several of them includes layout widgets.
 
-<iframe width="560" height="315" src="{{yt-embed}}/b_sQ9bMltGU?rel=0" title="Watch the Widget of the Week playlist" {{yt-set}}></iframe>
-[Flutter Widget of the Week playlist]({{yt-playlist}}PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG)
+<iframe width="560" height="315" src="{{site.yt.embed}}/b_sQ9bMltGU?rel=0" title="Watch the Widget of the Week playlist" {{site.yt.set}}></iframe>
+[Flutter Widget of the Week playlist]({{site.yt.playlist}}PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG)
 
 ## Other resources
 
@@ -1306,7 +1304,7 @@ The following resources might help when writing layout code.
 [`DataTable`]: {{api}}/material/DataTable-class.html
 [Elevation]: {{site.material}}/styles/elevation
 [`Expanded`]: {{api}}/widgets/Expanded-class.html
-[Flutter in Focus]: {{yt-watch}}?v=wgTBLj7rMPM&list=PLjxrf2q8roU2HdJQDjJzOeO6J3FoFLWr2
+[Flutter in Focus]: {{site.yt.watch}}?v=wgTBLj7rMPM&list=PLjxrf2q8roU2HdJQDjJzOeO6J3FoFLWr2
 [`GridView`]: {{api}}/widgets/GridView-class.html
 [`GridTile`]: {{api}}/material/GridTile-class.html
 [HTML/CSS Analogs in Flutter]: {{site.url}}/get-started/flutter-for/web-devs

--- a/src/ui/layout/responsive/adaptive-responsive.md
+++ b/src/ui/layout/responsive/adaptive-responsive.md
@@ -4,8 +4,6 @@ description: It's important to create apps, whether for mobile or web, so that t
 short-title: Responsive and adaptive
 ---
 
-{% include docs/yt_shims.liquid %}
-
 One of Flutter's primary goals is to create a framework
 that allows you to develop apps from a single codebase
 that look and feel great on any platform.
@@ -50,7 +48,7 @@ an app can be both, or neither.
 
 Learn more in the following 5-minute video:
 
-<iframe width="560" height="315" src="{{yt-embed}}/HD5gYnspYzk?si=dsA37QUjHBb2Zh_-" title="Learn the difference between adaptive and responsive Flutter apps" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/HD5gYnspYzk?si=dsA37QUjHBb2Zh_-" title="Learn the difference between adaptive and responsive Flutter apps" {{site.yt.set}}></iframe>
 [Adaptive vs Responsive][]
 
 ## Creating a responsive Flutter app
@@ -135,17 +133,17 @@ Learn more about creating an adaptive Flutter app with
 You might also check out the following episodes
 of The Boring Show:
 
-<iframe style="max-width: 100%" width="560" height="315" src="{{yt-embed}}/n6Awpg1MO6M" title="Learn about adaptive layouts on the Boring Show" {{yt-set}}></iframe>
+<iframe style="max-width: 100%" width="560" height="315" src="{{site.yt.embed}}/n6Awpg1MO6M" title="Learn about adaptive layouts on the Boring Show" {{site.yt.set}}></iframe>
 [Adaptive layouts][]
 
-<iframe style="max-width: 100%" width="560" height="315" src="{{yt-embed}}/eikOZzfc0l4" title="Continue to learn about adaptive layouts on the Boring Show" {{yt-set}}></iframe>
+<iframe style="max-width: 100%" width="560" height="315" src="{{site.yt.embed}}/eikOZzfc0l4" title="Continue to learn about adaptive layouts on the Boring Show" {{site.yt.set}}></iframe>
 [Adaptive layouts, part 2][]
 
 For an excellent example of an adaptive app,
 check out Flutter Folio, a scrapbooking app created
 in collaboration with gskinner and the Flutter team:
 
-<iframe style="max-width: 100%" width="560" height="315" src="{{yt-embed}}/yytBENOnF0w" title="Watch a demonstration of the Flutter Folio app" {{yt-set}}></iframe>
+<iframe style="max-width: 100%" width="560" height="315" src="{{site.yt.embed}}/yytBENOnF0w" title="Watch a demonstration of the Flutter Folio app" {{site.yt.set}}></iframe>
 
 The [Folio source code][] is also available on GitHub.
 Learn more on the [gskinner blog][].
@@ -161,8 +159,8 @@ in the following resources:
 * [Designing truly adaptive user interfaces][] a blog post and video by
   Aloïs Deniel, presented at the Flutter Vikings 2020 conference.
 
-[Adaptive layouts]: {{yt-watch}}?v=n6Awpg1MO6M&t=694s
-[Adaptive layouts, part 2]: {{yt-watch}}?v=eikOZzfc0l4&t=11s
+[Adaptive layouts]: {{site.yt.watch}}?v=n6Awpg1MO6M&t=694s
+[Adaptive layouts, part 2]: {{site.yt.watch}}?v=eikOZzfc0l4&t=11s
 [Adaptive vs Responsive]: {{site.youtube-site}}/HD5gYnspYzk?si=5ItDD7UjXvGCRM0K
 [Building adaptive apps]: {{site.url}}/ui/layout/responsive/building-adaptive-apps
 

--- a/src/ui/layout/responsive/building-adaptive-apps.md
+++ b/src/ui/layout/responsive/building-adaptive-apps.md
@@ -3,8 +3,6 @@ title: Building adaptive apps
 description: Some considerations and instructions on how to build adaptive apps to run on a variety of platforms.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 <?code-excerpt path-base="ui/layout/adaptive_app_demos"?>
 
 ## Overview
@@ -25,7 +23,7 @@ apps, but they fall into three major categories:
 * [Input](#input)
 * [Idioms and norms](#idioms-and-norms)
 
-<iframe style="max-width: 100%" width="560" height="315" src="{{yt-embed}}/RCdeSKVt7LI" title="Learn how to build platform-adaptive Flutter apps" {{yt-set}}></iframe>
+<iframe style="max-width: 100%" width="560" height="315" src="{{site.yt.embed}}/RCdeSKVt7LI" title="Learn how to build platform-adaptive Flutter apps" {{site.yt.set}}></iframe>
 
 This page covers all three categories in detail
 using code snippets to illustrate the concepts.

--- a/src/ui/layout/scrolling/index.md
+++ b/src/ui/layout/scrolling/index.md
@@ -3,8 +3,6 @@ title: Scrolling
 description: Overview of Flutter's scrolling support
 ---
 
-{% include docs/yt_shims.liquid %}
-
 Flutter has many built-in widgets that automatically
 scroll and also offers a variety of widgets
 that you can customize to create specific scrolling
@@ -20,9 +18,9 @@ child when necessary. Other useful widgets include
 You can check out more of these widgets on the
 [scrolling page][] of the Widget catalog.
 
-<iframe width="560" height="315" src="{{yt-embed}}/DbkIQSvwnZc" title="Learn how to use the Scrollbar Flutter Widget" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/DbkIQSvwnZc" title="Learn how to use the Scrollbar Flutter Widget" {{site.yt.set}}></iframe>
 
-<iframe width="560" height="315" src="{{yt-embed}}/KJpkjHGiI5A" title="Learn how to use the ListView Flutter Widget" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/KJpkjHGiI5A" title="Learn how to use the ListView Flutter Widget" {{site.yt.set}}></iframe>
 
 ### Infinite scrolling
 
@@ -43,10 +41,10 @@ The following widgets provide more specific scrolling
 behavior.
 
 A video on using [`DraggableScrollableSheet`][]
-<iframe width="560" height="315" src="{{yt-embed}}/Hgw819mL_78" title="Learn how to use the DraggableScrollableSheet Flutter Widget" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/Hgw819mL_78" title="Learn how to use the DraggableScrollableSheet Flutter Widget" {{site.yt.set}}></iframe>
 
 Turn the scrollable area into a wheel! [`ListWheelScrollView`][]
-<iframe width="560" height="315" src="{{yt-embed}}/dUhmWAz4C7Y" title="Learn how to use the ListWheelScrollView Flutter Widget" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/dUhmWAz4C7Y" title="Learn how to use the ListWheelScrollView Flutter Widget" {{site.yt.set}}></iframe>
 
 [`DraggableScrollableSheet`]: {{site.api}}/flutter/widgets/DraggableScrollableSheet-class.html
 [`GridView`]: {{site.api}}/flutter/widgets/GridView-class.html
@@ -58,7 +56,7 @@ Turn the scrollable area into a wheel! [`ListWheelScrollView`][]
 {% comment %}
   Not yet, but coming. Two dimensional scrolling:
   TableView and TreeView.
-  Video: {{yt-watch}}?v=UDZ0LPQq-n8
+  Video: {{site.yt.watch}}?v=UDZ0LPQq-n8
 {% endcomment %}
 
 ## Fancy scrolling
@@ -93,4 +91,4 @@ or do you use a sliver?
 
 Check out the "ShrinkWrap vs Slivers" video:
 
-<iframe width="560" height="315" src="{{yt-embed}}/LUqDNnv_dh0" title="Learn how to nest scrolling widgets in Flutter" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/LUqDNnv_dh0" title="Learn how to nest scrolling widgets in Flutter" {{site.yt.set}}></iframe>

--- a/src/ui/layout/scrolling/slivers.md
+++ b/src/ui/layout/scrolling/slivers.md
@@ -4,8 +4,6 @@ description: Where to find information on using slivers to implement fancy scrol
 toc: false
 ---
 
-{% include docs/yt_shims.liquid %}
-
 A sliver is a portion of a scrollable area that you
 can define to behave in a special way.
 You can use slivers to achieve custom scrolling effects,
@@ -14,7 +12,7 @@ such as elastic scrolling.
 For a free, instructor-led video workshop that uses DartPad,
 check out the following video about using slivers.
 
-<iframe width="560" height="315" src="{{yt-embed}}/YY-_yrZdjGc" title="Learn how to build beautiful scrolling examples in Flutter" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/YY-_yrZdjGc" title="Learn how to build beautiful scrolling examples in Flutter" {{site.yt.set}}></iframe>
 
 ## Resources
 
@@ -35,7 +33,7 @@ in Flutter, see the following resources:
     video that gives an overview of the
     `SliverAppBar` widget.
 
-<iframe width="560" height="315" src="{{yt-embed}}/R9C5KMJKluE" title="Learn about the SliverAppBar Widget" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/R9C5KMJKluE" title="Learn about the SliverAppBar Widget" {{site.yt.set}}></iframe>
 </dd>
 
 <dt markdown="1"> **[SliverList and SliverGrid][]**
@@ -44,7 +42,7 @@ in Flutter, see the following resources:
     video that gives an overview of the `SliverList`
     and `SliverGrid` widgets.
 
-<iframe width="560" height="315" src="{{yt-embed}}/ORiTTaVY6mM" title="Learn about the SliverList and SliverBar Widget" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/ORiTTaVY6mM" title="Learn about the SliverList and SliverBar Widget" {{site.yt.set}}></iframe>
 </dd>
 
 <dt markdown="1"> **[Slivers explained - Making dynamic layouts][]**
@@ -53,7 +51,7 @@ in Flutter, see the following resources:
     where Ian Hickson, Flutter's Tech Lead, and Filip Hracek
     discuss the power of slivers.
 
-<iframe width="560" height="315" src="{{yt-embed}}/Mz3kHQxBjGg" title="Watch the Boring Show to learn about slivers" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/Mz3kHQxBjGg" title="Watch the Boring Show to learn about slivers" {{site.yt.set}}></iframe>
 </dd>
 </dl>
 
@@ -68,11 +66,11 @@ check out these related API docs:
 * [`SliverList`][]
 
 [`CustomScrollView`]: {{site.api}}/flutter/widgets/CustomScrollView-class.html
-[sliver-app-bar-video]: {{yt-watch}}?v=R9C5KMJKluE
+[sliver-app-bar-video]: {{site.yt.watch}}?v=R9C5KMJKluE
 [`SliverAppBar`]: {{site.api}}/flutter/material/SliverAppBar-class.html
 [`SliverGrid`]: {{site.api}}/flutter/widgets/SliverGrid-class.html
-[SliverList and SliverGrid]: {{yt-watch}}?v=ORiTTaVY6mM
+[SliverList and SliverGrid]: {{site.yt.watch}}?v=ORiTTaVY6mM
 [`SliverList`]: {{site.api}}/flutter/widgets/SliverList-class.html
 [Slivers, DeMystified]: {{site.flutter-medium}}/slivers-demystified-6ff68ab0296f
-[Slivers explained - Making dynamic layouts]: {{yt-watch}}?v=Mz3kHQxBjGg
-[The Boring Show]: {{yt-playlist}}PLOU2XLYxmsIK0r_D-zWcmJ1plIcDNnRkK
+[Slivers explained - Making dynamic layouts]: {{site.yt.watch}}?v=Mz3kHQxBjGg
+[The Boring Show]: {{site.yt.playlist}}PLOU2XLYxmsIK0r_D-zWcmJ1plIcDNnRkK

--- a/src/ui/navigation/deep-linking.md
+++ b/src/ui/navigation/deep-linking.md
@@ -3,8 +3,6 @@ title: Deep linking
 description: Navigate to routes when the app receives a new URL.
 ---
 
-{% include docs/yt_shims.liquid %}
-
 Flutter supports deep linking on iOS, Android, and web browsers.
 Opening a URL displays that screen in your app. With the following
 steps, you can launch and display routes by using named routes
@@ -29,7 +27,7 @@ the pattern: `/#/path/to/app/screen`, but this can be changed by
 
 If you are a visual learner, check out the following video:
 
-<iframe width="560" height="315" src="{{yt-embed}}/KNAb2XL7k2g" title="Learn how to create and link to routes in your Flutter app" {{yt-set}}></iframe>
+<iframe width="560" height="315" src="{{site.yt.embed}}/KNAb2XL7k2g" title="Learn how to create and link to routes in your Flutter app" {{site.yt.set}}></iframe>
 **Deep linking in Flutter**
 
 ## Get started

--- a/src/ui/widgets/index.md
+++ b/src/ui/widgets/index.md
@@ -4,8 +4,6 @@ description: A catalog of some of Flutter's rich set of widgets.
 short-title: Widgets
 ---
 
-{% include docs/yt_shims.liquid %}
-
 Create beautiful apps faster with Flutter's collection of visual, structural,
 platform, and interactive widgets. In addition to browsing widgets by category,
 you can also see all the widgets in the [widget index][].
@@ -36,36 +34,36 @@ help you quickly get started with Flutter widgets.
 <div class="card-deck card-deck--responsive">
     <div class="video-card">
         <div class="card-body">
-            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{yt-embed}}/1z6YP7YmvwA" title="Learn about the TextStyle Flutter Widget" {{yt-set}}></iframe>
+            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{site.yt.embed}}/1z6YP7YmvwA" title="Learn about the TextStyle Flutter Widget" {{site.yt.set}}></iframe>
         </div>
     </div>
     <div class="video-card">
         <div class="card-body">
-            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{yt-embed}}/VdkRy3yZiPo" title="Learn about the flutter_rating_bar Flutter Package" {{yt-set}}></iframe>
+            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{site.yt.embed}}/VdkRy3yZiPo" title="Learn about the flutter_rating_bar Flutter Package" {{site.yt.set}}></iframe>
         </div>
     </div>
     <div class="video-card">
         <div class="card-body">
-            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{yt-embed}}/gYNTcgZVcWw" title="Learn about the LinearGradient Flutter Widget" {{yt-set}}></iframe>
+            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{site.yt.embed}}/gYNTcgZVcWw" title="Learn about the LinearGradient Flutter Widget" {{site.yt.set}}></iframe>
         </div>
     </div>
     <div class="video-card">
         <div class="card-body">
-            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{yt-embed}}/-Nny8kzW380" title="Learn about the AutoComplete Flutter Widget" {{yt-set}}></iframe>
+            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{site.yt.embed}}/-Nny8kzW380" title="Learn about the AutoComplete Flutter Widget" {{site.yt.set}}></iframe>
         </div>
     </div>
     <div class="video-card">
         <div class="card-body">
-            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{yt-embed}}/y9xchtVTtqQ" title="Learn about the NavigationRail Flutter Widget" {{yt-set}}></iframe>
+            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{site.yt.embed}}/y9xchtVTtqQ" title="Learn about the NavigationRail Flutter Widget" {{site.yt.set}}></iframe>
         </div>
     </div>
     <div class="video-card">
         <div class="card-body">
-            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{yt-embed}}/qjA0JFiPMnQ" title="Learn about the mason Flutter Package" {{yt-set}}></iframe>
+            <iframe style="max-width: 100%; width: 100%; height: 230px;" src="{{site.yt.embed}}/qjA0JFiPMnQ" title="Learn about the mason Flutter Package" {{site.yt.set}}></iframe>
         </div>
     </div>
 </div>
 
-<a class="btn btn-primary full-width" target="_blank" href="{{yt-playlist}}PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG" >See more Widget of the Weeks</a>
+<a class="btn btn-primary full-width" target="_blank" href="{{site.yt.playlist}}PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG" >See more Widget of the Weeks</a>
 
 [widget index]: {{site.url}}/reference/widgets


### PR DESCRIPTION
This aligns closer with other similar variables on the site and will make the 11ty migration easier to review. It also avoids the mistake of accidentally not including the shims.