### PR TITLE
MaterialState migration guide

### DIFF
--- a/src/release/breaking-changes/index.md
+++ b/src/release/breaking-changes/index.md
@@ -31,6 +31,7 @@ release, and listed in alphabetical order:
 
 ### Not yet released to stable
 
+* [Rename `MaterialState` to `WidgetState`][]
 * [Introduce new `ColorScheme` roles][]
 * [Stop generating AssetManifest.json][]
 * [Rename `MemoryAllocations` to `FlutterMemoryAllocations`][]
@@ -39,6 +40,7 @@ release, and listed in alphabetical order:
 * [Deprecate `ButtonBar` in favor of `OverflowBar`][]
 * [Deprecated API removed after v3.19][]
 
+[Rename `MaterialState` to `WidgetState`]: /release/breaking-changes/material-state
 [Introduce new `ColorScheme` roles]: /release/breaking-changes/new-color-scheme-roles
 [Stop generating AssetManifest.json]: /release/breaking-changes/asset-manifest-dot-json
 [Rename `MemoryAllocations` to `FlutterMemoryAllocations`]: /release/breaking-changes/flutter-memory-allocations

--- a/src/release/breaking-changes/material-state.md
+++ b/src/release/breaking-changes/material-state.md
@@ -1,7 +1,7 @@
 ---
 title: Rename MaterialState to WidgetState
 description: >-
-  MaterialState and it's related APIs have been moved
+  MaterialState and its related APIs have been moved
   outside of the Material library and renamed to
   WidgetState.
 ---
@@ -17,7 +17,7 @@ Previously, `MaterialState` provided logic for handling multiple different
 states a widget could have, like "hovered", "focused", and
 "disabled". Because this functionality is useful outside of the
 Material library, namely for the base Widgets layer and Cupertino,
-it was decided to move it outside of Material. Aspart of the move, and to
+it was decided to move it outside of Material. As part of the move, and to
 avoid future confusion, the different`MaterialState` classes have been renamed
 to `WidgetState`. The behavior of the two are the same.
 

--- a/src/release/breaking-changes/material-state.md
+++ b/src/release/breaking-changes/material-state.md
@@ -15,12 +15,11 @@ of the Material library and renamed to `WidgetState`.
 
 Previously, `MaterialState` provided logic for handling multiple different
 states a widget could have, like "hovered", "focused", and
-"disabled". Because this functionality could be useful outside
-of the Material library, namely for the base Widgets layer and
-Cupertino, it was decided to move it outside of Material. As
-part of the move, and to avoid future confusion, the different
-`MaterialState` classes have been renamed to `WidgetState`. The
-behavior of the two are the same.
+"disabled". Because this functionality is useful outside of the
+Material library, namely for the base Widgets layer and Cupertino,
+it was decided to move it outside of Material. Aspart of the move, and to
+avoid future confusion, the different`MaterialState` classes have been renamed
+to `WidgetState`. The behavior of the two are the same.
 
 | Before    | Now |
 | -------- | ------- |
@@ -34,7 +33,6 @@ behavior of the two are the same.
 | `MaterialStateProperty` | `WidgetStateProperty` |
 | `MaterialStatePropertyAll` | `WidgetStatePropertyAll` |
 | `MaterialStatesController` | `WidgetStatesController` |
-| `MaterialStateMixin` | `WidgetStateMixin` |
 
 The classes `MaterialStateOutlineInputBorder` and
 `MaterialStateUnderlineInputBorder` were left in the
@@ -56,15 +54,20 @@ MaterialState selected = MaterialState.selected;
 final MaterialStateProperty<Color> backgroundColor;
 
 class _MouseCursor extends MaterialStateMouseCursor{
-    const _MouseCursor(this.resolveCallback);
+  const _MouseCursor(this.resolveCallback);
 
-    final MaterialPropertyResolver<MouseCursor?> resolveCallback;
+  final MaterialPropertyResolver<MouseCursor?> resolveCallback;
 
-    @override
-    MouseCursor resolve(Set<MaterialState> states) => resolveCallback(states) ?? MouseCursor.uncontrolled;
+  @override
+  MouseCursor resolve(Set<MaterialState> states) => resolveCallback(states) ?? MouseCursor.uncontrolled;
 }
 
