### PR TITLE
Reorder duplicated Kotlin and Java snippets

### DIFF
--- a/src/_includes/docs/add-to-app/android-initial-route-cached-engine.md
+++ b/src/_includes/docs/add-to-app/android-initial-route-cached-engine.md
@@ -12,31 +12,7 @@ with a custom initial route can configure their cached
 executing the Dart entrypoint. The following example
 demonstrates the use of an initial route with a cached engine:
 
-{% samplecode "cached-engine-with-initial-route", "Java,Kotlin" %}
-{% sample "Java" %}
-
-```java title="MyApplication.java"
-public class MyApplication extends Application {
-  @Override
-  public void onCreate() {
-    super.onCreate();
-    // Instantiate a FlutterEngine.
-    flutterEngine = new FlutterEngine(this);
-    // Configure an initial route.
-    flutterEngine.getNavigationChannel().setInitialRoute("your/route/here");
-    // Start executing Dart code to pre-warm the FlutterEngine.
-    flutterEngine.getDartExecutor().executeDartEntrypoint(
-      DartEntrypoint.createDefault()
-    );
-    // Cache the FlutterEngine to be used by FlutterActivity or FlutterFragment.
-    FlutterEngineCache
-      .getInstance()
-      .put("my_engine_id", flutterEngine);
-  }
-}
-```
-
-{% endsample %}
+{% samplecode "cached-engine-with-initial-route", "Kotlin,Java" %}
 {% sample "Kotlin" %}
 
 ```kotlin title="MyApplication.kt"
@@ -56,6 +32,30 @@ class MyApplication : Application() {
     FlutterEngineCache
       .getInstance()
       .put("my_engine_id", flutterEngine)
+  }
+}
+```
+
+{% endsample %}
+{% sample "Java" %}
+
+```java title="MyApplication.java"
+public class MyApplication extends Application {
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    // Instantiate a FlutterEngine.
+    flutterEngine = new FlutterEngine(this);
+    // Configure an initial route.
+    flutterEngine.getNavigationChannel().setInitialRoute("your/route/here");
+    // Start executing Dart code to pre-warm the FlutterEngine.
+    flutterEngine.getDartExecutor().executeDartEntrypoint(
+      DartEntrypoint.createDefault()
+    );
+    // Cache the FlutterEngine to be used by FlutterActivity or FlutterFragment.
+    FlutterEngineCache
+      .getInstance()
+      .put("my_engine_id", flutterEngine);
   }
 }
 ```

--- a/src/content/add-to-app/android/_initial-route-cached-engine.md
+++ b/src/content/add-to-app/android/_initial-route-cached-engine.md
@@ -12,31 +12,7 @@ with a custom initial route can configure their cached
 executing the Dart entrypoint. The following example
 demonstrates the use of an initial route with a cached engine:
 
-{% samplecode "cached-engine-with-initial-route", "Java,Kotlin" %}
-{% sample "Java" %}
-
-```java title="MyApplication.java"
-public class MyApplication extends Application {
-  @Override
-  public void onCreate() {
-    super.onCreate();
-    // Instantiate a FlutterEngine.
-    flutterEngine = new FlutterEngine(this);
-    // Configure an initial route.
-    flutterEngine.getNavigationChannel().setInitialRoute("your/route/here");
-    // Start executing Dart code to pre-warm the FlutterEngine.
-    flutterEngine.getDartExecutor().executeDartEntrypoint(
-      DartEntrypoint.createDefault()
-    );
-    // Cache the FlutterEngine to be used by FlutterActivity or FlutterFragment.
-    FlutterEngineCache
-      .getInstance()
-      .put("my_engine_id", flutterEngine);
-  }
-}
-```
-
-{% endsample %}
+{% samplecode "cached-engine-with-initial-route", "Kotlin,Java" %}
 {% sample "Kotlin" %}
 
 ```kotlin title="MyApplication.kt"
@@ -56,6 +32,30 @@ class MyApplication : Application() {
     FlutterEngineCache
       .getInstance()
       .put("my_engine_id", flutterEngine)
+  }
+}
+```
+
+{% endsample %}
+{% sample "Java" %}
+
+```java title="MyApplication.java"
+public class MyApplication extends Application {
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    // Instantiate a FlutterEngine.
+    flutterEngine = new FlutterEngine(this);
+    // Configure an initial route.
+    flutterEngine.getNavigationChannel().setInitialRoute("your/route/here");
+    // Start executing Dart code to pre-warm the FlutterEngine.
+    flutterEngine.getDartExecutor().executeDartEntrypoint(
+      DartEntrypoint.createDefault()
+    );
+    // Cache the FlutterEngine to be used by FlutterActivity or FlutterFragment.
+    FlutterEngineCache
+      .getInstance()
+      .put("my_engine_id", flutterEngine);
   }
 }
 ```

--- a/src/content/add-to-app/android/add-flutter-fragment.md
+++ b/src/content/add-to-app/android/add-flutter-fragment.md
@@ -45,55 +45,7 @@ To add a `FlutterFragment` to a host `Activity`, instantiate and
 attach an instance of `FlutterFragment` in `onCreate()` within the
 `Activity`, or at another time that works for your app:
 
