### PR TITLE
More fixes to adding a platform pages

### DIFF
--- a/src/_includes/docs/install/next-steps.md
+++ b/src/_includes/docs/install/next-steps.md
@@ -34,15 +34,15 @@ consult the following resources.
 {%- endcase %}
 {%- case config.add-xcode %}
 {%- when 'Y' %}
-* [Add macOS compliation tools](/platform-integration/macos/install-macos/install-macos-from-{{target}})
+* [Add macOS compilation tools](/platform-integration/macos/install-macos/install-macos-from-{{target}})
 {%- endcase %}
 {%- case config.add-linux-tools %}
 {%- when 'Y' %}
-* [Add Linux compiliation tools](/platform-integration/linux/install-linux/install-linux-from-{{target}})
+* [Add Linux compilation tools](/platform-integration/linux/install-linux/install-linux-from-{{target}})
 {%- endcase %}
 {%- case config.add-visual-studio %}
 {%- when 'Y' %}
-* [Add Windows desktop compiliation tools](/platform-integration/windows/install-windows/install-windows-from-{{target}})
+* [Add Windows desktop compilation tools](/platform-integration/windows/install-windows/install-windows-from-{{target}})
 {%- endcase %}
 * [Uninstall Flutter][uninstall]
 

--- a/src/content/get-started/install/linux/index.md
+++ b/src/content/get-started/install/linux/index.md
@@ -21,7 +21,7 @@ js: [{url: '/assets/js/temp/linux-install-redirector.js'}]
           {% assign icon = target | downcase -%}
           {% if icon == 'desktop' -%}
             <span class="material-symbols">desktop_windows</span>
-          {% elsif icon == 'mobile' -%}
+          {% elsif icon == 'android' -%}
             <span class="material-symbols">phone_android</span>
           {% else -%}
             <span class="material-symbols">web</span>

--- a/src/content/platform-integration/android/install-android/index.md
+++ b/src/content/platform-integration/android/install-android/index.md
@@ -1,22 +1,20 @@
 ---
 title: Add Android as a target platform for Flutter
 description: Configure your system to develop Flutter for Android.
-short-title: Set up Android compliation
-target-list: [Windows, 'web on Windows', Linux, 'web on Linux', macOS, 'web on macOS', iOS, web on ChromeOS]
+short-title: Set up Android development
+target-list: [Windows, 'web on Windows', Linux, 'web on Linux', macOS, 'web on macOS', iOS, 'web on ChromeOS']
 ---
 
-To choose the guide to add Android Studio to your Flutter configuration,
-click the [Getting Started path][] you followed.
+To set up your development environment for targeting Android,
+choose the guide that corresponds to the [Getting Started path][] you followed,
+or the platform you already have set up.
 
 {% for target in target-list %}
-{% capture index0Modulo2 %}{{ forloop.index0 | modulo:2 }}{% endcapture %}
-{% capture indexModulo2 %}{{ forloop.index | modulo:2 }}{% endcapture %}
-{% assign
-targetlink='/platform-integration/android/install-android/install-android-from-'
-| append: target | downcase | replace: " ", "-" %}
-  {% if index0Modulo2 == '0' %}
-  <div class="card-deck mb-8">
-  {% endif %}
+{% assign row = forloop.index0 | modulo: 2 %}
+{% assign targetLink = '/platform-integration/android/install-android/install-android-from-' | append: target | downcase | replace: " ", "-" %}
+{% if row == 0 %}
+<div class="card-deck mb-8">
+{% endif %}
 
   {% if target contains 'macOS' or target contains 'iOS' %}
     {% assign bug = 'card-macos' %}
@@ -28,9 +26,7 @@ targetlink='/platform-integration/android/install-android/install-android-from-'
     {% assign bug = 'card-chromeos' %}
   {% endif %}
 
-  <a class="card card-app-type {{bug}}"
-     id="install-{{target | downcase}}"
-     href="{{targetlink}}">
+  <a class="card card-app-type {{bug}}" id="install-{{target | downcase}}" href="{{targetLink}}">
     <div class="card-body">
       <header class="card-title text-center m-0">
         <span class="d-block h1">
