### PR TITLE
Revert "doc: mention default flavors"

### DIFF
--- a/src/content/deployment/flavors.md
+++ b/src/content/deployment/flavors.md
@@ -235,12 +235,6 @@ TODO: When available, add an app sample.
 **lib** / **main.dart** to consume the flavors.
 2. Test the setup using `flutter run --flavor free`
 at the command line, or in your IDE.
-Alternatively, you can set a default flavor in your `pubspec.yaml`:
-
-```yaml
-flutter:
-  default-flavor: free
-```
 
 For examples of build flavors for [iOS][], [macOS][], and [Android][],
 check out the integration test samples in the [Flutter repo][].


### PR DESCRIPTION
Reverts flutter/website#10632. This PR added documentation for a feature that has not yet landed in stable (nor master, for that matter).