### PR TITLE
Adds note for the common error of indentations

### DIFF
--- a/src/content/ui/assets/assets-and-images.md
+++ b/src/content/ui/assets/assets-and-images.md
@@ -45,6 +45,21 @@ Only files located directly in the directory are included.
 To add files located in subdirectories, create an entry per directory.
 :::
 
+:::note
+A common mistake is incorrectly indenting your `assets` entry
+```yaml
+flutter:
+assets:
+  - directory/
+```
+when it should be a key _of_ the `flutter` entry.
+```yaml
+flutter:
+  assets:
+    - directory/
+```
+:::
+
 ### Asset bundling
 
 The `assets` subsection of the `flutter` section

--- a/src/content/ui/assets/assets-and-images.md
+++ b/src/content/ui/assets/assets-and-images.md
@@ -46,7 +46,10 @@ To add files located in subdirectories, create an entry per directory.
 :::
 
 :::note
-A common mistake is incorrectly indenting your `assets` entry
+Indentation matters in YAML. If you see an error like
+`Error: unable to find directory entry in pubspec.yaml`
+then you _might_ have indented incorrectly in your
+pubspec file. Consider the following [broken] example:
 ```yaml
 flutter:
 assets:

--- a/src/content/ui/assets/assets-and-images.md
+++ b/src/content/ui/assets/assets-and-images.md
@@ -55,7 +55,8 @@ flutter:
 assets:
   - directory/
 ```
-when it should be a key _of_ the `flutter` entry.
+The `assets:` line should be indented by exactly
+two spaces below the `flutter:` line:
 ```yaml
 flutter:
   assets:


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Adds a note to address common mistake when specifying the `assets` entry in `pubspec.yaml` 

_Issues fixed by this PR (if any):_

#11104

_PRs or commits this PR depends on (if any):_

N/A

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
