### PR TITLE
Tiny update architectural-overview.md

### DIFF
--- a/src/content/resources/architectural-overview.md
+++ b/src/content/resources/architectural-overview.md
@@ -80,7 +80,7 @@ the primitives necessary to support all Flutter applications.
 The engine is responsible for rasterizing composited scenes
 whenever a new frame needs to be painted.
 It provides the low-level implementation of Flutter's core API,
-including graphics (through [Impeller][] on iOS and coming to Android,
+including graphics (through [Impeller][] on iOS and coming to Android and MacOS,
 and [Skia][] on other platforms) text layout,
 file and network I/O, accessibility support,
 plugin architecture, and a Dart runtime

--- a/src/content/resources/architectural-overview.md
+++ b/src/content/resources/architectural-overview.md
@@ -80,7 +80,7 @@ the primitives necessary to support all Flutter applications.
 The engine is responsible for rasterizing composited scenes
 whenever a new frame needs to be painted.
 It provides the low-level implementation of Flutter's core API,
-including graphics (through [Impeller][] on iOS and coming to Android and MacOS,
+including graphics (through [Impeller][] on iOS and coming to Android and macOS,
 and [Skia][] on other platforms) text layout,
 file and network I/O, accessibility support,
 plugin architecture, and a Dart runtime


### PR DESCRIPTION
According to https://docs.flutter.dev/perf/impeller, it seems that Flutter Impeller can be used on MacOS as experimental feature.

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
