### PR TITLE
Refactor integration test pages

### DIFF
--- a/examples/testing/integration_tests/how_to/integration_test/counter_test.dart
+++ b/examples/testing/integration_tests/how_to/integration_test/counter_test.dart
@@ -9,26 +9,27 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized(); // NEW
 
   // #docregion initial
-  testWidgets('tap on the floating action button, verify counter',
-      (tester) async {
-    // Load app widget.
-    await tester.pumpWidget(const MyApp());
+  group('end-to-end test', () {
+    testWidgets('tap on the floating action button, verify counter',
+        (tester) async {
+      // Load app widget.
+      await tester.pumpWidget(const MyApp());
 
-    // Verify the counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
+      // Verify the counter starts at 0.
+      expect(find.text('0'), findsOneWidget);
 
-    // Finds the floating action button to tap on.
-    final fab = find.byKey(const Key('increment'));
+      // Finds the floating action button to tap on.
+      final fab = find.byKey(const ValueKey('increment'));
 
-    // Emulate a tap on the floating action button.
-    await tester.tap(fab);
+      // Emulate a tap on the floating action button.
+      await tester.tap(fab);
 
-    // Trigger a frame.
-    await tester.pumpAndSettle();
+      // Trigger a frame.
+      await tester.pumpAndSettle();
 
-    // Verify the counter increments by 1.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+      // Verify the counter increments by 1.
+      expect(find.text('1'), findsOneWidget);
+    });
   });
 }
 // #enddocregion initial

--- a/src/_includes/docs/test/integration/linux-example.md
+++ b/src/_includes/docs/test/integration/linux-example.md
@@ -1,0 +1,18 @@
+```console
+$ flutter test integration_test/app_test.dart
+
+Connected devices:
+
+Linux (desktop) • linux  • linux-x64      • Ubuntu 22.04.4 LTS 6.5.0-35-generic
+Chrome (web)    • chrome • web-javascript • Google Chrome 104.0.5112.101
+
+[1]: Linux (linux)
+[2]: Chrome (chrome)
+
+Please choose one (or "q" to quit): 1
+
+00:00 +0: /path/to/counter_app/integration_test/app_test.dart     B
+00:16 +0: /path/to/counter_app/integration_test/app_test.dart
+
+✓ Built build/linux/x64/debug/bundle/counter_app
+```

--- a/src/_includes/docs/test/integration/macos-example.md
+++ b/src/_includes/docs/test/integration/macos-example.md
@@ -1,0 +1,38 @@
+```console
+$ flutter test integration_test
+Resolving dependencies... 
+Downloading packages... 
+  flutter_lints 3.0.2 (4.0.0 available)
+> leak_tracker 10.0.4 (was 10.0.0) (10.0.5 available)
+> leak_tracker_flutter_testing 3.0.3 (was 2.0.1) (3.0.5 available)
+> leak_tracker_testing 3.0.1 (was 2.0.1)
+  lints 3.0.0 (4.0.0 available)
+  material_color_utilities 0.8.0 (0.11.1 available)
+> meta 1.12.0 (was 1.11.0) (1.15.0 available)
+> test_api 0.7.0 (was 0.6.1) (0.7.1 available)
+> vm_service 14.2.1 (was 13.0.0) (14.2.2 available)
+Changed 6 dependencies!
+8 packages have newer versions incompatible with dependency constraints.
+Try `flutter pub outdated` for more information.
+
+Connected devices:
+
+macOS (desktop)                 • macos                 • darwin-arm64   • macOS 14.4.1 23E224 darwin-arm64
+Mac Designed for iPad (desktop) • mac-designed-for-ipad • darwin         • macOS 14.4.1 23E224 darwin-arm64
+Chrome (web)                    • chrome                • web-javascript • Google Chrome 124.0.6367.208
+
+No wireless devices were found.
+
+[1]: macOS (macos)
+[2]: Mac Designed for iPad (mac-designed-for-ipad)
+[3]: Chrome (chrome)
+Please choose one (or "q" to quit): 1
+
+00:01 +0: loading /path/to/counter_app/integration_test/app_test.dart        R
+00:02 +0: loading /path/to/counter_app/integration_test/app_test.dart    846ms
+00:03 +0: loading /path/to/counter_app/integration_test/app_test.dart        B
+
+Building macOS application...
+✓ Built build/macos/Build/Products/Debug/counter_app.app
+00:32 +1: All tests passed!
+```

--- a/src/_includes/docs/test/integration/windows-example.md
+++ b/src/_includes/docs/test/integration/windows-example.md
@@ -1,0 +1,33 @@
+```powershell
+PS C:\path\to\counter_app> flutter test .\integration_test\app_test.dart
+Resolving dependencies...
+Downloading packages...
+  flutter_lints 3.0.2 (4.0.0 available)
+  leak_tracker 10.0.4 (10.0.5 available)
+  leak_tracker_flutter_testing 3.0.3 (3.0.5 available)
+  lints 3.0.0 (4.0.0 available)
+  material_color_utilities 0.8.0 (0.11.1 available)
+  meta 1.12.0 (1.15.0 available)
+  test_api 0.7.0 (0.7.1 available)
+  vm_service 14.2.1 (14.2.2 available)
+Got dependencies!
+8 packages have newer versions incompatible with dependency constraints.
+Try `flutter pub outdated` for more information.
+
+Connected devices:
+
+Windows (desktop) • windows • windows-x64    • Microsoft Windows [Version 10.0.22631.3593]
+Chrome (web)      • chrome  • web-javascript • Google Chrome 124.0.6367.207
+Edge (web)        • edge    • web-javascript • Microsoft Edge 124.0.2478.97
+
+[1]: Windows (windows)
+[2]: Chrome (chrome)
+[3]: Edge (edge)
+
+Please choose one (or "q" to quit): 1
+
+00:00 +0: loading C:/path/to/counter_app/integration_test/app_test.dart               B
+00:29 +0: loading C:/path/to/counter_app/counter_app/integration_test/app_test.dart   29.1s
+√ Built build\windows\x64\runner\Debug\counter_app.exe
+00:31 +1: All tests passed!
+```

--- a/src/content/cookbook/testing/integration/introduction.md
+++ b/src/content/cookbook/testing/integration/introduction.md
@@ -1,401 +1,60 @@
 ---
-title: An introduction to integration testing
+title: Integration testing concepts
 description: Learn about integration testing in Flutter.
 short-title: Introduction
 ---
 
 <?code-excerpt path-base="cookbook/testing/integration/introduction/"?>
 
-Unit tests and widget tests are handy for testing individual classes,
-functions, or widgets. However, they generally don't test how
-individual pieces work together as a whole, or capture the performance
-of an application running on a real device. These tasks are performed
-with *integration tests*.
+Unit tests and widget tests validate individual classes,
+functions, or widgets.
+They don't validate how individual pieces work
+together in whole or capture the performance
+of an app running on a real device.
+To perform these tasks, use *integration tests*.
 
-Integration tests are written using the [integration_test][] package, provided
-by the SDK.
+Integration tests verify the behavior of the complete app.
+This test can also be called end-to-end testing or GUI testing.
 
-In this recipe, learn how to test a counter app. It demonstrates
-how to set up integration tests, how to verify specific text is displayed
-by the app, how to tap specific widgets, and how to run integration tests.
+The Flutter SDK includes the [integration_test][] package.
 
-This recipe uses the following steps:
+## Terminology
 
-  1. Create an app to test.
-  2. Add the `integration_test` dependency.
-  3. Create the test files.
-  4. Write the integration test.
-  5. Run the integration test.
+**host machine**
+: The system on which you develop your app, like a desktop computer.
 
-## Create a new app to test
+**target device**
+: The mobile device, browser, or desktop application that runs
+your Flutter app.
 
-Integration testing requires an app to test.
-This example uses the built-in **Counter App** example
-that Flutter produces when you run the `flutter create` command.
-The counter app allows a user to tap on a button to increase a counter.
+  If you run your app in a web browser or as a desktop application,
+  the host machine and the target device are the same.
 
-1. To create an instance of the built-in Flutter app,
-   run the following command in your terminal:
+## Dependent package
 
-   ```console
-   $ flutter create counter_app
-   ```
+To run integration tests, add the `integration_test` package
+as a dependency for your Flutter app test file.
 
-1. Change into the `counter_app` directory.
+To migrate existing projects that use `flutter_driver`,
+consult the [Migrating from flutter_drive][] guide.
 
-1. Open `lib/main.dart` in your preferred IDE.
+Tests written with the `integration_test` package 
+can perform the following tasks.
 
-1. Add a `key` parameter to the `floatingActionButton()` widget
-   with an instance of a `Key` class with a string value of `increment`.
+* Run on the target device.
+  To test multiple Android or iOS devices, use Firebase Test Lab.
+* Run from the host machine with `flutter test integration_test`.
+* Use `flutter_test` APIs. This makes integration tests
+  similar to writing [widget tests][].
 
-   ```dart
-    floatingActionButton: FloatingActionButton(
-      [!key: const ValueKey('increment'),!]
-      onPressed: _incrementCounter,
-      tooltip: 'Increment',
-      child: const Icon(Icons.add),
-    ),
-   ```
+## Use cases for integration testing
 
-1. Save your `lib/main.dart` file.
+The other guides in this section explain how to use integration tests to validate
+[functionality][] and [performance][].
 
-After these changes,
-the `lib/main.dart` file should resemble the following code.
-
-<?code-excerpt "lib/main.dart"?>
-```dart title="lib/main.dart"
-import 'package:flutter/material.dart';
-
-void main() {
-  runApp(const MyApp());
-}
-
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Text(widget.title),
-      ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        // Provide a ValueKey to this button. This allows finding this
-        // specific button inside the test suite, and tapping it.
-        key: const ValueKey('increment'),
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ),
-    );
-  }
-}
-```
-
-## Add the `integration_test` dependency
-
-You need to add the testing packages to your new app.
-
-To add `integration_test` and `flutter_test` packages as
-`dev_dependencies` using `sdk: flutter`, run following command.
-
-```console
-$ flutter pub add 'dev:integration_test:{"sdk":"flutter"}'
-```
-Output
-```console
-Building flutter tool...
-Resolving dependencies... 
-Got dependencies.
-Resolving dependencies... 
-+ file 7.0.0
-+ flutter_driver 0.0.0 from sdk flutter
-+ fuchsia_remote_debug_protocol 0.0.0 from sdk flutter
-+ integration_test 0.0.0 from sdk flutter
-...
-  test_api 0.6.1 (0.7.1 available)
-  vm_service 13.0.0 (14.2.1 available)
-+ webdriver 3.0.3
-Changed 8 dependencies!
-7 packages have newer versions incompatible with dependency constraints.
-Try `flutter pub outdated` for more information.
-```
-
-Updated `pubspec.yaml` file
-
-```yaml title="pubspec.yaml"
-# ...
-dev_dependencies:
-  # ... added depencies
-  flutter_test:
-    sdk: flutter
-  flutter_lints: ^4.0.0
-  [!integration_test:!]
-    [!sdk: flutter!]
-# ...
-```
-
-## Create the integration test files
-
-1. Create a new directory named `integration_test`.
-1. Add empty file named `app_test.dart` in that directory.
-
-The resulting directory tree should resemble the following:
-
-```plaintext
-counter_app/
-  lib/
-    main.dart
-  integration_test/
-    app_test.dart
-```
-
-## Write the integration test
-
-1. Open your `integration_test/app_test.dart` file in your preferred IDE.
-
-1. Copy the following code and paste it into your
-   `integration_test/app_test.dart` file.
-   The last import should point to the `main.dart` file
-   of your `counter_app`.
-   (This `import` points to the example app called `introduction`.)
-
-    <?code-excerpt "integration_test/app_test.dart (integration-test)" replace="/introduction/counter_app/g"?>
-    ```dart title="integration_test/app_test.dart"
-    import 'package:flutter/material.dart';
-    import 'package:flutter_test/flutter_test.dart';
-    import 'package:integration_test/integration_test.dart';
-    import 'package:counter_app/main.dart';
-
-    void main() {
-      IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-
-      group('end-to-end test', () {
-        testWidgets('tap on the floating action button, verify counter',
-            (tester) async {
-          // Load app widget.
-          await tester.pumpWidget(const MyApp());
-
-          // Verify the counter starts at 0.
-          expect(find.text('0'), findsOneWidget);
-
-          // Finds the floating action button to tap on.
-          final fab = find.byKey(const ValueKey('increment'));
-
-          // Emulate a tap on the floating action button.
-          await tester.tap(fab);
-
-          // Trigger a frame.
-          await tester.pumpAndSettle();
-
-          // Verify the counter increments by 1.
-          expect(find.text('1'), findsOneWidget);
-        });
-      });
-    }
-    ```
-
-This example goes through three steps:
-
-1. Initialize `IntegrationTestWidgetsFlutterBinding`.
-   This singleton service executes tests on a physical device.
-
-2. Interact and test widgets using the `WidgetTester` class.
-
-3. Test the important scenarios.
-
-## Run integration tests
-
-The integration tests that run vary depending on the platform on which you test.
-You can test against a mobile platform or the web.
-
-### Test on a mobile device
-
-To test on a real iOS or Android device
-
-1. Connect the device.
-
-1. Run the following command from the root of the project.
-
-   ```console
-   $ flutter test integration_test/app_test.dart
-   ```
-
-   The result should resemble the following output:
-
-   ```console
-   $ flutter test integration_test/app_test.dart
-   00:04 +0: loading /path/to/counter_app/integration_test/app_test.dart
-   00:15 +0: loading /path/to/counter_app/integration_test/app_test.dart
-   00:18 +0: loading /path/to/counter_app/integration_test/app_test.dart   2,387ms
-   Xcode build done.                                           13.5s
-   00:21 +1: All tests passed!
-   ```
-
-1. Verify that the test removed the Counter App when it finished.
-   If not, subsequent tests fail. If needed, press on the app and choose
-   **Remove App** from the context menu.
-
-To learn more, consult the [Integration testing][] page.
-
----
-
-### Test in a web browser
-
-{% comment %}
-TODO(ryjohn): Add back after other WebDriver versions are supported:
-https://github.com/flutter/flutter/issues/90158
-
-To test for web,
-determine which browser you want to test against
-and download the corresponding web driver:
-
-* Chrome: Download [ChromeDriver][]
-* Firefox: [Download GeckoDriver][]
-* Safari: Safari can only be tested on a Mac;
-  the SafariDriver is already installed on Mac machines.
-* Edge [Download EdgeDriver][]
-{% endcomment -%}
-
-To test in a web browser, perform the following steps.
-
-1. Install [ChromeDriver][] into the directory of your choice.
-
-   ```console
-   $ npx @puppeteer/browsers install chromedriver@stable
-   ```
-
-   To simplify the install, this command uses the
-   [`@puppeteer/browsers`][puppeteer] Node library.
-
-   [puppeteer]: https://www.npmjs.com/package/@puppeteer/browsers
-
-1. Add the path to ChromeDriver to your `$PATH` environment variable.
-
-1. Verify the ChromeDriver install succeeded.
-
-   ```console
-   $ chromedriver --version
-   ChromeDriver 124.0.6367.60 (8771130bd84f76d855ae42fbe02752b03e352f17-refs/branch-heads/6367@{#798})
-   ```
-
-1. In your `counter_app` project directory,
-   create a new directory named `test_driver`.
-
-   ```console
-   $ mkdir test_driver
-   ```
-
-1. In this directory, create a new file named `integration_test.dart`.
-
-1. Copy the following code and paste it into your `integration_test.dart` file.
-
-   <?code-excerpt "test_driver/integration_test.dart"?>
-   ```dart title="test_driver/integration_test.dart"
-   import 'package:integration_test/integration_test_driver.dart';
-
-   Future<void> main() => integrationDriver();
-   ```
-
-1. Launch `chromedriver` as follows:
-
-   ```console
-   $ chromedriver --port=4444
-   ```
-
-1. From the root of the project, run the following command:
-
-   ```console
-   $ flutter drive \
-     --driver=test_driver/integration_test.dart \
-     --target=integration_test/app_test.dart \
-     -d chrome
-   ```
-
-   The response should resemble the following output:
-
-   ```console
-   Resolving dependencies...
-     leak_tracker 10.0.0 (10.0.5 available)
-     leak_tracker_flutter_testing 2.0.1 (3.0.5 available)
-     leak_tracker_testing 2.0.1 (3.0.1 available)
-     material_color_utilities 0.8.0 (0.11.1 available)
-     meta 1.11.0 (1.14.0 available)
-     test_api 0.6.1 (0.7.1 available)
-     vm_service 13.0.0 (14.2.1 available)
-   Got dependencies!
-   7 packages have newer versions incompatible with dependency constraints.
-   Try `flutter pub outdated` for more information.
-   Launching integration_test/app_test.dart on Chrome in debug mode...
-   Waiting for connection from debug service on Chrome...             10.9s
-   This app is linked to the debug service: ws://127.0.0.1:51523/3lofIjIdmbs=/ws
-   Debug service listening on ws://127.0.0.1:51523/3lofIjIdmbs=/ws
-   00:00 +0: end-to-end test tap on the floating action button, verify counter
-   00:01 +1: (tearDownAll)
-   00:01 +2: All tests passed!
-   All tests passed.
-   Application finished.
-   ```
-
-   To run this as a headless test, run `flutter drive`
-   with `-d web-server` option:
-
-   ```console
-   $ flutter drive \
-     --driver=test_driver/integration_test.dart \
-     --target=integration_test/app_test.dart \
-     -d web-server
-   ```
-
-[ChromeDriver]: https://googlechromelabs.github.io/chrome-for-testing/
-[Download EdgeDriver]: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
-[Download GeckoDriver]: {{site.github}}/mozilla/geckodriver/releases
-[flutter_driver]: {{site.api}}/flutter/flutter_driver/flutter_driver-library.html
+[functionality]: /testing/integration-tests/
+[performance]: /cookbook/testing/integration/profiling/
 [integration_test]: {{site.repo.flutter}}/tree/main/packages/integration_test
-[Integration testing]: /testing/integration-tests
+[Migrating from flutter_drive]:
+    /release/breaking-changes/flutter-driver-migration
+[widget tests]: /testing/overview#widget-tests

--- a/src/content/cookbook/testing/integration/profiling.md
+++ b/src/content/cookbook/testing/integration/profiling.md
@@ -1,5 +1,5 @@
 ---
-title: Performance profiling
+title: Measure performance with an integration test
 description: How to profile performance for a Flutter app.
 ---
 

--- a/src/content/platform-integration/web/faq.md
+++ b/src/content/platform-integration/web/faq.md
@@ -167,7 +167,7 @@ Not currently.
 [Web support for Flutter]: /platform-integration/web
 [web workers]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers
 [run your web apps in any supported browser]: /platform-integration/web/building#create-and-run
-[Integration testing]: /testing/integration-tests#running-in-a-browser
+[Integration testing]: /testing/integration-tests#test-in-a-web-browser
 [documentation for conditional imports]: {{site.dart-site}}/guides/libraries/create-library-packages#conditionally-importing-and-exporting-library-files
 [roadmap]: {{site.github}}/flutter/flutter/wiki/Roadmap#web-platform
 [space_hawaii]: https://alien-hawaii-2024.web.app/

--- a/src/content/testing/integration-tests/index.md
+++ b/src/content/testing/integration-tests/index.md
@@ -72,22 +72,16 @@ the `lib/main.dart` file should resemble the following code.
 ```dart title="lib/main.dart"
 import 'package:flutter/material.dart';
 
-void main() {
-  runApp(const MyApp());
-}
+void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    return const MaterialApp(
+      title: 'Counter App',
+      home: MyHomePage(title: 'Counter App Home Page'),
     );
   }
 }
@@ -114,7 +108,6 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         title: Text(widget.title),
       ),
       body: Center(
@@ -132,9 +125,9 @@ class _MyHomePageState extends State<MyHomePage> {
         ),
       ),
       floatingActionButton: FloatingActionButton(
-        // Provide a ValueKey to this button. This allows finding this
+        // Provide a Key to this button. This allows finding this
         // specific button inside the test suite, and tapping it.
-        key: const ValueKey('increment'),
+        key: const Key('increment'),
         onPressed: _incrementCounter,
         tooltip: 'Increment',
         child: const Icon(Icons.add),
@@ -219,16 +212,15 @@ and your app's Dart file.
    of your `counter_app`.
    (This `import` points to the example app called `introduction`.)
 
-    <?code-excerpt "integration_test/app_test.dart (integration-test)" replace="/introduction/counter_app/g"?>
-    ```dart title="integration_test/app_test.dart"
+    <?code-excerpt "integration_test/counter_test.dart (initial)" replace="/introduction/counter_app/g"?>
+    ```dart title="integration_test/counter_test.dart"
     import 'package:flutter/material.dart';
     import 'package:flutter_test/flutter_test.dart';
+    import 'package:how_to/main.dart';
     import 'package:integration_test/integration_test.dart';
-    import 'package:counter_app/main.dart';
 
     void main() {
-      IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-
+      // ···
       group('end-to-end test', () {
         testWidgets('tap on the floating action button, verify counter',
             (tester) async {

--- a/src/content/testing/integration-tests/index.md
+++ b/src/content/testing/integration-tests/index.md
@@ -1,318 +1,511 @@
 ---
-title: Integration testing
+title: Check app functionality with an integration test
 description: Learn how to write integration tests
 ---
 
 <?code-excerpt path-base="testing/integration_tests/how_to"?>
 
-This page describes how to use the [`integration_test`][] package to run
-integration tests. Tests written using this package have the following
-properties:
+This recipe describes how to use the
+[`integration_test`][] package to run integration tests.
+The Flutter SDK includes the `integration_test` package.
+Integration tests using this package have the following
+properties.
 
-* Compatibility with the `flutter drive` command,
-  for running tests on a physical device or emulator.
-* The ability to be run on [Firebase Test Lab][],
-  enabling automated testing on a variety of devices.
-* Compatibility with [flutter_test][] APIs,
-  enabling tests to be written in a similar style as [widget tests][]
+* Use the `flutter drive` command to run tests
+  on a physical device or emulator.
+* Run on [Firebase Test Lab][],
+  to automate testing on a variety of devices.
+* Use [flutter_test][] APIs to enable tests to be written in a style similar to [widget tests][]
 
-:::note
-The `integration_test` package is part of the Flutter SDK itself.
-To use it, make sure that you update your app's pubspec file
-to include this package as one of your `dev_dependencies`.
-For an example, see the [Project setup](#project-setup) section below.
-:::
+In this recipe, learn how to test a counter app.
 
-## Overview
+* how to set up integration tests
+* how to verify if an app displays specific text
+* how to tap specific widgets
+* how to run integration tests
 
-**Unit tests, widget tests, and integration tests**
+This recipe uses the following steps:
 
-There are three types of tests that Flutter supports.
-A **unit** test verifies the behavior of a method or class.
-A **widget test** verifies the behavior of Flutter widgets
-without running the app itself. An **integration test** (also
-called end-to-end testing or GUI testing) runs the full app.
+  1. Create an app to test.
+  2. Add the `integration_test` dependency.
+  3. Create the test files.
+  4. Write the integration test.
+  5. Run the integration test.
 
-**Hosts and targets**
+## Create a new app to test
 
-During development, you are probably writing the code
-on a desktop computer, called the **host** machine,
-and running the app on a mobile device, browser,
-or desktop application, called the **target** device.
-(If you are using a web
-browser or desktop application,
-the host machine is also the target device.)
+Integration testing requires an app to test.
+This example uses the built-in **Counter App** example
+that Flutter produces when you run the `flutter create` command.
+The counter app allows a user to tap on a button to increase a counter.
 
-**integration_test**
+1. To create an instance of the built-in Flutter app,
+   run the following command in your terminal:
 
-Tests written with the `integration_test` package can:
+   ```console
+   $ flutter create counter_app
+   ```
 
-1. Run directly on the target device, allowing you to test on
-   multiple Android or iOS devices using Firebase Test Lab.
-2. Run using `flutter test integration_test`.
-3. Use `flutter_test` APIs, making integration tests more
-   like writing [widget tests][].
+1. Change into the `counter_app` directory.
 
-**Migrating from flutter_driver**
+1. Open `lib/main.dart` in your preferred IDE.
 
-Existing projects using `flutter_driver` can be migrated to
-`integration_test` by following the [Migrating from flutter_drive][]
-guide.
+1. Add a `key` parameter to the `floatingActionButton()` widget
+   with an instance of a `Key` class with a string value of `increment`.
 
-## Project setup
+   ```dart
+    floatingActionButton: FloatingActionButton(
+      [!key: const ValueKey('increment'),!]
+      onPressed: _incrementCounter,
+      tooltip: 'Increment',
+      child: const Icon(Icons.add),
+    ),
+   ```
 
-Add `integration_test` and `flutter_test` to your `pubspec.yaml` file:
+1. Save your `lib/main.dart` file.
+
+After these changes,
+the `lib/main.dart` file should resemble the following code.
+
+<?code-excerpt "lib/main.dart"?>
+```dart title="lib/main.dart"
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
+      ),
+      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({super.key, required this.title});
+
+  final String title;
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  int _counter = 0;
+
+  void _incrementCounter() {
+    setState(() {
+      _counter++;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        title: Text(widget.title),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text(
+              'You have pushed the button this many times:',
+            ),
+            Text(
+              '$_counter',
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        // Provide a ValueKey to this button. This allows finding this
+        // specific button inside the test suite, and tapping it.
+        key: const ValueKey('increment'),
+        onPressed: _incrementCounter,
+        tooltip: 'Increment',
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+```
+
+## Add the `integration_test` dependency
+
+You need to add the testing packages to your new app.
+
+To add `integration_test` and `flutter_test` packages as
+`dev_dependencies` using `sdk: flutter`, run following command.
 
 ```console
-$ flutter pub add 'dev:flutter_test:{"sdk":"flutter"}'  'dev:integration_test:{"sdk":"flutter"}'
-"flutter_test" is already in "dev_dependencies". Will try to update the constraint.
+$ flutter pub add 'dev:integration_test:{"sdk":"flutter"}'
+```
+Output
+```console
+Building flutter tool...
 Resolving dependencies... 
-  collection 1.17.2 (1.18.0 available)
-+ file 6.1.4 (7.0.0 available)
+Got dependencies.
+Resolving dependencies... 
++ file 7.0.0
 + flutter_driver 0.0.0 from sdk flutter
 + fuchsia_remote_debug_protocol 0.0.0 from sdk flutter
 + integration_test 0.0.0 from sdk flutter
-  material_color_utilities 0.5.0 (0.8.0 available)
-  meta 1.9.1 (1.10.0 available)
-+ platform 3.1.0 (3.1.2 available)
-+ process 4.2.4 (5.0.0 available)
-  stack_trace 1.11.0 (1.11.1 available)
-  stream_channel 2.1.1 (2.1.2 available)
-+ sync_http 0.3.1
-  test_api 0.6.0 (0.6.1 available)
-+ vm_service 11.7.1 (11.10.0 available)
-+ webdriver 3.0.2
-Changed 9 dependencies!
+...
+  test_api 0.6.1 (0.7.1 available)
+  vm_service 13.0.0 (14.2.1 available)
++ webdriver 3.0.3
+Changed 8 dependencies!
+7 packages have newer versions incompatible with dependency constraints.
+Try `flutter pub outdated` for more information.
 ```
 
-In your project, create a new directory
-`integration_test` with a new file, `<name>_test.dart`:
+Updated `pubspec.yaml` file
 
-<?code-excerpt "integration_test/counter_test.dart (initial)" plaster="none"?>
-```dart
-import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:how_to/main.dart';
-import 'package:integration_test/integration_test.dart';
-
-void main() {
-  testWidgets('tap on the floating action button, verify counter',
-      (tester) async {
-    // Load app widget.
-    await tester.pumpWidget(const MyApp());
-
-    // Verify the counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-
-    // Finds the floating action button to tap on.
-    final fab = find.byKey(const Key('increment'));
-
-    // Emulate a tap on the floating action button.
-    await tester.tap(fab);
-
-    // Trigger a frame.
-    await tester.pumpAndSettle();
-
-    // Verify the counter increments by 1.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
-  });
-}
+```yaml title="pubspec.yaml"
+# ...
+dev_dependencies:
+  # ... added depencies
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^4.0.0
+  [!integration_test:!]
+    [!sdk: flutter!]
+# ...
 ```
 
-:::note
-Only use `testWidgets` to declare your tests.
-Otherwise, Flutter could report errors incorrectly.
-:::
+## Create the integration test files
 
-If you are looking for more examples, take a look at the [testing_app][] of
-the [samples][] repository.
+Integration tests reside in a separate directory inside 
+your Flutter project.
 
-### Directory structure
+1. Create a new directory named `integration_test`.
+1. Add empty file named `app_test.dart` in that directory.
 
-```yaml
-lib/
-  ...
-integration_test/
-  foo_test.dart
-  bar_test.dart
-test/
-  # Other unit tests go here.
+The resulting directory tree should resemble the following:
+
+```plaintext
+counter_app/
+  lib/
+    main.dart
+  integration_test/
+    app_test.dart
 ```
 
-See also:
+## Write the integration test
 
- * [integration_test usage][]
+The integration test file consists of a Dart code file
+with dependencies on `integration_test`, `flutter_test`,
+and your app's Dart file.
 
-## Running using the flutter command
+1. Open your `integration_test/app_test.dart` file in your preferred IDE.
 
-These tests can be launched with the
-`flutter test` command, where `<DEVICE_ID>`:
-is the optional device ID or pattern displayed
-in the output of the `flutter devices` command:
+1. Copy the following code and paste it into your
+   `integration_test/app_test.dart` file.
+   The last import should point to the `main.dart` file
+   of your `counter_app`.
+   (This `import` points to the example app called `introduction`.)
 
-```console
-$ flutter test integration_test/foo_test.dart -d <DEVICE_ID>
-```
+    <?code-excerpt "integration_test/app_test.dart (integration-test)" replace="/introduction/counter_app/g"?>
+    ```dart title="integration_test/app_test.dart"
+    import 'package:flutter/material.dart';
+    import 'package:flutter_test/flutter_test.dart';
+    import 'package:integration_test/integration_test.dart';
+    import 'package:counter_app/main.dart';
 
-This runs the tests in `foo_test.dart`. To run all tests in this directory on
-the default device, run:
+    void main() {
+      IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-```console
-$ flutter test integration_test
-```
+      group('end-to-end test', () {
+        testWidgets('tap on the floating action button, verify counter',
+            (tester) async {
+          // Load app widget.
+          await tester.pumpWidget(const MyApp());
 
-### Running in a browser
+          // Verify the counter starts at 0.
+          expect(find.text('0'), findsOneWidget);
 
-[Download and install ChromeDriver][chromedriver]
-and run it on port 4444:
+          // Finds the floating action button to tap on.
+          final fab = find.byKey(const ValueKey('increment'));
 
-```console
-$ chromedriver --port=4444
-```
+          // Emulate a tap on the floating action button.
+          await tester.tap(fab);
 
-To run tests with `flutter drive`, create a new directory containing a new file,
-`test_driver/integration_test.dart`:
+          // Trigger a frame.
+          await tester.pumpAndSettle();
 
-<?code-excerpt "test_driver/integration_test.dart"?>
-```dart
-import 'package:integration_test/integration_test_driver.dart';
+          // Verify the counter increments by 1.
+          expect(find.text('1'), findsOneWidget);
+        });
+      });
+    }
+    ```
 
-Future<void> main() => integrationDriver();
-```
+This example goes through three steps:
 
-Then add `IntegrationTestWidgetsFlutterBinding.ensureInitialized()` in your
-`integration_test/<name>_test.dart` file:
+1. Initialize `IntegrationTestWidgetsFlutterBinding`.
+   This singleton service executes tests on a physical device.
 
-<?code-excerpt "integration_test/counter_test.dart"?>
-```dart
-import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:how_to/main.dart';
-import 'package:integration_test/integration_test.dart';
+2. Interact and test widgets using the `WidgetTester` class.
 
-void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized(); // NEW
+3. Test the important scenarios.
 
-  testWidgets('tap on the floating action button, verify counter',
-      (tester) async {
-    // Load app widget.
-    await tester.pumpWidget(const MyApp());
+## Run integration tests
 
-    // Verify the counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
+The integration tests that run vary depending on the 
+platform on which you test.
 
-    // Finds the floating action button to tap on.
-    final fab = find.byKey(const Key('increment'));
+* To test a mobile platform,
+  you can use the command line or Firebase Test Lab.
+* To test in a web browser, use the command line.
 
-    // Emulate a tap on the floating action button.
-    await tester.tap(fab);
+### Test on a mobile device
 
-    // Trigger a frame.
-    await tester.pumpAndSettle();
+To test on a real iOS or Android device
 
-    // Verify the counter increments by 1.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
-  });
-}
-```
+1. Connect the device.
 
-In a separate process, run `flutter_drive`:
+1. Run the following command from the root of the project.
 
-```console
-$ flutter drive \
-   --driver=test_driver/integration_test.dart \
-   --target=integration_test/counter_test.dart \
-   -d web-server
-```
+   ```console
+   $ flutter test integration_test/app_test.dart
+   ```
+
+   The result should resemble the following output:
+
+   ```console
+   $ flutter test integration_test/app_test.dart
+   00:04 +0: loading /path/to/counter_app/integration_test/app_test.dart
+   00:15 +0: loading /path/to/counter_app/integration_test/app_test.dart
+   00:18 +0: loading /path/to/counter_app/integration_test/app_test.dart   2,387ms
+   Xcode build done.                                           13.5s
+   00:21 +1: All tests passed!
+   ```
+
+1. Verify that the test removed the Counter App when it finished.
+   If not, subsequent tests fail. If needed, press on the app and choose
+   **Remove App** from the context menu.
+
+To learn more, consult the [Integration testing][] page.
+
+---
+
+### Test in a web browser
+
+{% comment %}
+TODO(ryjohn): Add back after other WebDriver versions are supported:
+https://github.com/flutter/flutter/issues/90158
+
+To test for web,
+determine which browser you want to test against
+and download the corresponding web driver:
+
+* Chrome: Download [ChromeDriver][]
+* Firefox: [Download GeckoDriver][]
+* Safari: Safari can only be tested on a Mac;
+  the SafariDriver is already installed on Mac machines.
+* Edge [Download EdgeDriver][]
+{% endcomment -%}
+
+To test in a web browser, perform the following steps.
+
+1. Install [ChromeDriver][] into the directory of your choice.
+
+   ```console
+   $ npx @puppeteer/browsers install chromedriver@stable
+   ```
+
+   To simplify the install, this command uses the
+   [`@puppeteer/browsers`][puppeteer] Node library.
+
+   [puppeteer]: https://www.npmjs.com/package/@puppeteer/browsers
+
+1. Add the path to ChromeDriver to your `$PATH` environment variable.
+
+1. Verify the ChromeDriver install succeeded.
+
+   ```console
+   $ chromedriver --version
+   ChromeDriver 124.0.6367.60 (8771130bd84f76d855ae42fbe02752b03e352f17-refs/branch-heads/6367@{#798})
+   ```
+
+1. In your `counter_app` project directory,
+   create a new directory named `test_driver`.
+
+   ```console
+   $ mkdir test_driver
+   ```
+
+1. In this directory, create a new file named `integration_test.dart`.
+
+1. Copy the following code and paste it into your `integration_test.dart` file.
+
+   <?code-excerpt "test_driver/integration_test.dart"?>
+   ```dart title="test_driver/integration_test.dart"
+   import 'package:integration_test/integration_test_driver.dart';
+
+   Future<void> main() => integrationDriver();
+   ```
+
+1. Launch `chromedriver` as follows:
+
+   ```console
+   $ chromedriver --port=4444
+   ```
+
+1. From the root of the project, run the following command:
+
+   ```console
+   $ flutter drive \
+     --driver=test_driver/integration_test.dart \
+     --target=integration_test/app_test.dart \
+     -d chrome
+   ```
+
+   The response should resemble the following output:
+
+   ```console
+   Resolving dependencies...
+     leak_tracker 10.0.0 (10.0.5 available)
+     leak_tracker_flutter_testing 2.0.1 (3.0.5 available)
+     leak_tracker_testing 2.0.1 (3.0.1 available)
+     material_color_utilities 0.8.0 (0.11.1 available)
+     meta 1.11.0 (1.14.0 available)
+     test_api 0.6.1 (0.7.1 available)
+     vm_service 13.0.0 (14.2.1 available)
+   Got dependencies!
+   7 packages have newer versions incompatible with dependency constraints.
+   Try `flutter pub outdated` for more information.
+   Launching integration_test/app_test.dart on Chrome in debug mode...
+   Waiting for connection from debug service on Chrome...             10.9s
+   This app is linked to the debug service: ws://127.0.0.1:51523/3lofIjIdmbs=/ws
+   Debug service listening on ws://127.0.0.1:51523/3lofIjIdmbs=/ws
+   00:00 +0: end-to-end test tap on the floating action button, verify counter
+   00:01 +1: (tearDownAll)
+   00:01 +2: All tests passed!
+   All tests passed.
+   Application finished.
+   ```
+
+   To run this as a headless test, run `flutter drive`
+   with `-d web-server` option:
+
+   ```console
+   $ flutter drive \
+     --driver=test_driver/integration_test.dart \
+     --target=integration_test/app_test.dart \
+     -d web-server
+   ```
+
+[ChromeDriver]: https://googlechromelabs.github.io/chrome-for-testing/
+[Download EdgeDriver]: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
+[Download GeckoDriver]: {{site.github}}/mozilla/geckodriver/releases
 
 To learn more, see the
 [Running Flutter driver tests with web][] wiki page.
 
-## Testing on Firebase Test Lab
+### Test using the Firebase Test Lab
 
-You can use the Firebase Test Lab with both Android
-and iOS targets.
+To test both Android and iOS targets,
+you can use the Firebase Test Lab.
 
-### Android setup
+#### Android setup
 Follow the instructions in the [Android Device Testing][]
 section of the README.
 
-### iOS setup
+#### iOS setup
 Follow the instructions in the [iOS Device Testing][]
 section of the README.
 
-### Test Lab project setup
+#### Test Lab project setup
 
-Go to the [Firebase Console][],
-and create a new project if you don't have one
-already. Then navigate to **Quality > Test Lab**:
+1. Launch your [Firebase Console][].
 
-<img src='/assets/images/docs/integration-test/test-lab-1.png' class="mw-100" alt="Firebase Test Lab Console">
+1. Create a new Firebase project if necessary.
 
-### Uploading an Android APK
+1. Navigate to **Quality > Test Lab**.
 
-Create an APK using Gradle:
+   <img src='/assets/images/docs/integration-test/test-lab-1.png' class="mw-100" alt="Firebase Test Lab Console">
 
-```console
-$ pushd android
-# flutter build generates files in android/ for building the app
-flutter build apk
-./gradlew app:assembleAndroidTest
-./gradlew app:assembleDebug -Ptarget=integration_test/<name>_test.dart
-$ popd
-```
+#### Upload an Android APK
 
-Where `<name>_test.dart` is the file created in the
-**Project Setup** section.
+1. Create an APK using Gradle.
+
+   ```console
+   $ pushd android
+   # flutter build generates files in android/ for building the app
+   flutter build apk
+   ./gradlew app:assembleAndroidTest
+   ./gradlew app:assembleDebug -Ptarget=integration_test/<name>_test.dart
+   $ popd
+   ```
+
+   Where `<name>_test.dart` is the file created in the
+   **Project Setup** section.
 
 :::note
-To use `--dart-define` with `gradlew`, you must `base64` encode
-all parameters, and pass them to gradle in a comma separated list:
+To use `--dart-define` with `gradlew:
 
-```console
-./gradlew project:task -Pdart-defines="{base64(key=value)},[...]"
-```
+1. Encode all parameters with `base64`.
+1. Pass the parameters to gradle in a comma-separated list.
+
+   ```console
+   ./gradlew project:task -Pdart-defines="{base64   (key=value)},[...]"
+   ```
+
 :::
 
-Drag the "debug" APK from
+To start a Robo test and run other tests, drag the "debug" APK from
 `<flutter_project_directory>/build/app/outputs/apk/debug`
 into the **Android Robo Test** target on the web page.
-This starts a Robo test and allows you to run
-other tests:
 
 <img src='/assets/images/docs/integration-test/test-lab-2.png' class="mw-100" alt="Firebase Test Lab upload">
 
-Click **Run a test**,
-select the **Instrumentation** test type and drag
-the following two files:
+1. Click **Run a test**.
 
- * `<flutter_project_directory>/build/app/outputs/apk/debug/<file>.apk`
- * `<flutter_project_directory>/build/app/outputs/apk/androidTest/debug/<file>.apk`
+1. Select the **Instrumentation** test type.
+
+1. Add the App APK to the **App APK or AAB** box.
+
+   `<flutter_project_directory>/build/app/outputs/apk/debug/<file>.apk`
+
+1. Add the Test APK to the **Test APK** box.
+
+   `<flutter_project_directory>/build/app/outputs/apk/androidTest/debug/<file>.apk`
 
 <img src='/assets/images/docs/integration-test/test-lab-3.png' class="mw-100" alt="Firebase Test Lab upload two APKs">
 
-If a failure occurs,
-you can view the output by selecting the red icon:
+If a failure occurs, click the red icon to view the output:
 
 <img src='/assets/images/docs/integration-test/test-lab-4.png' class="mw-100" alt="Firebase Test Lab test results">
 
-### Uploading an Android APK from the command line
+#### Upload an Android APK from the command line
 
 See the [Firebase Test Lab section of the README][]
 for instructions on uploading the APKs from the command line.
 
-### Uploading Xcode tests
+#### Upload Xcode tests
 
-See the [Firebase TestLab iOS instructions][]
-for details on how to upload the .zip file
-to the Firebase TestLab section of the Firebase Console.
+To learn how to upload the .zip file,
+consult the [Firebase TestLab iOS instructions][]
+on the Firebase TestLab section of the Firebase Console.
 
-### Uploading Xcode tests from the command line
-See the [iOS Device Testing][] section in the README
-for instructions on how to upload the .zip file
-from the command line.
+#### Upload Xcode tests from the command line
+
+To learn how to upload the .zip file from the command line,
+consult the [iOS Device Testing][] section in the README.
 
 [Android Device Testing]: {{site.repo.flutter}}/tree/main/packages/integration_test#android-device-testing
 [chromedriver]: https://googlechromelabs.github.io/chrome-for-testing/
@@ -322,10 +515,14 @@ from the command line.
 [Firebase TestLab iOS instructions]: {{site.firebase}}/docs/test-lab/ios/firebase-console
 [flutter_test]: {{site.api}}/flutter/flutter_test/flutter_test-library.html
 [`integration_test`]: {{site.repo.flutter}}/tree/main/packages/integration_test#integration_test
-[integration_test usage]: {{site.repo.flutter}}/tree/main/packages/integration_test#usage
+[integration_test usage]:
+    {{site.repo.flutter}}/tree/main/packages/integration_test#usage
+[Integration testing]: /testing/integration-tests
 [iOS Device Testing]: {{site.repo.flutter}}/tree/main/packages/integration_test#ios-device-testing
-[Migrating from flutter_drive]: /release/breaking-changes/flutter-driver-migration
 [Running Flutter driver tests with web]: {{site.repo.flutter}}/wiki/Running-Flutter-Driver-tests-with-Web
 [samples]: {{site.repo.samples}}
 [testing_app]: {{site.repo.samples}}/tree/main/testing_app/integration_test
 [widget tests]: /testing/overview#widget-tests
+[testWidgets]: {{site.api}}/flutter/flutter_test/testWidgets.html
+[flutter_driver]: {{site.api}}/flutter/flutter_driver/flutter_driver-library.html
+

--- a/src/content/testing/integration-tests/index.md
+++ b/src/content/testing/integration-tests/index.md
@@ -1,6 +1,7 @@
 ---
 title: Check app functionality with an integration test
 description: Learn how to write integration tests
+os-list: [Windows, macOS, Linux]
 ---
 
 <?code-excerpt path-base="testing/integration_tests/how_to"?>
@@ -264,16 +265,100 @@ This example goes through three steps:
 
 ## Run integration tests
 
-The integration tests that run vary depending on the 
+The integration tests that run vary depending on the
 platform on which you test.
 
-* To test a mobile platform,
-  you can use the command line or Firebase Test Lab.
+* To test a desktop platform, use the command line or a CI system.
+* To test a mobile platform, use the command line or Firebase Test Lab.
 * To test in a web browser, use the command line.
+
+---
+
+### Test on a desktop platform
+
+<details markdown="1">
+<summary>Expand if you test Linux apps using a CI system</summary>
+
+To test a Linux app, your CI system must invoke an X server first.
+In the GitHub Action, GitLab Runner, or similar configuration file,
+set the integration test to work _with_ the `xvfb-run` tool.
+
+Doing this invokes an X Window system into which Flutter can
+launch and test your Linux app.
+
+As an example using GitHub Actions, your `jobs.setup.steps` should
+include a step resembling the following:
+
+```yaml
+      - name: Run Integration Tests
+        uses: username/xvfb-action@v1.1.2
+        with:
+          run: flutter test integration_test -d linux -r github
+```
+
+This starts the integration test within an X Window.
+
+If you don't configure your integration in this way,
+Flutter returns an error.
+
+```console
+Building Linux application...
+Error waiting for a debug connection: The log reader stopped unexpectedly, or never started.
+```
+
+</details>
+
+To test on a macOS, Windows, or Linux platform,
+complete the following tasks.
+
+1. Run the following command from the root of the project.
+
+   ```console
+   $ flutter test integration_test/app_test.dart
+   ```
+
+1. If offered a choice of platform to test,
+   choose the desktop platform.
+   Type `1` to choose the desktop platform.
+
+Based on platform, the command result should resemble the following output.
+
+{% comment %} Nav tabs {% endcomment -%}
+<ul class="nav nav-tabs" id="base-os-tabs" role="tablist">
+{% for os in os-list %}
+{% assign id = os | downcase -%}
+  <li class="nav-item">
+    <a class="nav-link {%- if id == 'windows' %} active {% endif %}" id="{{id}}-tab" href="#{{id}}" role="tab" aria-controls="{{id}} {{id}}-dl {{id}}-pub" aria-selected="true">{{os}}</a>
+  </li>
+{% endfor -%}
+</ul>
+
+{% comment %} Tab panes {% endcomment -%}
+<div class="tab-content">
+{% for os in os-list %}
+{% assign id = os | downcase -%}
+<div class="tab-pane {%- if id == 'windows' %} active {% endif %}" id="{{id}}" role="tabpanel" aria-labelledby="{{id}}-tab">
+
+{% case id %}
+{% when 'windows' %}
+  {% render docs/test/integration/windows-example.md %}
+{% when 'macos' %}
+  {% render docs/test/integration/macos-example.md %}
+{% when 'linux' %}
+  {% render docs/test/integration/linux-example.md %}
+{% endcase %}
+</div>
+
+{% endfor -%}
+</div>
+{% comment %} End: Tab panes. {% endcomment %}
+
+---
 
 ### Test on a mobile device
 
-To test on a real iOS or Android device
+To test on a real iOS or Android device,
+complete the following tasks.
 
 1. Connect the device.
 
@@ -283,7 +368,7 @@ To test on a real iOS or Android device
    $ flutter test integration_test/app_test.dart
    ```
 
-   The result should resemble the following output:
+   The result should resemble the following output. This example uses iOS.
 
    ```console
    $ flutter test integration_test/app_test.dart
@@ -297,8 +382,6 @@ To test on a real iOS or Android device
 1. Verify that the test removed the Counter App when it finished.
    If not, subsequent tests fail. If needed, press on the app and choose
    **Remove App** from the context menu.
-
-To learn more, consult the [Integration testing][] page.
 
 ---
 
@@ -409,12 +492,10 @@ To test in a web browser, perform the following steps.
      -d web-server
    ```
 
-[ChromeDriver]: https://googlechromelabs.github.io/chrome-for-testing/
-[Download EdgeDriver]: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
-[Download GeckoDriver]: {{site.github}}/mozilla/geckodriver/releases
-
 To learn more, see the
 [Running Flutter driver tests with web][] wiki page.
+
+---
 
 ### Test using the Firebase Test Lab
 
@@ -422,10 +503,12 @@ To test both Android and iOS targets,
 you can use the Firebase Test Lab.
 
 #### Android setup
+
 Follow the instructions in the [Android Device Testing][]
 section of the README.
 
 #### iOS setup
+
 Follow the instructions in the [iOS Device Testing][]
 section of the README.
 
@@ -507,22 +590,23 @@ on the Firebase TestLab section of the Firebase Console.
 To learn how to upload the .zip file from the command line,
 consult the [iOS Device Testing][] section in the README.
 
+[`integration_test`]: {{site.repo.flutter}}/tree/main/packages/integration_test#integration_test
 [Android Device Testing]: {{site.repo.flutter}}/tree/main/packages/integration_test#android-device-testing
-[chromedriver]: https://googlechromelabs.github.io/chrome-for-testing/
+[ChromeDriver]: https://googlechromelabs.github.io/chrome-for-testing/
+[Download EdgeDriver]: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
+[Download GeckoDriver]: {{site.github}}/mozilla/geckodriver/releases
 [Firebase Console]: http://console.firebase.google.com/
-[Firebase Test Lab]: {{site.firebase}}/docs/test-lab
 [Firebase Test Lab section of the README]: {{site.repo.flutter}}/tree/main/packages/integration_test#firebase-test-lab
+[Firebase Test Lab]: {{site.firebase}}/docs/test-lab
 [Firebase TestLab iOS instructions]: {{site.firebase}}/docs/test-lab/ios/firebase-console
 [flutter_test]: {{site.api}}/flutter/flutter_test/flutter_test-library.html
-[`integration_test`]: {{site.repo.flutter}}/tree/main/packages/integration_test#integration_test
-[integration_test usage]:
-    {{site.repo.flutter}}/tree/main/packages/integration_test#usage
 [Integration testing]: /testing/integration-tests
 [iOS Device Testing]: {{site.repo.flutter}}/tree/main/packages/integration_test#ios-device-testing
 [Running Flutter driver tests with web]: {{site.repo.flutter}}/wiki/Running-Flutter-Driver-tests-with-Web
+[widget tests]: /testing/overview#widget-tests
+
+[flutter_driver]: {{site.api}}/flutter/flutter_driver/flutter_driver-library.html
+[integration_test usage]: {{site.repo.flutter}}/tree/main/packages/integration_test#usage
 [samples]: {{site.repo.samples}}
 [testing_app]: {{site.repo.samples}}/tree/main/testing_app/integration_test
-[widget tests]: /testing/overview#widget-tests
 [testWidgets]: {{site.api}}/flutter/flutter_test/testWidgets.html
-[flutter_driver]: {{site.api}}/flutter/flutter_driver/flutter_driver-library.html
-

--- a/src/content/testing/testing-plugins.md
+++ b/src/content/testing/testing-plugins.md
@@ -110,9 +110,9 @@ or using `flutter test`.
 
 For information on running this type of test, check out the
 [integration test documentation][].
-The commands must be run in the `example` directory. 
+The commands must be run in the `example` directory.
 
-[integration test documentation]: /cookbook/testing/integration/introduction#run-integration-tests
+[integration test documentation]: /testing/integration
 
 ### Native unit tests
 

--- a/src/content/testing/testing-plugins.md
+++ b/src/content/testing/testing-plugins.md
@@ -112,7 +112,7 @@ For information on running this type of test, check out the
 [integration test documentation][].
 The commands must be run in the `example` directory.
 
-[integration test documentation]: /testing/integration
+[integration test documentation]: /cookbook/testing/integration/introduction
 
 ### Native unit tests
 


### PR DESCRIPTION
This PR removes the duplicate content between two pages ([Introduction](https://flutter-docs-prod--pr10563-fix-10464-kelxxfuk.web.app/cookbook/testing/integration/introduction) and [Write and run an integration test](https://flutter-docs-prod--pr10563-fix-10464-kelxxfuk.web.app/testing/integration-tests)), adds a CI note, and adds the desktop integration testing information.

Fixes #10464
Fixes #6115 
Fixes #9512 