### PR TITLE
Fix link to GitLab CI

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@ Hidenori Matsubayashi <Hidenori.Matsubayashi@sony.com>
 Pradumna Saraf <pradumnasaraf@gmail.com>
 Alex Li <alexv.525.li@gmail.com>
 Parker Lougheed <parlough@gmail.com>
+LinXunFeng <linxunfeng@yeah.net>

--- a/src/content/deployment/cd.md
+++ b/src/content/deployment/cd.md
@@ -318,7 +318,7 @@ information.
 [fastlane iOS beta deployment guide]: https://docs.fastlane.tools/getting-started/ios/beta-deployment/
 [Github Action in Flutter Project]: {{site.github}}/nabilnalakath/flutter-githubaction
 [GitHub Actions]: {{site.github}}/features/actions
-[GitLab]: https://docs.gitlab.com/ee/ci/README.html#doc-nav
+[GitLab]: https://docs.gitlab.com/ee/ci/
 [CircleCI]: https://circleci.com
 [Building and deploying Flutter apps with Fastlane]: https://circleci.com/blog/deploy-flutter-android
 [Match]: https://docs.fastlane.tools/actions/match/


### PR DESCRIPTION
Fix outdated GitLab CI link.

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
