### PR TITLE
[macOS] Add platform view documentation

### DIFF
--- a/examples/platform_integration/platform_views/lib/native_view_example_3.dart
+++ b/examples/platform_integration/platform_views/lib/native_view_example_3.dart
@@ -43,6 +43,8 @@ class TogetherWidget extends StatelessWidget {
       // return widget on Android.
       case TargetPlatform.iOS:
       // return widget on iOS.
+      case TargetPlatform.macOS:
+      // return widget on macOS.
       default:
         throw UnsupportedError('Unsupported platform view');
     }

--- a/examples/platform_integration/platform_views/lib/native_view_example_4.dart
+++ b/examples/platform_integration/platform_views/lib/native_view_example_4.dart
@@ -1,0 +1,53 @@
+// ignore_for_file: unused_local_variable
+
+// #docregion import
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+// #enddocregion import
+import 'package:flutter/widgets.dart';
+
+class MacOSCompositionWidget extends StatelessWidget {
+  const MacOSCompositionWidget({super.key});
+
+  @override
+  // #docregion macos-composition
+  Widget build(BuildContext context) {
+    // This is used in the platform side to register the view.
+    const String viewType = '<platform-view-type>';
+    // Pass parameters to the platform side.
+    final Map<String, dynamic> creationParams = <String, dynamic>{};
+
+    return AppKitView(
+      viewType: viewType,
+      layoutDirection: TextDirection.ltr,
+      creationParams: creationParams,
+      creationParamsCodec: const StandardMessageCodec(),
+    );
+  }
+  // #enddocregion macos-composition
+}
+
+class TogetherWidget extends StatelessWidget {
+  const TogetherWidget({super.key});
+
+  @override
+  // #docregion together-widget
+  Widget build(BuildContext context) {
+    // This is used in the platform side to register the view.
+    const String viewType = '<platform-view-type>';
+    // Pass parameters to the platform side.
+    final Map<String, dynamic> creationParams = <String, dynamic>{};
+
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+      // return widget on Android.
+      case TargetPlatform.iOS:
+      // return widget on iOS.
+      case TargetPlatform.macOS:
+      // return widget on macOS.
+      default:
+        throw UnsupportedError('Unsupported platform view');
+    }
+  }
+  // #enddocregion together-widget
+}

--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -470,6 +470,8 @@
           permalink: /platform-integration/macos/building
         - title: C interop
           permalink: /platform-integration/macos/c-interop
+        - title: Host a native macOS view
+          permalink: /platform-integration/macos/platform-views
     - title: Web
       permalink: /platform-integration/web
       children:

--- a/src/content/platform-integration/android/platform-views.md
+++ b/src/content/platform-integration/android/platform-views.md
@@ -19,9 +19,12 @@ This page discusses how to host your own native Android views
 within a Flutter app.
 If you'd like to embed native iOS views in your Flutter app,
 see [Hosting native iOS views][].
+If you'd like to embed native macOS views in your Flutter app,
+see [Hosting native macOS views][].
 :::
 
 [Hosting native iOS views]: /platform-integration/ios/platform-views
+[Hosting native macOS views]: /platform-integration/macos/platform-views
 
 Platform Views on Android have two implementations. They come with tradeoffs
 both in terms of performance and fidelity. 

--- a/src/content/platform-integration/ios/platform-views.md
+++ b/src/content/platform-integration/ios/platform-views.md
@@ -17,12 +17,14 @@ directly inside your Flutter app.
 :::note
 This page discusses how to host your own native iOS views
 within a Flutter app.
-If you'd like to embed native Android views
-in your Flutter app,
+If you'd like to embed native Android views in your Flutter app,
 see [Hosting native Android views][].
+If you'd like to embed native macOS views in your Flutter app,
+see [Hosting native macOS views][].
 :::
 
 [Hosting native Android views]: /platform-integration/android/platform-views
+[Hosting native macOS views]: /platform-integration/macos/platform-views
 
 
 iOS only uses Hybrid composition,
