### PR TITLE
Add FCM codelab to Flutter docs codelabs

### DIFF
--- a/src/content/codelabs/index.md
+++ b/src/content/codelabs/index.md
@@ -188,10 +188,16 @@ Learn how to use Flutter with other technologies.
   developing with Flutter. You will also learn to use
   the Auth and Firestore emulators.
 
+* [Send and receive notifications for a Flutter app using Firebase Cloud Messaging][]<br>
+  Learn how to develop a multi-platform app with Flutter
+  and Firebase Cloud Messaging, integrating FCM to send and
+  receive messages on Android, iOS, and web.
+
 [Add a user authentication flow to a Flutter app using FirebaseUI]: {{site.firebase}}/codelabs/firebase-auth-in-flutter-apps
 [firebase-ws]: {{site.yt.watch}}?v=wUSkeTaBonA
 [Get to know Firebase for Flutter]: {{site.firebase}}/codelabs/firebase-get-to-know-flutter
 [Local development for your Flutter apps using the Firebase Emulator Suite]: {{site.firebase}}/codelabs/get-started-firebase-emulators-and-flutter
+[Send and receive notifications for a Flutter app using Firebase Cloud Messaging]: {{site.firebase}}/codelabs/firebase-fcm-flutter
 
 ### Build games with Flutter
 


### PR DESCRIPTION
Add FCM codelab to the list of Firebase codelabs if flutter docs.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
