### PR TITLE
Add root dash_site command for consistency with dart.dev

### DIFF
--- a/dash_site
+++ b/dash_site
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+REQUIRED_DART_VERSION="3.3"
+REQUIRED_NODE_VERSION="20.10"
+REQUIRED_PNPM_VERSION="8.14"
+
+# Check that the 'dart' command is available on the user's path.
+if ! command -v dart &> /dev/null; then
+  echo "Dart not found. To learn how to setup Dart and Flutter, follow the instructions at https://docs.flutter.dev/get-started."
+  exit 1
+fi
+
+# Check that the current version of a tool is the same or
+# newer than a required version.
+version_is_new_enough() {
+  required_version="$1"
+  current_version="$2"
+
+  # Split the version strings into lists based on the dot separators.
+  IFS='.' read -ra required_list <<< "$required_version"
+  IFS='.' read -ra current_list <<< "$current_version"
+
+  # Compare each portion of the version number.
+  for ((i = 0; i < ${#required_list[@]}; i += 1)); do
+    required_segment="${required_list[i]:-0}"
+    current_segment="${current_list[i]:-0}"
+
+    if [[ "$required_segment" -gt "$current_segment" ]]; then
+      # The current version is too low.
+      return 0
+    elif [[ "$required_segment" -lt "$current_segment" ]]; then
+      # The current version is higher, which is ok.
+      return 1
+    fi
+  done
+
+  # The current version is (mostly) the same as the required version.
+  return 1
+}
+
+
+# Determine the available Dart SDK version.
+dart_version=$(dart --version | grep -oE 'Dart SDK version: [0-9.]+' | cut -d ' ' -f 4)
+
+# Validate the version of the installed Dart SDK.
+if version_is_new_enough "$REQUIRED_DART_VERSION" "$dart_version"; then
+  echo "Dart version $dart_version is too low. Version $REQUIRED_DART_VERSION or later is required."
+  exit 1
+fi
+
+# Check that the 'node' command is available on the user's path.
+if ! command -v node &> /dev/null; then
+  echo "'node' command not found. To learn how to install and setup Node, reference the repository README."
+  exit 1
+fi
+
+# Determine the available Node version.
+node_version=$(node --version | cut -d 'v' -f 2)
+
+# Validate the version of the Node installation.
+if version_is_new_enough "$REQUIRED_NODE_VERSION" "$node_version"; then
+  echo "Node version $node_version is too low. Version $REQUIRED_NODE_VERSION or later is required."
+  exit 1
+fi
+
+# Check that the 'npx' command is available on the user's path.
+if ! command -v npx &> /dev/null; then
+  echo "'npx' command from Node not found. Check your Node installation."
+  exit 1
+fi
+
+# Run extra logic if the 'pnpm' command is available on the user's path.
+if command -v pnpm &> /dev/null; then
+  # Determine the available pnpm version.
+  pnpm_version=$(pnpm --version)
+
+  # Validate the version of the pnpm installation.
+  if version_is_new_enough "$REQUIRED_PNPM_VERSION" "$pnpm_version"; then
+    echo "pnpm version $pnpm_version is too low. Version $REQUIRED_PNPM_VERSION or later is required."
+    exit 1
+  fi
+fi
+
+# Verify that Node packages have been installed.
+if [[ ! -d "node_modules" ]]; then
+  if command -v pnpm &> /dev/null; then
+    echo "Node packages not found. Installing with 'pnpm install'..."
+    pnpm install
+  elif command -v npm &> /dev/null; then
+    echo "Node packages not found. Installing with 'npm install'..."
+    npm install
+  else
+    echo "Neither 'pnpm' nor 'npm' found. To learn how to setup pnpm, reference the repository README."
+    exit 1
+  fi
+fi
+
+# Verify that Dart dependencies have been retrieved.
+if [[ ! -d ".dart_tool" ]]; then
+  dart pub get
+fi
+
+# Run the Flutter site tool and pass through all arguments.
+dart run flutter_site "$@"

--- a/tool/flutter_site/lib/flutter_site.dart
+++ b/tool/flutter_site/lib/flutter_site.dart
@@ -5,6 +5,7 @@
 import 'package:args/command_runner.dart';
 
 import 'src/commands/analyze_dart.dart';
+import 'src/commands/build.dart';
 import 'src/commands/check_all.dart';
 import 'src/commands/check_link_references.dart';
 import 'src/commands/check_links.dart';
@@ -22,6 +23,7 @@ final class FlutterSiteCommandRunner extends CommandRunner<int> {
           'flutter_site',
           'Infrastructure tooling for the Flutter documentation website.',
         ) {
+    addCommand(BuildSiteCommand());
     addCommand(CheckLinksCommand());
     addCommand(CheckLinkReferencesCommand());
     addCommand(VerifyFirebaseJsonCommand());

--- a/tool/flutter_site/lib/flutter_site.dart
+++ b/tool/flutter_site/lib/flutter_site.dart
@@ -11,6 +11,7 @@ import 'src/commands/check_link_references.dart';
 import 'src/commands/check_links.dart';
 import 'src/commands/format_dart.dart';
 import 'src/commands/refresh_excerpts.dart';
+import 'src/commands/serve.dart';
 import 'src/commands/test_dart.dart';
 import 'src/commands/verify_firebase_json.dart';
 
@@ -23,14 +24,15 @@ final class FlutterSiteCommandRunner extends CommandRunner<int> {
           'flutter_site',
           'Infrastructure tooling for the Flutter documentation website.',
         ) {
+    addCommand(AnalyzeDartCommand());
     addCommand(BuildSiteCommand());
+    addCommand(CheckAllCommand());
     addCommand(CheckLinksCommand());
     addCommand(CheckLinkReferencesCommand());
-    addCommand(VerifyFirebaseJsonCommand());
-    addCommand(RefreshExcerptsCommand());
     addCommand(FormatDartCommand());
-    addCommand(AnalyzeDartCommand());
+    addCommand(RefreshExcerptsCommand());
+    addCommand(ServeSiteCommand());
     addCommand(TestDartCommand());
-    addCommand(CheckAllCommand());
+    addCommand(VerifyFirebaseJsonCommand());
   }
 }

--- a/tool/flutter_site/lib/src/commands/build.dart
+++ b/tool/flutter_site/lib/src/commands/build.dart
@@ -11,7 +11,8 @@ final class BuildSiteCommand extends Command<int> {
     argParser.addFlag(
       _releaseFlag,
       defaultsTo: false,
-      help: 'Build a release build for dart.dev. Optimizes site resources.',
+      help: 'Build a release build for docs.flutter.dev. '
+          'Optimizes site resources.',
     );
   }
 

--- a/tool/flutter_site/lib/src/commands/build.dart
+++ b/tool/flutter_site/lib/src/commands/build.dart
@@ -1,0 +1,29 @@
+// Copyright 2024 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/command_runner.dart';
+
+final class BuildSiteCommand extends Command<int> {
+  static const String _releaseFlag = 'release';
+
+  BuildSiteCommand() {
+    argParser.addFlag(
+      _releaseFlag,
+      defaultsTo: false,
+      help: 'Build a release build for dart.dev. Optimizes site resources.',
+    );
+  }
+
+  @override
+  String get description => 'Build the site.';
+
+  @override
+  String get name => 'build';
+
+  @override
+  Future<int> run() async {
+    print('TODO: Not yet implemented.');
+    return 0;
+  }
+}

--- a/tool/flutter_site/lib/src/commands/serve.dart
+++ b/tool/flutter_site/lib/src/commands/serve.dart
@@ -1,0 +1,19 @@
+// Copyright 2024 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/command_runner.dart';
+
+final class ServeSiteCommand extends Command<int> {
+  @override
+  String get description => 'Serve the site locally.';
+
+  @override
+  String get name => 'serve';
+
+  @override
+  Future<int> run() async {
+    print('TODO: Not yet implemented.');
+    return 0;
+  }
+}


### PR DESCRIPTION
This command will be used as an easy entry point into site tooling while also verifying the user's setup and conveying any issues.

Instructions for use will come in follow-up PRs.

Contributes to https://github.com/flutter/website/issues/10203