### PR TITLE
[Fix] Add --[no-]shrink instruction for release builds

### DIFF
--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -250,7 +250,7 @@ To disable R8, pass the `--no-shrink` flag to
 Obfuscation and minification can considerably extend compile time
 of the Android application.
 
-`--[no-]shrink flag` has no effect. Code shrinking is always enabled in release builds. To learn more, see: [Shrink, obfuscate, and optimize your app](https://developer.android.com/studio/build/shrink-code)
+`--[no-]shrink` flag has no effect. Code shrinking is always enabled in release builds. To learn more, see: [Shrink, obfuscate, and optimize your app](https://developer.android.com/studio/build/shrink-code)
 :::
 
 ## Enable multidex support

--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -250,7 +250,9 @@ To disable R8, pass the `--no-shrink` flag to
 Obfuscation and minification can considerably extend compile time
 of the Android application.
 
-`--[no-]shrink` flag has no effect. Code shrinking is always enabled in release builds. To learn more, see: [Shrink, obfuscate, and optimize your app](https://developer.android.com/studio/build/shrink-code)
+The `--[no-]shrink` flag has no effect. Code shrinking is always enabled in release builds.
+To learn more, check out
+[Shrink, obfuscate, and optimize your app]({{site.android-dev}}/studio/build/shrink-code).
 :::
 
 ## Enable multidex support

--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -249,10 +249,8 @@ To disable R8, pass the `--no-shrink` flag to
 :::note
 Obfuscation and minification can considerably extend compile time
 of the Android application.
-:::
 
-:::note
---[no-]shrink flag has no effect. Code shrinking is always enabled in release builds. To learn more, see: https://developer.android.com/studio/build/shrink-code
+`--[no-]shrink flag` has no effect. Code shrinking is always enabled in release builds. To learn more, see: [Shrink, obfuscate, and optimize your app](https://developer.android.com/studio/build/shrink-code)
 :::
 
 ## Enable multidex support

--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -251,6 +251,10 @@ Obfuscation and minification can considerably extend compile time
 of the Android application.
 :::
 
+:::note
+--[no-]shrink flag has no effect. Code shrinking is always enabled in release builds. To learn more, see: https://developer.android.com/studio/build/shrink-code
+:::
+
 ## Enable multidex support
 
 When writing large apps or making use of large plugins,


### PR DESCRIPTION
Add --[no-]shrink instruction for release builds.

Fixes: #10032

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
