### PR TITLE
Revert "Add a link to the Flutter for web developers guide"

### DIFF
--- a/src/content/index.md
+++ b/src/content/index.md
@@ -32,13 +32,12 @@ Once you've gone through [Get started][],
 including [Write your first Flutter app][],
 here are some next steps.
 
-[Get started]: /get-started/install
 [Write your first Flutter app]: /get-started/codelab
 
 ### Docs
 
 Coming from another platform? Check out Flutter for:
-[Android][], [SwiftUI][], [UIKit][], [React Native][], [Web][], and
+[Android][], [SwiftUI][], [UIKit][], [React Native][], and
 [Xamarin.Forms][] developers.
 
 [Building layouts][]
@@ -58,15 +57,15 @@ Coming from another platform? Check out Flutter for:
 : Get the answers to frequently asked questions.
 
 [Android]: /get-started/flutter-for/android-devs
+[Building layouts]: /ui/layout
+[FAQ]: /resources/faq
+[Get started]: /get-started/install
+[interactivity]: /ui/interactivity
 [SwiftUI]: /get-started/flutter-for/swiftui-devs
 [UIKit]: /get-started/flutter-for/uikit-devs
 [React Native]: /get-started/flutter-for/react-native-devs
-[Web]: /get-started/flutter-for/web-devs
-[Xamarin.Forms]: /get-started/flutter-for/xamarin-forms-devs
-[Building layouts]: /ui/layout
 [Understanding constraints]: /ui/layout/constraints
-[interactivity]: /ui/interactivity
-[FAQ]: /resources/faq
+[Xamarin.Forms]: /get-started/flutter-for/xamarin-forms-devs
 
 ### Videos
 


### PR DESCRIPTION
Reverts flutter/website#10422

The content at `/get-started/install` is not really an introduction to Flutter for web developers. It's how to get started using Flutter for the web.

I'd argue we probably need to think about what content we would give a developer coming from the web to Flutter, but "install these tools" is probably not it.

