### PR TITLE
Remove transitional 'GPU thread' mentions

### DIFF
--- a/src/perf/ui-performance.md
+++ b/src/perf/ui-performance.md
@@ -42,8 +42,7 @@ steps to take, and tools that can help.
 
 To diagnose an app with performance problems, you'll enable
 the performance overlay to look at the UI and raster threads.
-(The raster thread was previously known as the GPU thread.)
-Before you begin, you want to make sure that you're running in
+Before you begin, make sure that you're running in
 [profile mode][], and that you're not using an emulator.
 For best results, you might choose the slowest device that
 your users might use.
@@ -218,7 +217,7 @@ on other threads.
     be rendered on the device. _Don't block this thread!_
     Shown in the bottom row of the performance overlay.
 </dd>
-<dt markdown="1">**Raster thread** (previously known as the GPU thread)</dt>
+<dt markdown="1">**Raster thread**</dt>
 <dd markdown="1">The raster thread takes the layer tree and displays
     it by talking to the GPU (graphic processing unit).
     You cannot directly access the raster thread or its data but,
@@ -226,11 +225,8 @@ on other threads.
     in the Dart code. Skia and Impeller, the graphics libraries,
     run on this thread.
     Shown in the top row of the performance overlay.
-    This thread was previously known as the "GPU thread" because it
-    rasterizes for the GPU. But it is running on the CPU.
-    We renamed it to "raster thread" because many developers wrongly
-    (but understandably)
-    assumed the thread runs on the GPU unit.
+    Note that while the raster thread rasterizes for the GPU,
+    the thread itself runs on the CPU.
 </dd>
 <dt markdown="1">**I/O thread**</dt>
 <dd markdown="1">Performs expensive tasks (mostly I/O) that would

--- a/src/tools/devtools/performance.md
+++ b/src/tools/devtools/performance.md
@@ -54,8 +54,7 @@ This chart contains Flutter frame information for your application.
 Each bar set in the chart represents a single Flutter frame.
 The bars are color-coded to highlight the different portions
 of work that occur when rendering a Flutter frame: work from
-the UI thread and work from the raster thread (previously known
-as the GPU thread).
+the UI thread and work from the raster thread.
 
 This chart contains Flutter frame timing information for your
 application. Each pair of bars in the chart represents a single
@@ -77,8 +76,7 @@ for data below by clicking the **Flutter frames** button above the chart.
 
 The pair of bars representing each Flutter frame are color-coded
 to highlight the different portions of work that occur when rendering
-a Flutter frame: work from the UI thread and work from the raster thread
-(previously known as the GPU thread).
+a Flutter frame: work from the UI thread and work from the raster thread.
 
 ### UI
 
@@ -91,15 +89,13 @@ to be rendered on the device. Do **not** block this thread.
 
 ### Raster
 
-The raster thread (previously known as the GPU thread)
-executes graphics code from the Flutter Engine.
+The raster thread executes graphics code from the Flutter Engine.
 This thread takes the layer tree and displays it by talking to
 the GPU (graphic processing unit). You can't directly access
 the raster thread or its data, but if this thread is slow,
 it's a result of something you've done in the Dart code.
 Skia, the graphics library, runs on this thread.
-[Impeller][] (in the stable channel for iOS)
-also uses this thread.
+[Impeller][] also uses this thread.
 
 [Impeller]: /perf/impeller
 


### PR DESCRIPTION
It has been around 3+ years since the transition was made, so we can probably remove these transitional mentions now. I've kept a modified form of one mention as it still seemed useful.

\cc @filiph 