### PR TITLE
Fix macOS deployment redirect

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -687,7 +687,7 @@
       { "source": "/to/java-gradle-incompatibility", "destination": "/release/breaking-changes/android-java-gradle-migration-guide", "type": 301 },
       { "source": "/to/linux-android-setup", "destination": "/get-started/install/linux/android", "type": 301 },
       { "source": "/to/macos-android-setup", "destination": "/get-started/install/macos/mobile-android", "type": 301 },
-      { "source": "/to/macos-deploy", "destination": "/deployment/ios/macos", "type": 301 },
+      { "source": "/to/macos-deploy", "destination": "/deployment/macos", "type": 301 },
       { "source": "/to/macos-entitlements", "destination": "/platform-integration/macos/building#entitlements-and-the-app-sandbox", "type": 301 },
       { "source": "/to/macos-ffi", "destination": "/platform-integration/macos/c-interop", "type": 301 },
       { "source": "/to/macos-ios-setup", "destination": "/get-started/install/macos/mobile-ios", "type": 301 },


### PR DESCRIPTION
Fixes this redirect: https://flutter.dev/to/macos-deploy

Fixes: https://github.com/flutter/flutter/issues/152092

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
