### PR TITLE
No longer require manually wrapping tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "markdown-it-attrs": "^4.1.6",
     "markdown-it-container": "^4.0.0",
     "markdown-it-deflist": "^3.0.0",
-    "markdown-it-table": "^4.1.1",
     "sass": "^1.77.6",
     "shiki": "^1.7.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,6 @@ importers:
       markdown-it-deflist:
         specifier: ^3.0.0
         version: 3.0.0
-      markdown-it-table:
-        specifier: ^4.1.1
-        version: 4.1.1
       sass:
         specifier: ^1.77.6
         version: 1.77.6
@@ -1698,10 +1695,6 @@ packages:
 
   markdown-it-deflist@3.0.0:
     resolution: {integrity: sha512-OxPmQ/keJZwbubjiQWOvKLHwpV2wZ5I3Smc81OjhwbfJsjdRrvD5aLTQxmZzzePeO0kbGzAo3Krk4QLgA8PWLg==}
-
-  markdown-it-table@4.1.1:
-    resolution: {integrity: sha512-dzFHRwCe97sXD071Gw/LSIwgAcO2vNsT0BcPCmnrKhNW/W57Bnknl8EaC+j4hM3bAqus1CiVPcTQAvLkUfHLhw==}
-    engines: {node: '>12.6'}
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
@@ -4781,8 +4774,6 @@ snapshots:
   markdown-it-container@4.0.0: {}
 
   markdown-it-deflist@3.0.0: {}
-
-  markdown-it-table@4.1.1: {}
 
   markdown-it@14.1.0:
     dependencies:

--- a/src/_11ty/plugins/markdown.js
+++ b/src/_11ty/plugins/markdown.js
@@ -1,6 +1,5 @@
 import markdownIt from 'markdown-it';
 import markdownItContainer from 'markdown-it-container';
-import { markdownItTable } from 'markdown-it-table';
 import markdownItDefinitionList from 'markdown-it-deflist';
 import markdownItAttrs from 'markdown-it-attrs';
 import markdownItAnchor from 'markdown-it-anchor';
