### PR TITLE
Minimize Windows Android install list to only Android Studio

### DIFF
--- a/src/get-started/install/windows/mobile.md
+++ b/src/get-started/install/windows/mobile.md
@@ -2,7 +2,7 @@
 title: Start building Flutter Android apps on Windows
 description: Configure your system to develop Flutter mobile apps on Windows.
 short-title: Make Android apps
-target: Android
+target: mobile
 config: WindowsAndroid
 devos: Windows
 next:


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

https://docs.flutter.dev/get-started/install/windows/mobile?tab=virtual shows all the install options for Windows devices. There's seems to be a lot unnecessary steps added, and this seems to be it falling back to not having the target set correctly.

I would expect this list to be [Android Studio] instead of [Visual Studio, Android Studio, Google Chrome]

_Issues fixed by this PR (if any):_

N/A

## Presubmit checklist

- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