@@ -367,6 +369,8 @@ Widget build(BuildContext context) {
     // return widget on Android.
     case TargetPlatform.iOS:
     // return widget on iOS.
+    case TargetPlatform.macOS:
+    // return widget on macOS.
     default:
       throw UnsupportedError('Unsupported platform view');
   }

--- a/src/content/platform-integration/macos/NativeView.swift
+++ b/src/content/platform-integration/macos/NativeView.swift
@@ -1,0 +1,9 @@
+import Cocoa
+import FlutterMacOS
+
+public class Plugin: NSObject, FlutterPlugin {
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    let factory = NativeViewFactory(messenger: registrar.messenger)
+    registrar.register(factory, withId: "<platform-view-type>")
+  }
+}

--- a/src/content/platform-integration/macos/platform-views.md
+++ b/src/content/platform-integration/macos/platform-views.md
@@ -194,7 +194,7 @@ When implementing the `build()` method in Dart,
 you can use [`defaultTargetPlatform`][]
 to detect the platform, and decide which widget to use:
 
-<?code-excerpt "lib/native_view_example_3.dart (together-widget)"?>
+<?code-excerpt "lib/native_view_example_4.dart (together-widget)"?>
 ```dart
 Widget build(BuildContext context) {
   // This is used in the platform side to register the view.

--- a/src/content/platform-integration/macos/platform-views.md
+++ b/src/content/platform-integration/macos/platform-views.md
@@ -1,0 +1,240 @@
+---
+title: Hosting native macOS views in your Flutter app with Platform Views
+short-title: macOS platform-views
+description: Learn how to host native macOS views in your Flutter app with Platform Views.
+---
+
+<?code-excerpt path-base="platform_integration/platform_views"?>
+
+Platform views allow you to embed native views in a Flutter app, so you can
+apply transforms, clips, and opacity to the native view from Dart.
+
+This allows you, for example, to use the native web views directly inside your
+Flutter app.
+
+:::note
+This page discusses how to host your own native macOS views within a Flutter
+app. If you'd like to embed native iOS views in your Flutter app, see
+[Hosting native iOS views][].
+:::
+
+[Hosting native iOS views]: /platform-integration/ios/platform-views
+
+macOS uses Hybrid composition, which means that the native `NSView` is appended
+to the view hierarchy.
+
+To create a platform view on macOS, use the following instructions:
+
+## On the Dart side
+
+On the Dart side, create a `Widget` and add the build implementation, as shown
+in the following steps.
+
+In the Dart widget file, make changes similar to those 
+shown in `native_view_example.dart`:
+
+<ol>
+<li>
+
+Add the following imports:
+
+<?code-excerpt "lib/native_view_example_4.dart (import)"?>
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+```
+
+</li>
+
+<li>
+
+Implement a `build()` method:
+
+<?code-excerpt "lib/native_view_example_4.dart (macos-composition)"?>
+```dart
+Widget build(BuildContext context) {
+  // This is used in the platform side to register the view.
+  const String viewType = '<platform-view-type>';
+  // Pass parameters to the platform side.
+  final Map<String, dynamic> creationParams = <String, dynamic>{};
+
+  return AppKitView(
+    viewType: viewType,
+    layoutDirection: TextDirection.ltr,
+    creationParams: creationParams,
+    creationParamsCodec: const StandardMessageCodec(),
+  );
+}
+```
+
+</li>
+</ol>
+
+For more information, see the API docs for: [`AppKitView`][].
+
+[`AppKitView`]: {{site.api}}/flutter/widgets/AppKitView-class.html
+
+## On the platform side
+
+On the platform side, use Swift:
+
+{% samplecode "macos-platform-views", "Swift" %}
+{% sample "Swift" %}
+
+Implement the factory and the platform view. The `FLNativeViewFactory` creates
+the platform view, and the platform view provides a reference to the `NSView`.
+For example, `FLNativeView.swift`:
+
+```swift
+import Cocoa
+import FlutterMacOS
+
+class FLNativeViewFactory: NSObject, FlutterPlatformViewFactory {
+    private var messenger: FlutterBinaryMessenger
+
+    init(messenger: FlutterBinaryMessenger) {
+        self.messenger = messenger
+        super.init()
+    }
+
+    func create(
+        viewIdentifier viewId: Int64,
+        arguments args: Any?
+    ) -> FlutterPlatformView {
+        return FLNativeView(
+            viewIdentifier: viewId,
+            arguments: args,
+            binaryMessenger: messenger)
+    }
+
+    /// Implementing this method is only necessary when the `arguments` in `createWithFrame` is not `nil`.
+    public func createArgsCodec() -> (FlutterMessageCodec & NSObjectProtocol)? {
+          return FlutterStandardMessageCodec.sharedInstance()
+    }
+}
+
+class FLNativeView: NSView {
+    private var _view: NSView
+
+    init(
+        frame: CGRect,
+        viewIdentifier viewId: Int64,
+        arguments args: Any?,
+        binaryMessenger messenger: FlutterBinaryMessenger?
+    ) {
+        _view = NSView()
+        super.init(frame: frame)
+        // macOS views can be created here
+        createNativeView(view: _view)
+    }
+
+    func createNativeView(view _view: NSView) {
+        _view.wantsLayer = true
+        _view.layer?.backgroundColor = NSColor.systemBlue.cgColor
+        _view.frame = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let nativeLabel = NSTextField()
+        nativeLabel.frame = CGRect(x: 0, y: 0, width: 180, height: 48.0)
+        nativeLabel.stringValue = "Native text from macOS"
+        nativeLabel.textColor = NSColor.white
+        nativeLabel.font = NSFont.systemFont(ofSize: 14)
+        nativeLabel.isBezeled = false
+        nativeLabel.focusRingType = .none
+        nativeLabel.isEditable = true
+        nativeLabel.sizeToFit()
+        _view.addSubview(nativeLabel)
+    }
+}
+```
+
+Finally, register the platform view. This can be done in an app or a plugin.
+
+For app registration, modify the App's `MainFlutterWindow.swift`:
+
+```swift
+import Cocoa
+import FlutterMacOS
+
+class MainFlutterWindow: NSWindow {
+    override func awakeFromNib() {
+        // ...
+
+        let registrar = flutterViewController.registrar(forPlugin: "plugin-name")
+        let factory = FLNativeViewFactory(messenger: registrar.messenger)
+        registrar.register(
+            factory,
+            withId: "<platform-view-type>")
+    }
+}
+```
+
+For plugin registration, modify the plugin's main file (for example,
+`FLPlugin.swift`):
+
+```swift
+import Cocoa
+import FlutterMacOS
+
+public class FLPlugin: NSObject, FlutterPlugin {
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        let factory = FLNativeViewFactory(messenger: registrar.messenger)
+        registrar.register(factory, withId: "<platform-view-type>")
+    }
+}
+```
+
+{% endsample %}
+{% endsamplecode %}
+
+For more information, see the API docs for:
+
+* [`FlutterPlatformViewFactory`][]
+* [`FlutterPlatformView`][]
+* [`PlatformView`][]
+
+[`FlutterPlatformView`]: {{site.api}}/ios-embedder/protocol_flutter_platform_view-p.html
+[`FlutterPlatformViewFactory`]: {{site.api}}/ios-embedder/protocol_flutter_platform_view_factory-p.html
+[`PlatformView`]: {{site.api}}/javadoc/io/flutter/plugin/platform/PlatformView.html
+
+## Putting it together
+
+When implementing the `build()` method in Dart,
+you can use [`defaultTargetPlatform`][]
+to detect the platform, and decide which widget to use:
+
+<?code-excerpt "lib/native_view_example_3.dart (together-widget)"?>
+```dart
+Widget build(BuildContext context) {
+  // This is used in the platform side to register the view.
+  const String viewType = '<platform-view-type>';
+  // Pass parameters to the platform side.
+  final Map<String, dynamic> creationParams = <String, dynamic>{};
+
+  switch (defaultTargetPlatform) {
+    case TargetPlatform.android:
+    // return widget on Android.
+    case TargetPlatform.iOS:
+    // return widget on iOS.
+    case TargetPlatform.macOS:
+    // return widget on macOS.
+    default:
+      throw UnsupportedError('Unsupported platform view');
+  }
+}
+```
+
+[`defaultTargetPlatform`]: {{site.api}}/flutter/foundation/defaultTargetPlatform.html
+
+## Performance
+Platform views in Flutter come with performance trade-offs.
+
+For example, in a typical Flutter app, the Flutter UI is composed on a dedicated
+raster thread. This allows Flutter apps to be fast, as this thread is rarely
+blocked.
+
+When a platform view is rendered with hybrid composition, the Flutter UI
+continues to be composed from the dedicated raster thread, but the platform view
+performs graphics operations on the platform thread. To rasterize the combined
+contents, Flutter performs synchronization between its raster thread and the
+platform thread. As such, any slow or blocking operations on the platform thread
+can negatively impact Flutter graphics performance.

