### PR TITLE
Replace terminal marker with CSS-based marker

### DIFF
--- a/src/_11ty/plugins/highlight.js
+++ b/src/_11ty/plugins/highlight.js
@@ -122,7 +122,7 @@ function _highlight(
     ? _parseNumbersAndRanges(highlightLines)
     : null;
 
-  const noHighlight = 'noHighlight' in attributes
+  const noHighlight = 'noHighlight' in attributes;
 
   // Find the spans enclosed in `[!` and `!]` that we should mark
   // and remove them from the text.
@@ -152,7 +152,7 @@ function _highlight(
 
           const bodyChildren = [preElement];
 
-          if (!['plaintext', 'console', 'ps', 'diff'].includes(language)) {
+          if (!['plaintext', 'console', 'ps', 'diff', 'powershell'].includes(language)) {
             const languageText = _createSpanWithText(language, {
               class: 'code-block-language',
               title: `Language ${language}`,
@@ -232,6 +232,18 @@ function _highlight(
 
           if (linesToHighlight?.has(line)) {
             lineElement.properties['class'] += ' highlighted-line';
+          }
+
+          if (lineElement.children.length < 1) return;
+
+          // Remove terminal command marker if present.
+          const firstSpan = lineElement.children[0];
+          const firstText = firstSpan.children[0];
+          if (firstText?.value.startsWith('$ ')) {
+            // If terminal marker is present on the first span,
+            // remove it and add a class to use CSS to display it.
+            firstText.value = firstText.value.substring(2);
+            firstSpan.properties['class'] += ' terminal-command';
           }
 
           const highlightRange = linesToMarkedRanges[line];

--- a/src/_11ty/plugins/highlight.js
+++ b/src/_11ty/plugins/highlight.js
@@ -3,6 +3,10 @@ import dashLightTheme from '../syntax/dash-light.js';
 
 import diff2html from "diff2html";
 
+const _terminalLanguages = {
+  'console': '$',
+};
+
 /**
  * Replaces the markdown-it code block renderer with our own that:
  *
@@ -236,14 +240,16 @@ function _highlight(
 
           if (lineElement.children.length < 1) return;
 
-          // Remove terminal command marker if present.
-          const firstSpan = lineElement.children[0];
-          const firstText = firstSpan.children[0];
-          if (firstText?.value.startsWith('$ ')) {
-            // If terminal marker is present on the first span,
-            // remove it and add a class to use CSS to display it.
-            firstText.value = firstText.value.substring(2);
-            firstSpan.properties['class'] += ' terminal-command';
+          if (language in _terminalLanguages) {
+            // Remove terminal command marker if present.
+            const firstSpan = lineElement.children[0];
+            const firstText = firstSpan.children[0];
+            if (firstText?.value.startsWith('$ ')) {
+              // If terminal marker is present on the first span,
+              // remove it and add a class to use CSS to display it.
+              firstText.value = firstText.value.substring(2);
+              firstSpan.properties['class'] += ' terminal-command';
+            }
           }
 
           const highlightRange = linesToMarkedRanges[line];

--- a/src/_sass/components/_code.scss
+++ b/src/_sass/components/_code.scss
@@ -42,6 +42,13 @@ pre {
       background: color.change($site-color-primary, $alpha: 0.05);
       border-left-color: $site-color-primary;
     }
+
+    .terminal-command::before {
+      color: $site-color-sub-grey;
+      content: "$";
+      content: "$" / "";
+      padding-right: 0.5rem;
+    }
   }
 
   &.show-line-numbers code {


### PR DESCRIPTION
Fixes https://github.com/flutter/website/issues/10613 for the common case of a `$` terminal marker for the `console` language. It looks at each line's contents to determine if the line starts with a `$`, then removes that and adds a CSS class to add it instead.