### PR TITLE
Fix animation of optimized gifs

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -178,7 +178,7 @@ ${content}
     // Save in `_site/assets/images` and update links to there.
     eleventyConfig.addPlugin(eleventyImageTransformPlugin, {
       extensions: 'html',
-      formats: ['avif', 'webp', 'png', 'svg'],
+      formats: ['webp', 'png', 'svg'],
       svgShortCircuit: true,
       widths: ['auto'],
       defaultAttributes: {
@@ -187,6 +187,10 @@ ${content}
       },
       urlPath: '/assets/images/',
       outputDir: '_site/assets/images/',
+      sharpOptions: {
+        animated: true,
+        limitInputPixels: false,
+      },
     });
   } else {
     // To be more consistent with the production build,
@@ -202,6 +206,10 @@ ${content}
       },
       urlPath: '/assets/images/',
       outputDir: '_site/assets/images/',
+      sharpOptions: {
+        animated: true,
+        limitInputPixels: false,
+      },
     });
   }
 

--- a/tool/flutter_site/lib/src/commands/build.dart
+++ b/tool/flutter_site/lib/src/commands/build.dart
@@ -35,6 +35,7 @@ final class BuildSiteCommand extends Command<int> {
       const ['eleventy'],
       environment: {
         'PRODUCTION': '$productionRelease',
+        'OPTIMIZE': '$productionRelease',
       },
     );
 


### PR DESCRIPTION
Fixes https://github.com/flutter/website/issues/10734 by disabling the currently broken avif conversion.