### PR TITLE
[Add-to-app] Add Xcode 16 warning to CocoaPods instructions

### DIFF
--- a/src/_includes/docs/add-to-app/ios-project/embed-cocoapods.md
+++ b/src/_includes/docs/add-to-app/ios-project/embed-cocoapods.md
@@ -54,6 +54,15 @@ This section presumes you called your Swift app `MyApp`.
    navigate to the root of your app directory.
    Use the `pod init` command to create the `Podfile` file.
 
+   :::warning
+   CocoaPods 1.15.2 does not support Xcode 16.
+   If the `pod init` command errors, consider re-creating your Xcode project
+   using Xcode 15 or older.
+
+   For more information, see
+   [CocoaPods#12456](https://github.com/CocoaPods/CocoaPods/issues/12456).
+   :::
+
 1. Update your `Podfile` config file.
 
    1. Add the following lines after the `platform` declaration.

--- a/src/_includes/docs/add-to-app/ios-project/embed-cocoapods.md
+++ b/src/_includes/docs/add-to-app/ios-project/embed-cocoapods.md
@@ -55,7 +55,7 @@ This section presumes you called your Swift app `MyApp`.
    Use the `pod init` command to create the `Podfile` file.
 
    :::warning
-   CocoaPods 1.15.2 does not support Xcode 16.
+   CocoaPods (as of version 1.15.2) does not support Xcode 16.
    If the `pod init` command errors, consider re-creating your Xcode project
    using Xcode 15 or older.
 

--- a/src/_includes/docs/add-to-app/ios-project/embed-cocoapods.md
+++ b/src/_includes/docs/add-to-app/ios-project/embed-cocoapods.md
@@ -59,7 +59,7 @@ This section presumes you called your Swift app `MyApp`.
    If the `pod init` command errors, consider re-creating your Xcode project
    using Xcode 15 or older.
 
-   For more information, see
+   To learn more about the CocoaPods issue, check out
    [CocoaPods#12456](https://github.com/CocoaPods/CocoaPods/issues/12456).
    :::
 


### PR DESCRIPTION
CocoaPods does not work with Xcode 16. Add a warning to affected docs. Once CocoaPods fixes this issue, we can remove this warning.

Part of https://github.com/flutter/flutter/issues/153402

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
