### PR TITLE
Add some indicator that site is building

### DIFF
--- a/tool/flutter_site/lib/src/commands/build.dart
+++ b/tool/flutter_site/lib/src/commands/build.dart
@@ -28,6 +28,8 @@ final class BuildSiteCommand extends Command<int> {
 
   @override
   Future<int> run() async {
+    print('Building site. This might take awhile...');
+
     final productionRelease = argResults.get<bool>(_releaseFlag, false);
 
     final process = await Process.start(

--- a/tool/flutter_site/lib/src/commands/serve.dart
+++ b/tool/flutter_site/lib/src/commands/serve.dart
@@ -6,7 +6,19 @@ import 'dart:io';
 
 import 'package:args/command_runner.dart';
 
+import '../utils.dart';
+
 final class ServeSiteCommand extends Command<int> {
+  static const String _verboseFlag = 'verbose';
+
+  ServeSiteCommand() {
+    argParser.addFlag(
+      _verboseFlag,
+      defaultsTo: false,
+      help: 'Show verbose logging.',
+    );
+  }
+
   @override
   String get description => 'Serve the site locally.';
 
@@ -15,11 +27,15 @@ final class ServeSiteCommand extends Command<int> {
 
   @override
   Future<int> run() async {
+    print('Building and serving site. This might take awhile...');
+
+    final verbose = argResults.get<bool>(_verboseFlag, false);
     final process = await Process.start(
       'npx',
       const ['eleventy', '--serve', '--incremental'],
-      environment: const {
+      environment: {
         'PRODUCTION': 'false',
+        if (verbose) 'DEBUG': 'Eleventy*',
       },
       runInShell: true,
       mode: ProcessStartMode.inheritStdio,


### PR DESCRIPTION
This isn't a perfect solution as it doesn't provide progress updates, but it will at least indicate to the command runner that the command is working and might take a while.

If I have time in the future, I can revisit this to be more robust.

Also adds a verbose flag to the `serve` command to get 11ty debug output.

Resolves https://github.com/flutter/website/issues/11011