### PR TITLE
Docs: Replace measure image with branch image

### DIFF
--- a/src/content/ui/adaptive-responsive/general.md
+++ b/src/content/ui/adaptive-responsive/general.md
@@ -140,7 +140,7 @@ In this scenario, use `LayoutBuilder`.
 
 ## Step 3: Branch
 
-![Step 3: Branch the code based on the desired UI](/assets/images/docs/ui/adaptive-responsive/measure.png)
+![Step 3: Branch the code based on the desired UI](/assets/images/docs/ui/adaptive-responsive/branch.png)
 
 At this point, you must decide what sizing breakpoints to use
 when choosing what version of the UI to display.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
The [General approach](https://docs.flutter.dev/ui/adaptive-responsive/general) article under Adaptive and Responsive design displays the wrong image under Step 3,
which is a duplicate from Step 2. This PR only changes the markdown in Step 3 to point to the correct existing image.

_Issues fixed by this PR (if any):_
n/a

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
