### PR TITLE
Make it clear that relative base hrefs are supported for the client/runtime if appropriately formed

### DIFF
--- a/src/content/ui/navigation/url-strategies.md
+++ b/src/content/ui/navigation/url-strategies.md
@@ -54,10 +54,10 @@ For example, to host your Flutter app at
 this tag to `<base href="/flutter_app/">`.
 
 Relative `base href` tags are supported for release builds but they must take
-into account the full URL where the page was served from. This means a relative
-`base href` for a request to `/flutter_app/`, `/flutter_app/nested/route`, and
-`/flutter_app/nested/route/` will be different (for example `"."`, `".."`, and
-`"../.."` accordingly).
+into account the full URL where the page was served from.
+This means a relative `base href` for a request to `/flutter_app/`,
+`/flutter_app/nested/route`, and `/flutter_app/nested/route/` will be different
+(for example `"."`, `".."`, and `"../.."` accordingly).
 
 [hash fragment]: https://en.wikipedia.org/wiki/Uniform_Resource_Locator#Syntax
 [`HashUrlStrategy`]: {{site.api}}/flutter/flutter_web_plugins/HashUrlStrategy-class.html

--- a/src/content/ui/navigation/url-strategies.md
+++ b/src/content/ui/navigation/url-strategies.md
@@ -35,7 +35,7 @@ PathUrlStrategy uses the [History API][], which requires additional
 configuration for web servers.
 
 To configure your web server to support PathUrlStrategy, check your web server's
-documentation to rewrite requests to `index.html`.Check your web server's
+documentation to rewrite requests to `index.html`. Check your web server's
 documentation for details on how to configure single-page apps.
 
 If you are using Firebase Hosting, choose the "Configure as a single-page app"
@@ -53,6 +53,11 @@ For example, to host your Flutter app at
 `my_app.dev/flutter_app`, change
 this tag to `<base href="/flutter_app/">`.
 
+Relative `base href` tags are supported for release builds but they must take
+into account the full URL where the page was served from. This means a relative
+`base href` for a request to `/flutter_app/`, `/flutter_app/nested/route`, and
+`/flutter_app/nested/route/` will be different (for example `"."`, `".."`, and
+`"../.."` accordingly).
 
 [hash fragment]: https://en.wikipedia.org/wiki/Uniform_Resource_Locator#Syntax
 [`HashUrlStrategy`]: {{site.api}}/flutter/flutter_web_plugins/HashUrlStrategy-class.html

--- a/src/content/ui/navigation/url-strategies.md
+++ b/src/content/ui/navigation/url-strategies.md
@@ -57,7 +57,7 @@ Relative `base href` tags are supported for release builds but they must take
 into account the full URL where the page was served from.
 This means a relative `base href` for a request to `/flutter_app/`,
 `/flutter_app/nested/route`, and `/flutter_app/nested/route/` will be different
-(for example `"."`, `".."`, and `"../.."` accordingly).
+(for example `"."`, `".."`, and `"../.."` respectively).
 
 [hash fragment]: https://en.wikipedia.org/wiki/Uniform_Resource_Locator#Syntax
 [`HashUrlStrategy`]: {{site.api}}/flutter/flutter_web_plugins/HashUrlStrategy-class.html


### PR DESCRIPTION
There are some places where a relative `base href` is not supported (and these are documented/validated), but there is nothing explicitly calling out that they are supported in the client app. This adds a note to solidify this so they can be used (for example in the DevTools server) without the worry of them being undocumented.

Fixes https://github.com/flutter/flutter/issues/154620

Related:
- https://github.com/flutter/devtools/issues/8067 - an issue best fixed by using relative `base href`s
- https://dart-review.googlesource.com/c/sdk/+/376682 - the change to use relative `base href`s in DevTools server

## Presubmit checklist

- [x] ~~This PR is marked as draft with an explanation if not meant to land until a future stable release.~~
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
