### PR TITLE
minor: change transformers args to list

### DIFF
--- a/src/content/ui/assets/asset-transformation.md
+++ b/src/content/ui/assets/asset-transformation.md
@@ -45,7 +45,7 @@ flutter:
     - path: assets/logo.svg
       transformers:
         - package: vector_graphics_compiler
-          args: '--tessellate --font-size=14'
+          args: ['--tessellate', '--font-size=14']
 ```
 
 ### Chaining asset transformers


### PR DESCRIPTION
The `args` in the `asset-transformation` section should be of type list of strings, not a single string as the documentation shows. Running the code as in the docs will result in the following issue:

```
Error detected in pubspec.yaml:
Unable to parse assets section.
In transformers section of asset "assets/logo.svg": In args section of transformer using package "vector_graphics_compiler": Expected args to be a list of String, but got --tessellate --font-size=14 (String).
Please correct the pubspec.yaml file
```

This PR convert the args section in the docs to list.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
