### PR TITLE
Update delete-data.md

### DIFF
--- a/examples/cookbook/networking/delete_data/lib/main.dart
+++ b/examples/cookbook/networking/delete_data/lib/main.dart
@@ -31,11 +31,11 @@ Future<Album> deleteAlbum(String id) async {
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response,
-    // then parse the JSON. After deleting,
+    // then return an empty Album. After deleting,
     // you'll get an empty JSON `{}` response.
     // Don't return `null`, otherwise `snapshot.hasData`
     // will always return false on `FutureBuilder`.
-    return Album.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+    return Album.empty();
   } else {
     // If the server did not return a "200 OK response",
     // then throw an exception.
@@ -45,10 +45,12 @@ Future<Album> deleteAlbum(String id) async {
 // #enddocregion deleteAlbum
 
 class Album {
-  final int id;
-  final String title;
+  int? id;
+  String? title;
 
-  const Album({required this.id, required this.title});
+  Album({this.id, this.title});
+
+  Album.empty();
 
   factory Album.fromJson(Map<String, dynamic> json) {
     return switch (json) {

--- a/src/content/cookbook/networking/delete-data.md
+++ b/src/content/cookbook/networking/delete-data.md
@@ -112,11 +112,11 @@ Future<Album> deleteAlbum(String id) async {
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response,
-    // then parse the JSON. After deleting,
+    // then return an empty Album. After deleting,
     // you'll get an empty JSON `{}` response.
     // Don't return `null`, otherwise `snapshot.hasData`
     // will always return false on `FutureBuilder`.
-    return Album.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+    return Album.empty();
   } else {
     // If the server did not return a "200 OK response",
     // then throw an exception.
@@ -173,7 +173,7 @@ Future<Album> deleteAlbum(String id) async {
     // you'll get an empty JSON `{}` response.
     // Don't return `null`, otherwise `snapshot.hasData`
     // will always return false on `FutureBuilder`.
-    return Album.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+    return Album.empty();
   } else {
     // If the server did not return a "200 OK response",
     // then throw an exception.
@@ -182,10 +182,12 @@ Future<Album> deleteAlbum(String id) async {
 }
 
 class Album {
-  final int id;
-  final String title;
+  int? id;
+  String? title;
 
-  const Album({required this.id, required this.title});
+  Album({this.id, this.title});
+
+  Album.empty();
 
   factory Album.fromJson(Map<String, dynamic> json) {
     return switch (json) {

--- a/src/content/cookbook/networking/delete-data.md
+++ b/src/content/cookbook/networking/delete-data.md
@@ -169,7 +169,7 @@ Future<Album> deleteAlbum(String id) async {
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response,
-    // then parse the JSON. After deleting,
+    // then return an empty Album. After deleting,
     // you'll get an empty JSON `{}` response.
     // Don't return `null`, otherwise `snapshot.hasData`
     // will always return false on `FutureBuilder`.


### PR DESCRIPTION
Fix "Delete data on the internet" cookbook sample.

The Album.fromJson method doesn't handle an empty map, which is returned from the jsonplaceholder API when the DELETE method is called. 

Fixes #10577