### PR TITLE
Update "Web embedding" documentation.

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -483,14 +483,18 @@
           permalink: /platform-integration/web/building
         - title: WebAssembly
           permalink: /platform-integration/web/wasm
-        - title: Web FAQ
-          permalink: /platform-integration/web/faq
-        - title: Web renderers
-          permalink: /platform-integration/web/renderers
         - title: Customize app initialization
           permalink: /platform-integration/web/initialization
+        - title: Embedding Flutter web
+          permalink: /platform-integration/web/embedding-flutter-web
+        - title: Web content in Flutter
+          permalink: /platform-integration/web/web-content-in-flutter
+        - title: Web renderers
+          permalink: /platform-integration/web/renderers
         - title: Display images on the web
           permalink: /platform-integration/web/web-images
+        - title: Web FAQ
+          permalink: /platform-integration/web/faq
     - title: Windows
       permalink: /platform-integration/windows
       children:
@@ -655,6 +659,8 @@
           permalink: /add-to-app/ios/project-setup
         - title: Add a single Flutter screen
           permalink: /add-to-app/ios/add-flutter-screen
+    - title: Add to a web app
+      permalink: /platform-integration/web/embedding-flutter-web
     - title: Debug embedded Flutter module
       permalink: /add-to-app/debugging
     - title: Add multiple Flutter instances

--- a/src/content/deployment/web.md
+++ b/src/content/deployment/web.md
@@ -168,6 +168,8 @@ create a release build.
 
 ## Embedding a Flutter app into an HTML page
 
+See [Embedding Flutter web][].
+
 ### `hostElement`
 
 _Added in Flutter 3.10_<br>
@@ -208,20 +210,8 @@ reference [Legacy web app initialization][web-init-legacy].
 :::
 
 [customizing-web-init]: /platform-integration/web/initialization
+[Embedding Flutter web]: /platform-integration/web/embedding-flutter-web
 [web-init-legacy]: /platform-integration/web/initialization-legacy
-
-### Iframe
-
-You can embed a Flutter web app,
-as you would embed other content,
-in an [`iframe`][] tag of an HTML file.
-In the following example, replace "URL"
-with the location of your HTML page:
-
-```html
-<iframe src="URL"></iframe>
-```
-
 
 ## PWA Support
 
@@ -242,6 +232,4 @@ so please [give us feedback][] if you see something that doesn't look right.
 [GitHub Pages]: https://pages.github.com/
 [give us feedback]: {{site.repo.flutter}}/issues/new?title=%5Bweb%5D:+%3Cdescribe+issue+here%3E&labels=%E2%98%B8+platform-web&body=Describe+your+issue+and+include+the+command+you%27re+running,+flutter_web%20version,+browser+version
 [Google Cloud Hosting]: https://cloud.google.com/solutions/web-hosting
-[`iframe`]: https://html.com/tags/iframe/
 [Web renderers]: /platform-integration/web/renderers
-

--- a/src/content/deployment/web.md
+++ b/src/content/deployment/web.md
@@ -170,48 +170,7 @@ create a release build.
 
 See [Embedding Flutter web][].
 
-### `hostElement`
-
-_Added in Flutter 3.10_<br>
-You can embed a Flutter web app into
-any HTML element of your web page.
-
-To tell Flutter web in which element to render,
-pass an object with a `config` field to the `_flutter.loader.load` function
-that specifies a `HTMLElement` as the `hostElement`.
-
-```html highlightLines=11-13
-<html>
-  <body>
-    <!-- Ensure your flutter target is present on the page... -->
-    <div id="flutter_host">Loading...</div>
-
-    <script>
-      {% raw %}{{flutter_js}}{% endraw %}
-      {% raw %}{{flutter_build_config}}{% endraw %}
-
-      _flutter.loader.load({
-        config: {
-          hostElement: document.getElementById('flutter_host'),
-        }
-      });
-    </script>
-  </body>
-</html>
-```
-
-To learn more about other configuration options,
-check out [Customizing web app initialization][customizing-web-init].
-
-:::version-note
-This method of specifying the `hostElement` was changed in Flutter 3.22.
-To learn how to configure the `hostElement` in earlier Flutter versions,
-reference [Legacy web app initialization][web-init-legacy].
-:::
-
-[customizing-web-init]: /platform-integration/web/initialization
 [Embedding Flutter web]: /platform-integration/web/embedding-flutter-web
