### PR TITLE
Migrate `app-figure.md` includes to `render`

### DIFF
--- a/src/_includes/docs/app-figure.md
+++ b/src/_includes/docs/app-figure.md
@@ -1,19 +1,19 @@
-{% assign alt = include.alt | default: include.caption -%}
-{% assign caption = include.caption | default: '' -%}
-{% if include.width -%}
-{% assign width = 'width: ' | append: include.width | append: ';' -%}
+{% assign alt = alt | default: caption -%}
+{% assign caption = caption | default: '' -%}
+{% if width -%}
+{% assign width = 'width: ' | append: width | append: ';' -%}
 {% else -%}
 {% assign width = '' -%}
 {% endif -%}
-{% if include.height -%}
-{% assign height = 'height: ' | append: include.height | append: ';' -%}
+{% if height -%}
+{% assign height = 'height: ' | append: height | append: ';' -%}
 {% else -%}
 {% assign height = '' -%}
 {% endif -%}
 
-<figure class="site-figure {{include.class}}">
+<figure class="site-figure {{class}}">
   <div class="site-figure-container">
-    <img src='/assets/images/docs/{{include.image}}' class='{{include.img-class}}' alt='{{alt}}' style='{{width}} {{height}}'>
+    <img src='/assets/images/docs/{{image}}' class='{{img-class}}' alt='{{alt}}' style='{{width}} {{height}}'>
     {% if caption -%}
       <figcaption class="figure-caption">{{caption}}</figcaption>
     {% endif -%}

--- a/src/_includes/docs/install/test-drive/try-hot-reload.md
+++ b/src/_includes/docs/install/test-drive/try-hot-reload.md
@@ -1,6 +1,6 @@
 After the app build completes, your device displays your app.
 
-{% include docs/app-figure.md img-class="site-mobile-screenshot border" image="get-started/macos/starter-app.png" caption="Starter app on macOS" %}
+{% render docs/app-figure.md, img-class:"site-mobile-screenshot border", image:"get-started/macos/starter-app.png", caption:"Starter app on macOS" %}
 
 ## Try hot reload
 
@@ -30,4 +30,4 @@ You can change your app source code, run the hot reload command in
 
 Your app updates the string as you watch.
 
-{% include docs/app-figure.md img-class="site-mobile-screenshot border" image="get-started/macos/starter-app-hot-reload.png" caption="Starter app after hot reload" %}
+{% render docs/app-figure.md, img-class:"site-mobile-screenshot border", image:"get-started/macos/starter-app-hot-reload.png", caption:"Starter app after hot reload" %}

--- a/src/content/add-to-app/android/project-setup.md
+++ b/src/content/add-to-app/android/project-setup.md
@@ -258,7 +258,7 @@ flutter build aar
 
 Then, follow the on-screen instructions to integrate.
 
-{% include docs/app-figure.md image="development/add-to-app/android/project-setup/build-aar-instructions.png" %}
+{% render docs/app-figure.md, image:"development/add-to-app/android/project-setup/build-aar-instructions.png" %}
 
 More specifically, this command creates
 (by default all debug/profile/release modes)
@@ -376,7 +376,7 @@ check out [Using Flutter in China][] page.
 You can also build an AAR for your Flutter module in Android Studio using
 the `Build > Flutter > Build AAR` menu.
 
-{% include docs/app-figure.md image="development/add-to-app/android/project-setup/ide-build-aar.png" %}
+{% render docs/app-figure.md, image:"development/add-to-app/android/project-setup/ide-build-aar.png" %}
 :::
 
 </div>

--- a/src/content/add-to-app/debugging.md
+++ b/src/content/add-to-app/debugging.md
@@ -94,9 +94,8 @@ For an iOS target, complete the follow steps:
 
    1. If your dev machine uses IPv6, add `--vm-service-host=::0`.
 
-   {% include docs/app-figure.md img-class="site-mobile-screenshot
-   border" image="development/add-to-app/debugging/wireless-port.png"
-   caption="Arguments Passed On Launch with an IPv4 network added" width="100%" %}
+   {% render docs/app-figure.md, img-class:"site-mobile-screenshot border", image:"development/add-to-app/debugging/wireless-port.png",
+   caption:"Arguments Passed On Launch with an IPv4 network added", width:"100%" %}
 
 #### To determine if you're on an IPv6 network
 
@@ -110,7 +109,7 @@ For an iOS target, complete the follow steps:
 
 1. Check for an **IPv6 address** section.
 
