### PR TITLE
Fix yaml indentation in "Use a custom font" cookbook

### DIFF
--- a/src/cookbook/design/fonts.md
+++ b/src/cookbook/design/fonts.md
@@ -180,7 +180,7 @@ To add font files to your Flutter app, complete the following steps.
          fonts:
            - asset: fonts/RobotoMono-Regular.ttf
            - asset: fonts/RobotoMono-Bold.ttf
-            weight: 700
+             weight: 700
    ```
 
 This `pubspec.yaml` file defines the italic style for the


### PR DESCRIPTION
This PR fixes the indentation of a pubspec.yaml example inside the fonts cookbook.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