--- a/src/content/platform-integration/macos/platform-views.md
+++ b/src/content/platform-integration/macos/platform-views.md
@@ -81,15 +81,15 @@ On the platform side, use Swift:
 {% samplecode "macos-platform-views", "Swift" %}
 {% sample "Swift" %}
 
-Implement the factory and the platform view. The `FLNativeViewFactory` creates
-the platform view, and the platform view provides a reference to the `NSView`.
-For example, `FLNativeView.swift`:
+Implement the factory and the platform view. The `NativeViewFactory` creates the
+platform view, and the platform view provides a reference to the `NSView`. For
+example, `NativeView.swift`:
 
 ```swift
 import Cocoa
 import FlutterMacOS
 
-class FLNativeViewFactory: NSObject, FlutterPlatformViewFactory {
+class NativeViewFactory: NSObject, FlutterPlatformViewFactory {
     private var messenger: FlutterBinaryMessenger
 
     init(messenger: FlutterBinaryMessenger) {
@@ -101,7 +101,7 @@ class FLNativeViewFactory: NSObject, FlutterPlatformViewFactory {
         viewIdentifier viewId: Int64,
         arguments args: Any?
     ) -> FlutterPlatformView {
-        return FLNativeView(
+        return NativeView(
             viewIdentifier: viewId,
             arguments: args,
             binaryMessenger: messenger)
@@ -113,7 +113,7 @@ class FLNativeViewFactory: NSObject, FlutterPlatformViewFactory {
     }
 }
 
-class FLNativeView: NSView {
+class NativeView: NSView {
     private var _view: NSView
 
     init(
@@ -160,7 +160,7 @@ class MainFlutterWindow: NSWindow {
         // ...
 
         let registrar = flutterViewController.registrar(forPlugin: "plugin-name")
-        let factory = FLNativeViewFactory(messenger: registrar.messenger)
+        let factory = NativeViewFactory(messenger: registrar.messenger)
         registrar.register(
             factory,
             withId: "<platform-view-type>")
@@ -169,15 +169,15 @@ class MainFlutterWindow: NSWindow {
 ```
 
 For plugin registration, modify the plugin's main file (for example,