-MaterialStateBorderSide? get side;
+BorderSide side = MaterialStateBorderSide.resolveWith((Set<MaterialState> states) {
+  if (states.contains(MaterialState.selected)) {
+    return const BorderSide(color: Colors.red);
+  }
+  return null;
+});
 ```
 
 Code after migration:
@@ -75,20 +78,25 @@ WidgetState selected = WidgetState.selected;
 final WidgetStateProperty<Color> backgroundColor;
 
 class _MouseCursor extends WidgetStateMouseCursor{
-    const _MouseCursor(this.resolveCallback);
+  const _MouseCursor(this.resolveCallback);
 
-    final WidgetPropertyResolver<MouseCursor?> resolveCallback;
+  final WidgetPropertyResolver<MouseCursor?> resolveCallback;
 
-    @override
-    MouseCursor resolve(Set<WidgetState> states) => resolveCallback(states) ?? MouseCursor.uncontrolled;
+  @override
+  MouseCursor resolve(Set<WidgetState> states) => resolveCallback(states) ?? MouseCursor.uncontrolled;
 }
 
-WidgetStateBorderSide? get side;
+BorderSide side = WidgetStateBorderSide.resolveWith((Set<WidgetState> states) {
+  if (states.contains(WidgetState.selected)) {
+    return const BorderSide(color: Colors.red);
+  }
+  return null;
+});
 ```
 
 ## Timeline
 
-Landed in version: 3.20.0-1.2.pre<br>
+Landed in version: 3.21.0-10.0.pre<br>
 In stable release: not yet
 
 ## References

