### PR TITLE
Fix mismatch in Gradle plugin page

### DIFF
--- a/src/release/breaking-changes/flutter-gradle-plugin-apply.md
+++ b/src/release/breaking-changes/flutter-gradle-plugin-apply.md
@@ -125,7 +125,7 @@ Remove the whole `buildscript` block from `<app-src/android/build.gradle`:
 -    }
 -
 -    dependencies {
--        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+-        classpath "org.jetbrains.kotlin:gradle-plugin:$kotlin_version"
 -    }
 -}
 ```
@@ -167,7 +167,7 @@ remove these 2 chunks of code that use the legacy imperative apply method:
 
 ```diff
 -apply plugin: 'com.android.application'
--apply plugin: 'kotlin-android'
+-apply plugin: 'com.jetbrains.kotlin.android'
 -apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 ```
 


### PR DESCRIPTION
Fixes #10299

The section # android/app/build.gradle says to add the `id kotlin-android` to `plugins`.

The section # Google Mobile Services and Crashlytics says to add the `id org.jetbrains.kotlin.android`

Changed the first to `id org.jetbrains.kotlin.android`