### PR TITLE
Support "C++" as a tab language in samplecode/sample

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -62,7 +62,7 @@ export default function (eleventyConfig) {
 
     const tabs = tabsString.split(',').map((tab) => tab.trim());
     tabs.forEach((tabName) => {
-      const tabId = `${_currentTabsTitle}-${tabName.toLowerCase()}`;
+      const tabId = `${_currentTabsTitle}-${tabName.toLowerCase().replaceAll("+", "-plus")}`;
       tabMarkup += `<li class="nav-item">
   <a class="nav-link ${activeTab ? "active" : ""}" id="${tabId}-tab" href="#${tabId}" role="tab" aria-controls="${tabId}" aria-selected="true">${tabName}</a>
 </li>`;
@@ -79,7 +79,7 @@ export default function (eleventyConfig) {
   });
 
   eleventyConfig.addPairedShortcode('sample', function(content, tabName) {
-    const tabId = `${_currentTabsTitle}-${tabName.toLowerCase()}`;
+    const tabId = `${_currentTabsTitle}-${tabName.toLowerCase().replaceAll("+", "-plus")}`;
     const tabContent = `<div class="tab-pane ${_currentTabIsActive ? "active" : ""}" id="${tabId}" role="tabpanel" aria-labelledby="${tabId}-tab">
 
 ${content}


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Replaces `+` with `-plus` as it was also replaced by `-plus` in the previous fix #6524. 

![issueFix](https://github.com/flutter/website/assets/50594304/cec4c8e9-5393-4f51-95e9-00c6c08c713c)

_Issues fixed by this PR (if any):_
fixes #10378

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
