### PR TITLE
Updated test drive page VsCode instructions

### DIFF
--- a/src/_includes/docs/install/test-drive/vscode.md
+++ b/src/_includes/docs/install/test-drive/vscode.md
@@ -2,8 +2,11 @@
 
 ### Create a sample Flutter app {:#create-app-vs-code}
 
-1. To use the DevTools from VS Code, install the [Flutter extension](https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter).
-   This will also automatically install the [Dart extension](https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code).With this extensions, you will be able to easily debug you application.
+1. To use Flutter DevTools from VS Code, install the
+    [Flutter extension](https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter).
+   This also automatically installs the
+   [Dart extension](https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code).
+   With these extensions, you can debug you application.
 
 2. Open the Command Palette.
 

--- a/src/_includes/docs/install/test-drive/vscode.md
+++ b/src/_includes/docs/install/test-drive/vscode.md
@@ -2,9 +2,8 @@
 
 ### Create a sample Flutter app {:#create-app-vs-code}
 
-1. To use the DevTools from VS Code, you need the [Dart extension](https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code).
-   To easily debug your application you should also install
-   the [Flutter extension](https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter).
+1. To use the DevTools from VS Code, install the [Flutter extension](https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter).
+   This will also automatically install the [Dart extension](https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code).With this extensions, you will be able to easily debug you application.
 
 2. Open the Command Palette.
 
@@ -65,8 +64,8 @@ hot reload at this time.
    You can watch the launch progress in the **Debug Console** view.
 
 {% capture save_changes -%}
-  : invoke **Save All**, or click **Hot Reload**
-  {% include docs/install/test-drive/hot-reload-icon.md %}.
+: invoke **Save All**, or click **Hot Reload**
+{% include docs/install/test-drive/hot-reload-icon.md %}.
 {% endcapture %}
 
 {% include docs/install/test-drive/try-hot-reload.md save_changes=save_changes ide="VS Code" %}


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
The test drive page is instructing to install the dart extension which was by
default installed previously by the VsCode Flutter extension.
_Issues fixed by this PR (if any):_
https://github.com/flutter/website/issues/10856
_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
