### PR TITLE
Fix special key omission on Get Started/Test Drive page

### DIFF
--- a/src/_includes/docs/install/test-drive/vscode.md
+++ b/src/_includes/docs/install/test-drive/vscode.md
@@ -9,9 +9,9 @@
 2. Open the Command Palette.
 
    Go to **View** <span aria-label="and then">></span> **Command Palette** or
-   press <kbd>{{special}}</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>.
+   press <kbd class="special-key"></kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>.
 
-3. Type `flutter`
+3. Type `flutter`.
 
 4. Select the **Flutter: New Project**.
 
@@ -46,9 +46,9 @@ hot reload at this time.
 1. Open the Command Palette.
 
    Go to **View** <span aria-label="and then">></span> **Command Palette** or
-   press <kbd>{{special}}</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>.
+   press <kbd class="special-key"></kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>.
 
-1. Type `flutter`
+1. Type `flutter`.
 
 1. Select the **Flutter: Select Device**.
 
@@ -74,3 +74,10 @@ hot reload at this time.
 [Material Components]: {{site.material}}/components
 
 </div>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    const specialKey = navigator.userAgent.includes('Mac')? 'Command' : 'Control';
+    document.querySelectorAll('.special-key').forEach((element)=>element.textContent=specialKey);
+  });
+</script>


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Command, Control key omitted on Get Started/Test Drive page

_Issues fixed by this PR (if any):_
#10720 

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
