### PR TITLE
Add a link to the Flutter for web developers guide

### DIFF
--- a/src/content/index.md
+++ b/src/content/index.md
@@ -32,12 +32,13 @@ Once you've gone through [Get started][],
 including [Write your first Flutter app][],
 here are some next steps.
 
+[Get started]: /get-started/install
 [Write your first Flutter app]: /get-started/codelab
 
 ### Docs
 
 Coming from another platform? Check out Flutter for:
-[Android][], [SwiftUI][], [UIKit][], [React Native][], and
+[Android][], [SwiftUI][], [UIKit][], [React Native][], [Web][], and
 [Xamarin.Forms][] developers.
 
 [Building layouts][]
@@ -57,15 +58,15 @@ Coming from another platform? Check out Flutter for:
 : Get the answers to frequently asked questions.
 
 [Android]: /get-started/flutter-for/android-devs
-[Building layouts]: /ui/layout
-[FAQ]: /resources/faq
-[Get started]: /get-started/install
-[interactivity]: /ui/interactivity
 [SwiftUI]: /get-started/flutter-for/swiftui-devs
 [UIKit]: /get-started/flutter-for/uikit-devs
 [React Native]: /get-started/flutter-for/react-native-devs
-[Understanding constraints]: /ui/layout/constraints
+[Web]: /get-started/flutter-for/web-devs
 [Xamarin.Forms]: /get-started/flutter-for/xamarin-forms-devs
+[Building layouts]: /ui/layout
+[Understanding constraints]: /ui/layout/constraints
+[interactivity]: /ui/interactivity
+[FAQ]: /resources/faq
 
 ### Videos
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Add a link to the Flutter for web developers guide.

![image](https://github.com/flutter/website/assets/32262985/9357c629-3bec-493d-8918-323db1369fd2)


_Issues fixed by this PR (if any):_
None.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