-[web-init-legacy]: /platform-integration/web/initialization-legacy
 
 ## PWA Support
 

--- a/src/content/platform-integration/web/embedding-flutter-web.md
+++ b/src/content/platform-integration/web/embedding-flutter-web.md
@@ -1,0 +1,326 @@
+---
+title: Embedding Flutter on the Web
+short-title: Embedding Flutter web
+description: Learn the different ways to embed Flutter views into web content.
+---
+
+Flutter views and web content can be composed to produce a web application
+in different ways. Choose one of the following depending on your use-case:
+
+* A Flutter view controls the full page (full-screen mode)
+* Adding Flutter views to an existing web application (embedded mode)
+
+## Full-screen mode
+
+In full screen mode, the Flutter web application takes control of the whole
+browser window and covers its viewport completely when rendering. This is the
+default embedding mode for Flutter, and no additional configuration is needed.
+
+```html highlightLines=6
+<!DOCTYPE html>
+<html>
+  <head>
+  </head>
+  <body>
+    <script src="flutter_bootstrap.js" defer></script>
+  </body>
+</html>
+```
+
+When Flutter web is bootstrapped without referencing `multiViewEnabled` or a 
+`hostElement`, it uses full-screen mode.
+
+See [Customize app initialization][] to learn more about the
+`flutter_bootstrap.js` file.
+
+[Customize app initialization]: {{site.docs}}/platform-integration/web/initialization/
+
+### `iframe` embedding
+
+Full-screen mode is recommended when embedding a Flutter web application in an
+`iframe`. The page that embeds the `iframe` can size and position it as needed,
+and Flutter will fill it completely.
+
+```html
+<iframe src="https://url-to-your-flutter/index.html"></iframe>
+```
+
+Check [`<iframe>`: The Inline Frame element][] in MDN to learn more about the
+pros and cons of `iframe`s.
+
+[`<iframe>`: The Inline Frame element]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
+
+## Embedded mode
+
+Flutter web applications can also render content into an arbitrary number of
+elements (commonly `div`s) of another web application; this is called "embedded
+mode" (or "multi-view").
+
+In this mode:
+
+* A Flutter web application can launch, but doesn't render until the first
+"view" is added, with `addView`.
+* The host application may add or remove views from the embedded Flutter web
+application.
+* The Flutter application gets notified of when views are added or removed, so
+it can adjust its widgets accordingly.
+
+### Enable multi-view mode
+
+Enable multi-view mode setting `multiViewEnabled: true` in the
+`initializeEngine` method as shown:
+
+```js highlightLines=8
+// flutter_bootstrap.js
+{% raw %}{{flutter_js}}{% endraw %}
+{% raw %}{{flutter_build_config}}{% endraw %}
+
+_flutter.loader.load({
+  onEntrypointLoaded: async function onEntrypointLoaded(engineInitializer) {
+    let engine = await engineInitializer.initializeEngine({
+      multiViewEnabled: true, // Enables embedded mode.
+    });
+    let app = await engine.runApp();
+    // Make this `app` object available to your JS app.
+  }
+});
+```
+
+### Manage Flutter views from JS
+
+To add or remove views, use the `app` object returned by the `runApp` method:
+
+```js highlightLines=2-4,7
+// Adding a view...
+let viewId = app.addView({
+  hostElement: document.querySelector('#some-element'),
+});
+
+// Removing viewId...
+let viewConfig = flutterApp.removeView(viewId);
+```
+
+### Handling view changes from Dart
+
+View additions and removals are surfaced to Flutter through the
+[`didChangeMetrics` method][] of the `WidgetsBinding` class.
+
+The complete list of views attached to your Flutter app is available
+through the `WidgetsBinding.instance.platformDispatcher.views` iterable. These
+views are of [type `FlutterView`][].
+
+To render content into each `FlutterView`, your Flutter app needs to create a
+[`View` widget][]. `View` widgets can be grouped together under a
+[`ViewCollection` widget][].
+
+The following is an example from the _Multi View Playground_ that encapsulates
+the above in a `MultiViewApp` widget that can be used as the root widget for
+your app. A [`WidgetBuilder` function][] will run for each `FlutterView`:
+
+```dart highlightLines=25,39,46-49,56-61,72
+// multi_view_app.dart
+
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' show FlutterView;
+import 'package:flutter/widgets.dart';
+
+/// Calls [viewBuilder] for every view added to the app to obtain the widget to
+/// render into that view. The current view can be looked up with [View.of].
+class MultiViewApp extends StatefulWidget {
+  const MultiViewApp({super.key, required this.viewBuilder});
+
+  final WidgetBuilder viewBuilder;
+
+  @override
+  State<MultiViewApp> createState() => _MultiViewAppState();
+}
+
+class _MultiViewAppState extends State<MultiViewApp> with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _updateViews();
+  }
+
+  @override
+  void didUpdateWidget(MultiViewApp oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Need to re-evaluate the viewBuilder callback for all views.
+    _views.clear();
+    _updateViews();
+  }
+
+  @override
+  void didChangeMetrics() {
+    _updateViews();
+  }
+
+  Map<Object, Widget> _views = <Object, Widget>{};
+
+  void _updateViews() {
+    final Map<Object, Widget> newViews = <Object, Widget>{};
+    for (final FlutterView view in WidgetsBinding.instance.platformDispatcher.views) {
+      final Widget viewWidget = _views[view.viewId] ?? _createViewWidget(view);
+      newViews[view.viewId] = viewWidget;
+    }
+    setState(() {
+      _views = newViews;
+    });
+  }
+
+  Widget _createViewWidget(FlutterView view) {
+    return View(
+      view: view,
+      child: Builder(
+        builder: widget.viewBuilder,
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ViewCollection(views: _views.values.toList(growable: false));
+  }
+}
+```
+
+For more information, check out [`WidgetsBinding` mixin][] in the API docs, or
+the [Multi View Playground repo][] that was used during development.
+
+[`didChangeMetrics` method]: {{site.api}}/flutter/widgets/WidgetsBindingObserver/didChangeMetrics.html
+[Multi View Playground repo]: {{site.github}}/goderbauer/mvp
+[type `FlutterView`]: {{site.api}}/flutter/dart-ui/FlutterView-class.html
+[`View` widget]: {{site.api}}/flutter/widgets/View-class.html
+[`ViewCollection` widget]: {{site.api}}/flutter/widgets/ViewCollection-class.html
+[`WidgetsBinding` mixin]: {{site.api}}/flutter/widgets/WidgetsBinding-mixin.html
+[`WidgetBuilder` function]: {{site.api}}/flutter/widgets/WidgetBuilder.html
+
+### Identifying views
+
+Each `FlutterView` has an identifier that is assigned by Flutter when it is
+attached. This `viewId` can be used to uniquely identify each view, retrieve
+its initial configuration, or decide what to render in it.
+
+The `viewId` of the `FlutterView` that is being rendered can be retrieved from
+its `BuildContext` like this:
+
+```dart highlightLines=4-5
+class SomeWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // Retrieve the `viewId` where this Widget is being built:
+    final int viewId = View.of(context).viewId;
+    // ...
+```
+
+Read more about the [`View.of` constructor][].
+
+[`View.of` constructor]: {{site.api}}/flutter/widgets/View/of.html
+
+### Initial view configuration
+
+Flutter views can receive any initialization data from JS when starting up.
+The values are passed through the `initialData` property of the `addView`
+method, as shown:
+
+```js highlightLines=4-7
+// Adding a view with initial data...
+let viewId = app.addView({
+  hostElement: someElement,
+  initialData: {
+    greeting: 'Hello, world!',
+    randomValue: Math.floor(Math.random() * 100),
+  }
+});
+```
+
+In Dart, the `initialData` is available as a `JSAny` object, accessible through
+the top-level `views` property in the `dart:ui_web` library. The data is
+accessed through the `viewId` of the current view, like so: 
+
+```dart
+final initialData = ui_web.views.getInitialData(viewId) as YourJsInteropType;
+```
+
+To learn how to define the `YourJsInteropType` class to map the `initialData`
+object passed from JS so it's type-safe in your Dart program, check out:
+[JS Interoperability][] on dart.dev.
+
+[JS Interoperability]: {{site.dart-site}}/interop/js-interop
+
+### View constraints
+
+By default, an embedded Flutter web view considers the size of its `hostElement`
+as an immutable property, and will tightly constrain its layout to the available
+space.
+
+On the web, it's common for the intrinsic size of an element to affect the
+layout of the page (like an `img` tag or `p` tags that can reflow content around
+them).
+
+When adding a view to Flutter web, you may configure it with constraints that
+inform Flutter of how the view needs to be laid out:
+
+```js highlightLines=4-8
+// Adding a view with initial data...
+let viewId = app.addView({
+  hostElement: someElement,
+  viewConstraints: {
+    maxWidth: 320,
+    minHeight: 0,
+    maxHeight: Infinity,
+  }
+});
+```
+
+The view constraints passed from JS need to be compatible with the CSS styling
+of the `hostElement` where Flutter is being embedded. For example, Flutter
+won’t try to "fix" contradictory constants like passing  `max-height: 100px`
+in CSS, but `maxHeight: Infinity` to Flutter.
+
+Learn more about the [`ViewConstraints` class][], and
+[Understanding constraints][].
+
+[`ViewConstraints` class]: {{site.api}}/flutter/dart-ui/ViewConstraints-class.html
+[Understanding constraints]: {{site.docs}}/ui/layout/constraints
+
+## Custom element (`hostElement`)
+
+_Between Flutter 3.10 and 3.24_<br />
+You can embed a single-view Flutter web app into any HTML element of your web
+page.
+
+To tell Flutter web in which element to render, pass an object with a `config`
+field to the `_flutter.loader.load` function that specifies a `HTMLElement` as
+the `hostElement`.
+
+```js highlightLines=3
+_flutter.loader.load({
+  config: {
+    hostElement: document.getElementById('flutter_host'),
+  }
+});
+```
+
+To learn more about other configuration options,
+check out [Customizing web app initialization][].
+
+:::version-note
+This method of specifying the `hostElement` is superseded by the
+**Embedded mode** described above, please consider migrating to it.
+To learn how to configure the `hostElement` in earlier Flutter versions,
+reference [Legacy web app initialization][].
+:::
+
+[Customizing web app initialization]: {{site.docs}}/platform-integration/web/initialization
+[Legacy web app initialization]: {{site.docs}}/platform-integration/web/initialization-legacy

