### PR TITLE
Add italian course platform to list

### DIFF
--- a/src/resources/courses.md
+++ b/src/resources/courses.md
@@ -31,5 +31,5 @@ To include your course, [submit a PR][]:
 [Dart & Flutter - Zero to Mastery 2023 + Clean Architecture]: https://www.udemy.com/course/flutter-made-easy-zero-to-mastery/?referralCode=CCBFCD16CC71F359EE3C
 [Dart & Flutter - Zero to Mastery 2023 - Keiko Corp. Food Reviews App]: https://academy.zerotomastery.io/courses/2092303/lectures/47623876
 [Sticky Grouped Headers in Flutter]: https://academy.droidcon.com/course/sticky-grouped-headers-in-flutter
-[Flutter University - From Zero to Mastery]: https://www.fudeo.it
+[Flutter University - From Zero to Mastery]: https://www.fudeo.it/?utm_source=flutter_dev
 [submit a PR]: {{site.repo.this}}/pulls

--- a/src/resources/courses.md
+++ b/src/resources/courses.md
@@ -19,6 +19,7 @@ To include your course, [submit a PR][]:
 * [Dart & Flutter - Zero to Mastery 2023 + Clean Architecture][] by Max Berktold & Max Steffen
 * [Dart & Flutter - Zero to Mastery 2023 - Keiko Corp. Food Reviews App][] by Marco Napoli
 * [Sticky Grouped Headers in Flutter][] by Marco Napoli
+* [Flutter University - From Zero to Mastery][] by Fudeo (Italian)
 
 [Flutter & Dart - The Complete Guide, 2023 Edition]: https://www.udemy.com/course/learn-flutter-dart-to-build-ios-android-apps/
 [The Complete 2021 Flutter Development Bootcamp Using Dart]: https://www.appbrewery.co/p/flutter-development-bootcamp-with-dart/
@@ -30,4 +31,5 @@ To include your course, [submit a PR][]:
 [Dart & Flutter - Zero to Mastery 2023 + Clean Architecture]: https://www.udemy.com/course/flutter-made-easy-zero-to-mastery/?referralCode=CCBFCD16CC71F359EE3C
 [Dart & Flutter - Zero to Mastery 2023 - Keiko Corp. Food Reviews App]: https://academy.zerotomastery.io/courses/2092303/lectures/47623876
 [Sticky Grouped Headers in Flutter]: https://academy.droidcon.com/course/sticky-grouped-headers-in-flutter
+[Flutter University - From Zero to Mastery]: https://www.fudeo.it
 [submit a PR]: {{site.repo.this}}/pulls


### PR DESCRIPTION
Hello 👋
I'm adding a link to my course platform: we have about:
- 15 courses (all in italian) 
- Over 2k students
- Teaching Flutter since 2019 (we love Flutter!)

Hopefully adding the link here is gonna allow even more people to start their journey with Flutter, that are less experienced with english and want some educational content in their mother tongue :)
[Fudeo: Flutter University (Italian)](https://www.fudeo.it/)

Thank you!
Have a good work

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
