### PR TITLE
Update sjtug mirror pubhosted url

### DIFF
--- a/src/_data/mirrors.yml
+++ b/src/_data/mirrors.yml
@@ -8,7 +8,7 @@
 - group: 'Shanghai Jiao Tong University *nix User Group'
   mirror: 'mirror.sjtu.edu.cn'
   urls:
-    pubhosted: 'https://mirror.sjtu.edu.cn/flutter-infra'
+    pubhosted: 'https://mirror.sjtu.edu.cn/dart-pub'
     flutterstorage: 'https://mirror.sjtu.edu.cn'
     issues: 'https://github.com/sjtug/mirror-requests'
     group: https://github.com/sjtug


### PR DESCRIPTION
According to https://mirror.sjtu.edu.cn/docs/flutter_infra, the PUB_HOSTED_URL should be set as "https://mirror.sjtu.edu.cn/dart-pub" now.

