### PR TITLE
remove redundant callout/link to "Transforming assets at build time" page

### DIFF
--- a/src/content/ui/assets/assets-and-images.md
+++ b/src/content/ui/assets/assets-and-images.md
@@ -64,7 +64,6 @@ from at runtime.
 
 Flutter supports using a Dart package to transform asset files when building your app.
 To do this, specify the asset files and transformer package in your pubspec file.
-To learn more, check out [Transforming assets at build time][].
 To learn how to do this and write your own asset-transforming packages, see
 [Transforming assets at build time][].
 


### PR DESCRIPTION
(Let me know if I should be filing issues for tiny changes such as these.)

On the Assets and images page, there is a small section, "Automatic transformation of asset files at build time" that serves as a breadcrumb to a page that contains information about a niche feature. However, it contains what feels to me like redundant text:

https://github.com/flutter/website/blob/bcbe0418e7095e26250945d4f257506b76282e76/src/content/ui/assets/assets-and-images.md?plain=1#L67-L69

This PR address that by removing the first sentence that links to Transforming assets at build time.

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
