### PR TITLE
Adding a Cupertino design page

### DIFF
--- a/src/content/ui/design/cupertino/index.md
+++ b/src/content/ui/design/cupertino/index.md
@@ -10,25 +10,32 @@ and feel to iOS, including rounded corners, gradients,
 and minimalistic design.
 They also include iOS interactions and animations. 
 
+The following 15-minute video provides a high-level
+glimpse of the Cupertino package:
+
+{% ytEmbed '3PdUaidHc-E?si=xDp3bU50oSuljzye', 'Flutter's Cupertino Package' %}
+
 ## More information {:.no_toc}
 
-To learn more about Cuperino design and Flutter,
-check out:
+To learn more about using the Cupertino
+package with Flutter,
+check out the following resources:
 
 * The (mostly visual) [Cupertino widget catalog][]
   on doc.flutter.dev
 * The [Cupertino library][] page in the API docs
+* The [Cupertino API examples][] on the flutter/flutter
+  repo. ([Instructions][]) For example,
+  to run `CupertinoSwitch`:
 
-PENDING:
-What other resources can we link to?
-- There _was_ a Cupertino codelab that got pulled
-  from our codelab site because it was out of date.
-  However, a version still
-  exists on the Chinese codelabs site.
-- I looked for an Umbrella bug for the Cupertino
-  library, but couldn't find one.
-- I searched the projects on the flutter/flutter
-  repo for "Cupertino" but found nothing.
+```console
+cd path/to/flutter
+cd examples/api
+flutter run lib/cupertino/switch/cupertino_switch.0.dart
+```
 
+[Cupertino API examples]: {{site.github}}/flutter/flutter/tree/master/examples/api/lib/cupertino
 [Cupertino library]: {{site.api}}/flutter/cupertino/cupertino-library.html
 [Cupertino widget catalog]: /ui/widgets/cupertino
+[Instructions]: {{site.github}}/flutter/flutter/tree/master/examples/api#api-example-code
+

--- a/src/content/ui/design/cupertino/index.md
+++ b/src/content/ui/design/cupertino/index.md
@@ -1,0 +1,34 @@
+---
+title: Cupertino design for Flutter
+description: Learn about Cupertino design for Flutter.
+---
+
+The Flutter Cupertino library is a collection
+of widgets that implement Apple's iOS design language
+for Flutter apps. The widgets have a similar look
+and feel to iOS, including rounded corners, gradients,
+and minimalistic design.
+They also include iOS interactions and animations. 
+
+## More information {:.no_toc}
+
+To learn more about Cuperino design and Flutter,
+check out:
+
+* The (mostly visual) [Cupertino widget catalog][]
+  on doc.flutter.dev
+* The [Cupertino library][] page in the API docs
+
+PENDING:
+What other resources can we link to?
+- There _was_ a Cupertino codelab that got pulled
+  from our codelab site because it was out of date.
+  However, a version still
+  exists on the Chinese codelabs site.
+- I looked for an Umbrella bug for the Cupertino
+  library, but couldn't find one.
+- I searched the projects on the flutter/flutter
+  repo for "Cupertino" but found nothing.
+
+[Cupertino library]: {{site.api}}/flutter/cupertino/cupertino-library.html
+[Cupertino widget catalog]: /ui/widgets/cupertino

--- a/src/content/ui/design/cupertino/index.md
+++ b/src/content/ui/design/cupertino/index.md
@@ -13,7 +13,7 @@ They also include iOS interactions and animations.
 The following 15-minute video provides a high-level
 glimpse of the Cupertino package:
 
-{% ytEmbed '3PdUaidHc-E?si=xDp3bU50oSuljzye', 'Flutter's Cupertino Package' %}
+{% ytEmbed '3PdUaidHc-E?si=xDp3bU50oSuljzye', 'Flutter\'s Cupertino Package' %}
 
 ## More information {:.no_toc}
 


### PR DESCRIPTION
Fixes https://github.com/flutter/website/issues/9401

I'm creating a long overdue page for the Cupertino widgets. But I need your help, @sethladd, @jmagman, @loic-sharma, @domesticmouse, and anyone else with input.

- I'd like to add a codelab, but we don't have a current one. (Though the Chinese website has a link to an out of date version, @zoeyfan:  https://codelabs.flutter-io.cn/codelabs/flutter-cupertino/index.html#0 )
- I'd like to add examples, but I'm not sure where we might have some recent examples stashed.
-  What else am I missing?