### PR TITLE
Begin addressing SwiftPM docs feedback from walkthrough

### DIFF
--- a/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
+++ b/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
@@ -6,10 +6,10 @@ To turn it on:
 1. Switch to Flutter's `main` channel:
 
    ```sh
-   flutter channel main
+   flutter channel main --no-cache-artifacts
    ```
 
-1. Make sure you have the latest Flutter SDK:
+1. Upgrade to the latest Flutter SDK and download artifacts:
 
    ```sh
    flutter upgrade

--- a/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
@@ -116,6 +116,25 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
        targets: [
            .target(
                name: [!"plugin_name"!],
+               dependencies: [],
+               resources: [
+                   // If your plugin requires a privacy manifest, for example if it uses
+                   // any required reason APIs, update the PrivacyInfo.xcprivacy file to
+                   // describe your plugin's privacy impact, and then uncomment these lines.
+                   // For more information, see:
+                   // https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
+                   // .process("PrivacyInfo.xcprivacy"),
+   
+                   // If you have other resources that need to be bundled with your plugin, refer to
+                   // the following instructions to add them:
+                   // https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package
+               ],
+               cSettings: [
+                   .headerSearchPath("include/[!plugin_name!]")
+               ]
+           )
+       ]
+   )
    ```
 
    :::note

