### PR TITLE
Improve SwiftPM markdown formatting

### DIFF
--- a/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
+++ b/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
@@ -9,13 +9,13 @@ To turn it on:
    flutter channel main
    ```
 
-2. Make sure you have the latest Flutter SDK:
+1. Make sure you have the latest Flutter SDK:
 
    ```sh
    flutter upgrade
    ```
 
-3. Turn on the Swift Package Manager feature:
+1. Turn on the Swift Package Manager feature:
 
    ```sh
    flutter config --enable-swift-package-manager

--- a/src/_includes/docs/swift-package-manager/migrate-ios-project-manually.md
+++ b/src/_includes/docs/swift-package-manager/migrate-ios-project-manually.md
@@ -20,23 +20,23 @@ the following files in your issue:
 ### Step 1: Add FlutterGeneratedPluginSwiftPackage Package Dependency {:.no_toc}
 
 1. Open your app (`ios/Runner.xcworkspace`) in Xcode.
-2. Navigate to **Package Dependencies** for the project.
+1. Navigate to **Package Dependencies** for the project.
 
    {% render docs/captioned-image.liquid,
    image:"development/packages-and-plugins/swift-package-manager/package-dependencies.png",
    caption:"The project's package dependencies" %}
 
-3. Click <span class="material-symbols-outlined">add</span>.
-4. In the dialog that opens, click **Add Local...**.
-5. Navigate to `ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage`
+1. Click <span class="material-symbols-outlined">add</span>.
+1. In the dialog that opens, click **Add Local...**.
+1. Navigate to `ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage`
    and click **Add Package**.
-6. Ensure that it's added to the `Runner` target and click **Add Package**.
+1. Ensure that it's added to the `Runner` target and click **Add Package**.
  
    {% render docs/captioned-image.liquid,
    image:"development/packages-and-plugins/swift-package-manager/choose-package-products.png",
    caption:"Ensure that the package is added to the `Runner` target" %}
 
