### PR TITLE
Fix incorrect SwiftPM plugin migration step

### DIFF
--- a/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
@@ -225,7 +225,8 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
     If you would like to use a custom `modulemap` with your Swift package,
     refer to [Swift Package Manager's documentation][].
 
-1. Move all remaining files from `ios/Classes` to `ios/Sources/plugin_name`.
+1. Move all remaining files from `ios/Classes` to
+   `ios/plugin_name/Sources/plugin_name`.
 
 1. The `ios/Assets`, `ios/Resources`, and `ios/Classes` directories should now
    be empty and can be deleted.

--- a/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
@@ -157,7 +157,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
    For more instructions, see
    [https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package](https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package).
 
-1. Move all files from `ios/Classes` to `ios/Sources/plugin_name`.
+1. Move all files from `ios/Classes` to `ios/plugin_name/Sources/plugin_name`.
 
 1. The `ios/Assets`, `ios/Resources`, and `ios/Classes` directories should now
    be empty and can be deleted.


### PR DESCRIPTION
This was caught by @brianquinlan while migrating the `cupertino_http` plugin.

Review URL: https://flutter-docs-prod--pr11029-brian-feedback-9wffzaxo.web.app/packages-and-plugins/swift-package-manager/for-plugin-authors#how-to-add-swift-package-manager-support-to-an-existing-flutter-plugin

Part of: https://github.com/dart-lang/http/issues/1276#issuecomment-2274503918

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
