### PR TITLE
fix: owl image url in implicit animations codelab

### DIFF
--- a/examples/animation/implicit/opacity1/lib/main.dart
+++ b/examples/animation/implicit/opacity1/lib/main.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 
 const owlUrl =
-    'https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg';
+    'https://raw.githubusercontent.com/flutter/website/main/src/content/assets/images/docs/owl.jpg';
 
 class FadeInDemo extends StatefulWidget {
   const FadeInDemo({super.key});

--- a/examples/animation/implicit/opacity2/lib/main.dart
+++ b/examples/animation/implicit/opacity2/lib/main.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 
 const owlUrl =
-    'https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg';
+    'https://raw.githubusercontent.com/flutter/website/main/src/content/assets/images/docs/owl.jpg';
 
 class FadeInDemo extends StatefulWidget {
   const FadeInDemo({super.key});

--- a/examples/animation/implicit/opacity3/lib/main.dart
+++ b/examples/animation/implicit/opacity3/lib/main.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 
 const owlUrl =
-    'https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg';
+    'https://raw.githubusercontent.com/flutter/website/main/src/content/assets/images/docs/owl.jpg';
 
 class FadeInDemo extends StatefulWidget {
   const FadeInDemo({super.key});

--- a/examples/animation/implicit/opacity4/lib/main.dart
+++ b/examples/animation/implicit/opacity4/lib/main.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 
 const owlUrl =
-    'https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg';
+    'https://raw.githubusercontent.com/flutter/website/main/src/content/assets/images/docs/owl.jpg';
 
 class FadeInDemo extends StatefulWidget {
   const FadeInDemo({super.key});

--- a/examples/animation/implicit/opacity5/lib/main.dart
+++ b/examples/animation/implicit/opacity5/lib/main.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 
 const owlUrl =
-    'https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg';
+    'https://raw.githubusercontent.com/flutter/website/main/src/content/assets/images/docs/owl.jpg';
 
 class FadeInDemo extends StatefulWidget {
   const FadeInDemo({super.key});

--- a/src/_includes/docs/implicit-animations/fade-in-complete.md
+++ b/src/_includes/docs/implicit-animations/fade-in-complete.md
@@ -7,7 +7,7 @@
 import 'package:flutter/material.dart';
 
 const owlUrl =
-    'https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg';
+    'https://raw.githubusercontent.com/flutter/website/main/src/content/assets/images/docs/owl.jpg';
 
 class FadeInDemo extends StatefulWidget {
   const FadeInDemo({super.key});

--- a/src/_includes/docs/implicit-animations/fade-in-starter-code.md
+++ b/src/_includes/docs/implicit-animations/fade-in-starter-code.md
@@ -7,7 +7,7 @@
 import 'package:flutter/material.dart';
 
 const owlUrl =
-    'https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg';
+    'https://raw.githubusercontent.com/flutter/website/main/src/content/assets/images/docs/owl.jpg';
 
 class FadeInDemo extends StatefulWidget {
   const FadeInDemo({super.key});


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
The [owl image URL](https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg) in the [implicit animations codelab](https://docs.flutter.dev/codelabs/implicit-animations)'s [Fade-in text effect example](https://docs.flutter.dev/codelabs/implicit-animations#example-fade-in-text-effect) was broken.
Old URL - [https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg](https://raw.githubusercontent.com/flutter/website/main/src/assets/images/docs/owl.jpg) resolves to `404: Not Found`

_Issues fixed by this PR (if any):_
Updated the [owl image URL](https://raw.githubusercontent.com/flutter/website/main/src/content/assets/images/docs/owl.jpg) in [Fade-in text effect example](https://docs.flutter.dev/codelabs/implicit-animations#example-fade-in-text-effect), inside the [implicit animations codelab](https://docs.flutter.dev/codelabs/implicit-animations).

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
