### PR TITLE
add breadcrumb about flavor-conditional asset bundling to assets page

### DIFF
--- a/src/content/ui/assets/assets-and-images.md
+++ b/src/content/ui/assets/assets-and-images.md
@@ -71,7 +71,7 @@ To learn how to do this and write your own asset-transforming packages, see
 ### Conditional bundling of assets based on app flavor
 
 If your project utilizes the [flavors feature][], you can configure individual
-assets can be configured to be bundled only in certain flavors of your app.
+assets to be bundled only in certain flavors of your app.
 For more information, check out [Conditionally bundling assets based on flavor].
 
 ## Loading assets

--- a/src/content/ui/assets/assets-and-images.md
+++ b/src/content/ui/assets/assets-and-images.md
@@ -68,6 +68,12 @@ To learn more, check out [Transforming assets at build time][].
 To learn how to do this and write your own asset-transforming packages, see
 [Transforming assets at build time][].
 
+### Conditional bundling of assets based on app flavor
+
+If your project utilizes the [flavors feature][], you can configure individual
+assets can be configured to be bundled only in certain flavors of your app.
+For more information, check out [Conditionally bundling assets based on flavor].
+
 ## Loading assets
 
 Your app can access its assets through an
@@ -512,3 +518,5 @@ For more details, see
 [MaterialApp]: {{site.api}}/flutter/material/MaterialApp-class.html
 [CupertinoApp]: {{site.api}}/flutter/cupertino/CupertinoApp-class.html
 [Transforming assets at build time]: /ui/assets/asset-transformation
+[Conditionally bundling assets based on flavor]: /deployment/flavors#conditionally-bundling-assets-based-on-flavor
+[flavors feature]: /deployment/flavors


### PR DESCRIPTION
This is a follow-up to https://github.com/flutter/website/pull/9864#issuecomment-1831179497.

This adds a breadcrumb to the "Assets and images" page that mentions and links to the flavor-conditional asset bundling feature. This is meant to aid discovery of the feature for users who are new to the assets feature.

I chose adding a simple bread crumb over a full explanation + example pubspec as this is a relatively niche feature, and I didn't want there to be a significant amount of text between the top-level "Specifying assets" and "Loading assets" sections, as the beginning of these sections are going to be what I feel like the vast-majority of visitors are going to be interested in.

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
