### PR TITLE
fix: adding proper command for extracting archives

### DIFF
--- a/src/_includes/docs/install/flutter/download.md
+++ b/src/_includes/docs/install/flutter/download.md
@@ -30,19 +30,21 @@
    {% assign prompt='$' %}
    {% assign dirdl='~/Downloads/' %}
    {% capture uz -%}
-   {{prompt}} {{unzip}} {{dirdl}}flutter_sdk_v1.0.0.zip -d {{path}}
+   {{prompt}} {{unzip}} {{dirdl}}flutter_sdk_v1.0.0.zip \
+        -d {{path}}
    {%- endcapture %}
 {% else -%}
    {% assign diroptions='`/usr/bin/`' %}
    {% assign dirinstall='`/usr/bin/`' %}
-   {% assign unzip='unzip' %}
+   {% assign unzip='tar' %}
    {% assign path='/usr/bin/' %}
    {% assign flutter-path='/usr/bin/flutter' %}
    {% assign terminal='a shell' %}
    {% assign prompt='$' %}
    {% assign dirdl='~/Downloads/' %}
    {% capture uz -%}
-   {{prompt}} {{dirdl}}flutter_sdk_v1.0.0.zip {{path}}
+   {{prompt}} {{unzip}} -xf {{dirdl}}flutter_sdk_v1.0.0.zip \
+        -C {{path}}
    {%- endcapture %}
 {% endcase -%}
 
@@ -84,7 +86,7 @@ then extract the SDK.
    {% render docs/install/admonitions/install-paths.md %}
    {% endif %}
 
-1. Extract the zip file into the directory you want to store the Flutter SDK.
+1. Extract the file into the directory you want to store the Flutter SDK.
 
    ```console
    {{uz}}


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Some commands for extracting files were wrong in the documentation. So I fixed these commands for Linux and macOS. For some weird reason, some flags, such as `-C` from `tar` command, were not showing, so I used multilines as a sorta of hack in order to make these flags appear, so I hope it is not a problem.

Also I removed the word `zip` from the description because the downloaded artifact may not be a zip file, therefore it could cause a slight confusion to the user, in my opinion.

_Issues fixed by this PR (if any):_
#10607 

## Presubmit checklist

- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
