### PR TITLE
Add missing note about building Android plugin

### DIFF
--- a/src/packages-and-plugins/developing-packages.md
+++ b/src/packages-and-plugins/developing-packages.md
@@ -409,6 +409,12 @@ Locate the file `lib/hello.dart`.
 
 We recommend you edit the Android code using Android Studio.
 
+Before editing the Android platform code in Android Studio,
+first make sure that the code has been built at least once
+(in other words, run the example app from your IDE/editor,
+or in a terminal execute
+`cd hello/example; flutter build apk --config-only`).
+
 Then use the following steps:
 
 1. Launch Android Studio.
@@ -434,7 +440,7 @@ Before editing the iOS platform code in Xcode,
 first make sure that the code has been built at least once
 (in other words, run the example app from your IDE/editor,
 or in a terminal execute
-`cd hello/example; flutter build ios --no-codesign`).
+`cd hello/example; flutter build ios --no-codesign --config-only`).
 
 Then use the following steps:
 
@@ -518,7 +524,7 @@ Before editing the macOS platform code in Xcode,
 first make sure that the code has been built at least once
 (in other words, run the example app from your IDE/editor,
 or in a terminal execute
-`cd hello/example; flutter build macos`).
+`cd hello/example; flutter build macos --config-only`).
 
 Then use the following steps:
 


### PR DESCRIPTION
Every other platform's section had the note about needing to build at least once before opening the native project, but it was missing for Android; this adds it.

It also updates the iOS and macOS docs to add the `--config-only` flag, which is an option that was added after these docs were originally written, and makes the step much faster. (Windows and Linux are unchanged since that option does not yet exist for those platforms).

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
