### PR TITLE
Update app-size.md with fixed devtools command

### DIFF
--- a/src/content/perf/app-size.md
+++ b/src/content/perf/app-size.md
@@ -165,7 +165,7 @@ analyzed in deeper detail in DevTools where a tree or a treemap view can
 break down the contents of the application into the individual file level and
 up to function level for the Dart AOT artifact.
 
-This can be done by `flutter pub global run devtools`, selecting
+This can be done by `dart devtools`, selecting
 `Open app size tool` and uploading the JSON file.
 
 {% include docs/app-figure.md image="perf/devtools-size.png" alt="Example breakdown of app in DevTools" %}


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

After [devtools](https://pub.dev/packages/devtools) got discontinued on pub.dev, they can be run via `dart devtools`

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
