### PR TITLE
Implement and migrate to a shortcode-controlled, tabbed interface

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -10,6 +10,7 @@ import {
   regexReplace,
   toISOString,
 } from './src/_11ty/filters.js';
+import { registerShortcodes } from './src/_11ty/shortcodes.js';
 import { markdown } from './src/_11ty/plugins/markdown.js';
 import { configureHighlighting } from './src/_11ty/plugins/highlight.js';
 
@@ -50,48 +51,7 @@ export default function (eleventyConfig) {
 
   eleventyConfig.addPlugin(EleventyRenderPlugin);
 
-  let _currentTabsTitle = '';
-  let _currentTabIsActive = false;
-
-  // TODO(parlough): Replace samplecode with something easier.
-  eleventyConfig.addShortcode('samplecode', function(tabsTitle, tabsString) {
-    _currentTabsTitle = tabsTitle.toLowerCase();
-    let tabMarkup = `<ul class="nav nav-tabs sample-code-tabs" id="${_currentTabsTitle}-language" role="tablist">`;
-
-    let activeTab = true;
-    _currentTabIsActive = true;
-
-    const tabs = tabsString.split(',').map((tab) => tab.trim());
-    tabs.forEach((tabName) => {
-      const tabId = `${_currentTabsTitle}-${tabName.toLowerCase().replaceAll("+", "-plus")}`;
-      tabMarkup += `<li class="nav-item">
-  <a class="nav-link ${activeTab ? "active" : ""}" id="${tabId}-tab" href="#${tabId}" role="tab" aria-controls="${tabId}" aria-selected="true">${tabName}</a>
-</li>`;
-      activeTab = false;
-    });
-
-    tabMarkup += `</ul><div class="tab-content">
-`;
-    return tabMarkup;
-  });
-
-  eleventyConfig.addShortcode('endsamplecode', function() {
-    return `</div>`
-  });
-
-  eleventyConfig.addPairedShortcode('sample', function(content, tabName) {
-    const tabId = `${_currentTabsTitle}-${tabName.toLowerCase().replaceAll("+", "-plus")}`;
-    const tabContent = `<div class="tab-pane ${_currentTabIsActive ? "active" : ""}" id="${tabId}" role="tabpanel" aria-labelledby="${tabId}-tab">
-
-${content}
-
-</div>
-`;
-
-    _currentTabIsActive = false;
-
-    return tabContent;
-  });
+  registerShortcodes(eleventyConfig);
 
   // TODO(parlough): Make this more generic.
   eleventyConfig.addFilter('children_pages', function (pages, pageUrl) {

--- a/src/_11ty/shortcodes.js
+++ b/src/_11ty/shortcodes.js
@@ -1,0 +1,54 @@
+import { slugify } from './utils/slugify.js';
+
+export function registerShortcodes(eleventyConfig) {
+  _setupTabs(eleventyConfig);
+}
+
+function _setupTabs(eleventyConfig) {
+  let tabs = [];
+  let currentTabId = 0;
+  let markTabAsActive = true;
+
+  eleventyConfig.addPairedShortcode('tabs', function(content, saveKey) {
+    let tabMarkup = `<div class="tabs-wrapper" ${saveKey ? `data-tab-save-key="${slugify(saveKey)}"` : ''}><ul class="nav nav-tabs" role="tablist">`;
+    let activeTab = true;
+
+    tabs.forEach((tab) => {
+      const tabName = tab.name;
+      const tabSaveId = slugify(tabName);
+      const tabId = `${tab.id}-tab`;
+      const tabPanelId = `${tabId}-panel`;
+      tabMarkup += `<li class="nav-item">
+  <a class="nav-link ${activeTab ? "active" : ""}" data-tab-save-id="${tabSaveId}" id="${tabId}" href="#${tabPanelId}" role="tab" aria-controls="${tabPanelId}" aria-selected="${activeTab ? "true" : "false"}">${tabName}</a>
+</li>`;
+      activeTab = false;
+    });
+
+    tabMarkup += '</ul><div class="tab-content">\n';
+    tabMarkup += content;
+    tabMarkup += '\n</div></div>';
+
+    // Reset shared variables.
+    tabs = [];
+    markTabAsActive = true;
+
+    return tabMarkup;
+  });
+
+  eleventyConfig.addPairedShortcode('tab', function(content, tabName) {
+    const tabIdNumber = currentTabId++;
+    tabs.push({name: tabName, id: tabIdNumber});
+    const tabId = `${tabIdNumber}-tab`;
+    const tabPanelId = `${tabId}-panel`;
+    const tabContent = `<div class="tab-pane ${markTabAsActive ? "active" : ""}" id="${tabPanelId}" role="tabpanel" aria-labelledby="${tabId}">
+
+${content}
+
+</div>
+`;
+
+    markTabAsActive = false;
+
+    return tabContent;
+  });
+}

--- a/src/_11ty/shortcodes.js
+++ b/src/_11ty/shortcodes.js
@@ -1,15 +1,19 @@
-import { slugify } from './utils/slugify.js';
+import {slugify} from './utils/slugify.js';
 
 export function registerShortcodes(eleventyConfig) {
   _setupTabs(eleventyConfig);
 }
 
 function _setupTabs(eleventyConfig) {
-  let tabs = [];
+  // Variable shared between all tabs to ensure each has a unique ID.
   let currentTabId = 0;
+
+  // Variables that are shared between the tabs within a tabs shortcode,
+  // and should be reset before returning from tabs.
+  let tabs = [];
   let markTabAsActive = true;
 
-  eleventyConfig.addPairedShortcode('tabs', function(content, saveKey) {
+  eleventyConfig.addPairedShortcode('tabs', function (content, saveKey) {
     let tabMarkup = `<div class="tabs-wrapper" ${saveKey ? `data-tab-save-key="${slugify(saveKey)}"` : ''}><ul class="nav nav-tabs" role="tablist">`;
     let activeTab = true;
 
@@ -35,7 +39,7 @@ function _setupTabs(eleventyConfig) {
     return tabMarkup;
   });
 
-  eleventyConfig.addPairedShortcode('tab', function(content, tabName) {
+  eleventyConfig.addPairedShortcode('tab', function (content, tabName) {
     const tabIdNumber = currentTabId++;
     tabs.push({name: tabName, id: tabIdNumber});
     const tabId = `${tabIdNumber}-tab`;
@@ -47,6 +51,7 @@ ${content}
 </div>
 `;
 
+    // No other tabs should be marked as active.
     markTabAsActive = false;
 
     return tabContent;

--- a/src/_includes/docs/add-to-app/android-initial-route-cached-engine.md
+++ b/src/_includes/docs/add-to-app/android-initial-route-cached-engine.md
@@ -12,8 +12,8 @@ with a custom initial route can configure their cached
 executing the Dart entrypoint. The following example
 demonstrates the use of an initial route with a cached engine:
 
-{% samplecode "cached-engine-with-initial-route", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 ```kotlin title="MyApplication.kt"
 class MyApplication : Application() {
@@ -36,8 +36,8 @@ class MyApplication : Application() {
 }
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 ```java title="MyApplication.java"
 public class MyApplication extends Application {
@@ -60,8 +60,8 @@ public class MyApplication extends Application {
 }
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 By setting the initial route of the navigation channel, the associated
 `FlutterEngine` displays the desired route upon initial execution of the

--- a/src/_includes/docs/community/china/download-urls.md
+++ b/src/_includes/docs/community/china/download-urls.md
@@ -14,11 +14,6 @@
 {% endif %}
 {% capture filepath -%}{{mainpath | replace: "opsys", plat}}{{file-format}} {% endcapture -%}
 
-
-<div id="{{id}}-dl" class="tab-pane
-  {%- if id == 'windows' %} active {% endif %}"
-  role="tabpanel" aria-labelledby="{{id}}-dl-tab">
-
 To download the {{include.ref-os}} 3.13 version of the Flutter SDK,
 you would change the original URL from:
 
@@ -31,5 +26,3 @@ to the mirror URL:
 ```console
 https://storage.flutter-io.cn/{{filepath}}
 ```
-
-</div>

--- a/src/_includes/docs/community/china/os-settings.md
+++ b/src/_includes/docs/community/china/os-settings.md
@@ -48,10 +48,6 @@ EOT
       {%- assign file-format = 'tar.xz' %}
 {% endcase %}
 
-<div id="{{id}}" class="tab-pane
-  {%- if id == 'windows' %} active {% endif %}"
-  role="tabpanel" aria-labelledby="{{id}}-tab">
-
 This procedure requires using {{shell}}.
 
 1. Open a new window in {{shell}} to prepare running scripts.
@@ -120,5 +116,3 @@ file that your preferred shell uses. This would resemble the following:
 ```console
 {{permaddexample}} 
 ```
-
-</div>

--- a/src/_includes/docs/community/china/pub-settings.md
+++ b/src/_includes/docs/community/china/pub-settings.md
@@ -1,10 +1,6 @@
 
 {% assign id =  include.os | downcase -%}
 
-<div id="{{id}}-pub" class="tab-pane
-  {%- if id == 'windows' %} active {% endif %}"
-  role="tabpanel" aria-labelledby="{{id}}-tab">
-
 1. Configure a proxy.
    To configure a proxy, check out the
    [Dart documentation on proxies]({{site.dart-site}}/tools/pub/troubleshoot#pub-get-fails-from-behind-a-corporate-firewall).
@@ -41,5 +37,3 @@
    ```
 
    {% endif %}
-
-</div>

--- a/src/_includes/docs/debug/debug-flow-android.md
+++ b/src/_includes/docs/debug/debug-flow-android.md
@@ -21,20 +21,9 @@ Running Gradle task 'bundleDebug'...                               27.1s
 ✓ Built build/app/outputs/bundle/debug/app-debug.aab.
 ```
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="vscode-to-android-studio-setup" role="tablist">
-    <li class="nav-item">
-        <a class="nav-link active" id="from-vscode-to-android-studio-tab" href="#from-vscode-to-android-studio" role="tab" aria-controls="from-vscode-to-android-studio" aria-selected="true">Start from VS Code</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="from-android-studio-to-vscode-tab" href="#from-android-studio-to-vscode" role="tab" aria-controls="from-android-studio-to-vscode" aria-selected="false">Start from Android Studio</a>
-    </li>
-</ul>
 
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-
-<div class="tab-pane active" id="from-vscode-to-android-studio" role="tabpanel" aria-labelledby="from-vscode-to-android-studio-tab">
+{% tabs %}
+{% tab "Start from VS Code" %}
 
 #### Start debugging with VS Code first {:#from-vscode-to-android-studio}
 
@@ -46,9 +35,8 @@ If you use VS Code to debug most of your code, start with this section.
 
 {% include docs/debug/debug-android-attach-process.md %}
 
-</div>
-
-<div class="tab-pane" id="from-android-studio-to-vscode" role="tabpanel" aria-labelledby="from-android-studio-to-vscode-tab">
+{% endtab %}
+{% tab "Start from Android Studio" %}
 
 #### Start debugging with Android Studio first {:#from-android-studio}
 
@@ -58,6 +46,5 @@ If you use Android Studio to debug most of your code, start with this section.
 
 {% include docs/debug/debug-android-attach-process.md %}
 
-</div>
-</div>
-{% comment %} End: Tab panes. {% endcomment -%}
+{% endtab %}
+{% endtabs %}

--- a/src/_includes/docs/debug/debug-flow-ios.md
+++ b/src/_includes/docs/debug/debug-flow-ios.md
@@ -12,20 +12,8 @@ Warning: Building for device with codesigning disabled. You will have to manuall
 Building com.example.myApp for device (ios)...
 ```
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="vscode-to-xcode-ios-setup" role="tablist">
-    <li class="nav-item">
-        <a class="nav-link active" id="from-vscode-to-xcode-ios-tab" href="#from-vscode-to-xcode-ios" role="tab" aria-controls="from-vscode-to-xcode-ios" aria-selected="true">Start from VS Code</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="from-xcode-ios-tab" href="#from-xcode-ios" role="tab" aria-controls="from-xcode-ios" aria-selected="false">Start from Xcode</a>
-    </li>
-</ul>
-
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-
-<div class="tab-pane active" id="from-vscode-to-xcode-ios" role="tabpanel" aria-labelledby="from-vscode-to-xcode-ios-tab">
+{% tabs "darwin-debug-flow" %}
+{% tab "Start from VS Code" %}
 
 #### Start debugging with VS Code first {:#vscode-ios}
 
@@ -45,9 +33,8 @@ To attach to the Flutter app in Xcode:
 1. Select **Runner**. It should be at the top of the
    **Attach to Process** menu under the **Likely Targets** heading.
 
-</div>
-
-<div class="tab-pane" id="from-xcode-ios" role="tabpanel" aria-labelledby="from-xcode-ios-tab">
+{% endtab %}
+{% tab "Start from Xcode" %}
 
 #### Start debugging with Xcode first {:#xcode-ios}
 
@@ -115,6 +102,5 @@ If you use Xcode to debug most of your code, start with this section.
     ![Alt text](/assets/images/docs/testing/debugging/vscode-ui/screens/vscode-add-attach-uri-filled.png)
 {% endcomment %}
 
-</div>
-</div>
-{% comment %} End: Tab panes. {% endcomment -%}
+{% endtab %}
+{% endtabs %}

--- a/src/_includes/docs/debug/debug-flow-macos.md
+++ b/src/_includes/docs/debug/debug-flow-macos.md
@@ -11,20 +11,8 @@ flutter build macos --debug
 Building macOS application...
 ```
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="vscode-to-xcode-macos-setup" role="tablist">
-    <li class="nav-item">
-        <a class="nav-link active" id="from-vscode-to-xcode-macos-tab" href="#from-vscode-to-xcode-macos" role="tab" aria-controls="from-vscode-to-xcode-macos" aria-selected="true">Start from VS Code</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="from-xcode-macos-tab" href="#from-xcode-macos" role="tab" aria-controls="from-xcode-macos" aria-selected="false">Start from Xcode</a>
-    </li>
-</ul>
-
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-
-<div class="tab-pane active" id="from-vscode-to-xcode-macos" role="tabpanel" aria-labelledby="from-vscode-to-xcode-macos-tab">
+{% tabs "darwin-debug-flow" %}
+{% tab "Start from VS Code" %}
 
 #### Start debugging with VS Code first {:#vscode-macos}
 
@@ -42,9 +30,8 @@ Building macOS application...
    **Runner** should be at the top of the **Attach to Process** menu
    under the **Likely Targets** heading.
 
-</div>
-
-<div class="tab-pane" id="from-xcode-macos" role="tabpanel" aria-labelledby="from-xcode-macos-tab">
+{% endtab %}
+{% tab "Start from Xcode" %}
 
 #### Start debugging with Xcode first {:#xcode-macos}
 
@@ -95,6 +82,5 @@ Building macOS application...
    ![Alt text](/assets/images/docs/testing/debugging/vscode-ui/screens/vscode-add-attach-uri-filled.png)
 {% endcomment %}
 
-</div>
-</div>
-{% comment %} End: Tab panes. {% endcomment -%}
+{% endtab %}
+{% endtabs %}

--- a/src/_includes/docs/debug/debug-flow-windows.md
+++ b/src/_includes/docs/debug/debug-flow-windows.md
@@ -12,20 +12,8 @@ Building Windows application...                                    31.4s
 √  Built build\windows\runner\Debug\my_app.exe.
 ```
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="vscode-to-vs-setup" role="tablist">
-    <li class="nav-item">
-        <a class="nav-link active" id="from-vscode-to-vs-tab" href="#from-vscode-to-vs" role="tab" aria-controls="from-vscode-to-vs" aria-selected="true">Start from VS Code</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="from-vs-to-vscode-tab" href="#from-vs-to-vscode" role="tab" aria-controls="from-vs-to-vscode" aria-selected="false">Start from Visual Studio</a>
-    </li>
-</ul>
-
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-
-<div class="tab-pane active" id="from-vscode-to-vs" role="tabpanel" aria-labelledby="from-vscode-to-vs-tab">
+{% tabs %}
+{% tab "Start from VS Code" %}
 
 #### Start debugging with VS Code first {:#vscode-windows}
 
@@ -81,9 +69,8 @@ If you use VS Code to debug most of your code, start with this section.
    ![Visual Studio debugger running and monitoring the Flutter app](/assets/images/docs/testing/debugging/native/visual-studio/debugger-active.png){:width="100%"}
 {% endcomment %}
 
-</div>
-
-<div class="tab-pane" id="from-vs-to-vscode" role="tabpanel" aria-labelledby="from-vs-to-vscode-tab">
+{% endtab %}
+{% tab "Start from Visual Studio" %}
 
 #### Start debugging with Visual Studio first
 
@@ -150,6 +137,5 @@ If you use Visual Studio to debug most of your code, start with this section.
    ![Alt text](/assets/images/docs/testing/debugging/vscode-ui/screens/vscode-add-attach-uri-filled.png)
 {% endcomment %}
 
-</div>
-</div>
-{% comment %} End: Tab panes. {% endcomment -%}
+{% endtab %}
+{% endtabs %}

--- a/src/_includes/docs/install/compiler/android.md
+++ b/src/_includes/docs/install/compiler/android.md
@@ -31,7 +31,7 @@ Otherwise, you can skip to the [next section][check-dev].
 
 [check-dev]: #check-your-development-setup
 
-{% tabs %}
+{% tabs "android-studio-experience" %}
 {% tab "First time using Android Studio" %}
 
 1. Launch **Android Studio**.
@@ -114,7 +114,7 @@ Otherwise, you can skip to the [next section][check-dev].
 
 ### Configure your target Android device
 
-{% tabs %}
+{% tabs "android-emulator-or-not" %}
 {% tab "Virtual device" %}
 
 {% include docs/install/devices/android-emulator.md devos=include.devos %}

--- a/src/_includes/docs/install/compiler/android.md
+++ b/src/_includes/docs/install/compiler/android.md
@@ -1,4 +1,3 @@
-
 ## Configure Android development
 
 {% case include.devos %}
@@ -32,23 +31,8 @@ Otherwise, you can skip to the [next section][check-dev].
 
 [check-dev]: #check-your-development-setup
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="android-studio-start" role="tablist">
-    <li class="nav-item">
-        <a class="nav-link active" id="first-start-tab" href="#first-start" role="tab" aria-controls="first-start" aria-selected="true">First time using Android Studio</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="later-start-tab" href="#later-start" role="tab" aria-controls="later-start" aria-selected="false">Current Android Studio User</a>
-    </li>
-</ul>
-
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-
-<div class="tab-pane active"
-     id="first-start"
-     role="tabpanel"
-     aria-labelledby="first-start-tab">
+{% tabs %}
+{% tab "First time using Android Studio" %}
 
 1. Launch **Android Studio**.
 
@@ -64,12 +48,8 @@ Otherwise, you can skip to the [next section][check-dev].
    * **Android SDK Platform-Tools**
    * **Android Emulator**
 
-</div>
-
-<div class="tab-pane"
-     id="later-start"
-     role="tabpanel"
-     aria-labelledby="later-start-tab">
+{% endtab %}
+{% tab "Current Android Studio User" %}
 
 1. Launch **Android Studio**.
 
@@ -129,40 +109,25 @@ Otherwise, you can skip to the [next section][check-dev].
 
    1. When the install finishes, click **Finish**.
 
-</div>
-</div>
-{% comment %} End: Tab panes. {% endcomment %}
+{% endtab %}
+{% endtabs %}
 
 ### Configure your target Android device
 
-{% comment %} Nav tabs {% endcomment %}
-<ul class="nav nav-tabs" id="android-devices-vp" role="tablist">
-    <li class="nav-item">
-        <a class="nav-link active" id="virtual-tab" href="#virtual" role="tab" aria-controls="virtual" aria-selected="true">Virtual Device</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="physical-tab" href="#physical" role="tab" aria-controls="physical" aria-selected="false">Physical Device</a>
-    </li>
-</ul>
-
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-
-<div class="tab-pane active" id="virtual" role="tabpanel" aria-labelledby="virtual-tab">
+{% tabs %}
+{% tab "Virtual device" %}
 
 {% include docs/install/devices/android-emulator.md devos=include.devos %}
 
-</div>
-
-<div class="tab-pane" id="physical" role="tabpanel" aria-labelledby="physical-tab">
+{% endtab %}
+{% tab "Physical device" %}
 
 {% include docs/install/devices/android-physical.md devos=include.devos %}
 
-</div>
-</div>
-{% comment %} End: Tab panes. {% endcomment -%}
+{% endtab %}
+{% endtabs %}
 
-{% if attempt-time == 'first' %}
+{% if include.attempt == 'first' %}
 
 ### Agree to Android licenses
 

--- a/src/_includes/docs/install/compiler/xcode.md
+++ b/src/_includes/docs/install/compiler/xcode.md
@@ -60,32 +60,18 @@ Try to keep to the current version of Xcode.
 
 With Xcode, you can run Flutter apps on an iOS device or on the simulator.
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="ios-devices-vp" role="tablist">
-    <li class="nav-item">
-        <a class="nav-link active" id="virtual-tab" href="#virtual" role="tab" aria-controls="virtual" aria-selected="true">Virtual Device</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="physical-tab" href="#physical" role="tab" aria-controls="physical" aria-selected="false">Physical Device</a>
-    </li>
-</ul>
-
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-
-<div class="tab-pane active" id="virtual" role="tabpanel" aria-labelledby="virtual-tab">
+{% tabs %}
+{% tab "Virtual device" %}
 
 {% include docs/install/devices/ios-simulator.md %}
 
-</div>
-
-<div class="tab-pane" id="physical" role="tabpanel" aria-labelledby="physical-tab">
+{% endtab %}
+{% tab "Physical device" %}
 
 {% include docs/install/devices/ios-physical.md %}
 
-</div>
-</div>
-{% comment %} End: Tab panes. {% endcomment -%}
+{% endtab %}
+{% endtabs %}
 
 {% endif %}
 

--- a/src/_includes/docs/install/compiler/xcode.md
+++ b/src/_includes/docs/install/compiler/xcode.md
@@ -60,7 +60,7 @@ Try to keep to the current version of Xcode.
 
 With Xcode, you can run Flutter apps on an iOS device or on the simulator.
 
-{% tabs %}
+{% tabs "ios-simulator-or-not" %}
 {% tab "Virtual device" %}
 
 {% include docs/install/devices/ios-simulator.md %}

--- a/src/_includes/docs/install/deprecated/ios-setup.md
+++ b/src/_includes/docs/install/deprecated/ios-setup.md
@@ -249,25 +249,8 @@ you [attached the device to your Mac](#attach).
 
 Enabling certificates varies in different versions of iOS.
 
-{% comment %} Nav tabs {% endcomment
-   -%}
-<ul class="nav nav-tabs" id="ios-versions" role="tablist">
-    <li class="nav-item">
-        <a class="nav-link" id="ios14-tab" href="#ios14" role="tab" aria-controls="ios14" aria-selected="true">iOS 14</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="ios15-tab" href="#ios15" role="tab" aria-controls="ios15" aria-selected="false">iOS 15</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link active" id="ios16-tab" href="#ios16" role="tab" aria-controls="ios16" aria-selected="false">iOS 16 or later</a>
-    </li>
-</ul>
-
-{% comment %} Tab panes {% endcomment
-   -%}
-<div class="tab-content">
-
-<div class="tab-pane" id="ios14" role="tabpanel" aria-labelledby="ios14-tab">
+{% tabs "ios-versions" %}
+{% tab "iOS 14" %}
 
 1. Open the **Settings** app on the iOS device.
 
@@ -276,9 +259,8 @@ Enabling certificates varies in different versions of iOS.
 
 1. Tap to toggle your Certificate to **Enable**
 
-</div>
-
-<div class="tab-pane" id="ios15" role="tabpanel" aria-labelledby="ios15-tab">
+{% endtab %}
+{% tab "iOS 15" %}
 
 1. Open the **Settings** app on the iOS device.
 
@@ -287,9 +269,8 @@ Enabling certificates varies in different versions of iOS.
 
 1. Tap to toggle your Certificate to **Enable**.
 
-</div>
-
-<div class="tab-pane active" id="ios16" role="tabpanel" aria-labelledby="ios16-tab">
+{% endtab %}
+{% tab "iOS 16 or later" %}
 
 1. Open the **Settings** app on the iOS device.
 
@@ -304,9 +285,8 @@ Enabling certificates varies in different versions of iOS.
 
 1. When the dialog displays, tap **Trust**.
 
-</div>
-</div>{% comment %} End: Tab panes. {% endcomment
-   -%}
+{% endtab %}
+{% endtabs %}
 
 If prompted, enter your Mac password into the
 **codesign wants to access key...** dialog and tap **Always Allow**.

--- a/src/_includes/docs/install/devices/ios-physical.md
+++ b/src/_includes/docs/install/devices/ios-physical.md
@@ -148,23 +148,8 @@ you [attached the device to your Mac](#attach).
 
 Enabling certificates varies in different versions of iOS.
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="ios-versions" role="tablist">
-    <li class="nav-item">
-        <a class="nav-link" id="ios14-tab" href="#ios14" role="tab" aria-controls="ios14" aria-selected="true">iOS 14</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="ios15-tab" href="#ios15" role="tab" aria-controls="ios15" aria-selected="false">iOS 15</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link active" id="ios16-tab" href="#ios16" role="tab" aria-controls="ios16" aria-selected="false">iOS 16 or later</a>
-    </li>
-</ul>
-
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-
-<div class="tab-pane" id="ios14" role="tabpanel" aria-labelledby="ios14-tab">
+{% tabs "ios-versions" %}
+{% tab "iOS 14" %}
 
 1. Open the **Settings** app on the iOS device.
 
@@ -173,9 +158,8 @@ Enabling certificates varies in different versions of iOS.
 
 1. Tap to toggle your Certificate to **Enable**
 
-</div>
-
-<div class="tab-pane" id="ios15" role="tabpanel" aria-labelledby="ios15-tab">
+{% endtab %}
+{% tab "iOS 15" %}
 
 1. Open the **Settings** app on the iOS device.
 
@@ -184,9 +168,8 @@ Enabling certificates varies in different versions of iOS.
 
 1. Tap to toggle your Certificate to **Enable**.
 
-</div>
-
-<div class="tab-pane active" id="ios16" role="tabpanel" aria-labelledby="ios16-tab">
+{% endtab %}
+{% tab "iOS 16 or later" %}
 
 1. Open the **Settings** app on the iOS device.
 
@@ -206,9 +189,8 @@ Enabling certificates varies in different versions of iOS.
 
 1. When the dialog displays, tap **Trust**.
 
-</div>
-</div>
-{% comment %} End: Tab panes. {% endcomment %}
+{% endtab %}
+{% endtabs %}
 
 If the **codesign wants to access key...** dialog displays:
 

--- a/src/_includes/docs/install/flutter-sdk.md
+++ b/src/_includes/docs/install/flutter-sdk.md
@@ -12,7 +12,7 @@
 To install the Flutter SDK, you can use the VS Code Flutter extension
 or download and install the Flutter bundle yourself.
 
-{% tabs %}
+{% tabs "vs-code-or-download" %}
 {% tab "Use VS Code to install" %}
 
 {% include docs/install/flutter/vscode.md os=include.os terminal=include.terminal target=v-target %}

--- a/src/_includes/docs/install/flutter-sdk.md
+++ b/src/_includes/docs/install/flutter-sdk.md
@@ -12,31 +12,15 @@
 To install the Flutter SDK, you can use the VS Code Flutter extension
 or download and install the Flutter bundle yourself.
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="flutter-install" role="tablist">
-    <li class="nav-item">
-        <a class="nav-link active" id="vscode-tab" href="#vscode" role="tab" aria-controls="vscode" aria-selected="true">Use VS Code to install</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="download-tab" href="#download" role="tab" aria-controls="download" aria-selected="false">Download and install</a>
-    </li>
-</ul>
-
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-
-<div class="tab-pane active" id="vscode" role="tabpanel" aria-labelledby="vscode-tab">
+{% tabs %}
+{% tab "Use VS Code to install" %}
 
 {% include docs/install/flutter/vscode.md os=include.os terminal=include.terminal target=v-target %}
 
-</div>
+{% endtab %}
+{% tab "Download and install" %}
 
-<div class="tab-pane" id="download" role="tabpanel" aria-labelledby="download-tab">
+{% include docs/install/flutter/download.md os=include.os terminal=include.terminal target=v-target %}
 
-{% include docs/install/flutter/download.md os=include.os terminal=include.terminal target=v-target%}
-
-</div>
-</div>
-
-{% comment %} End: Tab panes. {% endcomment -%}
-
+{% endtab %}
+{% endtabs %}

--- a/src/_includes/docs/release/archive-release_os.md
+++ b/src/_includes/docs/release/archive-release_os.md
@@ -1,10 +1,6 @@
 {% assign id =  include.os | downcase -%}
 {% assign channels =  'stable beta' | split: ' ' -%}
 
-<div id="{{id}}" class="tab-pane
-  {%- if id == 'windows' %} active {% endif %}"
-  role="tabpanel" aria-labelledby="{{id}}-tab">
-
 {% for channel in channels -%}
 
 ## {{channel | capitalize }} channel ({{include.os}})
@@ -19,5 +15,3 @@ Select from the following scrollable list:
 </div>
 
 {% endfor -%}
-
-</div>

--- a/src/content/add-to-app/android/_initial-route-cached-engine.md
+++ b/src/content/add-to-app/android/_initial-route-cached-engine.md
@@ -12,8 +12,8 @@ with a custom initial route can configure their cached
 executing the Dart entrypoint. The following example
 demonstrates the use of an initial route with a cached engine:
 
-{% samplecode "cached-engine-with-initial-route", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 ```kotlin title="MyApplication.kt"
 class MyApplication : Application() {
@@ -36,8 +36,8 @@ class MyApplication : Application() {
 }
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 ```java title="MyApplication.java"
 public class MyApplication extends Application {
@@ -60,8 +60,8 @@ public class MyApplication extends Application {
 }
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 By setting the initial route of the navigation channel, the associated
 `FlutterEngine` displays the desired route upon initial execution of the

--- a/src/content/add-to-app/android/add-flutter-fragment.md
+++ b/src/content/add-to-app/android/add-flutter-fragment.md
@@ -45,8 +45,8 @@ To add a `FlutterFragment` to a host `Activity`, instantiate and
 attach an instance of `FlutterFragment` in `onCreate()` within the
 `Activity`, or at another time that works for your app:
 
-{% samplecode "add-fragment", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 ```kotlin title="MyActivity.kt"
 class MyActivity : FragmentActivity() {
@@ -94,8 +94,8 @@ class MyActivity : FragmentActivity() {
 }
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 ```java title="MyActivity.java"
 public class MyActivity extends FragmentActivity {
@@ -142,8 +142,8 @@ public class MyActivity extends FragmentActivity {
 }
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 The previous code is sufficient to render a Flutter UI
 that begins with a call to your `main()` Dart entrypoint,
@@ -153,8 +153,8 @@ Flutter behavior. Flutter depends on various OS signals that
 must  be forwarded from your host `Activity` to `FlutterFragment`.
 These calls are shown in the following example:
 
-{% samplecode "forward-activity-calls", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 ```kotlin title="MyActivity.kt"
 class MyActivity : FragmentActivity() {
@@ -207,8 +207,8 @@ class MyActivity : FragmentActivity() {
 }
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 ```java title="MyActivity.java"
 public class MyActivity extends FragmentActivity {
@@ -268,8 +268,8 @@ public class MyActivity extends FragmentActivity {
 }
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 With the OS signals forwarded to Flutter,
 your `FlutterFragment` works as expected.
@@ -294,8 +294,8 @@ To use a pre-warmed `FlutterEngine` in a `FlutterFragment`,
 instantiate a `FlutterFragment` with the `withCachedEngine()`
 factory method.  
 
-{% samplecode "use-prewarmed-engine", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 ```kotlin title="MyApplication.kt"
 // Somewhere in your app, before your FlutterFragment is needed,
@@ -318,8 +318,8 @@ FlutterEngineCache
 FlutterFragment.withCachedEngine("my_engine_id").build()
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 ```java title="MyApplication.java"
 // Somewhere in your app, before your FlutterFragment is needed,
@@ -342,8 +342,8 @@ FlutterEngineCache
 FlutterFragment.withCachedEngine("my_engine_id").build();
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 `FlutterFragment` internally knows about [`FlutterEngineCache`][]
 and retrieves the pre-warmed `FlutterEngine` based on the ID
@@ -377,8 +377,8 @@ initial routes (routes other than `/`).
 To facilitate this, `FlutterFragment`'s `Builder`
 allows you to specify a desired initial route, as shown:
 
-{% samplecode "launch-with-initial-route", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 ```kotlin title="MyActivity.kt"
 // With a new FlutterEngine.
@@ -387,8 +387,8 @@ val flutterFragment = FlutterFragment.withNewEngine()
     .build()
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 ```java title="MyActivity.java"
 // With a new FlutterEngine.
@@ -397,8 +397,8 @@ FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
     .build();
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 :::note
 `FlutterFragment`'s initial route property has no effect when a pre-warmed
@@ -418,8 +418,8 @@ Dart entrypoint: `main()`, but you can define other entrypoints.
 Dart entrypoint to execute for the given Flutter experience.
 To specify an entrypoint, build `FlutterFragment`, as shown:
 
-{% samplecode "launch-with-custom-entrypoint", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 ```kotlin title="MyActivity.kt"
 val flutterFragment = FlutterFragment.withNewEngine()
@@ -427,8 +427,8 @@ val flutterFragment = FlutterFragment.withNewEngine()
     .build()
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 ```java title="MyActivity.java"
 FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
@@ -436,8 +436,8 @@ FlutterFragment flutterFragment = FlutterFragment.withNewEngine()
     .build();
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 The `FlutterFragment` configuration results in the execution
 of a Dart entrypoint called `mySpecialEntrypoint()`.
@@ -469,8 +469,8 @@ then you need to use `TextureView` instead of `SurfaceView`.
 Select a `TextureView` by building a `FlutterFragment` with a
 `texture` `RenderMode`:
 
-{% samplecode "launch-with-rendermode", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 ```kotlin title="MyActivity.kt"
 // With a new FlutterEngine.
@@ -484,8 +484,8 @@ val flutterFragment = FlutterFragment.withCachedEngine("my_engine_id")
     .build()
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 ```java title="MyActivity.java"
 // With a new FlutterEngine.
@@ -499,8 +499,8 @@ FlutterFragment flutterFragment = FlutterFragment.withCachedEngine("my_engine_id
     .build();
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 Using the configuration shown, the resulting `FlutterFragment`
 renders its UI to a `TextureView`.
@@ -537,8 +537,8 @@ for information about controlling the `RenderMode`.
 To enable transparency for a `FlutterFragment`,
 build it with the following configuration:
 
-{% samplecode "launch-with-transparency", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 ```kotlin title="MyActivity.kt"
 // Using a new FlutterEngine.
@@ -552,8 +552,8 @@ val flutterFragment = FlutterFragment.withCachedEngine("my_engine_id")
     .build()
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 ```java title="MyActivity.java"
 // Using a new FlutterEngine.
@@ -567,8 +567,8 @@ FlutterFragment flutterFragment = FlutterFragment.withCachedEngine("my_engine_id
     .build();
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 ## The relationship between `FlutterFragment` and its `Activity`
 
@@ -601,8 +601,8 @@ prevent Flutter from controlling the `Activity`'s system UI,
 use the `shouldAttachEngineToActivity()` method in
 `FlutterFragment`'s `Builder`, as shown:
 
-{% samplecode "attach-to-activity", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 ```kotlin title="MyActivity.kt"
 // Using a new FlutterEngine.
@@ -616,8 +616,8 @@ val flutterFragment = FlutterFragment.withCachedEngine("my_engine_id")
     .build()
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 ```java title="MyActivity.java"
 // Using a new FlutterEngine.
@@ -631,8 +631,8 @@ FlutterFragment flutterFragment = FlutterFragment.withCachedEngine("my_engine_id
     .build();
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 Passing `false` to the `shouldAttachEngineToActivity()`
 `Builder` method prevents Flutter from interacting with

--- a/src/content/add-to-app/android/add-flutter-screen.md
+++ b/src/content/add-to-app/android/add-flutter-screen.md
@@ -55,8 +55,8 @@ import io.flutter.embedding.android.FlutterActivity;
 ```
 :::
 
-{% samplecode "default-activity-launch", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 ```kotlin title="ExistingActivity.kt"
 myButton.setOnClickListener {
@@ -66,8 +66,8 @@ myButton.setOnClickListener {
 }
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 ```java title="ExistingActivity.java"
 myButton.setOnClickListener(new OnClickListener() {
@@ -80,8 +80,8 @@ myButton.setOnClickListener(new OnClickListener() {
 });
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 The previous example assumes that your Dart entrypoint
 is called `main()`, and your initial Flutter route is '/'.
@@ -91,8 +91,8 @@ The following example demonstrates how to launch a
 `FlutterActivity` that initially renders a custom
 route in Flutter.
 
-{% samplecode "custom-activity-launch", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 ```kotlin title="ExistingActivity.kt"
 myButton.setOnClickListener {
@@ -105,8 +105,8 @@ myButton.setOnClickListener {
 }
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 ```java title="ExistingActivity.java"
 myButton.addOnClickListener(new OnClickListener() {
@@ -122,8 +122,8 @@ myButton.addOnClickListener(new OnClickListener() {
 });
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 Replace `"/my_route"` with your desired initial route.
 
@@ -151,8 +151,8 @@ location in your app to instantiate a `FlutterEngine`.
 The following example arbitrarily pre-warms a
 `FlutterEngine` in the `Application` class:
 
-{% samplecode "prewarm-engine", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 ```kotlin title="MyApplication.kt"
 class MyApplication : Application() {
@@ -177,8 +177,8 @@ class MyApplication : Application() {
 }
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 ```java title="MyApplication.java"
 public class MyApplication extends Application {
@@ -203,8 +203,8 @@ public class MyApplication extends Application {
 }
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 The ID passed to the [`FlutterEngineCache`][] can be whatever you want.
 Make sure that you pass the same ID to any `FlutterActivity`
@@ -232,8 +232,8 @@ to instruct your `FlutterActivity` to use the cached
 To accomplish this, use `FlutterActivity`'s `withCachedEngine()`
 builder:
 
-{% samplecode "cached-engine-activity-launch", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 ```kotlin title="ExistingActivity.kt"
 myButton.setOnClickListener {
@@ -245,8 +245,8 @@ myButton.setOnClickListener {
 }
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 ```java title="ExistingActivity.java"
 myButton.addOnClickListener(new OnClickListener() {
@@ -261,8 +261,8 @@ myButton.addOnClickListener(new OnClickListener() {
 });
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 When using the `withCachedEngine()` factory method,
 pass the same ID that you used when caching the desired
@@ -353,8 +353,8 @@ with explicit transparency support.
 To launch your `FlutterActivity` with a transparent background,
 pass the appropriate `BackgroundMode` to the `IntentBuilder`:
 
-{% samplecode "transparent-activity-launch", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 ```kotlin title="ExistingActivity.kt"
 // Using a new FlutterEngine.
@@ -374,8 +374,8 @@ startActivity(
 );
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 ```java title="ExistingActivity.java"
 // Using a new FlutterEngine.
@@ -395,8 +395,8 @@ startActivity(
 );
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 You now have a `FlutterActivity` with a transparent background.
 

--- a/src/content/add-to-app/android/project-setup.md
+++ b/src/content/add-to-app/android/project-setup.md
@@ -41,20 +41,8 @@ the Flutter module still runs correctly.
 
 ## Integrate your Flutter module
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="add-to-app-android" role="tablist">
-    <li class="nav-item">
-        <a class="nav-link active" id="with-android-studio-tab" href="#with-android-studio" role="tab" aria-controls="with-android-studio" aria-selected="true">With Android Studio</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="without-android-studio-tab" href="#without-android-studio" role="tab" aria-controls="without-android-studio" aria-selected="false">Without Android Studio</a>
-    </li>
-</ul>
-
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-
-<div class="tab-pane active" id="with-android-studio" role="tabpanel" aria-labelledby="with-android-studio-tab">
+{% tabs %}
+{% tab "With Android Studio" %}
 
 ### Integrate with Android Studio {:.no_toc}
 
@@ -102,9 +90,8 @@ set your Project pane to display **Project Files**.
 This shows all files without filtering.
 :::
 
-</div>
-
-<div class="tab-pane" id="without-android-studio" role="tabpanel" aria-labelledby="without-android-studio-tab">
+{% endtab %}
+{% tab "Without Android Studio" %}
 
 ### Integrate without Android Studio {:.no_toc}
 
@@ -204,9 +191,8 @@ host Android app, make the following changes.
    }
    ```
 
-</div>
-</div>
-{% comment %} End: Tab panes. {% endcomment -%}
+{% endtab %}
+{% endtabs %}
 
 ## Add the Flutter module as a dependency
 
@@ -225,20 +211,8 @@ existing app in Gradle. You can achieve this in two ways.
     one-click build process, but requires the Flutter SDK.
     This is the mechanism used by the Android Studio IDE plugin.
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="add-to-app-android-deps" role="tablist">
-    <li class="nav-item">
-        <a class="nav-link active" id="android-archive-tab" href="#android-archive" role="tab" aria-controls="android-archive" aria-selected="true">Android Archive</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="module-source-tab" href="#module-source" role="tab" aria-controls="module-source" aria-selected="false">Module source code</a>
-    </li>
-</ul>
-
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-
-<div class="tab-pane active" id="android-archive" role="tabpanel" aria-labelledby="android-archive-tab">
+{% tabs %}
+{% tab "Android Archive" %}
 
 ### Depend on the Android Archive (AAR) {:.no_toc}
 
@@ -379,9 +353,8 @@ the `Build > Flutter > Build AAR` menu.
 {% render docs/app-figure.md, image:"development/add-to-app/android/project-setup/ide-build-aar.png" %}
 :::
 
-</div>
-
-<div class="tab-pane" id="module-source" role="tabpanel" aria-labelledby="module-source-tab">
+{% endtab %}
+{% tab "Module source code" %}
 
 ### Depend on the module's source code {:.no_toc}
 
@@ -427,9 +400,8 @@ dependencies {
 }
 ```
 
-</div>
-</div>
-{% comment %} End: Tab panes. {% endcomment -%}
+{% endtab %}
+{% endtabs %}
 
 Your app now includes the Flutter module as a dependency.
 

--- a/src/content/add-to-app/ios/add-flutter-screen.md
+++ b/src/content/add-to-app/ios/add-flutter-screen.md
@@ -39,8 +39,8 @@ trade-offs of pre-warming an engine.
 
 Where you create a `FlutterEngine` depends on your host app.
 
-{% samplecode "engine", "SwiftUI,UIKit-Swift,UIKit-ObjC" %}
-{% sample "SwiftUI" %}
+{% tabs "darwin-framework" %}
+{% tab "SwiftUI" %}
 
 In this example, we create a `FlutterEngine` object inside a SwiftUI `ObservableObject`. 
 We then pass this `FlutterEngine` into a `ContentView` using the 
@@ -74,8 +74,8 @@ struct MyApp: App {
 }
 ```
 
-{% endsample %}
-{% sample "UIKit-Swift" %}
+{% endtab %}
+{% tab "UIKit-Swift" %}
 
 As an example, we demonstrate creating a
 `FlutterEngine`, exposed as a property, on app startup in
@@ -101,8 +101,8 @@ class AppDelegate: FlutterAppDelegate { // More on the FlutterAppDelegate.
 }
 ```
 
-{% endsample %}
-{% sample "UIKit-ObjC" %}
+{% endtab %}
+{% tab "UIKit-ObjC" %}
 
 In this example, we create a `FlutterEngine` 
 object inside a SwiftUI `ObservableObject`. 
@@ -139,13 +139,13 @@ We then pass this `FlutterEngine` into a
 @end
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 ### Show a FlutterViewController with your FlutterEngine
 
-{% samplecode "vc", "SwiftUI,UIKit-Swift,UIKit-ObjC" %}
-{% sample "SwiftUI" %}
+{% tabs "darwin-framework" %}
+{% tab "SwiftUI" %}
 
 The following example shows a generic `ContentView` with a
 `Button` hooked to present a [`FlutterViewController`][].
@@ -190,8 +190,8 @@ func showFlutter() {
 }
 ```
 
-{% endsample %}
-{% sample "UIKit-Swift" %}
+{% endtab %}
+{% tab "UIKit-Swift" %}
 
 The following example shows a generic `ViewController` with a
 `UIButton` hooked to present a [`FlutterViewController`][].
@@ -224,8 +224,8 @@ class ViewController: UIViewController {
 }
 ```
 
-{% endsample %}
-{% sample "UIKit-ObjC" %}
+{% endtab %}
+{% tab "UIKit-ObjC" %}
 
 The following example shows a generic `ViewController` with a
 `UIButton` hooked to present a [`FlutterViewController`][].
@@ -262,8 +262,8 @@ created in the `AppDelegate`.
 @end
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 Now, you have a Flutter screen embedded in your iOS app.
 
@@ -292,8 +292,8 @@ To let the `FlutterViewController` present without an existing
 `FlutterEngine`, omit the `FlutterEngine` construction, and create the
 `FlutterViewController` without an engine reference.
 
-{% samplecode "no-engine-vc", "SwiftUI,UIKit-Swift,UIKit-ObjC" %}
-{% sample "SwiftUI" %}
+{% tabs "darwin-framework" %}
+{% tab "SwiftUI" %}
 
 ```swift
 import SwiftUI
@@ -328,8 +328,8 @@ func openFlutterApp() {
 }
 ```
 
-{% endsample %}
-{% sample "UIKit-Swift" %}
+{% endtab %}
+{% tab "UIKit-Swift" %}
 
 ```swift title="ViewController.swift"
 // Existing code omitted.
@@ -339,8 +339,8 @@ func showFlutter() {
 }
 ```
 
-{% endsample %}
-{% sample "UIKit-ObjC" %}
+{% endtab %}
+{% tab "UIKit-ObjC" %}
 
 ```objc title="ViewController.m"
 // Existing code omitted.
@@ -352,8 +352,8 @@ func showFlutter() {
 @end
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 See [Loading sequence and performance][]
 for more explorations on latency and memory usage.
@@ -458,8 +458,8 @@ Otherwise, plugins that depend on these events might have undefined behavior.
 
 For instance:
 
-{% samplecode "app-delegate", "Swift,Objective-C" %}
-{% sample "Swift" %}
+{% tabs "darwin-language" %}
+{% tab "Swift" %}
 
 ```swift title="AppDelegate.swift"
 import Foundation
@@ -519,8 +519,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FlutterAppLifeCycleProvid
 }
 ```
 
-{% endsample %}
-{% sample "Objective-C" %}
+{% endtab %}
+{% tab "Objective-C" %}
 
 ```objc title="AppDelegate.h"
 @import Flutter;
@@ -635,8 +635,8 @@ performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))comp
 @end
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 ## Launch options
 
@@ -674,22 +674,22 @@ function in a specific file.
 For instance the following runs `myOtherEntrypoint()`
 in `lib/other_file.dart` instead of `main()` in `lib/main.dart`:
 
-{% samplecode "entrypoint-library", "Swift,Objective-C" %}
-{% sample "Swift" %}
+{% tabs "darwin-language" %}
+{% tab "Swift" %}
 
 ```swift
 flutterEngine.run(withEntrypoint: "myOtherEntrypoint", libraryURI: "other_file.dart")
 ```
 
-{% endsample %}
-{% sample "Objective-C" %}
+{% endtab %}
+{% tab "Objective-C" %}
 
 ```objc
 [flutterEngine runWithEntrypoint:@"myOtherEntrypoint" libraryURI:@"other_file.dart"];
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 
 ### Route
@@ -698,8 +698,8 @@ Starting in Flutter version 1.22, an initial route can be set for your Flutter
 [`WidgetsApp`][] when constructing the FlutterEngine or the
 FlutterViewController.
 
-{% samplecode "initial-route", "Swift,Objective-C" %}
-{% sample "Swift" %}
+{% tabs "darwin-language" %}
+{% tab "Swift" %}
 
 ```swift
 let flutterEngine = FlutterEngine()
@@ -708,8 +708,8 @@ engine.run(
   withEntrypoint: "main", initialRoute: "/onboarding")
 ```
 
-{% endsample %}
-{% sample "Objective-C" %}
+{% endtab %}
+{% tab "Objective-C" %}
 
 ```objc
 FlutterEngine *flutterEngine = [[FlutterEngine alloc] init];
@@ -718,8 +718,8 @@ FlutterEngine *flutterEngine = [[FlutterEngine alloc] init];
                     initialRoute:@"/onboarding"];
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 This code sets your `dart:ui`'s [`PlatformDispatcher.defaultRouteName`][]
 to `"/onboarding"` instead of `"/"`.
@@ -727,16 +727,16 @@ to `"/onboarding"` instead of `"/"`.
 Alternatively, to construct a FlutterViewController directly without pre-warming
 a FlutterEngine:
 
-{% samplecode "initial-route-without-pre-warming", "Swift,Objective-C" %}
-{% sample "Swift" %}
+{% tabs "darwin-language" %}
+{% tab "Swift" %}
 
 ```swift
 let flutterViewController = FlutterViewController(
       project: nil, initialRoute: "/onboarding", nibName: nil, bundle: nil)
 ```
 
-{% endsample %}
-{% sample "Objective-C" %}
+{% endtab %}
+{% tab "Objective-C" %}
 
 ```objc
 FlutterViewController* flutterViewController =
@@ -746,8 +746,8 @@ FlutterViewController* flutterViewController =
                                               bundle:nil];
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 :::tip
 In order to imperatively change your current Flutter

--- a/src/content/add-to-app/ios/project-setup.md
+++ b/src/content/add-to-app/ios/project-setup.md
@@ -117,41 +117,24 @@ To use Flutter debugging features such as hot reload,
 consult [Debugging your add-to-app module][].
 :::
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="ios-project-setup" role="tablist">
-    <li class="nav-item">
-        <a class="nav-link active" id="embed-using-cocoapods-tab" href="#embed-using-cocoapods" role="tab" aria-controls="embed-using-cocoapods" aria-selected="true">Use CocoaPods</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="embed-using-frameworks-tab" href="#embed-using-frameworks" role="tab" aria-controls="embed-using-frameworks" aria-selected="false">Use frameworks</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="embed-using-both-tab" href="#embed-using-both" role="tab" aria-controls="embed-using-both" aria-selected="false">Use frameworks and CocoaPods</a>
-    </li>
-</ul>
+{% tabs %}
+{% tab "Use CocoaPods" %}
 
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
+{% render docs/add-to-app/ios-project/embed-cocoapods.md, yt-embed: site.yt.embed, yt-set: site.yt.set, yt-watch: site.yt.watch  %}
 
-<div class="tab-pane active" id="embed-using-cocoapods" role="tabpanel" aria-labelledby="embed-using-cocoapods-tab">
-
-{% render docs/add-to-app/ios-project/embed-cocoapods.md, yt-embed:
-site.yt.embed, yt-set: site.yt.set, yt-watch: site.yt.watch  %}
-
-</div>
-
-<div class="tab-pane" id="embed-using-frameworks" role="tabpanel" aria-labelledby="embed-using-frameworks-tab">
+{% endtab %}
+{% tab "Use frameworks" %}
 
 {% render docs/add-to-app/ios-project/embed-frameworks.md %}
 
-</div>
-<div class="tab-pane" id="embed-using-both" role="tabpanel" aria-labelledby="embed-using-both-tab">
+{% endtab %}
+{% tab "Use frameworks and CocoaPods" %}
 
 {% render docs/add-to-app/ios-project/embed-split.md %}
 
-</div>
-</div>
-{% comment %} End: Tab panes. {% endcomment %}
+{% endtab %}
+{% endtabs %}
+
 
 ## Set local network privacy permissions
 

--- a/src/content/assets/js/archive.js
+++ b/src/content/assets/js/archive.js
@@ -298,7 +298,7 @@ function getProvenanceLink(os, release, date, channel) {
 
 // Send requests to render the tables.
 document.addEventListener("DOMContentLoaded", function(_) {
-  const foundSdkArchivesElement = document.getElementById('sdk-archives') !== null;
+  const foundSdkArchivesElement = document.querySelector('.tabs-wrapper[data-tab-save-key="os-archive-tabs"]') !== null;
   if (foundSdkArchivesElement) {
     fetchFlutterReleases('windows', updateTable, updateTableFailed);
     fetchFlutterReleases('macos', updateTable, updateTableFailed);

--- a/src/content/assets/js/main.js
+++ b/src/content/assets/js/main.js
@@ -7,38 +7,8 @@ document.addEventListener("DOMContentLoaded", function(_) {
   setupCopyButtons();
 
   setupSearch();
-
-  setupTabs($('#os-archive-tabs'), 'dev.flutter.tab-os', _getOSForArchive);
-  setupTabs($('#editor-setup'), 'io.flutter.tool-id');
-  setupTabs($('.sample-code-tabs'), 'io.flutter.tool-id');
-  setupTabs($('#vscode-to-xcode-ios-setup'), 'dev.flutter.debug.vscode-to-xcode-ios');
-  setupTabs($('#vscode-to-xcode-macos-setup'), 'dev.flutter.debug.vscode-to-xcode-macos');
-  setupTabs($('#vscode-to-android-studio-setup'), 'dev.flutter.debug.vscode-to-as');
-  setupTabs($('#vscode-to-vs-setup'), 'dev.flutter.debug.vscode-to-vs');
-  setupTabs($('#add-to-app-android'), 'dev.flutter.add-to-app.android');
-  setupTabs($('#add-to-app-android-deps'), 'dev.flutter.add-to-app.android.deps');
-  setupTabs($('#ios-versions'), 'dev.flutter.ios-versions');
-  setupTabs($('#android-devices-vp'), 'dev.flutter.install.android-devices-vp');
-  setupTabs($('#android-studio-start'), 'dev.flutter.install.android-studio-start');
-  setupTabs($('#flutter-install'), 'dev.flutter.install.options');
-  setupTabs($('#ios-devices-vp'), 'dev.flutter.install.ios-devices-vp');
-  setupTabs($('#china-os-tabs'), 'dev.flutter.china-os');
-  setupTabs($('#china-os-dl-tabs'), 'dev.flutter.china-os-dl');
-  setupTabs($('#china-os-pub-tabs'), 'dev.flutter.china-os-pub');
-  setupTabs($('#base-os-tabs'), 'dev.flutter.os');
-  setupTabs($('#xcode-ide-vs-ui'), 'dev.flutter.xcode-ux');
-  setupTabs($('#ios-project-setup'), 'dev.flutter.ios.project-setup');
+  setupTabs();
 });
-
-function _getOSForArchive() {
-  const os = getOS();
-  // The archive doesn't have chromeos, fall back to linux.
-  if (os === 'chromeos') {
-    return 'linux';
-  }
-
-  return os;
-}
 
 /**
  * Get the user's current operating system, or

--- a/src/content/assets/js/tabs.js
+++ b/src/content/assets/js/tabs.js
@@ -26,6 +26,8 @@ function setupTabs() {
         }
       });
 
+      // If a tab was previously specified as selected in local storage,
+      // save a reference to it that can be switched to later.
       if (saveId && localStorage.getItem(localStorageKey) === saveId) {
         tabToChangeTo = tab;
       }

--- a/src/content/assets/js/tabs.js
+++ b/src/content/assets/js/tabs.js
@@ -40,7 +40,7 @@ function setupTabs() {
       const currentOperatingSystem = _getOsForArchive();
 
       if (currentOperatingSystem) {
-        _activateTabWithSaveId(currentOperatingSystem);
+        _activateTabWithSaveId(tabWrapper, currentOperatingSystem);
       }
     }
   });

--- a/src/content/assets/js/tabs.js
+++ b/src/content/assets/js/tabs.js
@@ -1,59 +1,67 @@
-function setupTabs(container, storageName, defaultTabGetter) {
-  const tabs = $(container).find('li a');
+function setupTabs() {
+  const tabsWrappers = document.querySelectorAll('.tabs-wrapper');
 
-  function getTabIdFromQuery(query) {
-    const match = query.match(/(#|\btab=)([\w-]+)/);
-    return match ? match[2] : '';
-  }
+  tabsWrappers.forEach(function (tabWrapper) {
+    const saveKey = tabWrapper.dataset.tabSaveKey;
+    const localStorageKey = `tab-save-${saveKey}`;
+    const tabs = tabWrapper.querySelectorAll('a.nav-link');
 
-  function clickHandler(e) {
-    e.preventDefault();
-    $(this).tab('show');
-    const id = getTabIdFromQuery($(this).attr('href'));
+    tabs.forEach(function (tab) {
+      const saveId = tab.dataset.tabSaveId;
 
-    if (storageName && window.localStorage) {
-      window.localStorage.setItem(storageName, id);
+      tab.addEventListener('click', function (event) {
+        event.preventDefault();
+        if (saveKey && saveId) {
+          _activateTabsWithSaveId(saveKey, saveId);
+          localStorage.setItem(localStorageKey, saveId);
+        } else {
+          _clearActiveTabs(tabs);
+          _setActiveTab(tab);
+        }
+      });
+
+      if (saveId && localStorage.getItem(localStorageKey) === saveId) {
+        tab.click();
+      } else if (tabWrapper.id === 'os-archive-tabs') {
+        // TODO(parlough): Add default selection for archive tabs.
+      }
+    });
+  });
+}
+
+function _clearActiveTabs(tabs) {
+  tabs.forEach(function (tab) {
+    tab.classList.remove('active');
+    tab.ariaSelected = 'false';
+    document.getElementById(`${tab.id}-panel`)?.classList.remove('active');
+  });
+}
+
+function _setActiveTab(tab) {
+  tab.classList.add('active');
+  tab.ariaSelected = 'true';
+  document.getElementById(`${tab.id}-panel`)?.classList.add('active');
+}
+
+function _activateTabsWithSaveId(saveKey, saveId) {
+  const tabsWrappers = document.querySelectorAll(`.tabs-wrapper[data-tab-save-key="${saveKey}"]`);
+
+  tabsWrappers.forEach(function (tabWrapper) {
+    const tabToActivate = tabWrapper.querySelector(`a.nav-link[data-tab-save-id="${saveId}"]`);
+    if (tabToActivate) {
+      const tabs = tabWrapper.querySelectorAll('a.nav-link');
+      _clearActiveTabs(tabs);
+      _setActiveTab(tabToActivate);
     }
+  });
+}
 
-    updateUrlQuery(id);
+function _getOsForArchive() {
+  const os = getOS();
+  // The archive doesn't have chromeos, fall back to linux.
+  if (os === 'chromeos') {
+    return 'linux';
   }
 
-  function updateUrlQuery(id) {
-    const loc = window.location;
-    const query = '?tab=' + id;
-    if (id && loc.search !== query) {
-      const url = loc.protocol + '//' + loc.host + loc.pathname + query + loc.hash;
-      history.replaceState(undefined, undefined, url);
-    }
-  }
-
-  function selectTab(id) {
-    const tab = tabs.filter('[href="#' + id + '"]');
-    tab.click();
-  }
-
-  function getSelectedTab() {
-    let selectedTab = getTabIdFromQuery(location.search);
-    if (!selectedTab && storageName && window.localStorage) {
-      selectedTab = window.localStorage.getItem(storageName);
-    }
-
-    if (selectedTab) {
-      return selectedTab;
-    }
-
-    if (defaultTabGetter) {
-      return defaultTabGetter();
-    }
-
-    return null;
-  }
-
-  function initializeTabs() {
-    tabs.click(clickHandler);
-    const selectedTab = getSelectedTab();
-    selectTab(selectedTab);
-  }
-
-  initializeTabs();
+  return os;
 }

--- a/src/content/community/china/index.md
+++ b/src/content/community/china/index.md
@@ -35,22 +35,17 @@ _All examples that follow presume that you are using the CFUG mirror._
 
 To set your machine to use a mirror site:
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="china-os-tabs" role="tablist">
-{% for os in os-list %}
-{% assign id = os | downcase -%}
-  <li class="nav-item">
-    <a class="nav-link {%- if id == 'windows' %} active {% endif %}" id="{{id}}-tab" href="#{{id}}" role="tab" aria-controls="{{id}} {{id}}-dl {{id}}-pub" aria-selected="true">{{os}}</a>
-  </li>
-{% endfor -%}
-</ul>
+{% tabs "china-setup-os" %}
 
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
 {% for os in os-list %}
+{% tab os %}
+
 {% include docs/community/china/os-settings.md ref-os=os sdk=flutter-sdk %}
+
+{% endtab %}
 {% endfor -%}
-</div>
+
+{% endtabs %}
 
 ### Download Flutter archives based on a mirror site
 
@@ -65,22 +60,17 @@ This should improve download speed.
 The following example shows how to change the URL for Flutter's download site
 from Google's archive to CFUG's mirror.
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="china-os-dl-tabs" role="tablist">
-{% for os in os-list %}
-{% assign id = os | downcase -%}
-  <li class="nav-item">
-    <a class="nav-link {%- if id == 'windows' %} active {% endif %}" id="{{id}}-dl-tab" href="#{{id}}-dl" role="tab" aria-controls="{{id}} {{id}}-dl {{id}}-pub" aria-selected="true">{{os}}</a>
-  </li>
-{% endfor -%}
-</ul>
+{% tabs "china-setup-os" %}
 
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
 {% for os in os-list %}
+{% tab os %}
+
 {% include docs/community/china/download-urls.md ref-os=os filepath=sdk-path %}
+
+{% endtab %}
 {% endfor -%}
-</div>
+
+{% endtabs %}
 
 :::note
 Not every mirror supports downloading artifacts using their direct URL.
@@ -97,23 +87,17 @@ From <https://github.com/flutter/website/pull/9338#discussion_r1328077020>
 
 To enable access to `pub.dev`:
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="china-os-pub-tabs" role="tablist">
-{% for os in os-list %}
-{% assign id = os | downcase -%}
-  <li class="nav-item">
-    <a class="nav-link {%- if id == 'windows' %} active {% endif %}" id="{{id}}-pub-tab" href="#{{id}}-pub" role="tab" aria-controls="{{id}} {{id}}-pub" aria-selected="true">{{os}}</a>
-  </li>
-{% endfor -%}
-</ul>
+{% tabs "china-setup-os" %}
 
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-{% include docs/community/china/pub-settings.md os="Windows" filepath=path %}
-{% include docs/community/china/pub-settings.md os="macOS" filepath=path %}
-{% include docs/community/china/pub-settings.md os="Linux" filepath=path %}
-{% include docs/community/china/pub-settings.md os="ChromeOS" filepath=path %}
-</div>
+{% for os in os-list %}
+{% tab os %}
+
+{% include docs/community/china/pub-settings.md os=os filepath=path %}
+
+{% endtab %}
+{% endfor -%}
+
+{% endtabs %}
 
 To learn more about publishing packages, check out the
 [Dart documentation on publishing packages][].

--- a/src/content/cookbook/navigation/set-up-universal-links.md
+++ b/src/content/cookbook/navigation/set-up-universal-links.md
@@ -129,20 +129,8 @@ Personal development teams don't support the Associated Domains
 capability. To add associated domains, choose the IDE tab.
 :::
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="xcode-ide-vs-ui" role="tablist">
-    <li class="nav-item">
-        <a class="nav-link active" id="xcode-ui-tab" href="#xcode-ui" role="tab" aria-controls="xcode-ui" aria-selected="true">Use Xcode UI</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="xcode-ide-tab" href="#xcode-ide" role="tab" aria-controls="xcode-ide" aria-selected="false">Use an IDE</a>
-    </li>
-</ul>
-
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-
-<div class="tab-pane active" id="xcode-ui" role="tabpanel" aria-labelledby="xcode-ui-tab">
+{% tabs %}
+{% tab "Xcode" %}
 
 1. Launch Xcode if necessary.
 
@@ -171,10 +159,8 @@ capability. To add associated domains, choose the IDE tab.
       alt="Xcode add associated domains screenshot"
       width="100%" />
 
-</div>
-
-<div class="tab-pane" id="xcode-ide" role="tabpanel"
-aria-labelledby="xcode-ide-tab">
+{% endtab %}
+{% tab "Other editors" %}
 
 1. Open the `ios/Runner/Runner.entitlements` XML file in your preferred IDE.
 
@@ -213,10 +199,9 @@ the following steps.
       alt="Xcode add associated domains screenshot"
       width="100%" />
 
-</div>
+{% endtab %}
+{% endtabs %}
 
-</div>
-{% comment %} End: Tab panes. {% endcomment -%}
 You have finished configuring the application for deep linking.
 
 ## Associate your app with your web domain

--- a/src/content/get-started/editor.md
+++ b/src/content/get-started/editor.md
@@ -35,19 +35,8 @@ Android Studio, or IntelliJ.
 If you choose another IDE, skip ahead
 to the [next step: Test drive](/get-started/test-drive).
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="editor-setup" role="tablist">
-  <li class="nav-item">
-    <a class="nav-link active" id="vscode-tab" href="#vscode" role="tab" aria-controls="vscode" aria-selected="true">Visual Studio Code</a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link" id="androidstudio-tab" href="#androidstudio" role="tab" aria-controls="androidstudio" aria-selected="false">Android Studio and IntelliJ</a>
-  </li>
-</ul>
-
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-<div class="tab-pane active" id="vscode" role="tabpanel" aria-labelledby="vscode-tab">
+{% tabs %}
+{% tab "Visual Studio Code" %}
 
 ## Install VS Code
 
@@ -98,8 +87,8 @@ follow Microsoft's instructions for the relevant platform:
      of this panel.
    - Displays the output of Flutter Doctor command.
 
-</div>
-<div class="tab-pane" id="androidstudio" role="tabpanel" aria-labelledby="androidstudio-tab">
+{% endtab %}
+{% tab "Android Studio and IntelliJ" %}
 
 ## Install Android Studio or IntelliJ IDEA
 
@@ -173,6 +162,6 @@ Use the following instructions for Linux or Windows:
 
 1. Click **Restart** when prompted.
 
-</div>
-</div>{% comment %} End: Tab panes. {% endcomment -%}
+{% endtab %}
+{% endtabs %}
 

--- a/src/content/get-started/test-drive/index.md
+++ b/src/content/get-started/test-drive/index.md
@@ -55,22 +55,20 @@ These tasks depend on which integrated development environment (IDE) you use.
 
 Select your preferred IDE for Flutter apps.
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="editor-setup" role="tablist">
-  <li class="nav-item">
-    <a class="nav-link active" id="vscode-tab" href="#vscode" role="tab" aria-controls="vscode" aria-selected="true">Visual Studio Code</a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link" id="androidstudio-tab" href="#androidstudio" role="tab" aria-controls="androidstudio" aria-selected="false">Android Studio and IntelliJ</a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link" id="terminal-tab" href="#terminal" role="tab" aria-controls="terminal" aria-selected="false">Terminal & editor</a>
-  </li>
-</ul>
+{% tabs %}
+{% tab "Visual Studio Code" %}
 
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-  {% include docs/install/test-drive/vscode.md %}
-  {% include docs/install/test-drive/androidstudio.md %}
-  {% include docs/install/test-drive/terminal.md %}
-</div>
+{% include docs/install/test-drive/vscode.md %}
+
+{% endtab %}
+{% tab "Android Studio and IntelliJ" %}
+
+{% include docs/install/test-drive/androidstudio.md %}
+
+{% endtab %}
+{% tab "Terminal & editor" %}
+
+{% include docs/install/test-drive/terminal.md %}
+
+{% endtab %}
+{% endtabs %}

--- a/src/content/get-started/uninstall/index.md
+++ b/src/content/get-started/uninstall/index.md
@@ -1,32 +1,23 @@
 ---
 title: Uninstall Flutter
 description: How to remove the Flutter SDK.
-toc: true
+toc: false
 os-list: [Windows, macOS, Linux, ChromeOS]
 ---
 
-To remove all of Flutter from your {{os}} development machine,
+To remove all of Flutter from your development machine,
 delete the directories that store Flutter and its configuration files.
 
 ## Uninstall the Flutter SDK
 
 Select your development platform from the following tabs.
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="base-os-tabs" role="tablist">
-{% for os in os-list %}
-{% assign id = os | downcase -%}
-  <li class="nav-item">
-    <a class="nav-link {%- if id == 'windows' %} active {% endif %}" id="{{id}}-tab" href="#{{id}}" role="tab" aria-controls="{{id}} {{id}}-dl {{id}}-pub" aria-selected="true">{{os}}</a>
-  </li>
-{% endfor -%}
-</ul>
+{% tabs %}
 
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
 {% for os in os-list %}
-{% assign id = os | downcase -%}
+{% tab os %}
 
+{% assign id = os | downcase -%}
 {% case os %}
 {% when 'Windows' -%}
 {% assign dirinstall='C:\\user\{username}\dev\' %}
@@ -82,8 +73,6 @@ Select your development platform from the following tabs.
 {{prompt}} {{rm}} {{dirconfig}}.pub-cache
 {% endcapture %}
 {% endcase -%}
-
-<div class="tab-pane {%- if id == 'windows' %} active {% endif %}" id="{{id}}" role="tabpanel" aria-labelledby="{{id}}-tab">
 
 This guide presumes that you installed Flutter in `{{path}}` on {{os}}.
 
@@ -148,11 +137,10 @@ remove the `.pub-cache` directory from your home directory.
 {% include docs/install/reqs/{{os | downcase}}/unset-path.md terminal=terminal -%}
 {% endcase %}
 
-</div>
-
+{% endtab %}
 {% endfor -%}
-</div>
-{% comment %} End: Tab panes. {% endcomment -%}
+
+{% endtabs %}
 
 ## Reinstall Flutter
 

--- a/src/content/platform-integration/android/platform-views.md
+++ b/src/content/platform-integration/android/platform-views.md
@@ -167,8 +167,8 @@ On the platform side, use the standard
 `io.flutter.plugin.platform` package
 in either Kotlin or Java:
 
-{% samplecode "android-platform-views", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 In your native code, implement the following:
 
@@ -269,8 +269,8 @@ class PlatformViewPlugin : FlutterPlugin {
 }
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 In your native code, implement the following:
 
@@ -389,8 +389,8 @@ public class PlatformViewPlugin implements FlutterPlugin {
 }
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 For more information, see the API docs for:
 

--- a/src/content/platform-integration/android/splash-screen.md
+++ b/src/content/platform-integration/android/splash-screen.md
@@ -152,8 +152,8 @@ while additional loading continues in Dart.
 To achieve this, the following
 Android APIs might be helpful:
 
-{% samplecode "android-splash-alignment", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 ```kotlin title="MainActivity.kt"
 import android.os.Build
@@ -177,8 +177,8 @@ class MainActivity : FlutterActivity() {
 }
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 ```java title="MainActivity.java"
 import android.os.Build;
@@ -208,8 +208,8 @@ public class MainActivity extends FlutterActivity {
 }
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 Then, you can reimplement the first frame in Flutter
 that shows elements of your Android launch screen in

--- a/src/content/platform-integration/ios/platform-views.md
+++ b/src/content/platform-integration/ios/platform-views.md
@@ -87,8 +87,8 @@ For more information, see the API docs for:
 
 On the platform side, use either Swift or Objective-C:
 
-{% samplecode "ios-platform-views", "Swift,Objective-C" %}
-{% sample "Swift" %}
+{% tabs "darwin-language" %}
+{% tab "Swift" %}
 
 Implement the factory and the platform view.
 The `FLNativeViewFactory` creates the platform view,
@@ -201,8 +201,8 @@ class FLPlugin: NSObject, FlutterPlugin {
 }
 ```
 
-{% endsample %}
-{% sample "Objective-C" %}
+{% endtab %}
+{% tab "Objective-C" %}
 
 In Objective-C, add the headers for the factory and the platform view.
 For example, as shown in `FLNativeView.h`:
@@ -335,8 +335,8 @@ modify the main plugin file
 @end
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 For more information, see the API docs for:
 

--- a/src/content/platform-integration/platform-channels.md
+++ b/src/content/platform-integration/platform-channels.md
@@ -102,8 +102,8 @@ messages happens automatically when you send and receive values.
 The following table shows how Dart values are received on the
 platform side and vice versa:
 
-{% samplecode "type-mappings", "Kotlin,Java,Swift,Obj-C,C++,C" %}
-{% sample "Kotlin" %}
+{% tabs "platform-channel-language" %}
+{% tab "Kotlin" %}
 
 | Dart              | Kotlin        |
 | ----------------- | ------------- |
@@ -123,8 +123,8 @@ platform side and vice versa:
 
 {:.table .table-striped}
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 | Dart              | Java                  |
 | ----------------- | --------------------- |
@@ -144,8 +144,8 @@ platform side and vice versa:
 
 {:.table .table-striped}
 
-{% endsample %}
-{% sample "Swift" %}
+{% endtab %}
+{% tab "Swift" %}
 
 | Dart              | Swift                                     |
 | ----------------- | ----------------------------------------- |
@@ -165,8 +165,8 @@ platform side and vice versa:
 
 {:.table .table-striped}
 
-{% endsample %}
-{% sample "Obj-C" %}
+{% endtab %}
+{% tab "Obj-C" %}
 
 | Dart              | Objective-C                                      |
 | ----------------- | ------------------------------------------------ |
@@ -186,8 +186,8 @@ platform side and vice versa:
 
 {:.table .table-striped}
 
-{% endsample %}
-{% sample "C++" %}
+{% endtab %}
+{% tab "C++" %}
 
 | Dart               | C++                                                        |
 | ------------------ | ---------------------------------------------------------- |
@@ -207,8 +207,8 @@ platform side and vice versa:
 
 {:.table .table-striped}
 
-{% endsample %}
-{% sample "C" %}
+{% endtab %}
+{% tab "C" %}
 
 | Dart               | C (GObject)                 |
 | ------------------ | --------------------------- |
@@ -227,8 +227,8 @@ platform side and vice versa:
 
 {:.table .table-striped}
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 ## Example: Calling platform-specific code using platform channels {:#example}
 
@@ -356,8 +356,8 @@ Widget build(BuildContext context) {
 
 ### Step 3: Add an Android platform-specific implementation
 
-{% samplecode "android-channel", "Kotlin,Java" %}
-{% sample "Kotlin" %}
+{% tabs "android-language" %}
+{% tab "Kotlin" %}
 
 Start by opening the Android host portion of your Flutter app
 in Android Studio:
@@ -468,8 +468,8 @@ And replace with the following:
     }
 ```
 
-{% endsample %}
-{% sample "Java" %}
+{% endtab %}
+{% tab "Java" %}
 
 Start by opening the Android host portion of your Flutter app
 in Android Studio:
@@ -584,8 +584,8 @@ And replace with the following:
           }
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 You should now be able to run the app on Android. If using the Android
 Emulator, set the battery level in the Extended Controls panel
@@ -593,8 +593,8 @@ accessible from the **...** button in the toolbar.
 
 ### Step 4: Add an iOS platform-specific implementation
 
-{% samplecode "ios-channel", "Swift,Objective-C" %}
-{% sample "Swift" %}
+{% tabs "darwin-language" %}
+{% tab "Swift" %}
 
 Start by opening the iOS host portion of your Flutter app in Xcode:
 
@@ -677,8 +677,8 @@ batteryChannel.setMethodCallHandler({
 })
 ```
 
-{% endsample %}
-{% sample "Objective-C" %}
+{% endtab %}
+{% tab "Objective-C" %}
 
 Start by opening the iOS host portion of the Flutter app in Xcode:
 
@@ -766,8 +766,8 @@ __weak typeof(self) weakSelf = self;
 }];
 ```
 
-{% endsample %}
-{% endsamplecode %}
+{% endtab %}
+{% endtabs %}
 
 You should now be able to run the app on iOS.
 If using the iOS Simulator,

--- a/src/content/release/archive.md
+++ b/src/content/release/archive.md
@@ -36,29 +36,24 @@ curl [provenance URL] | jq -r .payload | base64 -d | jq
 ```
 :::
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="os-archive-tabs" role="tablist">
-  <li class="nav-item">
-    <a class="nav-link active" id="windows-tab" href="#windows" role="tab" aria-controls="windows" aria-selected="true">Windows</a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link" id="macos-tab" href="#macos" role="tab" aria-controls="macos" aria-selected="false">macOS</a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link" id="linux-tab" href="#linux" role="tab" aria-controls="linux" aria-selected="false">Linux</a>
-  </li>
-</ul>
 
-{% comment %} Tab panes {% endcomment -%}
-<div id="sdk-archives" class="tab-content">
+{% tabs "os-archive-tabs" %}
+{% tab "Windows" %}
 
 {% include docs/release/archive-release_os.md os="Windows" %}
 
+{% endtab %}
+{% tab "macOS" %}
+
 {% include docs/release/archive-release_os.md os="macOS" %}
+
+{% endtab %}
+{% tab "Linux" %}
 
 {% include docs/release/archive-release_os.md os="Linux" %}
 
-</div>
+{% endtab %}
+{% endtabs %}
 
 ## Master channel
 

--- a/src/content/testing/integration-tests/index.md
+++ b/src/content/testing/integration-tests/index.md
@@ -1,7 +1,6 @@
 ---
 title: Check app functionality with an integration test
 description: Learn how to write integration tests
-os-list: [Windows, macOS, Linux]
 ---
 
 <?code-excerpt path-base="testing/integration_tests/how_to"?>
@@ -316,35 +315,23 @@ complete the following tasks.
 
 Based on platform, the command result should resemble the following output.
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="base-os-tabs" role="tablist">
-{% for os in os-list %}
-{% assign id = os | downcase -%}
-  <li class="nav-item">
-    <a class="nav-link {%- if id == 'windows' %} active {% endif %}" id="{{id}}-tab" href="#{{id}}" role="tab" aria-controls="{{id}} {{id}}-dl {{id}}-pub" aria-selected="true">{{os}}</a>
-  </li>
-{% endfor -%}
-</ul>
+{% tabs %}
+{% tab "Windows" %}
 
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-{% for os in os-list %}
-{% assign id = os | downcase -%}
-<div class="tab-pane {%- if id == 'windows' %} active {% endif %}" id="{{id}}" role="tabpanel" aria-labelledby="{{id}}-tab">
+{% render docs/test/integration/windows-example.md %}
 
-{% case id %}
-{% when 'windows' %}
-  {% render docs/test/integration/windows-example.md %}
-{% when 'macos' %}
-  {% render docs/test/integration/macos-example.md %}
-{% when 'linux' %}
-  {% render docs/test/integration/linux-example.md %}
-{% endcase %}
-</div>
+{% endtab %}
+{% tab "macOS" %}
 
-{% endfor -%}
-</div>
-{% comment %} End: Tab panes. {% endcomment %}
+{% render docs/test/integration/macos-example.md %}
+
+{% endtab %}
+{% tab "Linux" %}
+
+{% render docs/test/integration/linux-example.md %}
+
+{% endtab %}
+{% endtabs %}
 
 ---
 

--- a/src/content/tools/vs-code.md
+++ b/src/content/tools/vs-code.md
@@ -4,7 +4,7 @@ short-title: VS Code
 description: How to develop Flutter apps in Visual Studio Code.
 ---
 
-<ul class="nav nav-tabs" id="ide" role="tablist">
+<ul class="nav nav-tabs" id="ide-tabs" role="tablist">
   <li class="nav-item">
     <a class="nav-link" href="/tools/android-studio" role="tab" aria-selected="false">Android Studio and IntelliJ</a>
   </li>

--- a/src/content/ui/accessibility-and-internationalization/accessibility.md
+++ b/src/content/ui/accessibility-and-internationalization/accessibility.md
@@ -98,26 +98,8 @@ navigate around your app.
 
 **To turn on the screen reader on your device, complete the following steps:**
 
-{% comment %} Nav tabs {% endcomment -%}
-<ul class="nav nav-tabs" id="editor-setup" role="tablist">
-    <li class="nav-item">
-        <a class="nav-link active" id="talkback-tab" href="#talkback" role="tab" aria-controls="talkback" aria-selected="true">TalkBack on Android</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="voiceover-tab" href="#voiceover" role="tab" aria-controls="voiceover" aria-selected="false">VoiceOver on iPhone</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="browsers-tab" href="#browsers" role="tab" aria-controls="browsers" aria-selected="false">Browsers</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" id="desktop-tab" href="#desktop" role="tab" aria-controls="desktop" aria-selected="false">Desktop</a>
-    </li>
-</ul>
-
-{% comment %} Tab panes {% endcomment -%}
-<div class="tab-content">
-
-<div class="tab-pane active" id="talkback" role="tabpanel" aria-labelledby="talkback-tab">
+{% tabs %}
+{% tab "TalkBack on Android" %}
 
 1. On your device, open **Settings**.
 2. Select **Accessibility** and then **TalkBack**.
@@ -129,9 +111,8 @@ accessibility features, view the following video.
 
 <iframe width="560" height="315" src="{{site.yt.embed}}/FQyj_XTl01w" title="Learn about the accessibility features on the Google Pixel" {{site.yt.set}}></iframe>
 
-</div>
-
-<div class="tab-pane" id="voiceover" role="tabpanel" aria-labelledby="voiceover-tab">
+{% endtab %}
+{% tab "VoiceOver on iPhone" %}
 
 1. On your device, open **Settings > Accessibility > VoiceOver**
 2. Turn the VoiceOver setting on or off
@@ -141,9 +122,8 @@ accessibility features, view the following video.
 
 <iframe width="560" height="315" src="{{site.yt.embed}}/qDm7GiKra28" title="Learn how to navigate your iPhone or iPad with VoiceOver" {{site.yt.set}}></iframe>
 
-</div>
-
-<div class="tab-pane" id="browsers" role="tabpanel" aria-labelledby="browsers-tab">
+{% endtab %}
+{% tab "Browsers" %}
 
 For web, the following screen readers are currently supported:
 
@@ -172,9 +152,8 @@ void main() {
 }
 ```
 
-</div>
-
-<div class="tab-pane" id="desktop" role="tabpanel" aria-labelledby="desktop-tab">
+{% endtab %}
+{% tab "Desktop" %}
 
 Windows comes with a screen reader called Narrator
 but some developers recommend using the more popular
@@ -197,8 +176,8 @@ To learn about using Orca, check out
 
 [orca]: https://www.a11yproject.com/posts/getting-started-with-orca
 
-</div>
-</div>{% comment %} End: Tab panes. {% endcomment -%}
+{% endtab %}
+{% endtabs %}
 
 <br/>
 


### PR DESCRIPTION
Introduces new `{% tabs "save-key" %}` and `{% tab "name" %}` 11ty/Liquid paired shortcodes to add tabs to the site and switches the various tab methods across the site (`codesample` and raw HTML) to use them.

The `save-key` parameter is optional and allows syncing of tabs across the site to the same tab. For example, the `darwin-language` key is used to switch all tabs with the same key to either `Swift` or `Objective-C`. The `name` parameter tab is not optional. Both `save-key` and `name` must be in quotes or refer to a Liquid/11ty variable that is a string. The `{% endtab %}` and `{% endtabs %}` closing shortcodes are required to close a tab and a tab menu respectively.

**Example:**

````liquid
{% tabs "darwin-language" %}
{% tab "Swift" %}

Some words about the following Swift snippet...

```swift
let flutterViewController = FlutterViewController(
      project: nil, initialRoute: "/onboarding", nibName: nil, bundle: nil)
```

{% endtab %}
{% tab "Objective-C" %}

Some words about the following Objective-C snippet...

```objc
FlutterViewController* flutterViewController =
      [[FlutterViewController alloc] initWithProject:nil
                                        initialRoute:@"/onboarding"
                                             nibName:nil
                                              bundle:nil];
```

{% endtab %}
{% endtabs %}
````

Resolves https://github.com/flutter/website/issues/8926
Contributes to https://github.com/flutter/website/issues/8889
Contributes to https://github.com/flutter/website/issues/8030