### PR TITLE
Clarify WillPopScope disables predictive back

### DIFF
--- a/src/content/release/breaking-changes/android-predictive-back.md
+++ b/src/content/release/breaking-changes/android-predictive-back.md
@@ -44,7 +44,7 @@ whether it was successful.
 
 ### PopScope
 
-The `PopScope` class directly replaces `WillPopScope` in order to enabled
+The `PopScope` class directly replaces `WillPopScope` in order to enable
 predictive back. Instead of deciding whether a pop is possible at the time it
 occurs, this is set ahead of time with the `canPop` boolean. You can still
 listen to pops by using `onPopInvoked`.

--- a/src/content/release/breaking-changes/android-predictive-back.md
+++ b/src/content/release/breaking-changes/android-predictive-back.md
@@ -351,10 +351,9 @@ return PopScope(
      for migrating Android apps to support predictive back.
   1. Make sure you're using version `3.14.0-7.0.pre`
      of Flutter or greater.
-  1. Make sure your Flutter app does not use the
-     WillPopScope widget. Using it will disable
-     predictive back. Use PopScope instead if
-     needed.
+  1. Make sure your Flutter app doesn't use the
+     `WillPopScope` widget. Using it disables
+     predictive back. If needed, use `PopScope` instead.
   1. Run the app and perform a back gesture (swipe from the
      left side of the screen).
 

--- a/src/content/release/breaking-changes/android-predictive-back.md
+++ b/src/content/release/breaking-changes/android-predictive-back.md
@@ -44,9 +44,10 @@ whether it was successful.
 
 ### PopScope
 
-The `PopScope` class directly replaces `WillPopScope`. Instead of deciding
-whether a pop is possible at the time it occurs, this is set ahead of time with
-the `canPop` boolean. You can still listen to pops by using `onPopInvoked`.
+The `PopScope` class directly replaces `WillPopScope` in order to enabled
+predictive back. Instead of deciding whether a pop is possible at the time it
+occurs, this is set ahead of time with the `canPop` boolean. You can still
+listen to pops by using `onPopInvoked`.
 
 ```dart
 PopScope(
@@ -350,6 +351,10 @@ return PopScope(
      for migrating Android apps to support predictive back.
   1. Make sure you're using version `3.14.0-7.0.pre`
      of Flutter or greater.
+  1. Make sure your Flutter app does not use the
+     WillPopScope widget. Using it will disable
+     predictive back. Use PopScope instead if
+     needed.
   1. Run the app and perform a back gesture (swipe from the
      left side of the screen).
 


### PR DESCRIPTION
Make it clear that using WillPopScope does not support predictive back. In https://github.com/flutter/flutter/pull/152057#pullrequestreview-2191560087 it was mentioned that this should be explicitly communicated in this breaking changes page.

_Issues fixed by this PR (if any):_ n/a

_PRs or commits this PR depends on (if any):_ https://github.com/flutter/flutter/pull/152057

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