-{% samplecode "add-fragment", "Java,Kotlin" %}
-{% sample "Java" %}
-
-```java title="MyActivity.java"
-public class MyActivity extends FragmentActivity {
-    // Define a tag String to represent the FlutterFragment within this
-    // Activity's FragmentManager. This value can be whatever you'd like.
-    private static final String TAG_FLUTTER_FRAGMENT = "flutter_fragment";
-
-    // Declare a local variable to reference the FlutterFragment so that you
-    // can forward calls to it later.
-    private FlutterFragment flutterFragment;
-
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        // Inflate a layout that has a container for your FlutterFragment.
-        // For this example, assume that a FrameLayout exists with an ID of
-        // R.id.fragment_container.
-        setContentView(R.layout.my_activity_layout);
-
-        // Get a reference to the Activity's FragmentManager to add a new
-        // FlutterFragment, or find an existing one.
-        FragmentManager fragmentManager = getSupportFragmentManager();
-
-        // Attempt to find an existing FlutterFragment,
-        // in case this is not the first time that onCreate() was run.
-        flutterFragment = (FlutterFragment) fragmentManager
-            .findFragmentByTag(TAG_FLUTTER_FRAGMENT);
-
-        // Create and attach a FlutterFragment if one does not exist.
-        if (flutterFragment == null) {
-            flutterFragment = FlutterFragment.createDefault();
-
-            fragmentManager
-                .beginTransaction()
-                .add(
-                    R.id.fragment_container,
-                    flutterFragment,
-                    TAG_FLUTTER_FRAGMENT
-                )
-                .commit();
-        }
-    }
-}
-```
-
-{% endsample %}
+{% samplecode "add-fragment", "Kotlin,Java" %}
 {% sample "Kotlin" %}
 
 ```kotlin title="MyActivity.kt"
@@ -143,6 +95,54 @@ class MyActivity : FragmentActivity() {
 ```
 
 {% endsample %}
+{% sample "Java" %}
+
+```java title="MyActivity.java"
+public class MyActivity extends FragmentActivity {
+    // Define a tag String to represent the FlutterFragment within this
+    // Activity's FragmentManager. This value can be whatever you'd like.
+    private static final String TAG_FLUTTER_FRAGMENT = "flutter_fragment";
+
+    // Declare a local variable to reference the FlutterFragment so that you
+    // can forward calls to it later.
+    private FlutterFragment flutterFragment;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // Inflate a layout that has a container for your FlutterFragment.
+        // For this example, assume that a FrameLayout exists with an ID of
+        // R.id.fragment_container.
+        setContentView(R.layout.my_activity_layout);
+
+        // Get a reference to the Activity's FragmentManager to add a new
+        // FlutterFragment, or find an existing one.
+        FragmentManager fragmentManager = getSupportFragmentManager();
+
+        // Attempt to find an existing FlutterFragment,
+        // in case this is not the first time that onCreate() was run.
+        flutterFragment = (FlutterFragment) fragmentManager
+            .findFragmentByTag(TAG_FLUTTER_FRAGMENT);
+
+        // Create and attach a FlutterFragment if one does not exist.
+        if (flutterFragment == null) {
+            flutterFragment = FlutterFragment.createDefault();
+
+            fragmentManager
+                .beginTransaction()
+                .add(
+                    R.id.fragment_container,
+                    flutterFragment,
+                    TAG_FLUTTER_FRAGMENT
+                )
+                .commit();
+        }
+    }
+}
+```
+
+{% endsample %}
 {% endsamplecode %}
 
 The previous code is sufficient to render a Flutter UI
@@ -153,7 +153,61 @@ Flutter behavior. Flutter depends on various OS signals that
 must  be forwarded from your host `Activity` to `FlutterFragment`.
 These calls are shown in the following example:
 
-{% samplecode "forward-activity-calls", "Java,Kotlin" %}
+{% samplecode "forward-activity-calls", "Kotlin,Java" %}
+{% sample "Kotlin" %}
+
+```kotlin title="MyActivity.kt"
+class MyActivity : FragmentActivity() {
+  override fun onPostResume() {
+    super.onPostResume()
+    flutterFragment!!.onPostResume()
+  }
+
+  override fun onNewIntent(@NonNull intent: Intent) {
+    flutterFragment!!.onNewIntent(intent)
+  }
+
+  override fun onBackPressed() {
+    flutterFragment!!.onBackPressed()
+  }
+
+  override fun onRequestPermissionsResult(
+    requestCode: Int,
+    permissions: Array<String?>,
+    grantResults: IntArray
+  ) {
+    flutterFragment!!.onRequestPermissionsResult(
+      requestCode,
+      permissions,
+      grantResults
+    )
+  }
+
+  override fun onActivityResult(
+    requestCode: Int,
+    resultCode: Int,
+    data: Intent?
+  ) {
+    super.onActivityResult(requestCode, resultCode, data)
+    flutterFragment!!.onActivityResult(
+      requestCode,
+      resultCode,
+      data
+    )
+  }
+
+  override fun onUserLeaveHint() {
+    flutterFragment!!.onUserLeaveHint()
+  }
+
+  override fun onTrimMemory(level: Int) {
+    super.onTrimMemory(level)
+    flutterFragment!!.onTrimMemory(level)
+  }
+}
+```
+
+{% endsample %}
 {% sample "Java" %}
 
 ```java title="MyActivity.java"
@@ -215,60 +269,6 @@ public class MyActivity extends FragmentActivity {
 ```
 
 {% endsample %}
