### PR TITLE
Add more client-side fragment redirects for old get started pages

### DIFF
--- a/src/assets/js/temp/chromeos-install-redirector.js
+++ b/src/assets/js/temp/chromeos-install-redirector.js
@@ -1,17 +1,12 @@
 const oldToNew = {
-  'ios-setup': '/get-started/install/macos/mobile-ios',
-  'set-up-the-ios-simulator': '/get-started/install/macos/mobile-ios#configure-your-target-ios-device',
-  'deploy-to-physical-ios-devices': '/deployment/ios',
-  'deploy-to-ios-devices': '/deployment/ios',
+  'configuring-web-app-support': '/get-started/install/chromeos/web',
 
-  'macos-setup': '/get-started/install/macos/desktop',
-
-  'android-setup': '/get-started/install/macos/mobile-android#configure-android-development',
-  'set-up-your-android-device': '/get-started/install/macos/mobile-android#configure-your-target-android-device',
-  'set-up-the-android-emulator': '/get-started/install/macos/mobile-android#configure-your-target-android-device',
-  'agree-to-android-licenses': '/get-started/install/macos/mobile-android#agree-to-android-licenses',
-
-  'update-your-path': '/get-started/install/macos/mobile-ios?tab=download#add-flutter-to-your-path',
+  'android-setup-without-android-studio': '/get-started/install/chromeos/android?tab=download#configure-android-development',
+  'android-setup': '/get-started/install/chromeos/android?tab=download#configure-android-development',
+  'configuring-android-app-support': '/get-started/install/chromeos/android?tab=download#configure-android-development',
+  'set-up-your-android-device': '/get-started/install/chromeos/android#configure-your-target-android-device',
+  'set-up-the-android-emulator': '/get-started/install/chromeos/android#configure-your-target-android-device',
+  'agree-to-android-licenses': '/get-started/install/chromeos/android#agree-to-android-licenses',
 };
 
 function handleRedirect() {
@@ -51,7 +46,7 @@ function handleRedirect() {
 
 const currentLocation = window.location.pathname;
 
-if (currentLocation.includes('/get-started/install/macos') &&
+if (currentLocation.includes('/get-started/install/chromeos') &&
     currentLocation.split('/')
         .filter(value => value.trim().length !== 0).length === 3) {
   handleRedirect();

--- a/src/assets/js/temp/linux-install-redirector.js
+++ b/src/assets/js/temp/linux-install-redirector.js
@@ -1,17 +1,12 @@
 const oldToNew = {
-  'ios-setup': '/get-started/install/macos/mobile-ios',
-  'set-up-the-ios-simulator': '/get-started/install/macos/mobile-ios#configure-your-target-ios-device',
-  'deploy-to-physical-ios-devices': '/deployment/ios',
-  'deploy-to-ios-devices': '/deployment/ios',
+  'linux-setup': '/get-started/install/linux/desktop',
 
-  'macos-setup': '/get-started/install/macos/desktop',
+  'android-setup': '/get-started/install/linux/android#configure-android-development',
+  'set-up-your-android-device': '/get-started/install/linux/android#configure-your-target-android-device',
+  'set-up-the-android-emulator': '/get-started/install/linux/android#configure-your-target-android-device',
+  'agree-to-android-licenses': '/get-started/install/linux/android#agree-to-android-licenses',
 
-  'android-setup': '/get-started/install/macos/mobile-android#configure-android-development',
-  'set-up-your-android-device': '/get-started/install/macos/mobile-android#configure-your-target-android-device',
-  'set-up-the-android-emulator': '/get-started/install/macos/mobile-android#configure-your-target-android-device',
-  'agree-to-android-licenses': '/get-started/install/macos/mobile-android#agree-to-android-licenses',
-
-  'update-your-path': '/get-started/install/macos/mobile-ios?tab=download#add-flutter-to-your-path',
+  'update-your-path': '/get-started/install/linux/android?tab=download#add-flutter-to-your-path'
 };
 
 function handleRedirect() {
@@ -51,7 +46,7 @@ function handleRedirect() {
 
 const currentLocation = window.location.pathname;
 
-if (currentLocation.includes('/get-started/install/macos') &&
+if (currentLocation.includes('/get-started/install/linux') &&
     currentLocation.split('/')
         .filter(value => value.trim().length !== 0).length === 3) {
   handleRedirect();

--- a/src/assets/js/temp/windows-install-redirector.js
+++ b/src/assets/js/temp/windows-install-redirector.js
@@ -5,6 +5,8 @@ const oldToNew = {
   'set-up-the-android-emulator': '/get-started/install/windows/mobile#configure-your-target-android-device',
   'agree-to-android-licenses': '/get-started/install/windows/mobile#agree-to-android-licenses',
   'android-setup': '/get-started/install/windows/mobile#configure-android-development',
+
+  'update-your-path': '/get-started/install/windows/mobile?tab=download#update-your-windows-path-variable',
 };
 
 function handleRedirect() {

--- a/src/get-started/install/chromeos/index.md
+++ b/src/get-started/install/chromeos/index.md
@@ -3,6 +3,7 @@ title: Choose your first type of app
 description: Configure your system to develop Flutter on ChromeOS.
 short-title: ChromeOS
 target-list: [Android, Web]
+js: [{url: '/assets/js/temp/chromeos-install-redirector.js'}]
 ---
 
 {% assign os = 'chromeos' -%}

--- a/src/get-started/install/linux/index.md
+++ b/src/get-started/install/linux/index.md
@@ -3,6 +3,7 @@ title: Choose your first type of app
 description: Configure your system to develop Flutter on Linux.
 short-title: Linux
 target-list: [Desktop, Android, Web]
+js: [{url: '/assets/js/temp/linux-install-redirector.js'}]
 ---
 
 {% assign os = 'linux' -%}


### PR DESCRIPTION
This adds redirects from the `/get-started/install/<platform>` pages if a fragment (`#link-target-fragment`) from the old page format is specified. These JS based redirects are necessary as fragments aren't sent to the server, so Firebase redirects won't work.

We likely won't maintain these indefinitely, but a lot of links referencing these still exist in old versions of tools and the internet, so we can keep them for the foreseeable future.

Fixes https://github.com/flutter/website/issues/10271
