### PR TITLE
Clarify notice about installation in China

### DIFF
--- a/src/_includes/docs/china-notice.md
+++ b/src/_includes/docs/china-notice.md
@@ -1,11 +1,12 @@
 :::important
 If you want to use Flutter in China,
-check out [using Flutter in China][in china].
+check out [using Flutter in China][].
 If you're not developing in China, ignore this notice
 and follow the other instructions on this page.
 
 如果你正在中国的网络环境下配置 Flutter，
-请参考 [在中国网络环境下使用 Flutter][in china] 文档.
+请参考 [在中国网络环境下使用 Flutter][] 文档.
 :::
 
-[in china]: https://docs.flutter.cn/community/china/
+[using Flutter in China]: /community/china
+[在中国网络环境下使用 Flutter]: https://docs.flutter.cn/community/china/

--- a/src/_includes/docs/china-notice.md
+++ b/src/_includes/docs/china-notice.md
@@ -1,5 +1,11 @@
 :::important
-If you develop apps in China, check out [using Flutter in China][].
+If you want to use Flutter in China,
+check out [using Flutter in China][in china].
+If you're not developing in China, ignore this notice
+and follow the other instructions on this page.
+
+如果你正在中国的网络环境下配置 Flutter，
+请参考 [在中国网络环境下使用 Flutter][in china] 文档.
 :::
 
-[using Flutter in China]: /community/china
+[in china]: https://docs.flutter.cn/community/china/

--- a/src/_includes/docs/china-notice.md
+++ b/src/_includes/docs/china-notice.md
@@ -1,4 +1,4 @@
-:::important
+:::note Developing in China
 If you want to use Flutter in China,
 check out [using Flutter in China][].
 If you're not developing in China, ignore this notice


### PR DESCRIPTION
Clarify that the note is not meant to be for each country, but rather specifically for China.

Also add Chinese instructions to better catch the attention of Chinese readers.

Resolves https://github.com/flutter/website/issues/11158
Resolves https://github.com/flutter/website/issues/11166

**Staged:** https://flutter-docs-prod--pr11167-fix-clarify-china-notice-q4g69pok.web.app/get-started/install/