### PR TITLE
Reduce directories excerpter tool gets fragments from

### DIFF
--- a/build.excerpt.yaml
+++ b/build.excerpt.yaml
@@ -3,10 +3,6 @@ targets:
     sources:
       include:
         - examples/**
-        # Some default includes that aren't really used here but will prevent
-        # false-negative warnings:
-        - $package$
-        - lib/$lib$
       exclude:
         - '**/.*/**'
         - '**/android/**'


### PR DESCRIPTION
This fixes some issues with unrelated files having unexpected formats when running locally, and results in slightly faster refresh excerpt times.
