### PR TITLE
Update deprecation policy

### DIFF
--- a/src/content/release/compatibility-policy.md
+++ b/src/content/release/compatibility-policy.md
@@ -43,9 +43,9 @@ break them overnight. This is independent of our compatibility policy
 which is exclusively based on whether submitted tests fail, as
 described above.
 
-Deprecated APIs are not removed on a scheduled basis. If any are removed,
-we follow the same procedures listed above for making breaking changes
-in removing the deprecated API.
+The Flutter team doesn't remove deprecated APIs on a scheduled basis.
+If the team removes a deprecated API,
+it follows the same procedures as those for breaking changes.
 
 
 ## Dart and other libraries used by Flutter

--- a/src/content/release/compatibility-policy.md
+++ b/src/content/release/compatibility-policy.md
@@ -43,12 +43,9 @@ break them overnight. This is independent of our compatibility policy
 which is exclusively based on whether submitted tests fail, as
 described above.
 
-Deprecated APIs are removed after a migration grace period. This grace
-period is one calendar year after being released on the stable channel,
-or after 4 stable releases, whichever is longer.
-
-When a deprecation does reach end of life, we follow the same procedures
-listed above for making breaking changes in removing the deprecated API.
+Deprecated APIs are not removed on a scheduled basis. If any are removed,
+we follow the same procedures listed above for making breaking changes
+in removing the deprecated API.
 
 
 ## Dart and other libraries used by Flutter


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

This updates the deprecation policy. We are pausing our cadence of removing deprecated API from the framework until we can create a new policy.
The last couple of cycles we noticed customers having more difficult migrations, and it being harder to remove the APIs in the scheduled time period. So we need to reevaluate the policy and update it.

This is the policy working as intended. Signals like flutter/tests provide feedback on how we are affecting users - so that for folks that contributed!

Related to https://github.com/flutter/flutter/pull/151257

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
