### PR TITLE
Fix a broken link about MobX

### DIFF
--- a/src/content/data-and-backend/state-mgmt/options.md
+++ b/src/content/data-and-backend/state-mgmt/options.md
@@ -142,7 +142,7 @@ A state container approach familiar to many web developers.
 [Redux and epics for better-organized code in Flutter apps]: {{site.medium}}/upday-devs/reduce-duplication-achieve-flexibility-means-success-for-the-flutter-app-e5e432839e61
 [Redux Saga Middleware Dart and Flutter]: {{site.pub-pkg}}/redux_saga
 [Flutter_Redux_Gen - VS Code Plugin to generate boiler plate code]: https://marketplace.visualstudio.com/items?itemName=BalaDhruv.flutter-redux-gen
-  
+
 ## Fish-Redux
 
 Fish Redux is an assembled flutter application framework
@@ -206,7 +206,7 @@ A popular library based on observables and reactions.
 * [Flutter: State Management with Mobx][], a video by Paul Halliday
 
 [Flutter: State Management with Mobx]: {{site.yt.watch}}?v=p-MUBLOEkCs
-[Getting started with MobX.dart]: https://mobx.netlify.com/getting-started
+[Getting started with MobX.dart]: https://mobx.netlify.app/getting-started
 [MobX.dart, Hassle free state-management for your Dart and Flutter apps]: {{site.github}}/mobxjs/mobx.dart
 
 ## Dart Board


### PR DESCRIPTION
This pull request replace a broken link as follows.
- Before: https://mobx.netlify.com/getting-started
- After: https://mobx.netlify.app/getting-started

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
