### PR TITLE
Fix incorrect keytool command for PowerShell in Android deployment documentation

### DIFF
--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -127,8 +127,8 @@ If not, create one using one of the following methods:
    On Windows, use the following command in PowerShell:
 
    ```powershell
-   keytool -genkey -v -keystore %userprofile%\upload-keystore.jks ^
-           -storetype JKS -keyalg RSA -keysize 2048 -validity 10000 ^
+   keytool -genkey -v -keystore $env:USERPROFILE\upload-keystore.jks `
+           -storetype JKS -keyalg RSA -keysize 2048 -validity 10000 `
            -alias upload
    ```
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
This pull request addresses an issue in the Android deployment documentation where the keytool command for generating a keystore is incorrectly formatted for PowerShell. The current documentation uses the CMD.EXE(Command Prompt) syntax, which leads to errors when executed in PowerShell. This PR updates the documentation to use the correct PowerShell syntax for setting environment variables and line continuation.

**Changes:**
- Updated the `keytool` command to use `$env:USERPROFILE` instead of `%userprofile%`.
- Changed line continuation from `^` to `` ` `` to conform to PowerShell syntax.

This change will help users following the documentation to successfully generate a keystore on Windows using PowerShell.

_Issues fixed by this PR (if any):_ None

_PRs or commits this PR depends on (if any):_ None

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
