### PR TITLE
Don't override background color of active tab

### DIFF
--- a/src/_sass/vendor/_bootstrap.scss
+++ b/src/_sass/vendor/_bootstrap.scss
@@ -225,6 +225,7 @@ a.card {
 
     &.active, &:active {
       border-color: $site-color-primary;
+      background-color: unset;
     }
   }
 }


### PR DESCRIPTION
**Before:**
<img width="733" alt="Active tab has white background" src="https://github.com/user-attachments/assets/b8112645-f194-438b-ae90-d271982237e6">

**After:**
<img width="803" alt="Active tab doesn't add any special background" src="https://github.com/user-attachments/assets/d4b15188-8b53-4709-b392-b4a85fd682c4">
