### PR TITLE
Update CHANGELOG name

### DIFF
--- a/src/content/release/release-notes/index.md
+++ b/src/content/release/release-notes/index.md
@@ -8,8 +8,8 @@ This page links to announcements and release notes for
 releases to the stable channel.
 
 :::note
-For information about bug-fix releases, check out
-[Hotfixes to the Stable Channel][] on the Flutter wiki.
+For information about bug-fix releases, check out our
+[CHANGELOG][].
 :::
 
 * 3.22.0
@@ -131,4 +131,4 @@ For information about bug-fix releases, check out
 [1.12.13 announcement]: {{site.flutter-medium}}/announcing-flutter-1-12-what-a-year-22c256ba525d
 [1.12.13 release notes and change log]: /release/release-notes/release-notes-1.12.13
 [Archived release notes]: /release/release-notes/release-notes-archive
-[Hotfixes to the Stable Channel]: {{site.repo.flutter}}/blob/main/CHANGELOG.md
+[CHANGELOG]: {{site.repo.flutter}}/blob/main/CHANGELOG.md


### PR DESCRIPTION
This change removes references to "Hotfixes to the stable channel"

### Context

Hotfixes-to-the-stable-channel previously lived in the Flutter Wiki.  The decision was made to migrate the wiki to docs which opened an opportunity to align with Dart on how we post our changelog. 

https://github.com/flutter/flutter/pull/151931 was merged to align the processes by moving Hotfixes-to-the-stable-channel to the root of Flutter and renaming it CHANGELOG.md to align with Dart.

Some missed links outside of flutter/flutter were called out in https://github.com/flutter/flutter/issues/152162.
