### PR TITLE
Fix SDK installation guide on Linux

### DIFF
--- a/src/_data/shells.yml
+++ b/src/_data/shells.yml
@@ -1,14 +1,14 @@
 - name: bash
-  set-path: echo 'export PATH="/usr/bin/flutter/bin:$PATH"' >> ~/.bash_profile
+  set-path: echo 'export PATH="~/development/flutter/bin:$PATH"' >> ~/.bash_profile
 - name: zsh
-  set-path: echo 'export PATH="/usr/bin/flutter/bin:$PATH"' >> ~/.zshenv
+  set-path: echo 'export PATH="~/development/flutter/bin:$PATH"' >> ~/.zshenv
 - name: fish
-  set-path: fish_add_path -g -p /usr/bin/flutter/bin
+  set-path: fish_add_path -g -p ~/development/flutter/bin
 - name: csh
-  set-path: echo 'setenv PATH "/usr/bin/flutter/bin:$PATH"' >> ~/.cshrc
+  set-path: echo 'setenv PATH "~/development/flutter/bin:$PATH"' >> ~/.cshrc
 - name: tcsh
-  set-path: echo 'setenv PATH "/usr/bin/flutter/bin:$PATH"' >> ~/.tcshrc
+  set-path: echo 'setenv PATH "~/development/flutter/bin:$PATH"' >> ~/.tcshrc
 - name: ksh
-  set-path: echo 'export PATH="/usr/bin/flutter/bin:$PATH"' >> ~/.profile
+  set-path: echo 'export PATH="~/development/flutter/bin:$PATH"' >> ~/.profile
 - name: sh
-  set-path: echo 'export PATH="/usr/bin/flutter/bin:$PATH"' >> ~/.profile
+  set-path: echo 'export PATH="~/development/flutter/bin:$PATH"' >> ~/.profile

--- a/src/_includes/docs/install/flutter/download.md
+++ b/src/_includes/docs/install/flutter/download.md
@@ -34,11 +34,11 @@
           -d {{path}}
    {%- endcapture %}
 {% else -%}
-   {% assign diroptions='`/usr/bin/`' %}
-   {% assign dirinstall='`/usr/bin/`' %}
+   {% assign diroptions='`~/development/`' %}
+   {% assign dirinstall='`~/development/`' %}
    {% assign unzip='tar' %}
-   {% assign path='/usr/bin/' %}
-   {% assign flutter-path='/usr/bin/flutter' %}
+   {% assign path='~/development/' %}
+   {% assign flutter-path='~/development/flutter' %}
    {% assign terminal='a shell' %}
    {% assign prompt='\$' %}
    {% assign dirdl='~/Downloads/' %}

--- a/src/_includes/docs/install/reqs/linux/set-path.md
+++ b/src/_includes/docs/install/reqs/linux/set-path.md
@@ -33,7 +33,7 @@ add Flutter to the `PATH` environment variable.
    :::note
    If the above doesn't work, you might be using a non-login shell.
    In that case, add the same line to ~/.bashrc: `console $ echo
-   'export PATH="/usr/bin/flutter/bin:$PATH"' >> ~/.bashrc `.
+   'export PATH="~/development/flutter/bin:$PATH"' >> ~/.bashrc `.
    To ensure consistency across all shell types, source ~/.bashrc from
    ~/.bash_profile by adding the following to ~/.bash_profile: ` if [ -f
    ~/.bashrc ]; then source ~/.bashrc fi `.

--- a/src/content/get-started/test-drive/index.md
+++ b/src/content/get-started/test-drive/index.md
@@ -24,7 +24,7 @@ toc: false
    {% assign prompt2='$' %}
    {% assign dirdl='~/Downloads/' %}
 {% else -%}
-   {% assign path='/usr/bin/' %}
+   {% assign path='~/development/' %}
    {% assign terminal='a shell' %}
    {% assign prompt1='$' %}
    {% assign prompt2='$' %}


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ 

Currently, the installation guide on Linux goes against the [FHS](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard). According to FHS (Filesystem Hierarchy Standard): 
- ```/usr``` should not be modified by the administrator, except when installing or removing vendor-supplied packages.
- ```/usr/bin``` should only be managed by the package manager.
- There must be no subdirectories in ```/usr/bin```.

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
