### PR TITLE
Correct incorrect mention of `SliverGridList` to `SliverGrid`

### DIFF
--- a/src/cookbook/lists/floating-app-bar.md
+++ b/src/cookbook/lists/floating-app-bar.md
@@ -41,7 +41,7 @@ and widgets together.
 
 The scrollable lists and widgets provided to the
 `CustomScrollView` are known as _slivers_. There are several types
-of slivers, such as `SliverList`, `SliverGridList`, and `SliverAppBar`.
+of slivers, such as `SliverList`, `SliverGrid`, and `SliverAppBar`.
 In fact, the `ListView` and `GridView` widgets use the `SliverList` and
 `SliverGrid` widgets to implement scrolling.
 


### PR DESCRIPTION
**Page URL**

https://docs.flutter.dev/cookbook/lists/floating-app-bar

**Page source**

https://github.com/flutter/website/tree/main/src/cookbook/lists/floating-app-bar.md

**Describe the problem**

a typo in the "SliverGridList" - there is no such class
