### PR TITLE
Fix typo in staggered-animations.md

### DIFF
--- a/src/content/ui/animations/staggered-animations.md
+++ b/src/content/ui/animations/staggered-animations.md
@@ -285,7 +285,7 @@ The animation runs forward, then backward.
 
 class _StaggerDemoState extends State<StaggerDemo>
     with TickerProviderStateMixin {
-  late AnimationController_controller;
+  late AnimationController _controller;
 
   @override
   void initState() {


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Added a missing space between `AnimationController` and `_controller` in a code example. Nothing special.

_Issues fixed by this PR (if any):_

None.

_PRs or commits this PR depends on (if any):_

None.

## Presubmit checklist

- [N/A] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
