### PR TITLE
more on Flutter web indexability

### DIFF
--- a/src/content/platform-integration/web/faq.md
+++ b/src/content/platform-integration/web/faq.md
@@ -35,10 +35,10 @@ consider separating your primary application experience—created in Flutter—f
 your landing page, marketing content, and help content—created using
 search-engine optimized HTML.
 
-Having said that, as we mention in our [roadmap][], we plan to investigate
-search engine indexability of Flutter Web. To that end we've built a small
-website containing [Hawaii-themed space stories][space_hawaii], which we
-would like search engines to pick up and index.
+That said, as mentioned in the [roadmap][], the Flutter team plans to
+investigate search engine indexability of Flutter web. To that end, we built a
+small website containing [Hawaii-themed space stories][space_hawaii], hoping
+that search engines find and index this site.
 
 ### How do I create an app that also runs on the web?
 

--- a/src/content/platform-integration/web/faq.md
+++ b/src/content/platform-integration/web/faq.md
@@ -35,6 +35,11 @@ consider separating your primary application experience—created in Flutter—f
 your landing page, marketing content, and help content—created using
 search-engine optimized HTML.
 
+Having said that, as we mention in our [roadmap][], we plan to investigate
+search engine indexability of Flutter Web. To that end we've built a small
+website containing [Hawaii-themed space stories][space_hawaii], which we
+would like search engines to pick up and index.
+
 ### How do I create an app that also runs on the web?
 
 See [building a web app with Flutter][].
@@ -164,3 +169,5 @@ Not currently.
 [run your web apps in any supported browser]: /platform-integration/web/building#create-and-run
 [Integration testing]: /testing/integration-tests#running-in-a-browser
 [documentation for conditional imports]: {{site.dart-site}}/guides/libraries/create-library-packages#conditionally-importing-and-exporting-library-files
+[roadmap]: {{site.github}}/flutter/flutter/wiki/Roadmap#web-platform
+[space_hawaii]: https://alien-hawaii-2024.web.app/


### PR DESCRIPTION
Expand on what we're doing about indexability.

One unusual aspect of this change is linking to the test site and spelling out "Hawaii-themed space stories". This is intentional, and hopefully, not too disruptive to the message. In order to prove that SEO works we need an already indexed website to link to the test site so search engines find it and attempt to index it. I thought sneaking one such link into a section of our web FAQ that already talks about SEO would be a safe place for it.

One place I violate the style guide is I use "we" in the text. However, it seems to be consistent with how the word is used elsewhere on the site. I'm open to suggestions for how to remove it, if it's important.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
