### PR TITLE
Add scroll-margin-top to headers

### DIFF
--- a/src/_sass/components/_content.scss
+++ b/src/_sass/components/_content.scss
@@ -71,6 +71,7 @@
 
   h1, h2, h3, h4, h5, h6 {
     text-wrap: balance;
+    scroll-margin-top: 5rem;
   }
 
   .header-wrapper {


### PR DESCRIPTION
This allows headers to be visible in the viewport when navigating to them, rather than below the navbar.