### PR TITLE
Update video_player compatibility

### DIFF
--- a/src/content/cookbook/plugins/play-video.md
+++ b/src/content/cookbook/plugins/play-video.md
@@ -87,7 +87,7 @@ You must test network-hosted videos on physical iOS devices.
 
 ### MacOS
 
-If you are using network-based videos, you will need to [add the
+If you use network-based videos, [add the
 `com.apple.security.network.client`
 entitlement](https://docs.flutter.dev/platform-integration/macos/building#entitlements-and-the-app-sandbox)
 

--- a/src/content/cookbook/plugins/play-video.md
+++ b/src/content/cookbook/plugins/play-video.md
@@ -93,11 +93,16 @@ entitlement](https://docs.flutter.dev/platform-integration/macos/building#entitl
 
 ### Web
 
-> The Web platform does **not** support `dart:io`, so avoid using the `VideoPlayerController.file` constructor for the plugin. Using the constructor attempts to create a `VideoPlayerController.file` that will throw an `UnimplementedError`.
+> The Web platform does **not** support `dart:io`, so avoid using the `VideoPlayerController.file`
+> constructor for the plugin. Using the constructor attempts to create a
+> `VideoPlayerController.file` that will throw an `UnimplementedError`.
 
-\* Different web browsers may have different video-playback capabilities (supported formats, autoplay...). Check [package:video_player_web](https://pub.dev/packages/video_player_web) for more web-specific information.
+\* Different web browsers may have different video-playback capabilities (supported formats,
+autoplay...). Check [package:video_player_web](https://pub.dev/packages/video_player_web) for more
+web-specific information.
 
-The `VideoPlayerOptions.mixWithOthers` option can't be implemented in web, at least at the moment. If you use this option in web it will be silently ignored.
+The `VideoPlayerOptions.mixWithOthers` option can't be implemented in web, at least at the moment.
+If you use this option in web it will be silently ignored.
 
 ## 3. Create and initialize a `VideoPlayerController`
 

--- a/src/content/cookbook/plugins/play-video.md
+++ b/src/content/cookbook/plugins/play-video.md
@@ -85,24 +85,24 @@ The `video_player` plugin can only play asset videos in iOS simulators.
 You must test network-hosted videos on physical iOS devices.
 :::
 
-### MacOS
-
-If you use network-based videos, [add the
-`com.apple.security.network.client`
-entitlement](https://docs.flutter.dev/platform-integration/macos/building#entitlements-and-the-app-sandbox)
+### macOS
+If you use network-based videos, 
+[add the `com.apple.security.network.client` entitlement][mac-entitlement].
 
 ### Web
 
-> The Web platform does **not** support `dart:io`, so avoid using the `VideoPlayerController.file`
-> constructor for the plugin. Using the constructor attempts to create a
-> `VideoPlayerController.file` that will throw an `UnimplementedError`.
+Flutter web does **not** support `dart:io`,
+so avoid using the `VideoPlayerController.file` constructor for the plugin.
+Using this constructor attempts to create a`VideoPlayerController.file`
+that throws an `UnimplementedError`.
 
-\* Different web browsers may have different video-playback capabilities (supported formats,
-autoplay...). Check [package:video_player_web](https://pub.dev/packages/video_player_web) for more
-web-specific information.
+Different web browsers might have different video-playback capabilities,
+such as supported formats or autoplay.
+Check the [video_player_web](https://pub.dev/packages/video_player_web)
+package for more web-specific information.
 
-The `VideoPlayerOptions.mixWithOthers` option can't be implemented in web, at least at the moment.
-If you use this option in web it will be silently ignored.
+The `VideoPlayerOptions.mixWithOthers` option can't be implemented in web,
+at least at the moment. If you use this option in web it will be silently ignored.
 
 ## 3. Create and initialize a `VideoPlayerController`
 
@@ -370,3 +370,5 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
 [`play()`]: {{site.pub-api}}/video_player/latest/video_player/VideoPlayerController/play.html
 [`video_player`]: {{site.pub-pkg}}/video_player
 [`VideoPlayer`]: {{site.pub-api}}/video_player/latest/video_player/VideoPlayer-class.html
+[mac-entitlement]: platform-integration/macos/building#entitlements-and-the-app-sandbox
+[video_player_web]: {{site-pub-pkg}}/video_player_web

--- a/src/content/cookbook/plugins/play-video.md
+++ b/src/content/cookbook/plugins/play-video.md
@@ -16,7 +16,7 @@ stored on the file system, as an asset, or from the internet.
 
 :::warning
 At this time,
-the `video_player` plugin doesn't work with any desktop platform.
+the `video_player` plugin doesn't work on Linux and Windows.
 To learn more, check out the [`video_player`][] package.
 :::
 
@@ -84,6 +84,20 @@ For iOS, add the following to the `Info.plist` file found at
 The `video_player` plugin can only play asset videos in iOS simulators.
 You must test network-hosted videos on physical iOS devices.
 :::
+
+### MacOS
+
+If you are using network-based videos, you will need to [add the
+`com.apple.security.network.client`
+entitlement](https://docs.flutter.dev/platform-integration/macos/building#entitlements-and-the-app-sandbox)
+
+### Web
+
+> The Web platform does **not** support `dart:io`, so avoid using the `VideoPlayerController.file` constructor for the plugin. Using the constructor attempts to create a `VideoPlayerController.file` that will throw an `UnimplementedError`.
+
+\* Different web browsers may have different video-playback capabilities (supported formats, autoplay...). Check [package:video_player_web](https://pub.dev/packages/video_player_web) for more web-specific information.
+
+The `VideoPlayerOptions.mixWithOthers` option can't be implemented in web, at least at the moment. If you use this option in web it will be silently ignored.
 
 ## 3. Create and initialize a `VideoPlayerController`
 

--- a/src/content/cookbook/plugins/play-video.md
+++ b/src/content/cookbook/plugins/play-video.md
@@ -86,6 +86,7 @@ You must test network-hosted videos on physical iOS devices.
 :::
 
 ### macOS
+
 If you use network-based videos, 
 [add the `com.apple.security.network.client` entitlement][mac-entitlement].
 
@@ -98,8 +99,7 @@ that throws an `UnimplementedError`.
 
 Different web browsers might have different video-playback capabilities,
 such as supported formats or autoplay.
-Check the [video_player_web](https://pub.dev/packages/video_player_web)
-package for more web-specific information.
+Check the [video_player_web] package for more web-specific information.
 
 The `VideoPlayerOptions.mixWithOthers` option can't be implemented in web,
 at least at the moment. If you use this option in web it will be silently ignored.
@@ -370,5 +370,5 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
 [`play()`]: {{site.pub-api}}/video_player/latest/video_player/VideoPlayerController/play.html
 [`video_player`]: {{site.pub-pkg}}/video_player
 [`VideoPlayer`]: {{site.pub-api}}/video_player/latest/video_player/VideoPlayer-class.html
-[mac-entitlement]: platform-integration/macos/building#entitlements-and-the-app-sandbox
-[video_player_web]: {{site-pub-pkg}}/video_player_web
+[mac-entitlement]: {{site.url}}/platform-integration/macos/building#entitlements-and-the-app-sandbox
+[video_player_web]: {{site.pub-pkg}}/video_player_web


### PR DESCRIPTION
The [Changelog](https://pub.dev/packages/video_player/changelog#280) mentions that in 2.8.0 MacOS support was added.
I took hints from the [readme file](https://github.com/flutter/packages/blob/bb8c7b2bfdf557310d66f9b545fccd82eea2dd55/packages/video_player/video_player/README.md).

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