-`FLPlugin.swift`):
+`Plugin.swift`):
 
 ```swift
 import Cocoa
 import FlutterMacOS
 
-public class FLPlugin: NSObject, FlutterPlugin {
+public class Plugin: NSObject, FlutterPlugin {
     public static func register(with registrar: FlutterPluginRegistrar) {
-        let factory = FLNativeViewFactory(messenger: registrar.messenger)
+        let factory = NativeViewFactory(messenger: registrar.messenger)
         registrar.register(factory, withId: "<platform-view-type>")
     }
 }

--- a/src/content/platform-integration/macos/platform-views.md
+++ b/src/content/platform-integration/macos/platform-views.md
@@ -76,11 +76,6 @@ For more information, see the API docs for: [`AppKitView`][].
 
 ## On the platform side
 
-On the platform side, use Swift:
-
-{% samplecode "macos-platform-views", "Swift" %}
-{% sample "Swift" %}
-
 Implement the factory and the platform view. The `NativeViewFactory` creates the
 platform view, and the platform view provides a reference to the `NSView`. For
 example, `NativeView.swift`:
@@ -182,9 +177,6 @@ public class Plugin: NSObject, FlutterPlugin {
   }
 }
 ```
-
-{% endsample %}
-{% endsamplecode %}
 
 For more information, see the API docs for:
 

