### PR TITLE
[web] Polish web embedding docs.

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -489,7 +489,7 @@
           permalink: /platform-integration/web/wasm
         - title: Customize app initialization
           permalink: /platform-integration/web/initialization
-        - title: Embedding Flutter web
+        - title: Add Flutter to any web app
           permalink: /platform-integration/web/embedding-flutter-web
         - title: Web content in Flutter
           permalink: /platform-integration/web/web-content-in-flutter

--- a/src/content/platform-integration/web/embedding-flutter-web.md
+++ b/src/content/platform-integration/web/embedding-flutter-web.md
@@ -7,14 +7,15 @@ description: Learn the different ways to embed Flutter views into web content.
 Flutter views and web content can be composed to produce a web application
 in different ways. Choose one of the following depending on your use-case:
 
-* A Flutter view controls the full page (full-screen mode)
+* A Flutter view controls the full page (full page mode)
 * Adding Flutter views to an existing web application (embedded mode)
 
-## Full-screen mode
+## Full page mode
 
-In full screen mode, the Flutter web application takes control of the whole
+In full page mode, the Flutter web application takes control of the whole
 browser window and covers its viewport completely when rendering. This is the
-default embedding mode for Flutter, and no additional configuration is needed.
+default embedding mode for new Flutter web projects, and no additional
+configuration is needed.
 
 ```html highlightLines=6
 <!DOCTYPE html>
@@ -28,7 +29,7 @@ default embedding mode for Flutter, and no additional configuration is needed.
 ```
 
 When Flutter web is bootstrapped without referencing `multiViewEnabled` or a 
-`hostElement`, it uses full-screen mode.
+`hostElement`, it uses full page mode.
 
 To learn more about the `flutter_bootstrap.js` file,
 check out [Customize app initialization][].
@@ -37,7 +38,7 @@ check out [Customize app initialization][].
 
 ### `iframe` embedding
 
-Full-screen mode is recommended when embedding a Flutter web application in an
+Full page mode is recommended when embedding a Flutter web application through an
 `iframe`. The page that embeds the `iframe` can size and position it as needed,
 and Flutter will fill it completely.
 

--- a/src/content/platform-integration/web/embedding-flutter-web.md
+++ b/src/content/platform-integration/web/embedding-flutter-web.md
@@ -101,7 +101,7 @@ let viewId = app.addView({
 });
 
 // Removing viewId...
-let viewConfig = flutterApp.removeView(viewId);
+let viewConfig = app.removeView(viewId);
 ```
 
 ### Handling view changes from Dart

--- a/src/content/platform-integration/web/embedding-flutter-web.md
+++ b/src/content/platform-integration/web/embedding-flutter-web.md
@@ -213,14 +213,14 @@ the [Multi View Playground repo][] that was used during development.
 
 Flutter's [`runApp` function][] assumes that there's at least one view available
 to render into (the `implicitView`), however in Flutter web's multi-view mode,
-this is no longer true, and it'll start failing with `Unexpected null value`
-errors.
+the `implicitView` doesn't exist anymore, so `runApp` will start failing with
+`Unexpected null value` errors.
 
-In multi-view mode, your Dart main must call the [`runWidget` function] instead,
-which doesn't require an `implicitView`, and will only render into the views
-that have been explicitly added into your app.
+In multi-view mode, your `main.dart` must call the [`runWidget` function][]
+instead. It doesn't require an `implicitView`, and will only render into the
+views that have been explicitly added into your app.
 
-The following example uses the `MultiViewApp` described right above to render
+The following example uses the `MultiViewApp` described above to render
 copies of the `MyApp()` widget on every `FlutterView` available:
 
 ```dart highlightLines=3
