### PR TITLE
Fix text alignment with respect to video

### DIFF
--- a/src/content/ui/adaptive-responsive/index.md
+++ b/src/content/ui/adaptive-responsive/index.md
@@ -71,5 +71,6 @@ You might also check out the Google I/O 2024 talk about
 this subject.
 
 <iframe width="560" height="315" src="{{site.yt.embed}}/LeKLGzpsz9I?si=9RIdY3g80eUl_YHj" title="Watch the adaptive/responsive video from Google I/O 2024" {{site.yt.set}}></iframe>
+
 How to build Adaptive UI with Flutter
 :::


### PR DESCRIPTION
Brought text below the video instead of on the right side of the video

This PR is not changing anything, only fixing this weird alignment issue

![image](https://github.com/flutter/website/assets/31812582/7d5485af-c307-4ae5-88df-06597e42e9fd)

After fix:

![image](https://github.com/flutter/website/assets/31812582/8ee100fa-bc0b-4115-83cc-c493ae2f6948)

I have not created a seperate issue for this small problem

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