--- a/src/content/platform-integration/macos/platform-views.md
+++ b/src/content/platform-integration/macos/platform-views.md
@@ -14,10 +14,14 @@ Flutter app.
 
 :::note
 This page discusses how to host your own native macOS views within a Flutter
-app. If you'd like to embed native iOS views in your Flutter app, see
-[Hosting native iOS views][].
+app.
+If you'd like to embed native Android views in your Flutter app,
+see [Hosting native Android views][].
+If you'd like to embed native iOS views in your Flutter app,
+see [Hosting native iOS views][].
 :::
 
+[Hosting native Android views]: /platform-integration/android/platform-views
 [Hosting native iOS views]: /platform-integration/ios/platform-views
 
 macOS uses Hybrid composition, which means that the native `NSView` is appended

--- a/src/content/platform-integration/macos/platform-views.md
+++ b/src/content/platform-integration/macos/platform-views.md
@@ -90,60 +90,60 @@ import Cocoa
 import FlutterMacOS
 
 class NativeViewFactory: NSObject, FlutterPlatformViewFactory {
-    private var messenger: FlutterBinaryMessenger
+  private var messenger: FlutterBinaryMessenger
 
-    init(messenger: FlutterBinaryMessenger) {
-        self.messenger = messenger
-        super.init()
-    }
+  init(messenger: FlutterBinaryMessenger) {
+    self.messenger = messenger
+    super.init()
+  }
 
-    func create(
-        viewIdentifier viewId: Int64,
-        arguments args: Any?
-    ) -> FlutterPlatformView {
-        return NativeView(
-            viewIdentifier: viewId,
-            arguments: args,
-            binaryMessenger: messenger)
-    }
+  func create(
+    viewIdentifier viewId: Int64,
+    arguments args: Any?
+  ) -> FlutterPlatformView {
+    return NativeView(
+      viewIdentifier: viewId,
+      arguments: args,
+      binaryMessenger: messenger)
+  }
 
-    /// Implementing this method is only necessary when the `arguments` in `createWithFrame` is not `nil`.
-    public func createArgsCodec() -> (FlutterMessageCodec & NSObjectProtocol)? {
-          return FlutterStandardMessageCodec.sharedInstance()
-    }
+  /// Implementing this method is only necessary when the `arguments` in `createWithFrame` is not `nil`.
+  public func createArgsCodec() -> (FlutterMessageCodec & NSObjectProtocol)? {
+    return FlutterStandardMessageCodec.sharedInstance()
+  }
 }
 
 class NativeView: NSView {
-    private var _view: NSView
+  private var _view: NSView
 
-    init(
-        frame: CGRect,
-        viewIdentifier viewId: Int64,
-        arguments args: Any?,
-        binaryMessenger messenger: FlutterBinaryMessenger?
-    ) {
-        _view = NSView()
-        super.init(frame: frame)
-        // macOS views can be created here
-        createNativeView(view: _view)
-    }
+  init(
+    frame: CGRect,
+    viewIdentifier viewId: Int64,
+    arguments args: Any?,
+    binaryMessenger messenger: FlutterBinaryMessenger?
+  ) {
+    _view = NSView()
+    super.init(frame: frame)
+    // macOS views can be created here
+    createNativeView(view: _view)
+  }
 
-    func createNativeView(view _view: NSView) {
-        _view.wantsLayer = true
-        _view.layer?.backgroundColor = NSColor.systemBlue.cgColor
-        _view.frame = CGRect(x: 0, y: 0, width: 200, height: 200)
+  func createNativeView(view _view: NSView) {
+    _view.wantsLayer = true
+    _view.layer?.backgroundColor = NSColor.systemBlue.cgColor
+    _view.frame = CGRect(x: 0, y: 0, width: 200, height: 200)
 
-        let nativeLabel = NSTextField()
-        nativeLabel.frame = CGRect(x: 0, y: 0, width: 180, height: 48.0)
-        nativeLabel.stringValue = "Native text from macOS"
-        nativeLabel.textColor = NSColor.white
-        nativeLabel.font = NSFont.systemFont(ofSize: 14)
-        nativeLabel.isBezeled = false
-        nativeLabel.focusRingType = .none
-        nativeLabel.isEditable = true
-        nativeLabel.sizeToFit()
-        _view.addSubview(nativeLabel)
-    }
+    let nativeLabel = NSTextField()
+    nativeLabel.frame = CGRect(x: 0, y: 0, width: 180, height: 48.0)
+    nativeLabel.stringValue = "Native text from macOS"
+    nativeLabel.textColor = NSColor.white
+    nativeLabel.font = NSFont.systemFont(ofSize: 14)
+    nativeLabel.isBezeled = false
+    nativeLabel.focusRingType = .none
+    nativeLabel.isEditable = true
+    nativeLabel.sizeToFit()
+    _view.addSubview(nativeLabel)
+  }
 }
 ```
 
@@ -156,15 +156,15 @@ import Cocoa
 import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
-    override func awakeFromNib() {
-        // ...
+  override func awakeFromNib() {
+    // ...
 
-        let registrar = flutterViewController.registrar(forPlugin: "plugin-name")
-        let factory = NativeViewFactory(messenger: registrar.messenger)
-        registrar.register(
-            factory,
-            withId: "<platform-view-type>")
-    }
+    let registrar = flutterViewController.registrar(forPlugin: "plugin-name")
+    let factory = NativeViewFactory(messenger: registrar.messenger)
+    registrar.register(
+      factory,
+      withId: "<platform-view-type>")
+  }
 }
 ```
 
