### PR TITLE
Fix typos

### DIFF
--- a/examples/layout/constraints/lib/main.dart
+++ b/examples/layout/constraints/lib/main.dart
@@ -1012,7 +1012,7 @@ class Example26 extends Example {
       'If all of Row\'s children are wrapped in Expanded widgets, each Expanded has a size proportional to its flex parameter, '
       'and only then each Expanded widget forces its child to have the Expanded\'s width.'
       '\n\n'
-      'In other words, Expanded ignores the preffered width of its children.';
+      'In other words, Expanded ignores the preferred width of its children.';
 
   @override
   Widget build(BuildContext context) {

--- a/src/deployment/windows.md
+++ b/src/deployment/windows.md
@@ -98,7 +98,7 @@ or [codemagic.yaml][cmyaml]
 to package the application and deploy it
 to the Microsoft Partner Center.
 Additional options (such as the list of
-capabilites and language resources
+capabilities and language resources
 contained in the package)
 can be configured using this package.
 

--- a/src/get-started/fwe/networking.md
+++ b/src/get-started/fwe/networking.md
@@ -30,7 +30,7 @@ gives more background on how authorization works on the web.
 * Tutorial: [Make authenticated requests][]
 * Article: [MDN's article on Authorization for websites][]
 
-## Making data retrived from the network useful
+## Making data retrieved from the network useful
 
 Once you retrieve data from the network,
 you need a way to convert the data from the network

--- a/src/resources/faq.md
+++ b/src/resources/faq.md
@@ -781,7 +781,7 @@ Chromebooks][].
 ### Is Flutter ABI compatible?
 
 Flutter and Dart don't offer application binary interface (ABI)
-compatibility. Offering ABI compatability is not a current
+compatibility. Offering ABI compatibility is not a current
 goal for Flutter or Dart.
 
 ## Framework

--- a/src/ui/layout/constraints.md
+++ b/src/ui/layout/constraints.md
@@ -1131,7 +1131,7 @@ class Example26 extends Example {
       'If all of Row\'s children are wrapped in Expanded widgets, each Expanded has a size proportional to its flex parameter, '
       'and only then each Expanded widget forces its child to have the Expanded\'s width.'
       '\n\n'
-      'In other words, Expanded ignores the preffered width of its children.';
+      'In other words, Expanded ignores the preferred width of its children.';
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

This PR fixes a few typos I spotted.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.