-{% sample "Kotlin" %}
-
-```kotlin title="MyActivity.kt"
-class MyActivity : FragmentActivity() {
-  override fun onPostResume() {
-    super.onPostResume()
-    flutterFragment!!.onPostResume()
-  }
-
-  override fun onNewIntent(@NonNull intent: Intent) {
-    flutterFragment!!.onNewIntent(intent)
-  }
-
-  override fun onBackPressed() {
-    flutterFragment!!.onBackPressed()
-  }
-
-  override fun onRequestPermissionsResult(
-    requestCode: Int,
-    permissions: Array<String?>,
-    grantResults: IntArray
-  ) {
-    flutterFragment!!.onRequestPermissionsResult(
-      requestCode,
-      permissions,
-      grantResults
-    )
-  }
-
-  override fun onActivityResult(
-    requestCode: Int,
-    resultCode: Int,
-    data: Intent?
-  ) {
-    super.onActivityResult(requestCode, resultCode, data)
-    flutterFragment!!.onActivityResult(
-      requestCode,
-      resultCode,
-      data
-    )
-  }
-
-  override fun onUserLeaveHint() {
-    flutterFragment!!.onUserLeaveHint()
-  }
-
-  override fun onTrimMemory(level: Int) {
-    super.onTrimMemory(level)
-    flutterFragment!!.onTrimMemory(level)
-  }
-}
-```
-
-{% endsample %}
 {% endsamplecode %}
 
 With the OS signals forwarded to Flutter,
@@ -294,31 +294,7 @@ To use a pre-warmed `FlutterEngine` in a `FlutterFragment`,
 instantiate a `FlutterFragment` with the `withCachedEngine()`
 factory method.  
 
-{% samplecode "use-prewarmed-engine", "Java,Kotlin" %}
-{% sample "Java" %}
-
-```java title="MyApplication.java"
-// Somewhere in your app, before your FlutterFragment is needed,
-// like in the Application class ...
-// Instantiate a FlutterEngine.
-FlutterEngine flutterEngine = new FlutterEngine(context);
-
-// Start executing Dart code in the FlutterEngine.
-flutterEngine.getDartExecutor().executeDartEntrypoint(
-    DartEntrypoint.createDefault()
-);
-
-// Cache the pre-warmed FlutterEngine to be used later by FlutterFragment.
-FlutterEngineCache
-  .getInstance()
-  .put("my_engine_id", flutterEngine);
-```
-
-```java title="MyActivity.java"
-FlutterFragment.withCachedEngine("my_engine_id").build();
-```
-
-{% endsample %}
+{% samplecode "use-prewarmed-engine", "Kotlin,Java" %}
 {% sample "Kotlin" %}
 
 ```kotlin title="MyApplication.kt"
@@ -340,6 +316,30 @@ FlutterEngineCache
 
 ```kotlin title="MyActivity.java"
 FlutterFragment.withCachedEngine("my_engine_id").build()
+```
+
+{% endsample %}
+{% sample "Java" %}
+
+```java title="MyApplication.java"
+// Somewhere in your app, before your FlutterFragment is needed,
+// like in the Application class ...
+// Instantiate a FlutterEngine.
+FlutterEngine flutterEngine = new FlutterEngine(context);
+
+// Start executing Dart code in the FlutterEngine.
+flutterEngine.getDartExecutor().executeDartEntrypoint(
+    DartEntrypoint.createDefault()
+);
+
+// Cache the pre-warmed FlutterEngine to be used later by FlutterFragment.
+FlutterEngineCache
+  .getInstance()
+  .put("my_engine_id", flutterEngine);
+```
+
+```java title="MyActivity.java"
+FlutterFragment.withCachedEngine("my_engine_id").build();
 ```
 
 {% endsample %}
@@ -377,17 +377,7 @@ initial routes (routes other than `/`).
 To facilitate this, `FlutterFragment`'s `Builder`
 allows you to specify a desired initial route, as shown:
 
-{% samplecode "launch-with-initial-route", "Java,Kotlin" %}
-{% sample "Java" %}
-
-```java title="MyActivity.java"
-// With a new FlutterEngine.
-FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
-    .initialRoute("myInitialRoute/")
-    .build();
-```
-
-{% endsample %}
+{% samplecode "launch-with-initial-route", "Kotlin,Java" %}
 {% sample "Kotlin" %}
 
 ```kotlin title="MyActivity.kt"
@@ -395,6 +385,16 @@ FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
 val flutterFragment = FlutterFragment.withNewEngine()
     .initialRoute("myInitialRoute/")
     .build()
