### PR TITLE
Give emulator more time to start in link check test

### DIFF
--- a/tool/flutter_site/lib/src/commands/check_links.dart
+++ b/tool/flutter_site/lib/src/commands/check_links.dart
@@ -75,7 +75,7 @@ Future<int> _checkLinks({bool checkExternal = false}) async {
   );
 
   // Give the emulator a few seconds to start up.
-  await Future<void>.delayed(const Duration(seconds: 3));
+  await Future<void>.delayed(const Duration(seconds: 5));
 
   try {
     // Check to see if the emulator is running.
@@ -116,7 +116,7 @@ Future<bool> _isPortInUse(int port) async {
       InternetAddress.loopbackIPv4,
       port,
       shared: false,
-    ).timeout(const Duration(seconds: 2)); // Ignore timeout.
+    ).timeout(const Duration(seconds: 3)); // Ignore timeout.
 
     // If we reach this line, the port was available,
     // and we know the Firebase hosting emulator is not running.


### PR DESCRIPTION
The test has been flaky due to not waiting long enough for the Firebase emulator to start.