### PR TITLE
[site] fix link pointing to android developer site

### DIFF
--- a/src/content/ui/adaptive-responsive/large-screens.md
+++ b/src/content/ui/adaptive-responsive/large-screens.md
@@ -234,7 +234,7 @@ guidance on adding
 
 [Apple guidelines]: https://developer.apple.com/design/human-interface-guidelines/designing-for-ipados#Best-practices
 [input support for widgets]: /ui/adaptive-responsive/input#custom-widgets
-[m3-guide]: {{site.android-dev}}/developer.android.com/docs/quality-guidelines/large-screen-app-quality
+[m3-guide]: {{site.android-dev}}/docs/quality-guidelines/large-screen-app-quality
 [User input]: /ui/adaptive-responsive/input
 
 ### Navigation


### PR DESCRIPTION
The link has the domain name duplicated, and so navigating the link ends in a 404 error

_Description of what this PR is changing or adding, and why:_

While reading the documentation, I found a link that returned a 404.
https://docs.flutter.dev/ui/adaptive-responsive/large-screens#:~:text=Material%203%20guidelines

This PR merely attempts to fix the link based on how other links in the same document are written.

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
