### PR TITLE
Update android guides to use kotlin DSL

### DIFF
--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -68,7 +68,7 @@ For example:
 
 1. Add the dependency on Android's Material in `<my-app>/android/app/build.gradle`:
 
-```groovy
+```kotlin
 dependencies {
     // ...
     implementation("com.google.android.material:material:<version>")
@@ -189,7 +189,7 @@ To configure gradle, edit the `<project>/android/app/build.gradle` file.
 
 1. Set the `keystoreProperties` object to load the `key.properties` file.
 
-   ```groovy diff title="[project]/android/app/build.gradle"
+   ```kotlin diff title="[project]/android/app/build.gradle"
    + def keystoreProperties = new Properties()
    + def keystorePropertiesFile = rootProject.file('key.properties')
    + if (keystorePropertiesFile.exists()) {

--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -204,16 +204,16 @@ To configure gradle, edit the `<project>/android/app/build.gradle` file.
 1. Add the signing configuration before the `buildTypes` property block
    inside the `android` property block.
 
-   ```groovy diff title="[project]/android/app/build.gradle"
+   ```kotlin diff title="[project]/android/app/build.gradle"
      android {
          // ...
 
    +     signingConfigs {
    +         release {
-   +             keyAlias keystoreProperties['keyAlias']
-   +             keyPassword keystoreProperties['keyPassword']
-   +             storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
-   +             storePassword keystoreProperties['storePassword']
+   +             keyAlias = keystoreProperties['keyAlias']
+   +             keyPassword = keystoreProperties['keyPassword']
+   +             storeFile = keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
+   +             storePassword = keystoreProperties['storePassword']
    +         }
    +     }
          buildTypes {
@@ -221,8 +221,8 @@ To configure gradle, edit the `<project>/android/app/build.gradle` file.
                  // TODO: Add your own signing config for the release build.
                  // Signing with the debug keys for now,
                  // so `flutter run --release` works.
-   -             signingConfig signingConfigs.debug
-   +             signingConfig signingConfigs.release
+   -             signingConfig = signingConfigs.debug
+   +             signingConfig = signingConfigs.release
              }
          }
      ...
@@ -333,7 +333,7 @@ review the `android` block in the default
 The default Gradle build script is found at `[project]/android/app/build.gradle`.
 You can change the values of any of these properties.
 
-```groovy title="[project]/android/app/build.gradle"
+```kotlin title="[project]/android/app/build.gradle"
 android {
     namespace = "com.example.[project]"
     // Any value starting with "flutter." gets its value from

--- a/src/content/platform-integration/android/platform-views.md
+++ b/src/content/platform-integration/android/platform-views.md
@@ -410,11 +410,11 @@ For more information, see the API docs for:
 Finally, modify your `build.gradle` file
 to require one of the minimal Android SDK versions:
 
-```groovy
+```kotlin
 android {
     defaultConfig {
-        minSdkVersion 19 // if using hybrid composition
-        minSdkVersion 20 // if using virtual display.
+        minSdk = 19 // if using hybrid composition
+        minSdk = 20 // if using virtual display.
     }
 }
 ```


### PR DESCRIPTION
In the latest stable flutter release the default language for `build.gradle` file moved from groovy to kotlin DSL. I just made a few changes to update a couple of android guides to reflect the new default language.

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
