### PR TITLE
Introducing a red or grey screen of death

### DIFF
--- a/src/content/testing/common-errors.md
+++ b/src/content/testing/common-errors.md
@@ -42,7 +42,7 @@ on debugging this sort of error:
 
 [Flutter errors demystified]: {{site.medium}}/@hpatilabhi10/flutter-errors-demystified-red-screen-errors-vs-debug-console-errors-acb3b8ed2625
 [Flutter stuck on white screen]: https://www.dhiwise.com/post/flutter-stuck-on-white-screen-understanding-and-fixing
-[Understanding and addressing the grey screen in Flutter]: {{site.medium}/@LordChris/understanding-and-addressing-the-grey-screen-in-flutter-5e72c31f408f
+[Understanding and addressing the grey screen in Flutter]: {{site.medium}}/@LordChris/understanding-and-addressing-the-grey-screen-in-flutter-5e72c31f408f
 
 ## 'A RenderFlex overflowed…'
 

--- a/src/content/testing/common-errors.md
+++ b/src/content/testing/common-errors.md
@@ -18,6 +18,32 @@ make this page more useful to you and the Flutter community.
 [open an issue]: {{site.repo.this}}/issues/new/choose
 [submit a pull request]: {{site.repo.this}}/pulls
 
+## A solid red or grey screen when running your app
+
+Typically called a "red (or grey) screen of death",
+this is sometimes how Flutter lets
+you know that there's an error.
+
+The red screen can appear when the app runs in
+debug or profile mode. The grey screen can appear
+when the app runs in release mode.
+
+Generally, these errors occur when there's an
+uncaught exception (and you might need another
+try-catch block), or when there is some rendering error,
+such as an overflow error.
+
+The following articles provide some useful insights
+on debugging this sort of error:
+
+* [Flutter errors demystified][] by Abishek
+* [Understanding and addressing the grey screen in Flutter][] by Christopher Nwosu-Madueke
+* [Flutter stuck on white screen][] by Kesar Bhimani
+
+[Flutter errors demystified]: {{site.medium}}/@hpatilabhi10/flutter-errors-demystified-red-screen-errors-vs-debug-console-errors-acb3b8ed2625
+[Flutter stuck on white screen]: https://www.dhiwise.com/post/flutter-stuck-on-white-screen-understanding-and-fixing
+[Understanding and addressing the grey screen in Flutter]: {{site.medium}/@LordChris/understanding-and-addressing-the-grey-screen-in-flutter-5e72c31f408f
+
 ## 'A RenderFlex overflowed…'
 
 RenderFlex overflow is one of the most frequently


### PR DESCRIPTION
The red screen can indicate an error when running in in debug or profile mode. A grey screen indicates an error when running in release mode. Added some text about these errors with some links on where they can learn more about debugging.

Fixes https://github.com/flutter/website/issues/7773