### PR TITLE
[Future][web] Change `--web-renderer` default from `auto` to `canvaskit`

### DIFF
--- a/src/content/platform-integration/web/renderers.md
+++ b/src/content/platform-integration/web/renderers.md
@@ -21,11 +21,11 @@ your needs. The two renderers are:
 The `--web-renderer` command line option takes one of three values:
 `canvaskit`, `html`, or `auto`.
 
-* `canvaskit` (soon to be default) - always use the CanvasKit renderer
-* `auto` (default) - automatically chooses which renderer to use. This option
+* `canvaskit` (default) - always use the CanvasKit renderer
+* `html` - always use the HTML renderer
+* `auto` - automatically chooses which renderer to use. This option
     chooses the HTML renderer when the app is running in a mobile browser, and
     CanvasKit renderer when the app is running in a desktop browser.
-* `html` - always use the HTML renderer
 
 This flag can be used with the `run` or `build` subcommands. For example:
 
@@ -97,22 +97,22 @@ mobile browsers and optimizing for performance on desktop browsers.
 
 ## Examples
 
-Run in Chrome using the default renderer option (`auto`):
+Run in Chrome using the default renderer option (`canvaskit`):
 
 ```console
 flutter run -d chrome
 ```
 
-Build your app in release mode, using the default (`auto`) option:
+Build your app in release mode, using the default (`canvaskit`) option:
 
 ```console
 flutter build web --release
 ```
 
-Build your app in release mode, using just the CanvasKit renderer:
+Build your app in release mode, using the `auto` renderer option:
 
 ```console
-flutter build web --web-renderer canvaskit --release
+flutter build web --web-renderer auto --release
 ```
 
 Run your app in profile mode using the HTML renderer:


### PR DESCRIPTION
Changes the documentation of the default renderer on web. The default renderer is changing from `auto` to `canvaskit`.

The PR making the code changes: https://github.com/flutter/flutter/pull/149773
The issue: https://github.com/flutter/flutter/issues/149826

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
