### PR TITLE
[Part 2] Remove references to old release notes name

### DIFF
--- a/src/content/release/release-notes/release-notes-1.22.0.md
+++ b/src/content/release/release-notes/release-notes-1.22.0.md
@@ -5,10 +5,9 @@ description: Release notes for Flutter 1.22.0.
 ---
 
 This page has release notes for 1.22.0.
-For information about subsequent bug-fix releases, see
-[Hotfixes to the Stable Channel][].
+For information about subsequent bug-fix releases, see our [CHANGELOG][]
 
-[Hotfixes to the Stable Channel]: https://github.com/flutter/flutter/blob/master/docs/releases/Hotfixes-to-the-Stable-Channel.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/master/CHANGELOG.md
 
 ## Merged PRs by labels for `flutter/flutter` 
 

--- a/src/content/release/release-notes/release-notes-2.0.0.md
+++ b/src/content/release/release-notes/release-notes-2.0.0.md
@@ -5,10 +5,9 @@ description: Release notes for Flutter 2.0.0.
 ---
 
 This page has release notes for 2.0.0.
-For information about subsequent bug-fix releases, see
-[Hotfixes to the Stable Channel][].
+For information about subsequent bug-fix releases, see our [CHANGELOG][]
 
-[Hotfixes to the Stable Channel]: https://github.com/flutter/flutter/blob/master/docs/releases/Hotfixes-to-the-Stable-Channel.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/master/CHANGELOG.md
 
 ## Merged PRs by labels for `flutter/flutter` 
 

--- a/src/content/release/release-notes/release-notes-2.10.0.md
+++ b/src/content/release/release-notes/release-notes-2.10.0.md
@@ -4,10 +4,9 @@ short-title: 2.10.0 release notes
 description: Release notes for Flutter 2.10.0.
 ---
 This page has release notes for 2.10.0.
-For information about subsequent bug-fix releases, see
-[Hotfixes to the Stable Channel][].
+For information about subsequent bug-fix releases, see our [CHANGELOG][]
 
-[Hotfixes to the Stable Channel]: https://github.com/flutter/flutter/blob/master/docs/releases/Hotfixes-to-the-Stable-Channel.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/master/CHANGELOG.md
 
 ## Merged PRs by labels for `flutter/flutter` 
 

--- a/src/content/release/release-notes/release-notes-2.2.0.md
+++ b/src/content/release/release-notes/release-notes-2.2.0.md
@@ -4,10 +4,9 @@ short-title: 2.2.0 release notes
 description: Release notes for Flutter 2.2.0.
 ---
 This page has release notes for 2.2.0.
-For information about subsequent bug-fix releases, see
-[Hotfixes to the Stable Channel][].
+For information about subsequent bug-fix releases, see our [CHANGELOG][]
 
-[Hotfixes to the Stable Channel]: https://github.com/flutter/flutter/blob/master/docs/releases/Hotfixes-to-the-Stable-Channel.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/master/CHANGELOG.md
 
 ## Merged PRs by labels for `flutter/flutter` 
 

--- a/src/content/release/release-notes/release-notes-2.5.0.md
+++ b/src/content/release/release-notes/release-notes-2.5.0.md
@@ -4,10 +4,9 @@ short-title: 2.5.0 release notes
 description: Release notes for Flutter 2.5.0.
 ---
 This page has release notes for 2.5.0.
-For information about subsequent bug-fix releases, see
-[Hotfixes to the Stable Channel][].
+For information about subsequent bug-fix releases, see our [CHANGELOG][]
 
-[Hotfixes to the Stable Channel]: https://github.com/flutter/flutter/blob/master/docs/releases/Hotfixes-to-the-Stable-Channel.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/master/CHANGELOG.md
 
 ## Merged PRs by labels for `flutter/flutter` 
 

--- a/src/content/release/release-notes/release-notes-2.8.0.md
+++ b/src/content/release/release-notes/release-notes-2.8.0.md
@@ -4,10 +4,9 @@ short-title: 2.8.0 release notes
 description: Release notes for Flutter 2.8.0.
 ---
 This page has release notes for 2.8.0.
-For information about subsequent bug-fix releases, see
-[Hotfixes to the Stable Channel][].
+For information about subsequent bug-fix releases, see our [CHANGELOG][]
 
-[Hotfixes to the Stable Channel]: https://github.com/flutter/flutter/blob/master/docs/releases/Hotfixes-to-the-Stable-Channel.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/master/CHANGELOG.md
 
 ## Merged PRs by labels for `flutter/flutter` 
 

--- a/src/content/release/release-notes/release-notes-3.0.0.md
+++ b/src/content/release/release-notes/release-notes-3.0.0.md
@@ -6,9 +6,9 @@ description: Release notes for Flutter 3.0.0.
 
 This page has release notes for 3.0.0.
 For information about subsequent bug-fix releases,
-see [Hotfixes to the Stable Channel][].
+see our [CHANGELOG][].
 
-[Hotfixes to the Stable Channel]: {{site.repo.flutter}}/blob/master/docs/releases/Hotfixes-to-the-Stable-Channel.md
+[CHANGELOG]: {{site.repo.flutter}}/blob/master/CHANGELOG.md
 
 ## If you see warnings about bindings
 

