### PR TITLE
Replace `list-certificates` and `create-certificates` with `certificates list` and `certificates create`

### DIFF
--- a/src/content/deployment/macos.md
+++ b/src/content/deployment/macos.md
@@ -287,7 +287,7 @@ If you do not have a Mac Installer Distribution certificate,
 you can create a new certificate by executing the following:
 
 ```bash
-app-store-connect create-certificate \
+app-store-connect certificates create \
     --type MAC_INSTALLER_DISTRIBUTION \
     --certificate-key=@file:/path/to/cert_key \
     --save
@@ -301,7 +301,7 @@ Use `cert_key` of the private key you created earlier.
 Fetch the Mac Installer Distribution certificates:
 
 ```bash
-app-store-connect list-certificates \
+app-store-connect certificates list \
     --type MAC_INSTALLER_DISTRIBUTION \
     --certificate-key=@file:/path/to/cert_key \
     --save


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

`app-storec-connect list-certificates` and `app-store-connect create-certificates` are deprecated, see: 

https://github.com/codemagic-ci-cd/cli-tools/blob/0bed134d36130ae0408fe973bd5fcd982f98f251/CHANGELOG.md?plain=1#L90

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
