### PR TITLE
[macOS] Update sidebar title for dart:ffi interop

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -468,7 +468,7 @@
           permalink: /platform-integration/macos/install-macos
         - title: Build a macOS app
           permalink: /platform-integration/macos/building
-        - title: C interop
+        - title: Bind to native code
           permalink: /platform-integration/macos/c-interop
     - title: Web
       permalink: /platform-integration/web


### PR DESCRIPTION
iOS and Android pages have been re-titles "Bint to native code" in the sidebar. This updates macOS to match. There are no equivalent pages for Windows, Linux, or web.

Spotted while working on macOS Platform Views documentation.

## Presubmit checklist

- [X] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
