### PR TITLE
Remove use of include_cached plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,5 @@ gem 'activesupport', '~> 7.1.3'
 gem 'liquid-tag-parser', '~> 2.0.2'
 
 group :jekyll_plugins do
-  gem 'jekyll-include-cache', '~> 0.2.1'
   gem 'jekyll-toc', '~> 0.18.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,8 +48,6 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
-    jekyll-include-cache (0.2.1)
-      jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
     jekyll-toc (0.18.0)
@@ -103,7 +101,6 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 7.1.3)
   jekyll (= 4.3.3)
-  jekyll-include-cache (~> 0.2.1)
   jekyll-sass-converter (~> 3.0.0)
   jekyll-toc (~> 0.18.0)
   liquid-tag-parser (~> 2.0.2)

--- a/_config.yml
+++ b/_config.yml
@@ -122,7 +122,6 @@ sass:
 
 plugins:
   - jekyll-toc
-  - jekyll-include-cache
 
 toc:
   min_level: 2

--- a/src/_includes/sidenav-level-1.html
+++ b/src/_includes/sidenav-level-1.html
@@ -34,7 +34,7 @@
             {% if isActive -%}
             {% include sidenav-level-2.html parent_id=id children=entry.children active_entries=active_entries -%}
             {% else -%}
-            {% include_cached sidenav-level-2.html parent_id=id children=entry.children -%}
+            {% include sidenav-level-2.html parent_id=id children=entry.children -%}
             {% endif -%}
           </ul>
         </li>

--- a/src/_includes/sidenav-level-2.html
+++ b/src/_includes/sidenav-level-2.html
@@ -43,7 +43,7 @@
       {% if isActive -%}
         {% include sidenav-level-3.html parent_id=id children=entry.children active_entries=active_entries -%}
       {% else -%}
-        {% include_cached sidenav-level-3.html parent_id=id children=entry.children -%}
+        {% include sidenav-level-3.html parent_id=id children=entry.children -%}
       {% endif -%}
     </ul>
   </li>

--- a/src/_includes/sidenav-level-3.html
+++ b/src/_includes/sidenav-level-3.html
@@ -42,7 +42,7 @@
       {% if isActive -%}
         {% include sidenav-level-4.html parent_id=id children=entry.children active_entries=active_entries -%}
       {% else -%}
-        {% include_cached sidenav-level-4.html parent_id=id children=entry.children -%}
+        {% include sidenav-level-4.html parent_id=id children=entry.children -%}
       {% endif -%}
     </ul>
   </li>

--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -74,7 +74,7 @@
   </head>
   <body{% if page.body_class %} class="{{ page.body_class }}"{% endif %}>
 
-    {% include_cached cookie-notice.html %}
+    {% include cookie-notice.html %}
 
     {% if jekyll.environment == "production" %}
       <noscript>
@@ -90,13 +90,13 @@
     {% include header.html %}
 
     {% if page.show_banner -%}
-      {% include_cached banner.html %}
+      {% include banner.html %}
     {% endif -%}
 
     {{ content }}
 
     {% if page.show_footer %}
-      {% include_cached footer.html %}
+      {% include footer.html %}
     {% endif %}
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.0/jquery.min.js" integrity="sha512-3gJwYpMe3QewGELv8k/BX9vcqhryRdzRMxVfq6ngyWXwo03GFEzjsUm8Q7RZcHPHksttq7/GFoxjCVUjkjvPdw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -29,7 +29,7 @@ layout: base
           {% include snackbar.html class="snackbar--dismissible" label="This page is deprecated and its content may be out of date." action="Dismiss" %}
         {% endif %}
 
-        {% include_cached next-prev-nav.html prev=page.prev next=page.next %}
+        {% include next-prev-nav.html prev=page.prev next=page.next %}
 
         <header class="site-content__title">
           {% include page-github-links.html %}
@@ -44,7 +44,7 @@ layout: base
         {% endif -%}
         {{ content | inject_anchors }}
 
-        {% include_cached next-prev-nav.html prev=page.prev next=page.next %}
+        {% include next-prev-nav.html prev=page.prev next=page.next %}
       </div>
     </main>
   </div>


### PR DESCRIPTION
Contributes to https://github.com/flutter/website/issues/10203 as we'll only use normal Liquid includes and render syntax after the migration.

The usage of `include_cached` was simply a performance optimization, so this doesn't affect rendering results.