--- a/src/content/release/release-notes/release-notes-3.10.0.md
+++ b/src/content/release/release-notes/release-notes-3.10.0.md
@@ -5,9 +5,9 @@ description: Release notes for Flutter 3.10.0.
 ---
 This page has release notes for 3.10.0.
 For information about subsequent bug-fix releases,
-see [Hotfixes to the Stable Channel][].
+see our [CHANGELOG][].
 
-[Hotfixes to the Stable Channel]: {{site.repo.flutter}}/blob/master/docs/releases/Hotfixes-to-the-Stable-Channel.md
+[CHANGELOG]: {{site.repo.flutter}}/blob/master/CHANGELOG.md
 
 ## Framework
 

--- a/src/content/release/release-notes/release-notes-3.13.0.md
+++ b/src/content/release/release-notes/release-notes-3.13.0.md
@@ -5,9 +5,9 @@ description: Release notes for Flutter 3.13.0.
 ---
 This page has release notes for 3.13.0.
 For information about subsequent bug-fix releases,
-see [Hotfixes to the Stable Channel][].
+see our [CHANGELOG][].
 
-[Hotfixes to the Stable Channel]: {{site.repo.flutter}}/blob/master/docs/releases/Hotfixes-to-the-Stable-Channel.md
+[CHANGELOG]: {{site.repo.flutter}}/blob/master/CHANGELOG.md
 
 ## Framework
 

--- a/src/content/release/release-notes/release-notes-3.16.0.md
+++ b/src/content/release/release-notes/release-notes-3.16.0.md
@@ -6,9 +6,9 @@ description: Release notes for Flutter 3.16.0.
 
 This page has release notes for 3.16.0.
 For information about subsequent bug-fix releases,
-see [Hotfixes to the Stable Channel][].
+see our [CHANGELOG][].
 
-[Hotfixes to the Stable Channel]: {{site.repo.flutter}}/blob/master/docs/releases/Hotfixes-to-the-Stable-Channel.md
+[CHANGELOG]: {{site.repo.flutter}}/blob/master/CHANGELOG.md
 
 ## Flutter
 

--- a/src/content/release/release-notes/release-notes-3.19.0.md
+++ b/src/content/release/release-notes/release-notes-3.19.0.md
@@ -6,9 +6,9 @@ description: Release notes for Flutter 3.19.0.
 
 This page has release notes for 3.19.0.
 For information about subsequent bug-fix releases,
-see [Hotfixes to the Stable Channel][].
+see our [CHANGELOG][].
 
-[Hotfixes to the Stable Channel]: {{site.repo.flutter}}/blob/master/docs/releases/Hotfixes-to-the-Stable-Channel.md
+[CHANGELOG]: {{site.repo.flutter}}/blob/master/CHANGELOG.md
 
 ## Flutter
 

--- a/src/content/release/release-notes/release-notes-3.22.0.md
+++ b/src/content/release/release-notes/release-notes-3.22.0.md
@@ -6,9 +6,9 @@ description: Release notes for Flutter 3.22.0.
 
 This page has release notes for 3.22.0.
 For information about subsequent bug-fix releases,
-see [Hotfixes to the Stable Channel][].
+see our [CHANGELOG][].
 
-[Hotfixes to the Stable Channel]: {{site.repo.flutter}}/blob/master/docs/releases/Hotfixes-to-the-Stable-Channel.md
+[CHANGELOG]: {{site.repo.flutter}}/blob/master/CHANGELOG.md
 
 ## Flutter
 

--- a/src/content/release/release-notes/release-notes-3.3.0.md
+++ b/src/content/release/release-notes/release-notes-3.3.0.md
@@ -3,11 +3,12 @@ title: Flutter 3.3.0 release notes
 short-title: 3.3.0 release notes
 description: Release notes for Flutter 3.3.0.
 ---
+
 This page has release notes for 3.3.0.
 For information about subsequent bug-fix releases,
-see [Hotfixes to the Stable Channel][].
+see our [CHANGELOG][].
 
-[Hotfixes to the Stable Channel]: {{site.repo.flutter}}/blob/master/docs/releases/Hotfixes-to-the-Stable-Channel.md
+[CHANGELOG]: {{site.repo.flutter}}/blob/master/CHANGELOG.md
 
 ## What's changed
 

--- a/src/content/release/release-notes/release-notes-3.7.0.md
+++ b/src/content/release/release-notes/release-notes-3.7.0.md
@@ -5,9 +5,9 @@ description: Release notes for Flutter 3.7.0.
 ---
 This page has release notes for 3.7.0.
 For information about subsequent bug-fix releases,
-see [Hotfixes to the Stable Channel][].
+see our [CHANGELOG][].
 
-[Hotfixes to the Stable Channel]: {{site.repo.flutter}}/blob/master/docs/releases/Hotfixes-to-the-Stable-Channel.md
+[CHANGELOG]: {{site.repo.flutter}}/blob/master/CHANGELOG.md
 
 ## What's changed
 


### PR DESCRIPTION
Continues to remove references to "Hotfixes to the stable channel" from the website. 

This PR removes the reference from the release note history and points to CHANGELOG.md.
