### PR TITLE
Fix typo: `Platform.isAndoid` -> `Platform.isAndroid`

### DIFF
--- a/src/content/ui/adaptive-responsive/capabilities.md
+++ b/src/content/ui/adaptive-responsive/capabilities.md
@@ -67,7 +67,7 @@ as host platforms add functionality.
 The following guidelines explain best practices
 when developing the capabilities and policies for your app:
 
-**Avoid using `Platform.isAndoid` and similar functions
+**Avoid using `Platform.isAndroid` and similar functions
 to make layout decisions or assumptions about what a device can do.**
 
 Instead, describe what you want to branch on in a method. 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
