### PR TITLE
Add iOS and macOS content CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,3 +15,14 @@
 
 # Covers all configuration files for the website
 /*          @sfshaza2 @atsansone @parlough @khanhnwin @domesticmouse @MaryaBelanger
+
+# Covers iOS documentation content
+**/add-to-app/ios/ @jmagman
+**/deployment/ios.md @jmagman
+**/flavors.md @jmagman
+**/flavors/
+**/platform-integration/ios/ @jmagman
+
+# Covers macOS documentation content
+**/deployment/macos.md @jmagman
+**/platform-integration/macos/ @jmagman


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Add myself as CODEOWNER for iOS- and macOS-specific docs content.

_Issues fixed by this PR (if any):_ None, follow up from conversation with @atsansone.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