--- a/src/release/breaking-changes/material-state.md
+++ b/src/release/breaking-changes/material-state.md
@@ -96,7 +96,7 @@ BorderSide side = WidgetStateBorderSide.resolveWith((Set<WidgetState> states) {
 
 ## Timeline
 
-Landed in version: 3.21.0-10.0.pre<br>
+Landed in version: 3.21.0-11.0.pre<br>
 In stable release: not yet
 
 ## References

--- a/src/release/breaking-changes/material-state.md
+++ b/src/release/breaking-changes/material-state.md
@@ -1,0 +1,106 @@
+---
+title: Rename MaterialState to WidgetState
+description: >-
+  MaterialState and it's related APIs have been moved
+  outside of the Material library and renamed to
+  WidgetState.
+---
+
+## Summary
+
+`MaterialState`, and its related APIs have been moved out
+of the Material library and renamed to `WidgetState`.
+
+## Background
+
+`MaterialState` provided logic for handeling multiple different
+states a widget could have, like "hovered", "focused", and
+"disabled". Because this functionality could be useful outside
+of the Material library, namely the base Widgets layer and
+Cupertino, it was decided to move it outside of Material. As
+part of the move, and to avoid future confusion, the different
+MaterialState classes have been renamed to `WidgetState`. The
+behavior of the two are the same.
+
+| Before    | Now |
+| -------- | ------- |
+| MaterialState | WidgetState |
+| MaterialStatePropertyResolver | WidgetStatePropertyResolver |
+| MaterialStateColor | WidgetStateColor |
+| MaterialStateMouseCursor | WidgetStateColorMouseCursor |
+| MaterialStateBorderSide | WidgetStateBorderSide |
+| MaterialStateOutlinedBorder | WidgetStateOutlinedBorder |
+| MaterialStateTextStyle | WidgetStateTextStyle |
+| MaterialStateProperty | WidgetStateProperty |
+| MaterialStatePropertyAll | WidgetStatePropertyAll |
+| MaterialStatesController | WidgetStatesController |
+| MaterialStateMixin | WidgetStateMixin |
+
+The classes `MaterialStateOutlineInputBorder` and
+`MaterialStateUnderlineInputBorder` were left in the
+Material library with no `WidgetState` equivilant, as
+they are Material design specific.
+
+## Migration guide
+
+A [Flutter fix][] is available to help migrate the `MaterialState`
+classes to `WidgetState`.
+
+To migrate, replace `MaterialState` with `WidgetState`.
+
+Code before migration:
+
+```dart
+MaterialState selected = MaterialState.selected;
+
+final MaterialStateProperty<Color> backgroundColor;
+
+class _MouseCursor extends MaterialStateMouseCursor{
+    const _MouseCursor(this.resolveCallback);
+
+    final MaterialPropertyResolver<MouseCursor?> resolveCallback;
+
+    @override
+    MouseCursor resolve(Set<MaterialState> states) => resolveCallback(states) ?? MouseCursor.uncontrolled;
+}
+
+MaterialStateBorderSide? get side;
+```
+
+Code after migration:
+
+```dart
+WidgetState selected = WidgetState.selected;
+
+final WidgetStateProperty<Color> backgroundColor;
+
+class _MouseCursor extends WidgetStateMouseCursor{
+    const _MouseCursor(this.resolveCallback);
+
+    final WidgetPropertyResolver<MouseCursor?> resolveCallback;
+
+    @override
+    MouseCursor resolve(Set<WidgetState> states) => resolveCallback(states) ?? MouseCursor.uncontrolled;
+}
+
+WidgetStateBorderSide? get side;
+```
+
+## Timeline
+
+Landed in version: xxx<br>
+In stable release: not yet
+
+## References
+
+Relevant issues:
+
+* [Create widgets level support for State][]
+
+Relevant PRs:
+
+* [Widget State Properties][]
+
+[Create widgets level support for State]: {{site.repo.flutter}}/issues/138270
+[Flutter fix]: {{site.url}}/tools/flutter-fix
+[Widget State Properties]: {{site.repo.flutter}}/pull/142151

--- a/src/release/breaking-changes/material-state.md
+++ b/src/release/breaking-changes/material-state.md
@@ -8,38 +8,38 @@ description: >-
 
 ## Summary
 
-`MaterialState`, and its related APIs have been moved out
+`MaterialState`, and its related APIs, have been moved out
 of the Material library and renamed to `WidgetState`.
 
 ## Background
 
-`MaterialState` provided logic for handeling multiple different
+Previously, `MaterialState` provided logic for handling multiple different
 states a widget could have, like "hovered", "focused", and
 "disabled". Because this functionality could be useful outside
-of the Material library, namely the base Widgets layer and
+of the Material library, namely for the base Widgets layer and
 Cupertino, it was decided to move it outside of Material. As
 part of the move, and to avoid future confusion, the different
-MaterialState classes have been renamed to `WidgetState`. The
+`MaterialState` classes have been renamed to `WidgetState`. The
 behavior of the two are the same.
 
 | Before    | Now |
 | -------- | ------- |
-| MaterialState | WidgetState |
-| MaterialStatePropertyResolver | WidgetStatePropertyResolver |
-| MaterialStateColor | WidgetStateColor |
-| MaterialStateMouseCursor | WidgetStateColorMouseCursor |
-| MaterialStateBorderSide | WidgetStateBorderSide |
-| MaterialStateOutlinedBorder | WidgetStateOutlinedBorder |
-| MaterialStateTextStyle | WidgetStateTextStyle |
-| MaterialStateProperty | WidgetStateProperty |
-| MaterialStatePropertyAll | WidgetStatePropertyAll |
-| MaterialStatesController | WidgetStatesController |
-| MaterialStateMixin | WidgetStateMixin |
+| `MaterialState` | `WidgetState` |
+| `MaterialStatePropertyResolver` | `WidgetStatePropertyResolver` |
+| `MaterialStateColor` | `WidgetStateColor` |
+| `MaterialStateMouseCursor` | `WidgetStateColorMouseCursor` |
+| `MaterialStateBorderSide` | `WidgetStateBorderSide` |
+| `MaterialStateOutlinedBorder` | `WidgetStateOutlinedBorder` |
+| `MaterialStateTextStyle` | `WidgetStateTextStyle` |
+| `MaterialStateProperty` | `WidgetStateProperty` |
+| `MaterialStatePropertyAll` | `WidgetStatePropertyAll` |
+| `MaterialStatesController` | `WidgetStatesController` |
+| `MaterialStateMixin` | `WidgetStateMixin` |
 
 The classes `MaterialStateOutlineInputBorder` and
 `MaterialStateUnderlineInputBorder` were left in the
-Material library with no `WidgetState` equivilant, as
-they are Material design specific.
+Material library with no `WidgetState` equivilent, as
+they are specific to Material design.
 
 ## Migration guide
 
@@ -88,7 +88,7 @@ WidgetStateBorderSide? get side;
 
 ## Timeline
 
-Landed in version: xxx<br>
+Landed in version: 3.20.0-1.2.pre<br>
 In stable release: not yet
 
 ## References


### PR DESCRIPTION
Adds a migration guide guide for MaterialState logic being marked deprecated by [flutter/pull/142151](https://github.com/flutter/flutter/pull/142151)

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
