### PR TITLE
Add titles to all DartPads

### DIFF
--- a/src/_includes/docs/implicit-animations/fade-in-complete.md
+++ b/src/_includes/docs/implicit-animations/fade-in-complete.md
@@ -1,5 +1,5 @@
 <?code-excerpt "animation/implicit/opacity5/lib/main.dart"?>
-```dartpad
+```dartpad title="Implicit Animation Opacity DartPad hands-on example 5"
 // Copyright 2019 the Dart project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file.

--- a/src/_includes/docs/implicit-animations/fade-in-complete.md
+++ b/src/_includes/docs/implicit-animations/fade-in-complete.md
@@ -1,5 +1,5 @@
 <?code-excerpt "animation/implicit/opacity5/lib/main.dart"?>
-```dartpad title="Implicit Animation Opacity DartPad hands-on example 5"
+```dartpad title="Flutter Implicit Animation Opacity hands-on example in DartPad"
 // Copyright 2019 the Dart project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file.

--- a/src/_includes/docs/implicit-animations/fade-in-starter-code.md
+++ b/src/_includes/docs/implicit-animations/fade-in-starter-code.md
@@ -1,5 +1,5 @@
 <?code-excerpt "animation/implicit/opacity1/lib/main.dart"?>
-```dartpad
+```dartpad title="Implicit Animation Opacity DartPad hands-on example 1"
 // Copyright 2019 the Dart project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file.

--- a/src/_includes/docs/implicit-animations/shape-shifting-complete.md
+++ b/src/_includes/docs/implicit-animations/shape-shifting-complete.md
@@ -1,5 +1,5 @@
 <?code-excerpt "animation/implicit/container5/lib/main.dart"?>
-```dartpad
+```dartpad title="Implicit Animation Containers DartPad hands-on complete example"
 // Copyright 2019 the Dart project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file.

--- a/src/_includes/docs/implicit-animations/shape-shifting-starter-code.md
+++ b/src/_includes/docs/implicit-animations/shape-shifting-starter-code.md
@@ -1,5 +1,5 @@
 <?code-excerpt "animation/implicit/container1/lib/main.dart"?>
-```dartpad
+```dartpad title="Implicit Animation Containers DartPad hands-on starting example"
 // Copyright 2019 the Dart project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file.

