### PR TITLE
Update Gradle plugin upgrade guide

### DIFF
--- a/src/release/breaking-changes/flutter-gradle-plugin-apply.md
+++ b/src/release/breaking-changes/flutter-gradle-plugin-apply.md
@@ -56,12 +56,12 @@ pluginManagement {
 }
 
 plugins {
-    id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "{agpVersion}" apply false
-    id("org.jetbrains.kotlin.android") version "{kotlinVersion}" apply false
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "{agpVersion}" apply false
+    id "org.jetbrains.kotlin.android version "{kotlinVersion}" apply false
 }
 
-include(":app")
+include ":app"
 ```
 
 If you made some changes to this file, make sure they're placed after

--- a/src/release/breaking-changes/flutter-gradle-plugin-apply.md
+++ b/src/release/breaking-changes/flutter-gradle-plugin-apply.md
@@ -58,7 +58,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "{agpVersion}" apply false
-    id "org.jetbrains.kotlin.android version "{kotlinVersion}" apply false
+    id "org.jetbrains.kotlin.android" version "{kotlinVersion}" apply false
 }
 
 include ":app"

--- a/src/release/breaking-changes/flutter-gradle-plugin-apply.md
+++ b/src/release/breaking-changes/flutter-gradle-plugin-apply.md
@@ -44,10 +44,9 @@ pluginManagement {
         def flutterSdkPath = properties.getProperty("flutter.sdk")
         assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
         return flutterSdkPath
-    }
-    settings.ext.flutterSdkPath = flutterSdkPath()
+    }()
 
-    includeBuild("${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle")
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
     repositories {
         google()
@@ -57,12 +56,12 @@ pluginManagement {
 }
 
 plugins {
-    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "{agpVersion}" apply false
-    id "org.jetbrains.kotlin.android" version "{kotlinVersion}" apply false
+    id("dev.flutter.flutter-plugin-loader") version "1.0.0"
+    id("com.android.application") version "{agpVersion}" apply false
+    id("org.jetbrains.kotlin.android") version "{kotlinVersion}" apply false
 }
 
-include ":app"
+include(":app")
 ```
 
 If you made some changes to this file, make sure they're placed after


### PR DESCRIPTION
This PR makes a tiny adjustement to [Deprecated imperative apply of Flutter's Gradle plugins](https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply) migration guide.

This change brings the suggested `settings.gradle` in line with `settings.gradle` from the latest generated template: https://github.com/flutter/flutter/blob/1e8dd1e4d6d70c5e06525bea3fb164a03d7a6c1d/packages/flutter_tools/templates/app_shared/android.tmpl/settings.gradle.tmpl

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
