### PR TITLE
Update how to enable Swift Package Manager instructions

### DIFF
--- a/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
+++ b/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
@@ -1,7 +1,6 @@
 ## How to turn on Swift Package Manager
 
-Flutter's Swift Package Manager support is turned off by default.
-To turn it on:
+Swift Package Manager is available on the `main` channel:
 
 1. Switch to Flutter's `main` channel:
 
@@ -13,12 +12,6 @@ To turn it on:
 
    ```sh
    flutter upgrade
-   ```
-
-3. Turn on the Swift Package Manager feature:
-
-   ```sh
-   flutter config --enable-swift-package-manager
    ```
 
 Using the Flutter CLI to run an app modifies the project to add Swift Package

--- a/src/content/packages-and-plugins/swift-package-manager/for-app-developers.md
+++ b/src/content/packages-and-plugins/swift-package-manager/for-app-developers.md
@@ -29,8 +29,6 @@ If you find a bug in Flutter's Swift Package Manager support,
 [Swift packages]: https://swiftpackageindex.com/
 [open an issue]: {{site.github}}/flutter/flutter/issues/new?template=2_bug.yml
 
-{% include docs/swift-package-manager/how-to-enable-disable.md %}
-
 ## How to add Swift Package Manager integration
 
 ### Add to a Flutter app
@@ -137,6 +135,8 @@ To undo this migration:
     caption:"The build pre-action to remove" %}
 
 [Turn off Swift Package Manager]: /packages-and-plugins/swift-package-manager/for-app-developers/#how-to-turn-off-swift-package-manager
+
+{% include docs/swift-package-manager/how-to-enable-disable.md %}
 
 ## How to use a Swift Package Manager Flutter plugin that requires a higher OS version
 

--- a/src/content/packages-and-plugins/swift-package-manager/for-plugin-authors.md
+++ b/src/content/packages-and-plugins/swift-package-manager/for-plugin-authors.md
@@ -30,8 +30,6 @@ If you find a bug in Flutter's Swift Package Manager support,
 [Swift packages]: https://swiftpackageindex.com/
 [open an issue]: {{site.github}}/flutter/flutter/issues/new?template=2_bug.yml
 
-{% include docs/swift-package-manager/how-to-enable-disable.md %}
-
 ## How to add Swift Package Manager support to an existing Flutter plugin
 
 This guide shows how to add Swift Package Manager support to a plugin that
@@ -46,7 +44,6 @@ Plugins that don't support CocoaPods won't be usable by projects that haven't
 migrated to Swift Package Manager yet.
 Plugins that don't support Swift Package Manager can cause problems for projects
 that have migrated.
-
 
 {% tabs %}
 {% tab "Swift plugin" %}
@@ -153,3 +150,5 @@ To update your unit tests:
 8. Ensure tests pass **Product > Test**.
 
 [library type recommendations]: https://developer.apple.com/documentation/packagedescription/product/library(name:type:targets:)
+
+{% include docs/swift-package-manager/how-to-enable-disable.md %}


### PR DESCRIPTION
> [!WARNING]
> Don't land this until https://github.com/flutter/flutter/pull/152049 has passed post-submit tests. That PR is likely to be reverted due to post-submit failures.

https://github.com/flutter/flutter/pull/152049 enables SwiftPM by default on the `main` channel. This updates the docs accordingly.

I also moved the "how to turn on/off SPM" guides down. This makes it so that the "How to migrate app" is the first section on the app developers page, and that the "How to migrate plugin" is the first section on the plugin developers page. This was feedback from today's Swift Package Manager walkthrough meeting.

Part of https://github.com/flutter/flutter/issues/151567

_PRs or commits this PR depends on (if any):_ https://github.com/flutter/flutter/pull/152049

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
