### PR TITLE
[ios]update add-to-SwiftUI-app doc

### DIFF
--- a/src/content/add-to-app/ios/add-flutter-screen.md
+++ b/src/content/add-to-app/ios/add-flutter-screen.md
@@ -42,9 +42,8 @@ Where you create a `FlutterEngine` depends on your host app.
 {% tabs "darwin-framework" %}
 {% tab "SwiftUI" %}
 
-In this example, we create a `FlutterEngine` object inside a SwiftUI `ObservableObject`. 
-We then pass this `FlutterEngine` into a `ContentView` using the 
- `environmentObject()` property. 
+In this example, we create a `FlutterEngine` object inside a SwiftUI [Observable](https://developer.apple.com/documentation/observation/observable) object called `FlutterDependencies`. 
+We pre-warm the engine by calling `run()`, and then inject this object into a `ContentView` using the `environment()` view modifier. 
 
  ```swift title="MyApp.swift"
 import SwiftUI
@@ -52,7 +51,8 @@ import Flutter
 // The following library connects plugins with iOS platform code to this app.
 import FlutterPluginRegistrant
 
-class FlutterDependencies: ObservableObject {
+@Observable
+class FlutterDependencies {
   let flutterEngine = FlutterEngine(name: "my flutter engine")
   init() {
     // Runs the default Dart entrypoint with a default Flutter route.
@@ -64,11 +64,12 @@ class FlutterDependencies: ObservableObject {
 
 @main
 struct MyApp: App {
-    // flutterDependencies will be injected using EnvironmentObject.
-    @StateObject var flutterDependencies = FlutterDependencies()
+    // flutterDependencies will be injected via environment.
+    @State var flutterDependencies = FlutterDependencies()
     var body: some Scene {
       WindowGroup {
-        ContentView().environmentObject(flutterDependencies)
+        ContentView()
+          .environment(flutterDependencies)
       }
     }
 }
@@ -104,10 +105,7 @@ class AppDelegate: FlutterAppDelegate { // More on the FlutterAppDelegate.
 {% endtab %}
 {% tab "UIKit-ObjC" %}
 
-In this example, we create a `FlutterEngine` 
-object inside a SwiftUI `ObservableObject`. 
-We then pass this `FlutterEngine` into a 
-`ContentView` using the `environmentObject()` property.
+As an example, we demonstrate creating a FlutterEngine, exposed as a property, on app startup in the app delegate.
 
 ```objc title="AppDelegate.h"
 @import UIKit;
@@ -147,45 +145,36 @@ We then pass this `FlutterEngine` into a
 {% tabs "darwin-framework" %}
 {% tab "SwiftUI" %}
 
-The following example shows a generic `ContentView` with a
-`Button` hooked to present a [`FlutterViewController`][].
-The `FlutterViewController` constructor takes the pre-warmed 
-`FlutterEngine` as an argument. `FlutterEngine` is passed in 
-as an `EnvironmentObject` via `flutterDependencies`.
+The following example shows a generic `ContentView` with a `NavigationLink` hooked to a flutter screen. 
+We firstly create a `FlutterViewControllerRepresentable` to represent the `FlutterViewController`. 
+The `FlutterViewController` constructor takes the pre-warmed `FlutterEngine` as an argument, which is injected via environment. 
 
 ```swift title="ContentView.swift"
 import SwiftUI
 import Flutter
 
-struct ContentView: View {
-  // Flutter dependencies are passed in an EnvironmentObject.
-  @EnvironmentObject var flutterDependencies: FlutterDependencies
-
-  // Button is created to call the showFlutter function when pressed.
-  var body: some View {
-    Button("Show Flutter!") {
-      showFlutter()
-    }
-  }
-
-func showFlutter() {
-    // Get the RootViewController.
-    guard
-      let windowScene = UIApplication.shared.connectedScenes
-        .first(where: { $0.activationState == .foregroundActive && $0 is UIWindowScene }) as? UIWindowScene,
-      let window = windowScene.windows.first(where: \.isKeyWindow),
-      let rootViewController = window.rootViewController
-    else { return }
-
-    // Create the FlutterViewController.
-    let flutterViewController = FlutterViewController(
+struct FlutterViewControllerRepresentable: UIViewControllerRepresentable {
+  // Flutter dependencies are passed in via environment.
+  @Environment(FlutterDependencies.self) var flutterDependencies
+  
+  func makeUIViewController(context: Context) -> some UIViewController {
+    return FlutterViewController(
       engine: flutterDependencies.flutterEngine,
       nibName: nil,
       bundle: nil)
-    flutterViewController.modalPresentationStyle = .overCurrentContext
-    flutterViewController.isViewOpaque = false
+  }
+  
+  func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
+}
 
-    rootViewController.present(flutterViewController, animated: true)
+struct ContentView: View {
+
+  var body: some View {
+    NavigationStack {
+      NavigationLink("My Flutter Feature") {
+        FlutterViewControllerRepresentable()
+      }
+    }
   }
 }
 ```
@@ -295,35 +284,28 @@ To let the `FlutterViewController` present without an existing
 {% tabs "darwin-framework" %}
 {% tab "SwiftUI" %}
 
-```swift
+```swift title="ContentView.swift"
 import SwiftUI
 import Flutter
 
-struct ContentView: View {
-  var body: some View {
-    Button("Show Flutter!") {
-      openFlutterApp()
-    }
-  }
-
-func openFlutterApp() {
-    // Get the RootViewController.
-    guard
-      let windowScene = UIApplication.shared.connectedScenes
-        .first(where: { $0.activationState == .foregroundActive && $0 is UIWindowScene }) as? UIWindowScene,
-      let window = windowScene.windows.first(where: \.isKeyWindow),
-      let rootViewController = window.rootViewController
-    else { return }
-
-    // Create the FlutterViewController without an existing FlutterEngine.
-    let flutterViewController = FlutterViewController(
+struct FlutterViewControllerRepresentable: UIViewControllerRepresentable {
+  func makeUIViewController(context: Context) -> some UIViewController {
+    return FlutterViewController(
       project: nil,
       nibName: nil,
       bundle: nil)
-    flutterViewController.modalPresentationStyle = .overCurrentContext
-    flutterViewController.isViewOpaque = false
+  }
+  
+  func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
+}
 
-    rootViewController.present(flutterViewController, animated: true)
+struct ContentView: View {
+  var body: some View {
+    NavigationStack {
+      NavigationLink("My Flutter Feature") {
+        FlutterViewControllerRepresentable()
+      }
+    }
   }
 }
 ```
@@ -374,14 +356,15 @@ The `FlutterAppDelegate` performs functions such as:
 Creating a subclass of the `FlutterAppDelegate` in UIKit apps was shown 
 in the [Start a FlutterEngine and FlutterViewController section][]. 
 In a SwiftUI app, you can create a subclass of the 
-`FlutterAppDelegate` that conforms to the `ObservableObject` protocol as follows:
+`FlutterAppDelegate` and annotate it with the [`Observable()`](https://developer.apple.com/documentation/observation/observable()) macro as follows:
 
 ```swift
 import SwiftUI
 import Flutter
 import FlutterPluginRegistrant
 
-class AppDelegate: FlutterAppDelegate, ObservableObject {
+@Observable
+class AppDelegate: FlutterAppDelegate {
   let flutterEngine = FlutterEngine(name: "my flutter engine")
 
   override func application(
@@ -409,44 +392,36 @@ struct MyApp: App {
 }
 ```
 
-Then, in your view, the `AppDelegate` is accessible as an `EnvironmentObject`.
+Then, in your view, the `AppDelegate` is accessible via environment.
 
-```swift
+```swift title="ContentView.swift"
 import SwiftUI
 import Flutter
 
-struct ContentView: View {
-  // Access the AppDelegate using an EnvironmentObject.
-  @EnvironmentObject var appDelegate: AppDelegate
-
-  var body: some View {
-    Button("Show Flutter!") {
-      openFlutterApp()
-    }
-  }
-
-func openFlutterApp() {
-    // Get the RootViewController.
-    guard
-      let windowScene = UIApplication.shared.connectedScenes
-        .first(where: { $0.activationState == .foregroundActive && $0 is UIWindowScene }) as? UIWindowScene,
-      let window = windowScene.windows.first(where: \.isKeyWindow),
-      let rootViewController = window.rootViewController
-    else { return }
-
-    // Create the FlutterViewController.
-    let flutterViewController = FlutterViewController(
-      // Access the Flutter Engine via AppDelegate.
+struct FlutterViewControllerRepresentable: UIViewControllerRepresentable {
+  // Access the AppDelegate via environment.
+  @Environment(AppDelegate.self) var appDelegate
+  
+  func makeUIViewController(context: Context) -> some UIViewController {
+    return FlutterViewController(
       engine: appDelegate.flutterEngine,
       nibName: nil,
       bundle: nil)
-    flutterViewController.modalPresentationStyle = .overCurrentContext
-    flutterViewController.isViewOpaque = false
-
-    rootViewController.present(flutterViewController, animated: true)
   }
+  
+  func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
 }
 
+struct ContentView: View {
+
+  var body: some View {
+    NavigationStack {
+      NavigationLink("My Flutter Feature") {
+        FlutterViewControllerRepresentable()
+      }
+    }
+  }
+}
 ```
 
 ### If you can't directly make FlutterAppDelegate a subclass
@@ -465,11 +440,12 @@ For instance:
 import Foundation
 import Flutter
 
-class AppDelegate: UIResponder, UIApplicationDelegate, FlutterAppLifeCycleProvider, ObservableObject {
+@Observable
+class AppDelegate: UIResponder, UIApplicationDelegate, FlutterAppLifeCycleProvider {
 
   private let lifecycleDelegate = FlutterPluginAppLifeCycleDelegate()
 
-  let flutterEngine = FlutterEngine(name: "flutter_nps_engine")
+  let flutterEngine = FlutterEngine(name: "my flutter engine")
 
   override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {

--- a/src/content/add-to-app/ios/add-flutter-screen.md
+++ b/src/content/add-to-app/ios/add-flutter-screen.md
@@ -8,7 +8,7 @@ This guide describes how to add a single Flutter screen to an existing iOS app.
 
 ## Start a FlutterEngine and FlutterViewController
 
-To launch a Flutter screen from an existing iOS, you start a
+To launch a Flutter screen from an existing iOS app, you start a
 [`FlutterEngine`][] and a [`FlutterViewController`][].
 
 :::note
@@ -42,8 +42,10 @@ Where you create a `FlutterEngine` depends on your host app.
 {% tabs "darwin-framework" %}
 {% tab "SwiftUI" %}
 
-In this example, we create a `FlutterEngine` object inside a SwiftUI [Observable](https://developer.apple.com/documentation/observation/observable) object called `FlutterDependencies`. 
-We pre-warm the engine by calling `run()`, and then inject this object into a `ContentView` using the `environment()` view modifier. 
+In this example, we create a `FlutterEngine` object inside a SwiftUI [`Observable`][] 
+object called `FlutterDependencies`. 
+Pre-warm the engine by calling `run()`, and then inject this object 
+into a `ContentView` using the `environment()` view modifier. 
 
  ```swift title="MyApp.swift"
 import SwiftUI
@@ -64,7 +66,7 @@ class FlutterDependencies {
 
 @main
 struct MyApp: App {
-    // flutterDependencies will be injected via environment.
+    // flutterDependencies will be injected through the view environment.
     @State var flutterDependencies = FlutterDependencies()
     var body: some Scene {
       WindowGroup {
@@ -105,7 +107,8 @@ class AppDelegate: FlutterAppDelegate { // More on the FlutterAppDelegate.
 {% endtab %}
 {% tab "UIKit-ObjC" %}
 
-As an example, we demonstrate creating a FlutterEngine, exposed as a property, on app startup in the app delegate.
+The following example demonstrates creating a `FlutterEngine`, 
+exposed as a property, on app startup in the app delegate.
 
 ```objc title="AppDelegate.h"
 @import UIKit;
@@ -145,16 +148,19 @@ As an example, we demonstrate creating a FlutterEngine, exposed as a property, o
 {% tabs "darwin-framework" %}
 {% tab "SwiftUI" %}
 
-The following example shows a generic `ContentView` with a `NavigationLink` hooked to a flutter screen. 
-We firstly create a `FlutterViewControllerRepresentable` to represent the `FlutterViewController`. 
-The `FlutterViewController` constructor takes the pre-warmed `FlutterEngine` as an argument, which is injected via environment. 
+The following example shows a generic `ContentView` with a 
+[`NavigationLink`][] hooked to a flutter screen. 
+First, create a `FlutterViewControllerRepresentable` to represent the 
+`FlutterViewController`. The `FlutterViewController` constructor takes 
+the pre-warmed `FlutterEngine` as an argument, which is injected through
+the view environment. 
 
 ```swift title="ContentView.swift"
 import SwiftUI
 import Flutter
 
 struct FlutterViewControllerRepresentable: UIViewControllerRepresentable {
-  // Flutter dependencies are passed in via environment.
+  // Flutter dependencies are passed in through the view environment.
   @Environment(FlutterDependencies.self) var flutterDependencies
   
   func makeUIViewController(context: Context) -> some UIViewController {
@@ -356,7 +362,7 @@ The `FlutterAppDelegate` performs functions such as:
 Creating a subclass of the `FlutterAppDelegate` in UIKit apps was shown 
 in the [Start a FlutterEngine and FlutterViewController section][]. 
 In a SwiftUI app, you can create a subclass of the 
-`FlutterAppDelegate` and annotate it with the [`Observable()`](https://developer.apple.com/documentation/observation/observable()) macro as follows:
+`FlutterAppDelegate` and annotate it with the [`Observable()`][] macro as follows:
 
 ```swift
 import SwiftUI
@@ -392,14 +398,14 @@ struct MyApp: App {
 }
 ```
 
-Then, in your view, the `AppDelegate` is accessible via environment.
+Then, in your view, the `AppDelegate` is accessible through the view environment.
 
 ```swift title="ContentView.swift"
 import SwiftUI
 import Flutter
 
 struct FlutterViewControllerRepresentable: UIViewControllerRepresentable {
-  // Access the AppDelegate via environment.
+  // Access the AppDelegate through the view environment.
   @Environment(AppDelegate.self) var appDelegate
   
   func makeUIViewController(context: Context) -> some UIViewController {
@@ -764,3 +770,6 @@ in any way you'd like, before presenting the Flutter UI using a
 [`WidgetsApp`]: {{site.api}}/flutter/widgets/WidgetsApp-class.html
 [`PlatformDispatcher.defaultRouteName`]: {{site.api}}/flutter/dart-ui/PlatformDispatcher/defaultRouteName.html
 [Start a FlutterEngine and FlutterViewController section]:/add-to-app/ios/add-flutter-screen/#start-a-flutterengine-and-flutterviewcontroller
+[`Observable`]: https://developer.apple.com/documentation/observation/observable
+[`NavigationLink`]: https://developer.apple.com/documentation/swiftui/navigationlink
+[`Observable()`]: https://developer.apple.com/documentation/observation/observable()


### PR DESCRIPTION
The existing sample has been outdated in the past 2 years. This update includes: 

1. Use Swift Macros
2. Deprecate `StateObject`, `ObservedObject`, `EnvironmentObject`
3. Use `NavigationStack` example to present the flutter screen
4. Use `UIViewControllerRepresentable`
5. Remove messy logic to access window from `UIApplication.shared`
6. Rephrased a few description to be accurate

I did not include the new `@Entry` macro since iOS 18 is not yet released, and our current way of environment usage is just as good. Can update next year if needed. 

_Issues fixed by this PR (if any):_

Fixes https://github.com/flutter/website/issues/10262
Fixes https://github.com/flutter/flutter/issues/150944
Fixes https://github.com/flutter/website/issues/10904


_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
