### PR TITLE
Expand instructions on how to switch to specific version

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -709,6 +709,7 @@
       { "source": "/to/review-gradle-config", "destination": "/deployment/android#review-the-gradle-build-configuration", "type": 301 },
       { "source": "/to/save-layer-perf", "destination": "/perf/best-practices#use-savelayer-thoughtfully", "type": 301 },
       { "source": "/to/state-management-sample", "destination": "/data-and-backend/state-mgmt/simple", "type": 301 },
+      { "source": "/to/switch-flutter-version", "destination": "/release/upgrade/#switching-to-a-specific-flutter-version", "type": 301 },
       { "source": "/to/track-widget-creation", "destination": "/tools/devtools/inspector#track-widget-creation", "type": 301 },
       { "source": "/to/troubleshoot-devices", "destination": "/get-started/install", "type": 301 },
       { "source": "/to/unbounded-constraints", "destination": "/ui/layout/constraints#unbounded", "type": 301 },

--- a/src/content/release/upgrade.md
+++ b/src/content/release/upgrade.md
@@ -34,6 +34,7 @@ We send announcements regarding these changes to the
 To avoid being broken by future versions of Flutter,
 consider submitting your tests to our [test registry][].
 
+
 ## Switching Flutter channels
 
 Flutter has two release channels:
@@ -99,6 +100,7 @@ For example:
 $ flutter channel beta
 $ flutter upgrade
 ```
+
 
 ## Switching to a specific Flutter version
 

--- a/src/content/release/upgrade.md
+++ b/src/content/release/upgrade.md
@@ -34,7 +34,6 @@ We send announcements regarding these changes to the
 To avoid being broken by future versions of Flutter,
 consider submitting your tests to our [test registry][].
 
-
 ## Switching Flutter channels
 
 Flutter has two release channels:
@@ -101,10 +100,27 @@ $ flutter channel beta
 $ flutter upgrade
 ```
 
-:::note
-If you need a specific version of the Flutter SDK,
-you can download it from the [Flutter SDK archive][].
-:::
+## Switching to a specific Flutter version
+
+To switch to a specific Flutter version:
+
+1. Find your desired **Flutter version** on the [Flutter SDK archive][].
+
+1. Navigate to the Flutter SDK:
+
+   ```console
+   $ cd /path/to/flutter
+   ```
+
+   :::tip
+   You can find the Flutter SDK's path using `flutter doctor --verbose`.
+   :::
+
+1. Use `git checkout` to switch to your desired **Flutter version**:
+
+   ```console
+   $ git checkout <Flutter version>
+   ```
 
 
 ## Upgrading packages


### PR DESCRIPTION
Explains how to switch to a specific Flutter version.

This will be used by the Flutter tool's error message when a user attempts to `flutter downgrade` but has never used the `flutter upgrade` command: https://github.com/flutter/flutter/pull/154434

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
