### PR TITLE
Emphasize current OS card on install page

### DIFF
--- a/src/_sass/base/_base.scss
+++ b/src/_sass/base/_base.scss
@@ -38,7 +38,6 @@ dd {
 .card-footer.card-footer--transparent {
   border: none;
   background-color: transparent;
-
 }
 
 .card-footer.card-footer--links {

--- a/src/_sass/vendor/_bootstrap.scss
+++ b/src/_sass/vendor/_bootstrap.scss
@@ -116,6 +116,10 @@ a.card {
   font-family: $site-font-family-alt;
   font-size: bootstrap.$font-size-lg;
   margin-bottom: bs-spacer(2);
+
+  .card-highlight & {
+    font-weight: 700;
+  }
 }
 
 .breadcrumb {

--- a/src/assets/js/page/install-current.js
+++ b/src/assets/js/page/install-current.js
@@ -1,0 +1,14 @@
+// Depends on main.js being loaded first.
+// Focuses the card for the current OS on `/get-started/install/`.
+document.addEventListener("DOMContentLoaded", function(_) {
+  if (!getOS) return;
+
+  const currentOS = getOS();
+  if (!currentOS) return;
+
+  const osButton = document.getElementById(`install-${currentOS}`);
+  if (!osButton) return;
+
+  osButton.focus();
+  osButton.classList.add('card-highlight');
+});

--- a/src/get-started/install/index.md
+++ b/src/get-started/install/index.md
@@ -3,14 +3,12 @@ title: Choose your development platform to get started
 short-title: Install
 description: Install Flutter and get started. Downloads available for Windows, macOS, Linux, and ChromeOS operating systems.
 os-list: [Windows, macOS, Linux, ChromeOS]
+js: [{url: '/assets/js/page/install-current.js'}]
 ---
-
-<!-- ## Choose your development platform to get started
-{:.no_toc} -->
 
 <div class="card-deck mb-8">
 {% for os in page.os-list %}
-  <a class="card" id="install-{{os | remove: ' ' | downcase}}" href="{{site.url}}/get-started/install/{{os | remove: ' ' | downcase}}">
+  <a class="card" id="install-{{os | remove: ' ' | downcase}}" href="{{site.url}}/get-started/install/{{os | remove: ' ' | downcase}}" aria-label="Set up Flutter on {{os}}">
     <div class="card-body">
       <header class="card-title text-center m-0">
         <span class="d-block h1">


### PR DESCRIPTION
I'm not sure we want to pre-navigate to the target page, as then there's the question of how to get back if that's not what they want. What this PR does instead is highlight the current OS's card and auto focuses it on site load. So attention is drawn to the likely correct card and keyboard users can just click enter. I also added some aria labels to make it more clear what the cards are navigating to.

Closes https://github.com/flutter/website/issues/4446