### PR TITLE
Fix typo in url

### DIFF
--- a/examples/cookbook/effects/drag_a_widget/lib/main.dart
+++ b/examples/cookbook/effects/drag_a_widget/lib/main.dart
@@ -15,7 +15,7 @@ const List<Item> _items = [
     totalPriceCents: 1299,
     uid: '1',
     imageProvider: NetworkImage('https://docs.flutter.dev'
-        'cookbook/img-files/effects/split-check/Food1.jpg'),
+        '/cookbook/img-files/effects/split-check/Food1.jpg'),
   ),
   Item(
     name: 'Veggie Delight',

--- a/src/content/cookbook/effects/drag-a-widget.md
+++ b/src/content/cookbook/effects/drag-a-widget.md
@@ -261,7 +261,7 @@ const List<Item> _items = [
     totalPriceCents: 1299,
     uid: '1',
     imageProvider: NetworkImage('https://docs.flutter.dev'
-        'cookbook/img-files/effects/split-check/Food1.jpg'),
+        '/cookbook/img-files/effects/split-check/Food1.jpg'),
   ),
   Item(
     name: 'Veggie Delight',


### PR DESCRIPTION
Fixes https://github.com/flutter/website/issues/10854

A missing "/" at the beginning of the image URL broke the demo. This fixes that.