### PR TITLE
Update long lists cookbook

### DIFF
--- a/src/content/cookbook/lists/long-lists.md
+++ b/src/content/cookbook/lists/long-lists.md
@@ -100,10 +100,16 @@ class MyApp extends StatelessWidget {
 
 ## Children's extent
 
-To specify each item's extent, you can use either `itemExtent` or `prototypeItem`.
+To specify each item's extent, you can use either [`prototypeItem`][], [`itemExtent`][],
+or [`itemExtentBuilder`][].
+
 Specifying either is more efficient than letting the children determine their own extent
 because the scrolling machinery can make use of the foreknowledge of the children's
 extent to save work, for example when the scroll position changes drastically.
+
+Use [`prototypeItem`][] or [`itemExtent`][] if your list has items of fixed size.
+
+Use [`itemExtentBuilder`][] if your list has items of different sizes.
 
 <noscript>
   <img src="/assets/images/docs/cookbook/long-lists.gif" alt="Long Lists Demo" class="site-mobile-screenshot" />
@@ -112,3 +118,6 @@ extent to save work, for example when the scroll position changes drastically.
 [`List.generate`]: {{site.api}}/flutter/dart-core/List/List.generate.html
 [`ListView`]: {{site.api}}/flutter/widgets/ListView-class.html
 [`ListView.builder`]: {{site.api}}/flutter/widgets/ListView/ListView.builder.html
+[`prototypeItem`]: {{site.api}}/flutter/widgets/ListView/prototypeItem.html
+[`itemExtent`]: {{site.api}}/flutter/widgets/ListView/itemExtent.html
+[`itemExtentBuilder`]: {{site.api}}/flutter/widgets/ListView/itemExtentBuilder.html


### PR DESCRIPTION
Updates the long list cookbook to add `ListView.extentItemBuilder`, which was added recently for lists with extends of different sizes: https://github.com/flutter/flutter/pull/131393

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
