### PR TITLE
Adds note about color equality after wide gamut.

### DIFF
--- a/src/content/release/breaking-changes/wide-gamut-framework.md
+++ b/src/content/release/breaking-changes/wide-gamut-framework.md
@@ -141,6 +141,20 @@ final x = color.withOpacity(0.0);
 final x = color.withValues(alpha: 0.0);
 ```
 
+### Equality
+
+Now that Color will be storing its color components as floating-point numbers
+equality will work slightly different. When calculating colors there may be tiny
+difference in numbers which could be considered equal. To accommodate this use
+the [`closeTo`][] matcher or the [`isColorSameAs`][] matcher.
+
+```dart
+// Before
+expect(calculateColor(), const Color(0xffff00ff));
+// After
+expect(calculateColor(), isSameColorAs(const Color(0xffff00ff)));
+```
+
 ## Timeline
 
 ### Phase 1 - New API introduction, old API deprecation
@@ -168,3 +182,5 @@ Relevant PRs:
 [Impeller]: {{site.api}}/perf/impeller
 [wide gamut color spaces]: https://en.wikipedia.org/wiki/RGB_color_spaces
 [inheritance to composition]: https://en.wikipedia.org/wiki/Composition_over_inheritance
+[`closeTo`]: {{site.api}}/documentation/matcher/latest/matcher/closeTo.html
+[`isColorSameAs`]: {{site.api}}/flutter/flutter_test/isSameColorAs.html

--- a/src/content/release/breaking-changes/wide-gamut-framework.md
+++ b/src/content/release/breaking-changes/wide-gamut-framework.md
@@ -143,10 +143,11 @@ final x = color.withValues(alpha: 0.0);
 
 ### Equality
 
-Now that Color will be storing its color components as floating-point numbers
-equality will work slightly different. When calculating colors there may be tiny
-difference in numbers which could be considered equal. To accommodate this use
-the [`closeTo`][] matcher or the [`isColorSameAs`][] matcher.
+Once `Color` stores its color components as floating-point numbers,
+equality works slightly differently.
+When calculating colors there might be tiny
+difference in values that could be considered equal.
+To accommodate this use the [`closeTo`][] matcher or the [`isColorSameAs`][] matcher.
 
 ```dart
 // Before


### PR DESCRIPTION
## _Description of what this PR is changing or adding, and why:_
Adding more details about the changing of Color equality.

## _Issues fixed by this PR (if any):_
https://github.com/flutter/flutter/issues/127855

## _PRs or commits this PR depends on (if any):_
https://github.com/flutter/engine/pull/54981

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
