### PR TITLE
doc: mention default flavors

### DIFF
--- a/src/content/deployment/flavors.md
+++ b/src/content/deployment/flavors.md
@@ -234,8 +234,8 @@ TODO: When available, add an app sample.
 1. Once the flavors are set up, modify the Dart code in
 **lib** / **main.dart** to consume the flavors.
 2. Test the setup using `flutter run --flavor free`
-at the command line, or in your IDE. Alternatively, you
-can set a default flavor in your `pubspec.yaml`:
+at the command line, or in your IDE.
+Alternatively, you can set a default flavor in your `pubspec.yaml`:
 
 ```yaml
 flutter:

--- a/src/content/deployment/flavors.md
+++ b/src/content/deployment/flavors.md
@@ -234,7 +234,13 @@ TODO: When available, add an app sample.
 1. Once the flavors are set up, modify the Dart code in
 **lib** / **main.dart** to consume the flavors.
 2. Test the setup using `flutter run --flavor free`
-at the command line, or in your IDE.
+at the command line, or in your IDE. Alternatively, you
+can set a default flavor in your `pubspec.yaml`:
+
+```yaml
+flutter:
+  default-flavor: free
+```
 
 For examples of build flavors for [iOS][], [macOS][], and [Android][],
 check out the integration test samples in the [Flutter repo][].


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Document the `default-flavor` entry in `pubspec.yaml` introduced in https://github.com/flutter/flutter/pull/147968

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
