### PR TITLE
Fix getOS() for all operating systems

### DIFF
--- a/src/content/assets/js/main.js
+++ b/src/content/assets/js/main.js
@@ -52,13 +52,13 @@ function getOS() {
     return 'macos';
   }
 
-  if (userAgent.indexOf('Win')) {
+  if (userAgent.indexOf('Win') !== -1) {
     // Windows
     return 'windows';
   }
 
   if ((userAgent.indexOf('Linux') !== -1 || userAgent.indexOf("X11") !== -1)
-    && userAgent.indexOf('Android') !== -1) {
+    && userAgent.indexOf('Android') === -1) {
     // Linux, but not Android
     return 'linux';
   }


### PR DESCRIPTION
In the current website getOS() returns "macos" if the user agent is on macOS or iOS and otherwise windows, since -1 is truthy, `if (userAgent.indexOf('Win'))` is always true and so "windows" is always returned. This PR fixes that behaviour as well as fixing an android check that would only return linux if the device is android, rather than the opposite.

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