--- a/src/content/platform-integration/web/embedding-flutter-web.md
+++ b/src/content/platform-integration/web/embedding-flutter-web.md
@@ -1,5 +1,5 @@
 ---
-title: Embedding Flutter on the Web
+title: Embedding Flutter on the web
 short-title: Embedding Flutter web
 description: Learn the different ways to embed Flutter views into web content.
 ---
@@ -30,8 +30,8 @@ default embedding mode for Flutter, and no additional configuration is needed.
 When Flutter web is bootstrapped without referencing `multiViewEnabled` or a 
 `hostElement`, it uses full-screen mode.
 
-See [Customize app initialization][] to learn more about the
-`flutter_bootstrap.js` file.
+To learn more about the `flutter_bootstrap.js` file,
+check out [Customize app initialization][].
 
 [Customize app initialization]: {{site.docs}}/platform-integration/web/initialization/
 
@@ -45,10 +45,10 @@ and Flutter will fill it completely.
 <iframe src="https://url-to-your-flutter/index.html"></iframe>
 ```
 
-Check [`<iframe>`: The Inline Frame element][] in MDN to learn more about the
-pros and cons of `iframe`s.
+To learn more about the pros and cons of an `iframe`,
+check out the [Inline Frame element][] docs on MDN.
 
-[`<iframe>`: The Inline Frame element]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
+[Inline Frame element]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
 
 ## Embedded mode
 
@@ -60,10 +60,10 @@ In this mode:
 
 * A Flutter web application can launch, but doesn't render until the first
 "view" is added, with `addView`.
-* The host application may add or remove views from the embedded Flutter web
-application.
-* The Flutter application gets notified of when views are added or removed, so
-it can adjust its widgets accordingly.
+* The host application can add or remove views from the embedded Flutter web
+   application.
+* The Flutter application is notified when views are added or removed,
+  so it can adjust its widgets accordingly.
 
 ### Enable multi-view mode
 
@@ -113,9 +113,9 @@ To render content into each `FlutterView`, your Flutter app needs to create a
 [`View` widget][]. `View` widgets can be grouped together under a
 [`ViewCollection` widget][].
 
-The following is an example from the _Multi View Playground_ that encapsulates
+The following example, from the _Multi View Playground_, encapsulates
 the above in a `MultiViewApp` widget that can be used as the root widget for
-your app. A [`WidgetBuilder` function][] will run for each `FlutterView`:
+your app. A [`WidgetBuilder` function][] runs for each `FlutterView`:
 
 ```dart highlightLines=25,39,46-49,56-61,72
 // multi_view_app.dart