@@ -44,26 +40,26 @@ targetlink='/platform-integration/android/install-android/install-android-from-'
             <span class="material-symbols">phone_iphone</span>
           {% else -%}
             <span class="material-symbols">web</span>
-          {% endcase %}
+          {% endcase -%}
           <span class="material-symbols">add</span>
           <span class="material-symbols">phone_android</span>
         </span>
-        <span class="text-muted">
+        <span class="text-muted d-block">
         Make Android and
-        {% if target contains "iOS" %}
+        {% if target contains "iOS" -%}
         {{target}} apps on macOS
-        {% elsif target contains "on" %}
+        {%- elsif target contains "on" -%}
         {{ target | replace: "on", "apps on" }}
-        {% else %}
+        {%- else -%}
         {{target}} desktop apps
-        {% endif %}
+        {%- endif -%}
         </span>
       </header>
     </div>
   </a>
-  {% if indexModulo2 == '0' %}
-  </div>
-  {% endif %}
+{% if row == 1 %}
+</div>
+{% endif %}
 {% endfor %}
 
 [Getting Started path]: /get-started/install

--- a/src/content/platform-integration/ios/install-ios/index.md
+++ b/src/content/platform-integration/ios/install-ios/index.md
@@ -1,20 +1,18 @@
 ---
 title: Add iOS as a target platform for Flutter
 description: Configure your system to develop Flutter for iOS.
-short-title: Set up iOS compilation
+short-title: Set up iOS development
 target-list: [macOS, Android, web]
 ---
 
-To choose the guide to add the iOS compiler and simulator
-to your Flutter configuration,
-click the [Getting Started path][] you followed.
+To set up your development environment for targeting iOS,
+choose the guide that corresponds to the [Getting Started path][] you followed,
+or the platform you already have set up.
 
 <div class="card-deck mb-8">
 {% for target in target-list %}
-{% assign targetlink='/platform-integration/ios/install-ios/install-ios-from-' | append: target | downcase %}
-  <a class="card card-app-type card-macos"
-     id="install-{{target | downcase}}"
-     href="{{targetlink}}">
+{% assign targetLink = '/platform-integration/ios/install-ios/install-ios-from-' | append: target | downcase %}
+  <a class="card card-app-type card-macos" id="install-{{target | downcase}}" href="{{targetLink}}">
     <div class="card-body">
       <header class="card-title text-center m-0">
         <span class="d-block h1">

--- a/src/content/platform-integration/ios/install-ios/install-ios-from-android.md
+++ b/src/content/platform-integration/ios/install-ios/install-ios-from-android.md
@@ -1,5 +1,5 @@
 ---
-title: Add iOS devtools to Flutter from Android start
+title: Add iOS as a target platform from Android start
 description: Configure your system to develop Flutter mobile apps also on iOS.
 short-title: Starting from Android
 ---

--- a/src/content/platform-integration/ios/install-ios/install-ios-from-macos.md
+++ b/src/content/platform-integration/ios/install-ios/install-ios-from-macos.md
@@ -1,5 +1,5 @@
 ---
-title: Add iOS devtools to Flutter from macOS start
+title: Add iOS as a target platform from macOS start
 description: Configure your system to develop Flutter mobile apps on iOS.
 short-title: Starting from macOS
 ---

--- a/src/content/platform-integration/ios/install-ios/install-ios-from-web.md
+++ b/src/content/platform-integration/ios/install-ios/install-ios-from-web.md
@@ -1,5 +1,5 @@
 ---
-title: Add iOS devtools to Flutter from web start
+title: Add iOS as a target platform from web start
 description: Configure your system to develop Flutter mobile apps on iOS.
 short-title: Starting from web
 ---

--- a/src/content/platform-integration/linux/install-linux/index.md
+++ b/src/content/platform-integration/linux/install-linux/index.md
@@ -1,19 +1,18 @@
 ---
-title: Add Linux devtools for Flutter
+title: Add Linux as a target platform for Flutter
 description: Configure your system to develop Flutter for Linux.
-short-title: Add Linux DevTools
-target-list: [Android, Web]
+short-title: Setup Linux development
+target-list: [Android, web]
 ---
 