-7. Ensure that `FlutterGeneratedPluginSwiftPackage` was added to **Frameworks,
+1. Ensure that `FlutterGeneratedPluginSwiftPackage` was added to **Frameworks,
    Libraries, and Embedded Content**.
 
    {% render docs/captioned-image.liquid,
@@ -48,18 +48,18 @@ the following files in your issue:
 **The following steps must be completed for each flavor.**
 
 1. Go to **Product > Scheme > Edit Scheme**.
-2. Expand the **Build** section in the left side bar.
-3. Click **Pre-actions**.
-4. Click <span class="material-symbols-outlined">add</span> and
+1. Expand the **Build** section in the left side bar.
+1. Click **Pre-actions**.
+1. Click <span class="material-symbols-outlined">add</span> and
    select **New Run Script Action** from the menu.
-5. Click the **Run Script** title and change it to:
+1. Click the **Run Script** title and change it to:
 
    ```plaintext
    Run Prepare Flutter Framework Script
    ```
 
-6. Change the **Provide build settings from** to the `Runner` app.
-7. Input the following in the text box:
+1. Change the **Provide build settings from** to the `Runner` app.
+1. Input the following in the text box:
 
    ```sh
    "$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh" prepare
@@ -72,14 +72,14 @@ the following files in your issue:
 ### Step 3: Run app {:.no_toc}
 
 1. Run the app in Xcode.
-2. Ensure that  **Run Prepare Flutter Framework Script** runs as a pre-action
+1. Ensure that  **Run Prepare Flutter Framework Script** runs as a pre-action
    and that `FlutterGeneratedPluginSwiftPackage` is a target dependency.
 
    {% render docs/captioned-image.liquid,
    image:"development/packages-and-plugins/swift-package-manager/flutter-pre-action-build-log.png",
    caption:"Ensure **Run Prepare Flutter Framework Script** runs as a pre-action" %}
 
-3. Ensure that the app runs on the command line with `flutter run`.
+1. Ensure that the app runs on the command line with `flutter run`.
 
 [turn on Swift Package Manager]: /packages-and-plugins/swift-package-manager/for-app-developers/#how-to-turn-on-swift-package-manager
 [file an issue]: {{site.github}}/flutter/flutter/issues/new?template=2_bug.yml

--- a/src/_includes/docs/swift-package-manager/migrate-ios-project.md
+++ b/src/_includes/docs/swift-package-manager/migrate-ios-project.md
@@ -7,7 +7,7 @@ To migrate your project:
 
 1. [Turn on Swift Package Manager][].
 
-2. Run the iOS app using the Flutter CLI.
+1. Run the iOS app using the Flutter CLI.
 
    If your iOS project doesn't have Swift Package Manager integration yet, the
    Flutter CLI tries to migrate your project and outputs something like:
@@ -21,13 +21,13 @@ To migrate your project:
    `ios/Runner.xcodeproj/project.pbxproj` and
    `ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme` files.
 
-3. If the Flutter CLI's automatic migration fails, follow the steps in
+1. If the Flutter CLI's automatic migration fails, follow the steps in
    [add Swift Package Manager integration manually][manualIntegration].
 
 [Optional] To check if your project is migrated:
 
 1. Run the app in Xcode.
-2. Ensure that  **Run Prepare Flutter Framework Script** runs as a pre-action
+1. Ensure that  **Run Prepare Flutter Framework Script** runs as a pre-action
    and that `FlutterGeneratedPluginSwiftPackage` is a target dependency.
 
    {% render docs/captioned-image.liquid,

--- a/src/_includes/docs/swift-package-manager/migrate-macos-project-manually.md
+++ b/src/_includes/docs/swift-package-manager/migrate-macos-project-manually.md
@@ -20,23 +20,23 @@ the following files in your issue:
 ### Step 1: Add FlutterGeneratedPluginSwiftPackage Package Dependency {:.no_toc}
 
 1. Open your app (`macos/Runner.xcworkspace`) in Xcode.
-2. Navigate to **Package Dependencies** for the project.
+1. Navigate to **Package Dependencies** for the project.
 
    {% render docs/captioned-image.liquid,
    image:"development/packages-and-plugins/swift-package-manager/package-dependencies.png",
    caption:"The project's package dependencies" %}
 
-3. Click <span class="material-symbols-outlined">add</span>.
-4. In the dialog that opens, click the **Add Local...**.
-5. Navigate to `macos/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage`
+1. Click <span class="material-symbols-outlined">add</span>.
+1. In the dialog that opens, click the **Add Local...**.
+1. Navigate to `macos/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage`
    and click the **Add Package**.
-6. Ensure that it's added to the Runner Target and click **Add Package**.
+1. Ensure that it's added to the Runner Target and click **Add Package**.
 
    {% render docs/captioned-image.liquid,
    image:"development/packages-and-plugins/swift-package-manager/choose-package-products.png",
    caption:"Ensure that the package is added to the `Runner` target" %}
 
-7. Ensure that `FlutterGeneratedPluginSwiftPackage` was added to **Frameworks,
+1. Ensure that `FlutterGeneratedPluginSwiftPackage` was added to **Frameworks,
    Libraries, and Embedded Content**.
 
    {% render docs/captioned-image.liquid,
@@ -48,18 +48,18 @@ the following files in your issue:
 **The following steps must be completed for each flavor.**
 
 1. Go to **Product > Scheme > Edit Scheme**.
-2. Expand the **Build** section in the left side bar.
-3. Click **Pre-actions**.
-4. Click the <span class="material-symbols-outlined">add</span> button
+1. Expand the **Build** section in the left side bar.
+1. Click **Pre-actions**.
+1. Click the <span class="material-symbols-outlined">add</span> button
    and select **New Run Script Action** from the menu.
-5. Click the **Run Script** title and change it to:
+1. Click the **Run Script** title and change it to:
 
    ```plaintext
    Run Prepare Flutter Framework Script
    ```
 
-6. Change the **Provide build settings from** to the `Runner` target.
-7. Input the following in the text box:
+1. Change the **Provide build settings from** to the `Runner` target.
+1. Input the following in the text box:
 
    ```sh
    "$FLUTTER_ROOT"/packages/flutter_tools/bin/macos_assemble.sh prepare
@@ -72,14 +72,14 @@ the following files in your issue:
 ### Step 3: Run app {:.no_toc}
 
 1. Run the app in Xcode.
-2. Ensure that  **Run Prepare Flutter Framework Script** runs as a pre-action
+1. Ensure that  **Run Prepare Flutter Framework Script** runs as a pre-action
    and that `FlutterGeneratedPluginSwiftPackage` is a target dependency.
 
    {% render docs/captioned-image.liquid,
    image:"development/packages-and-plugins/swift-package-manager/flutter-pre-action-build-log.png",
    caption:"Ensure `Run Prepare Flutter Framework Script` runs as a pre-action" %}
 
-3. Ensure that the app runs on the command line with `flutter run`.
+1. Ensure that the app runs on the command line with `flutter run`.
 
 [turn on Swift Package Manager]: /packages-and-plugins/swift-package-manager/for-app-developers/#how-to-turn-on-swift-package-manager
 [file an issue]: {{site.github}}/flutter/flutter/issues/new?template=2_bug.yml

--- a/src/_includes/docs/swift-package-manager/migrate-macos-project.md
+++ b/src/_includes/docs/swift-package-manager/migrate-macos-project.md
@@ -7,7 +7,7 @@ To migrate your project:
 
 1. [Turn on Swift Package Manager][].
 
-2. Run the macOS app using the Flutter CLI.
+1. Run the macOS app using the Flutter CLI.
 
    If your macOS project doesn't have Swift Package Manager integration yet, the
    Flutter CLI tries to migrate your project and outputs something like:
@@ -21,13 +21,13 @@ To migrate your project:
    `macos/Runner.xcodeproj/project.pbxproj` and
    `macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme` files.
 
-3. If the Flutter CLI's automatic migration fails, follow the steps in
+1. If the Flutter CLI's automatic migration fails, follow the steps in
    [add Swift Package Manager integration manually][manualIntegration].
 
 [Optional] To check if your project is migrated:
 
 1. Run the app in Xcode.
-2. Ensure that  **Run Prepare Flutter Framework Script** runs as a pre-action
+1. Ensure that  **Run Prepare Flutter Framework Script** runs as a pre-action
    and that `FlutterGeneratedPluginSwiftPackage` is a target dependency.
 
    {% render docs/captioned-image.liquid,

--- a/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
@@ -3,7 +3,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 
 1. [Turn on the Swift Package Manager feature][enableSPM].
 
-2. Start by creating a directory under the `ios`, `macos`, and/or `darwin`
+1. Start by creating a directory under the `ios`, `macos`, and/or `darwin`
    directories.
    Name this new directory the name of the platform package.
 
@@ -13,7 +13,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
    └── <b>plugin_name/</b>
    </pre>
 
-3. Within this new directory, create the following files/directories:
+1. Within this new directory, create the following files/directories:
 
     - `Package.swift` (file)
     - `Sources` (directory)
@@ -36,7 +36,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
          └── <b>.gitkeep</b>
    </pre>
 
-4. Use the following template in the `Package.swift` file:
+1. Use the following template in the `Package.swift` file:
 
    ```swift title="Package.swift"
    // swift-tools-version: 5.9
@@ -87,10 +87,9 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
    version of the plugin name.
    :::
 
-5. If your plugin has a [`PrivacyInfo.xcprivacy` file][], move it to
+1. If your plugin has a [`PrivacyInfo.xcprivacy` file][], move it to
    `ios/Sources/plugin_name/PrivacyInfo.xcprivacy` and uncomment the resource in
    the `Package.swift` file.
-
 
    ```swift title="Package.swift"
                resources: [
@@ -107,24 +106,24 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
                ],
    ```
 
-6. Move any resource files from `ios/Assets` to `ios/Sources/plugin_name`
+1. Move any resource files from `ios/Assets` to `ios/Sources/plugin_name`
    (or a subdirectory).
    Add the resource files to your `Package.swift` file, if applicable.
    For more instructions, see
    [https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package](https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package).
 
-7. Move any public headers from `ios/Classes` to
+1. Move any public headers from `ios/Classes` to
    `ios/Sources/plugin_name/include/plugin_name`.
 
-    * If you're unsure which headers are public, check your `podspec` file's
-      [`public_header_files`][] attribute.
-      If this attribute isn't specified, all of your headers were public.
-      You should consider whether you want all of your headers to be public.
+   * If you're unsure which headers are public, check your `podspec` file's
+     [`public_header_files`][] attribute.
+     If this attribute isn't specified, all of your headers were public.
+     You should consider whether you want all of your headers to be public.
 
-    * The `pluginClass` defined in your `pubspec.yaml` file must be public and
-      within this directory.
+   * The `pluginClass` defined in your `pubspec.yaml` file must be public and
+     within this directory.
 
-8. Handling `modulemap`.
+1. Handling `modulemap`.
 
    Skip this step if your plugin does not have a `modulemap`.
 
@@ -166,153 +165,153 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
     If you would like to use a custom `modulemap` with your Swift package,
     refer to [Swift Package Manager's documentation][].
 
-9. Move all remaining files from `ios/Classes` to `ios/Sources/plugin_name`.
+1. Move all remaining files from `ios/Classes` to `ios/Sources/plugin_name`.
 
-10. The `ios/Assets`, `ios/Resources`, and `ios/Classes` directories should now
-    be empty and can be deleted.
+1. The `ios/Assets`, `ios/Resources`, and `ios/Classes` directories should now
+   be empty and can be deleted.
 
-11. If your header files are no longer in the same directory as your
-    implementation files, you should update your import statements.
+1. If your header files are no longer in the same directory as your
+   implementation files, you should update your import statements.
 
-    For example, imagine the following migration:
+   For example, imagine the following migration:
 
-    * Before:
+   * Before:
 
-      <pre>
-      ios/Classes/
-      ├── PublicHeaderFile.h
-      └── ImplementationFile.m
-      </pre>
+     <pre>
+     ios/Classes/
+     ├── PublicHeaderFile.h
+     └── ImplementationFile.m
+     </pre>
 
-    * After:
+   * After:
 
-      <pre>
-      ios/plugin_name_ios/Sources/plugin_name_ios/
-      └── <b>include/plugin_name_ios/</b>
-         └── PublicHeaderFile.h
-      └── ImplementationFile.m
-      </pre>
+     <pre>
+     ios/plugin_name_ios/Sources/plugin_name_ios/
+     └── <b>include/plugin_name_ios/</b>
+        └── PublicHeaderFile.h
+     └── ImplementationFile.m
+     </pre>
 
-    In this example, the import statements in `ImplementationFile.m`
-    should be updated:
+   In this example, the import statements in `ImplementationFile.m`
+   should be updated:
 
-    ```diff2html
-    --- a/Sources/plugin_name_ios/ImplementationFile.m
-    +++ b/Sources/plugin_name_ios/ImplementationFile.m
-    @@ -1,1 +1,1 @@
-    - #import "PublicHeaderFile.h"
-    + #import "./include/plugin_name_ios/PublicHeaderFile.h"
-    ```
+   ```diff2html
+   --- a/Sources/plugin_name_ios/ImplementationFile.m
+   +++ b/Sources/plugin_name_ios/ImplementationFile.m
+   @@ -1,1 +1,1 @@
+   - #import "PublicHeaderFile.h"
+   + #import "./include/plugin_name_ios/PublicHeaderFile.h"
+   ```
 
-12. If your plugin uses [Pigeon][], update your Pigeon input file.
+1.  If your plugin uses [Pigeon][], update your Pigeon input file.
 
-    ```diff2html
-    --- a/pigeons/messages.dart
-    +++ b/pigeons/messages.dart
-    @@ -18,8 +18,8 @@ import 'package:pigeon/pigeon.dart';
-       javaOptions: JavaOptions(),
-    -  objcHeaderOut: 'ios/Classes/messages.g.h',
-    -  objcSourceOut: 'ios/Classes/messages.g.m',
-    +  objcHeaderOut: 'ios/plugin_name_ios/Sources/plugin_name_ios/messages.g.h',
-    +  objcSourceOut: 'ios/plugin_name_ios/Sources/plugin_name_ios/messages.g.m',
-       copyrightHeader: 'pigeons/copyright.txt',
-    ```
+   ```diff2html
+   --- a/pigeons/messages.dart
+   +++ b/pigeons/messages.dart
+   @@ -18,8 +18,8 @@ import 'package:pigeon/pigeon.dart';
+      javaOptions: JavaOptions(),
+   -  objcHeaderOut: 'ios/Classes/messages.g.h',
+   -  objcSourceOut: 'ios/Classes/messages.g.m',
+   +  objcHeaderOut: 'ios/plugin_name_ios/Sources/plugin_name_ios/messages.g.h',
+   +  objcSourceOut: 'ios/plugin_name_ios/Sources/plugin_name_ios/messages.g.m',
+      copyrightHeader: 'pigeons/copyright.txt',
+   ```
 
-    If your `objcHeaderOut` file is no longer within the same directory as the
-    `objcSourceOut`, you can change the `#import` using
-    `ObjcOptions.headerIncludePath`:
+   If your `objcHeaderOut` file is no longer within the same directory as the
+   `objcSourceOut`, you can change the `#import` using
+   `ObjcOptions.headerIncludePath`:
 
-    ```diff2html
-    --- a/pigeons/messages.dart
-    +++ b/pigeons/messages.dart
-    @@ -18,8 +18,8 @@ import 'package:pigeon/pigeon.dart';
-       javaOptions: JavaOptions(),
-    -  objcHeaderOut: 'ios/Classes/messages.g.h',
-    -  objcSourceOut: 'ios/Classes/messages.g.m',
-    +  objcHeaderOut: 'ios/plugin_name_ios/Sources/plugin_name_ios/include/plugin_name_ios/messages.g.h',
-    +  objcSourceOut: 'ios/plugin_name_ios/Sources/plugin_name_ios/messages.g.m',
-    +  objcOptions: ObjcOptions(
-    +    headerIncludePath: './include/plugin_name_ios/messages.g.h',
-    +  ),
-       copyrightHeader: 'pigeons/copyright.txt',
-    ```
+   ```diff2html
+   --- a/pigeons/messages.dart
+   +++ b/pigeons/messages.dart
+   @@ -18,8 +18,8 @@ import 'package:pigeon/pigeon.dart';
+      javaOptions: JavaOptions(),
+   -  objcHeaderOut: 'ios/Classes/messages.g.h',
+   -  objcSourceOut: 'ios/Classes/messages.g.m',
+   +  objcHeaderOut: 'ios/plugin_name_ios/Sources/plugin_name_ios/include/plugin_name_ios/messages.g.h',
+   +  objcSourceOut: 'ios/plugin_name_ios/Sources/plugin_name_ios/messages.g.m',
+   +  objcOptions: ObjcOptions(
+   +    headerIncludePath: './include/plugin_name_ios/messages.g.h',
+   +  ),
+      copyrightHeader: 'pigeons/copyright.txt',
+   ```
 
-    Run Pigeon to re-generate its code with the latest configuration.
+   Run Pigeon to re-generate its code with the latest configuration.
 
-13. Update your `Package.swift` file with any customizations you might need.
+1. Update your `Package.swift` file with any customizations you might need.
 
-    1. Open the `ios/plugin_name/` directory in Xcode.
+   1. Open the `ios/plugin_name/` directory in Xcode.
 
-    2. In Xcode, open your `Package.swift` file.
-       Verify Xcode doesn't produce any warnings or errors for this file.
+   1. In Xcode, open your `Package.swift` file.
+      Verify Xcode doesn't produce any warnings or errors for this file.
 
-       :::tip
-       If Xcode doesn't show any files, quit Xcode (**Xcode > Quit Xcode**) and
-       reopen.
+      :::tip
+      If Xcode doesn't show any files, quit Xcode (**Xcode > Quit Xcode**) and
+      reopen.
 
-       If Xcode doesn't update after you make a change, try clicking
-       **File > Packages > Reset Package Caches**.
-       :::
+      If Xcode doesn't update after you make a change, try clicking
+      **File > Packages > Reset Package Caches**.
+      :::
 
-    3. If your `ios/plugin_name.podspec` file has [CocoaPods `dependency`][]s,
-       add the corresponding [Swift Package Manager dependencies][] to your
-       `Package.swift` file.
+   1. If your `ios/plugin_name.podspec` file has [CocoaPods `dependency`][]s,
+      add the corresponding [Swift Package Manager dependencies][] to your
+      `Package.swift` file.
 
-    4. If your package must be linked explicitly `static` or `dynamic`
-       ([not recommended by Apple][]), update the [Product][] to define the
-       type:
+   1. If your package must be linked explicitly `static` or `dynamic`
+      ([not recommended by Apple][]), update the [Product][] to define the
+      type:
 
-       ```swift title="Package.swift"
-       products: [
-           .library(name: "plugin-name", type: .static, targets: ["plugin_name"])
-       ],
-       ```
+      ```swift title="Package.swift"
+      products: [
+          .library(name: "plugin-name", type: .static, targets: ["plugin_name"])
+      ],
+      ```
 
-    5. Make any other customizations. For more information on how to write a
-       `Package.swift` file, see
-       [https://developer.apple.com/documentation/packagedescription](https://developer.apple.com/documentation/packagedescription).
+   1. Make any other customizations. For more information on how to write a
+      `Package.swift` file, see
+      [https://developer.apple.com/documentation/packagedescription](https://developer.apple.com/documentation/packagedescription).
 
-       :::tip
-       If you add targets to your `Package.swift` file, use unique names.
-       This avoids conflicts with targets from other packages.
-       :::
+      :::tip
+      If you add targets to your `Package.swift` file, use unique names.
+      This avoids conflicts with targets from other packages.
+      :::
 
-14. Update your `ios/plugin_name.podspec` to point to new paths.
+1.  Update your `ios/plugin_name.podspec` to point to new paths.
 
-    ```diff2html
-    --- a/ios/plugin_name.podspec
-    +++ b/ios/plugin_name.podspec
-    @@ -21,4 +21,4 @@ 
-    - s.source_files = 'Classes/**/*.{h,m}'
-    - s.public_header_files = 'Classes/**/*.h'
-    - s.module_map = 'Classes/cocoapods_plugin_name.modulemap'
-    - s.resource_bundles = {'plugin_name_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
-    + s.source_files = 'plugin_name/Sources/plugin_name/**/*.{h,m}'
-    + s.public_header_files = 'plugin_name/Sources/plugin_name/include/**/*.h'
-    + s.module_map = 'plugin_name/Sources/plugin_name/include/cocoapods_plugin_name.modulemap'
-    + s.resource_bundles = {'plugin_name_privacy' => ['plugin_name/Sources/plugin_name/PrivacyInfo.xcprivacy']}
-    ```
+   ```diff2html
+   --- a/ios/plugin_name.podspec
+   +++ b/ios/plugin_name.podspec
+   @@ -21,4 +21,4 @@
+   - s.source_files = 'Classes/**/*.{h,m}'
+   - s.public_header_files = 'Classes/**/*.h'
+   - s.module_map = 'Classes/cocoapods_plugin_name.modulemap'
+   - s.resource_bundles = {'plugin_name_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
+   + s.source_files = 'plugin_name/Sources/plugin_name/**/*.{h,m}'
+   + s.public_header_files = 'plugin_name/Sources/plugin_name/include/**/*.h'
+   + s.module_map = 'plugin_name/Sources/plugin_name/include/cocoapods_plugin_name.modulemap'
+   + s.resource_bundles = {'plugin_name_privacy' => ['plugin_name/Sources/plugin_name/PrivacyInfo.xcprivacy']}
+   ```
 
-15. Update loading of resources from bundle to use `SWIFTPM_MODULE_BUNDLE`:
+1. Update loading of resources from bundle to use `SWIFTPM_MODULE_BUNDLE`:
 
-    ```objc
-    #if SWIFT_PACKAGE
-       NSBundle *bundle = SWIFTPM_MODULE_BUNDLE;
-     #else
-       NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-     #endif
-     NSURL *imageURL = [bundle URLForResource:@"image" withExtension:@"jpg"];
-    ```
+   ```objc
+   #if SWIFT_PACKAGE
+      NSBundle *bundle = SWIFTPM_MODULE_BUNDLE;
+    #else
+      NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    #endif
+    NSURL *imageURL = [bundle URLForResource:@"image" withExtension:@"jpg"];
+   ```
 
-    :::note
-    `SWIFTPM_MODULE_BUNDLE` only works if there are actual resources
-    (either [defined in the `Package.swift` file][Bundling resources] or
-    [automatically included by Xcode][Xcode resource detection]).
-    Otherwise, using `SWIFTPM_MODULE_BUNDLE` results in an error.
-    :::
+   :::note
+   `SWIFTPM_MODULE_BUNDLE` only works if there are actual resources
+   (either [defined in the `Package.swift` file][Bundling resources] or
+   [automatically included by Xcode][Xcode resource detection]).
+   Otherwise, using `SWIFTPM_MODULE_BUNDLE` results in an error.
+   :::
 
-16. If your `ios/Sources/plugin_name/include` directory only contains a
-    `.gitkeep`, you'll want update your `.gitignore` to include the following:
+1. If your `ios/Sources/plugin_name/include` directory only contains a
+   `.gitkeep`, you'll want update your `.gitignore` to include the following:
 
     ```text title=".gitignore"
     !.gitkeep
@@ -321,45 +320,45 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
     Run `flutter pub publish --dry-run` to ensure the `include` directory
     is published.
 
-17. Verify the plugin still works with CocoaPods.
+1. Verify the plugin still works with CocoaPods.
 
-    1. Turn off Swift Package Manager:
+   1. Turn off Swift Package Manager:
 
-       ```sh
-       flutter config --no-enable-swift-package-manager
-       ```
+      ```sh
+      flutter config --no-enable-swift-package-manager
+      ```
 
-    2. Run `flutter run` with the example app and ensure it builds and runs.
+   1. Run `flutter run` with the example app and ensure it builds and runs.
 
-    3. Run CocoaPods validation lints:
+   1. Run CocoaPods validation lints:
 
-       ```sh
-       pod lib lint ios/plugin_name.podspec  --configuration=Debug --skip-tests --use-modular-headers --use-libraries
-       ```
+      ```sh
+      pod lib lint ios/plugin_name.podspec  --configuration=Debug --skip-tests --use-modular-headers --use-libraries
+      ```
 
-       ```sh
-       pod lib lint ios/plugin_name.podspec  --configuration=Debug --skip-tests --use-modular-headers
-       ```
+      ```sh
+      pod lib lint ios/plugin_name.podspec  --configuration=Debug --skip-tests --use-modular-headers
+      ```
 
-18. Verify the plugin works with Swift Package Manager.
+1. Verify the plugin works with Swift Package Manager.
 
-    1. Turn on Swift Package Manager:
+   1. Turn on Swift Package Manager:
 
-       ```sh
-       flutter config --enable-swift-package-manager
-       ```
+      ```sh
+      flutter config --enable-swift-package-manager
+      ```
 
-    2. Run `flutter run` with the example app and ensure it builds and runs.
+   1. Run `flutter run` with the example app and ensure it builds and runs.
 
-    3. Open the example app in Xcode. Ensure that **Package Dependencies**
-       shows in the left **Project Navigator**.
+   1. Open the example app in Xcode. Ensure that **Package Dependencies**
+      shows in the left **Project Navigator**.
 
-19. Verify tests pass.
+1. Verify tests pass.
 
-  * **If your plugin has native unit tests (XCTest), make sure you also
-    [update unit tests in the plugin's example app][].**
+   * **If your plugin has native unit tests (XCTest), make sure you also
+     [update unit tests in the plugin's example app][].**
 
-  * Follow instructions for [testing plugins][].
+   * Follow instructions for [testing plugins][].
 
 [enableSPM]: /packages-and-plugins/swift-package-manager/for-plugin-authors#how-to-turn-on-swift-package-manager
 [`PrivacyInfo.xcprivacy` file]: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files

--- a/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
@@ -203,7 +203,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
    + #import "./include/plugin_name_ios/PublicHeaderFile.h"
    ```
 
-1.  If your plugin uses [Pigeon][], update your Pigeon input file.
+1. If your plugin uses [Pigeon][], update your Pigeon input file.
 
    ```diff2html
    --- a/pigeons/messages.dart
@@ -276,7 +276,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
       This avoids conflicts with targets from other packages.
       :::
 
-1.  Update your `ios/plugin_name.podspec` to point to new paths.
+1. Update your `ios/plugin_name.podspec` to point to new paths.
 
    ```diff2html
    --- a/ios/plugin_name.podspec

--- a/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
@@ -3,7 +3,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 
 1. [Turn on the Swift Package Manager feature][enableSPM].
 
-2. Start by creating a directory under the `ios`, `macos`, and/or `darwin`
+1. Start by creating a directory under the `ios`, `macos`, and/or `darwin`
    directories.
    Name this new directory the name of the platform package.
 
@@ -13,11 +13,11 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
    └── <b>plugin_name/</b>
    </pre>
 
-3. Within this new directory, create the following files/directories:
+1. Within this new directory, create the following files/directories:
 
-    - `Package.swift` (file)
-    - `Sources` (directory)
-    - `Sources/plugin_name` (directory)
+   - `Package.swift` (file)
+   - `Sources` (directory)
+   - `Sources/plugin_name` (directory)
 
    Your plugin should look like:
 
@@ -29,7 +29,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
       └── <b>Sources/plugin_name/</b>
    </pre>
 
-4. Use the following template in the `Package.swift` file:
+1. Use the following template in the `Package.swift` file:
 
    ```swift title="Package.swift"
    // swift-tools-version: 5.9
@@ -77,7 +77,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
    version of the plugin name.
    :::
 
-5. If your plugin has a [`PrivacyInfo.xcprivacy` file][], move it to
+1. If your plugin has a [`PrivacyInfo.xcprivacy` file][], move it to
    `ios/Sources/plugin_name/PrivacyInfo.xcprivacy` and uncomment the resource in
    the `Package.swift` file.
 
@@ -96,18 +96,18 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
                ],
    ```
 
-6. Move any resource files from `ios/Assets` to `ios/Sources/plugin_name`
+1. Move any resource files from `ios/Assets` to `ios/Sources/plugin_name`
    (or a subdirectory).
    Add the resource files to your `Package.swift` file, if applicable.
    For more instructions, see
    [https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package](https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package).
 
-7. Move all files from `ios/Classes` to `ios/Sources/plugin_name`.
+1. Move all files from `ios/Classes` to `ios/Sources/plugin_name`.
 
-8. The `ios/Assets`, `ios/Resources`, and `ios/Classes` directories should now
+1. The `ios/Assets`, `ios/Resources`, and `ios/Classes` directories should now
    be empty and can be deleted.
 
-9. If your plugin uses [Pigeon][], update your Pigeon input file.
+1. If your plugin uses [Pigeon][], update your Pigeon input file.
 
    ```diff2html
    --- a/pigeons/messages.dart
@@ -121,112 +121,112 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
       swiftOptions: SwiftOptions(),
    ```
 
-10. Update your `Package.swift` file with any customizations you might need.
+1. Update your `Package.swift` file with any customizations you might need.
 
-    1. Open the `ios/plugin_name/` directory in Xcode.
+   1. Open the `ios/plugin_name/` directory in Xcode.
 
-    2. In Xcode, open your `Package.swift` file.
-       Verify Xcode doesn't produce any warnings or errors for this file.
+   1. In Xcode, open your `Package.swift` file.
+      Verify Xcode doesn't produce any warnings or errors for this file.
 
-       :::tip
-       If Xcode doen't show any files, quit Xcode (**Xcode > Quit Xcode**) and
-       reopen.
+      :::tip
+      If Xcode doen't show any files, quit Xcode (**Xcode > Quit Xcode**) and
+      reopen.
 
-       If Xcode doesn't update after you make a change, try clicking
-       **File > Packages > Reset Package Caches**.
-       :::
+      If Xcode doesn't update after you make a change, try clicking
+      **File > Packages > Reset Package Caches**.
+      :::
 
-    3. If your `ios/plugin_name.podspec` file has [CocoaPods `dependency`][]s,
-       add the corresponding [Swift Package Manager dependencies][] to your
-       `Package.swift` file.
+   1. If your `ios/plugin_name.podspec` file has [CocoaPods `dependency`][]s,
+      add the corresponding [Swift Package Manager dependencies][] to your
+      `Package.swift` file.
 
-    4. If your package must be linked explicitly `static` or `dynamic`
-       ([not recommended by Apple][]), update the [Product][] to define the
-       type:
+   1. If your package must be linked explicitly `static` or `dynamic`
+      ([not recommended by Apple][]), update the [Product][] to define the
+      type:
 
-       ```swift title="Package.swift"
-       products: [
-           .library(name: "plugin-name", type: .static, targets: ["plugin_name"])
-       ],
-       ```
+      ```swift title="Package.swift"
+      products: [
+          .library(name: "plugin-name", type: .static, targets: ["plugin_name"])
+      ],
+      ```
 
-    5. Make any other customizations. For more information on how to write a
-       `Package.swift` file, see
-       [https://developer.apple.com/documentation/packagedescription](https://developer.apple.com/documentation/packagedescription).
+   1. Make any other customizations. For more information on how to write a
+      `Package.swift` file, see
+      [https://developer.apple.com/documentation/packagedescription](https://developer.apple.com/documentation/packagedescription).
 
-       :::tip
-       If you add targets to your `Package.swift` file, use unique names.
-       This avoids conflicts with targets from other packages.
-       :::
+      :::tip
+      If you add targets to your `Package.swift` file, use unique names.
+      This avoids conflicts with targets from other packages.
+      :::
 
-11. Update your `ios/plugin_name.podspec` to point to new paths.
+1. Update your `ios/plugin_name.podspec` to point to new paths.
 
-    ```diff2html
-    --- a/ios/plugin_name.podspec
-    +++ b/ios/plugin_name.podspec
-    @@ -1,2 +1,2 @@ 
-    - s.source_files = 'Classes/**/*.swift'
-    - s.resource_bundles = {'plugin_name_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
-    + s.source_files = 'plugin_name/Sources/plugin_name/**/*.swift'
-    + s.resource_bundles = {'plugin_name_privacy' => ['plugin_name/Sources/plugin_name/PrivacyInfo.xcprivacy']}
-    ```
+   ```diff2html
+   --- a/ios/plugin_name.podspec
+   +++ b/ios/plugin_name.podspec
+   @@ -1,2 +1,2 @@
+   - s.source_files = 'Classes/**/*.swift'
+   - s.resource_bundles = {'plugin_name_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
+   + s.source_files = 'plugin_name/Sources/plugin_name/**/*.swift'
+   + s.resource_bundles = {'plugin_name_privacy' => ['plugin_name/Sources/plugin_name/PrivacyInfo.xcprivacy']}
+   ```
 
-12. Update loading of resources from bundle to use [`Bundle.module`][].
+1. Update loading of resources from bundle to use [`Bundle.module`][].
 
-    ```swift
-    #if SWIFT_PACKAGE
-         let settingsURL = Bundle.module.url(forResource: "image", withExtension: "jpg")
-    #else
-         let settingsURL = Bundle(for: Self.self).url(forResource: "image", withExtension: "jpg")
-    #endif
-    ```
+   ```swift
+   #if SWIFT_PACKAGE
+        let settingsURL = Bundle.module.url(forResource: "image", withExtension: "jpg")
+   #else
+        let settingsURL = Bundle(for: Self.self).url(forResource: "image", withExtension: "jpg")
+   #endif
+   ```
 
-    :::note
-    `Bundle.module` only works if there are resources
-    [defined in the `Package.swift` file][Bundling resources] or
-    [automatically included by Xcode][Xcode resource detection]).
-    Otherwise, using `Bundle.module` results in an error.
-    :::
+   :::note
+   `Bundle.module` only works if there are resources
+   [defined in the `Package.swift` file][Bundling resources] or
+   [automatically included by Xcode][Xcode resource detection]).
+   Otherwise, using `Bundle.module` results in an error.
+   :::
 
-13. Verify the plugin still works with CocoaPods.
+1. Verify the plugin still works with CocoaPods.
 
-    1. Turn off Swift Package Manager.
+   1. Turn off Swift Package Manager.
 
-       ```sh
-       flutter config --no-enable-swift-package-manager
-       ```
+      ```sh
+      flutter config --no-enable-swift-package-manager
+      ```
 
-    2. Run `flutter run` with the example app and ensure it builds and runs.
+   1. Run `flutter run` with the example app and ensure it builds and runs.
 
-    3. Run CocoaPods validation lints.
+   1. Run CocoaPods validation lints.
 
-       ```sh
-       pod lib lint ios/plugin_name.podspec  --configuration=Debug --skip-tests --use-modular-headers --use-libraries
-       ```
+      ```sh
+      pod lib lint ios/plugin_name.podspec  --configuration=Debug --skip-tests --use-modular-headers --use-libraries
+      ```
 
-       ```sh
-       pod lib lint ios/plugin_name.podspec  --configuration=Debug --skip-tests --use-modular-headers
-       ```
+      ```sh
+      pod lib lint ios/plugin_name.podspec  --configuration=Debug --skip-tests --use-modular-headers
+      ```
 
-14. Verify the plugin works with Swift Package Manager.
+1. Verify the plugin works with Swift Package Manager.
 
-    1. Turn on Swift Package Manager.
+   1. Turn on Swift Package Manager.
 
        ```sh
        flutter config --enable-swift-package-manager
        ```
 
-    2. Run `flutter run` with the example app and ensure it builds and runs.
+   1. Run `flutter run` with the example app and ensure it builds and runs.
 
-    3. Open the example app in Xcode. Ensure that **Package Dependencies**
-       shows in the left **Project Navigator**.
+   1. Open the example app in Xcode. Ensure that **Package Dependencies**
+      shows in the left **Project Navigator**.
 
-15. Verify tests pass.
+1. Verify tests pass.
 
-  * **If your plugin has native unit tests (XCTest), make sure you also
+   * **If your plugin has native unit tests (XCTest), make sure you also
     [update unit tests in the plugin's example app][].**
 
-  * Follow instructions for [testing plugins][].
+   * Follow instructions for [testing plugins][].
 
 [enableSPM]: /packages-and-plugins/swift-package-manager/for-plugin-authors#how-to-turn-on-swift-package-manager
 [`PrivacyInfo.xcprivacy` file]: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files

--- a/src/content/packages-and-plugins/swift-package-manager/for-app-developers.md
+++ b/src/content/packages-and-plugins/swift-package-manager/for-app-developers.md
@@ -16,7 +16,7 @@ Flutter's Swift Package Manager integration has several benefits:
 
 1. **Provides access to the Swift package ecosystem**.
    Flutter plugins can use the growing ecosystem of [Swift packages][]. 
-2. **Simplifies Flutter installation**.
+1. **Simplifies Flutter installation**.
    Xcode includes Swift Package Manager.
    You don't need to install Ruby and CocoaPods if your project uses
    Swift Package Manager.
@@ -100,41 +100,41 @@ To undo this migration:
 
 1. [Turn off Swift Package Manager][].
 
-2. Open your app (`ios/Runner.xcworkspace` or `ios/Runner.xcworkspace`) in
+1. Open your app (`ios/Runner.xcworkspace` or `ios/Runner.xcworkspace`) in
    Xcode.
 
-3. Navigate to **Package Dependencies** for the project.
+1. Navigate to **Package Dependencies** for the project.
 
-4. Click the `FlutterGeneratedPluginSwiftPackage` package, then click
+1. Click the `FlutterGeneratedPluginSwiftPackage` package, then click
    <span class="material-symbols-outlined">remove</span>.
 
    {% render docs/captioned-image.liquid,
    image:"development/packages-and-plugins/swift-package-manager/remove-generated-package.png",
    caption:"The `FlutterGeneratedPluginSwiftPackage` to remove" %}
 
-5. Navigate to **Frameworks, Libraries, and Embedded Content** for the `Runner`
+1. Navigate to **Frameworks, Libraries, and Embedded Content** for the `Runner`
    target.
 
-6. Click `FlutterGeneratedPluginSwiftPackage`, then click the
+1. Click `FlutterGeneratedPluginSwiftPackage`, then click the
    <span class="material-symbols-outlined">remove</span>.
 
    {% render docs/captioned-image.liquid,
    image:"development/packages-and-plugins/swift-package-manager/remove-generated-framework.png",
    caption:"The `FlutterGeneratedPluginSwiftPackage` to remove" %}
 
-7. Go to **Product > Scheme > Edit Scheme**.
+1. Go to **Product > Scheme > Edit Scheme**.
 
-8. Expand the **Build** section in the left side bar.
+1. Expand the **Build** section in the left side bar.
 
-9. Click **Pre-actions**.
+1. Click **Pre-actions**.
 
-10. Expand **Run Prepare Flutter Framework Script**.
+1. Expand **Run Prepare Flutter Framework Script**.
 
-11. Click **<span class="material-symbols">delete</span>**.
+1. Click **<span class="material-symbols">delete</span>**.
 
-    {% render docs/captioned-image.liquid,
-    image:"development/packages-and-plugins/swift-package-manager/remove-flutter-pre-action.png",
-    caption:"The build pre-action to remove" %}
+   {% render docs/captioned-image.liquid,
+   image:"development/packages-and-plugins/swift-package-manager/remove-flutter-pre-action.png",
+   caption:"The build pre-action to remove" %}
 
 [Turn off Swift Package Manager]: /packages-and-plugins/swift-package-manager/for-app-developers/#how-to-turn-off-swift-package-manager
 

--- a/src/content/packages-and-plugins/swift-package-manager/for-plugin-authors.md
+++ b/src/content/packages-and-plugins/swift-package-manager/for-plugin-authors.md
@@ -17,7 +17,7 @@ Flutter's Swift Package Manager integration has several benefits:
 
 1. **Access to the Swift package ecosystem**.
    Flutter plugins can use the growing ecosystem of [Swift packages][]! 
-2. **Simplifies Flutter installation**.
+1. **Simplifies Flutter installation**.
    Swift Package Manager is bundled with Xcode.
    In the future, you won’t need to install Ruby and CocoaPods to target iOS or
    macOS.
@@ -73,7 +73,7 @@ To update your unit tests:
 
 1. Open your `example/ios/Runner.xcworkspace` in Xcode.
 
-2. If you were using a CocoaPod dependency for tests, such as `OCMock`,
+1. If you were using a CocoaPod dependency for tests, such as `OCMock`,
    you'll want to remove it from your `Podfile` file.
 
    ```diff2html
@@ -91,13 +91,13 @@ To update your unit tests:
    Then in the terminal, run `pod install` in the `plugin_name_ios/example/ios`
    directory.
 
-3. Navigate to **Package Dependencies** for the project.
+1. Navigate to **Package Dependencies** for the project.
 
    {% render docs/captioned-image.liquid,
    image:"development/packages-and-plugins/swift-package-manager/package-dependencies.png",
    caption:"The project's package dependencies" %}
 
-4. Click the **+** button and add any test-only dependencies by searching for
+1. Click the **+** button and add any test-only dependencies by searching for
    them in the top right search bar.
 
    {% render docs/captioned-image.liquid,
@@ -110,15 +110,15 @@ To update your unit tests:
    version.
    :::
 
-5. Ensure the dependency is added to the `RunnerTests` Target.
+1. Ensure the dependency is added to the `RunnerTests` Target.
 
    {% render docs/captioned-image.liquid,
    image:"development/packages-and-plugins/swift-package-manager/choose-package-products-test.png",
    caption:"Ensure the dependency is added to the `RunnerTests` target" %}
 
-6. Click the **Add Package** button.
+1. Click the **Add Package** button.
 
-7. If you've explicitly set your plugin's library type to `.dynamic` in its
+1. If you've explicitly set your plugin's library type to `.dynamic` in its
    `Package.swift` file
    ([not recommended by Apple][library type recommendations]),
    you'll also need to add it as a dependency to the `RunnerTests` target.
@@ -138,18 +138,18 @@ To update your unit tests:
       image:"development/packages-and-plugins/swift-package-manager/add-runner-tests-link-binary-with-libraries.png",
       caption:"Add `Link Binary With Libraries` Build Phase" %}
 
-   2. Navigate to **Package Dependencies** for the project.
+   1. Navigate to **Package Dependencies** for the project.
 
-   3. Click <span class="material-symbols-outlined">add</span>.
+   1. Click <span class="material-symbols-outlined">add</span>.
 
-   4. In the dialog that opens, click the **Add Local...** button.
+   1. In the dialog that opens, click the **Add Local...** button.
 
-   5. Navigate to `plugin_name/plugin_name_ios/ios/plugin_name_ios` and click
+   1. Navigate to `plugin_name/plugin_name_ios/ios/plugin_name_ios` and click
       the **Add Package** button.
 
-   6. Ensure that it's added to the `RunnerTests` target and click the
+   1. Ensure that it's added to the `RunnerTests` target and click the
       **Add Package** button.
 
-8. Ensure tests pass **Product > Test**.
+1. Ensure tests pass **Product > Test**.
 
 [library type recommendations]: https://developer.apple.com/documentation/packagedescription/product/library(name:type:targets:)


### PR DESCRIPTION
This updates the SwiftPM docs to use non-increasing values for numbered lists. This will make it easier to review future changes.

Previously if you inserted new list items, you would need to re-format the content. For example:

```diff
+ 9. New content

- 9. Old content
-    That takes two lines.
+ 10. Old content
+     That takes new lines.
```

Notice how list item 10 now has 1 more digit so all of its content had to be shifted over by one space.

By using non-increasing values, you don't need to reformat the content. For example:

```diff
+ 1. New content

  1. Old content
     That takes two lines.
```

Prepares for: https://github.com/flutter/flutter/issues/152276

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
