### PR TITLE
[Swift Package Manager] Update docs after 3.24 release

### DIFF
--- a/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
+++ b/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
@@ -25,9 +25,11 @@ Using the Flutter CLI to run an app [migrates the project][addSPM] to add
 Swift Package Manager integration.
 This makes your project download the Swift packages that
 your Flutter plugins depend on.
-If you disable the Swift Package Manager feature,
-you will need to [remove Swift Package Manager integration][removeSPM] from apps
-that are migrated.
+An app with Swift Package Manager integration requires Flutter version 3.24 or
+higher.
+To use an older Flutter version,
+you will need to [remove Swift Package Manager integration][removeSPM]
+from the app.
 
 Flutter falls back to CocoaPods for dependencies that do not support Swift
 Package Manager yet.

--- a/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
@@ -440,8 +440,8 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 
       **Do not commit the migration's changes to your version control system.**
 
-      Otherwise, the plugin's example app won't build if the
-      Swift Package Manager feature is turned off.
+      Otherwise, the plugin's example app won't build unless Flutter version
+      3.24 or higher is installed.
 
       If you accidentally commit the migration's changes to the plugin's example
       app, follow the steps to


### PR DESCRIPTION
Prior to Flutter 3.24, a Flutter app that was migrated to have Swift Package Manager integration could not be built on the stable branch.

With Flutter 3.24, the app will now build successfully. However, plugins will continue to be installed using CocoaPods as the SwiftPM feature remains unavailable on the stable channel. 

_Issues fixed by this PR (if any):_ https://github.com/flutter/flutter/issues/153448

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
