### PR TITLE
Migration guide for InputDecoration.collapsed invalid parameters

### DIFF
--- a/src/content/release/breaking-changes/can-request-focus.md
+++ b/src/content/release/breaking-changes/can-request-focus.md
@@ -36,7 +36,7 @@ Code before migration:
 class _MyWidgetState extends State<MyWidget> {
   @override
   Widget build(BuildContext context) {
-    TextField(
+    return TextField(
       canRequestFocus: false,
     );
   }

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -33,12 +33,14 @@ release, and listed in alphabetical order:
 
 ### Not yet released to stable
 
+* [Remove invalid parameters for `InputDecoration.collapsed`][]
 * [Navigator's page APIs breaking change][]
 * [Generic types in `PopScope`][]
 * [Stop generating `AssetManifest.json`][]
 * [Deprecate `TextField.canRequestFocus`][]
 * [Deprecate `ButtonBar` in favor of `OverflowBar`][]
 
+[Remove invalid parameters for `InputDecoration.collapsed`]: /release/breaking-changes/input-decoration-collapsed
 [Navigator's page APIs breaking change]: /release/breaking-changes/navigator-and-page-api
 [Generic types in `PopScope`]: /release/breaking-changes/popscope-with-result
 [Stop generating `AssetManifest.json`]: /release/breaking-changes/asset-manifest-dot-json

--- a/src/content/release/breaking-changes/input-decoration-collapsed.md
+++ b/src/content/release/breaking-changes/input-decoration-collapsed.md
@@ -1,0 +1,75 @@
+---
+title: Remove invalid parameters for `InputDecoration.collapsed`
+description: >
+  `InputDecoration.collapsed` constructor parameters `floatingLabelBehavior`
+  and`floatingLabelAlignment` are deprecated without replacement because they
+  have no effect.
+---
+
+## Summary
+
+`InputDecoration.collapsed` invalid parameters `floatingLabelBehavior` and
+`floatingLabelAlignment` are deprecated.
+
+## Background
+
+`InputDecoration.collapsed` constructor is used to create a minimal decoration
+without label.
+
+The parameters `floatingLabelAlignment` and `floatingLabelBehavior` have
+no effect because an input decoration created using `InputDecoration.collapsed`
+has no label.
+
+## Migration guide
+
+To migrate, remove usage of `floatingLabelBehavior` and `floatingLabelAlignment`
+parameters when calling `InputDecoration.collapsed` constructor.
+Those parameters had no effect.
+
+Code before migration:
+
+```dart
+InputDecoration.collapsed(
+  hintText: 'Hint',
+  floatingLabelAlignment: FloatingLabelAlignment.center,
+  floatingLabelBehavior: FloatingLabelBehavior.auto,
+),
+```
+
+Code after migration:
+
+```dart
+InputDecoration.collapsed(
+  hintText: 'Hint',
+),
+```
+
+## Timeline
+
+Landed in version: v3.24.0-0.1.pre<br>
+In stable release: Not yet
+
+## References
+
+API documentation:
+
+* [`InputDecoration.collapsed`][]
+* [`InputDecoration.floatingLabelAlignment`][]
+* [`InputDecoration.floatingLabelBehavior`][]
+
+Relevant issues:
+
+* [Add prefixIcon and suffixIcon parameters to InputDecoration.collapsed][]
+
+Relevant PRs:
+
+* [Deprecate invalid InputDecoration.collapsed parameters][]
+* [Cleanup InputDecoration.collapsed constructor][]
+
+[`InputDecoration.collapsed`]: {{site.api}}/flutter/material/InputDecoration/InputDecoration.collapsed.html
+[`InputDecoration.floatingLabelAlignment`]: {{site.api}}/flutter/material/InputDecoration/floatingLabelAlignment.html
+[`InputDecoration.floatingLabelBehavior`]: {{site.api}}/flutter/material/InputDecoration/floatingLabelBehavior.html
+
+[Add prefixIcon and suffixIcon parameters to InputDecoration.collapsed]: {{site.repo.flutter}}/issues/61331
+[Deprecate invalid InputDecoration.collapsed parameters]: {{site.repo.flutter}}/pull/152486
+[Cleanup InputDecoration.collapsed constructor]: {{site.repo.flutter}}/pull/152165


### PR DESCRIPTION
Added a migration guide for a deprecation in https://github.com/flutter/flutter/pull/152486. 

## Presubmit checklist

- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