--- a/src/content/cookbook/animation/animated-container.md
+++ b/src/content/cookbook/animation/animated-container.md
@@ -139,7 +139,7 @@ FloatingActionButton(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'dart:math';
 
 import 'package:flutter/material.dart';

--- a/src/content/cookbook/animation/animated-container.md
+++ b/src/content/cookbook/animation/animated-container.md
@@ -139,7 +139,7 @@ FloatingActionButton(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter animated container hands-on example in DartPad" run="true"
 import 'dart:math';
 
 import 'package:flutter/material.dart';

--- a/src/content/cookbook/animation/opacity-animation.md
+++ b/src/content/cookbook/animation/opacity-animation.md
@@ -123,9 +123,9 @@ to `true` or `false`. How to fade the box in and out? With an
 
 The `AnimatedOpacity` widget requires three arguments:
 
-  * `opacity`: A value from 0.0 (invisible) to 1.0 (fully visible).
-  * `duration`: How long the animation should take to complete.
-  * `child`: The widget to animate. In this case, the green box.
+* `opacity`: A value from 0.0 (invisible) to 1.0 (fully visible).
+* `duration`: How long the animation should take to complete.
+* `child`: The widget to animate. In this case, the green box.
 
 <?code-excerpt "lib/main.dart (AnimatedOpacity)" replace="/^child: //g;/^\),$/)/g"?>
 ```dart
@@ -146,7 +146,7 @@ AnimatedOpacity(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="Implicit Animation Opacity DartPad hands-on example" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/animation/page-route-animation.md
+++ b/src/content/cookbook/animation/page-route-animation.md
@@ -228,7 +228,7 @@ transitionsBuilder: (context, animation, secondaryAnimation, child) {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter page routing hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/animation/page-route-animation.md
+++ b/src/content/cookbook/animation/page-route-animation.md
@@ -228,7 +228,7 @@ transitionsBuilder: (context, animation, secondaryAnimation, child) {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/animation/physics-simulation.md
+++ b/src/content/cookbook/animation/physics-simulation.md
@@ -332,7 +332,7 @@ is no longer required.
 ## Interactive Example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter physics simulation hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
 

--- a/src/content/cookbook/animation/physics-simulation.md
+++ b/src/content/cookbook/animation/physics-simulation.md
@@ -332,7 +332,7 @@ is no longer required.
 ## Interactive Example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
 

--- a/src/content/cookbook/design/drawer.md
+++ b/src/content/cookbook/design/drawer.md
@@ -174,7 +174,7 @@ check out the [Navigation][] section of the cookbook.
 :::
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/design/drawer.md
+++ b/src/content/cookbook/design/drawer.md
@@ -174,7 +174,7 @@ check out the [Navigation][] section of the cookbook.
 :::
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter drawer hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/design/orientation.md
+++ b/src/content/cookbook/design/orientation.md
@@ -76,7 +76,7 @@ use `MediaQuery.of(context).orientation` instead of an
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter app orientation hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/design/orientation.md
+++ b/src/content/cookbook/design/orientation.md
@@ -76,7 +76,7 @@ use `MediaQuery.of(context).orientation` instead of an
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/design/snackbars.md
+++ b/src/content/cookbook/design/snackbars.md
@@ -100,7 +100,7 @@ see the [Gestures][] section of the cookbook.
 :::
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter snackbar hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const SnackBarDemo());

--- a/src/content/cookbook/design/snackbars.md
+++ b/src/content/cookbook/design/snackbars.md
@@ -100,7 +100,7 @@ see the [Gestures][] section of the cookbook.
 :::
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const SnackBarDemo());

--- a/src/content/cookbook/design/tabs.md
+++ b/src/content/cookbook/design/tabs.md
@@ -96,7 +96,7 @@ body: const TabBarView(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="Flutter TabBar DartPad hands-on example" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/design/themes.md
+++ b/src/content/cookbook/design/themes.md
@@ -188,7 +188,7 @@ To learn more, watch this short Widget of the Week video on the `Theme` widget:
 ## Try an interactive example
 
 <?code-excerpt "lib/main.dart (FullApp)"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter themes hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 // Include the Google Fonts package to provide more text format options
 // https://pub.dev/packages/google_fonts

--- a/src/content/cookbook/design/themes.md
+++ b/src/content/cookbook/design/themes.md
@@ -188,7 +188,7 @@ To learn more, watch this short Widget of the Week video on the `Theme` widget:
 ## Try an interactive example
 
 <?code-excerpt "lib/main.dart (FullApp)"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 // Include the Google Fonts package to provide more text format options
 // https://pub.dev/packages/google_fonts

--- a/src/content/cookbook/effects/download-button.md
+++ b/src/content/cookbook/effects/download-button.md
@@ -472,7 +472,7 @@ Run the app:
 <!-- start dartpad -->
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter download button hands-on example in DartPad" run="true"
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 

--- a/src/content/cookbook/effects/download-button.md
+++ b/src/content/cookbook/effects/download-button.md
@@ -472,7 +472,7 @@ Run the app:
 <!-- start dartpad -->
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 

--- a/src/content/cookbook/effects/drag-a-widget.md
+++ b/src/content/cookbook/effects/drag-a-widget.md
@@ -243,7 +243,7 @@ Run the app:
 <!-- Start DartPad -->
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/effects/drag-a-widget.md
+++ b/src/content/cookbook/effects/drag-a-widget.md
@@ -243,7 +243,7 @@ Run the app:
 <!-- Start DartPad -->
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter drag a widget hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/effects/expandable-fab.md
+++ b/src/content/cookbook/effects/expandable-fab.md
@@ -410,7 +410,7 @@ Run the app:
 <!-- start dartpad -->
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';

--- a/src/content/cookbook/effects/expandable-fab.md
+++ b/src/content/cookbook/effects/expandable-fab.md
@@ -410,7 +410,7 @@ Run the app:
 <!-- start dartpad -->
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter expandable floating action button hands-on example in DartPad" run="true"
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';

--- a/src/content/cookbook/effects/gradient-bubbles.md
+++ b/src/content/cookbook/effects/gradient-bubbles.md
@@ -258,7 +258,7 @@ Run the app:
 
 <!-- start dartpad -->
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter graident bubbles hands-on example in DartPad" run="true"
 import 'dart:math';
 import 'dart:ui' as ui;
 

--- a/src/content/cookbook/effects/gradient-bubbles.md
+++ b/src/content/cookbook/effects/gradient-bubbles.md
@@ -258,7 +258,7 @@ Run the app:
 
 <!-- start dartpad -->
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'dart:math';
 import 'dart:ui' as ui;
 

--- a/src/content/cookbook/effects/nested-nav.md
+++ b/src/content/cookbook/effects/nested-nav.md
@@ -392,7 +392,7 @@ Run the app:
   first screen.
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 const routeHome = '/';

--- a/src/content/cookbook/effects/nested-nav.md
+++ b/src/content/cookbook/effects/nested-nav.md
@@ -392,7 +392,7 @@ Run the app:
   first screen.
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter nested navigation hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 const routeHome = '/';

--- a/src/content/cookbook/effects/parallax-scrolling.md
+++ b/src/content/cookbook/effects/parallax-scrolling.md
@@ -569,7 +569,7 @@ Run the app:
 * Scroll up and down to observe the parallax effect.
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter parallax scrolling hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 

--- a/src/content/cookbook/effects/parallax-scrolling.md
+++ b/src/content/cookbook/effects/parallax-scrolling.md
@@ -569,7 +569,7 @@ Run the app:
 * Scroll up and down to observe the parallax effect.
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 

--- a/src/content/cookbook/effects/photo-filter-carousel.md
+++ b/src/content/cookbook/effects/photo-filter-carousel.md
@@ -505,7 +505,7 @@ You now have a draggable, tappable photo filter carousel.
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';

--- a/src/content/cookbook/effects/photo-filter-carousel.md
+++ b/src/content/cookbook/effects/photo-filter-carousel.md
@@ -505,7 +505,7 @@ You now have a draggable, tappable photo filter carousel.
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter photo filter carousel hands-on example in DartPad" run="true"
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';

--- a/src/content/cookbook/effects/shimmer-loading.md
+++ b/src/content/cookbook/effects/shimmer-loading.md
@@ -577,7 +577,7 @@ on and off as the content loads.
 ## Interactive example
 
 <?code-excerpt "lib/original_example.dart" remove="code-excerpt-closing-bracket"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter shimmer loading hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/effects/shimmer-loading.md
+++ b/src/content/cookbook/effects/shimmer-loading.md
@@ -577,7 +577,7 @@ on and off as the content loads.
 ## Interactive example
 
 <?code-excerpt "lib/original_example.dart" remove="code-excerpt-closing-bracket"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/effects/staggered-menu-animation.md
+++ b/src/content/cookbook/effects/staggered-menu-animation.md
@@ -374,7 +374,7 @@ pops into place.
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/effects/staggered-menu-animation.md
+++ b/src/content/cookbook/effects/staggered-menu-animation.md
@@ -374,7 +374,7 @@ pops into place.
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter staggered menu animation hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/effects/typing-indicator.md
+++ b/src/content/cookbook/effects/typing-indicator.md
@@ -666,7 +666,7 @@ Run the app:
 <!-- Start DartPad -->
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter typing indicator hands-on example in DartPad" run="true"
 import 'dart:math';
 
 import 'package:flutter/cupertino.dart';

--- a/src/content/cookbook/effects/typing-indicator.md
+++ b/src/content/cookbook/effects/typing-indicator.md
@@ -666,7 +666,7 @@ Run the app:
 <!-- Start DartPad -->
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'dart:math';
 
 import 'package:flutter/cupertino.dart';

--- a/src/content/cookbook/forms/focus.md
+++ b/src/content/cookbook/forms/focus.md
@@ -137,7 +137,7 @@ FloatingActionButton(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/forms/focus.md
+++ b/src/content/cookbook/forms/focus.md
@@ -137,7 +137,7 @@ FloatingActionButton(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter text focus hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/forms/retrieve-input.md
+++ b/src/content/cookbook/forms/retrieve-input.md
@@ -106,7 +106,7 @@ FloatingActionButton(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/forms/retrieve-input.md
+++ b/src/content/cookbook/forms/retrieve-input.md
@@ -106,7 +106,7 @@ FloatingActionButton(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter retrieve input hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/forms/text-field-changes.md
+++ b/src/content/cookbook/forms/text-field-changes.md
@@ -160,7 +160,7 @@ void dispose() {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter text field change hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/forms/text-field-changes.md
+++ b/src/content/cookbook/forms/text-field-changes.md
@@ -160,7 +160,7 @@ void dispose() {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/forms/text-input.md
+++ b/src/content/cookbook/forms/text-input.md
@@ -62,7 +62,7 @@ TextFormField(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart" replace="/^child\: //g"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter text input hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/forms/text-input.md
+++ b/src/content/cookbook/forms/text-input.md
@@ -62,7 +62,7 @@ TextFormField(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart" replace="/^child\: //g"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/forms/validation.md
+++ b/src/content/cookbook/forms/validation.md
@@ -163,7 +163,7 @@ rebuilds the form to display any error messages and returns `false`.
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter form validation hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/forms/validation.md
+++ b/src/content/cookbook/forms/validation.md
@@ -163,7 +163,7 @@ rebuilds the form to display any error messages and returns `false`.
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/gestures/dismissible.md
+++ b/src/content/cookbook/gestures/dismissible.md
@@ -127,7 +127,7 @@ provide a `background` parameter to the `Dismissible`.
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter Swipe to Dismiss hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/gestures/dismissible.md
+++ b/src/content/cookbook/gestures/dismissible.md
@@ -127,7 +127,7 @@ provide a `background` parameter to the `Dismissible`.
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/gestures/handling-taps.md
+++ b/src/content/cookbook/gestures/handling-taps.md
@@ -59,7 +59,7 @@ GestureDetector(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter tap handling hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/gestures/handling-taps.md
+++ b/src/content/cookbook/gestures/handling-taps.md
@@ -59,7 +59,7 @@ GestureDetector(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/gestures/ripples.md
+++ b/src/content/cookbook/gestures/ripples.md
@@ -39,7 +39,7 @@ InkWell(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/gestures/ripples.md
+++ b/src/content/cookbook/gestures/ripples.md
@@ -39,7 +39,7 @@ InkWell(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter Material ripples hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/images/network-image.md
+++ b/src/content/cookbook/images/network-image.md
@@ -43,7 +43,7 @@ check out [Fade in images with a placeholder][].
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter network images hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/images/network-image.md
+++ b/src/content/cookbook/images/network-image.md
@@ -43,7 +43,7 @@ check out [Fade in images with a placeholder][].
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/lists/basic-list.md
+++ b/src/content/cookbook/lists/basic-list.md
@@ -42,7 +42,7 @@ ListView(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/lists/basic-list.md
+++ b/src/content/cookbook/lists/basic-list.md
@@ -42,7 +42,7 @@ ListView(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter lists hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/lists/floating-app-bar.md
+++ b/src/content/cookbook/lists/floating-app-bar.md
@@ -143,7 +143,7 @@ SliverList(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
- run="true"
+```dartpad title="Flutter Floating AppBar hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/lists/floating-app-bar.md
+++ b/src/content/cookbook/lists/floating-app-bar.md
@@ -143,7 +143,7 @@ SliverList(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/lists/floating-app-bar.md
+++ b/src/content/cookbook/lists/floating-app-bar.md
@@ -143,7 +143,7 @@ SliverList(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+ run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/lists/grid-lists.md
+++ b/src/content/cookbook/lists/grid-lists.md
@@ -40,7 +40,7 @@ GridView.count(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/lists/grid-lists.md
+++ b/src/content/cookbook/lists/grid-lists.md
@@ -40,7 +40,7 @@ GridView.count(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter GridView hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/lists/horizontal-list.md
+++ b/src/content/cookbook/lists/horizontal-list.md
@@ -58,7 +58,7 @@ default drag for scrolling devices.
 :::
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/lists/horizontal-list.md
+++ b/src/content/cookbook/lists/horizontal-list.md
@@ -58,7 +58,7 @@ default drag for scrolling devices.
 :::
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter horizontal list hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/lists/long-lists.md
+++ b/src/content/cookbook/lists/long-lists.md
@@ -55,7 +55,7 @@ ListView.builder(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/lists/long-lists.md
+++ b/src/content/cookbook/lists/long-lists.md
@@ -55,7 +55,7 @@ ListView.builder(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter create long list hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/lists/mixed-list.md
+++ b/src/content/cookbook/lists/mixed-list.md
@@ -122,7 +122,7 @@ ListView.builder(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/lists/mixed-list.md
+++ b/src/content/cookbook/lists/mixed-list.md
@@ -122,7 +122,7 @@ ListView.builder(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter create mixed lists hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/lists/spaced-items.md
+++ b/src/content/cookbook/lists/spaced-items.md
@@ -163,7 +163,7 @@ The number of items is defined by the variable `items`,
 change this value to see what happens when the items won't fit the screen.
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter Spaced Items hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const SpacedItemsList());

--- a/src/content/cookbook/lists/spaced-items.md
+++ b/src/content/cookbook/lists/spaced-items.md
@@ -163,7 +163,7 @@ The number of items is defined by the variable `items`,
 change this value to see what happens when the items won't fit the screen.
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const SpacedItemsList());

--- a/src/content/cookbook/navigation/hero-animations.md
+++ b/src/content/cookbook/navigation/hero-animations.md
@@ -141,7 +141,7 @@ widgets, for simplicity.
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const HeroApp());

--- a/src/content/cookbook/navigation/hero-animations.md
+++ b/src/content/cookbook/navigation/hero-animations.md
@@ -141,7 +141,7 @@ widgets, for simplicity.
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter Hero animation hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const HeroApp());

--- a/src/content/cookbook/navigation/named-routes.md
+++ b/src/content/cookbook/navigation/named-routes.md
@@ -165,7 +165,7 @@ onPressed: () {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter Named Routes hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/navigation/named-routes.md
+++ b/src/content/cookbook/navigation/named-routes.md
@@ -165,7 +165,7 @@ onPressed: () {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/navigation/navigate-with-arguments.md
+++ b/src/content/cookbook/navigation/navigate-with-arguments.md
@@ -200,7 +200,7 @@ MaterialApp(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/navigation/navigate-with-arguments.md
+++ b/src/content/cookbook/navigation/navigate-with-arguments.md
@@ -200,7 +200,7 @@ MaterialApp(
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter complete navigation hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());

--- a/src/content/cookbook/navigation/navigation-basics.md
+++ b/src/content/cookbook/navigation/navigation-basics.md
@@ -130,7 +130,7 @@ onPressed: () {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() {
@@ -218,7 +218,7 @@ depending on your needs.
 :::
 
 <?code-excerpt "lib/main_cupertino.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/cupertino.dart';
 
 void main() {

--- a/src/content/cookbook/navigation/navigation-basics.md
+++ b/src/content/cookbook/navigation/navigation-basics.md
@@ -130,7 +130,7 @@ onPressed: () {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter navigation hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() {
@@ -218,7 +218,7 @@ depending on your needs.
 :::
 
 <?code-excerpt "lib/main_cupertino.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter Cupertino theme hands-on example in DartPad" run="true"
 import 'package:flutter/cupertino.dart';
 
 void main() {

--- a/src/content/cookbook/navigation/passing-data.md
+++ b/src/content/cookbook/navigation/passing-data.md
@@ -188,7 +188,7 @@ body: ListView.builder(
 ### Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 class Todo {

--- a/src/content/cookbook/navigation/passing-data.md
+++ b/src/content/cookbook/navigation/passing-data.md
@@ -188,7 +188,7 @@ body: ListView.builder(
 ### Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter passing data hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 class Todo {

--- a/src/content/cookbook/navigation/returning-data.md
+++ b/src/content/cookbook/navigation/returning-data.md
@@ -206,7 +206,7 @@ Future<void> _navigateAndDisplaySelection(BuildContext context) async {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/navigation/returning-data.md
+++ b/src/content/cookbook/navigation/returning-data.md
@@ -206,7 +206,7 @@ Future<void> _navigateAndDisplaySelection(BuildContext context) async {
 ## Interactive example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter Return from Data hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/cookbook/navigation/set-up-app-links.md
+++ b/src/content/cookbook/navigation/set-up-app-links.md
@@ -55,7 +55,7 @@ It provides a simple API to handle complex routing scenarios.
    create a `GoRouter` object in the `main.dart` file:
 
     <?code-excerpt "lib/main.dart"?>
-    ```dartpad title="" run="true"
+    ```dartpad title="Flutter GoRouter hands-on example in DartPad" run="true"
     import 'package:flutter/material.dart';
     import 'package:go_router/go_router.dart';
     

--- a/src/content/cookbook/navigation/set-up-app-links.md
+++ b/src/content/cookbook/navigation/set-up-app-links.md
@@ -55,7 +55,7 @@ It provides a simple API to handle complex routing scenarios.
    create a `GoRouter` object in the `main.dart` file:
 
     <?code-excerpt "lib/main.dart"?>
-    ```dartpad run="true"
+    ```dartpad title="" run="true"
     import 'package:flutter/material.dart';
     import 'package:go_router/go_router.dart';
     

--- a/src/content/cookbook/navigation/set-up-universal-links.md
+++ b/src/content/cookbook/navigation/set-up-universal-links.md
@@ -52,7 +52,7 @@ It provides a simple API to handle complex routing scenarios.
 3. To handle the routing, create a `GoRouter` object in the `main.dart` file:
 
     <?code-excerpt "lib/main.dart"?>
-    ```dartpad title="" run="true"
+    ```dartpad title="Flutter GoRouter hands-on example in DartPad" run="true"
     import 'package:flutter/material.dart';
     import 'package:go_router/go_router.dart';
     

--- a/src/content/cookbook/navigation/set-up-universal-links.md
+++ b/src/content/cookbook/navigation/set-up-universal-links.md
@@ -52,7 +52,7 @@ It provides a simple API to handle complex routing scenarios.
 3. To handle the routing, create a `GoRouter` object in the `main.dart` file:
 
     <?code-excerpt "lib/main.dart"?>
-    ```dartpad run="true"
+    ```dartpad title="" run="true"
     import 'package:flutter/material.dart';
     import 'package:go_router/go_router.dart';
     

--- a/src/content/cookbook/plugins/play-video.md
+++ b/src/content/cookbook/plugins/play-video.md
@@ -251,7 +251,7 @@ FloatingActionButton(
 ## Complete example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter video player hands-on example in DartPad" run="true"
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/src/content/cookbook/plugins/play-video.md
+++ b/src/content/cookbook/plugins/play-video.md
@@ -251,7 +251,7 @@ FloatingActionButton(
 ## Complete example
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/src/content/get-started/codelab-web.md
+++ b/src/content/get-started/codelab-web.md
@@ -129,7 +129,7 @@ of the Flutter DevTools tooling.
 The starting app is displayed in the following DartPad.
 
 <?code-excerpt "lib/starter.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const SignUpApp());
@@ -877,7 +877,7 @@ the animation works, and that clicking the
 ### Complete sample
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const SignUpApp());

--- a/src/content/get-started/codelab-web.md
+++ b/src/content/get-started/codelab-web.md
@@ -129,7 +129,7 @@ of the Flutter DevTools tooling.
 The starting app is displayed in the following DartPad.
 
 <?code-excerpt "lib/starter.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter beginning getting started hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const SignUpApp());
@@ -877,7 +877,7 @@ the animation works, and that clicking the
 ### Complete sample
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="" run="true"
+```dartpad title="Flutter complete getting started hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const SignUpApp());

--- a/src/content/ui/index.md
+++ b/src/content/ui/index.md
@@ -32,7 +32,7 @@ The minimal Flutter app simply calls the [`runApp()`][]
 function with a widget:
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="Flutter Hello World hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() {
@@ -99,7 +99,7 @@ of which the following are commonly used:
 Below are some simple widgets that combine these and other widgets:
 
 <?code-excerpt "lib/main_myappbar.dart"?>
-```dartpad run="true"
+```dartpad title="Flutter combining widgets hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 class MyAppBar extends StatelessWidget {
@@ -230,7 +230,7 @@ between screens of your application. Using the [`MaterialApp`][]
 widget is entirely optional but a good practice.
 
 <?code-excerpt "lib/main_tutorial.dart"?>
-```dartpad run="true"
+```dartpad title="Flutter Material design hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() {
@@ -312,7 +312,7 @@ The first step in building an interactive application is to detect
 input gestures. See how that works by creating a simple button:
 
 <?code-excerpt "lib/main_mybutton.dart"?>
-```dartpad run="true"
+```dartpad title="Flutter button hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 class MyButton extends StatelessWidget {
@@ -385,7 +385,7 @@ this idea. `StatefulWidgets` are special widgets that know how to generate
 Consider this basic example, using the [`ElevatedButton`][] mentioned earlier:
 
 <?code-excerpt "lib/main_counter.dart"?>
-```dartpad run="true"
+```dartpad title="Flutter state management hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 class Counter extends StatefulWidget {
@@ -476,7 +476,7 @@ The following slightly more complex example shows how
 this works in practice:
 
 <?code-excerpt "lib/main_counterdisplay.dart"?>
-```dartpad run="true"
+```dartpad title="Flutter Hello World hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 class CounterDisplay extends StatelessWidget {
@@ -568,7 +568,7 @@ intended purchases. Start by defining the presentation class,
 `ShoppingListItem`:
 
 <?code-excerpt "lib/main_shoppingitem.dart"?>
-```dartpad run="true"
+```dartpad title="Flutter complete shopping list item hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 class Product {
@@ -672,7 +672,7 @@ built widgets and applies only the differences to the underlying
 Here's an example parent widget that stores mutable state:
 
 <?code-excerpt "lib/main_shoppinglist.dart"?>
-```dartpad run="true"
+```dartpad title="Flutter storing mutable state hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 class Product {

--- a/src/content/ui/interactivity/actions-and-shortcuts.md
+++ b/src/content/ui/interactivity/actions-and-shortcuts.md
@@ -431,7 +431,7 @@ invoke actions to accomplish their work. All the invoked actions and
 shortcuts are logged.
 
 <?code-excerpt "ui/advanced/actions_and_shortcuts/lib/copyable_text.dart"?>
-```dartpad run="true"
+```dartpad title="Copyable text DartPad hands-on example" run="true"
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 

--- a/src/content/ui/layout/constraints.md
+++ b/src/content/ui/layout/constraints.md
@@ -166,7 +166,7 @@ Use the numbered horizontal scrolling bar to switch between
 29 different examples.
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad run="true"
+```dartpad title="Constraints DartPad hands-on example" run="true"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const HomePage());


### PR DESCRIPTION
Fixes #10530

Adds titles to the `iframe` tags that frame embedded DartPads as a accessibility requirement. 

From: https://buganizer.corp.google.com/issues/337851628

### OBSERVED RESULTS
Navigating through the interactive code example, I noticed that the iframe is not having a defined title.

* [Screencast VoiceOver](http://screencast/cast/NjcwNzcxNDUxOTQ2NTk4NHxkN2JiNDY2YS0xYg)
* [Screencast ChromeVox](http://screencast/cast/NjcwMzg1NTEyMjI1MTc3NnxkNDY3ZGVjZC00ZQ)

### EXPECTED RESULTS
* Ensure that when the user is on the code section the `iframe` should have a definite name like: `Interactive code iframe text section`.

* Element has no title attribute aria-label attribute does not exist or is empty aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty Element's default semantics were not overridden with role="none" or role="presentation"

### USER IMPACT
Screen reader and Cognitive users are confused because they do not know what is the name of that section is.
