### PR TITLE
Fix spelling mistake on restorable state

### DIFF
--- a/src/content/platform-integration/android/restore-state-android.md
+++ b/src/content/platform-integration/android/restore-state-android.md
@@ -68,7 +68,7 @@ You can enable state restoration with just a few tasks:
 
 3. If you use any Navigator API (like `push`, `pushNamed`, and so on)
    migrate to the API that has "restorable" in the name
-   (`restorablePush`, `resstorablePushNamed`, and so on)
+   (`restorablePush`, `restorablePushNamed`, and so on)
    to restore the navigation stack.
 
 Other considerations:


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

Simple spelling issue/fix that I identified while going through some of the documentation in place for the restorationScopeId piece for new apps created with the `--template=skeleton` flag.

## Presubmit checklist

- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