-   {% include docs/app-figure.md img-class="site-mobile-screenshot border" image="development/add-to-app/ipv6.png" caption="WiFi dialog box for macOS System Settings" width="60%" %}
+   {% render docs/app-figure.md, img-class:"site-mobile-screenshot border", image:"development/add-to-app/ipv6.png", caption:"WiFi dialog box for macOS System Settings", width:"60%" %}
 
 ### Debug over Wi-Fi on Android devices
 

--- a/src/content/add-to-app/index.md
+++ b/src/content/add-to-app/index.md
@@ -30,7 +30,7 @@ memory resources. See more in the [multiple Flutters][] page.
 
 ### Add to Android applications
 
-{% include docs/app-figure.md image="development/add-to-app/android-overview.gif" alt="Add-to-app steps on Android" %}
+{% render docs/app-figure.md, image:"development/add-to-app/android-overview.gif", alt:"Add-to-app steps on Android" %}
 
 * Auto-build and import the Flutter module by adding a
   Flutter SDK hook to your Gradle script.
@@ -52,7 +52,7 @@ memory resources. See more in the [multiple Flutters][] page.
 
 ### Add to iOS applications
 
-{% include docs/app-figure.md image="development/add-to-app/ios-overview.gif" alt="Add-to-app steps on iOS" %}
+{% render docs/app-figure.md, image:"development/add-to-app/ios-overview.gif", alt:"Add-to-app steps on iOS" %}
 
 * Auto-build and import the Flutter module by adding a Flutter
   SDK hook to your CocoaPods and to your Xcode build phase.

--- a/src/content/add-to-app/ios/project-setup.md
+++ b/src/content/add-to-app/ios/project-setup.md
@@ -293,7 +293,7 @@ Settings > Build Phases > Link Binary With Libraries**.
 In the target's build settings, add `$(PROJECT_DIR)/Flutter/Release/`
 to the **Framework Search Paths** (`FRAMEWORK_SEARCH_PATHS`).
 
-{% include docs/app-figure.md image="development/add-to-app/ios/project-setup/framework-search-paths.png" alt="Update Framework Search Paths in Xcode" %}
+{% render docs/app-figure.md, image:"development/add-to-app/ios/project-setup/framework-search-paths.png", alt:"Update Framework Search Paths in Xcode" %}
 
 :::tip
 To use the simulator, you will need to 
@@ -333,7 +333,7 @@ select **Embed & Sign**.
 They will then appear under **Embed Frameworks** within 
 **Build Phases** as follows: 
 
-{% include docs/app-figure.md image="development/add-to-app/ios/project-setup/embed-xcode.png" alt="Embed frameworks in Xcode" %}
+{% render docs/app-figure.md, image:"development/add-to-app/ios/project-setup/embed-xcode.png", alt:"Embed frameworks in Xcode" %}
 
 You should now be able to build the project in Xcode using `⌘B`.
 
@@ -414,7 +414,7 @@ Adjust the names as needed depending on your app's build configurations.
 Rename your app's **Info.plist** to **Info-Debug.plist**.
 Make a copy of it called **Info-Release.plist** and add it to your Xcode project.
 
-{% include docs/app-figure.md image="development/add-to-app/ios/project-setup/info-plists.png" alt="Info-Debug.plist and Info-Release.plist in Xcode" %}
+{% render docs/app-figure.md, image:"development/add-to-app/ios/project-setup/info-plists.png", alt:"Info-Debug.plist and Info-Release.plist in Xcode" %}
 
 </li>
 
@@ -427,7 +427,7 @@ Note Xcode will display this as "Bonjour services".
 Optionally, add the key `NSLocalNetworkUsageDescription` set to your
 desired customized permission dialog text.
 
-{% include docs/app-figure.md image="development/add-to-app/ios/project-setup/debug-plist.png" alt="Info-Debug.plist with additional keys" %}
+{% render docs/app-figure.md, image:"development/add-to-app/ios/project-setup/debug-plist.png", alt:"Info-Debug.plist with additional keys" %}
 
 </li>
 
@@ -436,12 +436,12 @@ desired customized permission dialog text.
 In your target's build settings, change the **Info.plist File**
 (`INFOPLIST_FILE`) setting path from `path/to/Info.plist` to `path/to/Info-$(CONFIGURATION).plist`.
 
