### PR TITLE
Update iOS and macOS content CODEOWNERS to include writers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,12 +17,12 @@
 /*          @sfshaza2 @atsansone @parlough @khanhnwin @domesticmouse @MaryaBelanger
 
 # Covers iOS documentation content
-**/add-to-app/ios/ @jmagman
-**/deployment/ios.md @jmagman
-**/flavors.md @jmagman
-**/flavors/
-**/platform-integration/ios/ @jmagman
+**/add-to-app/ios/ @jmagman @atsansone @parlough @sfshaza2 @domesticmouse @MaryaBelanger
+**/deployment/ios.md @jmagman @atsansone @parlough @sfshaza2 @domesticmouse @MaryaBelanger
+**/flavors.md @jmagman @atsansone @parlough @sfshaza2 @domesticmouse @MaryaBelanger
+**/flavors/ @jmagman @atsansone @parlough @sfshaza2 @domesticmouse @MaryaBelanger
+**/platform-integration/ios/ @jmagman @atsansone @parlough @sfshaza2 @domesticmouse @MaryaBelanger
 
 # Covers macOS documentation content
-**/deployment/macos.md @jmagman
-**/platform-integration/macos/ @jmagman
+**/deployment/macos.md @jmagman @atsansone @parlough @sfshaza2 @domesticmouse @MaryaBelanger
+**/platform-integration/macos/ @jmagman @atsansone @parlough @sfshaza2 @domesticmouse @MaryaBelanger


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Follow up on https://github.com/flutter/website/pull/10654#issuecomment-2130228787 to re-add tech writer ownership (which was the intention, but I misunderstood CODEOWNERs.

_Issues fixed by this PR (if any):_ N/A

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
