### PR TITLE
Fix last updated date on production deploy

### DIFF
--- a/cloud_build/deploy.yaml
+++ b/cloud_build/deploy.yaml
@@ -1,6 +1,8 @@
 steps:
   - name: gcr.io/cloud-builders/git
     args: ['submodule', 'update', '--init', '--recursive']
+  - name: gcr.io/cloud-builders/git
+    args: ['fetch', '--unshallow']
   - name: gcr.io/flutter-dev-230821/firebase-ghcli
     # Set up, build, then deploy site to production
     entrypoint: '/bin/bash'

--- a/src/_includes/page-github-links.html
+++ b/src/_includes/page-github-links.html
@@ -2,11 +2,10 @@
 {% capture pageSource -%} {{repo}}/tree/{{site.branch}}/{{page.inputPath | replace: './', ''}} {%- endcapture -%}
 {% assign siteTitle = title | default: page.url | escape -%}
 {% assign url = site.url | append: page.url -%}
-{% capture issueTitle -%} title=[PAGE ISSUE]: '{{siteTitle}}' {%- endcapture -%}
 
 <p id="page-github-links">
   <span>Unless stated otherwise, the documentation on this site reflects the latest stable version of Flutter. Page last updated on {{page.date | toSimpleDate}}.</span>
   <a href="{{pageSource}}" target="_blank" rel="noopener">View source</a>
   <span> or </span>
-  <a href="{{repo}}/issues/new?template=1_page_issue.yml&{{issueTitle}}&page-url={{url}}&page-source={{pageSource}}" title="Report an issue with this page" target="_blank" rel="noopener">report an issue</a>.
+  <a href="{{repo}}/issues/new?template=1_page_issue.yml&&page-url={{url}}&page-source={{pageSource}}" title="Report an issue with this page" target="_blank" rel="noopener">report an issue</a>.
 </p>

--- a/src/content/content.11tydata.js
+++ b/src/content/content.11tydata.js
@@ -1,3 +1,3 @@
-export default process.env.PRODUCTION === 'true' ? {
-  date: "git Last Modified"
-} : {};
+export default {
+  date: process.env.PRODUCTION === 'true' ? 'git Last Modified' : 'Last Modified',
+};


### PR DESCRIPTION
Cloud Build seems to only do a shallow clone, so "unshallowing" the checkout is required to get last modified information.