-To choose the guide to add Linux devtools to your Flutter configuration,
-click the [Getting Started path][] you followed.
+To set up your development environment for targeting Linux,
+choose the guide that corresponds to the [Getting Started path][] you followed,
+or the platform you already have set up.
 
 <div class="card-deck mb-8">
 {% for target in target-list %}
-{% assign targetlink='/platform-integration/linux/install-linux/install-linux-from-' | append: target | downcase %}
-  <a class="card card-app-type card-linux"
-     id="install-{{target | downcase}}"
-     href="{{targetlink}}">
+{% assign targetLink = '/platform-integration/linux/install-linux/install-linux-from-' | append: target | downcase %}
+  <a class="card card-app-type card-linux" id="install-{{target | downcase}}" href="{{targetLink}}">
     <div class="card-body">
       <header class="card-title text-center m-0">
         <span class="d-block h1">
@@ -25,7 +24,7 @@ click the [Getting Started path][] you followed.
             <span class="material-symbols">web</span>
           {% endcase -%}
         </span>
-        <span class="text-muted">
+        <span class="text-muted d-block">
         Make {{ target }} and Linux desktop apps
         </span>
       </header>

--- a/src/content/platform-integration/linux/install-linux/index.md
+++ b/src/content/platform-integration/linux/install-linux/index.md
@@ -1,7 +1,7 @@
 ---
 title: Add Linux as a target platform for Flutter
 description: Configure your system to develop Flutter for Linux.
-short-title: Setup Linux development
+short-title: Set up Linux development
 target-list: [Android, web]
 ---
 

--- a/src/content/platform-integration/linux/install-linux/install-linux-from-android.md
+++ b/src/content/platform-integration/linux/install-linux/install-linux-from-android.md
@@ -1,5 +1,5 @@
 ---
-title: Add Linux devtools to Flutter from Android start
+title: Add Linux as a target platform for Flutter from Android start
 description: Configure your system to develop Flutter mobile apps also on Linux.
 short-title: Starting from Android
 ---

--- a/src/content/platform-integration/linux/install-linux/install-linux-from-web.md
+++ b/src/content/platform-integration/linux/install-linux/install-linux-from-web.md
@@ -1,5 +1,5 @@
 ---
-title: Add Linux devtools to Flutter from web start
+title: Add Linux as a target platform for Flutter from web start
 description: Configure your system to develop Flutter mobile apps on Linux.
 short-title: Starting from web
 ---

--- a/src/content/platform-integration/macos/install-macos/index.md
+++ b/src/content/platform-integration/macos/install-macos/index.md
@@ -1,19 +1,18 @@
 ---
-title: Add macOS devtools for Flutter
+title: Add macOS as a target platform for Flutter
 description: Configure your system to develop Flutter for macOS.
-short-title: Add macOS desktop DevTools
-target-list: [iOS, Android, Web]
+short-title: Setup macOS development
+target-list: [iOS, Android, web]
 ---
 
-To choose the guide to add macOS devtools to your Flutter configuration,
-click the [Getting Started path][] you followed.
+To set up your development environment for targeting macOS,
+choose the guide that corresponds to the [Getting Started path][] you followed,
+or the platform you already have set up.
 
 <div class="card-deck mb-8">
 {% for target in target-list %}
-{% assign targetlink='/platform-integration/macos/install-macos/install-macos-from-' | append: target | downcase %}
-  <a class="card card-app-type card-macos"
-     id="install-{{target | downcase}}"
-     href="{{targetlink}}">
+{% assign targetLink = '/platform-integration/macos/install-macos/install-macos-from-' | append: target | downcase %}
+  <a class="card card-app-type card-macos" id="install-{{target | downcase}}" href="{{targetLink}}">
     <div class="card-body">
       <header class="card-title text-center m-0">
         <span class="d-block h1">
@@ -29,7 +28,7 @@ click the [Getting Started path][] you followed.
           <span class="material-symbols">add</span>
           <span class="material-symbols">laptop_mac</span>
         </span>
-        <span class="text-muted">
+        <span class="text-muted d-block">
         Make {{ target }} and macOS desktop apps
         </span>
       </header>

