### PR TITLE
Update Linux pre-req packages

### DIFF
--- a/src/_includes/docs/install/reqs/linux/software.md
+++ b/src/_includes/docs/install/reqs/linux/software.md
@@ -36,14 +36,12 @@ To develop Flutter on {{include.os}}:
 1. To develop {{include.target}} apps:
 
    {:type="a"}
-   1. Install the following prerequisite packages for Android Studio:
-      `libc6:i386`, `libncurses5:i386`, `libstdc++6:i386`, `lib32z1`, `libbz2-1.0:i386`
+   1. Install the following prerequisite packages for Android Studio.
 
       ```console
       $ sudo apt-get install \
-          libc6:i386 libncurses5:i386 \
-          libstdc++6:i386 lib32z1 \
-          libbz2-1.0:i386
+          libc6:amd64 libstdc++6:amd64 \
+          libbz2-1.0:amd64 libncurses5:amd64
       ```
 
    1. Install [Android Studio][] {{site.appmin.android_studio}} or later to debug and compile


### PR DESCRIPTION
Fixes #10696
Fixes #10729 

Per the Android Studio team in https://buganizer.corp.google.com/issues/344970814, the prerequisite packages for Android Studio are now:

* `libc6:amd64`
* `libstdc++6:amd64`
* `libbz2-1.0:amd64`
* `libncurses5:amd64`