-{% include docs/app-figure.md image="development/add-to-app/ios/project-setup/set-plist-build-setting.png" alt="Set INFOPLIST_FILE build setting" %}
+{% render docs/app-figure.md, image:"development/add-to-app/ios/project-setup/set-plist-build-setting.png", alt:"Set INFOPLIST_FILE build setting" %}
 
 This will resolve to the path **Info-Debug.plist** in **Debug** and
 **Info-Release.plist** in **Release**.
 
-{% include docs/app-figure.md image="development/add-to-app/ios/project-setup/plist-build-setting.png" alt="Resolved INFOPLIST_FILE build setting" %}
+{% render docs/app-figure.md, image:"development/add-to-app/ios/project-setup/plist-build-setting.png", alt:"Resolved INFOPLIST_FILE build setting" %}
 
 Alternatively, you can explicitly set the **Debug** path to **Info-Debug.plist**
 and the **Release** path to **Info-Release.plist**.
@@ -453,12 +453,13 @@ and the **Release** path to **Info-Release.plist**.
 If the **Info-Release.plist** copy is in your target's **Build Settings > Build Phases > Copy Bundle**
 Resources build phase, remove it.
 
-{% include docs/app-figure.md image="development/add-to-app/ios/project-setup/copy-bundle.png" alt="Copy Bundle build phase" %}
+{% render docs/app-figure.md, image:"development/add-to-app/ios/project-setup/copy-bundle.png", alt:"Copy Bundle build phase" %}
 
 The first Flutter screen loaded by your Debug app will now prompt
 for local network permission. The permission can also be allowed by enabling
 **Settings > Privacy > Local Network > Your App**.
-{% include docs/app-figure.md image="development/add-to-app/ios/project-setup/network-permission.png" alt="Local network permission dialog" %}
+
+{% render docs/app-figure.md, image:"development/add-to-app/ios/project-setup/network-permission.png", alt:"Local network permission dialog" %}
 
 </li>
 </ol>
@@ -476,7 +477,7 @@ Click the right arrow disclosure indicator icon to expand the available build co
 Hover over **Debug** and click the plus icon. Change **Any SDK** to **Any iOS Simulator SDK**.
 Add `arm64` to the build settings value.
 
-{% include docs/app-figure.md image="development/add-to-app/ios/project-setup/excluded-archs.png" alt="Set conditional EXCLUDED_ARCHS build setting" %}
+{% render docs/app-figure.md, image:"development/add-to-app/ios/project-setup/excluded-archs.png", alt:"Set conditional EXCLUDED_ARCHS build setting" %}
 
 When done correctly, Xcode will add `"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;` to your **project.pbxproj** file.
 

--- a/src/content/add-to-app/multiple-flutters.md
+++ b/src/content/add-to-app/multiple-flutters.md
@@ -80,7 +80,7 @@ or other planned work on enhancing multiple Flutter instances, check out
 You can find a sample demonstrating how to use `FlutterEngineGroup`
 on both Android and iOS on [GitHub][].
 