@@ -176,10 +176,10 @@ import Cocoa
 import FlutterMacOS
 
 public class Plugin: NSObject, FlutterPlugin {
-    public static func register(with registrar: FlutterPluginRegistrar) {
-        let factory = NativeViewFactory(messenger: registrar.messenger)
-        registrar.register(factory, withId: "<platform-view-type>")
-    }
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    let factory = NativeViewFactory(messenger: registrar.messenger)
+    registrar.register(factory, withId: "<platform-view-type>")
+  }
 }
 ```
 

--- a/src/content/platform-integration/macos/platform-views.md
+++ b/src/content/platform-integration/macos/platform-views.md
@@ -24,6 +24,11 @@ see [Hosting native iOS views][].
 [Hosting native Android views]: /platform-integration/android/platform-views
 [Hosting native iOS views]: /platform-integration/ios/platform-views
 
+:::note Version note
+Platform view support on macOS isn't fully functional as of the current release.
+For example, gesture support isn't yet available on macOS.
+Stay tuned for a future stable release.
+:::
 macOS uses Hybrid composition, which means that the native `NSView` is appended
 to the view hierarchy.
 


### PR DESCRIPTION
This adds documentation on authoring and using platform views for Flutter apps targeting macOS.

The initial version of this documentation is Swift-only, but a follow-up will add Objective-C example code.

Fixes: #9424

## Presubmit checklist

- [X] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
