### PR TITLE
Correct parameter name in migration guide

### DIFF
--- a/src/content/release/breaking-changes/new-color-scheme-roles.md
+++ b/src/content/release/breaking-changes/new-color-scheme-roles.md
@@ -69,7 +69,7 @@ Code after migration:
 ```dart
 ColorScheme.fromSeed(
     seedColor: Color(0xFF0000FF), // Bright blue
-    schemeVariant: FromSeedVariant.fidelity,
+    dynamicSchemeVariant: DynamicSchemeVariant.fidelity,
 )
 ```
 

--- a/src/content/release/breaking-changes/new-color-scheme-roles.md
+++ b/src/content/release/breaking-changes/new-color-scheme-roles.md
@@ -23,7 +23,7 @@ adapting to the Material Design 3 guidelines.
 The tone-based surface colors include: 
 
 - `surfaceBright`
-- `surfaceDim`,
+- `surfaceDim`
 - `surfaceContainer`
 - `surfaceContainerLow`
 - `surfaceContainerLowest`
@@ -53,8 +53,8 @@ the new color roles should be small and acceptable.
 However, when providing a brighter seed color to `ColorScheme.fromSeed`,
 it might construct a relatively darker version of `ColorScheme`.
 To force the output to still be bright,
-set `schemeVariant: FromSeedVariant.fidelity` in `ColorScheme.fromSeed`.
-For example:
+set `dynamicSchemeVariant: DynamicSchemeVariant.fidelity` in
+`ColorScheme.fromSeed`. For example:
 
 Code before migration:
 


### PR DESCRIPTION
This PR is to correct the parameter name in the migration guide:
 * `schemeVariant` -> `dynamicSchemeVariant`
 * `FromSeedVariant ` -> `DynamicSchemeVariant `
 
 Fixes https://github.com/flutter/flutter/issues/148359

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
