### PR TITLE
Speed up code excerpt updater

### DIFF
--- a/examples/cookbook/plugins/picture_using_camera/lib/main_step3.dart
+++ b/examples/cookbook/plugins/picture_using_camera/lib/main_step3.dart
@@ -41,7 +41,7 @@ class TakePictureScreen extends StatefulWidget {
 
 class TakePictureScreenState extends State<TakePictureScreen> {
   late CameraController _controller;
-  // ignore_for_file: unused_field
+  // ignore: unused_field
   late Future<void> _initializeControllerFuture;
 
   @override

--- a/src/content/cookbook/plugins/picture-using-camera.md
+++ b/src/content/cookbook/plugins/picture-using-camera.md
@@ -83,7 +83,7 @@ and display a preview of the camera's feed.
   4. Create and initialize the controller in the `initState()` method.
   5. Dispose of the controller in the `dispose()` method.
 
-<?code-excerpt "lib/main_step3.dart (controller)"?>
+<?code-excerpt "lib/main_step3.dart (controller)" remove="ignore:"?>
 ```dart
 // A screen that allows users to take a picture using a given camera.
 class TakePictureScreen extends StatefulWidget {

--- a/tool/flutter_site/lib/src/commands/refresh_excerpts.dart
+++ b/tool/flutter_site/lib/src/commands/refresh_excerpts.dart
@@ -121,25 +121,7 @@ Future<int> _refreshExcerpts({
     return 1;
   }
 
-  // A collection of replacements for the code excerpt updater tool
-  // to run by default.
-  // They must not contain (unencoded/unescaped) spaces.
-  const replacements = [
-    // Allows use of //!<br> to force a line break (against dart format)
-    r'/\/\/!<br>//g;',
-    // Replace commented out ellipses: /*...*/ --> ...
-    r'/\/\*(\s*\.\.\.\s*)\*\//$1/g;',
-    // Replace brackets with commented out ellipses: {/*-...-*/} --> ...
-    r'/\{\/\*-(\s*\.\.\.\s*)-\*\/\}/$1/g;',
-    // Remove markers declaring an analysis issue or runtime error.
-    r'/\/\/!(analysis-issue|runtime-error)[^\n]*//g;',
-    // Remove analyzer ignore for file markers.
-    r'/\x20*\/\/\s+ignore_for_file:[^\n]+\n//g;',
-    // Remove analyzer inline ignores.
-    r'/\x20*\/\/\s+ignore:[^\n]+//g;',
-  ];
-
-  final srcDirectoryPath = path.join(repositoryRoot, 'src');
+  final srcDirectoryPath = path.join(repositoryRoot, 'src', 'content');
   final updaterArguments = <String>[
     '--fragment-dir-path',
     path.join(fragments, 'examples'),
@@ -148,7 +130,6 @@ Future<int> _refreshExcerpts({
     if (verboseLogging) '--log-fine',
     '--yaml',
     '--no-escape-ng-interpolation',
-    '--replace=${replacements.join('')}',
     '--write-in-place',
     srcDirectoryPath,
   ];


### PR DESCRIPTION
Slightly reduce runtime of code excerpt updater by doing less unneeded work :) 

- Only run on `src/content` directory. All code excerpt instructions are within that directory currently.
- Don't add any of the global replacements, they currently are relied on by any of the excerpts on the site.