--- a/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
@@ -82,6 +82,42 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
    )
    ```
 
+1. Update the [supported platforms][] in your `Package.swift` file.
+
+   ```swift title="Package.swift"
+       platforms: [
+           // The platforms your plugin supports.
+           // If your plugin only supports iOS, remove `.macOS(...)`.
+           // If your plugin only supports macOS, remove `.iOS(...)`.
+           [!.iOS("12.0"),!]
+           [!.macOS("10.14")!]
+       ],
+   ```
+
+   [supported platforms]: https://developer.apple.com/documentation/packagedescription/supportedplatform
+
+1. Update the package, library, and target names in your `Package.swift` file.
+
+   ```swift title="Package.swift"
+   let package = Package(
+       name: [!"plugin_name"!],
+       platforms: [
+           // The platforms your plugin supports.
+           // If your plugin only supports iOS, remove `.macOS(...)`.
+           // If your plugin only supports macOS, remove `.iOS(...)`.
+           .iOS("12.0"),
+           .macOS("10.14")
+       ],
+       products: [
+           // If the plugin name contains "_", replace with "-" for the library name
+           .library(name: [!"plugin-name"!], targets: [[!"plugin_name"!]])
+       ],
+       dependencies: [],
+       targets: [
+           .target(
+               name: [!"plugin_name"!],
+   ```
+
    :::note
    If the plugin name contains `_`, the library name must be a `-` separated
    version of the plugin name.
@@ -328,7 +364,23 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
       flutter config --no-enable-swift-package-manager
       ```
 
-   1. Run `flutter run` with the example app and ensure it builds and runs.
+   1. Navigate to the plugin's example app.
+
+      ```sh
+      cd path/to/plugin/example/
+      ```
+
+   1. Ensure the plugin's example app builds and runs.
+
+      ```sh
+      flutter run
+      ```
+
+   1. Navigate to the plugin's top-level directory.
+
+      ```sh
+      cd path/to/plugin/
+      ```
 
    1. Run CocoaPods validation lints:
 
@@ -348,10 +400,21 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
       flutter config --enable-swift-package-manager
       ```
 
-   1. Run `flutter run` with the example app and ensure it builds and runs.
+   1. Navigate to the plugin's example app.
 
-   1. Open the example app in Xcode. Ensure that **Package Dependencies**
-      shows in the left **Project Navigator**.
+      ```sh
+      cd path/to/plugin/example/
+      ```
+
+   1. Ensure the plugin's example app builds and runs.
+
+      ```sh
+      flutter run
+      ```
+
+   1. Open the plugin's example app in Xcode.
+      Ensure that **Package Dependencies** shows in the left
+      **Project Navigator**.
 
 1. Verify tests pass.
 

--- a/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
@@ -106,6 +106,25 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
        targets: [
            .target(
                name: [!"plugin_name"!],
+               dependencies: [],
+               resources: [
+                   // If your plugin requires a privacy manifest, for example if it uses
+                   // any required reason APIs, update the PrivacyInfo.xcprivacy file to
+                   // describe your plugin's privacy impact, and then uncomment these lines.
+                   // For more information, see:
+                   // https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
+                   // .process("PrivacyInfo.xcprivacy"),
+   
+                   // If you have other resources that need to be bundled with your plugin, refer to
+                   // the following instructions to add them:
+                   // https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package
+               ],
+               cSettings: [
+                   .headerSearchPath("include/[!plugin_name!]")
+               ]
+           )
+       ]
+   )
    ```
 
    :::note

--- a/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
@@ -72,6 +72,42 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
    )
    ```
 
+1. Update the [supported platforms][] in your `Package.swift` file.
+
+   ```swift title="Package.swift"
+       platforms: [
+           // The platforms your plugin supports.
+           // If your plugin only supports iOS, remove `.macOS(...)`.
+           // If your plugin only supports macOS, remove `.iOS(...)`.
+           [!.iOS("12.0"),!]
+           [!.macOS("10.14")!]
+       ],
+   ```
+
+   [supported platforms]: https://developer.apple.com/documentation/packagedescription/supportedplatform
+
+1. Update the package, library, and target names in your `Package.swift` file.
+
+   ```swift title="Package.swift"
+   let package = Package(
+       name: [!"plugin_name"!],
+       platforms: [
+           // The platforms your plugin supports.
+           // If your plugin only supports iOS, remove `.macOS(...)`.
+           // If your plugin only supports macOS, remove `.iOS(...)`.
+           .iOS("12.0"),
+           .macOS("10.14")
+       ],
+       products: [
+           // If the plugin name contains "_", replace with "-" for the library name
+           .library(name: [!"plugin-name"!], targets: [[!"plugin_name"!]])
+       ],
+       dependencies: [],
+       targets: [
+           .target(
+               name: [!"plugin_name"!],
+   ```
+
    :::note
    If the plugin name contains `_`, the library name must be a `-` separated
    version of the plugin name.
@@ -196,7 +232,23 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
       flutter config --no-enable-swift-package-manager
       ```
 
-   1. Run `flutter run` with the example app and ensure it builds and runs.
+   1. Navigate to the plugin's example app.
+
+      ```sh
+      cd path/to/plugin/example/
+      ```
+
+   1. Ensure the plugin's example app builds and runs.
+
+      ```sh
+      flutter run
+      ```
+
+   1. Navigate to the plugin's top-level directory.
+
+      ```sh
+      cd path/to/plugin/
+      ```
 
    1. Run CocoaPods validation lints.
 
@@ -216,15 +268,26 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
        flutter config --enable-swift-package-manager
        ```
 
-   1. Run `flutter run` with the example app and ensure it builds and runs.
+   1. Navigate to the plugin's example app.
 
-   1. Open the example app in Xcode. Ensure that **Package Dependencies**
-      shows in the left **Project Navigator**.
+      ```sh
+      cd path/to/plugin/example/
+      ```
+
+   1. Ensure the plugin's example app builds and runs.
+
+      ```sh
+      flutter run
+      ```
+
+   1. Open the plugin's example app in Xcode.
+      Ensure that **Package Dependencies** shows in the left
+      **Project Navigator**.
 
 1. Verify tests pass.
 
    * **If your plugin has native unit tests (XCTest), make sure you also
-    [update unit tests in the plugin's example app][].**
+     [update unit tests in the plugin's example app][].**
 
    * Follow instructions for [testing plugins][].
 


### PR DESCRIPTION
Begin addressing the feedback from the walkthrough meeting: https://github.com/flutter/flutter/issues/152276

1. Updated the "enable SPM" instructions to avoid downloading artifacts twice
1. Added more substeps to the `Package.swift` section to clarify what content needs to be updated.
1. Clarified in which directory `flutter run` and `pod lib lint` commands should be run

_PRs or commits this PR depends on (if any):_ https://github.com/flutter/website/pull/10960

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