+```
+
+{% endsample %}
+{% sample "Java" %}
+
+```java title="MyActivity.java"
+// With a new FlutterEngine.
+FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
+    .initialRoute("myInitialRoute/")
+    .build();
 ```
 
 {% endsample %}
@@ -418,22 +418,22 @@ Dart entrypoint: `main()`, but you can define other entrypoints.
 Dart entrypoint to execute for the given Flutter experience.
 To specify an entrypoint, build `FlutterFragment`, as shown:
 
-{% samplecode "launch-with-custom-entrypoint", "Java,Kotlin" %}
-{% sample "Java" %}
-
-```java title="MyActivity.java"
-FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
-    .dartEntrypoint("mySpecialEntrypoint")
-    .build();
-```
-
-{% endsample %}
+{% samplecode "launch-with-custom-entrypoint", "Kotlin,Java" %}
 {% sample "Kotlin" %}
 
 ```kotlin title="MyActivity.kt"
 val flutterFragment = FlutterFragment.withNewEngine()
     .dartEntrypoint("mySpecialEntrypoint")
     .build()
+```
+
+{% endsample %}
+{% sample "Java" %}
+
+```java title="MyActivity.java"
+FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
+    .dartEntrypoint("mySpecialEntrypoint")
+    .build();
 ```
 
 {% endsample %}
@@ -469,22 +469,7 @@ then you need to use `TextureView` instead of `SurfaceView`.
 Select a `TextureView` by building a `FlutterFragment` with a
 `texture` `RenderMode`:
 
-{% samplecode "launch-with-rendermode", "Java,Kotlin" %}
-{% sample "Java" %}
-
-```java title="MyActivity.java"
-// With a new FlutterEngine.
-FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
-    .renderMode(FlutterView.RenderMode.texture)
-    .build();
-
-// With a cached FlutterEngine.
-FlutterFragment flutterFragment = FlutterFragment.withCachedEngine("my_engine_id")
-    .renderMode(FlutterView.RenderMode.texture)
-    .build();
-```
-
-{% endsample %}
+{% samplecode "launch-with-rendermode", "Kotlin,Java" %}
 {% sample "Kotlin" %}
 
 ```kotlin title="MyActivity.kt"
@@ -497,6 +482,21 @@ val flutterFragment = FlutterFragment.withNewEngine()
 val flutterFragment = FlutterFragment.withCachedEngine("my_engine_id")
     .renderMode(FlutterView.RenderMode.texture)
     .build()
+```
+
+{% endsample %}
+{% sample "Java" %}
+
+```java title="MyActivity.java"
+// With a new FlutterEngine.
+FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
+    .renderMode(FlutterView.RenderMode.texture)
+    .build();
+
+// With a cached FlutterEngine.
+FlutterFragment flutterFragment = FlutterFragment.withCachedEngine("my_engine_id")
+    .renderMode(FlutterView.RenderMode.texture)
+    .build();
 ```
 
 {% endsample %}
@@ -537,22 +537,7 @@ for information about controlling the `RenderMode`.
 To enable transparency for a `FlutterFragment`,
 build it with the following configuration:
 
-{% samplecode "launch-with-transparency", "Java,Kotlin" %}
-{% sample "Java" %}
-
-```java title="MyActivity.java"
-// Using a new FlutterEngine.
-FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
-    .transparencyMode(FlutterView.TransparencyMode.transparent)
-    .build();
-
-// Using a cached FlutterEngine.
-FlutterFragment flutterFragment = FlutterFragment.withCachedEngine("my_engine_id")
-    .transparencyMode(FlutterView.TransparencyMode.transparent)
-    .build();
-```
-
-{% endsample %}
+{% samplecode "launch-with-transparency", "Kotlin,Java" %}
 {% sample "Kotlin" %}
 
 ```kotlin title="MyActivity.kt"
@@ -565,6 +550,21 @@ val flutterFragment = FlutterFragment.withNewEngine()
 val flutterFragment = FlutterFragment.withCachedEngine("my_engine_id")
     .transparencyMode(FlutterView.TransparencyMode.transparent)
     .build()
+```
+
+{% endsample %}
+{% sample "Java" %}
+
+```java title="MyActivity.java"
+// Using a new FlutterEngine.
+FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
+    .transparencyMode(FlutterView.TransparencyMode.transparent)
+    .build();
+
+// Using a cached FlutterEngine.
+FlutterFragment flutterFragment = FlutterFragment.withCachedEngine("my_engine_id")
+    .transparencyMode(FlutterView.TransparencyMode.transparent)
+    .build();
 ```
 
 {% endsample %}
@@ -601,22 +601,7 @@ prevent Flutter from controlling the `Activity`'s system UI,
 use the `shouldAttachEngineToActivity()` method in
 `FlutterFragment`'s `Builder`, as shown:
 
-{% samplecode "attach-to-activity", "Java,Kotlin" %}
-{% sample "Java" %}
-
-```java title="MyActivity.java"
-// Using a new FlutterEngine.
-FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
-    .shouldAttachEngineToActivity(false)
-    .build();
-
-// Using a cached FlutterEngine.
-FlutterFragment flutterFragment = FlutterFragment.withCachedEngine("my_engine_id")
-    .shouldAttachEngineToActivity(false)
-    .build();
-```
-
-{% endsample %}
+{% samplecode "attach-to-activity", "Kotlin,Java" %}
 {% sample "Kotlin" %}
 
 ```kotlin title="MyActivity.kt"
