### PR TITLE
Corrected 2nd example in Step 3

### DIFF
--- a/src/content/ui/interactivity/index.md
+++ b/src/content/ui/interactivity/index.md
@@ -76,12 +76,14 @@ telling the framework to redraw the widget.
 ## Creating a stateful widget
 
 :::secondary What's the point?
+
 * A stateful widget is implemented by two classes:
-    a subclass of `StatefulWidget` and a subclass of `State`.
+  a subclass of `StatefulWidget` and a subclass of `State`.
 * The state class contains the widget's mutable state and
-    the widget's `build()` method.
+  the widget's `build()` method.
 * When the widget's state changes, the state object calls
-    `setState()`, telling the framework to redraw the widget.
+  `setState()`, telling the framework to redraw the widget.
+
 :::
 
 In this section, you'll create a custom stateful widget.
@@ -190,11 +192,38 @@ because it has an `onPressed` property that defines
 the callback function (`_toggleFavorite`) for handling a tap.
 You'll define the callback function next.
 
-<?code-excerpt "lib/main.dart (favorite-state-fields)" replace="/build|icon.*|onPressed.*|child: Text.*/[!$&!]/g"?>
+<?code-excerpt "lib/main.dart (favorite-state-build)" replace="/build|icon.*|onPressed.*|child: Text.*/[!$&!]/g"?>
 ```dart
 class _FavoriteWidgetState extends State<FavoriteWidget> {
-  bool _isFavorited = true;
-  int _favoriteCount = 41;
+  // ···
+  @override
+  Widget [!build!](BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          padding: const EdgeInsets.all(0),
+          child: IconButton(
+            padding: const EdgeInsets.all(0),
+            alignment: Alignment.center,
+            [!icon: (_isFavorited!]
+                ? const Icon(Icons.star)
+                : const Icon(Icons.star_border)),
+            color: Colors.red[500],
+            [!onPressed: _toggleFavorite,!]
+          ),
+        ),
+        SizedBox(
+          width: 18,
+          child: SizedBox(
+            [!child: Text('$_favoriteCount'),!]
+          ),
+        ),
+      ],
+    );
+  }
+  // ···
+}
 ```
 
 :::tip


### PR DESCRIPTION
Step 3 referred to the same example twice. [Fixed the second reference](https://github.com/flutter/website/pull/10818/files#diff-8ed1d4c698525a7a81fb2855483cd17fcb6af883dbc98386704b2ce98fe7a7f4R195-R226) to point to `favorite-state-build` instead of `favorite-state-fields`.

Fixes #10723