### PR TITLE
Fix links to Bitrise Flutter docs

### DIFF
--- a/src/deployment/cd.md
+++ b/src/deployment/cd.md
@@ -307,7 +307,7 @@ information.
 [Android app signing steps]: /deployment/android#signing-the-app
 [Appcircle]: https://appcircle.io/blog/guide-to-automated-mobile-ci-cd-for-flutter-projects-with-appcircle/
 [Apple Developer Account console]: {{site.apple-dev}}/account/ios/certificate/
-[Bitrise]: https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps
+[Bitrise]: https://devcenter.bitrise.io/en/getting-started/quick-start-guides/getting-started-with-flutter-apps
 [CI Options and Examples]: #reference-and-examples
 [Cirrus]: https://cirrus-ci.org
 [Cirrus script]: {{site.repo.flutter}}/blob/master/.cirrus.yml

--- a/src/testing/overview.md
+++ b/src/testing/overview.md
@@ -125,7 +125,7 @@ integration services, see the following:
 [code coverage]: https://en.wikipedia.org/wiki/Code_coverage
 [Codemagic CI/CD for Flutter]: https://blog.codemagic.io/getting-started-with-codemagic/
 [Continuous delivery using fastlane with Flutter]: /deployment/cd#fastlane
-[Flutter CI/CD with Bitrise]: https://devcenter.bitrise.io/en/getting-started/getting-started-with-flutter-apps
+[Flutter CI/CD with Bitrise]: https://devcenter.bitrise.io/en/getting-started/quick-start-guides/getting-started-with-flutter-apps
 [How to test a Flutter app]: {{site.codelabs}}/codelabs/flutter-app-testing
 [Test Flutter apps on Appcircle]: https://blog.appcircle.io/article/flutter-ci-cd-github-ios-android-web#
 [Test Flutter apps on Cirrus]: https://cirrus-ci.org/examples/#flutter


### PR DESCRIPTION
They also don't have a link destination that automatically picks a language, so they have to include the `/en/`.

Fixes https://github.com/flutter/website/issues/10290