### PR TITLE
Prevent text wrap on cookie notice button

### DIFF
--- a/src/_sass/components/_cookie-notice.scss
+++ b/src/_sass/components/_cookie-notice.scss
@@ -22,6 +22,10 @@
     padding-right: 1.5rem;
   }
 
+  button {
+    text-wrap: nowrap;
+  }
+
   &.show {
     display: block;
     animation-duration: 500ms;
@@ -41,7 +45,7 @@
     p {
       font-size: 1rem;
       line-height: 1.6;
-      margin-right: 2rem;
+      margin-right: 1.5rem;
       margin-bottom: 0;
     }
   }

--- a/src/content/assets/js/main.js
+++ b/src/content/assets/js/main.js
@@ -215,7 +215,7 @@ function initCookieNotice() {
 
   agreeBtn.addEventListener('click', (e) => {
     e.preventDefault();
-    Cookies.set(cookieKey, cookieConsentValue, { sameSite: 'strict', expires: 30 });
+    Cookies.set(cookieKey, cookieConsentValue, { sameSite: 'strict', expires: 90 });
     notice.classList.remove(activeClass);
   });
 }

--- a/tool/flutter_site/lib/src/commands/build.dart
+++ b/tool/flutter_site/lib/src/commands/build.dart
@@ -35,6 +35,7 @@ final class BuildSiteCommand extends Command<int> {
       const ['eleventy'],
       environment: {
         'PRODUCTION': '$productionRelease',
+        'OPTIMIZE': '$productionRelease',
       },
     );
 


### PR DESCRIPTION
Also expand saving of click from 30 to 90 days.

Before:

<img width="169" alt="Ok, got it button but text wrapped" src="https://github.com/flutter/website/assets/18372958/6f12d9cf-4b5f-4e85-b341-0d91b6fadbdc">
