### PR TITLE
Separate out design systems in widget catalogue

### DIFF
--- a/src/content/ui/widgets/index.md
+++ b/src/content/ui/widgets/index.md
@@ -9,10 +9,38 @@ Create beautiful apps faster with Flutter's collection of visual, structural,
 platform, and interactive widgets. In addition to browsing widgets by category,
 you can also see all the widgets in the [widget index][].
 
+## Design systems
+
+Flutter ships with two design systems as part of the SDK. 
+You can find many more designs systems shared by the ecosystem,
+on the [pub.dev package repository]({{site.pub}}).
+
 <div class="card-grid">
 {% assign categories = catalog.index | sort: 'name' -%}
 {% for section in categories %}
-    {%- if section.name != "Material 2 components" -%}
+    {%- if section.name == "Cupertino" or section.name == "Material components" -%}
+        <div class="card">
+            <div class="card-body">
+                <a href="{{page.url}}{{section.id}}"><header class="card-title">{{section.name}}</header></a>
+                <p class="card-text">{{section.description}}</p>
+            </div>
+            <div class="card-footer card-footer--transparent">
+                <a href="{{page.url}}{{section.id}}" aria-label="Navigate to the {{section.name}} widgets catalog">Visit</a>
+            </div>
+        </div>
+    {% endif -%}
+{% endfor %}
+</div>
+
+## Base widgets
+
+Base widgets support a range of base rendering options
+like input, layout, and text.
+
+<div class="card-grid">
+{% assign categories = catalog.index | sort: 'name' -%}
+{% for section in categories %}
+    {%- if section.name != "Cupertino" or section.name != "Material components" or section.name != "Material 2 components" -%}
         <div class="card">
             <div class="card-body">
                 <a href="{{page.url}}{{section.id}}"><header class="card-title">{{section.name}}</header></a>


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Separate out design systems from other widgets in the widget catalogue

_Issues fixed by this PR (if any):_

Contributes to https://github.com/flutter/website/issues/11024


## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
