### PR TITLE
Fix: Bug in `flutter_site/check_link_references` tool during matching

### DIFF
--- a/src/content/release/breaking-changes/3-19-deprecations.md
+++ b/src/content/release/breaking-changes/3-19-deprecations.md
@@ -170,7 +170,7 @@ Relevant PRs:
 * Deprecated in [#109817][]
 * Removed in [#139255][]
 
-[`TextButton`]: {{site.api}}/flutter/material/TextTheme-class.html
+[`TextTheme`]: {{site.api}}/flutter/material/TextTheme-class.html
 
 [#109817]: {{site.repo.flutter}}/pull/109817
 [#139255]: {{site.repo.flutter}}/pull/139255

--- a/src/content/release/breaking-changes/android-surface-plugins.md
+++ b/src/content/release/breaking-changes/android-surface-plugins.md
@@ -150,7 +150,7 @@ Relevant PRs:
 [`CameraCharacteristics.SENSOR_ORIENTATION`]: {{site.android-dev}}/reference/android/hardware/camera2/CameraCharacteristics#SENSOR_ORIENTATION
 [`RotatedBox`]: {{site.api}}/flutter/widgets/RotatedBox-class.html
 [Android orientation calculation documentation]: {{site.android-dev}}/media/camera/camera2/camera-preview#orientation_calculation
-[this`camera_android_camerax` PR]: {{site.repo.flutter}}/packages/pull/7044
+[this `camera_android_camerax` PR]: {{site.repo.flutter}}/packages/pull/7044
 [Issue 139702]: {{site.repo.flutter}}/issues/139702
 [Issue 145930]: {{site.repo.flutter}}/issues/145930
 [PR 51061]: {{site.repo.engine}}/pull/51061

--- a/tool/flutter_site/lib/src/commands/check_link_references.dart
+++ b/tool/flutter_site/lib/src/commands/check_link_references.dart
@@ -136,7 +136,7 @@ final _pullRequestTitlePattern = RegExp(
 /// by @craiglabenz in https://github.com/flutter/flutter/pull/100316</li>
 /// ```
 final _pullRequestTitleInListItemPattern = RegExp(
-  r'<li>.*? in.*?https://github.com/.*?/pull/.*?</li>',
+  r'<li>(?:(?!<li>).)*?in\s+(?:<a[^>]*?href="https://github\.com/[^/]+/[^/]+/pull/\d+">[\d]+</a>|https://github\.com/[^/]+/[^/]+/pull/\d+)(?:(?!<li>).)*?</li>',
   dotAll: true,
 );
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

When checking with `dart run flutter_site check_link_references`, if there is HTML like the following:
```html
<div>xxxxxx</div>

<li>xxx in xxx</li>
xxx
<li>[ref][refxxx]</li>
xxx
<li>xxx in <a href="https://github.com/flutter/flutter/pull/123456">123456</a></li>

<div>xxxxxx</div>
```

before checking, it will be changed to the following:
```diff 
<div>xxxxxx</div>

- <li>xxx in xxx</li>
- xxx
- <li>[ref][refxxx]</li>
- xxx
- <li>xxx in <a href="https://github.com/flutter/flutter/pull/123456">123456</a></li>

<div>xxxxxx</div>
```

this will cause `[ref][refxxx]` to be removed and no longer checked.

The expected HTML looks like this:
```diff
<div>xxxxxx</div>

<li>xxx in xxx</li>
xxx
<li>[ref][refxxx]</li>
xxx
- <li>xxx in <a href="https://github.com/flutter/flutter/pull/123456">123456</a></li>

<div>xxxxxx</div>
```


## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