-{% include docs/app-figure.md image="development/add-to-app/multiple-flutters-sample.gif" alt="A sample demonstrating multiple-Flutters" %}
+{% render docs/app-figure.md, image:"development/add-to-app/multiple-flutters-sample.gif", alt:"A sample demonstrating multiple-Flutters" %}
 
 [GitHub]: {{site.repo.samples}}/tree/main/add_to_app/multiple_flutters
 [`FlutterActivity`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterActivity.html

--- a/src/content/perf/app-size.md
+++ b/src/content/perf/app-size.md
@@ -56,7 +56,7 @@ dropping the .aab file.
 View the application's download and install size in the **Android vitals** ->
 **App size** tab.
 
-{% include docs/app-figure.md image="perf/vital-size.png" alt="App size tab in Google Play Console" %}
+{% render docs/app-figure.md, image:"perf/vital-size.png", alt:"App size tab in Google Play Console" %}
 
 The download size is calculated based on an XXXHDPI (~640dpi) device on an
 arm64-v8a architecture. Your end users' download sizes might vary depending on
@@ -145,7 +145,7 @@ In addition to analyzing a single build, two builds can also be diffed by
 loading two `*-code-size-analysis_*.json` files into DevTools.
 Check out the [DevTools documentation][] for details.
 
-{% include docs/app-figure.md image="perf/size-summary.png" alt="Size summary of an Android application in terminal" %}
+{% render docs/app-figure.md, image:"perf/size-summary.png", alt:"Size summary of an Android application in terminal" %}
 
 Through the summary, you can get a quick idea of the size usage per category
 (such as asset, native code, Flutter libraries, etc). The compiled Dart
@@ -168,7 +168,7 @@ up to function level for the Dart AOT artifact.
 This can be done by `dart devtools`, selecting
 `Open app size tool` and uploading the JSON file.
 
-{% include docs/app-figure.md image="perf/devtools-size.png" alt="Example breakdown of app in DevTools" %}
+{% render docs/app-figure.md, image:"perf/devtools-size.png", alt:"Example breakdown of app in DevTools" %}
 
 For further information on using the DevTools app size tool,
 check out the [DevTools documentation][].

--- a/src/content/platform-integration/ios/app-extensions.md
+++ b/src/content/platform-integration/ios/app-extensions.md
@@ -96,7 +96,7 @@ To add a target to an App Group:
     1. Select an App Group from the list.
     1. Click **+** to add a new App Group.
 
-{% include docs/app-figure.md image="development/platform-integration/app-extensions/xcode-app-groups.png" alt="Selecting an App Group within an Xcode Runner target configuration." %}
+{% render docs/app-figure.md, image:"development/platform-integration/app-extensions/xcode-app-groups.png", alt:"Selecting an App Group within an Xcode Runner target configuration." %}
 
 When two targets belong to the same App Group,
 they can read from and write to the same source.

--- a/src/content/platform-integration/ios/ios-app-clip.md
+++ b/src/content/platform-integration/ios/ios-app-clip.md
@@ -38,13 +38,13 @@ the project settings.
 
 Press **+** at the bottom of the target list to add a new target.
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/add-target.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/add-target.png" %}
 
 **2.2**
 
 Select the **App Clip** type for your new target.
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/add-app-clip.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/add-app-clip.png" %}
 
 **2.3**
 
@@ -58,21 +58,21 @@ Select the same language as your original target for **Language**.
 don't create a Swift App Clip target for
 an Objective-C main target, and vice versa.)
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/app-clip-details.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/app-clip-details.png" %}
 
 **2.4**
 
 In the following dialog,
 activate the new scheme for the new target.
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/activate-scheme.png" %}
+{% render docs/app-figure.md, image="development/platform-integration/ios-app-clip/activate-scheme.png" %}
 
 **2.5**
 
 Back in the project settings, open the **Build Phases** tab.
 Drag **Embedded App Clips** to above **Thin Binary**.
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/embedded-app-clips.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/embedded-app-clips.png" %}
 
 <a id="step-3"></a>
 ## Step 3 - Remove unneeded files
@@ -90,7 +90,7 @@ how much of this template to keep to invoke
 from this code later.
 :::
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/clean-files.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/clean-files.png" %}
 
 Move files to trash.
 
@@ -103,7 +103,7 @@ Open the `Info.plist` file in the App Clip group.
 Delete the entire dictionary entry for
 **Application Scene Manifest**.
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/scene-manifest.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/scene-manifest.png" %}
 
 ## Step 4 - Share build configurations
 
@@ -130,7 +130,7 @@ required build settings.
 Set **iOS Deployment Target** to at least **16.0** to take advantage of the
 15MB size limit.
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/configuration.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/configuration.png" %}
 
 **4.2**
 
@@ -154,7 +154,7 @@ select the file, then in the first tab of the inspector,
 also include the App Clip target in the `Target Membership`
 checkbox group.
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/add-target-membership.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/add-target-membership.png" %}
 
 ### Option 2 - Customize Flutter launch for App Clip
 
@@ -180,7 +180,7 @@ Open the `<app clip target>.entitlements` file.
 Add an `Associated Domains` Array type.
 Add a row to the array with `appclips:<your bundle id>`.
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/app-clip-entitlements.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/app-clip-entitlements.png" %}
 
 **6.2**
 
