### PR TITLE
Add missing `use-named-parameters` option for l10n

### DIFF
--- a/src/content/ui/accessibility-and-internationalization/internationalization.md
+++ b/src/content/ui/accessibility-and-internationalization/internationalization.md
@@ -844,7 +844,7 @@ at the command line or refer to the following table:
 | `[no-]format`                       | When specified, the `dart format` command is run after generating the localization files. |
 | `use-escaping`                      | Specifies whether to enable the use of single quotes as escaping syntax. |
 | `[no-]suppress-warnings`            | When specified, all warnings are suppressed. |
-| `use-named-parameters`              | Whether or not to use named parameters for the generated localization methods. |
+| `use-named-parameters`              | Whether to use named parameters for the generated localization methods. |
 
 {:.table .table-striped}
 

--- a/src/content/ui/accessibility-and-internationalization/internationalization.md
+++ b/src/content/ui/accessibility-and-internationalization/internationalization.md
@@ -844,6 +844,7 @@ at the command line or refer to the following table:
 | `[no-]format`                       | When specified, the `dart format` command is run after generating the localization files. |
 | `use-escaping`                      | Specifies whether to enable the use of single quotes as escaping syntax. |
 | `[no-]suppress-warnings`            | When specified, all warnings are suppressed. |
+| `use-named-parameters`              | Whether or not to use named parameters for the generated localization methods. |
 
 {:.table .table-striped}
 


### PR DESCRIPTION
This PR adds the missing `use-named-parameters` option for `l10n.yaml` file.

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
