### PR TITLE
Avoid include shadowing issues in getting started docs

### DIFF
--- a/src/_includes/docs/install/compiler/android.md
+++ b/src/_includes/docs/install/compiler/android.md
@@ -1,12 +1,7 @@
 
 ## Configure Android development
 
-{% assign devos = include.devos %}
-{% assign target = include.target %}
-{% assign compiler = include.compiler %}
-{% assign attempt-time = include.attempt %}
-
-{% case devos %}
+{% case include.devos %}
 {% when 'Windows' -%}
    {% assign terminal='PowerShell' %}
    {% assign prompt='C:\>' %}
@@ -155,13 +150,13 @@ Otherwise, you can skip to the [next section][check-dev].
 
 <div class="tab-pane active" id="virtual" role="tabpanel" aria-labelledby="virtual-tab">
 
-{% include docs/install/devices/android-emulator.md devos=devos %}
+{% include docs/install/devices/android-emulator.md devos=include.devos %}
 
 </div>
 
 <div class="tab-pane" id="physical" role="tabpanel" aria-labelledby="physical-tab">
 
-{% include docs/install/devices/android-physical.md devos=devos %}
+{% include docs/install/devices/android-physical.md devos=include.devos %}
 
 </div>
 </div>

--- a/src/_includes/docs/install/compiler/xcode.md
+++ b/src/_includes/docs/install/compiler/xcode.md
@@ -2,15 +2,12 @@
 ## Configure iOS development
 
 {% assign prompt1='$' %}
-{% assign devos = include.devos %}
-{% assign target = include.target %}
-{% assign attempt = include.attempt %}
 
 ### Configure Xcode
 
-{% if attempt=="first" %}
+{% if include.attempt=="first" %}
 
-To develop Flutter apps for {{target}}, install Xcode to compile to native bytecode.
+To develop Flutter apps for {{include.target}}, install Xcode to compile to native bytecode.
 
 1. To configure the command-line tools to use the installed version of Xcode,
    run the following commands.
@@ -33,7 +30,7 @@ To develop Flutter apps for {{target}}, install Xcode to compile to native bytec
 This section presumes you have installed and configured Xcode when you
 installed Flutter for
 
-{%- case target %}
+{%- case include.target %}
 {%- when 'iOS' %}
 [macOS desktop][macos-install]
 {%- when 'desktop' %}
@@ -48,7 +45,7 @@ installed Flutter for
 
 Try to keep to the current version of Xcode.
 
-{% if target=='iOS' %}
+{% if include.target=='iOS' %}
 
 ### Configure your target iOS device
 
@@ -83,13 +80,14 @@ With Xcode, you can run Flutter apps on an iOS device or on the simulator.
 
 {% endif %}
 
-{% if attempt=="first" %}
+{% if include.attempt=="first" %}
 
 ### Install CocoaPods
 
-If your apps depend on [Flutter plugins][] with native {{target}} code,
+If your apps depend on [Flutter plugins][] with native {{include.target}} code,
 install [CocoaPods][cocoapods].
-This program bundles various dependencies across Flutter and {{target}} code.
+This program bundles various dependencies across
+Flutter and {{include.target}} code.
 
 To install and set up CocoaPods, run the following commands:
 

--- a/src/_includes/docs/install/devices/android-emulator.md
+++ b/src/_includes/docs/install/devices/android-emulator.md
@@ -2,12 +2,7 @@
 
 {% include docs/help-link.md location='android-emulator' section='#android-setup' %}
 
-{% assign devos = include.devos %}
-{% assign target = include.target %}
-{% assign compiler = include.compiler %}
-{% assign attempt = include.attempt %}
-
-{% case devos %}
+{% case include.devos %}
 {% when 'Windows','Linux' -%}
 {% assign images = '**x86 Images**' -%}
 {% when 'macOS' -%}

--- a/src/_includes/docs/install/devices/android-physical.md
+++ b/src/_includes/docs/install/devices/android-physical.md
@@ -2,11 +2,6 @@
 
 {% include docs/help-link.md location='android-device' section='#android-setup' %}
 
-{% assign devos = include.devos %}
-{% assign target = include.target %}
-{% assign compiler = include.compiler %}
-{% assign attempt = include.attempt %}
-
 To configure your Flutter app to run on a physical Android device,
 you need an Android device running {{site.targetmin.android}} or later.
 
