### PR TITLE
Fixes. slash issue in uninstall page

### DIFF
--- a/src/content/get-started/uninstall/index.md
+++ b/src/content/get-started/uninstall/index.md
@@ -29,14 +29,14 @@ Select your development platform from the following tabs.
 
 {% case os %}
 {% when 'Windows' -%}
-{% assign dirinstall='C:\user\{username}\dev\' %}
+{% assign dirinstall='C:\\user\{username}\dev\' %}
 {% assign localappdata='%LOCALAPPDATA%\' %}
 {% assign appdata='%APPDATA%\' %}
 {% assign ps-localappdata='$env:LOCALAPPDATA\' %}
 {% assign ps-appdata='$env:APPDATA\' %}
 {% assign unzip='Expand-Archive' %}
-{% assign path='C:\user\{username}\dev' %}
-{% assign prompt='C:\>' %}
+{% assign path='C:\\user\{username}\dev' %}
+{% assign prompt='C:\\>' %}
 {% assign terminal='PowerShell' %}
 {% assign rm = 'Remove-Item -Recurse -Force -Path' %}
 {% capture rm-sdk %}Remove-Item -Recurse -Force -Path '{{dirinstall}}flutter'{% endcapture %}


### PR DESCRIPTION
### Description

Fixes #10690 
This PR fixes the broken slash in uninstall page. 

Existing: 
<img width="1406" alt="image" src="https://github.com/flutter/website/assets/41873024/8941aa03-1fa8-47a3-90f2-7161993474dc">


After Fix:

<img width="1332" alt="image" src="https://github.com/flutter/website/assets/41873024/3d3f65d2-9ff8-4127-a28d-adef13a9ef68">


## Presubmit checklist

- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
