### PR TITLE
Fix: Text in other languages was removed from anchors

### DIFF
--- a/src/_11ty/utils/slugify.js
+++ b/src/_11ty/utils/slugify.js
@@ -14,7 +14,7 @@ export function slugify(text) {
     .toLowerCase()
     .trim()
     .replace(/[:.]/g, '-')
-    .replace(/[^a-z0-9\s:._-]/g, '')
+    .replace(/[^\p{L}\p{N}\s:._-]/gu, '')
     .replace(/[\s-]+/g, '-')
     .replace(/^-+|-+$/g, '');
 }


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

> Markdown
```md
## Hello! 你好！ हैलो مرحبا -
```

If the header contains text in other languages, those languages are removed:

```html
<div class="header-wrapper">
  <h2 id="hello">Hello! 你好！ हैलो مرحبا -</h2>
  <a class="heading-link" href="#hello" aria-label="Link to 'Hello! 你好！ हैलो مرحبا -' section">#</a>
</div>
```

The expected HTML looks like this:

```html
<div class="header-wrapper">
  <h2 id="hello-你好-हल-مرحبا">Hello! 你好！ हैलो مرحبا -</h2>
  <a class="heading-link" href="#hello-你好-हल-مرحبا" aria-label="Link to 'Hello! 你好！ हैलो مرحبا -' section">#</a>
</div>
```

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
