### PR TITLE
Remove use of third-party dependency for cookie banner

### DIFF
--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -99,7 +99,6 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.0/jquery.min.js" integrity="sha512-3gJwYpMe3QewGELv8k/BX9vcqhryRdzRMxVfq6ngyWXwo03GFEzjsUm8Q7RZcHPHksttq7/GFoxjCVUjkjvPdw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/js/bootstrap.min.js" integrity="sha512-7rusk8kGPFynZWu26OKbTeI+QPoYchtxsmPeBqkHIEXJxeun4yJ4ISYe7C6sz9wdxeE1Gk3VxsIWgCZTc+vX3g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/3.0.5/js.cookie.min.js" integrity="sha512-nlp9/l96/EpjYBx7EP7pGASVXNe80hGhYAUrjeXnu/fyF5Py0/RXav4BBNs7n5Hx1WFhOEOWSAVjGeC3oKxDVQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
     <script src="{{ '/assets/js/tabs.js' | append: cache_bust }}"></script>
     <script src="{{ '/assets/js/archive.js' | append: cache_bust }}"></script>

--- a/src/content/assets/js/main.js
+++ b/src/content/assets/js/main.js
@@ -171,23 +171,29 @@ function initFixedColumns() {
  * Activate the cookie notice footer.
  */
 function initCookieNotice() {
-  const notice = document.getElementById('cookie-notice');
-  const agreeBtn = document.getElementById('cookie-consent');
   const cookieKey = 'cookie-consent';
-  const cookieConsentValue = 'true'
-  const activeClass = 'show';
-
-  if (Cookies.get(cookieKey) === cookieConsentValue) {
-    return;
+  const currentDate = Date.now();
+  const existingDateString = window.localStorage.getItem(cookieKey);
+  if (existingDateString) {
+    const existingDate = parseInt(existingDateString);
+    const halfYearMs = 1000 * 60 * 60 * 24 * 180;
+    // If the last consent is less than 180 days old, don't show the notice.
+    if (currentDate - existingDate < halfYearMs) {
+      return;
+    }
   }
 
-  notice.classList.add(activeClass);
+  const notice = document.getElementById('cookie-notice');
+  const agreeBtn = document.getElementById('cookie-consent');
+  const activeClass = 'show';
 
   agreeBtn.addEventListener('click', (e) => {
     e.preventDefault();
-    Cookies.set(cookieKey, cookieConsentValue, { sameSite: 'strict', expires: 90 });
+    window.localStorage.setItem(cookieKey, currentDate.toString());
     notice.classList.remove(activeClass);
   });
+
+  notice.classList.add(activeClass);
 }
 
 function setupInlineToc() {

--- a/src/content/assets/js/main.js
+++ b/src/content/assets/js/main.js
@@ -176,10 +176,12 @@ function initCookieNotice() {
   const existingDateString = window.localStorage.getItem(cookieKey);
   if (existingDateString) {
     const existingDate = parseInt(existingDateString);
-    const halfYearMs = 1000 * 60 * 60 * 24 * 180;
-    // If the last consent is less than 180 days old, don't show the notice.
-    if (currentDate - existingDate < halfYearMs) {
-      return;
+    if (Number.isInteger(existingDate)) {
+      const halfYearMs = 1000 * 60 * 60 * 24 * 180;
+      // If the last consent is less than 180 days old, don't show the notice.
+      if (currentDate - existingDate < halfYearMs) {
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
Switch implementation of banner to use `localStorage` instead of cookies (through `js-cookie`) to:

- Reduce the amount of dependencies we have
- Reduce page loading time
- Make upcoming site design changes a bit easier