### PR TITLE
Remove Q2 survey from the banner

### DIFF
--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -2,7 +2,6 @@
   For headings use h3 elements.
 {% endcomment -%}
 <div class="site-banner site-banner--default" role="alert">
-  <a href="https://medium.com/flutter/io24-5e211f708a37">Flutter 3.22 and Dart 3.4</a> are live! Check out <a href="/release/whats-new">what's new</a> on the website.<br>
-	Help improve Flutter! Take our <a href="https://google.qualtrics.com/jfe/form/SV_2mXOpGTNRLBQLWe?Source=Website">Q2 survey</a>.
+  <a href="https://medium.com/flutter/io24-5e211f708a37">Flutter 3.22 and Dart 3.4</a> are live! Check out <a href="/release/whats-new">what's new</a> on the website.
 </div>
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Taking down the banner as the survey will be closed tomorrow. 

_Issues fixed by this PR (if any):_ NA

_PRs or commits this PR depends on (if any):_ NA

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
