### PR TITLE
Remove extra visit link from widget catalog index

### DIFF
--- a/src/content/ui/widgets/index.md
+++ b/src/content/ui/widgets/index.md
@@ -24,9 +24,6 @@ on [pub.dev]({{site.pub}}), the package repository for Dart and Flutter.
                 <a href="{{page.url}}{{section.id}}"><header class="card-title">{{section.name}}</header></a>
                 <p class="card-text">{{section.description}}</p>
             </div>
-            <div class="card-footer card-footer--transparent">
-                <a href="{{page.url}}{{section.id}}" aria-label="Navigate to the {{section.name}} widgets catalog">Visit</a>
-            </div>
         </div>
     {% endif -%}
 {% endfor %}
@@ -45,9 +42,6 @@ like input, layout, and text.
             <div class="card-body">
                 <a href="{{page.url}}{{section.id}}"><header class="card-title">{{section.name}}</header></a>
                 <p class="card-text">{{section.description}}</p>
-            </div>
-            <div class="card-footer card-footer--transparent">
-                <a href="{{page.url}}{{section.id}}" aria-label="Navigate to the {{section.name}} widgets catalog">Visit</a>
             </div>
         </div>
     {% endif -%}


### PR DESCRIPTION
The name of the category is already a link.