### PR TITLE
[web] update web renderer documentation

### DIFF
--- a/src/content/deployment/web.md
+++ b/src/content/deployment/web.md
@@ -16,7 +16,7 @@ of your app and covers the following topics:
 * [Deploying to the web](#deploying-to-the-web)
 * [Deploying to Firebase Hosting](#deploying-to-firebase-hosting)
 * [Handling images on the web](#handling-images-on-the-web)
-* [Choosing a web renderer](#choosing-a-web-renderer)
+* [Choosing a build mode and a renderer](#choosing-a-build-mode-and-a-renderer)
 * [Minification](#minification)
 
 ## Building the app for release

--- a/src/content/deployment/web.md
+++ b/src/content/deployment/web.md
@@ -21,16 +21,11 @@ of your app and covers the following topics:
 
 ## Building the app for release
 
-Build the app for deployment using the
-`flutter build web` command.
-You can also choose which renderer to use
-by using the `--web-renderer` option (See [Web renderers][]).
-This generates the app, including the assets,
-and places the files into the `/build/web`
-directory of the project.
+Build the app for deployment using the `flutter build web` command. This
+generates the app, including the assets, and places the files into the
+`/build/web` directory of the project.
 
-The release build of a simple app has the
-following structure:
+The release build of a simple app has the following structure:
 
 ```plaintext
 /build/web
@@ -51,9 +46,7 @@ following structure:
   canvaskit
     canvaskit.js
     canvaskit.wasm
-    profiling
-      canvaskit.js
-      canvaskit.wasm
+    <other files>
   favicon.png
   flutter.js
   flutter_service_worker.js
@@ -62,11 +55,6 @@ following structure:
   manifest.json
   version.json
 ```
-
-:::note
-The `canvaskit` directory and its contents are only present when the
-CanvasKit renderer is selected—not when the HTML renderer is selected.
-:::
 
 Launch a web server (for example,
 `python -m http.server 8000`,
@@ -89,10 +77,12 @@ many others:
 * [Google Cloud Hosting][]
 
 ## Deploying to Firebase Hosting
+
 You can use the Firebase CLI to build and release your Flutter app with Firebase
 Hosting.
 
 ### Before you begin
+
 To get started, [install or update][install-firebase-cli] the Firebase CLI:
 
 ```console
@@ -145,20 +135,19 @@ This limits what you can do with images compared to mobile and desktop platforms
 
 For more information, see [Displaying images on the web][].
 
-## Choosing a web renderer
+## Choosing a build mode and a renderer
 
-By default, the `flutter build` and `flutter run` commands
-use the `auto` choice for the web renderer. This means that
-your app runs with the HTML renderer on mobile browsers and
-CanvasKit on desktop browsers. We recommend this combination
-to optimize for the characteristics of each platform.
+Flutter web provides two build modes (default and WebAssembly) and two renderers
+(`canvaskit` and `skwasm`).
 
 For more information, see [Web renderers][].
 
 ## Minification
 
-Minification is handled for you when you
-create a release build.
+To improve app start-up the compiler reduces the size of the compiled code by
+removing unused code (known as _tree shaking_), and by renaming code symbols to
+shorter strings (e.g. by renaming `AlignmentGeometryTween` to something like
+`ab`). Which of these two optimizations are applied depends on the build mode:
 
 | Type of web app build | Code minified? | Tree shaking performed? |
 |-----------------------|----------------|-------------------------|
@@ -180,8 +169,8 @@ Flutter-based PWAs can be installed in the same way as any other web-based
 PWA; the settings signaling that your Flutter app is a PWA are provided by
 `manifest.json`, which is produced by `flutter create` in the `web` directory.
 
-PWA support remains a work in progress,
-so please [give us feedback][] if you see something that doesn't look right.
+PWA support remains a work in progress. Please [give us feedback][] if you see
+something that doesn't work as expected.
 
 [dhttpd]: {{site.pub}}/packages/dhttpd
 [Displaying images on the web]: /platform-integration/web/web-images

--- a/src/content/platform-integration/web/building.md
+++ b/src/content/platform-integration/web/building.md
@@ -140,9 +140,8 @@ This populates a `build/web` directory
 with built files, including an `assets` directory,
 which need to be served together.
 
-You can also include `--web-renderer html`  or `--web-renderer canvaskit` to
-select between the HTML or CanvasKit renderers, respectively. For more
-information, see [Web renderers][].
+Flutter web offers multiple build modes and renderers. For more information,
+see [Web renderers][].
 
 To learn more, see
 [Build and release a web app][].

--- a/src/content/platform-integration/web/initialization-legacy.md
+++ b/src/content/platform-integration/web/initialization-legacy.md
@@ -134,7 +134,7 @@ You can add any of the following optional parameters:
 |`canvasKitMaximumSurfaces`| The maximum number of overlay surfaces that the CanvasKit renderer can use. |`double`|
 |`debugShowSemanticNodes`| If `true`, Flutter visibly renders the semantics tree onscreen (for debugging).  |`bool`|
 |`hostElement`| HTML Element into which Flutter renders the app. When not set, Flutter web takes over the whole page. |`HtmlElement`|
-|`renderer`| Specifies the [web renderer][web-renderers] for the current Flutter application, either `"canvaskit"` or `"html"`. |`String`|
+|`renderer`| Specifies the [web renderer][web-renderers] for the current Flutter application, either `"canvaskit"` or `"skwasm"`. |`String`|
 
 {:.table}
 

--- a/src/content/platform-integration/web/initialization.md
+++ b/src/content/platform-integration/web/initialization.md
@@ -95,7 +95,7 @@ order to successfully start your Flutter app:
 
 * A `{% raw %}{{flutter_js}}{% endraw %}` token,
   to make `_flutter.loader` available.
-* A `{% raw %}{{flutter_build_config}}{% endraw %}` token, 
+* A `{% raw %}{{flutter_build_config}}{% endraw %}` token,
   which provides information about the build to the
   `FlutterLoader` needed to start your app.
 * A call to `_flutter.loader.load()`, which actually starts the app.
@@ -133,7 +133,7 @@ The `config` argument is an object that can have the following optional fields:
 |`canvasKitMaximumSurfaces`| The maximum number of overlay surfaces that the CanvasKit renderer can use. |`double`|
 |`debugShowSemanticNodes`| If `true`, Flutter visibly renders the semantics tree onscreen (for debugging).  |`bool`|
 |`hostElement`| HTML Element into which Flutter renders the app. When not set, Flutter web takes over the whole page. |`HtmlElement`|
-|`renderer`| Specifies the [web renderer][web-renderers] for the current Flutter application, either `"canvaskit"` or `"html"`. |`String`|
+|`renderer`| Specifies the [web renderer][web-renderers] for the current Flutter application, either `"canvaskit"` or `"skwasm"`. |`String`|
 
 {:.table}
 

--- a/src/content/platform-integration/web/initialization.md
+++ b/src/content/platform-integration/web/initialization.md
@@ -152,16 +152,16 @@ The `serviceWorkerSettings` argument has the following optional fields.
 ## Example: Customizing Flutter configuration based on URL query parameters
 
 The following example shows a custom `flutter_bootstrap.js` that allows
-the user to force the app to use the `CanvasKit` renderer by providing
-a query parameter called `?force_canvaskit=true` in the URL of their website:
+the user to select a renderer by providing a `renderer` query parameter,
+e.g. `?renderer=skwasm`, in the URL of their website:
 
 ```js
 {% raw %}{{flutter_js}}{% endraw %}
 {% raw %}{{flutter_build_config}}{% endraw %}
 
 const searchParams = new URLSearchParams(window.location.search);
-const forceCanvaskit = searchParams.get('force_canvaskit') === 'true';
-const userConfig = forceCanvaskit ? {'renderer': 'canvaskit'} : {};
+const renderer = searchParams.get('renderer');
+const userConfig = renderer ? {'renderer': renderer} : {};
 _flutter.loader.load({
   config: userConfig,
   serviceWorkerSettings: {
@@ -171,7 +171,7 @@ _flutter.loader.load({
 ```
 
 This script evaluates the `URLSearchParams` of the page to determine whether
-the user passed `force_canvaskit=true` and then
+the user passed a `renderer` query parameter and then
 changes the user configuration of the Flutter app.
 It also passes the service worker settings to use the flutter service worker,
 along with the service worker version.

--- a/src/content/platform-integration/web/renderers.md
+++ b/src/content/platform-integration/web/renderers.md
@@ -6,11 +6,12 @@ description: Choosing build modes and renderers for a Flutter web app.
 Flutter web offers two _build modes_, and two _renderers_. A build mode
 is chosen when building the app and it determines which of the two renderers are
 available in the app, and how a renderer is chosen. A renderer is chosen at
-runtime when the app is being launched.
+runtime when the app is being launched, and it determines the set of web
+technologies used to render the UI.
 
 The two build modes are: default mode, and WebAssembly mode.
 
-The two rendering modes are: `canvaskit` and `skwasm`.
+The two renderers are: `canvaskit` and `skwasm`.
 
 ## Renderers
 
@@ -47,8 +48,8 @@ about 1.1MB in download size.
 ### Default build mode
 
 The default mode is used when `flutter run` and `flutter build web` commands are
-used without any extra arguments. This build mode only uses the `canvaskit`
-renderer.
+used without passing `--wasm` or by passing `--no-wasm`. This build mode only
+uses the `canvaskit` renderer.
 
 ### WebAssembly build mode
 

--- a/src/content/platform-integration/web/renderers.md
+++ b/src/content/platform-integration/web/renderers.md
@@ -122,7 +122,7 @@ by all app code, and all plugins and packages used by the app:
 
 - The code must only use the new JS interop library `dart:js_interop`. Old-style
   `dart:js`, `dart:js_util`, and `package:js` are no longer supported.
-- All Web API must use the new `package:web` instead of `dart:html`.
+- Code using Web APIs must use the new `package:web` instead of `dart:html`.
 - WebAssembly implements Dart's numeric types `int` and `double` exactly the
   same as the Dart VM. In JavaScript these types are emulated using the JS
   `Number` type. It is possible that your code accidentally or purposefully

--- a/src/content/platform-integration/web/renderers.md
+++ b/src/content/platform-integration/web/renderers.md
@@ -1,57 +1,85 @@
 ---
 title: Web renderers
-description: How to choose a web renderer for running and building a web app.
+description: Choosing build modes and renderers for a Flutter web app.
 ---
 
-When running and building apps for the web, you can choose between two different
-renderers. This page describes both renderers and how to choose the best one for
-your needs. The two renderers are:
+Flutter web offers two _build modes_, and two _renderers_. A build mode
+is chosen when building the app and it determines which of the two renderers are
+available in the app, and how a renderer is chosen. A renderer is chosen at
+runtime when the app is being launched.
 
-**CanvasKit renderer**
-: This renderer is fully consistent with Flutter mobile and desktop, has faster
-  performance with higher widget density, but adds about 1.5MB in download size.
-  [CanvasKit][canvaskit] uses WebGL to render Skia paint commands.
+The two build modes are: default mode, and WebAssembly mode.
 
-**HTML renderer**
-: This renderer, which has a smaller download size than the CanvasKit renderer,
-  uses a combination of HTML elements, CSS, Canvas elements, and SVG elements.
+The two rendering modes are: `canvaskit` and `skwasm`.
 
-## Command line options
+## Renderers
 
-The `--web-renderer` command line option takes one of three values:
-`canvaskit`, `html`, or `auto`.
+Rendering UI in Flutter begins in the framework with widgets and render objects.
+Once processed, render objects generate a `Scene` object made of layers. The
+scene is then passed to the Flutter _engine_ that turns it into pixels. All of
+the framework, including all widgets and custom app code, and much of the engine
+are written in Dart. However, a big part of the engine is written in C++, which
+includes Skia, as well as custom Flutter engine code. Multiple options are
+available on the web for how to compile Dart and C++, what graphics system to
+use to convert UI into pixels, how to split the workload across threads, etc.
 
-* `canvaskit` (default) - always use the CanvasKit renderer
-* `html` - always use the HTML renderer
-* `auto` - automatically chooses which renderer to use. This option
-    chooses the HTML renderer when the app is running in a mobile browser, and
-    CanvasKit renderer when the app is running in a desktop browser.
+Flutter web does not offer all possible combinations of options. Instead, it
+provides just two bundles of carefully chosen combinations.
 
-This flag can be used with the `run` or `build` subcommands. For example:
+### canvaskit
 
-```console
-flutter run -d chrome --web-renderer html
-```
+When using the `canvaskit` renderer, the Dart code is compiled to JavaScript,
+and the UI is rendered on the main thread into WebGL. It is compatible with all
+modern browsers. It includes a copy of Skia compiled to WebAssembly, which adds
+about 1.5MB in download size.
 
-```console
-flutter build web --web-renderer canvaskit
-```
+### skwasm
 
-This flag is ignored when a non-browser (mobile or desktop) device
-target is selected.
+When using `skwasm` the Dart code is compiled to WebAssembly. Additionally, if
+the hosting server meets the [SharedArrayBuffer security requirements][],
+Flutter will use a dedicated [web worker][] to offload part of the rendering
+workload to a separate thread, taking advantage of multiple CPU cores. This
+renderer includes a more compact version of Skia compiled to WebAssembly, adding
+about 1.1MB in download size.
 
-## Runtime configuration
+## Build modes
 
-To override the web renderer at runtime:
+### Default build mode
 
- 1. Build the app with the `auto` option.
- 1. Set up custom web app initialization
-    as described in [Write a custom `flutter_bootstrap.js`][custom-bootstrap].
+The default mode is used when `flutter run` and `flutter build web` commands are
+used without any extra arguments. This build mode only uses the `canvaskit`
+renderer.
+
+### WebAssembly build mode
+
+This mode is enabled by passing `--wasm` to `flutter run` and
+`flutter build web` commands.
+
+This mode makes both `skwasm` and `canvaskit` available. `skwasm` requires
+[wasm garbage collection][], which is not yet supported by all modern browsers.
+Therefore, at runtime Flutter will pick `skwasm` if garbage collection is
+supported, and fallback to `canvaskit` if not. This allows apps compiled in the
+WebAssembly mode to still run in all modern browsers.
+
+The `--wasm` flag is not supported by non-web platforms.
+
+## Choosing a renderer at runtime
+
+By default, when building in WebAssembly mode, Flutter will decide when to
+use `skwasm`, and when to fallback to `canvaskit`. This can be overridden by
+passing a configuration object to the loader, as follows:
+
+ 1. Build the app with the `--wasm` flag to make both `skwasm` and `canvaskit`
+    renderers available to the app.
+ 1. Set up custom web app initialization as described in
+    [Write a custom `flutter_bootstrap.js`][custom-bootstrap].
  1. Prepare a configuration object with the `renderer` property set to
-    `"canvaskit"` or `"html"`.
+    `"canvaskit"` or `"skwasm"`.
  1. Pass your prepared config object as the `config` property of
     a new object to the `_flutter.loader.load` method that is
     provided by the earlier injected code.
+
+Example:
 
 ```html highlightLines=9-14
 <body>
@@ -59,11 +87,11 @@ To override the web renderer at runtime:
     {% raw %}{{flutter_js}}{% endraw %}
     {% raw %}{{flutter_build_config}}{% endraw %}
 
-    // TODO: Replace this with your own code to determine which renderer to use.  
-    const useHtml = true;
-  
+    // TODO: Replace this with your own code to determine which renderer to use.
+    const useCanvasKit = true;
+
     const config = {
-      renderer: useHtml ? "html" : "canvaskit",
+      renderer: useCanvasKit ? "canvaskit" : "skwasm",
     };
     _flutter.loader.load({
       config: config,
@@ -72,8 +100,9 @@ To override the web renderer at runtime:
 </body>
 ```
 
-The web renderer can't be changed after the Flutter engine startup process
-begins in `main.dart.js`.
+The web renderer can't be changed after calling the `load` method. Therefore,
+any decisions about which renderer to use, must be made prior to calling
+`_flutter.loader.load`.
 
 :::version-note
 The method of specifying the web renderer was changed in Flutter 3.22.
@@ -85,42 +114,59 @@ check out [Legacy web app initialization][web-init-legacy].
 [customizing-web-init]: /platform-integration/web/initialization
 [web-init-legacy]: /platform-integration/web/initialization-legacy
 
-## Choosing which option to use
+## Choosing which build mode to use
 
-Choose the `canvaskit` option (default) if you are prioritizing performance and
-pixel-perfect consistency on both desktop and mobile browsers.
+Compiling Dart to WebAssembly comes with a few new requirements that must be met
+by all app code, and all plugins and packages used by the app:
 
-Choose the `html` option if you are optimizing download size over performance on
-both desktop and mobile browsers.
+- The code must only use the new JS interop library `dart:js_interop`. Old-style
+  `dart:js`, `dart:js_util`, and `package:js` are no longer supported.
+- All Web API must use the new `package:web` instead of `dart:html`.
+- WebAssembly implements Dart's numeric types `int` and `double` exactly the
+  same as the Dart VM. In JavaScript these types are emulated using the JS
+  `Number` type. It is possible that your code accidentally or purposefully
+  relies on the JS behavior for numbers. If so, such code needs to be updated to
+  behave correctly with the Dart VM behavior.
 
-Choose the `auto` option if you are optimizing for download size on
-mobile browsers and optimizing for performance on desktop browsers.
+General recommendations can be summarized as follows:
+
+* Choose the default mode if your app relies on plugins and packages that do
+  not yet support WebAssembly.
+* Choose the WebAssembly mode if your app's code and packages are compatible
+  with WebAssembly and app performance is important. `skwasm` has noticeably
+  better app start-up time and frame performance compared to `canvaskit`.
+  `skwasm` is particularly effective in multi-threaded mode, so consider
+  configuring the server such that it meets the
+  [SharedArrayBuffer security requirements][].
 
 ## Examples
 
-Run in Chrome using the default renderer option (`canvaskit`):
+Run in Chrome using the default build mode:
 
 ```console
 flutter run -d chrome
 ```
 
-Build your app in release mode, using the default (`canvaskit`) option:
+Build your app for release using the default build mode:
 
 ```console
-flutter build web --release
+flutter build web
 ```
 
-Build your app in release mode, using the `auto` renderer option:
+Build your app for release using the WebAssembly mode:
 
 ```console
-flutter build web --web-renderer auto --release
+flutter build web --wasm
 ```
 
-Run your app in profile mode using the HTML renderer:
+Run your app for profiling using the default build mode:
 
 ```console
-flutter run -d chrome --web-renderer html --profile
+flutter run -d chrome --profile
 ```
 
 [canvaskit]: https://skia.org/docs/user/modules/canvaskit/
 [file an issue]: {{site.repo.flutter}}/issues/new?title=[web]:+%3Cdescribe+issue+here%3E&labels=%E2%98%B8+platform-web&body=Describe+your+issue+and+include+the+command+you%27re+running,+flutter_web%20version,+browser+version
+[web worker]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API
+[wasm garbage collection]: https://developer.chrome.com/blog/wasmgc
+[SharedArrayBuffer security requirements]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements

--- a/src/content/platform-integration/web/wasm.md
+++ b/src/content/platform-integration/web/wasm.md
@@ -21,12 +21,12 @@ applications for the web.
 : Migrate your packages to [`package:web`][] and [`dart:js_interop`][]
   to make them compatible with Wasm. Read the
   [Requires JS-interop](#js-interop-wasm)
-  section to learn more. 
+  section to learn more.
 :::
 
 [`stable`]: {{site.github}}/flutter/flutter/blob/master/docs/releases/Flutter-build-release-channels.md#stable
 [`package:web`]: {{site.pub-pkg}}/web
-[`dart:js_interop`]: {{site.dart.api}}/{{site.dart.sdk.channel}}/dart-js_interop 
+[`dart:js_interop`]: {{site.dart.api}}/{{site.dart.sdk.channel}}/dart-js_interop
 
 ## Background
 
@@ -36,7 +36,7 @@ you need a browser that supports [WasmGC][].
 [Chromium and V8][] released stable support for WasmGC in Chromium 119.
 Note that Chrome on iOS uses WebKit, which doesn't yet [support WasmGC][].
 Firefox announced stable support for WasmGC in Firefox 120,
-but currently doesn't work due to a [known limitation](#known-limitations). 
+but currently doesn't work due to a [known limitation](#known-limitations).
 
 [WasmGC]: {{site.github}}/WebAssembly/gc/tree/main/proposals/gc
 [Chromium and V8]: https://chromestatus.com/feature/6062715726462976
@@ -147,7 +147,7 @@ Server started on port 8080
 
 As of {{last-update}},
 [only **Chromium-based browsers**](#chrome-119-or-later)
-(Version 119 or later) are able to run Flutter/Wasm content. 
+(Version 119 or later) are able to run Flutter/Wasm content.
 
 If your configured browser meets the requirements, open
 [`localhost:8080`](http://localhost:8080) in the browser to view the app.
@@ -164,8 +164,8 @@ The following list covers some common issues.
 
 ### Chrome 119 or later
 
-As mentioned in [Load it in a browser](#load-it-in-a-browser), 
-to run Flutter web apps compiled to Wasm, 
+As mentioned in [Load it in a browser](#load-it-in-a-browser),
+to run Flutter web apps compiled to Wasm,
 use _Chrome 119 or later_.
 
 Some earlier versions supported WasmGC with specific flags enabled,
@@ -176,7 +176,7 @@ and the latest version of Chrome.
 - **Why not Firefox?**
   Firefox versions 120 and later were previously able to run Flutter/Wasm,
   but they're [currently experiencing a bug][] that is
-  blocking compatibility with Wasm.
+  blocking compatibility with Flutter's Wasm renderer.
 - **Why not Safari?**
   Safari does not support WasmGC yet; [this bug][] tracks their
   implementation efforts.
@@ -206,7 +206,7 @@ static JS interop:
 The Dart and Flutter teams have migrated most packages
 to support Wasm in Flutter,
 such as [`package:url_launcher`][].
-To find Wasm-compatible packages, 
+To find Wasm-compatible packages,
 use the [`wasm-ready`][] filter on [pub.dev][].
 
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

The `--web-renderer` option has been deprecated and hidden (see https://github.com/flutter/flutter/pull/152683). This updates the docs to reflect the new reality.