--- a/src/content/platform-integration/macos/install-macos/index.md
+++ b/src/content/platform-integration/macos/install-macos/index.md
@@ -1,7 +1,7 @@
 ---
 title: Add macOS as a target platform for Flutter
 description: Configure your system to develop Flutter for macOS.
-short-title: Setup macOS development
+short-title: Set up macOS development
 target-list: [iOS, Android, web]
 ---
 

--- a/src/content/platform-integration/macos/install-macos/install-macos-from-android.md
+++ b/src/content/platform-integration/macos/install-macos/install-macos-from-android.md
@@ -1,5 +1,5 @@
 ---
-title: Add macOS devtools to Flutter from Android start
+title: Add macOS as a target platform for Flutter from Android start
 description: Configure your system to develop Flutter mobile apps also on macOS.
 short-title: Starting from Android
 ---

--- a/src/content/platform-integration/macos/install-macos/install-macos-from-ios.md
+++ b/src/content/platform-integration/macos/install-macos/install-macos-from-ios.md
@@ -1,5 +1,5 @@
 ---
-title: Add macOS devtools to Flutter from web start
+title: Add macOS as a target platform for Flutter from web start
 description: Configure your system to develop Flutter mobile apps on macOS.
 short-title: Starting from web
 ---

--- a/src/content/platform-integration/macos/install-macos/install-macos-from-web.md
+++ b/src/content/platform-integration/macos/install-macos/install-macos-from-web.md
@@ -1,5 +1,5 @@
 ---
-title: Add macOS devtools to Flutter from web start
+title: Add macOS as a target platform for Flutter from web start
 description: Configure your system to develop Flutter mobile apps on macOS.
 short-title: Starting from web
 ---

--- a/src/content/platform-integration/web/install-web/index.md
+++ b/src/content/platform-integration/web/install-web/index.md
@@ -1,7 +1,7 @@
 ---
-title: Add the web as a target platform for Flutter
+title: Set up web development for Flutter
 description: Configure your system to develop Flutter for the web.
-short-title: Setup web development
+short-title: Set up web development
 target-list: [windows-desktop, android-on-windows, linux-desktop, android-on-linux, macos-desktop, android-on-macos, ios-on-macos, android-on-chromeos]
 ---
 

--- a/src/content/platform-integration/web/install-web/index.md
+++ b/src/content/platform-integration/web/install-web/index.md
@@ -1,20 +1,20 @@
 ---
-title: Add Chrome DevTools for Flutter
-description: Configure your system to develop Flutter for Web.
-short-title: Add Chrome DevTools
+title: Add the web as a target platform for Flutter
+description: Configure your system to develop Flutter for the web.
+short-title: Setup web development
 target-list: [windows-desktop, android-on-windows, linux-desktop, android-on-linux, macos-desktop, android-on-macos, ios-on-macos, android-on-chromeos]
 ---
 
-To choose the guide to add Chrome DevTools to your Flutter configuration,
-click the [Getting Started path][] you followed.
+To set up your development environment for targeting the web,
+choose the guide that corresponds to the [Getting Started path][] you followed,
+or the platform you already have set up.
 
 {% for target in target-list %}
-{% capture index0Modulo2 %}{{ forloop.index0 | modulo:2 }}{% endcapture %}
-{% capture indexModulo2 %}{{ forloop.index | modulo:2 }}{% endcapture %}
-{% assign targetlink='/platform-integration/web/install-web/install-web-from-' | append: target | downcase %}
-  {% if index0Modulo2 == '0' %}
-  <div class="card-deck mb-8">
-  {% endif %}
+{% assign row = forloop.index0 | modulo: 2 %}
+{% assign targetLink = '/platform-integration/web/install-web/install-web-from-' | append: target | downcase %}
+{% if row == 0 %}
+<div class="card-deck mb-8">
+{% endif %}
   
   {% if target contains 'macos' or target contains 'ios' %}
     {% assign bug = 'card-macos' %}
@@ -26,23 +26,21 @@ click the [Getting Started path][] you followed.
     {% assign bug = 'card-chromeos' %}
   {% endif %}
 