@@ -197,7 +197,7 @@ Open the file and delete the
 entry for the main app's entitlement file
 (leave that entry for the App Clip's entitlement file).
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/main-app-entitlements.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/main-app-entitlements.png" %}
 
 **6.3**
 
@@ -207,7 +207,7 @@ Set the **Code Signing Entitlements** setting to the
 relative path of the second entitlements file
 created for the main app.
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/main-app-entitlements-setting.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/main-app-entitlements-setting.png" %}
 
 ## Step 7 - Integrate Flutter
 
@@ -222,14 +222,14 @@ build setting to `Runner/Runner-Bridging-Header.h`
 In other words,
 the same as the main app target's build settings.
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/bridge-header.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/bridge-header.png" %}
 
 **7.2**
 
 Now open the **Build Phases** tab. Press the **+** sign
 and select **New Run Script Phase**.
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/new-build-phase.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/new-build-phase.png" %}
 
 Drag that new phase to below the **Dependencies** phase.
 
@@ -244,7 +244,7 @@ Uncheck **Based on dependency analysis**.
 In other words,
 the same as the main app target's build phases.
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/xcode-backend-build.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/xcode-backend-build.png" %}
 
 This ensures that your Flutter Dart code is compiled
 when running the App Clip target.
@@ -265,7 +265,7 @@ Uncheck **Based on dependency analysis**.
 In other words,
 the same as the main app target's build phases.
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/xcode-backend-embed.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/xcode-backend-embed.png" %}
 
 This ensures that your Flutter app and engine are embedded
 into the App Clip bundle.
@@ -341,7 +341,7 @@ You can now run your App Clip target from Xcode by
 selecting your App Clip target from the scheme drop-down,
 selecting an iOS 16 or higher device and pressing run.
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/run-select.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/run-select.png" %}
 
 To test launching an App Clip from the beginning,
 also consult Apple's doc on
@@ -359,7 +359,7 @@ In order to debug your App Clip and use functionalities
 like hot reload, you must look for the Observatory URI
 from the console output in Xcode after running.
 
-{% include docs/app-figure.md image="development/platform-integration/ios-app-clip/observatory-uri.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/observatory-uri.png" %}
 
 You must then copy and paste it back into the
 `flutter attach` command to connect.

--- a/src/content/platform-integration/ios/ios-app-clip.md
+++ b/src/content/platform-integration/ios/ios-app-clip.md
@@ -65,7 +65,7 @@ an Objective-C main target, and vice versa.)
 In the following dialog,
 activate the new scheme for the new target.
 
-{% render docs/app-figure.md, image="development/platform-integration/ios-app-clip/activate-scheme.png" %}
+{% render docs/app-figure.md, image:"development/platform-integration/ios-app-clip/activate-scheme.png" %}
 
 **2.5**
 

--- a/src/content/ui/accessibility-and-internationalization/accessibility.md
+++ b/src/content/ui/accessibility-and-internationalization/accessibility.md
@@ -80,10 +80,10 @@ and with the largest font setting selected in iOS accessibility settings.
 
 <div class="row">
   <div class="col-md-6">
-    {% include docs/app-figure.md image="a18n/app-regular-fonts.png" caption="Default font setting" img-class="border" %}
+    {% render docs/app-figure.md, image:"a18n/app-regular-fonts.png", caption:"Default font setting", img-class:"border" %}
   </div>
   <div class="col-md-6">
-    {% include docs/app-figure.md image="a18n/app-large-fonts.png" caption="Largest accessibility font setting" img-class="border" %}
+    {% render docs/app-figure.md, image:"a18n/app-large-fonts.png", caption:"Largest accessibility font setting", img-class:"border" %}
   </div>
 </div>
 

--- a/src/content/ui/interactivity/index.md
+++ b/src/content/ui/interactivity/index.md
@@ -23,8 +23,7 @@ stateless widgets.
 The [building layouts tutorial][] showed you how to create
 the layout for the following screenshot.
 
-{% include docs/app-figure.md img-class="site-mobile-screenshot border"
-    image="ui/layout/lakes.jpg" caption="The layout tutorial app" %}
+{% render docs/app-figure.md, img-class:"site-mobile-screenshot border", image:"ui/layout/lakes.jpg", caption:"The layout tutorial app" %}
 
 When the app first launches, the star is solid red,
 indicating that this lake has previously been favorited.

--- a/src/content/ui/layout/index.md
+++ b/src/content/ui/layout/index.md
@@ -298,8 +298,7 @@ color to white and the text to dark grey to mimic a Material app.
 
 </div>
 <div class="col-md-6">
-  {% include docs/app-figure.md img-class="site-mobile-screenshot border w-75"
-      image="ui/layout/hello-world.png" alt="Hello World" %}
+  {% render docs/app-figure.md, img-class:"site-mobile-screenshot border w-75", image:"ui/layout/hello-world.png", alt:"Hello World" %}
 </div>
 </div>
 

