### PR TITLE
Document platform view constraint

### DIFF
--- a/src/content/platform-integration/android/platform-views.md
+++ b/src/content/platform-integration/android/platform-views.md
@@ -23,7 +23,7 @@ see [Hosting native iOS views][].
 
 [Hosting native iOS views]: /platform-integration/ios/platform-views
 
-Flutter supports two modes:
+Flutter supports two modes starting at api 23:
 Hybrid composition and virtual displays.
 
 Which one to use depends on the use case.


### PR DESCRIPTION
This has been the case since flutter 3.0 but did not appear to be documented. 

Related to https://github.com/flutter/flutter/issues/147210



## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
