### PR TITLE
Update other references to web initialization customization

### DIFF
--- a/src/content/deployment/web.md
+++ b/src/content/deployment/web.md
@@ -185,8 +185,8 @@ that specifies a `HTMLElement` as the `hostElement`.
     <div id="flutter_host">Loading...</div>
 
     <script>
-      {{flutter_js}}
-      {{flutter_build_config}}
+      {% raw %}{{flutter_js}}{% endraw %}
+      {% raw %}{{flutter_build_config}}{% endraw %}
 
       _flutter.loader.load({
         config: {

--- a/src/content/deployment/web.md
+++ b/src/content/deployment/web.md
@@ -172,41 +172,43 @@ create a release build.
 
 _Added in Flutter 3.10_<br>
 You can embed a Flutter web app into
-any HTML element of your web page, with `flutter.js` and the `hostElement`
-engine initialization parameter.
+any HTML element of your web page.
 
-To tell Flutter web in which element to render, use the `hostElement` parameter of the `initializeEngine`
-function:
+To tell Flutter web in which element to render,
+pass an object with a `config` field to the `_flutter.loader.load` function
+that specifies a `HTMLElement` as the `hostElement`.
 
-```html
+```html highlightLines=11-13
 <html>
-  <head>
-    <!-- ... -->
-    <script src="flutter.js" defer></script>
-  </head>
   <body>
-
     <!-- Ensure your flutter target is present on the page... -->
     <div id="flutter_host">Loading...</div>
 
     <script>
-      window.addEventListener("load", function (ev) {
-        _flutter.loader.loadEntrypoint({
-          onEntrypointLoaded: async function(engineInitializer) {
-            let appRunner = await engineInitializer.initializeEngine({
-              // Pass a reference to "div#flutter_host" into the Flutter engine.
-              hostElement: document.querySelector("#flutter_host")
-            });
-            await appRunner.runApp();
-          }
-        });
+      {{flutter_js}}
+      {{flutter_build_config}}
+
+      _flutter.loader.load({
+        config: {
+          hostElement: document.getElementById('flutter_host'),
+        }
       });
     </script>
   </body>
 </html>
 ```
 
-To learn more, check out [Customizing web app initialization][customizing-web-init].
+To learn more about other configuration options,
+check out [Customizing web app initialization][customizing-web-init].
+
+:::version-note
+This method of specifying the `hostElement` was changed in Flutter 3.22.
+To learn how to configure the `hostElement` in earlier Flutter versions,
+reference [Legacy web app initialization][web-init-legacy].
+:::
+
+[customizing-web-init]: /platform-integration/web/initialization
+[web-init-legacy]: /platform-integration/web/initialization-legacy
 
 ### Iframe
 
@@ -242,5 +244,4 @@ so please [give us feedback][] if you see something that doesn't look right.
 [Google Cloud Hosting]: https://cloud.google.com/solutions/web-hosting
 [`iframe`]: https://html.com/tags/iframe/
 [Web renderers]: /platform-integration/web/renderers
-[customizing-web-init]: /platform-integration/web/initialization
 

--- a/src/content/platform-integration/web/initialization.md
+++ b/src/content/platform-integration/web/initialization.md
@@ -29,7 +29,7 @@ your `index.html` file in the `web` subdirectory of your Flutter app:
   <body>
     <script src="flutter_bootstrap.js" async></script>
   </body>
-<html>
+</html>
 ```
 
 Alternatively, you can inline the entire contents of
@@ -44,7 +44,7 @@ your `index.html` file:
       {% raw %}{{flutter_bootstrap_js}}{% endraw %}
     </script>
   </body>
-<html>
+</html>
 ```
 
 The `{% raw %}{{flutter_bootstrap_js}}{% endraw %}` token is
@@ -90,7 +90,9 @@ substitute in either the `flutter_bootstrap.js` or `index.html` files:
 
 </div>
 
-## Write a custom `flutter_bootstrap.js`
+<a id="write-a-custom-flutter_bootstrap-js" aria-hidden="true"></a>
+
+## Write a custom `flutter_bootstrap.js` {:#custom-bootstrap-js}
 
 Any custom `flutter_bootstrap.js` script needs to have three components in
 order to successfully start your Flutter app:

--- a/src/content/platform-integration/web/renderers.md
+++ b/src/content/platform-integration/web/renderers.md
@@ -56,10 +56,10 @@ To override the web renderer at runtime:
 ```html highlightLines=9-14
 <body>
   <script>
-    {{flutter_js}}
-    {{flutter_build_config}}
+    {% raw %}{{flutter_js}}{% endraw %}
+    {% raw %}{{flutter_build_config}}{% endraw %}
 
-    // TODO: Replace this with your code to determine which renderer to use.  
+    // TODO: Replace this with your own code to determine which renderer to use.  
     const useHtml = true;
   
     const config = {

--- a/src/content/platform-integration/web/renderers.md
+++ b/src/content/platform-integration/web/renderers.md
@@ -44,32 +44,30 @@ target is selected.
 
 To override the web renderer at runtime:
 
-* Build the app with the `auto` option.
-* Prepare a configuration object with the `renderer` property set to
-  `"canvaskit"` or `"html"`.
-* Pass that object to the `engineInitializer.initializeEngine(configuration);`
-  method in the [Flutter Web app initialization][web-app-init] script.
+ 1. Build the app with the `auto` option.
+ 1. Set up custom web app initialization
+    as described in [Write a custom `flutter_bootstrap.js`][custom-bootstrap].
+ 1. Prepare a configuration object with the `renderer` property set to
+    `"canvaskit"` or `"html"`.
+ 1. Pass your prepared config object as the `config` property of
+    a new object to the `_flutter.loader.load` method that is
+    provided by the earlier injected code.
 
-```html
+```html highlightLines=9-14
 <body>
   <script>
-    let useHtml = true;
+    {{flutter_js}}
+    {{flutter_build_config}}
 
-    window.addEventListener('load', function(ev) {
-    _flutter.loader.loadEntrypoint({
-      serviceWorker: {
-        serviceWorkerVersion: serviceWorkerVersion,
-      },
-      onEntrypointLoaded: function(engineInitializer) {
-        let config = {
-          renderer: useHtml ? "html" : "canvaskit",
-        };
-        engineInitializer.initializeEngine(config).then(function(appRunner) {
-          appRunner.runApp();
-        });
-      }
+    // TODO: Replace this with your code to determine which renderer to use.  
+    const useHtml = true;
+  
+    const config = {
+      renderer: useHtml ? "html" : "canvaskit",
+    };
+    _flutter.loader.load({
+      config: config,
     });
-  });
   </script>
 </body>
 ```
@@ -77,12 +75,15 @@ To override the web renderer at runtime:
 The web renderer can't be changed after the Flutter engine startup process
 begins in `main.dart.js`.
 
-:::note
-Setting a `window.flutterWebRenderer`
-(an approach used in previous releases) displays a
-**deprecation notice** in the JS console. For more information,
-check out [Customizing web app initialization][web-app-init].
+:::version-note
+The method of specifying the web renderer was changed in Flutter 3.22.
+To learn how to configure the renderer in earlier Flutter versions,
+check out [Legacy web app initialization][web-init-legacy].
 :::
+
+[custom-bootstrap]: /platform-integration/web/initialization#custom-bootstrap-js
+[customizing-web-init]: /platform-integration/web/initialization
+[web-init-legacy]: /platform-integration/web/initialization-legacy
 
 ## Choosing which option to use
 
@@ -123,4 +124,3 @@ flutter run -d chrome --web-renderer html --profile
 
 [canvaskit]: https://skia.org/docs/user/modules/canvaskit/
 [file an issue]: {{site.repo.flutter}}/issues/new?title=[web]:+%3Cdescribe+issue+here%3E&labels=%E2%98%B8+platform-web&body=Describe+your+issue+and+include+the+command+you%27re+running,+flutter_web%20version,+browser+version
-[web-app-init]: /platform-integration/web/initialization


### PR DESCRIPTION
Closes https://github.com/flutter/website/issues/10739

**Staged links:**
- [Renderer runtime configuration](https://flutter-docs-prod--pr10819-feat-other-web-init-updates-n64v5nqz.web.app/platform-integration/web/renderers#runtime-configuration)
- [Host element embedding](https://flutter-docs-prod--pr10819-feat-other-web-init-updates-n64v5nqz.web.app/deployment/web#embedding-a-flutter-app-into-an-html-page)