### PR TITLE
Some initial cleanup to FWE user input page

### DIFF
--- a/src/content/get-started/fwe/user-input.md
+++ b/src/content/get-started/fwe/user-input.md
@@ -359,9 +359,10 @@ Widget build(BuildContext context) {
 
 <span class="material-symbols" aria-hidden="true">menu_book</span> **API Docs**: [`TextField`][] • [`RichText`][] • [`SelectableText`][] • [`Form`][]
 
-[Build a form with validation]: /cookbook/forms/validation[`Form`]: {{site.api}}/flutter/widgets/Form-class.html
+[Build a form with validation]: /cookbook/forms/validation
 [Form app]: https://flutter.github.io/samples/web/form_app/
 [Form app code]: {{site.github}}/flutter/samples/tree/main/form_app
+[`Form`]: {{site.api}}/flutter/widgets/Form-class.html
 [`TextField`]: {{site.api}}/flutter/material/TextField-class.html
 [`RichText`]: {{site.api}}/flutter/widgets/RichText-class.html
 [`SelectableText`]: {{site.api}}/flutter/material/SelectableText-class.html

--- a/src/content/get-started/fwe/user-input.md
+++ b/src/content/get-started/fwe/user-input.md
@@ -11,7 +11,7 @@ next:
 
 Now that you know how to manage state in your
 Flutter app, how can you let users interact
-with your app and change its state? 
+with your app and change its state?
 
 ## Introduction to handling user input
 
@@ -20,16 +20,16 @@ there are many different ways for users
 to interact with a Flutter app.
 The resources in this section introduce
 you to some of the common widgets used
-for enabling user interaction within your app. 
+for enabling user interaction within your app.
 
 Some user input mechanisms, like [scrolling][],
 have already been covered in [Layouts][].
 
 :::secondary About design system support
-Flutter ships with prebuilt components for two design systems as part of the SDK, 
+Flutter ships with prebuilt components for two design systems as part of the SDK,
 [Material][] and [Cupertino][].
-For educational purposes, this page focuses on Material widgets, components that 
-are stylized according to the [Material 3 design language][] specifications. 
+For educational purposes, this page focuses on Material widgets, components that
+are stylized according to the [Material 3 design language][] specifications.
 
 The Flutter community on [pub.dev][], the package repository for Dart and Flutter,
 create and support additional design languages such as [Fluent UI][], [macOS UI][],
@@ -43,7 +43,7 @@ No matter which design system you choose, the principals on this page apply.
 > The [widget catalog][] has an inventory of commonly used widgets in the [Material][] and [Cupertino][] libraries.
 
 Next, we'll cover a few of the Material widgets that support common
-use cases for handling user input in your Flutter app. 
+use cases for handling user input in your Flutter app.
 
 [scrolling]: /get-started/fwe/layout#scrolling-widgets
 [pub.dev]: {{site.pub}}
@@ -67,8 +67,8 @@ but styled differently for various use cases, including:
   dimension to otherwise mostly flat layouts.
 - `FilledButton`: A filled button that should be used for
   important, final actions that complete a flow,
-  like **Save**, **Join now**, or **Confirm**. 
-- `Tonal Button`:  A middle ground button between
+  like **Save**, **Join now**, or **Confirm**.
+- `Tonal Button`: A middle ground button between
   `FilledButton` and `OutlinedButton`.
   They’re useful in contexts where a lower-priority button requires more
   emphasis than an outline, like **Next**.
@@ -157,11 +157,11 @@ Widget build(BuildContext context) {
 
 ## Text
 
-Several widgets support text input. 
+Several widgets support text input.
 
 ### `SelectableText`
 
-Flutter's `Text` widget displays text on the screen, 
+Flutter's `Text` widget displays text on the screen,
 but doesn't allow users to highlight or copy the text.
 `SelectableText` displays a string of _user-selectable_ text.
 
@@ -193,7 +193,7 @@ From forth the fatal loins of these two foes''');
 `RichText` lets you display strings of rich text in your app.
 `TextSpan`, similar to `RichText`, allows you to display parts of text with
 different text styles. It's not for handling user input,
-but is useful if you're allowing users edit and format text. 
+but is useful if you're allowing users edit and format text.
 
 {% render docs/code-and-image.md,
 image:"fwe/user-input/RichText.png",
@@ -232,8 +232,8 @@ Widget build(BuildContext context) {
 
 ### `TextField`
 
-A `TextField` lets users enter text in text box using a hardware or onscreen
-keyboard. 
+A `TextField` lets users enter text in text box using a hardware or
+onscreen keyboard.
 
 `TextField`s have many different properties and configurations.
 A few of the highlights:
@@ -241,7 +241,7 @@ A few of the highlights:
 - `InputDecoration` determines the text field's appearance,
   such as color and border.
 - `controller`: A `TextEditingController` controls the text being edited.
-  Why might you need a controller? 
+  Why might you need a controller?
   By default, your app's users can type
   into the text field, but if you want to programmatically control the `TextField`
   and clear its value, for example, you'll need a `TextEditingController`.
@@ -249,7 +249,7 @@ A few of the highlights:
   the text field's value, such as when inserting or removing text.
 - `onSubmitted`: This callback is triggered when the user indicates that
   they are done editing the text in the field;
-  for example, by tapping the "enter" key when the text field is in focus. 
+  for example, by tapping the "enter" key when the text field is in focus.
 
 The class supports other configurable properties, such as
 `obscureText` that turns each letter into a `readOnly` circle as its entered and
@@ -293,15 +293,15 @@ Widget build(BuildContext context) {
 ### Form
 
 `Form` is an optional container for grouping together multiple
-form field widgets, such as `TextField`. 
+form field widgets, such as `TextField`.
 
 Each individual form field should be wrapped in a `FormField`
 widget with the `Form` widget as a common ancestor.
 Convenience widgets exist that pre-wrap form field widgets in a
 `FormField` for you.
-For example, the `Form` widget version of `TextField` is `TextFormField`. 
+For example, the `Form` widget version of `TextField` is `TextFormField`.
 
-Using a `Form` provides access to a `FormState`, 
+Using a `Form` provides access to a `FormState`,
 which lets you save, reset, and validate each `FormField`
 that descends from this `Form`.
 You can also provide a `GlobalKey` to identify a specific form,
@@ -373,7 +373,7 @@ Provide a way to users to select from several options.
 ### SegmentedButton
 
 `SegmentedButton` allows users to select from a
-minimal group of 2-5 items. 
+minimal group of 2-5 items.
 
 The data type, `<T>`, can be a built-in type such as
 `int`, `String`, `bool` or an enum.
@@ -381,7 +381,7 @@ A `SegmentedButton` has a few relevant properties:
 
 - `segments`, a list of `ButtonSegment`s, where each represents a "segment"
    or option that the user can select.
-   Visually, each `ButtonSegment` can have an icon, text label, or both. 
+   Visually, each `ButtonSegment` can have an icon, text label, or both.
 
 - `multiSelectionEnabled` indicates whether the user is allowed
    to select multiple options. This property defaults to false.
@@ -400,10 +400,10 @@ A `SegmentedButton` has a few relevant properties:
 
 {% render docs/code-and-image.md,
 image:"fwe/user-input/segmented-button.gif",
-caption: "This figure shows a SegmentedButton, each segment with an icon and 
+caption: "This figure shows a SegmentedButton, each segment with an icon and
 text representing its value."
-alt: "A GIF of a SegmentedButton with 4 segments: Day, Week, Month, and Year. 
-Each has a calendar icon to represent its value and a text label. 
+alt: "A GIF of a SegmentedButton with 4 segments: Day, Week, Month, and Year.
+Each has a calendar icon to represent its value and a text label.
 Day is first selected, then week and month, then year."
 code:"
 
@@ -483,7 +483,7 @@ leading profile image and content text."
 alt: "A screenshot of 4 Chips split over two rows with a leading circular
 profile image with content text."
 code:"
-```dart 
+```dart
 @override
 Widget build(BuildContext context) {
   return const SizedBox(
@@ -531,7 +531,7 @@ Widget build(BuildContext context) {
 
 A `DropdownMenu` allows users to select a choice from a menu
 of options and places the selected text into a `TextField`.
-It also allows users to filter the menu items based on the text input. 
+It also allows users to filter the menu items based on the text input.
 
 Configuration parameters include the following:
 
@@ -540,7 +540,7 @@ Configuration parameters include the following:
   The menu might contain information such as a text label, and
   a leading or trailing icon.
   (This is also the only required parameter.)
-- `TextEditingController` allows programmatically controlling the `TextField`. 
+- `TextEditingController` allows programmatically controlling the `TextField`.
 - The `onSelected` callback triggers when the user selects an option.
 - `initialSelection` allows you to configure the default value.
 - Additional parameters are also available for
@@ -548,10 +548,10 @@ Configuration parameters include the following:
 
 {% render docs/code-and-image.md,
 image:"fwe/user-input/dropdownmenu.gif",
-caption: "This figure shows a DropdownMenu widget with 5 value options. Each 
+caption: "This figure shows a DropdownMenu widget with 5 value options. Each
 option's text color is styled to represent the color value."
-alt: "A GIF the DropdownMenu widget that is selected, it displays 5 options: 
-Blue, Pink, Green, Orange, and Grey. The option text is displayed in the color 
+alt: "A GIF the DropdownMenu widget that is selected, it displays 5 options:
+Blue, Pink, Green, Orange, and Grey. The option text is displayed in the color
 of its value."
 code:"
 ```dart
@@ -609,7 +609,7 @@ Widget build(BuildContext context) {
 ### Slider
 
 The `Slider` widget lets a user adjust a value by moving an indicator,
-such as a volume bar. 
+such as a volume bar.
 
 Configuration parameters for the `Slider` widget:
 
@@ -675,9 +675,9 @@ each provides slight presentation differences.:
 - `Checkbox` is a container that is empty when false or
   filled with a checkmark when true.
 - `Switch` has a handle that is on the left when false and
-  slides to the right when true. 
+  slides to the right when true.
 - `Radio` is similar to a `Checkbox` in that it's a container that is
-  empty when false, but filled in when true. 
+  empty when false, but filled in when true.
 
 The configuration for `Checkbox` and `Switch` contain:
 
@@ -897,7 +897,7 @@ Widgets are provided so the user can select a date and time.
 There is a set of dialogs that enable users to select a date or time,
 as you'll see in the following sections.
 With the exception of differing date types -
-`DateTime` for dates vs `TimeOfDay` for time - 
+`DateTime` for dates vs `TimeOfDay` for time -
 these dialogs function similarly, you can configure them by providing:
 
 - a default `initialDate` or `initialTime`
@@ -905,7 +905,7 @@ these dialogs function similarly, you can configure them by providing:
 
 ### DatePickerDialog
 
-This dialog allows the user to select a date or a range of dates. 
+This dialog allows the user to select a date or a range of dates.
 Activate by calling the `showDatePicker` function,
 which returns a `Future<DateTime>`,
 so don't forget to await the asynchronous function call!
@@ -958,7 +958,7 @@ Widget build(BuildContext context) {
 `TimePickerDialog` is a dialog that presents a time picker.
 It can be activated by calling the `showTimePicker()` function.
 Instead of returning a `Future<DateTime>`,
-`showTimePicker` instead returns a `Future<TimeOfDay>`. 
+`showTimePicker` instead returns a `Future<TimeOfDay>`.
 Once again, don't forget to await the function call!
 
 {% render docs/code-and-image.md,
@@ -1002,13 +1002,13 @@ Widget build(BuildContext context) {
 
 :::tip
 Calling `showDatePicker()` and `showTimePicker()`
-is equivalent to calling `showDialog()` with `DatePickerDialog()` and  
+is equivalent to calling `showDialog()` with `DatePickerDialog()` and 
 `TimePickerDialog()`, respectively.
 Internally, both functions use the `showDialog()` function with
-their respective `Dialog` widgets. 
+their respective `Dialog` widgets.
 To enable state restoration, you can also push
 `DatePickerDialog()` and `TimePickerDialog()` directly
-on to the `Navigator` stack. 
+on to the `Navigator` stack.
 :::
 
 <br>
@@ -1023,13 +1023,13 @@ on to the `Navigator` stack.
 
 ### [`Dismissible`][]
 
-A `Dismissible` is a widget that enables users to dismiss it by swiping. 
+A `Dismissible` is a widget that enables users to dismiss it by swiping.
 It has a number of configuration parameters, including:
 
 - A `child` widget
 - An `onDismissed` callback that is triggered when the user swipes
 - Styling parameters such as `background`
-- It's important to include a `key` object as well so that they can be uniquely 
+- It's important to include a `key` object as well so that they can be uniquely
   identified from sibling `Dismissible` widgets in the widget tree.
 
 {% render docs/code-and-image.md,
@@ -1095,7 +1095,7 @@ Check out the [Material Widget library][] and
 
 > <span class="material-symbols" aria-hidden="true">flutter</span> **Demo**: 
 > See Flutter's [Material 3 Demo][] for a curated sample of user input widgets
-> available in the Material library. 
+> available in the Material library.
 
 If the Material and Cupertino libraries don't have a widget that
 does what you need, check out [pub.dev][] to find
@@ -1105,7 +1105,7 @@ a `Slidable` widget that is more customizable than
 the `Dismissible` widget described in the previous section.
 
 > <span class="material-symbols" aria-hidden="true">slideshow</span> **Video**: 
-> [flutter_slidable (Package of the Week)][] 
+> [flutter_slidable (Package of the Week)][]
 
 [Material Widget Library]: /ui/widgets/material
 [Material Library API docs]: {{site.api}}/flutter/material/material-library.html
@@ -1114,13 +1114,13 @@ the `Dismissible` widget described in the previous section.
 [`flutter_slidable`]: {{site.pub}}/packages/flutter_slidable
 [flutter_slidable (Package of the Week)]: {{site.youtube-site}}/watch?v=QFcFEpFmNJ8
 
-## Build interactive widgets with GestureDetector 
+## Build interactive widgets with GestureDetector
 
 Have you scoured the widget libraries, pub.dev, asked your coding friends,
 and still can't find a widget that
 fits the user interaction that you're looking for?
 You can build your own custom widget and
-make it interactive using `GestureDetector`. 
+make it interactive using `GestureDetector`.
 
 > <span class="material-symbols" aria-hidden="true">star</span> **Checkpoint**: 
 > Use this recipe as a starting point to create your own _custom_ button widget
@@ -1148,7 +1148,7 @@ make it interactive using `GestureDetector`.
 If you're building a custom widget,
 annotate its meaning with the `Semantics` widget.
 It provides descriptions and metadata to screen readers and
-other semantic analysis-based tools. 
+other semantic analysis-based tools.
 
 > <span class="material-symbols" aria-hidden="true">slideshow</span> **Video**: 
 > [Semantics (Flutter Widget of the Week)][]
@@ -1173,7 +1173,7 @@ simulate user interactions in your app:
 
 > <span class="material-symbols" aria-hidden="true">star</span> **Checkpoint**: 
 > Follow this [tap, drag, and enter text][] cookbook article and learn how to
-> use `WidgetTester` to simulate and test user interactions in your app. 
+> use `WidgetTester` to simulate and test user interactions in your app.
 
 > <span class="material-symbols" aria-hidden="true">bookmark</span> **Bonus Tutorial**: 
 > The [handle scrolling][] cookbook recipe shows you how to verify that
@@ -1196,7 +1196,7 @@ and other networking features.
 
 ## Feedback
 
-As this section of the website is evolving, 
+As this section of the website is evolving,
 we [welcome your feedback][]!
 
 [welcome your feedback]: https://google.qualtrics.com/jfe/form/SV_6A9KxXR7XmMrNsy?page="user-input"

--- a/src/content/get-started/fwe/user-input.md
+++ b/src/content/get-started/fwe/user-input.md
@@ -23,9 +23,9 @@ you to some of the common widgets used
 for enabling user interaction within your app. 
 
 Some user input mechanisms, like [scrolling][],
-have already been covered in [Layouts][]. 
-:::secondary About design system support
+have already been covered in [Layouts][].
 
+:::secondary About design system support
 Flutter ships with prebuilt components for two design systems as part of the SDK, 
 [Material][] and [Cupertino][].
 For educational purposes, this page focuses on Material widgets, components that 
@@ -37,15 +37,15 @@ and more. If the existing design system components don't quite fit what you need
 Flutter lets you build your own custom widgets,
 which is covered at the end of this section.
 No matter which design system you choose, the principals on this page apply.
-
 :::
 
-> <i class="material-symbols" aria-hidden="true">menu_book</i> **Reference**: 
+> <span class="material-symbols" aria-hidden="true">menu_book</span> **Reference**: 
 > The [widget catalog][] has an inventory of commonly used widgets in the [Material][] and [Cupertino][] libraries.
 
 Next, we'll cover a few of the Material widgets that support common
 use cases for handling user input in your Flutter app. 
 
+[scrolling]: /get-started/fwe/layout#scrolling-widgets
 [pub.dev]: {{site.pub}}
 [Layouts]: /get-started/fwe/layout
 [Material]: /ui/widgets/material
@@ -56,46 +56,56 @@ use cases for handling user input in your Flutter app.
 [macOS UI]: {{site.pub}}/packages/macos_ui
 
 ## Buttons
-<img src='/assets/images/docs/fwe/user-input/material-buttons.png' alt="A collection of Material 3 Buttons.">
+
+![A collection of Material 3 Buttons.](/assets/images/docs/fwe/user-input/material-buttons.png)
 
 Buttons allow a user to initiate an action in the UI by clicking or tapping.
 The Material library provides a variety of button types that are functionally similar,
 but styled differently for various use cases, including:
+
 - `ElevatedButton`: A button with some depth. Use elevated buttons to add
-dimension to otherwise mostly flat layouts.
-- `FilledButton`: A filled button that should be used for important, 
-final actions that complete a flow, like **Save**, **Join now**, or **Confirm**. 
-- `Tonal Button`:  A middle ground button between FilledButton and OutlinedButton.
-They’re useful in contexts where a lower-priority button requires more emphasis 
-than an outline, like **Next**.
+  dimension to otherwise mostly flat layouts.
+- `FilledButton`: A filled button that should be used for
+  important, final actions that complete a flow,
+  like **Save**, **Join now**, or **Confirm**. 
+- `Tonal Button`:  A middle ground button between
+  `FilledButton` and `OutlinedButton`.
+  They’re useful in contexts where a lower-priority button requires more
+  emphasis than an outline, like **Next**.
 - `OutlinedButton`: A button with text and a visible border.
   These buttons contain actions that are important,
   but aren't the primary action in an app.
 - `TextButton`: Clickable text, without a border.
-  Since text buttons don't have visible borders
-  and they must therefore rely on their position
+  Since text buttons don't have visible borders,
+  they must rely on their position
   relative to other content for context.
 - `IconButton`: A button with an icon.
-- and `FloatingActionButton`: An icon button that hovers over
+- `FloatingActionButton`: An icon button that hovers over
   content to promote a primary action.
 
-> <i class="material-symbols" aria-hidden="true">slideshow</i> **Video**: 
+> <span class="material-symbols" aria-hidden="true">slideshow</span> **Video**: 
 > [FloatingActionButton (Widget of the Week)][]
 
 There are usually 3 main aspects to constructing a button:
 style, callback, and its child,
-as seen in the following `ElevatedButton` sample code:  
+as seen in the following `ElevatedButton` sample code:
 
-<!--- TODO: WidgetStateProperty and styling in the the design section of
+
+{% comment %}
+TODO(khanhnwin):
+WidgetStateProperty and styling in the design section of
 FWE. Of course, a button's appearance can be dependent on its state.
-You can style a button based on its state using `WidgetStateProperty`. -->
+You can style a button based on its state using `WidgetStateProperty`.
+{% endcomment %}
 
-- A button's callback function, `onPressed`, determines what happens when the button is clicked, therefore, this function is where you update your app state.
-If the callback is  `null`,
-the button is disabled and nothing happens when a user presses the button.
+- A button's callback function, `onPressed`,
+  determines what happens when the button is clicked,
+  therefore, this function is where you update your app state.
+  If the callback is  `null`, the button is disabled and
+  nothing happens when a user presses the button.
 
 - The button's `child`, which is displayed within the button's content area,
-is usually text or an icon that indicates the button's purpose.
+  is usually text or an icon that indicates the button's purpose.
 
 - Finally, a button's `style` controls its appearance: color, border, and so on.
 
@@ -128,13 +138,13 @@ Widget build(BuildContext context) {
 
 <br>
 
-> <i class="material-symbols" aria-hidden="true">star</i> **Checkpoint**: 
+> <span class="material-symbols" aria-hidden="true">star</span> **Checkpoint**: 
 > Complete this tutorial that teaches you how to build a
 > "favorite" button: [Add interactivity to your Flutter app][]
 
 <br>
 
-<i class="material-symbols" aria-hidden="true">menu_book</i> **API Docs**: [`ElevatedButton`][] • [`FilledButton`][] • [`OutlinedButton`][] • [`TextButton`][] • [`IconButton`][] • [`FloatingActionButton`][]
+<span class="material-symbols" aria-hidden="true">menu_book</span> **API Docs**: [`ElevatedButton`][] • [`FilledButton`][] • [`OutlinedButton`][] • [`TextButton`][] • [`IconButton`][] • [`FloatingActionButton`][]
 
 [`ElevatedButton`]: {{site.api}}/flutter/material/ElevatedButton-class.html
 [`FilledButton`]: {{site.api}}/flutter/material/FilledButton-class.html
@@ -143,6 +153,7 @@ Widget build(BuildContext context) {
 [`IconButton`]: {{site.api}}/flutter/material/IconButton-class.html
 [`OutlinedButton`]: {{site.api}}/flutter/material/OutlinedButton-class.html
 [`TextButton`]: {{site.api}}/flutter/material/TextButton-class.html
+[Add interactivity to your Flutter app]: /ui/interactivity
 
 ## Text
 
@@ -157,7 +168,7 @@ but doesn't allow users to highlight or copy the text.
 {% render docs/code-and-image.md,
 image:"fwe/user-input/SelectableText.gif",
 caption: "This figure shows a cursor highlighting a portion of a string of text."
-alt: 'A GIF of a cursor hihglighting two lines of text from a paragraph.'
+alt: 'A GIF of a cursor highlighting two lines of text from a paragraph.'
 code:"
 ```dart
 @override
@@ -172,10 +183,13 @@ From forth the fatal loins of these two foes''');
 ```
 " %}
 
-> <i class="material-symbols" aria-hidden="true">slideshow</i> **Video**: 
+> <span class="material-symbols" aria-hidden="true">slideshow</span> **Video**: 
 > [SelectableText (Widget of the Week)][]
 
+[SelectableText (Widget of the Week)]: {{site.youtube-site}}/watch?v=ZSU3ZXOs6hc
+
 ### `RichText`
+
 `RichText` lets you display strings of rich text in your app.
 `TextSpan`, similar to `RichText`, allows you to display parts of text with
 different text styles. It's not for handling user input,
@@ -203,22 +217,27 @@ Widget build(BuildContext context) {
 ```
 " %}
 
-> <i class="material-symbols" aria-hidden="true">slideshow</i> **Video**: 
+> <span class="material-symbols" aria-hidden="true">slideshow</span> **Video**: 
 > [Rich Text (Widget of the Week)][]
 
-> <i class="material-symbols" aria-hidden="true">flutter</i> **Demo**: 
+> <span class="material-symbols" aria-hidden="true">flutter</span> **Demo**: 
 > [Rich Text Editor][]
 
-> <i class="material-symbols" aria-hidden="true">code</i> **Code**: 
+> <span class="material-symbols" aria-hidden="true">code</span> **Code**: 
 > [Rich Text Editor code][]
 
+[Rich Text (Widget of the Week)]: {{site.youtube-site}}/watch?v=rykDVh-QFfw
+[Rich Text Editor]: https://flutter.github.io/samples/rich_text_editor.html
+[Rich Text Editor code]: {{site.github}}/flutter/samples/tree/main/simplistic_editor
 
 ### `TextField`
+
 A `TextField` lets users enter text in text box using a hardware or onscreen
 keyboard. 
 
-`TextField`s have many different properties and configurations, so here are a 
-few of the highlights:
+`TextField`s have many different properties and configurations.
+A few of the highlights:
+
 - `InputDecoration` determines the text field's appearance,
   such as color and border.
 - `controller`: A `TextEditingController` controls the text being edited.
@@ -226,15 +245,15 @@ few of the highlights:
   By default, your app's users can type
   into the text field, but if you want to programmatically control the `TextField`
   and clear its value, for example, you'll need a `TextEditingController`.
-- `onChanged`: This callback function triggers when the user changes the
-text field's value, such as when inserting or removing text.
-- `onSubmitted`:  This callback is triggered when the user indicates that
+- `onChanged`: This callback function triggers when the user changes
+  the text field's value, such as when inserting or removing text.
+- `onSubmitted`: This callback is triggered when the user indicates that
   they are done editing the text in the field;
   for example, by tapping the "enter" key when the text field is in focus. 
 
-The class supports other configurable properties, such as `obscureText` that
-turns each letter into a `readOnly` circle as its entered and `readOnly` which
-prevents the user from changing the text.
+The class supports other configurable properties, such as
+`obscureText` that turns each letter into a `readOnly` circle as its entered and
+`readOnly` which prevents the user from changing the text.
 
 {% render docs/code-and-image.md,
 image:"fwe/user-input/TextField.gif",
@@ -257,7 +276,7 @@ Widget build(BuildContext context) {
 ```
 " %}
 
-> <i class="material-symbols" aria-hidden="true">star</i> **Checkpoint**: 
+> <span class="material-symbols" aria-hidden="true">star</span> **Checkpoint**: 
 > Complete this 4-part cookbook series that walks
 > you through how to create a text field,
 > retrieve its value, and update your app state:
@@ -265,6 +284,11 @@ Widget build(BuildContext context) {
 > 1. [Retrieve the value of a text field][]
 > 1. [Handle changes to a text field][]
 > 1. [Focus and text fields][].
+
+[Create and style a text field]: /cookbook/forms/text-input
+[Retrieve the value of a text field]: /cookbook/forms/retrieve-input
+[Handle changes to a text field]: /cookbook/forms/text-field-changes
+[Focus and text fields]: /cookbook/forms/focus
 
 ### Form
 
@@ -322,34 +346,25 @@ Widget build(BuildContext context) {
 }
 ```
 
-> <i class="material-symbols" aria-hidden="true">star</i> **Checkpoint**:
+> <span class="material-symbols" aria-hidden="true">star</span> **Checkpoint**:
 > Complete this tutorial to learn how to [build a form with validation][].
 
-> <i class="material-symbols" aria-hidden="true">flutter</i> **Demo**: 
+> <span class="material-symbols" aria-hidden="true">flutter</span> **Demo**: 
 > [Form app][]
 
-> <i class="material-symbols" aria-hidden="true">code</i> **Code**: 
+> <span class="material-symbols" aria-hidden="true">code</span> **Code**: 
 > [Form app code][]
 
 <br>
 
-<i class="material-symbols" aria-hidden="true">menu_book</i> **API Docs**: [`TextField`][] • [`RichText`][] • [`SelectableText`][] • [`Form`][]
+<span class="material-symbols" aria-hidden="true">menu_book</span> **API Docs**: [`TextField`][] • [`RichText`][] • [`SelectableText`][] • [`Form`][]
 
-[Build a form with validation]: /cookbook/forms/validation
-[Create and style a text field]: /cookbook/forms/text-input
-[Focus and text fields]: /cookbook/forms/focus
-[`Form`]: {{site.api}}/flutter/widgets/Form-class.html
+[Build a form with validation]: /cookbook/forms/validation[`Form`]: {{site.api}}/flutter/widgets/Form-class.html
 [Form app]: https://flutter.github.io/samples/web/form_app/
 [Form app code]: {{site.github}}/flutter/samples/tree/main/form_app
-[Handle changes to a text field]: /cookbook/forms/text-field-changes
-[Retrieve the value of a text field]: /cookbook/forms/retrieve-input
-[`RichText`]: {{site.api}}/flutter/widgets/RichText-class.html
-[Rich Text (Widget of the Week)]: {{site.youtube-site}}/watch?v=rykDVh-QFfw
-[Rich Text Editor]: https://flutter.github.io/samples/rich_text_editor.html
-[Rich Text Editor code]: {{site.github}}/flutter/samples/tree/main/simplistic_editor
-[`SelectableText`]: {{site.api}}/flutter/material/SelectableText-class.html
-[SelectableText (Widget of the Week)]: {{site.youtube-site}}/watch?v=ZSU3ZXOs6hc
 [`TextField`]: {{site.api}}/flutter/material/TextField-class.html
+[`RichText`]: {{site.api}}/flutter/widgets/RichText-class.html
+[`SelectableText`]: {{site.api}}/flutter/material/SelectableText-class.html
 
 ## Select a value from a group of options
 
@@ -360,7 +375,8 @@ Provide a way to users to select from several options.
 `SegmentedButton` allows users to select from a
 minimal group of 2-5 items. 
 
-The data type, `<T>`, can be a built-in type such as an `int`, `String`, `bool` or an enum.
+The data type, `<T>`, can be a built-in type such as
+`int`, `String`, `bool` or an enum.
 A `SegmentedButton` has a few relevant properties:
 
 - `segments`, a list of `ButtonSegment`s, where each represents a "segment"
@@ -371,15 +387,16 @@ A `SegmentedButton` has a few relevant properties:
    to select multiple options. This property defaults to false.
 
 - `selected` identifies the currently selected value(s).
-   **Note:** `selected` is of type of `Set<T>`,
-   so if you're only allowing users to select one value, that value must be provided as a
-   `Set` with a single element. 
+   **Note:** `selected` is of type of `Set<T>`, so if you're only
+   allowing users to select one value, that value must be
+  provided as a`Set` with a single element.
 
 - The `onSelectionChanged` callback triggers when a user selects any segments.
   It provides a list of the selected segments so you can update your app state.
 
-- Additional styling parameters allow you to modify the button's appearance. 
-  For example, `style` takes a `ButtonStyle` providing a way to configure a `selectedIcon`.
+- Additional styling parameters allow you to modify the button's appearance.
+  For example, `style` takes a `ButtonStyle`,
+  providing a way to configure a `selectedIcon`.
 
 {% render docs/code-and-image.md,
 image:"fwe/user-input/segmented-button.gif",
@@ -436,17 +453,24 @@ Widget build(BuildContext context) {
 
 ### Chip
 
-`Chip` is a compact way of representing an attribute, text, entity, or action
-for a specific context. Specialized `Chip` widgets exist for specific use cases:
+`Chip` is a compact way of representing an
+attribute, text, entity, or action for a specific context.
+Specialized `Chip` widgets exist for specific use cases:
 
 - [InputChip][] represents a complex piece of information,
-  such as an entity (person, place, or thing), or conversational text, in a compact form.
+  such as an entity (person, place, or thing), or
+  conversational text, in a compact form.
 - [ChoiceChip][] allows a single selection from a set of options.
-   Choice chips contain related descriptive text or categories.
+  Choice chips contain related descriptive text or categories.
 - [FilterChip][] uses tags or descriptive words to filter content.
 - [ActionChip][] represents an action related to primary content.
 
-Every `Chip` widget requires a `label`. It can optionally have an `avatar` (such as an icon or a user's profile picture) and `onDeleted` callback, which shows a delete icon that when triggered, deletes the chip. A `Chip`'s appreance can also be customized by setting a number of optional parameters such as `shape`, `color`, `iconTheme`, etc.
+Every `Chip` widget requires a `label`.
+It can optionally have an `avatar` (such as an icon or a user's profile picture)
+and an `onDeleted` callback, which shows a delete icon that
+when triggered, deletes the chip.
+A `Chip` widget's appearance can also be customized by setting a
+number of optional parameters such as `shape`, `color`, and `iconTheme`.
 
 You will typically use `Wrap`, a widget that displays its children in
 multiple horizontal or vertical runs, to make sure your chips wrap and
@@ -461,39 +485,39 @@ profile image with content text."
 code:"
 ```dart 
 @override
-  Widget build(BuildContext context) {
-    return const SizedBox(
-      width: 500,
-      child: Wrap(
-        alignment: WrapAlignment.center,
-        spacing: 8,
-        runSpacing: 4,
-        children: [
-          Chip(
-            avatar: CircleAvatar(
-                backgroundImage: AssetImage('assets/images/dash_chef.png')),
-            label: Text('Chef Dash'),
-          ),
-          Chip(
-            avatar: CircleAvatar(
-                backgroundImage:
-                    AssetImage('assets/images/dash_firefighter.png')),
-            label: Text('Firefighter Dash'),
-          ),
-          Chip(
-            avatar: CircleAvatar(
-                backgroundImage: AssetImage('assets/images/dash_musician.png')),
-            label: Text('Musician Dash'),
-          ),
-          Chip(
-            avatar: CircleAvatar(
-                backgroundImage: AssetImage('assets/images/dash_artist.png')),
-            label: Text('Artist Dash'),
-          ),
-        ],
-      ),
-    );
-  }
+Widget build(BuildContext context) {
+  return const SizedBox(
+    width: 500,
+    child: Wrap(
+      alignment: WrapAlignment.center,
+      spacing: 8,
+      runSpacing: 4,
+      children: [
+        Chip(
+          avatar: CircleAvatar(
+              backgroundImage: AssetImage('assets/images/dash_chef.png')),
+          label: Text('Chef Dash'),
+        ),
+        Chip(
+          avatar: CircleAvatar(
+              backgroundImage:
+                  AssetImage('assets/images/dash_firefighter.png')),
+          label: Text('Firefighter Dash'),
+        ),
+        Chip(
+          avatar: CircleAvatar(
+              backgroundImage: AssetImage('assets/images/dash_musician.png')),
+          label: Text('Musician Dash'),
+        ),
+        Chip(
+          avatar: CircleAvatar(
+              backgroundImage: AssetImage('assets/images/dash_artist.png')),
+          label: Text('Artist Dash'),
+        ),
+      ],
+    ),
+  );
+}
 ```
 " %}
 
@@ -504,20 +528,23 @@ code:"
 
 
 ### `DropdownMenu`
+
 A `DropdownMenu` allows users to select a choice from a menu
 of options and places the selected text into a `TextField`.
 It also allows users to filter the menu items based on the text input. 
 
 Configuration parameters include the following:
+
 - `dropdownMenuEntries` provides a list of `DropdownMenuEntry`s that
-   describes each menu item.
-  The menu might contain information such as a text label, and a leading or
-  trailing icon.
+  describes each menu item.
+  The menu might contain information such as a text label, and
+  a leading or trailing icon.
   (This is also the only required parameter.)
 - `TextEditingController` allows programmatically controlling the `TextField`. 
 - The `onSelected` callback triggers when the user selects an option.
 - `initialSelection` allows you to configure the default value.
-- Additional parameters are also  available for customizing the widget's look and behavior.
+- Additional parameters are also available for
+  customizing the widget's look and behavior.
 
 {% render docs/code-and-image.md,
 image:"fwe/user-input/dropdownmenu.gif",
@@ -574,19 +601,23 @@ Widget build(BuildContext context) {
 ```
 " %}
 
-> <i class="material-symbols" aria-hidden="true">slideshow</i> **Video**: 
+> <span class="material-symbols" aria-hidden="true">slideshow</span> **Video**: 
 > [DropdownMenu (Widget of the Week)][]
 
+[DropdownMenu (Widget of the Week)]: {{site.youtube-site}}/watch?v=giV9AbM2gd8?si=E23hjg72cjMTe_mz
+
 ### Slider
+
 The `Slider` widget lets a user adjust a value by moving an indicator,
 such as a volume bar. 
 
 Configuration parameters for the `Slider` widget:
+
 - `value` represents the slider's current value
 - `onChanged` is the callback that gets triggered when the handle is moved
 - `min` and `max` establish minimum and maximum values allowed by the slider
 - `divisions` establishes a discrete interval with which the user can move the
-handle along the track.
+  handle along the track.
 
 
 {% render docs/code-and-image.md,
@@ -617,41 +648,45 @@ Widget build(BuildContext context) {
 ```
 " %}
 
-> <i class="material-symbols" aria-hidden="true">slideshow</i> **Video**: 
+> <span class="material-symbols" aria-hidden="true">slideshow</span> **Video**: 
 > [Slider, RangeSlider, CupertinoSlider (Widget of the Week)][]
-
-[`DropdownMenu`]: {{site.api}}/flutter/material/DropdownMenu-class.html
-[DropdownMenu (Widget of the Week)]: {{site.youtube-site}}/watch?v=giV9AbM2gd8?si=E23hjg72cjMTe_mz
-[`SegmentedButton`]: {{site.api}}/flutter/material/SegmentedButton-class.html
-[`Slider`]: {{site.api}}/flutter/material/Slider-class.html
-[Slider, RangeSlider, CupertinoSlider (Widget of the Week)]: {{site.youtube-site}}/watch?v=ufb4gIPDmEss
 
 <br>
 
-<i class="material-symbols" aria-hidden="true">menu_book</i> **API Docs:** [`SegmentedButton`][] • [`DropdownMenu`][] • [`Slider`][] • [`Chip`][]
+<span class="material-symbols" aria-hidden="true">menu_book</span> **API Docs:** [`SegmentedButton`][] • [`DropdownMenu`][] • [`Slider`][] • [`Chip`][]
+
+[Slider, RangeSlider, CupertinoSlider (Widget of the Week)]: {{site.youtube-site}}/watch?v=ufb4gIPDmEss
+[`SegmentedButton`]: {{site.api}}/flutter/material/SegmentedButton-class.html
+[`DropdownMenu`]: {{site.api}}/flutter/material/DropdownMenu-class.html
+[`Slider`]: {{site.api}}/flutter/material/Slider-class.html
+[`Chip`]: {{site.api}}/flutter/material/Chip-class.html
 
 ## Toggle between values
 
 There are several ways that your UI can allow toggling between values.
 
 ### Checkbox, Switch, and Radio
+
 Provide an option to toggle a single value on and off.
 The functional logic behind these widgets are the same,
 as all 3 are built on top of `ToggleableStateMixin`, though
 each provides slight presentation differences.:
 
-- `Checkbox` is a container that is empty when false or filled with a checkmark
-when true.
-- `Switch` has a handle that is on the left when false and slides to the right
-when true. 
-- `Radio` is similar to a `Checkbox` in that it's a container that is empty when
-false, but filled in when true. 
+- `Checkbox` is a container that is empty when false or
+  filled with a checkmark when true.
+- `Switch` has a handle that is on the left when false and
+  slides to the right when true. 
+- `Radio` is similar to a `Checkbox` in that it's a container that is
+  empty when false, but filled in when true. 
 
-The  configuration for `Checkbox` and `Switch` contain:
+The configuration for `Checkbox` and `Switch` contain:
+
 - a `value` that is `true` or `false`
-- and an `onChanged` callback which is triggered when the user toggles the widget.
+- and an `onChanged` callback which is triggered when
+  the user toggles the widget
 
 ### Checkbox
+
 {% render docs/code-and-image.md,
 image:"fwe/user-input/checkbox.gif",
 caption: "This figure shows a checkbox being checked and unchecked."
@@ -677,6 +712,7 @@ Widget build(BuildContext context) {
 " %}
 
 ### Switch
+
 {% render docs/code-and-image.md,
 image:"fwe/user-input/Switch.gif",
 caption: "This figure shows a Switch widget that is toggled on and off."
@@ -705,15 +741,17 @@ Widget build(BuildContext context) {
 " %}
 
 ### Radio
-A group of `Radio` buttons that allows the user to select between
-mutually exclusive values. When the user selects a radio button in a group,
+
+A group of `Radio` buttons that allows the user to
+select between mutually exclusive values.
+When the user selects a radio button in a group,
 the other radio buttons are unselected.
 
 - A particular `Radio` button's `value` represent that button's value,
-- The selected value for a group of radio buttons is identified by the
-`groupValue` parameter.
-- `Radio` also has an `onChanged` callback that gets triggered when users click it,
-like `Switch` and `Checkbox`
+- The selected value for a group of radio buttons is identified by
+  the `groupValue` parameter.
+- `Radio` also has an `onChanged` callback that
+  gets triggered when users click it, like `Switch` and `Checkbox`
 
 {% render docs/code-and-image.md,
 image:"fwe/user-input/Radio.gif",
@@ -831,29 +869,42 @@ Widget build(BuildContext context) {
 ```
 " %}
 
-> <i class="material-symbols" aria-hidden="true">slideshow</i> **Video**: 
+> <span class="material-symbols" aria-hidden="true">slideshow</span> **Video**: 
 > [CheckboxListTile (Widget of the Week)][]
 
-> <i class="material-symbols" aria-hidden="true">slideshow</i> **Video**: 
+> <span class="material-symbols" aria-hidden="true">slideshow</span> **Video**: 
 > [SwitchListTile (Widget of the Week)][]
 
 <br>
 
-<i class="material-symbols" aria-hidden="true">menu_book</i> **API Docs**: 
+<span class="material-symbols" aria-hidden="true">menu_book</span> **API Docs**: 
 [`Checkbox`][] • [`CheckboxListTile`][] • [`Switch`][] • [`SwitchListTile`][] • 
 [`Radio`][]
 
+[CheckboxListTile (Widget of the Week)]: {{site.youtube-site}}/watch?v=RkSqPAn9szs
+[SwitchListTile (Widget of the Week)]: {{site.youtube-site}}/watch?v=0igIjvtEWNU
+
+[`Checkbox`]: {{site.api}}/flutter/material/Checkbox-class.html
+[`CheckboxListTile`]: {{site.api}}/flutter/material/CheckboxListTile-class.html
+[`Switch`]: {{site.api}}/flutter/material/Switch-class.html
+[`SwitchListTile`]: {{site.api}}/flutter/material/SwitchListTile-class.html
+[`Radio`]: {{site.api}}/flutter/material/Radio-class.html
 
 ## Select a date or time
 
 Widgets are provided so the user can select a date and time.
 
-There is a set of Dialogs that enable users to select a date or time, as you'll see next. With the exception of differing date types - `DateTime` for dates vs `TimeOfDay` for time -  these dialogs function similarly, you can configure them by [rpvodmg]:
+There is a set of dialogs that enable users to select a date or time,
+as you'll see in the following sections.
+With the exception of differing date types -
+`DateTime` for dates vs `TimeOfDay` for time - 
+these dialogs function similarly, you can configure them by providing:
 
 - a default `initialDate` or `initialTime`
-- or an `initialEntryMode` that determines the  picker UI that's displayed.
+- or an `initialEntryMode` that determines the picker UI that's displayed.
 
 ### DatePickerDialog
+
 This dialog allows the user to select a date or a range of dates. 
 Activate by calling the `showDatePicker` function,
 which returns a `Future<DateTime>`,
@@ -903,9 +954,11 @@ Widget build(BuildContext context) {
 " %}
 
 ### TimePickerDialog
-`TimePickerDialog` is a dialog that presents a time picker. It can be activated 
-by calling the `showTimePicker()` function. Instead of returning a 
-`Future<DateTime>`, `showTimePicker` instead returns a `Future<TimeOfDay>`. 
+
+`TimePickerDialog` is a dialog that presents a time picker.
+It can be activated by calling the `showTimePicker()` function.
+Instead of returning a `Future<DateTime>`,
+`showTimePicker` instead returns a `Future<TimeOfDay>`. 
 Once again, don't forget to await the function call!
 
 {% render docs/code-and-image.md,
@@ -951,26 +1004,33 @@ Widget build(BuildContext context) {
 Calling `showDatePicker()` and `showTimePicker()`
 is equivalent to calling `showDialog()` with `DatePickerDialog()` and  
 `TimePickerDialog()`, respectively.
-Internally, both functions use the `showDialog()` function with their respective `Dialog` widgets. 
+Internally, both functions use the `showDialog()` function with
+their respective `Dialog` widgets. 
 To enable state restoration, you can also push
-`DatePickerDialog()` and `TimePickerDialog()` directly onto the `Navigator` stack. 
+`DatePickerDialog()` and `TimePickerDialog()` directly
+on to the `Navigator` stack. 
 :::
 
 <br>
 
-<i class="material-symbols" aria-hidden="true">menu_book</i> **API Docs:** 
+<span class="material-symbols" aria-hidden="true">menu_book</span> **API Docs:** 
 [`showDatePicker`][] • [`showTimePicker`][]
+
+[`showDatePicker`]: {{site.api}}/flutter/material/showDatePicker.html
+[`showTimePicker`]: {{site.api}}/flutter/material/showTimePicker.html
 
 ## Swipe & slide
 
 ### [`Dismissible`][]
+
 A `Dismissible` is a widget that enables users to dismiss it by swiping. 
-It has a a number of configuration parameters, including:
+It has a number of configuration parameters, including:
+
 - A `child` widget
 - An `onDismissed` callback that is triggered when the user swipes
 - Styling parameters such as `background`
 - It's important to include a `key` object as well so that they can be uniquely 
-identified from sibling `Dismissible` widgets in the widget tree.
+  identified from sibling `Dismissible` widgets in the widget tree.
 
 {% render docs/code-and-image.md,
 image:"fwe/user-input/Dismissible.gif",
@@ -1010,76 +1070,97 @@ Widget build(BuildContext context) {
 ```
 " %}
 
-> <i class="material-symbols" aria-hidden="true">slideshow</i> **Video**: 
+> <span class="material-symbols" aria-hidden="true">slideshow</span> **Video**: 
 > [Dismissible (Widget of the Week)][]
 
-> <i class="material-symbols" aria-hidden="true">star</i> **Checkpoint**: 
+> <span class="material-symbols" aria-hidden="true">star</span> **Checkpoint**: 
 > Complete this tutorial on how to [implement swipe to dismiss][] using the
-> dismissable widget.
+> dismissible widget.
 
 <br>
 
-<i class="material-symbols" aria-hidden="true">menu_book</i> **API Docs:**
+<span class="material-symbols" aria-hidden="true">menu_book</span> **API Docs:**
 [`Dismissible`][]
+
+[Dismissible (Widget of the Week)]: {{site.youtube-site}}/watch?v=iEMgjrfuc58?si=f0S7IdaA9PIWIYvl
+[Implement swipe to dismiss]: /cookbook/gestures/dismissible
+[`Dismissible`]: {{site.api}}/flutter/widgets/Dismissible-class.html
 
 ## Looking for more widgets?
 
-This page features just a few of the  common Material widgets that you can use
-for handling user input in your Flutter app.
+This page features just a few of the common Material widgets that
+you can use for handling user input in your Flutter app.
 Check out the [Material Widget library][] and
 [Material Library API docs][] for a full list of widgets.
 
-> <i class="material-symbols" aria-hidden="true">flutter</i> **Demo**: 
+> <span class="material-symbols" aria-hidden="true">flutter</span> **Demo**: 
 > See Flutter's [Material 3 Demo][] for a curated sample of user input widgets
 > available in the Material library. 
 
-If the Material and Cupertino libraries don't have a widget that does what you need,
-check out [pub.dev][] to find Flutter & Dart community-owned and maintained packages.
-For example, [pkg: `flutter_slidable`][] provides a `Slidable` widget that is more
-customizable than the `Dismissible` widget described in the previous section.
+If the Material and Cupertino libraries don't have a widget that
+does what you need, check out [pub.dev][] to find
+Flutter & Dart community-owned and maintained packages.
+For example, the [`flutter_slidable`][] package provides
+a `Slidable` widget that is more customizable than
+the `Dismissible` widget described in the previous section.
 
-> <i class="material-symbols" aria-hidden="true">slideshow</i> **Video**: 
+> <span class="material-symbols" aria-hidden="true">slideshow</span> **Video**: 
 > [flutter_slidable (Package of the Week)][] 
 
 [Material Widget Library]: /ui/widgets/material
 [Material Library API docs]: {{site.api}}/flutter/material/material-library.html
+[Material 3 Demo]: https://flutter.github.io/samples/web/material_3_demo/
+
+[`flutter_slidable`]: {{site.pub}}/packages/flutter_slidable
+[flutter_slidable (Package of the Week)]: {{site.youtube-site}}/watch?v=QFcFEpFmNJ8
 
 ## Build interactive widgets with GestureDetector 
 
-If you've scoured the widget libraries, pub.dev, asked your coding friends,
-and still can't find a widget that fits the user interaction that you're looking for?
-You can build your own custom widget and make it interactive using `GestureDetector`. 
+Have you scoured the widget libraries, pub.dev, asked your coding friends,
+and still can't find a widget that
+fits the user interaction that you're looking for?
+You can build your own custom widget and
+make it interactive using `GestureDetector`. 
 
-> <i class="material-symbols" aria-hidden="true">star</i> **Checkpoint**: 
+> <span class="material-symbols" aria-hidden="true">star</span> **Checkpoint**: 
 > Use this recipe as a starting point to create your own _custom_ button widget
 > that can [handle taps][].
 
-> <i class="material-symbols" aria-hidden="true">slideshow</i> **Video**: 
+> <span class="material-symbols" aria-hidden="true">slideshow</span> **Video**: 
 > [GestureDetector (Widget of the Week)][]
 
-> <i class="material-symbols" aria-hidden="true">menu_book</i> **Reference**: 
-> Check out the [taps, drags, and other gestures][] which explains how to listen
+> <span class="material-symbols" aria-hidden="true">menu_book</span> **Reference**: 
+> Check out [Taps, drags, and other gestures][] which explains how to listen
 > for, and respond to, gestures in Flutter.
 
-> <i class="material-symbols" aria-hidden="true">slideshow</i> **Bonus Video**: 
-> Curious how Flutter's
-`GestureArena` turns raw user interaction data into
-human recognizable concepts like taps, drags, and pinches?
-Check out the this video: [GestureArena (Decoding Flutter)][]
+> <span class="material-symbols" aria-hidden="true">slideshow</span> **Bonus Video**: 
+> Curious how Flutter's `GestureArena` turns raw user interaction data into
+> human recognizable concepts like taps, drags, and pinches?
+> Check out this video: [GestureArena (Decoding Flutter)][]
+
+[handle taps]: /cookbook/gestures/handling-taps
+[GestureDetector (Widget of the Week)]: {{site.youtube-site}}/watch?v=WhVXkCFPmK4
+[Taps, drags, and other gestures]: /ui/interactivity/gestures#gestures
+[GestureArena (Decoding Flutter)]: {{site.youtube-site}}/watch?v=Q85LBtBdi0U
 
 ### Don't forget about accessibility!
 
-If you're building a custom widget, annotate its meaning with the `Semantics` widget. It provides descriptions and metadata to screen readers and other 
-semantic analysis-based tools. 
+If you're building a custom widget,
+annotate its meaning with the `Semantics` widget.
+It provides descriptions and metadata to screen readers and
+other semantic analysis-based tools. 
 
-> <i class="material-symbols" aria-hidden="true">slideshow</i> **Video**: 
+> <span class="material-symbols" aria-hidden="true">slideshow</span> **Video**: 
 > [Semantics (Flutter Widget of the Week)][]
 
 
 <br>
 
-<i class="material-symbols" aria-hidden="true">menu_book</i> **API Docs**:
+<span class="material-symbols" aria-hidden="true">menu_book</span> **API Docs**:
 [`GestureDetector`][] • [`Semantics`][]
+
+[`GestureDetector`]: {{site.api}}/flutter/widgets/GestureDetector-class.html
+[`Semantics`]: {{site.api}}/flutter/widgets/Semantics-class.html
 
 ## Testing
 
@@ -1087,22 +1168,21 @@ Once you have finished building user interactions
 into your app, don't forget to write tests to
 ensure that everything works as expected!
 
-These tutorials walk you through writing tests that simulate user interactions in your app:
+These tutorials walk you through writing tests that
+simulate user interactions in your app:
 
-> <i class="material-symbols" aria-hidden="true">star</i> **Checkpoint**: 
-> Follow this [tap, drag, and enter text][] cookbook article and learn how to use
-> `WidgetTester` to simulate and test user interactions in your app. 
+> <span class="material-symbols" aria-hidden="true">star</span> **Checkpoint**: 
+> Follow this [tap, drag, and enter text][] cookbook article and learn how to
+> use `WidgetTester` to simulate and test user interactions in your app. 
 
-> <i class="material-symbols" aria-hidden="true">bookmark</i> **Bonus Tutorial**: 
-> This [handle scrolling][] cookbook article shows you how to verify that lists
-> of widgets contain the expected content by scrolling through the lists using widget tests.
+> <span class="material-symbols" aria-hidden="true">bookmark</span> **Bonus Tutorial**: 
+> The [handle scrolling][] cookbook recipe shows you how to verify that
+> lists of widgets contain the expected content by
+> scrolling through the lists using widget tests.
 
-[GestureArena (Decoding Flutter)]: {{site.youtube-site}}/watch?v=Q85LBtBdi0U
-[GestureDetector (Widget of the Week)]: {{site.youtube-site}}/watch?v=WhVXkCFPmK4
-[Handle taps]: /cookbook/gestures/handling-taps
 [Semantics (Flutter Widget of the Week)]: {{site.youtube-site}}/watch?v=NvtMt_DtFrQ?si=o79BqAg9NAl8EE8_
 [Tap, drag, and enter text]: /cookbook/testing/widget/tap-drag
-[Taps, drags, and other gestures]: /ui/interactivity/gestures#gestures
+[Handle scrolling]: /cookbook/testing/widget/scrolling
 
 ## Next: Networking
 
@@ -1112,40 +1192,7 @@ you can make your app even more interesting by adding
 external data. In the next section,
 you'll learn now to fetch data for your app over a network,
 how to convert data to and from JSON, authentication,
-and other networking features. 
-
-[scrolling]: /get-started/fwe/layout#scrolling-widgets
-
-[Add interactivity to your Flutter app]: /ui/interactivity
-[Material 3 Demo]: https://flutter.github.io/samples/web/material_3_demo/
-
-
-
-[`Checkbox`]: {{site.api}}/flutter/material/Checkbox-class.html
-[`CheckboxListTile`]: {{site.api}}/flutter/material/CheckboxListTile-class.html
-[CheckboxListTile (Widget of the Week)]: {{site.youtube-site}}/watch?v=RkSqPAn9szs
-[`Switch`]: {{site.api}}/flutter/material/Switch-class.html
-[`SwitchListTile`]: {{site.api}}/flutter/material/SwitchListTile-class.html
-[SwitchListTile (Widget of the Week)]: {{site.youtube-site}}/watch?v=0igIjvtEWNU
-[`Radio`]: {{site.api}}/flutter/material/Radio-class.html
-[`Chip`]: {{site.api}}/flutter/material/Chip-class.html
-
-[Material Design date picker]: https://m3.material.io/components/date-pickers/overview
-[Material Design time picker]: https://m3.material.io/components/time-pickers/overview
-[`showDatePicker`]: {{site.api}}/flutter/material/showDatePicker.html
-[`showTimePicker`]: {{site.api}}/flutter/material/showTimePicker.html
-
-[`Dismissible`]: {{site.api}}/flutter/widgets/Dismissible-class.html
-[Dismissible (Widget of the Week)]: {{site.youtube-site}}/watch?v=iEMgjrfuc58?si=f0S7IdaA9PIWIYvl
-[Implement swipe to dismiss]: /cookbook/gestures/dismissible
-[pkg: `flutter_slidable`]: {{site.pub}}/packages/flutter_slidable
-[flutter_slidable (Package of the Week)]: {{site.youtube-site}}/watch?v=QFcFEpFmNJ8
-
-
-[`GestureDetector`]: {{site.api}}/flutter/widgets/GestureDetector-class.html
-[`Semantics`]: {{site.api}}/flutter/widgets/Semantics-class.html
-
-[Handle scrolling]: /cookbook/testing/widget/scrolling
+and other networking features.
 
 ## Feedback
 


### PR DESCRIPTION
- Fixes a few spelling and grammar mistakes
- Uses Markdown syntax where possible
- Uses `<span>` instead of `<i>` for the material icons usages
- Standardizes markdown formatting
- Updates lines to be within 80 characters and more semantic breaks
- Fixes a few duplicate words and spaces
- Colocates markdown link definitions to be within the section they are used

Once this lands, I'll follow up this PR with some new syntax/features to reduce some duplication between the custom cards.