### PR TITLE
Clarify that you shouldn't check-in SwiftPM changes to plugin's example app

### DIFF
--- a/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
+++ b/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
@@ -21,10 +21,16 @@ To turn it on:
    flutter config --enable-swift-package-manager
    ```
 
-Using the Flutter CLI to run an app modifies the project to add Swift Package
+Using the Flutter CLI to run an app migrates the project to add Swift Package
 Manager integration.
 This makes your project download the Swift packages that
 your Flutter plugins depend on.
+
+:::warning
+If you disable the Swift Package Manager feature,
+you will need to [remove Swift Package Manager integration][removeSPM] from apps
+that are migrated.
+:::
 
 Flutter falls back to CocoaPods for dependencies that do not support Swift
 Package Manager yet.

--- a/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
+++ b/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
@@ -25,12 +25,9 @@ Using the Flutter CLI to run an app migrates the project to add Swift Package
 Manager integration.
 This makes your project download the Swift packages that
 your Flutter plugins depend on.
-
-:::warning
 If you disable the Swift Package Manager feature,
 you will need to [remove Swift Package Manager integration][removeSPM] from apps
 that are migrated.
-:::
 
 Flutter falls back to CocoaPods for dependencies that do not support Swift
 Package Manager yet.

--- a/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
+++ b/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
@@ -21,8 +21,8 @@ To turn it on:
    flutter config --enable-swift-package-manager
    ```
 
-Using the Flutter CLI to run an app migrates the project to add Swift Package
-Manager integration.
+Using the Flutter CLI to run an app [migrates the project][addSPM] to add
+Swift Package Manager integration.
 This makes your project download the Swift packages that
 your Flutter plugins depend on.
 If you disable the Swift Package Manager feature,
@@ -77,5 +77,6 @@ This turns off Swift Package Manager for the current user.
 If a project is incompatible with Swift Package Manager, all contributors
 need to run this command. 
 
+[addSPM]: /packages-and-plugins/swift-package-manager/for-app-developers/#how-to-add-swift-package-manager-integration
 [removeSPM]: /packages-and-plugins/swift-package-manager/for-app-developers#how-to-remove-swift-package-manager-integration
 [open an issue]: {{site.github}}/flutter/flutter/issues/new?template=2_bug.yml

--- a/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
@@ -375,6 +375,8 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
     Run `flutter pub publish --dry-run` to ensure the `include` directory
     is published.
 
+1. Commit your plugin's changes to your version control system.
+
 1. Verify the plugin still works with CocoaPods.
 
    1. Turn off Swift Package Manager:
@@ -431,6 +433,21 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
       flutter run
       ```
 
+      :::warning
+      Using the Flutter CLI to run the plugin's example app with the
+      Swift Package Manager feature turned on migrates the project to add
+      Swift Package Manager integration.
+
+      **Do not commit the migration's changes to your version control system.**
+
+      Otherwise, the plugin's example app won't build if the
+      Swift Package Manager feature is turned off.
+
+      If you accidentally commit the migration's changes to your version control
+      system, follow the steps to
+      [undo the Swift Package Manager migration][removeSPM].
+      :::
+
    1. Open the plugin's example app in Xcode.
       Ensure that **Package Dependencies** shows in the left
       **Project Navigator**.
@@ -453,5 +470,6 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 [Product]: https://developer.apple.com/documentation/packagedescription/product
 [Bundling resources]: https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package#Explicitly-declare-or-exclude-resources
 [Xcode resource detection]: https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package#:~:text=Xcode%20detects%20common%20resource%20types%20for%20Apple%20platforms%20and%20treats%20them%20as%20a%20resource%20automatically
+[removeSPM]: /packages-and-plugins/swift-package-manager/for-app-developers#how-to-remove-swift-package-manager-integration
 [update unit tests in the plugin's example app]: /packages-and-plugins/swift-package-manager/for-plugin-authors/#how-to-update-unit-tests-in-a-plugins-example-app
 [testing plugins]: https://docs.flutter.dev/testing/testing-plugins

--- a/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
@@ -443,8 +443,8 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
       Otherwise, the plugin's example app won't build if the
       Swift Package Manager feature is turned off.
 
-      If you accidentally commit the migration's changes to your version control
-      system, follow the steps to
+      If you accidentally commit the migration's changes to the plugin's example
+      app, follow the steps to
       [undo the Swift Package Manager migration][removeSPM].
       :::
 

--- a/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
@@ -243,6 +243,8 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
    Otherwise, using `Bundle.module` results in an error.
    :::
 
+1. Commit your plugin's changes to your version control system.
+
 1. Verify the plugin still works with CocoaPods.
 
    1. Turn off Swift Package Manager.
@@ -299,6 +301,21 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
       flutter run
       ```
 
