### PR TITLE
Update macOS platform view example code (swift)

### DIFF
--- a/src/content/platform-integration/macos/platform-views.md
+++ b/src/content/platform-integration/macos/platform-views.md
@@ -139,7 +139,7 @@ class NativeView: NSView {
     let nativeLabel = NSTextField()
     nativeLabel.frame = CGRect(x: 0, y: 0, width: 180, height: 48.0)
     nativeLabel.stringValue = "Native text from macOS"
-    nativeLabel.textColor = NSColor.white
+    nativeLabel.textColor = NSColor.black
     nativeLabel.font = NSFont.systemFont(ofSize: 14)
     nativeLabel.isBezeled = false
     nativeLabel.focusRingType = .none

--- a/src/content/platform-integration/macos/platform-views.md
+++ b/src/content/platform-integration/macos/platform-views.md
@@ -102,9 +102,9 @@ class NativeViewFactory: NSObject, FlutterPlatformViewFactory {
   }
 
   func create(
-    viewIdentifier viewId: Int64,
+    withViewIdentifier viewId: Int64,
     arguments args: Any?
-  ) -> FlutterPlatformView {
+  ) -> NSView {
     return NativeView(
       viewIdentifier: viewId,
       arguments: args,
@@ -118,25 +118,24 @@ class NativeViewFactory: NSObject, FlutterPlatformViewFactory {
 }
 
 class NativeView: NSView {
-  private var _view: NSView
 
   init(
-    frame: CGRect,
     viewIdentifier viewId: Int64,
     arguments args: Any?,
     binaryMessenger messenger: FlutterBinaryMessenger?
   ) {
-    _view = NSView()
-    super.init(frame: frame)
+    super.init(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+    wantsLayer = true
+    layer?.backgroundColor = NSColor.systemBlue.cgColor
     // macOS views can be created here
-    createNativeView(view: _view)
+    createNativeView(view: self)
   }
-
+    
+    required init?(coder nsCoder: NSCoder) {
+        super.init(coder: nsCoder)
+    }
+    
   func createNativeView(view _view: NSView) {
-    _view.wantsLayer = true
-    _view.layer?.backgroundColor = NSColor.systemBlue.cgColor
-    _view.frame = CGRect(x: 0, y: 0, width: 200, height: 200)
-
     let nativeLabel = NSTextField()
     nativeLabel.frame = CGRect(x: 0, y: 0, width: 180, height: 48.0)
     nativeLabel.stringValue = "Native text from macOS"
@@ -149,6 +148,7 @@ class NativeView: NSView {
     _view.addSubview(nativeLabel)
   }
 }
+
 ```
 
 Finally, register the platform view. This can be done in an app or a plugin.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
The original macOS platform view code has several syntax errors, and the private `NSView` was passed to the `createNativeView` function, not the `NativeView` itself, so the function will make no changes to the UI.

This PR fixes those errors, and removes the private `NSView`.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
