### PR TITLE
Fix flow of rightside TOC

### DIFF
--- a/src/_sass/components/_toc.scss
+++ b/src/_sass/components/_toc.scss
@@ -6,6 +6,7 @@
     padding-left: 0;
     margin-left: 0;
     list-style: none;
+    flex-direction: column;
   }
 
   &__title {


### PR DESCRIPTION
On https://docs.flutter.dev/platform-integration/web/wasm, you can see the right side (wide screen) TOC has overlapping entries due to the wrong flex direction.