### PR TITLE
docs: Support for overriding endorsed plugin implementations

### DIFF
--- a/src/content/packages-and-plugins/developing-packages.md
+++ b/src/content/packages-and-plugins/developing-packages.md
@@ -186,10 +186,16 @@ If you can't, for whatever reason, get your implementation
 added by the original plugin author, then your plugin
 is _not_ endorsed. A developer can still use your
 implementation, but must manually add the plugin
-to the app's pubspec file. So, the developer
-must include both the `foobar` dependency _and_
-the `foobar_windows` dependency in order to achieve
-full functionality.
+to the app's `pubspec.yaml` file:
+
+```yaml
+dependencies:
+  foobar: ^1.0.0
+  foobar_windows: ^1.0.0 # Non-endorsed plugin implementation
+```
+
+This approach also works for overriding an already
+endorsed plugin implementation of `foobar`.
 
 For more information on federated plugins,
 why they are useful, and how they are


### PR DESCRIPTION
DRAFT: It should may land only after the next major release, when functionality is available in stable.

_Description of what this PR is changing or adding, and why:_

It is now possible to override native or Dart endorsed plugin implementations. This should be reflected in the docs.

_Issues fixed by this PR (if any):_

flutter/flutter#80374, flutter/flutter#59657, flutter/flutter#137040
See also: https://github.com/flutter/flutter/issues/80374#issuecomment-1141565904

_PRs or commits this PR depends on (if any):_

https://github.com/flutter/flutter/commit/d55a5f96c117725c134099b78deb7af431a93902

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