+      :::warning
+      Using the Flutter CLI to run the plugin's example app with the
+      Swift Package Manager feature turned on migrates the project to add
+      Swift Package Manager integration.
+
+      **Do not commit the migration's changes to your version control system.**
+
+      Otherwise, the plugin's example app won't build if the
+      Swift Package Manager feature is turned off.
+
+      If you accidentally commit the migration's changes to your version control
+      system, follow the steps to
+      [undo the Swift Package Manager migration][removeSPM].
+      :::
+
    1. Open the plugin's example app in Xcode.
       Ensure that **Package Dependencies** shows in the left
       **Project Navigator**.
@@ -320,5 +337,6 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 [`Bundle.module`]: https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package#Access-a-resource-in-code
 [Bundling resources]: https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package#Explicitly-declare-or-exclude-resources
 [Xcode resource detection]: https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package#:~:text=Xcode%20detects%20common%20resource%20types%20for%20Apple%20platforms%20and%20treats%20them%20as%20a%20resource%20automatically
+[removeSPM]: /packages-and-plugins/swift-package-manager/for-app-developers#how-to-remove-swift-package-manager-integration
 [update unit tests in the plugin's example app]: /packages-and-plugins/swift-package-manager/for-plugin-authors/#how-to-update-unit-tests-in-a-plugins-example-app
 [testing plugins]: https://docs.flutter.dev/testing/testing-plugins

--- a/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
@@ -311,8 +311,8 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
       Otherwise, the plugin's example app won't build if the
       Swift Package Manager feature is turned off.
 
-      If you accidentally commit the migration's changes to your version control
-      system, follow the steps to
+      If you accidentally commit the migration's changes to the plugin's example
+      app, follow the steps to
       [undo the Swift Package Manager migration][removeSPM].
       :::
 

--- a/src/content/packages-and-plugins/swift-package-manager/for-app-developers.md
+++ b/src/content/packages-and-plugins/swift-package-manager/for-app-developers.md
@@ -100,7 +100,13 @@ To undo this migration:
 
 1. [Turn off Swift Package Manager][].
 
-1. Open your app (`ios/Runner.xcworkspace` or `ios/Runner.xcworkspace`) in
+1. Clean your project:
+
+   ```sh
+   flutter clean
+   ```
+
+1. Open your app (`ios/Runner.xcworkspace` or `macos/Runner.xcworkspace`) in
    Xcode.
 
 1. Navigate to **Package Dependencies** for the project.


### PR DESCRIPTION
If you enable SwiftPM and run an app, the app is migrated to add SwiftPM integration. To run the app if you don't have SwiftPM enabled, you either need to enable SwiftPM or remove SwiftPM integration from the app.

This updates the SwiftPM plugin migration guide to recommend **not** checking-in the SwiftPM changes to the plugin's example apps. This ensures that users that don't have SwiftPM enabled can continue to run the plugin's example apps.

Preview links to updated sections:

1. [How to turn on Swift Package Manager](https://flutter-docs-prod--pr10976-spm-clarify-dont-migrate-4acxxqva.web.app/packages-and-plugins/swift-package-manager/for-app-developers#how-to-turn-on-swift-package-manager)
2. [How to remove Swift Package Manager integration](https://flutter-docs-prod--pr10976-spm-clarify-dont-migrate-4acxxqva.web.app/packages-and-plugins/swift-package-manager/for-app-developers#how-to-remove-swift-package-manager-integration)
3. [How to add Swift Package Manager support to an existing Flutter plugin](https://flutter-docs-prod--pr10976-spm-clarify-dont-migrate-4acxxqva.web.app/packages-and-plugins/swift-package-manager/for-plugin-authors#how-to-add-swift-package-manager-support-to-an-existing-flutter-plugin)

Part of https://github.com/flutter/flutter/issues/152276

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
