### PR TITLE
Update references to compile / min target sdk property

### DIFF
--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -323,11 +323,11 @@ to verify that the values are correct.
 `applicationId`
 : Specify the final, unique [application ID][].
   
-`minSdkVersion`
+`minSdk`
 : Specify the [minimum API level][] on which you designed the app to run.
   Defaults to `flutter.minSdkVersion`.
 
-`targetSdkVersion`
+`targetSdk`
 : Specify the target API level on which you designed the app to run.
   Defaults to `flutter.targetSdkVersion`.
   
@@ -349,7 +349,7 @@ to verify that the values are correct.
 
 #### Under the `android` block
   
-`compileSdkVersion`
+`compileSdk`
 : Specify the API level Gradle should use to compile your app.
   Defaults to `flutter.compileSdkVersion`.
 

--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -355,6 +355,11 @@ to verify that the values are correct.
 
 For more information, check out the module-level build
 section in the [Gradle build file][gradlebuild].
+
+:::note
+If you use a recent version of the Android SDK, you might get deprecation warnings about `compileSdkVersion`, `minSdkVersion` or `targetSdkVersion`.
+You can rename these properties to `compileSdk`, `minSdk` and `targetSdk` respectively.
+:::
   
 ## Build the app for release
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ 
This updates the Android docs to reference to the new property names of the deprecated `minSdkVersion` / `targetSdkVersion` / `compileSdkVersion`

_Issues fixed by this PR (if any):_ https://github.com/flutter/website/issues/10458

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
