### PR TITLE
Fixes Broken image link in "Who is Dash" page

### DIFF
--- a/src/content/dash/index.md
+++ b/src/content/dash/index.md
@@ -148,9 +148,7 @@ Dash 2.0 and 2.1
   <iframe width="560" height="315" src="{{site.yt.embed}}/oyy_1CjNdBU" title="Building DashCast, a Flutter-based podcast app" {{site.yt.set}}></iframe>
   <iframe width="560" height="315" src="{{site.yt.embed}}/dsiLVNDJ3t0" title="Revisiting DashCast, a Flutter-based podcast app" {{site.yt.set}}></iframe>
 
-<br>
-![Born to Hot Reload jacket](/assets/images/dash/ShamsDashJacket.png){:width="35%"}
-<br>
+   ![Born to Hot Reload jacket](/assets/images/dash/ShamsDashJacket.png){:width="35%"}
 
 [Flutter Interact]: {{site.yt.playlist}}PLjxrf2q8roU0o0wKRJTjyN0pSUA6TI8lg
 [Instagram account]: https://www.instagram.com/dash_the_dartlang_plushy/


### PR DESCRIPTION
### Description

Fixes #10667 
This PR fixes the broken image in dash page. 

Exisiting: 
<img width="1074" alt="image" src="https://github.com/flutter/website/assets/41873024/6e6066ca-9ae4-4f25-b3ea-fd479893a375">

After Fix:
<img width="1265" alt="image" src="https://github.com/flutter/website/assets/41873024/bd69d71e-4581-441f-946e-08c6d4659a4f">


## Presubmit checklist

- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