@@ -207,11 +207,11 @@ the [Multi View Playground repo][] that was used during development.
 
 ### Identifying views
 
-Each `FlutterView` has an identifier that is assigned by Flutter when it is
+Each `FlutterView` has an identifier assigned by Flutter when
 attached. This `viewId` can be used to uniquely identify each view, retrieve
 its initial configuration, or decide what to render in it.
 
-The `viewId` of the `FlutterView` that is being rendered can be retrieved from
+The `viewId` of the rendered `FlutterView` can be retrieved from
 its `BuildContext` like this:
 
 ```dart highlightLines=4-5
@@ -246,7 +246,7 @@ let viewId = app.addView({
 
 In Dart, the `initialData` is available as a `JSAny` object, accessible through
 the top-level `views` property in the `dart:ui_web` library. The data is
-accessed through the `viewId` of the current view, like so: 
+accessed through the `viewId` of the current view,  as shown:
 
 ```dart
 final initialData = ui_web.views.getInitialData(viewId) as YourJsInteropType;
@@ -261,11 +261,11 @@ object passed from JS so it's type-safe in your Dart program, check out:
 ### View constraints
 
 By default, an embedded Flutter web view considers the size of its `hostElement`
-as an immutable property, and will tightly constrain its layout to the available
+as an immutable property, and tightly constrains its layout to the available
 space.
 
 On the web, it's common for the intrinsic size of an element to affect the
