### PR TITLE
Fix contrast of 'console' code block language

### DIFF
--- a/src/_sass/components/_code.scss
+++ b/src/_sass/components/_code.scss
@@ -55,17 +55,8 @@ $generic-output-color: #8ae234;
   color: $color;
 }
 
-.language-console .highlight {
-  @include console-base;
-  .go { color: $generic-output-color; } /* Generic.Output */
-}
-
-pre.console-output {
-  @include console-base($generic-output-color)
-}
-
 // `terminal` is like `console` with prompts and output colored differently
-.language-terminal .highlight {
+.language-console .highlight {
   @include console-base;
   .gp { color: $flutter-color-yellow; font-weight: 700; } /* Generic.Prompt */
   .go { color: $generic-output-color; } /* Generic.Output */


### PR DESCRIPTION
Reuses `terminal` highlighting for `console`, as I recently consolidated them.

Fixes https://github.com/flutter/website/issues/10342
Fixes https://github.com/flutter/website/issues/10335
Contributes to legibility portion of https://github.com/flutter/website/issues/10341