### PR TITLE
Update: 'flutter.cn/docs' -> 'docs.flutter.cn'

### DIFF
--- a/src/_includes/docs/china-notice-cn.md
+++ b/src/_includes/docs/china-notice-cn.md
@@ -3,4 +3,4 @@
 请参考 [在中国网络环境下使用 Flutter][] 文档.
 :::
 
-[在中国网络环境下使用 Flutter]: https://flutter.cn/community/china
+[在中国网络环境下使用 Flutter]: https://docs.flutter.cn/community/china

--- a/src/_includes/docs/community/china/os-settings.md
+++ b/src/_includes/docs/community/china/os-settings.md
@@ -70,7 +70,7 @@ This procedure requires using {{shell}}.
 
 1. Download the Flutter archive from your mirror site.
    In your preferred browser, go to
-   [Flutter SDK archive](https://flutter.cn/docs/release/archive?tab={{id}}).
+   [Flutter SDK archive](https://docs.flutter.cn/release/archive?tab={{id}}).
 
 1. Create a folder where you can install Flutter. then change into it.
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
`flutter.cn/docs` has been migrated to `docs.flutter.cn`.
- https://github.com/cfug/flutter.cn/pull/1436

_Issues fixed by this PR (if any):_
None.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
