### PR TITLE
Fix code sample in iOS platform-channels guide

### DIFF
--- a/src/content/platform-integration/platform-channels.md
+++ b/src/content/platform-integration/platform-channels.md
@@ -633,7 +633,7 @@ a `FlutterMethodChannel` tied to the channel name
     let batteryChannel = FlutterMethodChannel(name: "samples.flutter.dev/battery",
                                               binaryMessenger: controller.binaryMessenger)
     batteryChannel.setMethodCallHandler({
-      (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
+      [weak self] (call: FlutterMethodCall, result: FlutterResult) -> Void in
       // This method is invoked on the UI thread.
       // Handle battery messages.
     })


### PR DESCRIPTION
This pull request fixes inconsistency between declaring callback for `batteryChannel.setMethodCallHandler` in first code sample and third code sample for section ["Step 4: Add an iOS platform-specific implementation"](https://docs.flutter.dev/platform-integration/platform-channels#step-4-add-an-ios-platform-specific-implementation)

In first code sample callback was declared as `(call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in`

```swift title="AppDelegate.swift"
batteryChannel.setMethodCallHandler({
  (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
  [weak self] (call: FlutterMethodCall, result: FlutterResult) -> Void in
  // This method is invoked on the UI thread.
  // Handle battery messages.
})
```

And in third code sample which contains actual implementation of callback it is declared as `[weak self] (call: FlutterMethodCall, result: FlutterResult) -> Void in`

```swift title="AppDelegate.swift"
batteryChannel.setMethodCallHandler({
  [weak self] (call: FlutterMethodCall, result: FlutterResult) -> Void in
  // This method is invoked on the UI thread.
  guard call.method == "getBatteryLevel" else {
    result(FlutterMethodNotImplemented)
    return
  }
  self?.receiveBatteryLevel(result: result)
})
```

I decided to use `[weak self] (call: FlutterMethodCall, result: FlutterResult) -> Void in` declaration to preserve consistency with [platform_channel_swift example](https://github.com/flutter/flutter/blob/main/examples/platform_channel_swift/ios/Runner/AppDelegate.swift#L36). Using weak reference to self is fine because in third code sample we check that self exists before calling method `receiveBatteryLevel` on it and `AppDelegate` exists as long as there are any strong reference to it (I guess strong reference to `AppDelegate` exists as long as iOS app is not in "Not running" state)

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
