### PR TITLE
Prevent a few icons from being mistakenly read by screen readers

### DIFF
--- a/src/_includes/inline-toc.html
+++ b/src/_includes/inline-toc.html
@@ -13,8 +13,8 @@
   <header class="site-toc__title">
     Contents
     {% if collapsible %}
-    <span class="site-toc--inline__toggle toc-toggle-down"><i class="material-symbols">keyboard_arrow_down</i></span>
-    <span class="site-toc--inline__toggle toc-toggle-up"><i class="material-symbols">keyboard_arrow_up</i></span>
+    <span class="site-toc--inline__toggle toc-toggle-down" title="Expand table of contents"><i class="material-symbols" aria-hidden="true">keyboard_arrow_down</i></span>
+    <span class="site-toc--inline__toggle toc-toggle-up" title="Collapse table of contents"><i class="material-symbols" aria-hidden="true">keyboard_arrow_up</i></span>
     {% endif -%}
   </header>
   <ul class="section-nav">
@@ -34,7 +34,7 @@
     {% endfor -%}
   </ul>
   {% if collapsible %}
-  <span class="site-toc--inline__toggle toc-toggle-more-items"><i class="material-symbols">more_horiz</i></span>
+  <span class="site-toc--inline__toggle toc-toggle-more-items" title="Expand table of contents"><i class="material-symbols" aria-hidden="true">more_horiz</i></span>
   {% endif -%}
 </div>
 {% endif -%}

--- a/src/_sass/components/_header.scss
+++ b/src/_sass/components/_header.scss
@@ -156,6 +156,7 @@
 
     &::before {
       content: 'search';
+      content: 'search' / '';
       font: $site-font-icon;
       pointer-events: none;
       position: absolute;

--- a/src/_sass/components/_sidebar.scss
+++ b/src/_sass/components/_sidebar.scss
@@ -83,13 +83,16 @@
     justify-content: space-between;
 
     &::after {
+      // Duplicated since Firefox doesn't support content alt text.
       content: 'keyboard_arrow_down';
+      content: 'keyboard_arrow_down' / '';
       font: $site-font-icon;
       transition: transform .25s ease-in-out;
     }
 
     &:not(.collapsed) {
       &::after {
+        content: 'keyboard_arrow_down' / '';
         transform: rotate(180deg);
       }
     }
@@ -161,8 +164,10 @@
         @include nav-link-active-style;
 
         &.collapsible {
-          &::before{
+          &::before {
+            // Duplicated since Firefox doesn't support content alt text.
             content: 'arrow_drop_down';
+            content: 'arrow_drop_down' / '';
             font: $site-font-icon;
             left: -24px;
             position: absolute;
@@ -171,6 +176,7 @@
 
           &.collapsed {
             &::before {
+              content: 'arrow_drop_down' / '';
               transform: rotate(-90deg);
             }
           }


### PR DESCRIPTION
- In the sidenav, set an empty alt content for screen readers for the arrows.
- In the inline TOC, hide the icons themselves from screen readers and add explanatory titles to the surrounding spans, providing more details to all users.