### PR TITLE
Add design doc for Cupertino modal bottom sheet routes

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -292,6 +292,7 @@
       { "source": "/go/cupertino-context-menu-action", "destination": "https://docs.google.com/document/d/1lCuPyAbIzAr0c2KIEZhREC_EnkTKBxNiqP6lGLT-KpU/edit", "type": 301 },
       { "source": "/go/cupertino-datepicker-redesign", "destination": "https://docs.google.com/document/d/1Ib5ztLzc19e1Uggz16BFlrJMg1TOdYLyP-WqtTpDltM/edit?usp=sharing&resourcekey=0-11oVmOsTHLD5fqxdAHZqNg", "type": 301 },
       { "source": "/go/cupertino-increase-contrast", "destination": "https://docs.google.com/document/d/1kePVlqWvJu5Ph0RL6wgg67F3SATmsJ8QY5N0S1MvaGg/edit#", "type": 301 },
+      { "source": "/go/cupertino-bottom-sheet-routes", "destination": "https://docs.google.com/document/d/16eMliX4HsDjRmEob2lksM6JBq2_LPVM26uYGyTid1ec/edit#", "type": 301 },
       { "source": "/go/cupertino-switch-onoff-labels", "destination": "https://docs.google.com/document/d/1DD5gx8x0ej5AJzGxzpr4hpgpqsvcDu-ozKliGnhHm7c/edit#", "type": 301 },
       { "source": "/go/custom-colors-m3", "destination": "https://docs.google.com/document/d/1LbD4JqBgAfHex02oR3r2jyu9lTBBNBmyec2ovT59Kr8/edit?usp=sharing", "type": 301 },
       { "source": "/go/custom-tabs-support", "destination": "https://docs.google.com/document/d/1GvsmPQz6aKixNUphL10XmSOL7M6nOH7W1jYwNp0LwnA", "type": 301 },


### PR DESCRIPTION
Adds a go link for a design doc. Addresses[ issue/148981](https://github.com/flutter/flutter/issues/148981)

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
