### PR TITLE
Fix CI Dart format check

### DIFF
--- a/tool/flutter_site/lib/src/commands/format_dart.dart
+++ b/tool/flutter_site/lib/src/commands/format_dart.dart
@@ -65,7 +65,7 @@ int formatDart({bool justCheck = false}) {
   }
 
   // If just checking formatting, exit with error code if any files changed.
-  if (justCheck && !normalOutput.contains('0 changed')) {
+  if (justCheck && !normalOutput.contains('(0 changed)')) {
     stderr.writeln('Error: Some files needed to be formatted!');
     return 1;
   }


### PR DESCRIPTION
If a multiple of 10 files (10, 20, 250, etc.) was formatted, this check accidentally allowed that and didn't fail on CI.