-  <a class="card card-app-type {{bug}}"
-     id="install-{{target | downcase}}"
-     href="{{targetlink}}">
+  <a class="card card-app-type {{bug}}" id="install-{{target | downcase}}" href="{{targetLink}}">
     <div class="card-body">
       <header class="card-title text-center m-0">
         <span class="d-block h1">
-          {% assign icon = target | downcase %}
+          {% assign icon = target | downcase -%}
           {% case icon %}
-          {% when 'macos-desktop' %}
+          {% when 'macos-desktop' -%}
             <span class="material-symbols">laptop_mac</span>
-          {% when 'ios-on-macos' %}
+          {% when 'ios-on-macos' -%}
             <span class="material-symbols">phone_iphone</span>
-          {% when 'windows-desktop','linux-desktop' %}
+          {% when 'windows-desktop','linux-desktop' -%}
             <span class="material-symbols">desktop_windows</span>
-          {% else %}
+          {% else -%}
             <span class="material-symbols">phone_android</span>
-          {% endcase %}
+          {% endcase -%}
           <span class="material-symbols">add</span>
           <span class="material-symbols">web</span>
         </span>
@@ -51,14 +49,14 @@ click the [Getting Started path][] you followed.
         {{ target | replace: "-", " " | capitalize | replace: "Macos",
         "macOS" | replace: "macos", "macOS" | replace: "Ios", "iOS" |
         replace: "windows", "Windows" | replace: "linux", "Linux" |
-        replace: "on", "apps on" | replace: "desktop", "desktop apps"}}
+        replace: "on", "apps on" | replace: "desktop", "desktop apps" }}
         </span>
       </header>
     </div>
   </a>
-  {% if indexModulo2 == '0' %}
-  </div>
-  {% endif %}
+{% if row == 1 %}
+</div>
+{% endif %}
 {% endfor %}
 
 [Getting Started path]: /get-started/install

--- a/src/content/platform-integration/web/install-web/install-web-from-android-on-chromeos.md
+++ b/src/content/platform-integration/web/install-web/install-web-from-android-on-chromeos.md
@@ -1,5 +1,5 @@
 ---
-title: Add Chrome DevTools to Flutter from Android on ChromeOS start
+title: Add web as a target platform for Flutter from Android on ChromeOS start
 description: Configure your system to develop Flutter web apps on ChromeOS.
 short-title: Starting from Android on ChromeOS
 ---

--- a/src/content/platform-integration/web/install-web/install-web-from-android-on-chromeos.md
+++ b/src/content/platform-integration/web/install-web/install-web-from-android-on-chromeos.md
@@ -1,5 +1,5 @@
 ---
-title: Add web as a target platform for Flutter from Android on ChromeOS start
+title: Set up web development for Flutter from Android on ChromeOS start
 description: Configure your system to develop Flutter web apps on ChromeOS.
 short-title: Starting from Android on ChromeOS
 ---

--- a/src/content/platform-integration/web/install-web/install-web-from-android-on-linux.md
+++ b/src/content/platform-integration/web/install-web/install-web-from-android-on-linux.md
@@ -1,5 +1,5 @@
 ---
-title: Add web DevTools to Flutter from Android on Linux start
+title: Set up web development for Flutter from Android on Linux start
 description: Configure your system to develop Flutter web apps on Linux.
 short-title: Starting from Android on Linux
 ---

--- a/src/content/platform-integration/web/install-web/install-web-from-android-on-macos.md
+++ b/src/content/platform-integration/web/install-web/install-web-from-android-on-macos.md
@@ -1,5 +1,5 @@
 ---
-title: Add Chrome DevTools to Flutter from Android on macOS start
+title: Set up web development for Flutter from Android on macOS start
 description: Configure your system to develop Flutter web apps on macOS.
 short-title: Starting from Android on macOS
 ---

--- a/src/content/platform-integration/web/install-web/install-web-from-android-on-windows.md
+++ b/src/content/platform-integration/web/install-web/install-web-from-android-on-windows.md
@@ -1,5 +1,5 @@
 ---