-layout of the page (like an `img` tag or `p` tags that can reflow content around
+layout of the page (like `img` or `p` tags that can reflow content around
 them).
 
 When adding a view to Flutter web, you may configure it with constraints that
@@ -288,8 +288,8 @@ of the `hostElement` where Flutter is being embedded. For example, Flutter
 won’t try to "fix" contradictory constants like passing  `max-height: 100px`
 in CSS, but `maxHeight: Infinity` to Flutter.
 
-Learn more about the [`ViewConstraints` class][], and
-[Understanding constraints][].
+To learn more, check out the [`ViewConstraints` class][],
+and [Understanding constraints][].
 
 [`ViewConstraints` class]: {{site.api}}/flutter/dart-ui/ViewConstraints-class.html
 [Understanding constraints]: {{site.docs}}/ui/layout/constraints
@@ -317,7 +317,7 @@ check out [Customizing web app initialization][].
 
 :::version-note
 This method of specifying the `hostElement` is superseded by the
-**Embedded mode** described above, please consider migrating to it.
+**Embedded mode** described above, **please consider migrating to it**.
 To learn how to configure the `hostElement` in earlier Flutter versions,
 reference [Legacy web app initialization][].
 :::

--- a/src/content/platform-integration/web/embedding-flutter-web.md
+++ b/src/content/platform-integration/web/embedding-flutter-web.md
@@ -268,7 +268,7 @@ On the web, it's common for the intrinsic size of an element to affect the
 layout of the page (like `img` or `p` tags that can reflow content around
 them).
 
-When adding a view to Flutter web, you may configure it with constraints that
+When adding a view to Flutter web, you might configure it with constraints that
 inform Flutter of how the view needs to be laid out:
 
 ```js highlightLines=4-8
@@ -300,7 +300,7 @@ _Between Flutter 3.10 and 3.24_<br />
 You can embed a single-view Flutter web app into any HTML element of your web
 page.
 
-To tell Flutter web in which element to render, pass an object with a `config`
+To tell Flutter web which element to render into, pass an object with a `config`
 field to the `_flutter.loader.load` function that specifies a `HTMLElement` as
 the `hostElement`.
 

--- a/src/content/platform-integration/web/faq.md
+++ b/src/content/platform-integration/web/faq.md
@@ -108,17 +108,11 @@ although no such support is built in.
 
 ### How do I embed a Flutter web app in a web page?
 
-You can embed a Flutter web app,
-as you would embed other content,
-in an [`iframe`][] tag of an HTML file.
-In the following example, replace "URL"
-with the location of your hosted HTML page:
+See [Embedding Flutter web][].
 
-```html
-<iframe src="URL"></iframe>
-```
+### How do I embed web content in a Flutter web app?
 
-If you encounter problems, please [file an issue][].
+See [Web content in Flutter][].
 
 ### How do I debug a web app?
 
@@ -152,21 +146,23 @@ Not currently.
 [Chrome DevTools]: {{site.developers}}/web/tools/chrome-devtools
 [Creating responsive apps]: /ui/adaptive-responsive
 [Debugging]: /tools/devtools/debugger
+[documentation for conditional imports]: {{site.dart-site}}/guides/libraries/create-library-packages#conditionally-importing-and-exporting-library-files
+[Embedding Flutter web]: /platform-integration/web/embedding-flutter-web
 [file an issue]: {{site.repo.flutter}}/issues/new?title=[web]:+%3Cdescribe+issue+here%3E&labels=%E2%98%B8+platform-web&body=Describe+your+issue+and+include+the+command+you%27re+running,+flutter_web%20version,+browser+version
 [Flutter DevTools]: /tools/devtools
 [Generating event timeline]: {{site.developers}}/web/tools/chrome-devtools/evaluate-performance/performance-reference
 [`http`]: {{site.pub}}/packages/http
 [`iframe`]: https://html.com/tags/iframe/
+[Integration testing]: /testing/integration-tests#test-in-a-web-browser
 [isolates]: {{site.dart-site}}/guides/language/concurrency
 [Issue 32248]: {{site.repo.flutter}}/issues/32248
 [Logging]: /tools/devtools/logging
 [Preparing a web app for release]: /deployment/web
+[roadmap]: {{site.github}}/flutter/flutter/blob/master/docs/roadmap/Roadmap.md#web-platform
+[run your web apps in any supported browser]: /platform-integration/web/building#create-and-run
 [Running Flutter inspector]: /tools/devtools/inspector
-[widget tests]: /testing/overview#widget-tests
+[space_hawaii]: https://alien-hawaii-2024.web.app/
+[Web content in Flutter]: /platform-integration/web/web-content-in-flutter
 [Web support for Flutter]: /platform-integration/web
 [web workers]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers
-[run your web apps in any supported browser]: /platform-integration/web/building#create-and-run
-[Integration testing]: /testing/integration-tests#test-in-a-web-browser
-[documentation for conditional imports]: {{site.dart-site}}/guides/libraries/create-library-packages#conditionally-importing-and-exporting-library-files
-[roadmap]: {{site.github}}/flutter/flutter/blob/master/docs/roadmap/Roadmap.md#web-platform
-[space_hawaii]: https://alien-hawaii-2024.web.app/
+[widget tests]: /testing/overview#widget-tests

--- a/src/content/platform-integration/web/initialization.md
+++ b/src/content/platform-integration/web/initialization.md
@@ -192,14 +192,22 @@ The initialization process is split into the following stages:
 **Initializing the Flutter engine**
 : The `onEntrypointLoaded` callback receives an
   **engine initializer** object as its only parameter.
-  Use the engine initializer to set the run-time configuration, and
-  start the Flutter web engine.
+  Use the engine initializer `initializeEngine()` function to
+  set the run-time configuration, like `multiViewEnabled: true`,
+  and start the Flutter web engine.
 
 **Running the app**
 : The `initializeEngine()` function returns a [`Promise`][js-promise]
   that resolves with an **app runner** object. The app runner has a
   single method, `runApp()`, that runs the Flutter app.
 
+**Adding or removing views to an app**
+: The object returned by `runApp()` is a **flutter app** object. In
+  multi-view mode, the flutter app has two methods: `addView` and `removeView`
+  that can be used to manage app views from the host app.
+  See [Embedded mode][embedded-mode].
+
+[embedded-mode]: {{site.docs}}/platform-integration/web/embedding-flutter-web/#embedded-mode
 [js-promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
 ## Example: Display a progress indicator

--- a/src/content/platform-integration/web/initialization.md
+++ b/src/content/platform-integration/web/initialization.md
@@ -201,11 +201,11 @@ The initialization process is split into the following stages:
   that resolves with an **app runner** object. The app runner has a
   single method, `runApp()`, that runs the Flutter app.
 
-**Adding or removing views to an app**
-: The object returned by `runApp()` is a **flutter app** object. In
-  multi-view mode, the flutter app has two methods: `addView` and `removeView`
-  that can be used to manage app views from the host app.
-  See [Embedded mode][embedded-mode].
+**Adding views to (or removing views from) an app**
+: The `runApp()` method returns a **flutter app** object.
+  In multi-view mode, the `addView` and `removeView`
+  methods can be used to manage app views from the host app.
+  To learn more, check out [Embedded mode][embedded-mode].
 
 [embedded-mode]: {{site.docs}}/platform-integration/web/embedding-flutter-web/#embedded-mode
 [js-promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise

--- a/src/content/platform-integration/web/web-content-in-flutter.md
+++ b/src/content/platform-integration/web/web-content-in-flutter.md
@@ -1,0 +1,83 @@
+---
+title: Embedding web content into a Flutter web app
+short-title: Web content in Flutter
+description: Learn how to load and display images on the web.
+---
+
+In some cases, Flutter web applications need to embed web content not
+rendered by Flutter. For example, embedding a `google_maps_flutter` or a
+`video_player` on the web, which use the Google Maps JS SDK or a standard
+`video` element for rendering, respectively.
+
+Flutter web can render arbitrary web content within the boundaries of a Widget,
+and the primitives used to implement the example packages mentioned previously,
+are available to all Flutter web applications.
+
+## `HtmlElementView`
+
+The `HtmlElementView` Flutter Widget reserves a space in the layout to be
+filled with any HTML Element. It has two constructors:
+
+* `HtmlElementView.fromTagName`.
+* `HtmlElementView` and `registerViewFactory`.
+
+### `HtmlElementView.fromTagName`
+
+The [`HtmlElementView.fromTagName` constructor][] creates an HTML Element from
+its `tagName`, and provides an `onElementCreated` method to configure that
+element before it's injected into the DOM:
+
+```dart
+// Create a `video` tag, and set its `src` and some `style` properties...
+HtmlElementView.fromTag('video', onElementCreated: (Object video) {
+  video as web.HTMLVideoElement;
+  video.src = 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4';
+  video.style.width = '100%';
+  video.style.height = '100%';
+  // other customizations to the element...
+});
+```
+
+Check out [`package:web`][] to learn more about the [`HTMLVideoElement` class].
+It's the recommended way to interact with DOM APIs.
+
+Learn more about the `Object` to `web.HTMLVideoElement` cast in Dart's
+[JS Interoperability][] documentation.
+
+[`HtmlElementView.fromTagName` constructor]: {{site.api}}/flutter/widgets/HtmlElementView/HtmlElementView.fromTagName.html
+[`HTMLVideoElement` class]: {{site.pub}}/documentation/web/latest/web/HTMLVideoElement-extension-type.html
+[`package:web`]: {{site.pub}}/packages/web
+
+### `HtmlElementView` and `registerViewFactory`
+
+If you need more control over generating the HTML code you inject, you can use
+the primitives that Flutter uses to implement the `fromTagName` constructor. In
+this scenario, register your own HTML Element factory for each type of HTML
+content that needs to be added to your app.
+
+The resulting code is more verbose, and it has two steps per platform view type:
+
+1. Register the HTML Element Factory using
+`platformViewRegistry.registerViewFactory` provided by `dart:ui_web.`  
+2. Place the widget with the desired `viewType`  with
+`HtmlElementView('viewType')` in your app's widget tree.
+
+See more details about this approach in the Flutter documentation for the
+[`HtmlElementView` widget][].
+
+[`HtmlElementView` widget]: {{site.api}}/flutter/widgets/HtmlElementView-class.html
+
+## `package:webview_flutter`
+
+Embedding a full HTML page inside a Flutter app is such a common feature, that
+the Flutter team offers a plugin to do so:
+
+* [`package:webview_flutter`][]
+
+The **not endorsed** web implementation of the plugin,
+[`package:webview_flutter_web`][], is implemented with the same primitives
+described above, and Dart's [JS Interoperability][] APIs.
+
+[JS Interoperability]: {{site.dart-site}}/interop/js-interop
+[`package:webview_flutter`]: {{site.pub}}/packages/webview_flutter
+[`package:webview_flutter_web`]: {{site.pub}}/packages/webview_flutter_web

--- a/src/content/platform-integration/web/web-content-in-flutter.md
+++ b/src/content/platform-integration/web/web-content-in-flutter.md
@@ -5,17 +5,17 @@ description: Learn how to load and display images on the web.
 ---
 
 In some cases, Flutter web applications need to embed web content not
-rendered by Flutter. For example, embedding a `google_maps_flutter` or a
-`video_player` on the web, which use the Google Maps JS SDK or a standard
-`video` element for rendering, respectively.
+rendered by Flutter. For example, embedding a `google_maps_flutter` view
+(which uses the Google Maps JavaScript SDK) or a `video_player`
+(which uses a standard `video` element).
 
-Flutter web can render arbitrary web content within the boundaries of a Widget,
+Flutter web can render arbitrary web content within the boundaries of a `Widget`,
 and the primitives used to implement the example packages mentioned previously,
 are available to all Flutter web applications.
 
 ## `HtmlElementView`
 
-The `HtmlElementView` Flutter Widget reserves a space in the layout to be
+The `HtmlElementView` Flutter widget reserves a space in the layout to be
 filled with any HTML Element. It has two constructors:
 
 * `HtmlElementView.fromTagName`.
@@ -38,15 +38,15 @@ HtmlElementView.fromTag('video', onElementCreated: (Object video) {
 });
 ```
 
-Check out [`package:web`][] to learn more about the [`HTMLVideoElement` class].
-It's the recommended way to interact with DOM APIs.
+To learn more about the way to interact with DOM APIs,
+check out the [`HTMLVideoElement` class] in [`package:web`][].
 
-Learn more about the `Object` to `web.HTMLVideoElement` cast in Dart's
-[JS Interoperability][] documentation.
+To learn more about the video `Object` that is cast to `web.HTMLVideoElement`,
+check out Dart's [JS Interoperability][] documentation.
 
 [`HtmlElementView.fromTagName` constructor]: {{site.api}}/flutter/widgets/HtmlElementView/HtmlElementView.fromTagName.html
 [`HTMLVideoElement` class]: {{site.pub}}/documentation/web/latest/web/HTMLVideoElement-extension-type.html
-[`package:web`]: {{site.pub}}/packages/web
+[`package:web`]: {{site.pub-pkg}}/web
 
 ### `HtmlElementView` and `registerViewFactory`
 
@@ -55,15 +55,15 @@ the primitives that Flutter uses to implement the `fromTagName` constructor. In
 this scenario, register your own HTML Element factory for each type of HTML
 content that needs to be added to your app.
 
-The resulting code is more verbose, and it has two steps per platform view type:
+The resulting code is more verbose, and has two steps per platform view type:
 
 1. Register the HTML Element Factory using
 `platformViewRegistry.registerViewFactory` provided by `dart:ui_web.`  
 2. Place the widget with the desired `viewType`  with
 `HtmlElementView('viewType')` in your app's widget tree.
 
-See more details about this approach in the Flutter documentation for the
-[`HtmlElementView` widget][].
+For more details about this approach, check out
+[`HtmlElementView` widget][] docs.
 
 [`HtmlElementView` widget]: {{site.api}}/flutter/widgets/HtmlElementView-class.html
 


### PR DESCRIPTION
This PR:

* Adds an "Embedding Flutter on the Web" documentation page describing the different ways that Flutter content can be added to a host website: full-screen, embedded mode/multiView, custom element (single-view embedded mode).
* Adds a "Embedding web content into a Flutter web app" documentation page describing how to add Web content into a Flutter web app as a Widget.

(Both of the pages are added under the "Platform integration > Web" section.)

The PR also:

* De-duplicates redundant embedding content from different pages, by linking directly to the new documents (Web FAQ, Web deployment)
* Adds an "Add to a web app" link under the "Add to an existing app" menu section, pointing to the Embedding on the web, so people looking at Add To App finds the Web docs more easily.

## Issues

Fixes: https://github.com/flutter/website/issues/10773


## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