@@ -629,6 +614,21 @@ val flutterFragment = FlutterFragment.withNewEngine()
 val flutterFragment = FlutterFragment.withCachedEngine("my_engine_id")
     .shouldAttachEngineToActivity(false)
     .build()
+```
+
+{% endsample %}
+{% sample "Java" %}
+
+```java title="MyActivity.java"
+// Using a new FlutterEngine.
+FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
+    .shouldAttachEngineToActivity(false)
+    .build();
+
+// Using a cached FlutterEngine.
+FlutterFragment flutterFragment = FlutterFragment.withCachedEngine("my_engine_id")
+    .shouldAttachEngineToActivity(false)
+    .build();
 ```
 
 {% endsample %}

--- a/src/content/add-to-app/android/add-flutter-screen.md
+++ b/src/content/add-to-app/android/add-flutter-screen.md
@@ -55,7 +55,18 @@ import io.flutter.embedding.android.FlutterActivity;
 ```
 :::
 
-{% samplecode "default-activity-launch", "Java,Kotlin" %}
+{% samplecode "default-activity-launch", "Kotlin,Java" %}
+{% sample "Kotlin" %}
+
+```kotlin title="ExistingActivity.kt"
+myButton.setOnClickListener {
+  startActivity(
+    FlutterActivity.createDefaultIntent(this)
+  )
+}
+```
+
+{% endsample %}
 {% sample "Java" %}
 
 ```java title="ExistingActivity.java"
@@ -70,17 +81,6 @@ myButton.setOnClickListener(new OnClickListener() {
 ```
 
 {% endsample %}
-{% sample "Kotlin" %}
-
-```kotlin title="ExistingActivity.kt"
-myButton.setOnClickListener {
-  startActivity(
-    FlutterActivity.createDefaultIntent(this)
-  )
-}
-```
-
-{% endsample %}
 {% endsamplecode %}
 
 The previous example assumes that your Dart entrypoint
@@ -91,7 +91,21 @@ The following example demonstrates how to launch a
 `FlutterActivity` that initially renders a custom
 route in Flutter.
 
-{% samplecode "custom-activity-launch", "Java,Kotlin" %}
+{% samplecode "custom-activity-launch", "Kotlin,Java" %}
+{% sample "Kotlin" %}
+
+```kotlin title="ExistingActivity.kt"
+myButton.setOnClickListener {
+  startActivity(
+    FlutterActivity
+      .withNewEngine()
+      .initialRoute("/my_route")
+      .build(this)
+  )
+}
+```
+
+{% endsample %}
 {% sample "Java" %}
 
 ```java title="ExistingActivity.java"
@@ -106,20 +120,6 @@ myButton.addOnClickListener(new OnClickListener() {
       );
   }
 });
-```
-
-{% endsample %}
-{% sample "Kotlin" %}
-
-```kotlin title="ExistingActivity.kt"
-myButton.setOnClickListener {
-  startActivity(
-    FlutterActivity
-      .withNewEngine()
-      .initialRoute("/my_route")
-      .build(this)
-  )
-}
 ```
 
 {% endsample %}
@@ -151,33 +151,7 @@ location in your app to instantiate a `FlutterEngine`.
 The following example arbitrarily pre-warms a
 `FlutterEngine` in the `Application` class:
 
-{% samplecode "prewarm-engine", "Java,Kotlin" %}
-{% sample "Java" %}
-
-```java title="MyApplication.java"
-public class MyApplication extends Application {
-  public FlutterEngine flutterEngine;
-  
-  @Override
-  public void onCreate() {
-    super.onCreate();
-    // Instantiate a FlutterEngine.
-    flutterEngine = new FlutterEngine(this);
-
-    // Start executing Dart code to pre-warm the FlutterEngine.
-    flutterEngine.getDartExecutor().executeDartEntrypoint(
-      DartEntrypoint.createDefault()
-    );
-
-    // Cache the FlutterEngine to be used by FlutterActivity.
-    FlutterEngineCache
-      .getInstance()
-      .put("my_engine_id", flutterEngine);
-  }
-}
-```
-
-{% endsample %}
+{% samplecode "prewarm-engine", "Kotlin,Java" %}
 {% sample "Kotlin" %}
 
 ```kotlin title="MyApplication.kt"
@@ -199,6 +173,32 @@ class MyApplication : Application() {
     FlutterEngineCache
       .getInstance()
       .put("my_engine_id", flutterEngine)
+  }
+}
+```
+
+{% endsample %}
+{% sample "Java" %}
+
+```java title="MyApplication.java"
+public class MyApplication extends Application {
+  public FlutterEngine flutterEngine;
+  
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    // Instantiate a FlutterEngine.
+    flutterEngine = new FlutterEngine(this);
+
+    // Start executing Dart code to pre-warm the FlutterEngine.
+    flutterEngine.getDartExecutor().executeDartEntrypoint(
+      DartEntrypoint.createDefault()
+    );
+
+    // Cache the FlutterEngine to be used by FlutterActivity.
+    FlutterEngineCache
+      .getInstance()
+      .put("my_engine_id", flutterEngine);
   }
 }
 ```
