### PR TITLE
Revert "document default flavor"

### DIFF
--- a/src/content/deployment/flavors.md
+++ b/src/content/deployment/flavors.md
@@ -235,12 +235,6 @@ TODO: When available, add an app sample.
 **lib** / **main.dart** to consume the flavors.
 2. Test the setup using `flutter run --flavor free`
 at the command line, or in your IDE.
-Alternatively, you can set a default flavor in your `pubspec.yaml`:
-
-```yaml
-flutter:
-  default-flavor: free
-```
 
 For examples of build flavors for [iOS][], [macOS][], and [Android][],
 check out the integration test samples in the [Flutter repo][].


### PR DESCRIPTION
Reverts flutter/website#10642.

This is a similar story to https://github.com/flutter/website/pull/10641. TL;DR a contributor merged a new feature into the master branch of flutter/flutter and also kindly drafted a website change to document this feature. However, this change shouldn't have been merged until the feature is actually available on the stable channel.

Question for @Sfshaza and/or other maintainers: I've had this happen to myself, and I'd like to make it easy for folks to not accidentally merge these PRs too early. In these types of situations where we have some change to flutter/flutter and want to proactively prepare website updates for them, what would you prefer? Here is an idea to start with: we continue to draft these PRs early, but maybe with sort of hard-to-miss message saying not to merge until next stable release. For example, the PR title could start with "[DON'T MERGE]" or "[NEXT STABLE]", and the first line of the description could read "**Do not merge until the next stable release after 3.22., which is when <link to Flutter PR> will be available.**".

I imagine this doesn't happen enough to warrant any technical investment, but—just as an idea—I think it would be really cool if we had some sort of automated mechanism for this (perhaps using GitHub labels and bots).