### PR TITLE
Clarify Gradle imperative apply migration docs for removal of unneeded kotlin dependency

### DIFF
--- a/src/content/release/breaking-changes/flutter-gradle-plugin-apply.md
+++ b/src/content/release/breaking-changes/flutter-gradle-plugin-apply.md
@@ -182,13 +182,15 @@ very top of your file, add:
 +}
 ```
 
-Finally, if your `dependencies` sections contains a dependency on
-```groovy
-implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+Finally, if your `dependencies` sections contains a dependency on `"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"`, 
+then remove that dependency.
+```diff
+dependencies {
+    -implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+}
 ```
-then remove that dependency. If it is the only dependency in the `dependencies` block, then 
+If it was the only dependency in the `dependencies` block, then 
 alternatively you may remove the block entirely.
-
 
 ### Validation
 

--- a/src/content/release/breaking-changes/flutter-gradle-plugin-apply.md
+++ b/src/content/release/breaking-changes/flutter-gradle-plugin-apply.md
@@ -186,7 +186,7 @@ Finally, if your `dependencies` sections contains a dependency on `"org.jetbrain
 then remove that dependency.
 ```diff
 dependencies {
-    -implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 ```
 If it was the only dependency in the `dependencies` block, then 

--- a/src/content/release/breaking-changes/flutter-gradle-plugin-apply.md
+++ b/src/content/release/breaking-changes/flutter-gradle-plugin-apply.md
@@ -182,7 +182,7 @@ very top of your file, add:
 +}
 ```
 
-Finally, if your `dependencies` sections contains a dependency on `"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"`, 
+Finally, if your `dependencies` block contains a dependency on `"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"`, 
 then remove that dependency.
 ```diff
 dependencies {

--- a/src/content/release/breaking-changes/flutter-gradle-plugin-apply.md
+++ b/src/content/release/breaking-changes/flutter-gradle-plugin-apply.md
@@ -182,6 +182,14 @@ very top of your file, add:
 +}
 ```
 
+Finally, if your `dependencies` sections contains a dependency on
+```groovy
+implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+```
+then remove that dependency. If it is the only dependency in the `dependencies` block, then 
+alternatively you may remove the block entirely.
+
+
 ### Validation
 
 Execute `flutter run` to confirm your app builds and launches on a connected


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Adds a note to remove an additional block from `android/app/build.gradle`, if it exists. This block was in templates shortly before the migration landed, and if not removed it will block migration.

See https://github.com/flutter/flutter/issues/145654#issuecomment-2075380981 for more context.

_Issues fixed by this PR (if any):_

https://github.com/flutter/flutter/issues/145654

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
