### PR TITLE
Fix link on the Get started → First week → Networking page

### DIFF
--- a/src/content/get-started/fwe/networking.md
+++ b/src/content/get-started/fwe/networking.md
@@ -6,7 +6,7 @@ prev:
   path: /get-started/fwe/user-input
 next:
   title: Local data and caching
-  path: /get-started/fwe/networking
+  path: /get-started/fwe/local-caching
 ---
 
 While it's said that "no man is an island",


### PR DESCRIPTION
The href of the next page link the bottom of the Get started → First week → [Networking page](https://docs.flutter.dev/get-started/fwe/networking) page is incorrect. The label ‘Local data and caching’ is correct but the link points back to the Networking page – this PR fixes the link.

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
