### PR TITLE
Prepare DartPad embed attribute specifying

### DIFF
--- a/src/_11ty/plugins/highlight.js
+++ b/src/_11ty/plugins/highlight.js
@@ -109,7 +109,7 @@ function _highlight(
     const theme = attributes['theme'] ?? 'light';
     const title = attributes['title'] ?? 'Runnable Flutter sample';
     const runAutomatically = attributes['run'] ?? 'false';
-    return `<pre><code data-dartpad="true" data-embed="true" data-theme="${theme}" data-title="${title}" data-run="${runAutomatically}">${markdown.utils.escapeHtml(content)}</code></pre>`;
+    return `<pre><code data-dartpad="true" data-embed="true" data-theme="${theme}" title="${title}" data-run="${runAutomatically}">${markdown.utils.escapeHtml(content)}</code></pre>`;
   }
 
   const showLineNumbers = 'showLineNumbers' in attributes;

--- a/src/_11ty/plugins/highlight.js
+++ b/src/_11ty/plugins/highlight.js
@@ -98,16 +98,19 @@ function _highlight(
   language,
   attributeString,
 ) {
-  // Specially handle DartPad snippets so that inject_embed can convert them.
-  if (language.includes('-dartpad')) {
-    return `<pre><code data-dartpad="true" data-embed="true" data-theme="light">${markdown.utils.escapeHtml(content)}</code></pre>`;
-  }
-
   if (language.includes('diff2html')) {
     return diff2html.html(content, {drawFileList: false});
   }
 
   const attributes = _parseAttributes(attributeString);
+
+  // Specially handle DartPad snippets so that inject_embed can convert them.
+  if (language.includes('dartpad')) {
+    const theme = attributes['theme'] ?? 'light';
+    const title = attributes['title'] ?? 'Runnable Flutter sample';
+    const runAutomatically = attributes['run'] ?? 'false';
+    return `<pre><code data-dartpad="true" data-embed="true" data-theme="${theme}" data-title="${title}" data-run="${runAutomatically}">${markdown.utils.escapeHtml(content)}</code></pre>`;
+  }
 
   const showLineNumbers = 'showLineNumbers' in attributes;
   let startingLineNumber = 0;

--- a/src/_includes/docs/implicit-animations/fade-in-complete.md
+++ b/src/_includes/docs/implicit-animations/fade-in-complete.md
@@ -1,5 +1,5 @@
 <?code-excerpt "animation/implicit/opacity5/lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-532px:ga_id-fade_in_complete
+```dartpad
 // Copyright 2019 the Dart project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file.

--- a/src/_includes/docs/implicit-animations/fade-in-starter-code.md
+++ b/src/_includes/docs/implicit-animations/fade-in-starter-code.md
@@ -1,5 +1,5 @@
 <?code-excerpt "animation/implicit/opacity1/lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-532px:ga_id-fade_in_starter_code
+```dartpad
 // Copyright 2019 the Dart project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file.

--- a/src/_includes/docs/implicit-animations/shape-shifting-complete.md
+++ b/src/_includes/docs/implicit-animations/shape-shifting-complete.md
@@ -1,5 +1,5 @@
 <?code-excerpt "animation/implicit/container5/lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px:ga_id-shape_shifting_complete
+```dartpad
 // Copyright 2019 the Dart project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file.

--- a/src/_includes/docs/implicit-animations/shape-shifting-starter-code.md
+++ b/src/_includes/docs/implicit-animations/shape-shifting-starter-code.md
@@ -1,5 +1,5 @@
 <?code-excerpt "animation/implicit/container1/lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:split-60:width-100%:height-500px:ga_id-shape_shifting_starter_code
+```dartpad
 // Copyright 2019 the Dart project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file.

--- a/src/content/cookbook/animation/animated-container.md
+++ b/src/content/cookbook/animation/animated-container.md
@@ -139,7 +139,7 @@ FloatingActionButton(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'dart:math';
 
 import 'package:flutter/material.dart';

--- a/src/content/cookbook/animation/opacity-animation.md
+++ b/src/content/cookbook/animation/opacity-animation.md
@@ -146,7 +146,7 @@ AnimatedOpacity(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/animation/page-route-animation.md
+++ b/src/content/cookbook/animation/page-route-animation.md
@@ -228,7 +228,7 @@ transitionsBuilder: (context, animation, secondaryAnimation, child) {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/animation/physics-simulation.md
+++ b/src/content/cookbook/animation/physics-simulation.md
@@ -338,7 +338,7 @@ is no longer required.
 ## Interactive Example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
 

--- a/src/content/cookbook/design/drawer.md
+++ b/src/content/cookbook/design/drawer.md
@@ -174,7 +174,7 @@ check out the [Navigation][] section of the cookbook.
 :::
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/design/orientation.md
+++ b/src/content/cookbook/design/orientation.md
@@ -76,7 +76,7 @@ use `MediaQuery.of(context).orientation` instead of an
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-500px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/design/snackbars.md
+++ b/src/content/cookbook/design/snackbars.md
@@ -100,7 +100,7 @@ see the [Gestures][] section of the cookbook.
 :::
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const SnackBarDemo());

--- a/src/content/cookbook/design/tabs.md
+++ b/src/content/cookbook/design/tabs.md
@@ -96,7 +96,7 @@ body: const TabBarView(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/design/themes.md
+++ b/src/content/cookbook/design/themes.md
@@ -188,7 +188,7 @@ To learn more, watch this short Widget of the Week video on the `Theme` widget:
 ## Try an interactive example
 
 <?code-excerpt "lib/main.dart (FullApp)"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 // Include the Google Fonts package to provide more text format options
 // https://pub.dev/packages/google_fonts

--- a/src/content/cookbook/effects/download-button.md
+++ b/src/content/cookbook/effects/download-button.md
@@ -472,7 +472,7 @@ Run the app:
 <!-- start dartpad -->
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 

--- a/src/content/cookbook/effects/drag-a-widget.md
+++ b/src/content/cookbook/effects/drag-a-widget.md
@@ -243,7 +243,7 @@ Run the app:
 <!-- Start DartPad -->
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/effects/expandable-fab.md
+++ b/src/content/cookbook/effects/expandable-fab.md
@@ -410,7 +410,7 @@ Run the app:
 <!-- start dartpad -->
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';

--- a/src/content/cookbook/effects/gradient-bubbles.md
+++ b/src/content/cookbook/effects/gradient-bubbles.md
@@ -257,7 +257,7 @@ Run the app:
 
 <!-- start dartpad -->
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'dart:math';
 import 'dart:ui' as ui;
 

--- a/src/content/cookbook/effects/nested-nav.md
+++ b/src/content/cookbook/effects/nested-nav.md
@@ -391,10 +391,8 @@ Run the app:
 * Click the **Finished** button to return to the
   first screen.
 
-<!-- Start DartPad -->
-
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 const routeHome = '/';

--- a/src/content/cookbook/effects/parallax-scrolling.md
+++ b/src/content/cookbook/effects/parallax-scrolling.md
@@ -567,10 +567,8 @@ Run the app:
 
 * Scroll up and down to observe the parallax effect.
 
-<!-- Start DartPad -->
-
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 

--- a/src/content/cookbook/effects/photo-filter-carousel.md
+++ b/src/content/cookbook/effects/photo-filter-carousel.md
@@ -504,7 +504,7 @@ You now have a draggable, tappable photo filter carousel.
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';

--- a/src/content/cookbook/effects/shimmer-loading.md
+++ b/src/content/cookbook/effects/shimmer-loading.md
@@ -577,7 +577,7 @@ on and off as the content loads.
 ## Interactive example
 
 <?code-excerpt "lib/original_example.dart" remove="code-excerpt-closing-bracket"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/effects/staggered-menu-animation.md
+++ b/src/content/cookbook/effects/staggered-menu-animation.md
@@ -375,7 +375,7 @@ pops into place.
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/effects/typing-indicator.md
+++ b/src/content/cookbook/effects/typing-indicator.md
@@ -664,7 +664,7 @@ Run the app:
 <!-- Start DartPad -->
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'dart:math';
 
 import 'package:flutter/cupertino.dart';

--- a/src/content/cookbook/forms/focus.md
+++ b/src/content/cookbook/forms/focus.md
@@ -137,7 +137,7 @@ FloatingActionButton(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/forms/retrieve-input.md
+++ b/src/content/cookbook/forms/retrieve-input.md
@@ -106,7 +106,7 @@ FloatingActionButton(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/forms/text-field-changes.md
+++ b/src/content/cookbook/forms/text-field-changes.md
@@ -160,7 +160,7 @@ void dispose() {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/forms/text-input.md
+++ b/src/content/cookbook/forms/text-input.md
@@ -62,7 +62,7 @@ TextFormField(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart" replace="/^child\: //g"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/forms/validation.md
+++ b/src/content/cookbook/forms/validation.md
@@ -163,7 +163,7 @@ rebuilds the form to display any error messages and returns `false`.
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/gestures/dismissible.md
+++ b/src/content/cookbook/gestures/dismissible.md
@@ -127,7 +127,7 @@ provide a `background` parameter to the `Dismissible`.
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/gestures/handling-taps.md
+++ b/src/content/cookbook/gestures/handling-taps.md
@@ -59,7 +59,7 @@ GestureDetector(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/gestures/ripples.md
+++ b/src/content/cookbook/gestures/ripples.md
@@ -39,7 +39,7 @@ InkWell(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/images/network-image.md
+++ b/src/content/cookbook/images/network-image.md
@@ -43,7 +43,7 @@ check out [Fade in images with a placeholder][].
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/lists/basic-list.md
+++ b/src/content/cookbook/lists/basic-list.md
@@ -42,7 +42,7 @@ ListView(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/lists/floating-app-bar.md
+++ b/src/content/cookbook/lists/floating-app-bar.md
@@ -143,7 +143,7 @@ SliverList(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/lists/grid-lists.md
+++ b/src/content/cookbook/lists/grid-lists.md
@@ -40,7 +40,7 @@ GridView.count(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/lists/horizontal-list.md
+++ b/src/content/cookbook/lists/horizontal-list.md
@@ -58,7 +58,7 @@ default drag for scrolling devices.
 :::
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/lists/long-lists.md
+++ b/src/content/cookbook/lists/long-lists.md
@@ -55,7 +55,7 @@ ListView.builder(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/lists/mixed-list.md
+++ b/src/content/cookbook/lists/mixed-list.md
@@ -122,7 +122,7 @@ ListView.builder(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/lists/spaced-items.md
+++ b/src/content/cookbook/lists/spaced-items.md
@@ -163,7 +163,7 @@ The number of items is defined by the variable `items`,
 change this value to see what happens when the items won't fit the screen.
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const SpacedItemsList());

--- a/src/content/cookbook/navigation/hero-animations.md
+++ b/src/content/cookbook/navigation/hero-animations.md
@@ -141,7 +141,7 @@ widgets, for simplicity.
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const HeroApp());

--- a/src/content/cookbook/navigation/named-routes.md
+++ b/src/content/cookbook/navigation/named-routes.md
@@ -165,7 +165,7 @@ onPressed: () {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/navigation/navigate-with-arguments.md
+++ b/src/content/cookbook/navigation/navigate-with-arguments.md
@@ -200,7 +200,7 @@ MaterialApp(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/navigation/navigation-basics.md
+++ b/src/content/cookbook/navigation/navigation-basics.md
@@ -130,7 +130,7 @@ onPressed: () {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() {
@@ -218,7 +218,7 @@ depending on your needs.
 :::
 
 <?code-excerpt "lib/main_cupertino.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/cupertino.dart';
 
 void main() {

--- a/src/content/cookbook/navigation/passing-data.md
+++ b/src/content/cookbook/navigation/passing-data.md
@@ -188,7 +188,7 @@ body: ListView.builder(
 ### Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 class Todo {

--- a/src/content/cookbook/navigation/returning-data.md
+++ b/src/content/cookbook/navigation/returning-data.md
@@ -206,7 +206,7 @@ Future<void> _navigateAndDisplaySelection(BuildContext context) async {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/navigation/set-up-app-links.md
+++ b/src/content/cookbook/navigation/set-up-app-links.md
@@ -46,7 +46,7 @@ It provides a simple API to handle complex routing scenarios.
    create a `GoRouter` object in the `main.dart` file:
 
     <?code-excerpt "lib/main.dart"?>
-    ```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+    ```dartpad run="true"
     import 'package:flutter/material.dart';
     import 'package:go_router/go_router.dart';
 

--- a/src/content/cookbook/navigation/set-up-universal-links.md
+++ b/src/content/cookbook/navigation/set-up-universal-links.md
@@ -43,7 +43,7 @@ It provides a simple API to handle complex routing scenarios.
 3. To handle the routing, create a `GoRouter` object in the `main.dart` file:
 
     <?code-excerpt "lib/main.dart"?>
-    ```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+    ```dartpad run="true"
     import 'package:flutter/material.dart';
     import 'package:go_router/go_router.dart';
 

--- a/src/content/cookbook/plugins/play-video.md
+++ b/src/content/cookbook/plugins/play-video.md
@@ -232,7 +232,7 @@ FloatingActionButton(
 ## Complete example
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-interactive_example
+```dartpad run="true"
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/src/content/get-started/codelab-web.md
+++ b/src/content/get-started/codelab-web.md
@@ -129,7 +129,7 @@ of the Flutter DevTools tooling.
 The starting app is displayed in the following DartPad.
 
 <?code-excerpt "lib/starter.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-starting_code
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const SignUpApp());
@@ -877,7 +877,7 @@ the animation works, and that clicking the
 ### Complete sample
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-starting_code
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const SignUpApp());

--- a/src/content/ui/index.md
+++ b/src/content/ui/index.md
@@ -32,7 +32,7 @@ The minimal Flutter app simply calls the [`runApp()`][]
 function with a widget:
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-310px:split-60:ga_id-starting_code
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() {
@@ -99,7 +99,7 @@ of which the following are commonly used:
 Below are some simple widgets that combine these and other widgets:
 
 <?code-excerpt "lib/main_myappbar.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 class MyAppBar extends StatelessWidget {
@@ -230,7 +230,7 @@ between screens of your application. Using the [`MaterialApp`][]
 widget is entirely optional but a good practice.
 
 <?code-excerpt "lib/main_tutorial.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() {
@@ -312,7 +312,7 @@ The first step in building an interactive application is to detect
 input gestures. See how that works by creating a simple button:
 
 <?code-excerpt "lib/main_mybutton.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 class MyButton extends StatelessWidget {
@@ -385,7 +385,7 @@ this idea. `StatefulWidgets` are special widgets that know how to generate
 Consider this basic example, using the [`ElevatedButton`][] mentioned earlier:
 
 <?code-excerpt "lib/main_counter.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 class Counter extends StatefulWidget {
@@ -476,7 +476,7 @@ The following slightly more complex example shows how
 this works in practice:
 
 <?code-excerpt "lib/main_counterdisplay.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 class CounterDisplay extends StatelessWidget {
@@ -568,7 +568,7 @@ intended purchases. Start by defining the presentation class,
 `ShoppingListItem`:
 
 <?code-excerpt "lib/main_shoppingitem.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 class Product {
@@ -672,7 +672,7 @@ built widgets and applies only the differences to the underlying
 Here's an example parent widget that stores mutable state:
 
 <?code-excerpt "lib/main_shoppinglist.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-false:width-100%:height-600px:split-60:ga_id-starting_code
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 class Product {

--- a/src/content/ui/interactivity/actions-and-shortcuts.md
+++ b/src/content/ui/interactivity/actions-and-shortcuts.md
@@ -431,7 +431,7 @@ invoke actions to accomplish their work. All the invoked actions and
 shortcuts are logged.
 
 <?code-excerpt "ui/advanced/actions_and_shortcuts/lib/copyable_text.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-starting_code
+```dartpad run="true"
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 

--- a/src/content/ui/layout/constraints.md
+++ b/src/content/ui/layout/constraints.md
@@ -166,7 +166,7 @@ Use the numbered horizontal scrolling bar to switch between
 29 different examples.
 
 <?code-excerpt "lib/main.dart"?>
-```run-dartpad:theme-light:mode-flutter:run-true:width-100%:height-600px:split-60:ga_id-starting_code
+```dartpad run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const HomePage());

--- a/tool/flutter_site/lib/src/commands/check_links.dart
+++ b/tool/flutter_site/lib/src/commands/check_links.dart
@@ -94,6 +94,7 @@ Future<int> _checkLinks({bool checkExternal = false}) async {
         ],
         stdout,
       );
+      await Future<void>.delayed(const Duration(seconds: 1));
       return result;
     } catch (e, stackTrace) {
       stderr.writeln('Error: linkcheck failed to execute properly!');
@@ -103,6 +104,7 @@ Future<int> _checkLinks({bool checkExternal = false}) async {
     }
   } finally {
     print('Shutting down Firebase hosting emulator...');
+    emulatorProcess.kill();
     emulatorProcess.kill(ProcessSignal.sigkill);
     print('Done!\n');
   }


### PR DESCRIPTION
Enables the mechanism for https://github.com/flutter/website/issues/10530 to be implemented, by adding a `title` attribute to DartPad code blocks.

````markdown
```dartpad run="true" title="The classic hello world program in Dart!"
void main() {
  print('Hello world!');
}
```

Contributes to https://github.com/flutter/website/issues/10530

@atsansone After this lands, feel free to add titles to the embedded DartPads. I'd be happy to review!

I'll follow up with similar changes for dart.dev