### PR TITLE
Add migration guide to opt out of edge-to-edge by default on Android

### DIFF
--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -14,11 +14,9 @@ To maintain non-edge-to-edge app behavior
 use the info in the [migration guide](#migration-guide).
 
 ## Context
-Android is enforcing [edge-to-edge mode][2] by default for all apps targeting
-Android 15 and above; see the [Android release notes][3] for more details on
-this change. As a result, all Flutter apps running on Android that target
-Android 15 and above will be opted into edge-to-edge mode by default, impacting
-devices running on Android SDK 15+/API 35+ just like any other Android app.
+By default, Android enforces [edge-to-edge mode][2] for all apps targeting
+Android 15 and later. For more details, check out the [Android release notes][3].
+This impacts devices running on Android SDK 15+ or API 35+.
 
 At the time of publishing this guide, Flutter apps target Android 14 by
 default and will not be opted into edge-to-edge mode automatically, but

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -1,0 +1,101 @@
+---
+title: Default `SystemUiMode` set to Edge-to-Edge
+description: >
+    Apps targeting Android SDK 15+ will be opted
+    into edge-to-edge by default.
+---
+
+## Summary
+If your Flutter app runs on Android and targets SDK version 15 or above,
+your app will automatically be displayed in [edge-to-edge mode][1] on
+devices running Android SDK 15+. In order to maintain your current
+non-edge-to-edge app layout (including an unset `SystemUiMode`),
+follow the [migration guide](#migration-guide) below.
+
+## Context
+Android is enforcing [edge-to-edge mode][2] by default for all apps targeting
+Android 15 and above; see the [Android release notes][3] for more details on
+this change. As a result, all Flutter apps running on Android that target
+Android 15 and above will be opted into edge-to-edge mode by default, impacting
+devices running on Android SDK 15+ just like any other Android app.
+
+At the time of publishing this guide, Flutter apps target Android 14 by
+default and will not be opted into edge-to-edge mode automatically, but
+your app will be impacted when you choose to target Android 15. If your app
+targets `flutter.targetSdkVersion` (as it does by default), then your app will
+target Android 15 starting with Flutter version 3.26, automatically opting your
+app into edge-to-edge as a result; see the [timeline](#timeline) below for
+details. If your app explicitly sets `SystemUiMode.edgeToEdge` for it to run in
+edge-to-edge mode via a call to [`SystemChrome.setEnabledSystemUIMode`][4],
+your app is already migrated. Apps needing more time to migrate to edge-to-edge
+mode will need to follow the steps below to opt out on devices running
+Android SDK 15+.
+
+Please note that 
+
+1. Android plans for the workaround detailed below to be temporary.
+2. Flutter plans to align with Android (and iOS) to
+support edge-to-edge by default within the year, so **please migrate to**
+**edge-to-edge before the operating system removes the ability to opt out**.
+
+## Migration Guide
+To opt out of edge-to-edge by default on API 35, a new style attribute
+specification is required in each activity that needs an opt out. If
+you have a parent style that all other styles that need an opt out inherit
+from, then you can modify the parent only. In the example below, you will
+update the style generated from `flutter create`.
+
+By default, the styles used in a Flutter app are set in the manifest
+(`your_app/android/app/src/main/AndroidManifest.xml`). Generally,
+styles used in your app are denoted by `@style` and help theme your app.
+Find these styles in your manifest. By default, you will find a normal theme
+that you need to migrate:
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application ...>
+        <activity ...>
+            <!-- Style you will need to modify: -->
+            <meta-data
+              android:name="io.flutter.embedding.android.NormalTheme"
+              android:resource="@style/NormalTheme"
+            />
+        </activity>
+    </application>
+</manifest>
+```
+To migrate this style, find where it is defined in
+`your_app/android/app/src/main/res/values/styles.xml`. There, add the
+following attribute to the style:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    ...
+    <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
+        ...
+	    <!-- Add the following line: -->
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+</resources>
+```
+
+This modified style will opt your app out of edge-to-edge by default for
+apps targeting Android 35+, so now you are done!
+
+## Timeline
+Flutter apps will target Android 15 in the next stable version (3.26), so if
+you wish to use this version and not manually set a lower target SDK version
+for your Flutter app, these [migration steps](#migration-guide) will be
+required to maintain an unset or non-edge-to-edge `SystemUiMode`.
+
+## References
+
+* [The supported Flutter `SystemUiMode`s][1]
+* [The Android 15 edge-to-edge behavior changes guide][3]
+
+
+[1]: https://api.flutter.dev/flutter/services/SystemUiMode.html
+[2]: https://developer.android.com/develop/ui/views/layout/edge-to-edge 
+[3]: https://developer.android.com/about/versions/15/behavior-changes-15#edge-to-edge 
+[4]: https://api.flutter.dev/flutter/services/SystemChrome/setEnabledSystemUIMode.html

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -18,16 +18,16 @@ By default, Android enforces [edge-to-edge mode][2] for all apps targeting
 Android 15 and later. For more details, check out the [Android release notes][3].
 This impacts devices running on Android SDK 15+ or API 35+.
 
-At the time of publishing this guide, Flutter apps target Android 14 by
-default and will not be opted into edge-to-edge mode automatically, but
-your app will be impacted when you choose to target Android 15. If your app
-targets `flutter.targetSdkVersion` (as it does by default), then your app will
-target Android 15 starting with Flutter version 3.26, automatically opting your
-app into edge-to-edge as a result; see the [timeline](#timeline) below for
-details. If your app explicitly sets `SystemUiMode.edgeToEdge` for it to run in
-edge-to-edge mode via a call to [`SystemChrome.setEnabledSystemUIMode`][4],
+Prior to the Q4 2024 release, Flutter apps target Android 14 by
+default and won't opt into edge-to-edge mode automatically, but
+your app _will_ be impacted when you choose to target Android 15.
+If your app targets `flutter.targetSdkVersion` (as it does by default),
+then it will target Android 15 starting with Flutter version 3.26, automatically opting your
+app into edge-to-edge. Visit the [timeline](#timeline) for details.
+If your app explicitly sets `SystemUiMode.edgeToEdge` to run in
+edge-to-edge mode by calling [`SystemChrome.setEnabledSystemUIMode`][4],
 then your app is already migrated. Apps needing more time to migrate to
-edge-to-edge mode will need to follow the steps below to opt out on
+edge-to-edge mode must use the following steps to opt out on
 devices running Android SDK 15+.
 
 Be aware of the following:

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -17,7 +17,7 @@ Android is enforcing [edge-to-edge mode][2] by default for all apps targeting
 Android 15 and above; see the [Android release notes][3] for more details on
 this change. As a result, all Flutter apps running on Android that target
 Android 15 and above will be opted into edge-to-edge mode by default, impacting
-devices running on Android SDK 15+ just like any other Android app.
+devices running on Android SDK 15+/API 35+ just like any other Android app.
 
 At the time of publishing this guide, Flutter apps target Android 14 by
 default and will not be opted into edge-to-edge mode automatically, but
@@ -27,9 +27,9 @@ target Android 15 starting with Flutter version 3.26, automatically opting your
 app into edge-to-edge as a result; see the [timeline](#timeline) below for
 details. If your app explicitly sets `SystemUiMode.edgeToEdge` for it to run in
 edge-to-edge mode via a call to [`SystemChrome.setEnabledSystemUIMode`][4],
-your app is already migrated. Apps needing more time to migrate to edge-to-edge
-mode will need to follow the steps below to opt out on devices running
-Android SDK 15+.
+then your app is already migrated. Apps needing more time to migrate to
+edge-to-edge mode will need to follow the steps below to opt out on
+devices running Android SDK 15+.
 
 Please note that 
 
@@ -39,7 +39,7 @@ support edge-to-edge by default within the year, so **please migrate to**
 **edge-to-edge before the operating system removes the ability to opt out**.
 
 ## Migration Guide
-To opt out of edge-to-edge by default on API 35, a new style attribute
+To opt out of edge-to-edge by default on SDK 15, a new style attribute
 specification is required in each activity that needs an opt out. If
 you have a parent style that all other styles that need an opt out inherit
 from, then you can modify the parent only. In the example below, you will
@@ -64,6 +64,7 @@ that you need to migrate:
     </application>
 </manifest>
 ```
+
 To migrate this style, find where it is defined in
 `your_app/android/app/src/main/res/values/styles.xml`. There, add the
 following attribute to the style:
@@ -81,7 +82,7 @@ following attribute to the style:
 ```
 
 This modified style will opt your app out of edge-to-edge by default for
-apps targeting Android 35+, so now you are done!
+apps targeting Android SDK 15+, so now you are done!
 
 ## Timeline
 Flutter apps will target Android 15 in the next stable version (3.26), so if

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -80,8 +80,8 @@ following attribute to the style:
 </resources>
 ```
 
-This modified style will opt your app out of edge-to-edge by default for
-apps targeting Android SDK 15+, so now you are done!
+This modified style opts your app out of edge-to-edge for
+apps targeting Android SDK 15+. So now you are done!
 
 ## Timeline
 Flutter apps will target Android 15 in the next stable version (3.26), so if

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -6,11 +6,12 @@ description: >
 ---
 
 ## Summary
-If your Flutter app runs on Android and targets SDK version 15 or above,
-your app will automatically be displayed in [edge-to-edge mode][1] on
-devices running Android SDK 15+. In order to maintain your current
-non-edge-to-edge app layout (including an unset `SystemUiMode`),
-follow the [migration guide](#migration-guide) below.
+If your Flutter app targets Android SDK version 15 or later,
+your app will automatically display in edge-to-edge mode,
+as shown in the [`SystemUiMode`][1] API page.
+To maintain non-edge-to-edge app behavior
+(including an unset `SystemUiMode`),
+use the info in the [migration guide](#migration-guide).
 
 ## Context
 Android is enforcing [edge-to-edge mode][2] by default for all apps targeting

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -32,10 +32,11 @@ devices running Android SDK 15+.
 
 Be aware of the following:
 
-1. Android plans for the workaround detailed below to be temporary.
+1. Android plans for the workaround detailed here to be temporary.
 2. Flutter plans to align with Android (and iOS) to
-support edge-to-edge by default within the year, so **please migrate to**
-**edge-to-edge before the operating system removes the ability to opt out**.
+    support edge-to-edge by default within the year,
+    so please **migrate to edge-to-edge mode before the operating system
+    removes the ability to opt out**.
 
 ## Migration Guide
 To opt out of edge-to-edge by default on SDK 15, a new style attribute

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -30,7 +30,7 @@ then your app is already migrated. Apps needing more time to migrate to
 edge-to-edge mode will need to follow the steps below to opt out on
 devices running Android SDK 15+.
 
-Please note that 
+Be aware of the following:
 
 1. Android plans for the workaround detailed below to be temporary.
 2. Flutter plans to align with Android (and iOS) to

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -64,9 +64,9 @@ that you need to migrate:
 </manifest>
 ```
 
-To migrate this style, find where it is defined in
-`your_app/android/app/src/main/res/values/styles.xml`. There, add the
-following attribute to the style:
+Find where this style is defined in
+`your_app/android/app/src/main/res/values/styles.xml`.
+There, add the following attribute to the style:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -45,11 +45,10 @@ you have a parent style that all other styles that need an opt out inherit
 from, then you can modify the parent only. In the example below, you will
 update the style generated from `flutter create`.
 
-By default, the styles used in a Flutter app are set in the manifest
+By default, the styles used in a Flutter app are set in the manifest file
 (`your_app/android/app/src/main/AndroidManifest.xml`). Generally,
-styles used in your app are denoted by `@style` and help theme your app.
-Find these styles in your manifest. By default, you will find a normal theme
-that you need to migrate:
+styles are denoted by `@style` and help theme your app.
+Modify these default styles in your manifest:
 
 ```xml
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -38,12 +38,12 @@ Be aware of the following:
     so please **migrate to edge-to-edge mode before the operating system
     removes the ability to opt out**.
 
-## Migration Guide
-To opt out of edge-to-edge by default on SDK 15, a new style attribute
-specification is required in each activity that needs an opt out. If
-you have a parent style that all other styles that need an opt out inherit
-from, then you can modify the parent only. In the example below, you will
-update the style generated from `flutter create`.
+## Migration guide
+
+To opt out of edge-to-edge on SDK 15, specify the new style attribute
+in each activity that requires it. If you have a parent style that child styles
+need to opt out of, you can modify the parent only.
+In the following example, update the style generated from `flutter create`.
 
 By default, the styles used in a Flutter app are set in the manifest file
 (`your_app/android/app/src/main/AndroidManifest.xml`). Generally,

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -1,8 +1,8 @@
 ---
-title: Default `SystemUiMode` set to Edge-to-Edge
+title: Set default for SystemUiMode to Edge-to-Edge
 description: >
-    Apps targeting Android SDK 15+ will be opted
-    into edge-to-edge by default.
+    By default, apps targeting Android SDK 15+ will opt
+    into edge-to-edge mode.
 ---
 
 ## Summary

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -95,7 +95,7 @@ required to maintain an unset or non-edge-to-edge `SystemUiMode`.
 * [The Android 15 edge-to-edge behavior changes guide][3]
 
 
-[1]: https://api.flutter.dev/flutter/services/SystemUiMode.html
-[2]: https://developer.android.com/develop/ui/views/layout/edge-to-edge 
-[3]: https://developer.android.com/about/versions/15/behavior-changes-15#edge-to-edge 
-[4]: https://api.flutter.dev/flutter/services/SystemChrome/setEnabledSystemUIMode.html
+[1]: {{site.api}}/flutter/services/SystemUiMode.html
+[2]: {{site.android-dev}}/develop/ui/views/layout/edge-to-edge 
+[3]: {{site.android-dev}}/about/versions/15/behavior-changes-15#edge-to-edge 
+[4]: {{site.api}}/flutter/services/SystemChrome/setEnabledSystemUIMode.html

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -41,7 +41,7 @@ release, and listed in alphabetical order:
 [Remove invalid parameters for `InputDecoration.collapsed`]: /release/breaking-changes/input-decoration-collapsed
 [Stop generating `AssetManifest.json`]: /release/breaking-changes/asset-manifest-dot-json
 [Deprecate `TextField.canRequestFocus`]: /release/breaking-changes/can-request-focus
-[Default `SystemUiMode` set to Edge-to-Edge]: /release/breaking-changes/default-systemuimode-edge-to-edge
+[Set default for SystemUiMode to Edge-to-Edge]: /release/breaking-changes/default-systemuimode-edge-to-edge
 
 <a id="released-in-flutter-324" aria-hidden="true"></a>
 ### Released in Flutter 3.24

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -36,10 +36,12 @@ release, and listed in alphabetical order:
 * [Remove invalid parameters for `InputDecoration.collapsed`][]
 * [Stop generating `AssetManifest.json`][]
 * [Deprecate `TextField.canRequestFocus`][]
+* [Default `SystemUiMode` set to Edge-to-Edge][]
 
 [Remove invalid parameters for `InputDecoration.collapsed`]: /release/breaking-changes/input-decoration-collapsed
 [Stop generating `AssetManifest.json`]: /release/breaking-changes/asset-manifest-dot-json
 [Deprecate `TextField.canRequestFocus`]: /release/breaking-changes/can-request-focus
+[Default `SystemUiMode` set to Edge-to-Edge]: /release/breaking-changes/default-systemuimode-edge-to-edge
 
 <a id="released-in-flutter-324" aria-hidden="true"></a>
 ### Released in Flutter 3.24

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -36,7 +36,7 @@ release, and listed in alphabetical order:
 * [Remove invalid parameters for `InputDecoration.collapsed`][]
 * [Stop generating `AssetManifest.json`][]
 * [Deprecate `TextField.canRequestFocus`][]
-* [Default `SystemUiMode` set to Edge-to-Edge][]
+* [Set default for SystemUiMode to Edge-to-Edge][]
 
 [Remove invalid parameters for `InputDecoration.collapsed`]: /release/breaking-changes/input-decoration-collapsed
 [Stop generating `AssetManifest.json`]: /release/breaking-changes/asset-manifest-dot-json


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Adds a migration guide telling folks how to opt out of edge-to-edge mode when their Flutter on Android app targets Android 15+.

This (targeting Android 15+) will happen by default in the next Flutter stable version, so the described migration steps will be necessary if folks do not explicitly use edge-to-edge mode in their app. Folks may also change the Android version they target, so the steps apply if their target Android 15+ themselves, as well.

_Issues fixed by this PR (if any):_
Part of https://github.com/flutter/website/issues/10755

_PRs or commits this PR depends on (if any):_
https://github.com/flutter/flutter/pull/153795 (merged)

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