--- a/src/content/ui/layout/tutorial.md
+++ b/src/content/ui/layout/tutorial.md
@@ -19,7 +19,7 @@ This tutorial explains how to design and build layouts in Flutter.
 
 If you use the example code provided, you can build the following app.
 
-{% include docs/app-figure.md img-class="site-mobile-screenshot border" image="ui/layout/layout-demo-app.png" caption="The finished app." width="50%" %}
+{% render docs/app-figure.md, img-class:"site-mobile-screenshot border", image:"ui/layout/layout-demo-app.png", caption:"The finished app.", width:"50%" %}
 
 <figcaption class="figure-caption">
 
@@ -67,7 +67,7 @@ Ask these questions to break the layout down to its basic elements.
 Identify the larger elements. In this example, you arrange the image, title,
 buttons, and description into a column.
 
-{% include docs/app-figure.md img-class="site-mobile-screenshot border" image="ui/layout/layout-sketch-intro.svg" caption="Major elements in the layout: image, row, row, and text block" width="50%" %}
+{% render docs/app-figure.md, img-class:"site-mobile-screenshot border", image:"ui/layout/layout-sketch-intro.svg", caption:"Major elements in the layout: image, row, row, and text block", width:"50%" %}
 
 </li>
 <li>
@@ -83,7 +83,7 @@ a column of text, a star icon, and a number.
 Its first child, the column, contains two lines of text.
 That first column might need more space.
 
-{% include docs/app-figure.md image="ui/layout/layout-sketch-title-block.svg" caption="Title section with text blocks and an icon" -%}
+{% render docs/app-figure.md, image:"ui/layout/layout-sketch-title-block.svg", caption:"Title section with text blocks and an icon" -%}
 
 </li>
 
@@ -92,7 +92,7 @@ That first column might need more space.
 Row 2, the **Button** section, has three children: each child contains
 a column which then contains an icon and text.
 
-{% include docs/app-figure.md image="ui/layout/layout-sketch-button-block.svg" caption="The Button section with three labeled buttons" width="50%" %}
+{% render docs/app-figure.md, image:"ui/layout/layout-sketch-button-block.svg", caption:"The Button section with three labeled buttons", width:"50%" %}
 
   </li>
 
@@ -167,7 +167,7 @@ the following layout.
 
 <?code-excerpt path-base="layout/lakes"?>
 
-{% include docs/app-figure.md image="ui/layout/layout-sketch-title-block-unlabeled.svg" caption="The Title section as sketch and prototype UI" %}
+{% render docs/app-figure.md, image:"ui/layout/layout-sketch-title-block-unlabeled.svg", caption:"The Title section as sketch and prototype UI" %}
 
 ### Add the `TitleSection` Widget
 
@@ -309,7 +309,7 @@ In this section, add the buttons that will add functionality to your app.
 The **Button** section contains three columns that use the same layout:
 an icon over a row of text.
 
-{% include docs/app-figure.md image="ui/layout/layout-sketch-button-block-unlabeled.svg" caption="The Button section as sketch and prototype UI" %}
+{% render docs/app-figure.md, image:"ui/layout/layout-sketch-button-block-unlabeled.svg", caption:"The Button section as sketch and prototype UI" %}
 
 Plan to distribute these columns in one row so each takes the same
 amount of space. Paint all text and icons with the primary color.
@@ -477,7 +477,7 @@ Add the button section to the `children` list.
 
 In this section, add the text description to this app.
 
-{% include docs/app-figure.md image="ui/layout/layout-sketch-add-text-block.svg" caption="The text block as sketch and prototype UI" %}
+{% render docs/app-figure.md, image:"ui/layout/layout-sketch-add-text-block.svg", caption:"The text block as sketch and prototype UI" %}
 
 <?code-excerpt path-base="layout/lakes"?>
 
@@ -640,7 +640,7 @@ Set the `image` property to the path of the image you added in
 
 That's it! When you hot reload the app, your app should look like this.
 
-{% include docs/app-figure.md img-class="site-mobile-screenshot border" image="ui/layout/layout-demo-app.png" caption="The finished app" width="50%" %}
+{% render docs/app-figure.md, img-class:"site-mobile-screenshot border", image:"ui/layout/layout-demo-app.png", caption:"The finished app", width:"50%" %}
 
 ## Resources
 


### PR DESCRIPTION
Contributes to https://github.com/flutter/website/issues/10525 by migrating all usages of `app-figure.md` to the newer `render` syntax instead of `include`, for improved encapsulation.