-title: Add web as a target platform for Flutter from Android on Windows start
+title: Set up web development for Flutter from Android on Windows start
 description: Configure your system to develop Flutter web apps on Windows.
 short-title: Starting from Android on Windows
 ---

--- a/src/content/platform-integration/web/install-web/install-web-from-android-on-windows.md
+++ b/src/content/platform-integration/web/install-web/install-web-from-android-on-windows.md
@@ -1,5 +1,5 @@
 ---
-title: Add Chrome DevTools to Flutter from Android on Windows start
+title: Add web as a target platform for Flutter from Android on Windows start
 description: Configure your system to develop Flutter web apps on Windows.
 short-title: Starting from Android on Windows
 ---

--- a/src/content/platform-integration/web/install-web/install-web-from-ios-on-macos.md
+++ b/src/content/platform-integration/web/install-web/install-web-from-ios-on-macos.md
@@ -1,5 +1,5 @@
 ---
-title: Add web as a target platform for Flutter from iOS on macOS start
+title: Set up web development for Flutter from iOS on macOS start
 description: Configure your system to develop Flutter web apps on macOS.
 short-title: Starting from iOS on macOS
 ---

--- a/src/content/platform-integration/web/install-web/install-web-from-ios-on-macos.md
+++ b/src/content/platform-integration/web/install-web/install-web-from-ios-on-macos.md
@@ -1,5 +1,5 @@
 ---
-title: Add Chrome DevTools to Flutter from iOS on macOS start
+title: Add web as a target platform for Flutter from iOS on macOS start
 description: Configure your system to develop Flutter web apps on macOS.
 short-title: Starting from iOS on macOS
 ---

--- a/src/content/platform-integration/web/install-web/install-web-from-linux-desktop.md
+++ b/src/content/platform-integration/web/install-web/install-web-from-linux-desktop.md
@@ -1,5 +1,5 @@
 ---
-title: Add web DevTools to Flutter from Linux start
+title: Set up web development for Flutter from Linux start
 description: Configure your system to develop Flutter web apps on Linux.
 short-title: Starting from Linux desktop
 ---

--- a/src/content/platform-integration/web/install-web/install-web-from-macos-desktop.md
+++ b/src/content/platform-integration/web/install-web/install-web-from-macos-desktop.md
@@ -1,5 +1,5 @@
 ---
-title: Add web as a target platform for Flutter from macOS start
+title: Set up web development for Flutter from macOS start
 description: Configure your system to develop Flutter web apps on macOS.
 short-title: Starting from macOS desktop
 ---

--- a/src/content/platform-integration/web/install-web/install-web-from-macos-desktop.md
+++ b/src/content/platform-integration/web/install-web/install-web-from-macos-desktop.md
@@ -1,5 +1,5 @@
 ---
-title: Add Chrome DevTools to Flutter from macOS start
+title: Add web as a target platform for Flutter from macOS start
 description: Configure your system to develop Flutter web apps on macOS.
 short-title: Starting from macOS desktop
 ---

--- a/src/content/platform-integration/web/install-web/install-web-from-windows-desktop.md
+++ b/src/content/platform-integration/web/install-web/install-web-from-windows-desktop.md
@@ -1,5 +1,5 @@
 ---
-title: Add web as a target platform for Flutter from Windows start
+title: Set up web development for Flutter from Windows start
 description: Configure your system to develop Flutter web apps on Windows.
 short-title: Starting from Windows desktop
 ---

--- a/src/content/platform-integration/web/install-web/install-web-from-windows-desktop.md
+++ b/src/content/platform-integration/web/install-web/install-web-from-windows-desktop.md
@@ -1,5 +1,5 @@
 ---
-title: Add Chrome DevTools to Flutter from Windows start
+title: Add web as a target platform for Flutter from Windows start
 description: Configure your system to develop Flutter web apps on Windows.
 short-title: Starting from Windows desktop
 ---

--- a/src/content/platform-integration/windows/install-windows/index.md
+++ b/src/content/platform-integration/windows/install-windows/index.md
@@ -1,7 +1,7 @@
 ---
 title: Add Windows as a target platform for Flutter
 description: Configure your system to develop Flutter for Windows.
