### PR TITLE
Clean up breadcrumbs across the site

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -117,7 +117,7 @@
       { "source": "/cookbook/testing/widget-test-tap-drag", "destination": "/cookbook/testing/widget/tap-drag", "type": 301 },
       { "source": "/deployment/fastlane-cd", "destination": "/deployment/cd#fastlane", "type": 301 },
       { "source": "/get-started", "destination": "/get-started/install", "type": 301 },
-      { "source": "/get-started/flutter-for", "destination": "/get-started/flutter-for/android-devs", "type": 301 },
+      { "source": "/get-started/flutter-for", "destination": "/get-started/learn-more", "type": 301 },
       { "source": "/get-started/flutter-for/ios-devs", "destination": "/get-started/flutter-for/swiftui-devs", "type": 301 },
       { "source": "/get-started/install/null", "destination": "/get-started/install", "type": 301 },
       { "source": "/get-started/web", "destination": "/platform-integration/web/building", "type": 301 },

--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -10,6 +10,7 @@
       permalink: /get-started/learn-more
     - divider
     - title: From another platform?
+      permalink: /get-started/flutter-for
       children:
         - title: Flutter for Android devs
           permalink: /get-started/flutter-for/android-devs

--- a/src/_includes/breadcrumbs.html
+++ b/src/_includes/breadcrumbs.html
@@ -9,10 +9,10 @@ Embeds breadcrumb RDFa, follows ARIA guidelines. References:
 {% assign url = page.url | regex_replace: '/index$|/index.html$|/$' -%}
 
 {% if url.size > 0 -%}
+{% assign breadcrumbs = page | breadcrumbsForPage -%}
+{% if breadcrumbs -%}
 <nav aria-label="breadcrumb">
-  <ol class="breadcrumb" vocab="http://schema.org/" typeof="BreadcrumbList">
-    {% assign breadcrumbs = page | breadcrumbsForPage -%}
-    {% if breadcrumbs and breadcrumbs.length > 1 -%}
+  <ol class="breadcrumb" vocab="https://schema.org/" typeof="BreadcrumbList">
     {% for crumb in breadcrumbs -%}
     <li class="breadcrumb-item {%- if forloop.last %} active {%- endif %}"
         property="itemListElement" typeof="ListItem"
@@ -25,7 +25,7 @@ Embeds breadcrumb RDFa, follows ARIA guidelines. References:
       <meta property="position" content="{{forloop.index0}}" />
     </li>
     {% endfor %}
-    {% endif -%}
   </ol>
 </nav>
+{% endif -%}
 {%- endif -%}

--- a/src/content/cookbook/index.md
+++ b/src/content/cookbook/index.md
@@ -2,7 +2,6 @@
 title: Cookbook
 description: >
   The Flutter cookbook provides recipes for many commonly performed tasks.
-show_breadcrumbs: false
 ---
 
 This cookbook contains recipes that demonstrate how to solve common problems 

--- a/src/content/get-started/flutter-for/index.md
+++ b/src/content/get-started/flutter-for/index.md
@@ -1,0 +1,10 @@
+---
+title: Learn Flutter when coming from another platform
+short-title: Flutter for
+sitemap: false
+description: >-
+  Utilize your background developing for another platform
+  to learn the basics of Flutter!
+# This is a placeholder page (Firebase redirects this page's URL to another);
+# it is necessary to allow breadcrumbs to work.
+---

--- a/src/content/get-started/fwe/index.md
+++ b/src/content/get-started/fwe/index.md
@@ -1,5 +1,6 @@
 ---
 title: First week experience of Flutter
+short-title: First week
 description: >
   You've gotten a taste of using the Flutter framework;
   now go beyond to learn the basics of Flutter.

--- a/src/content/get-started/install/_help-link.md
+++ b/src/content/get-started/install/_help-link.md
@@ -1,6 +1,0 @@
-<p class="install-help">
-    <a id='{{ include.location }}' href='/get-started/install/help{{ include.section }}'>
-    <span class='material-symbols'>help</span>
-    <span>Help</span>
-    </a>
-</p>

--- a/src/content/reference/reference.json
+++ b/src/content/reference/reference.json
@@ -1,0 +1,3 @@
+{
+  "show_breadcrumbs": false
+}

--- a/src/content/resources/resources.json
+++ b/src/content/resources/resources.json
@@ -1,0 +1,3 @@
+{
+  "show_breadcrumbs": false
+}

--- a/src/content/security/index.md
+++ b/src/content/security/index.md
@@ -1,7 +1,8 @@
 ---
 title: Security
-description: >
+description: >-
   An overview of the Flutter's team philosophy and processes for security.
+show_breadcrumbs: false
 ---
 
 The Flutter team takes the security of Flutter and the applications

--- a/src/content/tos/index.md
+++ b/src/content/tos/index.md
@@ -1,6 +1,7 @@
 ---
 title: Terms of Service
 description: The terms of service for the Flutter website.
+show_breadcrumbs: false
 ---
 
 The Flutter website (the "Website") is hosted by Google. By using and / or


### PR DESCRIPTION
- Enable breadcrumbs for the "Flutter for ..." pages
- Disable breadcrumbs in `/reference` and `/resources`
- Disable breadcrumbs on the TOS and security pages
- Include breadcrumbs on the index page in directories with them enabled for consistency

Fixes https://github.com/flutter/website/issues/10394