@@ -232,7 +232,20 @@ to instruct your `FlutterActivity` to use the cached
 To accomplish this, use `FlutterActivity`'s `withCachedEngine()`
 builder:
 
-{% samplecode "cached-engine-activity-launch", "Java,Kotlin" %}
+{% samplecode "cached-engine-activity-launch", "Kotlin,Java" %}
+{% sample "Kotlin" %}
+
+```kotlin title="ExistingActivity.kt"
+myButton.setOnClickListener {
+  startActivity(
+    FlutterActivity
+      .withCachedEngine("my_engine_id")
+      .build(this)
+  )
+}
+```
+
+{% endsample %}
 {% sample "Java" %}
 
 ```java title="ExistingActivity.java"
@@ -246,19 +259,6 @@ myButton.addOnClickListener(new OnClickListener() {
       );
   }
 });
-```
-
-{% endsample %}
-{% sample "Kotlin" %}
-
-```kotlin title="ExistingActivity.kt"
-myButton.setOnClickListener {
-  startActivity(
-    FlutterActivity
-      .withCachedEngine("my_engine_id")
-      .build(this)
-  )
-}
 ```
 
 {% endsample %}
@@ -353,28 +353,7 @@ with explicit transparency support.
 To launch your `FlutterActivity` with a transparent background,
 pass the appropriate `BackgroundMode` to the `IntentBuilder`:
 
-{% samplecode "transparent-activity-launch", "Java,Kotlin" %}
-{% sample "Java" %}
-
-```java title="ExistingActivity.java"
-// Using a new FlutterEngine.
-startActivity(
-  FlutterActivity
-    .withNewEngine()
-    .backgroundMode(FlutterActivityLaunchConfigs.BackgroundMode.transparent)
-    .build(context)
-);
-
-// Using a cached FlutterEngine.
-startActivity(
-  FlutterActivity
-    .withCachedEngine("my_engine_id")
-    .backgroundMode(FlutterActivityLaunchConfigs.BackgroundMode.transparent)
-    .build(context)
-);
-```
-
-{% endsample %}
+{% samplecode "transparent-activity-launch", "Kotlin,Java" %}
 {% sample "Kotlin" %}
 
 ```kotlin title="ExistingActivity.kt"
@@ -392,6 +371,27 @@ startActivity(
     .withCachedEngine("my_engine_id")
     .backgroundMode(FlutterActivityLaunchConfigs.BackgroundMode.transparent)
     .build(this)
+);
+```
+
+{% endsample %}
+{% sample "Java" %}
+
+```java title="ExistingActivity.java"
+// Using a new FlutterEngine.
+startActivity(
+  FlutterActivity
+    .withNewEngine()
+    .backgroundMode(FlutterActivityLaunchConfigs.BackgroundMode.transparent)
+    .build(context)
+);
+
+// Using a cached FlutterEngine.
+startActivity(
+  FlutterActivity
+    .withCachedEngine("my_engine_id")
+    .backgroundMode(FlutterActivityLaunchConfigs.BackgroundMode.transparent)
+    .build(context)
 );
 ```
 

--- a/src/content/cookbook/maintenance/error-reporting.md
+++ b/src/content/cookbook/maintenance/error-reporting.md
@@ -83,8 +83,10 @@ Alternatively, you can pass the DSN to Flutter using the `dart-define` tag:
 
 ### What does that give me?
 
-This is all you need for Sentry to capture unhandled errors in Dart and native layers.  
-This includes Swift, Objective-C, C, and C++ on iOS, and Java, Kotlin, C, and C++ on Android.
+This is all you need for Sentry to
+capture unhandled errors in Dart and native layers.  
+This includes Swift, Objective-C, C, and C++ on iOS, and
+Java, Kotlin, C, and C++ on Android.
 
 ## 4. Capture errors programmatically
 

--- a/src/content/platform-integration/android/splash-screen.md
+++ b/src/content/platform-integration/android/splash-screen.md
@@ -152,7 +152,32 @@ while additional loading continues in Dart.
 To achieve this, the following
 Android APIs might be helpful:
 
-{% samplecode "android-splash-alignment", "Java,Kotlin" %}
+{% samplecode "android-splash-alignment", "Kotlin,Java" %}
+{% sample "Kotlin" %}
+
+```kotlin title="MainActivity.kt"
+import android.os.Build
+import android.os.Bundle
+import androidx.core.view.WindowCompat
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity : FlutterActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    // Aligns the Flutter view vertically with the window.
+    WindowCompat.setDecorFitsSystemWindows(getWindow(), false)
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      // Disable the Android splash screen fade out animation to avoid
+      // a flicker before the similar frame is drawn in Flutter.
+      splashScreen.setOnExitAnimationListener { splashScreenView -> splashScreenView.remove() }
+    }
+
+    super.onCreate(savedInstanceState)
+  }
+}
+```
+
+{% endsample %}
 {% sample "Java" %}
 
 ```java title="MainActivity.java"
@@ -180,31 +205,6 @@ public class MainActivity extends FlutterActivity {
 
         super.onCreate(savedInstanceState);
     }
-}
-```
-
-{% endsample %}
-{% sample "Kotlin" %}
-
-```kotlin title="MainActivity.kt"
-import android.os.Build
-import android.os.Bundle
-import androidx.core.view.WindowCompat
-import io.flutter.embedding.android.FlutterActivity
-
-class MainActivity : FlutterActivity() {
-  override fun onCreate(savedInstanceState: Bundle?) {
-    // Aligns the Flutter view vertically with the window.
-    WindowCompat.setDecorFitsSystemWindows(getWindow(), false)
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-      // Disable the Android splash screen fade out animation to avoid
-      // a flicker before the similar frame is drawn in Flutter.
-      splashScreen.setOnExitAnimationListener { splashScreenView -> splashScreenView.remove() }
-    }
-
-    super.onCreate(savedInstanceState)
-  }
 }
 ```
 

