### PR TITLE
Flutter Gradle Plugin Apply Doc - Enhance copy code

### DIFF
--- a/src/content/release/breaking-changes/flutter-gradle-plugin-apply.md
+++ b/src/content/release/breaking-changes/flutter-gradle-plugin-apply.md
@@ -174,12 +174,12 @@ remove these 2 chunks of code that use the legacy imperative apply method:
 Now apply the plugins again, but this time using the Plugin DSL syntax. At the
 very top of your file, add:
 
-```diff
-+plugins {
-+    id "com.android.application"
-+    id "kotlin-android"
-+    id "dev.flutter.flutter-gradle-plugin"
-+}
+```groovy
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
 ```
 
 Finally, if your `dependencies` block contains a dependency on `"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"`, 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
This is a short PR, containing an enhancement to easily copy and paste a block of code when going through the [Flutter Gradle Plugin Apply](https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply) documentation.

This is how it currently looks:
<img width="727" alt="image" src="https://github.com/flutter/website/assets/10886846/d9f6f924-cc67-4043-94d8-41852b489d50">

The change made is removing the "+" signs of the _differ_ block of code and change the type to _groovy_, so when somebody copies the code, it can be paste straight away without removing those signs.

So it looks more like this code block on another part of the same document. 

<img width="719" alt="image" src="https://github.com/flutter/website/assets/10886846/4048c954-5cab-4dc0-95ec-e0340aabcae5">



_Issues fixed by this PR (if any):_

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
