### PR TITLE
Modified "add flutter to path"'s bash instructions to work for non-login shells.

### DIFF
--- a/src/_includes/docs/install/reqs/linux/set-path.md
+++ b/src/_includes/docs/install/reqs/linux/set-path.md
@@ -30,12 +30,13 @@ add Flutter to the `PATH` environment variable.
    ```
 
    {% if shell.name == 'shell' %}
-      <b>Note:</b><br> If the above does not work, you may be using a non-login
-      shell. In that case, add the same line to ~/.bashrc: ```console $ echo
-      'export PATH="/usr/bin/flutter/bin:$PATH"' >> ~/.bashrc ``` To ensure
-      consistency across all shell types, you can source ~/.bashrc from
-      ~/.bash_profile by adding the following to ~/.bash_profile: ``` if [ -f
-      ~/.bashrc ]; then source ~/.bashrc fi ```
+   :::note
+   If the above doesn't work, you might be using a non-login shell.
+   In that case, add the same line to ~/.bashrc: `console $ echo
+   'export PATH="/usr/bin/flutter/bin:$PATH"' >> ~/.bashrc `.
+   To ensure consistency across all shell types, source ~/.bashrc from
+   ~/.bash_profile by adding the following to ~/.bash_profile: ` if [ -f
+   ~/.bashrc ]; then source ~/.bashrc fi `.
    {% endif %}
 
    </details>

--- a/src/_includes/docs/install/reqs/linux/set-path.md
+++ b/src/_includes/docs/install/reqs/linux/set-path.md
@@ -30,14 +30,12 @@ add Flutter to the `PATH` environment variable.
    ```
 
    {% if shell.name == 'shell' %}
-      <b>Note:</b><br> If the above does not work, you may be using a non-login shell. In that case, add the same line to ~/.bashrc:
-      ```console 
-      $ echo 'export PATH="/usr/bin/flutter/bin:$PATH"' >> ~/.bashrc
-      ```
-      To ensure consistency across all shell types, you can source ~/.bashrc from ~/.bash_profile by adding the following to ~/.bash_profile:
-      ```
-      if [ -f ~/.bashrc ]; then source ~/.bashrc fi
-      ```
+      <b>Note:</b><br> If the above does not work, you may be using a non-login
+      shell. In that case, add the same line to ~/.bashrc: ```console $ echo
+      'export PATH="/usr/bin/flutter/bin:$PATH"' >> ~/.bashrc ``` To ensure
+      consistency across all shell types, you can source ~/.bashrc from
+      ~/.bash_profile by adding the following to ~/.bash_profile: ``` if [ -f
+      ~/.bashrc ]; then source ~/.bashrc fi ```
    {% endif %}
 
    </details>

--- a/src/_includes/docs/install/reqs/linux/set-path.md
+++ b/src/_includes/docs/install/reqs/linux/set-path.md
@@ -29,6 +29,17 @@ add Flutter to the `PATH` environment variable.
    $ {{shell.set-path}}
    ```
 
+   {% if shell.name == 'shell' %}
+      <b>Note:</b><br> If the above does not work, you may be using a non-login shell. In that case, add the same line to ~/.bashrc:
+      ```console 
+      $ echo 'export PATH="/usr/bin/flutter/bin:$PATH"' >> ~/.bashrc
+      ```
+      To ensure consistency across all shell types, you can source ~/.bashrc from ~/.bash_profile by adding the following to ~/.bash_profile:
+      ```
+      if [ -f ~/.bashrc ]; then source ~/.bashrc fi
+      ```
+   {% endif %}
+
    </details>
 
 {% endfor %}


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
The current bash instruction **only** works with login-shells or SSH.

_Issues fixed by this PR (if any):_
#10778 


_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
