### PR TITLE
Fix 2 links on fwe/state management page

### DIFF
--- a/src/content/get-started/fwe/state-management.md
+++ b/src/content/get-started/fwe/state-management.md
@@ -9,8 +9,6 @@ next:
   path: /get-started/fwe/user-input  
 ---
 
-# State management
-
 The _state_ of a Flutter app refers to all the objects it uses
 to display its UI or manage system resources.
 State management is how we organize our app
@@ -333,7 +331,7 @@ Column(
 
 ### ValueNotifier
 
-A [`ValueNotifer`] is a simpler version of a `ChangeNotifier`,
+A [`ValueNotifier`] is a simpler version of a `ChangeNotifier`,
 that stores a single value.
 It implements the `ValueListenable` and `Listenable` interfaces,
 so it's compatible
@@ -557,6 +555,7 @@ If you would like to learn more, check out the following resources:
 [Provider shopper]: https://flutter.github.io/samples/provider_shopper.html
 [State management]: /data-and-backend/state-mgmt/intro
 [StatefulWidget]: /flutter/widgets/StatefulWidget-class.html
+[`StatefulWidget`]: /flutter/widgets/StatefulWidget-class.html
 [`ChangeNotifier`]: {{site.api}}/flutter/foundation/ChangeNotifier-class.html
 [`InheritedNotifier`]: {{site.api}}/flutter/widgets/InheritedNotifier-class.html
 [`ListenableBuilder`]: {{site.api}}/flutter/widgets/ListenableBuilder-class.html

--- a/src/content/ui/index.md
+++ b/src/content/ui/index.md
@@ -32,7 +32,7 @@ The minimal Flutter app simply calls the [`runApp()`][]
 function with a widget:
 
 <?code-excerpt "lib/main.dart"?>
-```dartpad title="Flutter Hello World hands-on example in DartPad" run="true"
+y```dartpad title="Flutter Hello World hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() {

--- a/src/content/ui/index.md
+++ b/src/content/ui/index.md
@@ -32,7 +32,7 @@ The minimal Flutter app simply calls the [`runApp()`][]
 function with a widget:
 
 <?code-excerpt "lib/main.dart"?>
-y```dartpad title="Flutter Hello World hands-on example in DartPad" run="true"
+```dartpad title="Flutter Hello World hands-on example in DartPad" run="true"
 import 'package:flutter/material.dart';
 
 void main() {


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
* Fixed two links, one didn't work because of a typo, and the other because of backticks
* Removed the H1 at the top, because the page just said 'State Management' twice in row.

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