@@ -9,7 +8,6 @@ import { slugify } from '../utils/slugify.js';
 /** @type {import('markdown-it/lib').MarkdownIt} */
 export const markdown = (() => {
   const markdown = markdownIt({ html: true })
-    .use(markdownItTable)
     .use(markdownItDefinitionList)
     .use(markdownItAttrs, {
       leftDelimiter: '{:',
@@ -30,9 +28,27 @@ export const markdown = (() => {
     });
 
   _registerAsides(markdown);
+  _setUpTables(markdown);
 
   return markdown;
 })();
+
+/**
+ * Wrap all tables in a div with `table-wrapper` class.
+ *
+ * @param markdown {import('markdown-it/lib').MarkdownIt} markdown
+ */
+function _setUpTables(markdown) {
+  markdown.renderer.rules = {
+    ...markdown.renderer.rules,
+    table_open: function (tokens, idx, options, env, self) {
+      const token = tokens[idx];
+      // Render added attributes from `{:.table .table-striped}` syntax.
+      return `<div class="table-wrapper">\n<table ${self.renderAttrs(token)}>\n`;
+    },
+    table_close: () => '</table>\n</div>',
+  };
+}
 
 /**
  * Register a custom aside/admonition.

--- a/src/_includes/docs/install/reqs/linux/base.md
+++ b/src/_includes/docs/install/reqs/linux/base.md
@@ -12,8 +12,6 @@ and software requirements.
 Your {{include.os}} Flutter development environment must meet the following
 minimal hardware requirements.
 
-<div class="table-wrapper">
-
 |     Requirement              |                                    Minimum                               |    Recommended      |
 |:-----------------------------|:------------------------------------------------------------------------:|:-------------------:|
 | CPU Cores                    | 4                                                                        | 8                   |
@@ -22,8 +20,6 @@ minimal hardware requirements.
 | Free disk space in GB        | {% include docs/install/reqs/linux/storage.md target=include.target %}
 
 {:.table .table-striped}
-
-</div>
 
 {% if include.os == 'ChromeOS' and include.target == 'Android' %}
 To discover which hardware devices ChromeOS recommends for Android development,

--- a/src/_includes/docs/install/reqs/macos/base.md
+++ b/src/_includes/docs/install/reqs/macos/base.md
@@ -20,8 +20,6 @@ and software requirements.
 Your {{include.os}} Flutter development environment must meet the following
 minimal hardware requirements.
 
-<div class="table-wrapper">
-
 |     Requirement              |                                    Minimum                               |    Recommended      |
 |:-----------------------------|:------------------------------------------------------------------------:|:-------------------:|
 | CPU Cores                    | 4                                                                        | 8                   |
@@ -30,8 +28,6 @@ minimal hardware requirements.
 | Free disk space in GB        | {% include docs/install/reqs/macos/storage.md target=include.target %}
 
 {:.table .table-striped}
-
-</div>
 
 ### Software requirements
 

--- a/src/_includes/docs/install/reqs/windows/base.md
+++ b/src/_includes/docs/install/reqs/windows/base.md
@@ -12,8 +12,6 @@ and software requirements.
 Your {{include.os}} Flutter development environment must meet the following
 minimal hardware requirements.
 
-<div class="table-wrapper">
-
 |     Requirement              |                                    Minimum                               |    Recommended      |
 |:-----------------------------|:------------------------------------------------------------------------:|:-------------------:|
 | x86_64 CPU Cores             | 4                                                                        | 8                   |
@@ -22,8 +20,6 @@ minimal hardware requirements.
 | Free disk space in GB        | {% include docs/install/reqs/windows/storage.md target=include.target %}
 
 {:.table .table-striped}
-
-</div>
 
 ### Software requirements
 

--- a/src/content/get-started/flutter-for/react-native-devs.md
+++ b/src/content/get-started/flutter-for/react-native-devs.md
@@ -2309,8 +2309,6 @@ In Flutter, if you are using an IDE, you can use the IDE tools. If you start
 your application using `flutter run` you can also access the menu by typing `h`
 in the terminal window, or type the following shortcuts:
 
-<div class="table-wrapper">
-
 | Action| Terminal Shortcut| Debug functions and properties|
 | :------- | :------: | :------ |
 | Widget hierarchy of the app| `w`| debugDumpApp()|
@@ -2325,8 +2323,6 @@ in the terminal window, or type the following shortcuts:
 | To quit| `q` ||
 
 {:.table .table-striped}
-
-</div>
 
 ## Animation
 
@@ -2506,8 +2502,6 @@ The following table lists commonly-used React Native
 components mapped to the corresponding Flutter widget
 and common widget properties.
 
-<div class="table-wrapper">
-
 | React Native Component                                                                    | Flutter Widget                                                                                             | Description                                                                                                                            |
 | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | [`Button`](https://facebook.github.io/react-native/docs/button.html)                        | [`ElevatedButton`][]                           | A basic raised button.                                                                              |
@@ -2579,8 +2573,6 @@ and common widget properties.
 |                                                                                         | onChanged [required]                                                                                      | Called when the user selects a new value for the slider.                                                                                                                                                      |
 
 {:.table .table-striped}
-
-</div>
 
 
 [`AboutDialog`]: {{site.api}}/flutter/material/AboutDialog-class.html

--- a/src/content/platform-integration/web/initialization-legacy.md
+++ b/src/content/platform-integration/web/initialization-legacy.md
@@ -99,8 +99,6 @@ learn how to customize each stage of your app's initialization.
 
 The `loadEntrypoint` method accepts these parameters:
 
-<div class="table-wrapper">
-
 | Name | Description | JS&nbsp;Type |
 |-|-|-|
 |`entrypointUrl`| The URL of your Flutter app's entrypoint. Defaults to `"main.dart.js"`. |`String`|
@@ -109,11 +107,7 @@ The `loadEntrypoint` method accepts these parameters:
 
 {:.table}
 
-</div>
-
 The `serviceWorker` JavaScript object accepts the following properties:
-
-<div class="table-wrapper">
 
 | Name | Description | JS&nbsp;Type |
 |-|-|-|
@@ -123,8 +117,6 @@ The `serviceWorker` JavaScript object accepts the following properties:
 
 {:.table}
 
-</div>
-
 ### Initializing the engine
 
 As of _Flutter 3.7.0_, you can use the `initializeEngine` method to
@@ -132,8 +124,6 @@ configure several run-time options of the Flutter web engine through a
 plain JavaScript object.
 
 You can add any of the following optional parameters:
-
-<div class="table-wrapper">
 
 | Name | Description | Dart&nbsp;Type |
 |-|-|-|
@@ -147,8 +137,6 @@ You can add any of the following optional parameters:
 |`renderer`| Specifies the [web renderer][web-renderers] for the current Flutter application, either `"canvaskit"` or `"html"`. |`String`|
 
 {:.table}
-
-</div>
 
 [jsflutterconfig-source]: {{site.repo.engine}}/blob/main/lib/web_ui/lib/src/engine/configuration.dart#L247-L259
 [web-renderers]: /platform-integration/web/renderers

--- a/src/content/platform-integration/web/initialization.md
+++ b/src/content/platform-integration/web/initialization.md
@@ -77,8 +77,6 @@ the `flutter_bootstrap.js` file to the output directory.
 The following table lists the tokens that the build step will
 substitute in either the `flutter_bootstrap.js` or `index.html` files:
 
-<div class="table-wrapper">
-
 | Token | Replaced with |
 |---|---|
 | `{% raw %}{{flutter_js}}{% endraw %}` | The JavaScript code that makes the `FlutterLoader` object available in the `_flutter.loader` global variable. (See the `_flutter.loader.load() API` section below for more details.) |
@@ -87,8 +85,6 @@ substitute in either the `flutter_bootstrap.js` or `index.html` files:
 | `{% raw %}{{flutter_bootstrap_js}}{% endraw %}` | As mentioned above, this inlines the contents of the `flutter_bootstrap.js` file directly into the `index.html` file. Note that this token can only be used in the `index.html` and not the `flutter_bootstrap.js` file itself. |
 
 {:.table}
-
-</div>
 
 <a id="write-a-custom-flutter_bootstrap-js" aria-hidden="true"></a>
 
@@ -118,8 +114,6 @@ _flutter.loader.load();
 The `_flutter.loader.load()` JavaScript API can be invoked with optional
 arguments to customize initialization behavior:
 
-<div class="table-wrapper">
-
 | Name                    | Description                                                                                                                   | JS&nbsp;type |
 |-------------------------|-------------------------------------------------------------------------------------------------------------------------------|--------------|
 | `config`                | The Flutter configuration of your app.                                                                                        | `Object`     |
@@ -128,11 +122,7 @@ arguments to customize initialization behavior:
 
 {:.table}
 
-</div>
-
 The `config` argument is an object that can have the following optional fields:
-
-<div class="table-wrapper">
 
 | Name | Description | Dart&nbsp;type |
 |---|---|---|
@@ -147,13 +137,9 @@ The `config` argument is an object that can have the following optional fields:
 
 {:.table}
 
-</div>
-
 [web-renderers]: /platform-integration/web/renderers
 
 The `serviceWorkerSettings` argument has the following optional fields.
-
-<div class="table-wrapper">
 
 | Name                   | Description                                                                                                                             | JS&nbsp;type |
 |------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|--------------|
@@ -162,8 +148,6 @@ The `serviceWorkerSettings` argument has the following optional fields.
 | `timeoutMillis`        | The timeout value for the service worker load. Defaults to `4000`.                                                                      | `Number`     |
 
 {:.table}
-
-</div>
 
 ## Example: Customizing Flutter configuration based on URL query parameters
 

--- a/src/content/platform-integration/web/wasm.md
+++ b/src/content/platform-integration/web/wasm.md
@@ -113,16 +113,12 @@ Flutter web applications won't run with WebAssembly unless the server is
 configured to send specific HTTP headers.
 :::
 
-<div class="table-wrapper">
-
 | Name | Value |
 |-|-|
 | `Cross-Origin-Embedder-Policy` | `credentialless` <br> or <br> `require-corp` |
 | `Cross-Origin-Opener-Policy` | `same-origin` |
 
 {:.table}
-
-</div>
 
 To learn more about these headers, check out
 [Load cross-origin resources without CORP headers using COEP: credentialless][coep].

--- a/src/content/reference/supported-platforms.md
+++ b/src/content/reference/supported-platforms.md
@@ -20,8 +20,6 @@ Based on these tiers, Flutter supports deploying to the following platforms.
 
 {% assign opsys = platforms %}
 
-<div class="table-wrapper">
-
 | Target Platform | Hardware architectures | Supported versions | Best effort versions | Unsupported versions |
 |---|:---:|:---:|:---:|:---:|
 {%- for platform in opsys %}
@@ -29,5 +27,3 @@ Based on these tiers, Flutter supports deploying to the following platforms.
 {%- endfor %}
 
 {:.table .table-striped}
-
-</div>

--- a/src/content/release/breaking-changes/2-10-deprecations.md
+++ b/src/content/release/breaking-changes/2-10-deprecations.md
@@ -195,8 +195,6 @@ They are replaced by new buttons, `TextButton`, `ElevatedButton`, and
 `OutlinedButton`. These new widgets also use new associated themes, rather than
 the generic `ButtonTheme`.
 
-<div class="table-wrapper">
-
 | Old Widget      | Old Theme     | New Widget       | New Theme             |
 |-----------------|---------------|------------------|-----------------------|
 | `FlatButton`    | `ButtonTheme` | `TextButton`     | `TextButtonTheme`     |
@@ -204,8 +202,6 @@ the generic `ButtonTheme`.
 | `OutlineButton` | `ButtonTheme` | `OutlinedButton` | `OutlinedButtonTheme` |
 
 {:.table .table-striped .nowrap}
-
-</div>
 
 **Migration guide**
 

--- a/src/content/release/breaking-changes/buttons.md
+++ b/src/content/release/breaking-changes/buttons.md
@@ -35,8 +35,6 @@ labyrinth that evolving the existing classes in-place would entail,
 the new names sync Flutter back up with the Material Design spec,
 which uses the new names for the button components.
 
-<div class="table-wrapper">
-
 | Old Widget      | Old Theme     | New Widget       | New Theme             |
 |-----------------|---------------|------------------|-----------------------|
 | `FlatButton`    | `ButtonTheme` | `TextButton`     | `TextButtonTheme`     |
@@ -44,8 +42,6 @@ which uses the new names for the button components.
 | `OutlineButton` | `ButtonTheme` | `OutlinedButton` | `OutlinedButtonTheme` |
 
 {:.table .table-striped .nowrap}
-
-</div>
 
 The new themes follow the "normalized" pattern that Flutter adopted
 for new Material widgets about a year ago. Theme properties and widget

--- a/src/content/testing/native-debugging.md
+++ b/src/content/testing/native-debugging.md
@@ -143,8 +143,6 @@ The following screenshot and table explain the purpose of each tool.
 
 ![VS Code with the Flutter plugin UI additions](/assets/images/docs/testing/debugging/vscode-ui/screens/debugger-parts.png)
 
-<div class="table-wrapper">
-
 | Highlight Color in Screenshot | Bar, Panel, or Tab  | Contents                                                                          |
 |-------------------------------|---------------------|-----------------------------------------------------------------------------------|
 | **Yellow**                    | Variables           | List of current values of variables in the Flutter app                            |
@@ -162,8 +160,6 @@ The following screenshot and table explain the purpose of each tool.
 
 {:.table .table-striped}
 
-</div>
-
 To change where the panel (in **orange**) appears in VS Code,
 go to **View** > **Appearance** > **Panel Position**.
 
@@ -173,8 +169,6 @@ The toolbar allows you to debug using any debugger.
 You can step in, out, and over Dart statements, hot reload, or resume the app.
 
 ![Flutter debugger toolbar in VS Code](/assets/images/docs/testing/debugging/vscode-ui/screens/debug-toolbar.png)
-
-<div class="table-wrapper">
 
 | Icon                                                | Action                | Default keyboard shortcut                             |
 |-----------------------------------------------------|-----------------------|-------------------------------------------------------|
@@ -189,8 +183,6 @@ You can step in, out, and over Dart statements, hot reload, or resume the app.
 | {% render docs/vscode-flutter-bar/inspector.md %}   | Open Widget Inspector |                                                       |
 
 {:.table .table-striped}
-
-</div>
 
 ## Update test Flutter app
 

--- a/src/content/testing/overview.md
+++ b/src/content/testing/overview.md
@@ -27,8 +27,6 @@ to cover all the important use cases. This advice is based on
 the fact that there are trade-offs between different kinds of testing,
 seen below.
 
-<div class="table-wrapper">
-
 | Tradeoff             | Unit   | Widget | Integration |
 |----------------------|--------|--------|-------------|
 | **Confidence**       | Low    | Higher | Highest     |
@@ -37,8 +35,6 @@ seen below.
 | **Execution speed**  | Quick  | Quick  | Slow        |
 
 {:.table .table-striped}
-
-</div>
 
 ## Unit tests
 

--- a/src/content/ui/accessibility-and-internationalization/internationalization.md
+++ b/src/content/ui/accessibility-and-internationalization/internationalization.md
@@ -573,8 +573,6 @@ numbers based on the locale and the desired format.
 The `int`, `double`, and `number` types can use any of the
 following `NumberFormat` constructors:
 
-<div class="table-wrapper">
-
 | Message "format" value   | Output for 1200000 |
 |--------------------------|--------------------|
 | `compact`                | "1.2M"             |
@@ -590,8 +588,6 @@ following `NumberFormat` constructors:
 | `simpleCurrency`*        | "$1,200,000"       |
 
 {:.table .table-striped}
-
-</div>
 
 The starred `NumberFormat` constructors in the table
 offer optional, named parameters.
@@ -827,8 +823,6 @@ to specify the following:
 For a full list of options, either run `flutter gen-l10n --help`
 at the command line or refer to the following table:
 
-<div class="table-wrapper">
-
 | Option                              | Description |
 | ------------------------------------| ------------------ |
 | `arb-dir`                           | The directory where the template and translated arb files are located. The default is `lib/l10n`. |
@@ -851,8 +845,6 @@ at the command line or refer to the following table:
 | `[no-]suppress-warnings`            | When specified, all warnings are suppressed. |
 
 {:.table .table-striped}
-
-</div>
 
 
 ## How internationalization in Flutter works

--- a/src/content/ui/navigation/deep-linking.md
+++ b/src/content/ui/navigation/deep-linking.md
@@ -69,8 +69,6 @@ it will continue to work until you opt in to this behavior by adding
 The behavior varies slightly based on the platform and whether the app is
 launched and running.
 
-<div class="table-wrapper">
-
 | Platform / Scenario      | Using Navigator                                                     | Using Router                                                                                                                                                                                               |
 |--------------------------|---------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | iOS (not launched)       | App gets initialRoute ("/") and a short time after gets a pushRoute | App gets initialRoute ("/") and a short time after uses the RouteInformationParser to parse the route and call RouterDelegate.setNewRoutePath, which configures the Navigator with the corresponding Page. |
@@ -79,8 +77,6 @@ launched and running.
 | Android (launched)       | pushRoute is called                                                 | Path is parsed, and the Navigator is configured with a new set of Pages.                                                                                                                                   |
 
 {:.table .table-striped}
-
-</div>
 
 When using the [`Router`][Router] widget,
 your app has the ability to replace the


### PR DESCRIPTION
- Stop requiring tables be manually wrapped by `<div class="table-wrapper">[...]</div>`.
  - Do so by implementing custom wrapping in the `markdown.js` file
- Drop `markdown-it-table` dependency