-short-title: Setup Windows development
+short-title: Set up Windows development
 target-list: [Android, web]
 ---
 

--- a/src/content/platform-integration/windows/install-windows/index.md
+++ b/src/content/platform-integration/windows/install-windows/index.md
@@ -1,19 +1,18 @@
 ---
-title: Add Windows devtools for Flutter
+title: Add Windows as a target platform for Flutter
 description: Configure your system to develop Flutter for Windows.
-short-title: Add Windows desktop DevTools
-target-list: [Android, Web]
+short-title: Setup Windows development
+target-list: [Android, web]
 ---
 
-To choose the guide to add Visual Studio to your Flutter configuration,
-click the [Getting Started path][] you followed.
+To set up your development environment for targeting Windows,
+choose the guide that corresponds to the [Getting Started path][] you followed,
+or the platform you already have set up.
 
 <div class="card-deck mb-8">
 {% for target in target-list %}
-{% assign targetlink='/platform-integration/windows/install-windows/install-windows-from-' | append: target | downcase %}
-  <a class="card card-app-type card-windows"
-     id="install-{{target | downcase}}"
-     href="{{targetlink}}">
+{% assign targetLink = '/platform-integration/windows/install-windows/install-windows-from-' | append: target | downcase %}
+  <a class="card card-app-type card-windows" id="install-{{target | downcase}}" href="{{targetLink}}">
     <div class="card-body">
       <header class="card-title text-center m-0">
         <span class="d-block h1">
@@ -27,7 +26,7 @@ click the [Getting Started path][] you followed.
           <span class="material-symbols">add</span>
           <span class="material-symbols">desktop_windows</span>
         </span>
-        <span class="text-muted text-nowrap">
+        <span class="text-muted d-block">
         Make Windows desktop and {{ target }} apps
         </span>
       </header>

--- a/src/content/platform-integration/windows/install-windows/install-windows-from-android.md
+++ b/src/content/platform-integration/windows/install-windows/install-windows-from-android.md
@@ -1,5 +1,5 @@
 ---
-title: Add Windows devtools to Flutter from Android start
+title: Add Windows as a target platform for Flutter from Android start
 description: Configure your system to develop Flutter apps on Windows desktop.
 short-title: Starting from Android
 ---

--- a/src/content/platform-integration/windows/install-windows/install-windows-from-web.md
+++ b/src/content/platform-integration/windows/install-windows/install-windows-from-web.md
@@ -1,5 +1,5 @@
 ---
-title: Add Windows devtools to Flutter from Web start
+title: Add Windows as a target platform for Flutter from Web start
 description: Configure your system to develop Flutter apps on Windows desktop.
 short-title: Starting from Web
 ---


### PR DESCRIPTION
- "devtools" is a term that generally refers to the Dart/Flutter DevTools app, we shouldn't conflate it with the various apps/software/tools developers using when building for/developing on/debugging against a platform. This PR continues and expand on changes began in https://github.com/flutter/website/commit/8c0003e94988362179fd8532e201439425ed5ecd to move away from these usages of "devtools".
- The [web](https://docs.flutter.dev/platform-integration/web/install-web) and [android](https://docs.flutter.dev/platform-integration/android/install-android) pages had some rendering issues due to whitespace causing rendering differences. This PR addresses those.
- This PR also standardize styles and Liquid usage between the equivalent pages for different platforms.

Feel free to push any changes you'd like to this branch. I haven't had a chance to understand what content is covered or to put too much thought into the names. I put the page names as "Add X as a target platform ..." for now to be consistent with https://github.com/flutter/website/commit/8c0003e94988362179fd8532e201439425ed5ecd, but it seems the content might actually be "Set up your development environment for targeting X platform with Flutter"?

Closes https://github.com/flutter/website/issues/10389

@atsansone @sfshaza2 I've having trouble wrapping my head around these pages, or perhaps just their structure. It's also not clear to me what developers who didn't or don't follow the current version of the getting started instructions should do. I think it might be beneficial if us three could chat through this whole flow together. For now though, I kept this individual PR focused on fixing the rendering issues and replacing the "devtools" mentions.