### PR TITLE
Added decimalPatternDigits as valid number format for internationalization

### DIFF
--- a/src/ui/accessibility-and-internationalization/internationalization.md
+++ b/src/ui/accessibility-and-internationalization/internationalization.md
@@ -584,6 +584,7 @@ following `NumberFormat` constructors:
 | `compactLong`               | "1.2 million"      |
 | `currency`*                 | "USD1,200,000.00"  |
 | `decimalPattern`            | "1,200,000"        |
+| `decimalPatternDigits`*     | "1,200,000"        |
 | `decimalPercentPattern`*    | "120,000,000%"     |
 | `percentPattern`            | "120,000,000%"     |
 | `scientificPattern`         | "1E6"              |


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

The PR adds `decimalPatternDigits` to the list.

_Issues fixed by this PR (if any):_

`decimalPatternDigits` was added to the list of valid formats in ARB localization files but the website was not updated accordingly.
See https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart#L123C4-L123C24

## Presubmit checklist

- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