--- a/src/content/platform-integration/platform-channels.md
+++ b/src/content/platform-integration/platform-channels.md
@@ -102,26 +102,7 @@ messages happens automatically when you send and receive values.
 The following table shows how Dart values are received on the
 platform side and vice versa:
 
-{% samplecode "type-mappings", "Java,Kotlin,Obj-C,Swift,C++,C" %}
-{% sample "Java" %}
-
-| Dart                       | Java                |
-| -------------------------- | ------------------- |
-| null                       | null                |
-| bool                       | java.lang.Boolean   |
-| int                        | java.lang.Integer   |
-| int, if 32 bits not enough | java.lang.Long      |
-| double                     | java.lang.Double    |
-| String                     | java.lang.String    |
-| Uint8List                  | byte[]              |
-| Int32List                  | int[]               |
-| Int64List                  | long[]              |
-| Float32List                | float[]             |
-| Float64List                | double[]            |
-| List                       | java.util.ArrayList |
-| Map                        | java.util.HashMap   |
-
-{% endsample %}
+{% samplecode "type-mappings", "Kotlin,Java,Swift,Obj-C,C++,C" %}
 {% sample "Kotlin" %}
 
 | Dart                       | Kotlin      |
@@ -141,23 +122,23 @@ platform side and vice versa:
 | Map                        | HashMap     |
 
 {% endsample %}
-{% sample "Obj-C" %}
+{% sample "Java" %}
 
-| Dart                       | Objective-C                                    |
-| -------------------------- | ---------------------------------------------- |
-| null                       | nil (NSNull when nested)                       |
-| bool                       | NSNumber numberWithBool:                       |
-| int                        | NSNumber numberWithInt:                        |
-| int, if 32 bits not enough | NSNumber numberWithLong:                       |
-| double                     | NSNumber numberWithDouble:                     |
-| String                     | NSString                                       |
-| Uint8List                  | FlutterStandardTypedData typedDataWithBytes:   |
-| Int32List                  | FlutterStandardTypedData typedDataWithInt32:   |
-| Int64List                  | FlutterStandardTypedData typedDataWithInt64:   |
-| Float32List                | FlutterStandardTypedData typedDataWithFloat32: |
-| Float64List                | FlutterStandardTypedData typedDataWithFloat64: |
-| List                       | NSArray                                        |
-| Map                        | NSDictionary                                   |
+| Dart                       | Java                |
+| -------------------------- | ------------------- |
+| null                       | null                |
+| bool                       | java.lang.Boolean   |
+| int                        | java.lang.Integer   |
+| int, if 32 bits not enough | java.lang.Long      |
+| double                     | java.lang.Double    |
+| String                     | java.lang.String    |
+| Uint8List                  | byte[]              |
+| Int32List                  | int[]               |
+| Int64List                  | long[]              |
+| Float32List                | float[]             |
+| Float64List                | double[]            |
+| List                       | java.util.ArrayList |
+| Map                        | java.util.HashMap   |
 
 {% endsample %}
 {% sample "Swift" %}
@@ -177,6 +158,25 @@ platform side and vice versa:
 | Float64List                | FlutterStandardTypedData(float64: Data) |
 | List                       | Array                                   |
 | Map                        | Dictionary                              |
+
+{% endsample %}
+{% sample "Obj-C" %}
+
+| Dart                       | Objective-C                                    |
+| -------------------------- | ---------------------------------------------- |
+| null                       | nil (NSNull when nested)                       |
+| bool                       | NSNumber numberWithBool:                       |
+| int                        | NSNumber numberWithInt:                        |
+| int, if 32 bits not enough | NSNumber numberWithLong:                       |
+| double                     | NSNumber numberWithDouble:                     |
+| String                     | NSString                                       |
+| Uint8List                  | FlutterStandardTypedData typedDataWithBytes:   |
+| Int32List                  | FlutterStandardTypedData typedDataWithInt32:   |
+| Int64List                  | FlutterStandardTypedData typedDataWithInt64:   |
+| Float32List                | FlutterStandardTypedData typedDataWithFloat32: |
+| Float64List                | FlutterStandardTypedData typedDataWithFloat64: |
+| List                       | NSArray                                        |
+| Map                        | NSDictionary                                   |
 
 {% endsample %}
 {% sample "C++" %}
