### PR TITLE
Fix link umbrella blog post

### DIFF
--- a/src/content/release/whats-new.md
+++ b/src/content/release/whats-new.md
@@ -37,7 +37,7 @@ you to create your own macros.
 To learn more, check out [dart.dev/go/macros][].
 
 [3.22-tech]: {{site.flutter-medium}}/whats-new-in-flutter-3-22-fbde6c164fe3
-[3.22-umbrella]: {{site.flutter-medium}}/starting-2024-strong-with-flutter-and-dart-cae9845264fe
+[3.22-umbrella]: {{site.flutter-medium}}/io24-5e211f708a37
 [Dart 3.4 release]: {{site.medium}}/dartlang/dart-3-4-bd8d23b4462a
 [dart.dev/go/macros]: http://dart.dev/go/macros
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

The link of the umbrella blog post still referred to the 3.19 umbrella blog post. Replace it with the one for 3.22

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