@@ -18,18 +13,18 @@ you need an Android device running {{site.targetmin.android}} or later.
    enable **Wireless debugging** on your device as described in the
    [Android documentation]({{site.android-dev}}/studio/run/device#wireless).
 
-{%- if devos == 'Windows' %}
+{%- if include.devos == 'Windows' %}
 
 1. Install the [Google USB Driver]({{site.android-dev}}/studio/run/win-usb).
 
 {% endif %}
 
-1. Plug your device into your {{devos}} computer.
+1. Plug your device into your {{include.devos}} computer.
    If your device prompts you, authorize your computer to access your device.
 
 1. Verify that Flutter recognizes your connected Android device.
 
-   {%- if devos == 'Windows' %}
+   {%- if include.devos == 'Windows' %}
 
    In PowerShell, run:
 

--- a/src/_includes/docs/install/flutter-doctor.md
+++ b/src/_includes/docs/install/flutter-doctor.md
@@ -3,11 +3,9 @@
 
 {% include docs/help-link.md location='win-doctor' %}
 
-{% assign devos = include.devos %}
-{% assign target = include.target %}
 {% assign compiler = include.compiler %}
 
-{% case devos %}
+{% case include.devos %}
 {% when 'Windows' -%}
    {% assign terminal='PowerShell' %}
    {% assign prompt='C:\>' %}
@@ -18,13 +16,13 @@
    {% assign terminal='a shell' %}
    {% assign prompt='$' %}
 {% endcase -%}
-{% case target %}
+{% case include.target %}
 {% when 'macOS','Windows','Linux' %}
-{% assign work-target = target | append: ' desktop' %}
+{% assign work-target = include.target | append: ' desktop' %}
 {% when 'desktop' %}
-{% assign work-target = devos | append: ' desktop' %}
+{% assign work-target = include.devos | append: ' desktop' %}
 {% else %}
-{% assign work-target = target | append: ' on ' | append: devos %}
+{% assign work-target = include.target | append: ' on ' | append: include.devos %}
 {% endcase %}
 {% case work-target %}
 {% when 'macOS desktop','Web on macOS','iOS on macOS' %}
@@ -40,7 +38,7 @@
 ### Run Flutter doctor
 
 The `flutter doctor` command validates that all components of a
-complete Flutter development environment for {{devos}}.
+complete Flutter development environment for {{include.devos}}.
 
 1. Open {{terminal}}.
 
@@ -51,11 +49,11 @@ complete Flutter development environment for {{devos}}.
    {{prompt}} flutter doctor
    ```
 
-As you chose to develop for {{target}},
+As you chose to develop for {{include.target}},
 you do not need _all_ components.
 If you followed this guide, the result of your command should resemble:
 
-{% include docs/install/flutter-doctor-success.md config=include.config devos=devos -%}
+{% include docs/install/flutter-doctor-success.md config=include.config devos=include.devos -%}
 
 ### Troubleshoot Flutter doctor issues
 

--- a/src/_includes/docs/install/flutter-sdk.md
+++ b/src/_includes/docs/install/flutter-sdk.md
@@ -1,13 +1,10 @@
-{% assign os=include.os %}
-{% assign target = include.target %}
-{% assign terminal=include.terminal %}
-{% case target %}
+{% case include.target %}
 {% when 'mobile-ios' %}
    {% assign v-target = 'iOS' %}
 {% when 'mobile-android','mobile' %}
    {% assign v-target = 'Android' %}
 {% else %}
-   {% assign v-target = target %}
+   {% assign v-target = include.target %}
 {% endcase %}
 
 ## Install the Flutter SDK
@@ -30,13 +27,13 @@ or download and install the Flutter bundle yourself.
 
 <div class="tab-pane active" id="vscode" role="tabpanel" aria-labelledby="vscode-tab">
 
-{% include docs/install/flutter/vscode.md os=os terminal=terminal target=v-target %}
+{% include docs/install/flutter/vscode.md os=include.os terminal=include.terminal target=v-target %}
 
 </div>
 
 <div class="tab-pane" id="download" role="tabpanel" aria-labelledby="download-tab">
 
-{% include docs/install/flutter/download.md os=os terminal=terminal target=v-target%}
+{% include docs/install/flutter/download.md os=include.os terminal=include.terminal target=v-target%}
 
 </div>
 </div>

--- a/src/_includes/docs/install/flutter/download.md
+++ b/src/_includes/docs/install/flutter/download.md
@@ -1,11 +1,8 @@
-{% assign terminal=include.terminal %}
 
 ### Download then install Flutter {:.no_toc}
 
-{% assign os = include.os %}
-{% assign osl = os | downcase | replace: "chromeos","linux" %}
-{% assign target = include.target %}
-{% case os %}
+{% assign osl = include.os | downcase | replace: "chromeos","linux" %}
+{% case include.os %}
 {% when 'Windows' -%}
    {% assign unzip='Expand-Archive .\\' %}
    {% assign path='C:\\user\\{username}\\dev' %}
@@ -57,7 +54,7 @@ then extract the SDK.
 1. Download the following installation bundle to get the latest
    {{site.sdk.channel}} release of the Flutter SDK.
 
-   {% if os=='macOS' %}
+   {% if include.os=='macOS' %}
 
    | Intel Processor                                                     | Apple Silicon                                                                             |
    |---------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
@@ -71,9 +68,9 @@ then extract the SDK.
 
    For other release channels, and older builds, check out the [SDK archive][].
 
-   The Flutter SDK should download to the {{os}} default download directory:
-   `{{dirdl}}`.
-   {% if os=='Windows' %}
+   The Flutter SDK should download to the {{include.os}}
+   default download directory: `{{dirdl}}`.
+   {% if include.os=='Windows' %}
    If you changed the location of the Downloads directory,
    replace this path with that path.
    To find your Downloads directory location,
@@ -83,7 +80,7 @@ then extract the SDK.
 1. Create a folder where you can install Flutter.
 
    Consider creating a directory at {{diroptions}}.
-   {% if os == "Windows" -%}
+   {% if include.os == "Windows" -%}
    {% include docs/install/admonitions/install-paths.md %}
    {% endif %}
 
@@ -98,12 +95,11 @@ then extract the SDK.
 [SDK archive]: /release/archive
 [move-dl]: https://answers.microsoft.com/en-us/windows/forum/all/move-download-folder-to-other-drive-in-windows-10/67d58118-4ccd-473e-a3da-4e79fdb4c878
 
-{% case os %}
+{% case include.os %}
 {% when 'Windows' %}
-{% include docs/install/reqs/windows/set-path.md terminal=terminal target=target %}
+{% include docs/install/reqs/windows/set-path.md terminal=terminal target=include.target %}
 {% when 'macOS' %}
-{% include docs/install/reqs/macos/set-path.md terminal=terminal
-target=target dir=dirinstall %}
+{% include docs/install/reqs/macos/set-path.md terminal=terminal target=include.target dir=dirinstall %}
 {% else %}
-{% include docs/install/reqs/linux/set-path.md terminal=terminal target=target %}
+{% include docs/install/reqs/linux/set-path.md terminal=terminal target=include.target %}
 {% endcase %}

--- a/src/_includes/docs/install/flutter/vscode.md
+++ b/src/_includes/docs/install/flutter/vscode.md
@@ -1,6 +1,4 @@
-{% assign os=include.os %}
-{% assign terminal=include.terminal %}
-{%- if os=='macOS' -%}
+{%- if include.os=='macOS' -%}
 {% assign special = 'Command' %}
 {% else %}
 {% assign special = 'Control' %}
@@ -32,8 +30,8 @@ you have installed [Visual Studio Code][]
       click **Download SDK**.
 
       This option sends you the Flutter install page if you have not
-      installed Git {% if os == "Windows" %}for Windows {% endif %}as directed in
-      the [development tools prerequisites][].
+      installed Git {% if include.os == "Windows" %}for Windows {% endif %}as
+      directed in the [development tools prerequisites][].
 
 1. When prompted **Which Flutter template?**, ignore it.
    Press <kbd>Esc</kbd>.
@@ -47,7 +45,7 @@ you have installed [Visual Studio Code][]
    VS Code places you in your user profile to start.
    Choose a different location.
 
-   {% if os == "Windows" -%}
+   {% if include.os == "Windows" -%}
    Consider `%USERPROFILE%` or `C:\dev`.
 
    {% include docs/install/admonitions/install-paths.md %}
@@ -108,7 +106,7 @@ you have installed [Visual Studio Code][]
    in external terminals?
    ```
 
-{% if os=='Windows' %}
+{% if include.os=='Windows' %}
 
 1. Click **Add SDK to PATH**.
 
@@ -124,10 +122,10 @@ you have installed [Visual Studio Code][]
 
    If you agree, click **OK**.
 
-1. To enable `flutter` in all {{terminal}} windows:
+1. To enable `flutter` in all {{include.terminal}} windows:
 
    {:type="a"}
-   1. Close, then reopen all {{terminal}} windows.
+   1. Close, then reopen all {{include.terminal}} windows.
    1. Restart VS Code.
 
 [development tools prerequisites]: #development-tools

--- a/src/_includes/docs/install/next-steps.md
+++ b/src/_includes/docs/install/next-steps.md
@@ -3,19 +3,17 @@
 To learn more about managing your Flutter SDK install,
 consult the following resources.
 
-{% assign doctor = doctor %}
 {% assign config = doctor[include.config] %}
-{% assign target = include.target | remove: 'mobile-' | downcase %}
-{% assign devos = include.devos %}
-{% if target == 'desktop' %}
-  {% assign webtarget = devos | append: '-desktop' | downcase %}
-  {% assign andtarget = devos | downcase %}
-  {% assign target = devos | downcase %}
-{% elsif target == 'web' %}
-  {% assign andtarget = 'web-on-' | append: devos | downcase %}
+{% assign mod-target = include.target | remove: 'mobile-' | downcase %}
+{% if mod-target == 'desktop' %}
+  {% assign webtarget = include.devos | append: '-desktop' | downcase %}
+  {% assign andtarget = include.devos | downcase %}
+  {% assign mod-target = include.devos | downcase %}
+{% elsif mod-target == 'web' %}
+  {% assign andtarget = 'web-on-' | append: include.devos | downcase %}
 {% else %}
-  {% assign webtarget = target | append: '-on-' | append: devos | downcase %}
-  {% assign andtarget = devos | downcase %}
+  {% assign webtarget = mod-target | append: '-on-' | append: include.devos | downcase %}
+  {% assign andtarget = include.devos | downcase %}
 {% endif %}
 
 * [Upgrade Flutter][upgrade]
@@ -30,21 +28,21 @@ consult the following resources.
 {%- endcase %}
 {%- case config.add-simulator %}
 {%- when 'Y' %}
-* [Add iOS simulator or device](/platform-integration/ios/install-ios/install-ios-from-{{target}})
+* [Add iOS simulator or device](/platform-integration/ios/install-ios/install-ios-from-{{mod-target}})
 {%- endcase %}
 {%- case config.add-xcode %}
 {%- when 'Y' %}
-* [Add macOS compilation tools](/platform-integration/macos/install-macos/install-macos-from-{{target}})
+* [Add macOS compilation tools](/platform-integration/macos/install-macos/install-macos-from-{{mod-target}})
 {%- endcase %}
 {%- case config.add-linux-tools %}
 {%- when 'Y' %}
-* [Add Linux compilation tools](/platform-integration/linux/install-linux/install-linux-from-{{target}})
+* [Add Linux compilation tools](/platform-integration/linux/install-linux/install-linux-from-{{mod-target}})
 {%- endcase %}
 {%- case config.add-visual-studio %}
 {%- when 'Y' %}
-* [Add Windows desktop compilation tools](/platform-integration/windows/install-windows/install-windows-from-{{target}})
+* [Add Windows desktop compilation tools](/platform-integration/windows/install-windows/install-windows-from-{{mod-target}})
 {%- endcase %}
 * [Uninstall Flutter][uninstall]
 
 [upgrade]: /release/upgrade
-[uninstall]: /get-started/uninstall?tab={{devos}}
+[uninstall]: /get-started/uninstall?tab={{include.devos}}

--- a/src/_includes/docs/install/reqs/add-web.md
+++ b/src/_includes/docs/install/reqs/add-web.md
@@ -1,11 +1,10 @@
-{% assign devos = include.devos %}
 
 1. Allocate a minimum of 1 GB of storage for Google Chrome.
    Consider allocating 2 GB of storage for an optimal configuration.
 
-1. Download and install the {{devos}} version of [Google Chrome][]
+1. Download and install the {{include.devos}} version of [Google Chrome][]
    to debug JavaScript code for web apps.
 
-{% if devos == 'Linux' %}{% include docs/install/accordions/install-chrome-from-cli.md %}{% endif %}
+{% if include.devos == 'Linux' %}{% include docs/install/accordions/install-chrome-from-cli.md %}{% endif %}
 
 [Google Chrome]: https://www.google.com/chrome/dr/download/

--- a/src/_includes/docs/install/reqs/linux/base.md
+++ b/src/_includes/docs/install/reqs/linux/base.md
@@ -1,17 +1,15 @@
-{% assign os = include.os %}
-{% assign target = include.target %}
 
 {% include docs/install/admonitions/install-in-order.md %}
 
 ## Verify system requirements
 
 To install and run Flutter,
-your {{os}} environment must meet the following hardware
+your {{include.os}} environment must meet the following hardware
 and software requirements.
 
 ### Hardware requirements
 
-Your {{os}} Flutter development environment must meet the following
+Your {{include.os}} Flutter development environment must meet the following
 minimal hardware requirements.
 
 <div class="table-wrapper">
@@ -21,13 +19,13 @@ minimal hardware requirements.
 | CPU Cores                    | 4                                                                        | 8                   |
 | Memory in GB                 | 8                                                                        | 16                  |
 | Display resolution in pixels | WXGA (1366 x 768)                                                        | FHD (1920 x 1080)   |
-| Free disk space in GB        | {% include docs/install/reqs/linux/storage.md target=target %}
+| Free disk space in GB        | {% include docs/install/reqs/linux/storage.md target=include.target %}
 
 {:.table .table-striped}
 
 </div>
 
-{% if os == 'ChromeOS' and target == 'Android' %}
+{% if include.os == 'ChromeOS' and include.target == 'Android' %}
 To discover which hardware devices ChromeOS recommends for Android development,
 consult the [ChromeOS docs][chromeos-docs].
 {% endif %}
@@ -36,13 +34,13 @@ consult the [ChromeOS docs][chromeos-docs].
 
 ### Software requirements
 
-To write and compile Flutter code for {{target}},
-you must have the following version of {{os}} and the listed
+To write and compile Flutter code for {{include.target}},
+you must have the following version of {{include.os}} and the listed
 software packages.
 
 #### Operating system
 
-{% if os == 'Linux' %}
+{% if include.os == 'Linux' %}
 {%- capture supported-os %}
 Debian Linux {{site.devmin.linux.debian}} or later
 and Ubuntu Linux {{site.devmin.linux.ubuntu}} or later
@@ -55,7 +53,7 @@ Flutter supports {{supported-os}}.
 
 #### Development tools {:.no_toc}
 
-{% include docs/install/reqs/linux/software.md target=target os=os %}
+{% include docs/install/reqs/linux/software.md target=include.target os=include.os %}
 
 {% include docs/install/reqs/flutter-sdk/flutter-doctor-precedence.md %}
 

--- a/src/_includes/docs/install/reqs/linux/install-desktop-tools.md
+++ b/src/_includes/docs/install/reqs/linux/install-desktop-tools.md
@@ -1,8 +1,5 @@
-{% assign devos = include.devos %}
-{% assign target = include.target %}
-
-1. To develop {{devos}} {{target}} apps, use the following command to install
-   these packages:  
+1. To develop {{include.devos}} {{include.target}} apps, use the
+   following command to install these packages:  
    [`clang`][clang],
    [`cmake`][cmake],
    [`ninja-build`][ninjabuild],

--- a/src/_includes/docs/install/reqs/linux/set-path.md
+++ b/src/_includes/docs/install/reqs/linux/set-path.md
@@ -1,10 +1,6 @@
-{% assign terminal=include.terminal %}
-{% assign target = include.target %}
-{% assign dir = include.dir %}
-
 ### Add Flutter to your `PATH` {:.no_toc}
 
-To run Flutter commands in {{terminal}},
+To run Flutter commands in {{include.terminal}},
 add Flutter to the `PATH` environment variable.
 
 1. Check which shell starts when you open a new console window.

--- a/src/_includes/docs/install/reqs/linux/software.md
+++ b/src/_includes/docs/install/reqs/linux/software.md
@@ -1,9 +1,6 @@
-{% assign os = include.os %}
-{% assign target = include.target %}
+To develop Flutter on {{include.os}}:
 
-To develop Flutter on {{os}}:
-
-{% if os == "ChromeOS" %}
+{% if include.os == "ChromeOS" %}
 
 1. Enable [Linux][] on your Chromebook.
 
@@ -29,17 +26,17 @@ To develop Flutter on {{os}}:
    $ sudo apt-get install -y curl git unzip xz-utils zip libglu1-mesa
    ```
 
-{% case target %}
+{% case include.target %}
 {% when 'desktop' -%}
 
-{% include docs/install/reqs/linux/install-desktop-tools.md devos=os %}
+{% include docs/install/reqs/linux/install-desktop-tools.md devos=include.os %}
 
 {% when 'Android' -%}
 
-1. To develop {{target}} apps:
+1. To develop {{include.target}} apps:
 
    {:type="a"}
-   1. Install the following prequisite packages for Android Studio:
+   1. Install the following prerequisite packages for Android Studio:
       `libc6:i386`, `libncurses5:i386`, `libstdc++6:i386`, `lib32z1`, `libbz2-1.0:i386`
 
       ```console

--- a/src/_includes/docs/install/reqs/linux/unset-path.md
+++ b/src/_includes/docs/install/reqs/linux/unset-path.md
@@ -1,8 +1,7 @@
-{% assign terminal=include.terminal %}
 
 ### Remove Flutter from your Windows Path variable {:.no_toc}
 
-To remove Flutter commands from {{terminal}},
+To remove Flutter commands from {{include.terminal}},
 remove Flutter from the `PATH` environment variable.
 
 {% include docs/install/reqs/windows/open-envvars.md %}
@@ -22,4 +21,5 @@ remove Flutter from the `PATH` environment variable.
    1. Click **OK** three times.
 
 1. To enable these changes,
-   close and reopen any existing command prompts and {{terminal}} instances.
+   close and reopen any existing
+   command prompts and {{include.terminal}} instances.

--- a/src/_includes/docs/install/reqs/macos/base.md
+++ b/src/_includes/docs/install/reqs/macos/base.md
@@ -1,25 +1,23 @@
-{% assign target = include.target %}
-{% case target %}
+{% case include.target %}
 {% when 'mobile-ios' %}
 {% assign v-target = "iOS" %}
 {% when 'mobile-android' %}
 {% assign v-target = "Android" %}
 {% else %}
-{% assign v-target = target %}
+{% assign v-target = include.target %}
 {% endcase %}
-{% assign os = include.os %}
 
 {% include docs/install/admonitions/install-in-order.md %}
 
 ## Verify system requirements
 
 To install and run Flutter,
-your {{os}} environment must meet the following hardware
+your {{include.os}} environment must meet the following hardware
 and software requirements.
 
 ### Hardware requirements
 
-Your {{os}} Flutter development environment must meet the following
+Your {{include.os}} Flutter development environment must meet the following
 minimal hardware requirements.
 
 <div class="table-wrapper">
@@ -29,7 +27,7 @@ minimal hardware requirements.
 | CPU Cores                    | 4                                                                        | 8                   |
 | Memory in GB                 | 8                                                                        | 16                  |
 | Display resolution in pixels | WXGA (1366 x 768)                                                        | FHD (1920 x 1080)   |
-| Free disk space in GB        | {% include docs/install/reqs/macos/storage.md target=target %}
+| Free disk space in GB        | {% include docs/install/reqs/macos/storage.md target=include.target %}
 
 {:.table .table-striped}
 
@@ -45,7 +43,7 @@ install the following packages.
 Flutter supports macOS {{site.devmin.macos}} or later.
 This guide presumes your Mac runs the `zsh` as your default shell.
 
-{% include docs/install/reqs/macos/zsh-config.md target=target %}
+{% include docs/install/reqs/macos/zsh-config.md target=include.target %}
 
 {% include docs/install/reqs/macos/apple-silicon.md %}
 
@@ -53,7 +51,7 @@ This guide presumes your Mac runs the `zsh` as your default shell.
 
 Download and install the following packages.
 
-{% include docs/install/reqs/macos/software.md target=target %}
+{% include docs/install/reqs/macos/software.md target=include.target %}
 
 The developers of the preceding software provide support for those products.
 To troubleshoot installation issues, consult that product's documentation.

--- a/src/_includes/docs/install/reqs/macos/set-path.md
+++ b/src/_includes/docs/install/reqs/macos/set-path.md
@@ -1,10 +1,7 @@
-{% assign terminal=include.terminal %}
-{% assign target = include.target %}
-{% assign dir = include.dir %}
 
 ### Add Flutter to your `PATH` {:.no_toc}
 
-To run Flutter commands in {{terminal}},
+To run Flutter commands in {{include.terminal}},
 add Flutter to the `PATH` environment variable.
 This guide presumes your [Mac runs the latest default shell][zsh-mac], `zsh`.
 Zsh uses the `.zshenv` file for [environment variables][envvar].

--- a/src/_includes/docs/install/reqs/macos/software.md
+++ b/src/_includes/docs/install/reqs/macos/software.md
@@ -1,4 +1,3 @@
-{% assign target = include.target %}
 
 {% assign xcode = '[Xcode][] ' | append: site.appnow.xcode | append: ' to debug and compile native Swift or ObjectiveC code.' %}
 {% assign cocoapods = '[CocoaPods][] ' | append: site.appnow.cocoapods | append: ' to compile enable Flutter plugins in your native apps.' %}
@@ -16,7 +15,7 @@ type `git version` in your Terminal.
 If you need to install `git`, type `brew install git`.
 {% endcapture %}
 
-{% case target %}
+{% case include.target %}
 {% when 'desktop','iOS' %}
 
 * {{xcode}} {{git-xcode}} {{git-main}}

--- a/src/_includes/docs/install/reqs/macos/unset-path.md
+++ b/src/_includes/docs/install/reqs/macos/unset-path.md
@@ -1,8 +1,6 @@
-{% assign terminal=include.terminal %}
-
 ### Remove Flutter from your macOS PATH {:.no_toc}
 
-To remove Flutter commands from {{terminal}},
+To remove Flutter commands from {{include.terminal}},
 remove Flutter to the `PATH` environment variable.
 This guide presumes your [Mac runs the latest default shell][zsh-mac], `zsh`.
 Zsh uses the `.zshenv` file for [environment variables][envvar].

--- a/src/_includes/docs/install/reqs/macos/zsh-config.md
+++ b/src/_includes/docs/install/reqs/macos/zsh-config.md
@@ -1,4 +1,3 @@
-{% assign target = include.target %}
 
 <details>
 <summary><strong>To verify your shell configuration, expand this section</strong></summary>
@@ -17,7 +16,7 @@ Zsh or `zsh` is the default shell for macOS.
     $ dscl . -read ~/ UserShell
     ```
 
-    {{terminal}} should print the following as its response.
+    The command should print the following as its response.
 
     ```console
     UserShell: /bin/zsh

--- a/src/_includes/docs/install/reqs/windows/base.md
+++ b/src/_includes/docs/install/reqs/windows/base.md
@@ -1,17 +1,15 @@
-{% assign target = include.target %}
-{% assign os = include.os %}
 
 {% include docs/install/admonitions/install-in-order.md %}
 
 ## Verify system requirements
 
 To install and run Flutter,
-your {{os}} environment must meet the following hardware
+your {{include.os}} environment must meet the following hardware
 and software requirements.
 
 ### Hardware requirements
 
-Your {{os}} Flutter development environment must meet the following
+Your {{include.os}} Flutter development environment must meet the following
 minimal hardware requirements.
 
 <div class="table-wrapper">
@@ -21,7 +19,7 @@ minimal hardware requirements.
 | x86_64 CPU Cores             | 4                                                                        | 8                   |
 | Memory in GB                 | 8                                                                        | 16                  |
 | Display resolution in pixels | WXGA (1366 x 768)                                                        | FHD (1920 x 1080)   |
-| Free disk space in GB        | {% include docs/install/reqs/windows/storage.md target=target %}
+| Free disk space in GB        | {% include docs/install/reqs/windows/storage.md target=include.target %}
 
 {:.table .table-striped}
 
@@ -29,7 +27,7 @@ minimal hardware requirements.
 
 ### Software requirements
 
-To write and compile Flutter code for {{target}},
+To write and compile Flutter code for {{include.target}},
 you must have the following version of Windows and the listed
 software packages.
 
@@ -44,7 +42,7 @@ These versions of Windows should include the required
 Download and install the Windows version of the following packages:
 
 * [Git for Windows][] {{site.appmin.git_win}} or later to manage source code.
-{% include docs/install/reqs/windows/software.md target=target %}
+{% include docs/install/reqs/windows/software.md target=include.target %}
 
 The developers of the preceding software provide support for those products.
 To troubleshoot installation issues, consult that product's documentation.

--- a/src/_includes/docs/install/reqs/windows/set-path.md
+++ b/src/_includes/docs/install/reqs/windows/set-path.md
@@ -1,10 +1,9 @@
-{% assign terminal=include.terminal %}
 
 ### Update your Windows PATH variable {:.no_toc}
 
 {% include docs/help-link.md location='win-path' section='#unable-to-find-the-flutter-command' %}
 
-To run Flutter commands in {{terminal}},
+To run Flutter commands in {{include.terminal}},
 add Flutter to the `PATH` environment variable.
 This section presumes that you installed the Flutter SDK in
 `%USERPROFILE%\dev\flutter`.
@@ -44,4 +43,5 @@ This section presumes that you installed the Flutter SDK in
       1. Click **OK** three times.
 
 1. To enable these changes,
-   close and reopen any existing command prompts and {{terminal}} instances.
+   close and reopen any existing
+   command prompts and {{include.terminal}} instances.

--- a/src/_includes/docs/install/reqs/windows/software.md
+++ b/src/_includes/docs/install/reqs/windows/software.md
@@ -1,29 +1,29 @@
 {% if include.target == 'Android' %}
-{% assign target = 'mobile' %}
+{% assign mod-target = 'mobile' %}
 {% else %}
-{% assign target = include.target %}
+{% assign mod-target = include.target %}
 {% endif %}
 
-{% if target == 'desktop' -%}
+{% if mod-target == 'desktop' -%}
 
 * [Visual Studio 2022][] to debug and compile native C++ Windows code.
   Make sure to install the **Desktop development with C++** workload.
   This enables building Windows app including all of its default components.
   **Visual Studio** is an IDE separate from **[Visual Studio _Code_][]**.
 
-{% elsif target == 'mobile' -%}
+{% elsif mod-target == 'mobile' -%}
 
 * [Android Studio][] {{site.appmin.android_studio}} or later
   to debug and compile Java or Kotlin code for Android.
   Flutter requires the full version of Android Studio.
 
-{% elsif target == 'web' -%}
+{% elsif mod-target == 'web' -%}
 
 * [Google Chrome][] to debug JavaScript code for web apps.
 
 {% else -%}
 
-* [Visual Studio 2022][] with the the **Desktop development with C++** workload
+* [Visual Studio 2022][] with the **Desktop development with C++** workload
   or [Build Tools for Visual Studio 2022][].
   This enables building Windows app including all of its default components.
   **Visual Studio** is an IDE separate from **[Visual Studio _Code_][]**.

--- a/src/_includes/docs/install/reqs/windows/unset-path.md
+++ b/src/_includes/docs/install/reqs/windows/unset-path.md
@@ -1,8 +1,7 @@
-{% assign terminal=include.terminal %}
 
 ### Remove Flutter from your Windows Path variable {:.no_toc}
 
-To remove Flutter commands from {{terminal}},
+To remove Flutter commands from {{include.terminal}},
 remove Flutter to the `PATH` environment variable.
 
 {% include docs/install/reqs/windows/open-envvars.md %}
@@ -22,4 +21,5 @@ remove Flutter to the `PATH` environment variable.
    1. Click **OK** three times.
 
 1. To enable these changes,
-   close and reopen any existing command prompts and {{terminal}} instances.
+   close and reopen any existing
+   command prompts and {{include.terminal}} instances.


### PR DESCRIPTION
Fixes https://github.com/flutter/website/issues/10409

Issues with variable scope with LiquidJS includes were causing values in parent scopes to be reassigned and later incorrect. We will eventually move away from the deprecated `include` syntax in favor of `render`, but this fixes the issue for now by avoiding unnecessary variable shadowing.