### PR TITLE
[site] fix link pointing to google_generative_ai package

### DIFF
--- a/src/content/resources/ai-overview.md
+++ b/src/content/resources/ai-overview.md
@@ -20,5 +20,5 @@ The following resources can help you get started:
 * [Get started with the Gemini API in Dart or Flutter apps][tutorial]
 * [Google Generative AI SDK for Dart and Flutter][pkg]
 
-[pkg]: {{site.pub-pkg}}/packages/google_generative_ai
+[pkg]: {{site.pub-pkg}}/google_generative_ai
 [tutorial]: https://ai.google.dev/gemini-api/docs/get-started/dart


### PR DESCRIPTION
The link leads to a 404 error

Description of what this PR is changing or adding, and why:

While reading the documentation, I found following link returned a 404 error
[https://pub.dev/packages/packages/google_generative_ai](https://pub.dev/packages/packages/google_generative_ai)

This PR attempts to fix the broken link for the [google_generative_ai](https://pub.dev/packages/google_generative_ai) package.


## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