@@ -235,7 +235,7 @@ void main() {
 ```
 
 [`runApp` function]: {{site.api}}/flutter/widgets/runApp.html
-[`runWidget` function] {{site.api}}/flutter/widgets/runWidget.html
+[`runWidget` function]: {{site.api}}/flutter/widgets/runWidget.html
 
 ### Identifying views
 
@@ -253,6 +253,19 @@ class SomeWidget extends StatelessWidget {
     // Retrieve the `viewId` where this Widget is being built:
     final int viewId = View.of(context).viewId;
     // ...
+```
+
+Similarly, from the `viewBuilder` method of the `MultiViewApp`, the `viewId`
+can be retrieved like this:
+
+```dart highlightLines=4
+MultiViewApp(
+  viewBuilder: (BuildContext context) {
+    // Retrieve the `viewId` where this Widget is being built:
+    final int viewId = View.of(context).viewId;
+    // Decide what to render based on `viewId`...
+  },
+)
 ```
 
 Read more about the [`View.of` constructor][].

--- a/src/content/platform-integration/web/embedding-flutter-web.md
+++ b/src/content/platform-integration/web/embedding-flutter-web.md
@@ -1,6 +1,6 @@
 ---
-title: Embedding Flutter on the web
-short-title: Embedding Flutter web
+title: Adding Flutter to any web application
+short-title: Add Flutter to any web app
 description: Learn the different ways to embed Flutter views into web content.
 ---
 
@@ -16,9 +16,10 @@ in different ways. Choose one of the following depending on your use-case:
 ## Full page mode
 
 In full page mode, the Flutter web application takes control of the whole
-browser window and covers its viewport completely when rendering. This is the
-default embedding mode for new Flutter web projects, and no additional
-configuration is needed.
+browser window and covers its viewport completely when rendering.
+
+This is the default embedding mode for new Flutter web projects, and no
+additional configuration is needed.
 
 ```html highlightLines=6
 <!DOCTYPE html>
@@ -31,7 +32,7 @@ configuration is needed.
 </html>
 ```
 
-When Flutter web is bootstrapped without referencing `multiViewEnabled` or a 
+When Flutter web is launched without referencing `multiViewEnabled` or a
 `hostElement`, it uses full page mode.
 
 To learn more about the `flutter_bootstrap.js` file,
@@ -63,9 +64,9 @@ mode" (or "multi-view").
 In this mode:
 
 * A Flutter web application can launch, but doesn't render until the first
-"view" is added, with `addView`.
+  "view" is added, with `addView`.
 * The host application can add or remove views from the embedded Flutter web
-   application.
+  application.
 * The Flutter application is notified when views are added or removed,
   so it can adjust its widgets accordingly.
 

--- a/src/content/platform-integration/web/embedding-flutter-web.md
+++ b/src/content/platform-integration/web/embedding-flutter-web.md
@@ -209,6 +209,34 @@ the [Multi View Playground repo][] that was used during development.
 [`WidgetsBinding` mixin]: {{site.api}}/flutter/widgets/WidgetsBinding-mixin.html
 [`WidgetBuilder` function]: {{site.api}}/flutter/widgets/WidgetBuilder.html
 
+### Replace `runApp` by `runWidget` in Dart
+
+Flutter's [`runApp` function][] assumes that there's at least one view available
+to render into (the `implicitView`), however in Flutter web's multi-view mode,
+this is no longer true, and it'll start failing with `Unexpected null value`
+errors.
+
+In multi-view mode, your Dart main must call the [`runWidget` function] instead,
+which doesn't require an `implicitView`, and will only render into the views
+that have been explicitly added into your app.
+
+The following example uses the `MultiViewApp` described right above to render
+copies of the `MyApp()` widget on every `FlutterView` available:
+
+```dart highlightLines=3
+// main.dart
+void main() {
+  runWidget(
+    MultiViewApp(
+      viewBuilder: (BuildContext context) => const MyApp(),
+    ),
+  );
+}
+```
+
+[`runApp` function]: {{site.api}}/flutter/widgets/runApp.html
+[`runWidget` function] {{site.api}}/flutter/widgets/runWidget.html
+
 ### Identifying views
 
 Each `FlutterView` has an identifier assigned by Flutter when

--- a/src/content/platform-integration/web/embedding-flutter-web.md
+++ b/src/content/platform-integration/web/embedding-flutter-web.md
@@ -7,8 +7,11 @@ description: Learn the different ways to embed Flutter views into web content.
 Flutter views and web content can be composed to produce a web application
 in different ways. Choose one of the following depending on your use-case:
 
-* A Flutter view controls the full page (full page mode)
-* Adding Flutter views to an existing web application (embedded mode)
+* A Flutter view controls the full page ([full page mode][])
+* Adding Flutter views to an existing web application ([embedded mode][])
+
+[full page mode]: #full-page-mode
+[embedded mode]: #embedded-mode
 
 ## Full page mode
 


### PR DESCRIPTION
During an internal walkthrough of the Web embedding documents, we came up with the following action items:

* Document the need for the `runWidget` function
* Rename "Full-screen" to "Full page"
* Tweak the title to be smarter, _"embedding"_ is not very meaningful

One of our users was also running the docs, and encountered some of the issues that this PR addresses:

* Fixes: https://github.com/flutter/flutter/issues/153198

There's also some minor typo/formatting fixes.

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
