### PR TITLE
Draft: Adding info for customizing control center in iOS 18

### DIFF
--- a/src/content/platform-integration/ios/app-extensions.md
+++ b/src/content/platform-integration/ios/app-extensions.md
@@ -22,6 +22,14 @@ For more information, check out
 [Issue #9690]:   {{site.github}}/flutter/website/issues/9690
 [Issue #135056]: {{site.github}}/flutter/flutter/issues/135056
 
+The iOS 18 release, coming in September 2024 and currently in beta,
+adds new functionality for customizing a device's
+the Control Center, including creating multiple pages.
+You can also create new toggles for the Control Center
+using the [`ControlCenter`] API, to feature your app.
+
+[`ControlCenter`]: {{site.apple-dev}}/documentation/widgetkit/controlcenter
+
 ## How do you add an app extension to your Flutter app?
 
 To add an app extension to your Flutter app,


### PR DESCRIPTION
@jmagman, I'm not sure what else to say about this. Do we (or will we) have any examples on creating toggles for the Control Center?

iOS 18 adds the ability to greatly customize the control center on a device. Third party apps can create their own widgets for the control center.

Fixes https://github.com/flutter/website/issues/10895

cc: @sethladd 