@@ -1254,8 +1254,22 @@ void main() {
 
 In order for a channel's platform side handler to
 execute on a background thread, you must use the
-Task Queue API. Currently this feature is only
+Task Queue API. Currently, this feature is only
 supported on iOS and Android.
+
+In Kotlin:
+
+```kotlin
+override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+  val taskQueue =
+      flutterPluginBinding.binaryMessenger.makeBackgroundTaskQueue()
+  channel = MethodChannel(flutterPluginBinding.binaryMessenger,
+                          "com.example.foo",
+                          StandardMethodCodec.INSTANCE,
+                          taskQueue)
+  channel.setMethodCallHandler(this)
+}
+```
 
 In Java:
 
@@ -1272,20 +1286,6 @@ public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
           StandardMethodCodec.INSTANCE,
           taskQueue);
   channel.setMethodCallHandler(this);
-}
-```
-
-In Kotlin:
-
-```kotlin
-override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-  val taskQueue =
-      flutterPluginBinding.binaryMessenger.makeBackgroundTaskQueue()
-  channel = MethodChannel(flutterPluginBinding.binaryMessenger,
-                          "com.example.foo",
-                          StandardMethodCodec.INSTANCE,
-                          taskQueue)
-  channel.setMethodCallHandler(this)
 }
 ```
 
@@ -1339,6 +1339,14 @@ In Android, you can accomplish this by `post()`ing a
 which causes the `Runnable` to execute on the
 main thread at the next opportunity.
 
+In Kotlin:
+
+```kotlin
+Handler(Looper.getMainLooper()).post {
+  // Call the desired channel message here.
+}
+```
+
 In Java:
 
 ```java
@@ -1348,14 +1356,6 @@ new Handler(Looper.getMainLooper()).post(new Runnable() {
     // Call the desired channel message here.
   }
 });
-```
-
-In Kotlin:
-
-```kotlin
-Handler(Looper.getMainLooper()).post {
-  // Call the desired channel message here.
-}
 ```
 
 ### Jumping to the main thread in iOS

--- a/src/content/release/breaking-changes/flutter-gradle-plugin-apply.md
+++ b/src/content/release/breaking-changes/flutter-gradle-plugin-apply.md
@@ -73,7 +73,7 @@ tasks.register("clean", Delete) {
 
 The AGP version is the number that comes at the end of the line 
 `classpath 'com.android.tools.build:gradle:7.3.0'`, so `7.3.0` 
-in this case. Similarly, the kotlin version comes at the end of the line
+in this case. Similarly, the Kotlin version comes at the end of the line
 `ext.kotlin_version = '1.7.10'`, in this case `1.7.10`.
 
 Next, replace the contents of `<app-src>/android/settings.gradle` with the below,

--- a/src/content/release/breaking-changes/kotlin-version.md
+++ b/src/content/release/breaking-changes/kotlin-version.md
@@ -2,7 +2,7 @@
 title: Required Kotlin version 
 description: >
     Flutter apps built for the Android platform
-    require Kotlin 1.5.31 or greater.
+    now require Kotlin 1.5.31 or greater.
 ---
 
 ## Summary

--- a/src/content/resources/faq.md
+++ b/src/content/resources/faq.md
@@ -665,7 +665,7 @@ across mobile platforms.
 
 Yes, Flutter supports calling into the platform,
 including integrating with Java or Kotlin code on Android,
-and ObjectiveC or Swift code on iOS.
+and Swift or Objective-C code on iOS.
 This is enabled by a flexible message passing style
 where a Flutter app might send and receive messages
 to the mobile platform using a [`BasicMessageChannel`][].

--- a/src/content/testing/native-debugging.md
+++ b/src/content/testing/native-debugging.md
@@ -23,7 +23,8 @@ that portion of your code with a native debugger.
 
 - To debug iOS or macOS code written in Swift or Objective-C,
   you can use Xcode.
-- To debug Android code written in Java or Kotlin, you can use Android Studio.
+- To debug Android code written in Java or Kotlin,
+  you can use Android Studio.
 - To debug Windows code written in C++, you can use Visual Studio.
 
 This guide shows you how you can connect _two_

--- a/src/content/tools/hot-reload.md
+++ b/src/content/tools/hot-reload.md
@@ -58,7 +58,7 @@ and full restart?**
   (`⇧⌘\` in IntelliJ and Android Studio, `⇧⌘F5` in VSCode)
 * **Full restart** restarts the iOS, Android, or web app.
   This takes longer because it also recompiles the
-  Java / Kotlin / ObjC / Swift code. On the web,
+  Java / Kotlin / Objective-C / Swift code. On the web,
   it also restarts the Dart Development Compiler.
   There is no specific keyboard shortcut for this;
   you need to stop and start the run configuration.


### PR DESCRIPTION
After discussing with others, it seems to make sense to place Kotlin snippets before Java. It's been the Flutter tool's default for many years and is now Android's default as well. The one exception is in the add-to-app docs, where Java might be more common for old apps, but this PR also puts Kotlin first there as well for consistency.

Closes https://github.com/flutter/website/issues/10364