### PR TITLE
Update validation.md

### DIFF
--- a/src/content/cookbook/forms/validation.md
+++ b/src/content/cookbook/forms/validation.md
@@ -149,7 +149,7 @@ ElevatedButton(
 ### How does this work?
 
 To validate the form, use the `_formKey` created in
-step 1. You can use the `_formKey.currentState()`
+step 1. You can use the `_formKey.currentState`
 method to access the [`FormState`][],
 which is automatically created by Flutter when building a `Form`.
 

--- a/src/content/cookbook/forms/validation.md
+++ b/src/content/cookbook/forms/validation.md
@@ -150,7 +150,7 @@ ElevatedButton(
 
 To validate the form, use the `_formKey` created in
 step 1. You can use the `_formKey.currentState`
-method to access the [`FormState`][],
+accessor to access the [`FormState`][],
 which is automatically created by Flutter when building a `Form`.
 
 The `FormState` class contains the `validate()` method.


### PR DESCRIPTION
`currentState` here is a getter and not function or method to be invoked

_Description of what this PR is changing or adding, and why:_
`_formKey.currentState()` to `_formKey.currentState`. Since it threw me off thinking invoking would reveal fields, but there isn't a way to do it. 

_Issues fixed by this PR (if any):_
Typo `_formKey.currentState()` to `_formKey.currentState`.

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
