### PR TITLE
Update internationalization.md

### DIFF
--- a/src/content/ui/accessibility-and-internationalization/internationalization.md
+++ b/src/content/ui/accessibility-and-internationalization/internationalization.md
@@ -656,29 +656,30 @@ AppLocalizations.of(context).helloWorldOn(DateTime.utc(1959, 7, 9))
 <a id="ios-specifics"></a>
 ### Localizing for iOS: Updating the iOS app bundle
 
-Typically, iOS applications define key application metadata,
-including supported locales, in an `Info.plist` file
-that is built into the application bundle.
+Although the localizations are handled by flutter,
+you need to add the supported languages in the Xcode project.
+This ensures your entry in the App Store correctly displays
+the supported languages.
+
 To configure the locales supported by your app,
 use the following instructions:
 
-1. Open your project's `ios/Runner.xcworkspace` Xcode file.
+1. Open your project's `ios/Runner.xcodeproj` Xcode file.
 
-2. In the **Project Navigator**, open the `Info.plist` file
-   under the `Runner` project's `Runner` folder.
+2. In the **Project Navigator**, select the `Runner` project
+   file under **Projects**.
 
-3. Select the **Information Property List** item.
-   Then select **Add Item** from the **Editor** menu,
-   and select **Localizations** from the pop-up menu.
+4. Select the `Info` tab in the project editor.
 
-4. Select and expand the newly-created `Localizations` item.
-   For each locale your application supports,
-   add a new item and select the locale you wish to add
-   from the pop-up menu in the **Value** field.
-   This list should be consistent with the languages listed
-   in the [`supportedLocales`][] parameter.
+5. In the **Localizations** section, click the `Add` button
+   (`+`) to add the supported lanaguages and regions to your
+   project. When asked to choose files and reference language,
+   simply select `Finish`.
 
-5. Once all supported locales have been added, save the file.
+7. Xcode automatically creates empty `.strings` files and
+   updates the `ios/Runner.xcodeproj/project.pbxproj` file.
+   These files are used by the App Store to determine which
+   languages and regions your app supports.
 
 <a id="advanced-customization"></a>
 ## Advanced topics for further customization

--- a/src/content/ui/accessibility-and-internationalization/internationalization.md
+++ b/src/content/ui/accessibility-and-internationalization/internationalization.md
@@ -656,7 +656,7 @@ AppLocalizations.of(context).helloWorldOn(DateTime.utc(1959, 7, 9))
 <a id="ios-specifics"></a>
 ### Localizing for iOS: Updating the iOS app bundle
 
-Although the localizations are handled by flutter,
+Although the localizations are handled by Flutter,
 you need to add the supported languages in the Xcode project.
 This ensures your entry in the App Store correctly displays
 the supported languages.


### PR DESCRIPTION
Update section about iOS apps

_Description of what this PR is changing or adding, and why:_

The section about iOS apps was wrong or outdated. 
When following the current instructions, the app store entry would only show the english locale.
Also, the official apple documentation does not mention changes to the Info.plist file: https://developer.apple.com/documentation/xcode/adding-support-for-languages-and-regions

_Issues fixed by this PR (if any):_

https://github.com/flutter/website/issues/10221



_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
