### PR TITLE
Make TODOs clearer in Package.swift templates

### DIFF
--- a/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
@@ -45,36 +45,40 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
    import PackageDescription
    
    let package = Package(
+       // TODO: Update your plugin name.
        name: "plugin_name",
        platforms: [
-           // The platforms your plugin supports.
+           // TODO: Update the platforms your plugin supports.
            // If your plugin only supports iOS, remove `.macOS(...)`.
            // If your plugin only supports macOS, remove `.iOS(...)`.
            .iOS("12.0"),
            .macOS("10.14")
        ],
        products: [
+           // TODO: Update your library and target names.
            // If the plugin name contains "_", replace with "-" for the library name
            .library(name: "plugin-name", targets: ["plugin_name"])
        ],
        dependencies: [],
        targets: [
            .target(
+               // TODO: Update your target name.
                name: "plugin_name",
                dependencies: [],
                resources: [
-                   // If your plugin requires a privacy manifest, for example if it uses
-                   // any required reason APIs, update the PrivacyInfo.xcprivacy file to
-                   // describe your plugin's privacy impact, and then uncomment these lines.
+                   // TODO: If your plugin requires a privacy manifest
+                   // (e.g. if it uses any required reason APIs), update the PrivacyInfo.xcprivacy file
+                   // to describe your plugin's privacy impact, and then uncomment this line.
                    // For more information, see:
                    // https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
                    // .process("PrivacyInfo.xcprivacy"),
    
-                   // If you have other resources that need to be bundled with your plugin, refer to
+                   // TODO: If you have other resources that need to be bundled with your plugin, refer to
                    // the following instructions to add them:
                    // https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package
                ],
                cSettings: [
+                   // TODO: Update your plugin name.
                    .headerSearchPath("include/plugin_name")
                ]
            )
@@ -86,7 +90,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 
    ```swift title="Package.swift"
        platforms: [
-           // The platforms your plugin supports.
+           // TODO: Update the platforms your plugin supports.
            // If your plugin only supports iOS, remove `.macOS(...)`.
            // If your plugin only supports macOS, remove `.iOS(...)`.
            [!.iOS("12.0"),!]
@@ -100,36 +104,37 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 
    ```swift title="Package.swift"
    let package = Package(
+       // TODO: Update your plugin name.
        name: [!"plugin_name"!],
        platforms: [
-           // The platforms your plugin supports.
-           // If your plugin only supports iOS, remove `.macOS(...)`.
-           // If your plugin only supports macOS, remove `.iOS(...)`.
            .iOS("12.0"),
            .macOS("10.14")
        ],
        products: [
+           // TODO: Update your library and target names.
            // If the plugin name contains "_", replace with "-" for the library name
            .library(name: [!"plugin-name"!], targets: [[!"plugin_name"!]])
        ],
        dependencies: [],
        targets: [
            .target(
+               // TODO: Update your target name.
                name: [!"plugin_name"!],
                dependencies: [],
                resources: [
-                   // If your plugin requires a privacy manifest, for example if it uses
-                   // any required reason APIs, update the PrivacyInfo.xcprivacy file to
-                   // describe your plugin's privacy impact, and then uncomment these lines.
+                   // TODO: If your plugin requires a privacy manifest
+                   // (e.g. if it uses any required reason APIs), update the PrivacyInfo.xcprivacy file
+                   // to describe your plugin's privacy impact, and then uncomment this line.
                    // For more information, see:
                    // https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
                    // .process("PrivacyInfo.xcprivacy"),
    
-                   // If you have other resources that need to be bundled with your plugin, refer to
+                   // TODO: If you have other resources that need to be bundled with your plugin, refer to
                    // the following instructions to add them:
                    // https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package
                ],
                cSettings: [
+                   // TODO: Update your plugin name.
                    .headerSearchPath("include/[!plugin_name!]")
                ]
            )
@@ -148,14 +153,14 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 
    ```swift title="Package.swift"
                resources: [
-                   // If your plugin requires a privacy manifest, for example if it uses
-                   // any required reason APIs, update the PrivacyInfo.xcprivacy file to
-                   // describe your plugin's privacy impact, and then uncomment these lines.
+                   // TODO: If your plugin requires a privacy manifest
+                   // (e.g. if it uses any required reason APIs), update the PrivacyInfo.xcprivacy file
+                   // to describe your plugin's privacy impact, and then uncomment this line.
                    // For more information, see:
                    // https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
                    [!.process("PrivacyInfo.xcprivacy"),!]
    
-                   // If you have other resources that need to be bundled with your plugin, refer to
+                   // TODO: If you have other resources that need to be bundled with your plugin, refer to
                    // the following instructions to add them:
                    // https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package
                ],

--- a/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
@@ -38,32 +38,35 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
    import PackageDescription
    
    let package = Package(
+       // TODO: Update your plugin name.
        name: "plugin_name",
        platforms: [
-           // The platforms your plugin supports.
+           // TODO: Update the platforms your plugin supports.
            // If your plugin only supports iOS, remove `.macOS(...)`.
            // If your plugin only supports macOS, remove `.iOS(...)`.
            .iOS("12.0"),
            .macOS("10.14")
        ],
        products: [
-           // If the plugin name contains "_", replace with "-" for the library name
+           // TODO: Update your library and target names.
+           // If the plugin name contains "_", replace with "-" for the library name.
            .library(name: "plugin-name", targets: ["plugin_name"])
        ],
        dependencies: [],
        targets: [
            .target(
+               // TODO: Update your target name.
                name: "plugin_name",
                dependencies: [],
                resources: [
-                   // If your plugin requires a privacy manifest, for example if it uses
-                   // any required reason APIs, update the PrivacyInfo.xcprivacy file to
-                   // describe your plugin's privacy impact, and then uncomment these lines.
+                   // TODO: If your plugin requires a privacy manifest
+                   // (e.g. if it uses any required reason APIs), update the PrivacyInfo.xcprivacy file
+                   // to describe your plugin's privacy impact, and then uncomment this line.
                    // For more information, see:
                    // https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
                    // .process("PrivacyInfo.xcprivacy"),
    
-                   // If you have other resources that need to be bundled with your plugin, refer to
+                   // TODO: If you have other resources that need to be bundled with your plugin, refer to
                    // the following instructions to add them:
                    // https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package
                ]
@@ -76,7 +79,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 
    ```swift title="Package.swift"
        platforms: [
-           // The platforms your plugin supports.
+           // TODO: Update the platforms your plugin supports.
            // If your plugin only supports iOS, remove `.macOS(...)`.
            // If your plugin only supports macOS, remove `.iOS(...)`.
            [!.iOS("12.0"),!]
@@ -90,37 +93,34 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 
    ```swift title="Package.swift"
    let package = Package(
+       // TODO: Update your plugin name.
        name: [!"plugin_name"!],
        platforms: [
-           // The platforms your plugin supports.
-           // If your plugin only supports iOS, remove `.macOS(...)`.
-           // If your plugin only supports macOS, remove `.iOS(...)`.
            .iOS("12.0"),
            .macOS("10.14")
        ],
        products: [
+           // TODO: Update your library and target names.
            // If the plugin name contains "_", replace with "-" for the library name
            .library(name: [!"plugin-name"!], targets: [[!"plugin_name"!]])
        ],
        dependencies: [],
        targets: [
            .target(
+               // TODO: Update your target name.
                name: [!"plugin_name"!],
                dependencies: [],
                resources: [
-                   // If your plugin requires a privacy manifest, for example if it uses
-                   // any required reason APIs, update the PrivacyInfo.xcprivacy file to
-                   // describe your plugin's privacy impact, and then uncomment these lines.
+                   // TODO: If your plugin requires a privacy manifest
+                   // (e.g. if it uses any required reason APIs), update the PrivacyInfo.xcprivacy file
+                   // to describe your plugin's privacy impact, and then uncomment this line.
                    // For more information, see:
                    // https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
                    // .process("PrivacyInfo.xcprivacy"),
    
-                   // If you have other resources that need to be bundled with your plugin, refer to
+                   // TODO: If you have other resources that need to be bundled with your plugin, refer to
                    // the following instructions to add them:
                    // https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package
-               ],
-               cSettings: [
-                   .headerSearchPath("include/[!plugin_name!]")
                ]
            )
        ]
@@ -138,14 +138,14 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 
    ```swift title="Package.swift"
                resources: [
-                   // If your plugin requires a privacy manifest, for example if it uses
-                   // any required reason APIs, update the PrivacyInfo.xcprivacy file to
-                   // describe your plugin's privacy impact, and then uncomment these lines.
+                   // TODO: If your plugin requires a privacy manifest
+                   // (e.g. if it uses any required reason APIs), update the PrivacyInfo.xcprivacy file
+                   // to describe your plugin's privacy impact, and then uncomment this line.
                    // For more information, see:
                    // https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
                    [!.process("PrivacyInfo.xcprivacy"),!]
    
-                   // If you have other resources that need to be bundled with your plugin, refer to
+                   // TODO: If you have other resources that need to be bundled with your plugin, refer to
                    // the following instructions to add them:
                    // https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package
                ],


### PR DESCRIPTION
This adds `TODO:` to the `Package.swift` template to make make it more obvious what you need to edit.

Preview URL: [How to add Swift Package Manager support to an existing Flutter plugin](https://flutter-docs-prod--pr10979-spm-todos-tzx77xnz.web.app/packages-and-plugins/swift-package-manager/for-plugin-authors#how-to-add-swift-package-manager-support-to-an-existing-flutter-plugin)

Originally the idea was to make the code have compilation errors. I was hoping to use [compiler diagnostic directives](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0196-diagnostic-directives.md), however, Swift doesn't support putting these directives within a method call's arguments. In other words, we can't use compilation directives close enough to the places that need to be edited.

Part of https://github.com/flutter/flutter/issues/152276

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
