### PR TITLE
Fix: Formatting in 'Configure your target iOS device' guide

### DIFF
--- a/src/_includes/docs/install/devices/ios-physical.md
+++ b/src/_includes/docs/install/devices/ios-physical.md
@@ -82,13 +82,14 @@ Follow the Xcode signing flow to provision your project.
 
    {: type="a"}
    1. Go to **Xcode** <span aria-label="and then">></span>
-      **Settings...*
+      **Settings...**
    1. Click **Accounts**.
-   . Click **+**.
-   . Select **Apple ID** and click **Continue**.
-   . When prompted, enter your **Apple ID** and **Password**.
-   . Close the **Settings** dialog.
-     Development and testing supports any Apple ID.
+   1. Click **+**.
+   1. Select **Apple ID** and click **Continue**.
+   1. When prompted, enter your **Apple ID** and **Password**.
+   1. Close the **Settings** dialog.
+
+   Development and testing supports any Apple ID.
 
 1. Go to **File** <span aria-label="and then">></span> **Open...**
 
@@ -127,10 +128,11 @@ Follow the Xcode signing flow to provision your project.
    1. Creates and downloads a Development Certificate
    1. Registers your device with your account,
    1. Creates and downloads a provisioning profile if needed
-      If automatic signing fails in Xcode, verify that the project's
-      **General** <span aria-label="and then">></span>
-      **Identity** <span aria-label="and then">></span>
-      **Bundle Identifier** value is unique.
+
+If automatic signing fails in Xcode, verify that the project's
+**General** <span aria-label="and then">></span>
+**Identity** <span aria-label="and then">></span>
+**Bundle Identifier** value is unique.
 
 ![Check the app's Bundle ID][]{:.mw-100}
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

![1](https://github.com/flutter/website/assets/32262985/c2d1db4c-d5eb-4d20-a93d-c0681557ebfa)

_Issues fixed by this PR (if any):_

None.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
