### PR TITLE
Replace "Uri.parse" with "Uri.https"

### DIFF
--- a/examples/cookbook/networking/authenticated_requests/lib/main.dart
+++ b/examples/cookbook/networking/authenticated_requests/lib/main.dart
@@ -7,7 +7,7 @@ import 'package:http/http.dart' as http;
 Future<Album> fetchAlbum() async {
   // #docregion get
   final response = await http.get(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/1'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/1'),
     // Send authorization headers to the backend.
     headers: {
       HttpHeaders.authorizationHeader: 'Basic your_api_token_here',

--- a/examples/cookbook/networking/background_parsing/lib/main.dart
+++ b/examples/cookbook/networking/background_parsing/lib/main.dart
@@ -8,7 +8,7 @@ import 'package:http/http.dart' as http;
 // #docregion fetchPhotos
 Future<List<Photo>> fetchPhotos(http.Client client) async {
   final response = await client
-      .get(Uri.parse('https://jsonplaceholder.typicode.com/photos'));
+      .get(Uri.https('jsonplaceholder.typicode.com', 'photos'));
 
   // Use the compute function to run parsePhotos in a separate isolate.
   return compute(parsePhotos, response.body);

--- a/examples/cookbook/networking/background_parsing/lib/main_step2.dart
+++ b/examples/cookbook/networking/background_parsing/lib/main_step2.dart
@@ -4,6 +4,6 @@ import 'package:http/http.dart' as http;
 
 // #docregion fetchPhotos
 Future<http.Response> fetchPhotos(http.Client client) async {
-  return client.get(Uri.parse('https://jsonplaceholder.typicode.com/photos'));
+  return client.get(Uri.https('jsonplaceholder.typicode.com', 'photos'));
 }
 // #enddocregion fetchPhotos

--- a/examples/cookbook/networking/background_parsing/lib/main_step3.dart
+++ b/examples/cookbook/networking/background_parsing/lib/main_step3.dart
@@ -14,7 +14,7 @@ List<Photo> parsePhotos(String responseBody) {
 
 Future<List<Photo>> fetchPhotos(http.Client client) async {
   final response = await client
-      .get(Uri.parse('https://jsonplaceholder.typicode.com/photos'));
+      .get(Uri.https('jsonplaceholder.typicode.com', 'photos'));
 
   // Synchronously run parsePhotos in the main isolate.
   return parsePhotos(response.body);

--- a/examples/cookbook/networking/delete_data/lib/main.dart
+++ b/examples/cookbook/networking/delete_data/lib/main.dart
@@ -8,7 +8,7 @@ import 'package:http/http.dart' as http;
 
 Future<Album> fetchAlbum() async {
   final response = await http.get(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/1'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/1'),
   );
 
   if (response.statusCode == 200) {
@@ -23,7 +23,7 @@ Future<Album> fetchAlbum() async {
 // #docregion deleteAlbum
 Future<Album> deleteAlbum(String id) async {
   final http.Response response = await http.delete(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/$id'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/$id'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },

--- a/examples/cookbook/networking/delete_data/lib/main_step1.dart
+++ b/examples/cookbook/networking/delete_data/lib/main_step1.dart
@@ -5,7 +5,7 @@ import 'package:http/http.dart' as http;
 // #docregion deleteAlbum
 Future<http.Response> deleteAlbum(String id) async {
   final http.Response response = await http.delete(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/$id'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/$id'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },

--- a/examples/cookbook/networking/fetch_data/lib/main.dart
+++ b/examples/cookbook/networking/fetch_data/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:http/http.dart' as http;
 // #docregion fetchAlbum
 Future<Album> fetchAlbum() async {
   final response = await http
-      .get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1'));
+      .get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response,

--- a/examples/cookbook/networking/fetch_data/lib/main_step1.dart
+++ b/examples/cookbook/networking/fetch_data/lib/main_step1.dart
@@ -4,6 +4,6 @@ import 'package:http/http.dart' as http;
 
 // #docregion fetchAlbum
 Future<http.Response> fetchAlbum() {
-  return http.get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1'));
+  return http.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
 }
 // #enddocregion fetchAlbum

--- a/examples/cookbook/networking/send_data/lib/create_album.dart
+++ b/examples/cookbook/networking/send_data/lib/create_album.dart
@@ -7,7 +7,7 @@ import 'package:http/http.dart' as http;
 // #docregion CreateAlbum
 Future<http.Response> createAlbum(String title) {
   return http.post(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },

--- a/examples/cookbook/networking/send_data/lib/main.dart
+++ b/examples/cookbook/networking/send_data/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:http/http.dart' as http;
 // #docregion createAlbum
 Future<Album> createAlbum(String title) async {
   final response = await http.post(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },

--- a/examples/cookbook/networking/update_data/lib/main.dart
+++ b/examples/cookbook/networking/update_data/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:http/http.dart' as http;
 // #docregion fetchAlbum
 Future<Album> fetchAlbum() async {
   final response = await http.get(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/1'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/1'),
   );
 
   if (response.statusCode == 200) {
@@ -27,7 +27,7 @@ Future<Album> fetchAlbum() async {
 // #docregion updateAlbum
 Future<Album> updateAlbum(String title) async {
   final response = await http.put(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/1'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/1'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },

--- a/examples/cookbook/networking/update_data/lib/main_step2.dart
+++ b/examples/cookbook/networking/update_data/lib/main_step2.dart
@@ -6,7 +6,7 @@ import 'package:http/http.dart' as http;
 // #docregion updateAlbum
 Future<http.Response> updateAlbum(String title) {
   return http.put(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/1'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/1'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },

--- a/examples/cookbook/networking/update_data/lib/main_step5.dart
+++ b/examples/cookbook/networking/update_data/lib/main_step5.dart
@@ -6,7 +6,7 @@ import 'package:http/http.dart' as http;
 
 Future<Album> fetchAlbum() async {
   final response = await http.get(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/1'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/1'),
   );
 
   if (response.statusCode == 200) {
@@ -22,7 +22,7 @@ Future<Album> fetchAlbum() async {
 
 Future<Album> updateAlbum(String title) async {
   final response = await http.put(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/1'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/1'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },

--- a/examples/cookbook/testing/unit/mocking/lib/main.dart
+++ b/examples/cookbook/testing/unit/mocking/lib/main.dart
@@ -7,7 +7,7 @@ import 'package:http/http.dart' as http;
 // #docregion fetchAlbum
 Future<Album> fetchAlbum(http.Client client) async {
   final response = await client
-      .get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1'));
+      .get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response,

--- a/examples/cookbook/testing/unit/mocking/test/fetch_album_test.dart
+++ b/examples/cookbook/testing/unit/mocking/test/fetch_album_test.dart
@@ -21,7 +21,7 @@ void main() {
       // Use Mockito to return a successful response when it calls the
       // provided http.Client.
       when(client
-              .get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1')))
+              .get(Uri.https('jsonplaceholder.typicode.com', 'albums/1')))
           .thenAnswer((_) async =>
               http.Response('{"userId": 1, "id": 2, "title": "mock"}', 200));
 
@@ -34,7 +34,7 @@ void main() {
       // Use Mockito to return an unsuccessful response when it calls the
       // provided http.Client.
       when(client
-              .get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1')))
+              .get(Uri.https('jsonplaceholder.typicode.com', 'albums/1')))
           .thenAnswer((_) async => http.Response('Not Found', 404));
 
       expect(fetchAlbum(client), throwsException);

--- a/examples/get-started/flutter-for/android_devs/lib/async.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/async.dart
@@ -61,7 +61,7 @@ class _SampleAppPageState extends State<SampleAppPage> {
 
   // #docregion load-data
   Future<void> loadData() async {
-    var dataURL = Uri.parse('https://jsonplaceholder.typicode.com/posts');
+    var dataURL = Uri.https('jsonplaceholder.typicode.com', 'posts');
     http.Response response = await http.get(dataURL);
     setState(() {
       widgets = jsonDecode(response.body);

--- a/examples/get-started/flutter-for/android_devs/lib/network.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/network.dart
@@ -2,7 +2,7 @@ import 'dart:developer' as developer;
 import 'package:http/http.dart' as http;
 
 Future<void> loadData() async {
-  var dataURL = Uri.parse('https://jsonplaceholder.typicode.com/posts');
+  var dataURL = Uri.https('jsonplaceholder.typicode.com', 'posts');
   http.Response response = await http.get(dataURL);
   developer.log(response.body);
 }

--- a/examples/get-started/flutter-for/android_devs/lib/progress.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/progress.dart
@@ -78,7 +78,7 @@ class _SampleAppPageState extends State<SampleAppPage> {
   }
 
   Future<void> loadData() async {
-    var dataURL = Uri.parse('https://jsonplaceholder.typicode.com/posts');
+    var dataURL = Uri.https('jsonplaceholder.typicode.com', 'posts');
     http.Response response = await http.get(dataURL);
     setState(() {
       widgets = jsonDecode(response.body);

--- a/examples/get-started/flutter-for/ios_devs/lib/async.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/async.dart
@@ -37,7 +37,7 @@ class _SampleAppPageState extends State<SampleAppPage> {
 
   // #docregion load-data
   Future<void> loadData() async {
-    final Uri dataURL = Uri.parse('https://jsonplaceholder.typicode.com/posts');
+    final Uri dataURL = Uri.https('jsonplaceholder.typicode.com', 'posts');
     final http.Response response = await http.get(dataURL);
     setState(() {
       data = jsonDecode(response.body);

--- a/examples/get-started/flutter-for/ios_devs/lib/progress.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/progress.dart
@@ -39,7 +39,7 @@ class _SampleAppPageState extends State<SampleAppPage> {
 
   // #docregion load-data
   Future<void> loadData() async {
-    final Uri dataURL = Uri.parse('https://jsonplaceholder.typicode.com/posts');
+    final Uri dataURL = Uri.https('jsonplaceholder.typicode.com', 'posts');
     final http.Response response = await http.get(dataURL);
     setState(() {
       data = jsonDecode(response.body);

--- a/src/content/cookbook/networking/authenticated-requests.md
+++ b/src/content/cookbook/networking/authenticated-requests.md
@@ -19,7 +19,7 @@ class from the `dart:io` library.
 <?code-excerpt "lib/main.dart (get)"?>
 ```dart
 final response = await http.get(
-  Uri.parse('https://jsonplaceholder.typicode.com/albums/1'),
+  Uri.https('jsonplaceholder.typicode.com', 'albums/1'),
   // Send authorization headers to the backend.
   headers: {
     HttpHeaders.authorizationHeader: 'Basic your_api_token_here',
@@ -42,7 +42,7 @@ import 'package:http/http.dart' as http;
 
 Future<Album> fetchAlbum() async {
   final response = await http.get(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/1'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/1'),
     // Send authorization headers to the backend.
     headers: {
       HttpHeaders.authorizationHeader: 'Basic your_api_token_here',

--- a/src/content/cookbook/networking/background-parsing.md
+++ b/src/content/cookbook/networking/background-parsing.md
@@ -49,7 +49,7 @@ using the [`http.get()`][] method.
 <?code-excerpt "lib/main_step2.dart (fetchPhotos)"?>
 ```dart
 Future<http.Response> fetchPhotos(http.Client client) async {
-  return client.get(Uri.parse('https://jsonplaceholder.typicode.com/photos'));
+  return client.get(Uri.https('jsonplaceholder.typicode.com', 'photos'));
 }
 ```
 
@@ -122,7 +122,7 @@ List<Photo> parsePhotos(String responseBody) {
 
 Future<List<Photo>> fetchPhotos(http.Client client) async {
   final response = await client
-      .get(Uri.parse('https://jsonplaceholder.typicode.com/photos'));
+      .get(Uri.https('jsonplaceholder.typicode.com', 'photos'));
 
   // Synchronously run parsePhotos in the main isolate.
   return parsePhotos(response.body);
@@ -145,7 +145,7 @@ run the `parsePhotos()` function in the background.
 ```dart
 Future<List<Photo>> fetchPhotos(http.Client client) async {
   final response = await client
-      .get(Uri.parse('https://jsonplaceholder.typicode.com/photos'));
+      .get(Uri.https('jsonplaceholder.typicode.com', 'photos'));
 
   // Use the compute function to run parsePhotos in a separate isolate.
   return compute(parsePhotos, response.body);
@@ -180,7 +180,7 @@ import 'package:http/http.dart' as http;
 
 Future<List<Photo>> fetchPhotos(http.Client client) async {
   final response = await client
-      .get(Uri.parse('https://jsonplaceholder.typicode.com/photos'));
+      .get(Uri.https('jsonplaceholder.typicode.com', 'photos'));
 
   // Use the compute function to run parsePhotos in a separate isolate.
   return compute(parsePhotos, response.body);

--- a/src/content/cookbook/networking/delete-data.md
+++ b/src/content/cookbook/networking/delete-data.md
@@ -42,7 +42,7 @@ use something you already know, for example `id = 1`.
 ```dart
 Future<http.Response> deleteAlbum(String id) async {
   final http.Response response = await http.delete(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/$id'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/$id'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },
@@ -104,7 +104,7 @@ method to notify our screen that the data has been deleted.
 ```dart
 Future<Album> deleteAlbum(String id) async {
   final http.Response response = await http.delete(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/$id'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/$id'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },
@@ -147,7 +147,7 @@ import 'package:http/http.dart' as http;
 
 Future<Album> fetchAlbum() async {
   final response = await http.get(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/1'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/1'),
   );
 
   if (response.statusCode == 200) {
@@ -161,7 +161,7 @@ Future<Album> fetchAlbum() async {
 
 Future<Album> deleteAlbum(String id) async {
   final http.Response response = await http.delete(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/$id'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/$id'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },

--- a/src/content/cookbook/networking/fetch-data.md
+++ b/src/content/cookbook/networking/fetch-data.md
@@ -42,7 +42,7 @@ Import the http package.
 import 'package:http/http.dart' as http;
 ```
 
-If you are deploying to Android, edit your `AndroidManifest.xml` file to 
+If you are deploying to Android, edit your `AndroidManifest.xml` file to
 add the Internet permission.
 
 ```xml
@@ -50,7 +50,7 @@ add the Internet permission.
 <uses-permission android:name="android.permission.INTERNET" />
 ```
 
-Likewise, if you are deploying to macOS, edit your 
+Likewise, if you are deploying to macOS, edit your
 `macos/Runner/DebugProfile.entitlements` and `macos/Runner/Release.entitlements`
 files to include the network client entitlement.
 
@@ -68,7 +68,7 @@ This recipe covers how to fetch a sample album from the
 <?code-excerpt "lib/main_step1.dart (fetchAlbum)"?>
 ```dart
 Future<http.Response> fetchAlbum() {
-  return http.get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1'));
+  return http.get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
 }
 ```
 
@@ -149,7 +149,7 @@ function to return a `Future<Album>`:
 ```dart
 Future<Album> fetchAlbum() async {
   final response = await http
-      .get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1'));
+      .get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response,
@@ -246,7 +246,7 @@ it's not recommended to put an API call in a `build()` method.
 Flutter calls the `build()` method every time it needs
 to change anything in the view,
 and this happens surprisingly often.
-The `fetchAlbum()` method, if placed inside `build()`, is repeatedly 
+The `fetchAlbum()` method, if placed inside `build()`, is repeatedly
 called on each rebuild causing the app to slow down.
 
 Storing the `fetchAlbum()` result in a state variable ensures that
@@ -273,7 +273,7 @@ import 'package:http/http.dart' as http;
 
 Future<Album> fetchAlbum() async {
   final response = await http
-      .get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1'));
+      .get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response,

--- a/src/content/cookbook/networking/send-data.md
+++ b/src/content/cookbook/networking/send-data.md
@@ -32,7 +32,7 @@ Import the `http` package.
 import 'package:http/http.dart' as http;
 ```
 
-If you develop for android, 
+If you develop for android,
 add the following permission inside the manifest tag
 in the `AndroidManifest.xml` file located at `android/app/src/main`.
 
@@ -61,7 +61,7 @@ Use the `http.post()` method to send the encoded data:
 ```dart
 Future<http.Response> createAlbum(String title) {
   return http.post(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },
@@ -145,7 +145,7 @@ function to return a `Future<Album>`:
 ```dart
 Future<Album> createAlbum(String title) async {
   final response = await http.post(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },
@@ -254,7 +254,7 @@ import 'package:http/http.dart' as http;
 
 Future<Album> createAlbum(String title) async {
   final response = await http.post(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },

--- a/src/content/cookbook/networking/update-data.md
+++ b/src/content/cookbook/networking/update-data.md
@@ -42,7 +42,7 @@ This recipe covers how to update an album title to the
 ```dart
 Future<http.Response> updateAlbum(String title) {
   return http.put(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/1'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/1'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },
@@ -125,7 +125,7 @@ function to return a `Future<Album>`:
 ```dart
 Future<Album> updateAlbum(String title) async {
   final response = await http.put(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/1'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/1'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },
@@ -158,7 +158,7 @@ For a complete example, see the [Fetch data][] recipe.
 ```dart
 Future<Album> fetchAlbum() async {
   final response = await http.get(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/1'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/1'),
   );
 
   if (response.statusCode == 200) {
@@ -265,7 +265,7 @@ import 'package:http/http.dart' as http;
 
 Future<Album> fetchAlbum() async {
   final response = await http.get(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/1'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/1'),
   );
 
   if (response.statusCode == 200) {
@@ -281,7 +281,7 @@ Future<Album> fetchAlbum() async {
 
 Future<Album> updateAlbum(String title) async {
   final response = await http.put(
-    Uri.parse('https://jsonplaceholder.typicode.com/albums/1'),
+    Uri.https('jsonplaceholder.typicode.com', 'albums/1'),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },

--- a/src/content/cookbook/testing/unit/mocking.md
+++ b/src/content/cookbook/testing/unit/mocking.md
@@ -75,7 +75,7 @@ The function should now look like this:
 ```dart
 Future<Album> fetchAlbum(http.Client client) async {
   final response = await client
-      .get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1'));
+      .get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response,
@@ -89,7 +89,7 @@ Future<Album> fetchAlbum(http.Client client) async {
 }
 ```
 
-In your app code, you can provide an `http.Client` to the `fetchAlbum` method 
+In your app code, you can provide an `http.Client` to the `fetchAlbum` method
 directly with `fetchAlbum(http.Client())`. `http.Client()` creates a default
 `http.Client`.
 
@@ -163,7 +163,7 @@ void main() {
       // Use Mockito to return a successful response when it calls the
       // provided http.Client.
       when(client
-              .get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1')))
+              .get(Uri.https('jsonplaceholder.typicode.com', 'albums/1')))
           .thenAnswer((_) async =>
               http.Response('{"userId": 1, "id": 2, "title": "mock"}', 200));
 
@@ -176,7 +176,7 @@ void main() {
       // Use Mockito to return an unsuccessful response when it calls the
       // provided http.Client.
       when(client
-              .get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1')))
+              .get(Uri.https('jsonplaceholder.typicode.com', 'albums/1')))
           .thenAnswer((_) async => http.Response('Not Found', 404));
 
       expect(fetchAlbum(client), throwsException);
@@ -211,7 +211,7 @@ import 'package:http/http.dart' as http;
 
 Future<Album> fetchAlbum(http.Client client) async {
   final response = await client
-      .get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1'));
+      .get(Uri.https('jsonplaceholder.typicode.com', 'albums/1'));
 
   if (response.statusCode == 200) {
     // If the server did return a 200 OK response,
@@ -313,7 +313,7 @@ void main() {
       // Use Mockito to return a successful response when it calls the
       // provided http.Client.
       when(client
-              .get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1')))
+              .get(Uri.https('jsonplaceholder.typicode.com', 'albums/1')))
           .thenAnswer((_) async =>
               http.Response('{"userId": 1, "id": 2, "title": "mock"}', 200));
 
@@ -326,7 +326,7 @@ void main() {
       // Use Mockito to return an unsuccessful response when it calls the
       // provided http.Client.
       when(client
-              .get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1')))
+              .get(Uri.https('jsonplaceholder.typicode.com', 'albums/1')))
           .thenAnswer((_) async => http.Response('Not Found', 404));
 
       expect(fetchAlbum(client), throwsException);

--- a/src/content/get-started/flutter-for/android-devs.md
+++ b/src/content/get-started/flutter-for/android-devs.md
@@ -776,7 +776,7 @@ using `async`/`await` and letting Dart do the heavy lifting:
 <?code-excerpt "lib/async.dart (load-data)"?>
 ```dart
 Future<void> loadData() async {
-  var dataURL = Uri.parse('https://jsonplaceholder.typicode.com/posts');
+  var dataURL = Uri.https('jsonplaceholder.typicode.com', 'posts');
   http.Response response = await http.get(dataURL);
   setState(() {
     widgets = jsonDecode(response.body);
@@ -853,7 +853,7 @@ class _SampleAppPageState extends State<SampleAppPage> {
   }
 
   Future<void> loadData() async {
-    var dataURL = Uri.parse('https://jsonplaceholder.typicode.com/posts');
+    var dataURL = Uri.https('jsonplaceholder.typicode.com', 'posts');
     http.Response response = await http.get(dataURL);
     setState(() {
       widgets = jsonDecode(response.body);
@@ -887,7 +887,7 @@ and `await` on long-running tasks inside the function:
 <?code-excerpt "lib/async.dart (load-data)"?>
 ```dart
 Future<void> loadData() async {
-  var dataURL = Uri.parse('https://jsonplaceholder.typicode.com/posts');
+  var dataURL = Uri.https('jsonplaceholder.typicode.com', 'posts');
   http.Response response = await http.get(dataURL);
   setState(() {
     widgets = jsonDecode(response.body);
@@ -1120,7 +1120,7 @@ import 'dart:developer' as developer;
 import 'package:http/http.dart' as http;
 
 Future<void> loadData() async {
-  var dataURL = Uri.parse('https://jsonplaceholder.typicode.com/posts');
+  var dataURL = Uri.https('jsonplaceholder.typicode.com', 'posts');
   http.Response response = await http.get(dataURL);
   developer.log(response.body);
 }
@@ -1223,7 +1223,7 @@ class _SampleAppPageState extends State<SampleAppPage> {
   }
 
   Future<void> loadData() async {
-    var dataURL = Uri.parse('https://jsonplaceholder.typicode.com/posts');
+    var dataURL = Uri.https('jsonplaceholder.typicode.com', 'posts');
     http.Response response = await http.get(dataURL);
     setState(() {
       widgets = jsonDecode(response.body);
@@ -1595,7 +1595,7 @@ In Flutter there are two ways of adding touch listeners:
   ```dart
   class SampleTapApp extends StatelessWidget {
     const SampleTapApp({super.key});
-  
+
     @override
     Widget build(BuildContext context) {
       return Scaffold(

--- a/src/content/get-started/flutter-for/uikit-devs.md
+++ b/src/content/get-started/flutter-for/uikit-devs.md
@@ -1179,7 +1179,7 @@ In Flutter, there are two ways of adding touch listeners:
    ```dart
   class SampleTapApp extends StatelessWidget {
     const SampleTapApp({super.key});
-  
+
     @override
     Widget build(BuildContext context) {
       return Scaffold(
@@ -1704,7 +1704,7 @@ the heavy lifting:
 <?code-excerpt "lib/async.dart (load-data)"?>
 ```dart
 Future<void> loadData() async {
-  final Uri dataURL = Uri.parse('https://jsonplaceholder.typicode.com/posts');
+  final Uri dataURL = Uri.https('jsonplaceholder.typicode.com', 'posts');
   final http.Response response = await http.get(dataURL);
   setState(() {
     data = jsonDecode(response.body);
@@ -1760,7 +1760,7 @@ class _SampleAppPageState extends State<SampleAppPage> {
   }
 
   Future<void> loadData() async {
-    final Uri dataURL = Uri.parse('https://jsonplaceholder.typicode.com/posts');
+    final Uri dataURL = Uri.https('jsonplaceholder.typicode.com', 'posts');
     final http.Response response = await http.get(dataURL);
     setState(() {
       data = jsonDecode(response.body);
@@ -1812,7 +1812,7 @@ and `await` on long-running tasks inside the function:
 <?code-excerpt "lib/async.dart (load-data)"?>
 ```dart
 Future<void> loadData() async {
-  final Uri dataURL = Uri.parse('https://jsonplaceholder.typicode.com/posts');
+  final Uri dataURL = Uri.https('jsonplaceholder.typicode.com', 'posts');
   final http.Response response = await http.get(dataURL);
   setState(() {
     data = jsonDecode(response.body);
@@ -2039,7 +2039,7 @@ call `await` on the `async` function `http.get()`:
 <?code-excerpt "lib/progress.dart (load-data)"?>
 ```dart
 Future<void> loadData() async {
-  final Uri dataURL = Uri.parse('https://jsonplaceholder.typicode.com/posts');
+  final Uri dataURL = Uri.https('jsonplaceholder.typicode.com', 'posts');
   final http.Response response = await http.get(dataURL);
   setState(() {
     data = jsonDecode(response.body);
@@ -2105,7 +2105,7 @@ class _SampleAppPageState extends State<SampleAppPage> {
   bool get showLoadingDialog => data.isEmpty;
 
   Future<void> loadData() async {
-    final Uri dataURL = Uri.parse('https://jsonplaceholder.typicode.com/posts');
+    final Uri dataURL = Uri.https('jsonplaceholder.typicode.com', 'posts');
     final http.Response response = await http.get(dataURL);
     setState(() {
       data = jsonDecode(response.body);


### PR DESCRIPTION
This pull request replaces
```dart
Uri.parse('https://jsonplaceholder.typicode.com/<path>');
```
with
```dart
Uri.https('jsonplaceholder.typicode.com', '<path>')
```

as suggested below.
> To create a URI with https scheme, use [Uri.https](https://api.flutter.dev/flutter/dart-core/Uri/Uri.https.html) or [Uri.http](https://api.flutter.dev/flutter/dart-core/Uri/Uri.http.html):

https://api.dart.dev/stable/dart-core/Uri-class.html

I don't replace `Uri.parse('https://...')` of other URLs to avoid affecting a lot fo existing code.

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
