### PR TITLE
Improve formatting of code snippets in layout tutorial

### DIFF
--- a/examples/layout/lakes/step3/lib/main.dart
+++ b/examples/layout/lakes/step3/lib/main.dart
@@ -89,7 +89,7 @@ class TitleSection extends StatelessWidget {
 // #docregion button-with-text
 class ButtonSection extends StatelessWidget {
   const ButtonSection({super.key});
-// #enddocregion button-with-text
+  // #enddocregion button-with-text
 
   @override
   Widget build(BuildContext context) {
@@ -119,7 +119,7 @@ class ButtonSection extends StatelessWidget {
     );
     // #docregion button-start
   }
-// #docregion button-with-text
+  // #docregion button-with-text
 }
 // #enddocregion button-start
 
@@ -138,7 +138,7 @@ class ButtonWithText extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Column(
-// #enddocregion button-section
+      // #enddocregion button-section
       mainAxisSize: MainAxisSize.min,
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
@@ -155,9 +155,9 @@ class ButtonWithText extends StatelessWidget {
           ),
         ),
       ],
-// #docregion button-section
+      // #docregion button-section
     );
   }
-// #enddocregion button-with-text
+  // #enddocregion button-with-text
 }
 // #enddocregion button-section

--- a/src/content/ui/layout/tutorial.md
+++ b/src/content/ui/layout/tutorial.md
@@ -6,8 +6,6 @@ description: Learn how to build a layout in Flutter.
 
 {% assign examples = site.repo.this | append: "/tree/" | append: site.branch | append: "/examples" -%}
 
-<style>dl, dd { margin-bottom: 0; }</style>
-
 :::secondary What you'll learn
 * How to lay out widgets next to each other.
 * How to add space between widgets.
@@ -339,7 +337,7 @@ Add the following code after the `ButtonSection` class.
 ```dart
 class ButtonSection extends StatelessWidget {
   const ButtonSection({super.key});
-// ···
+  // ···
 }
 
 class ButtonWithText extends StatelessWidget {
@@ -438,7 +436,7 @@ class ButtonWithText extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Column(
-// ···
+      // ···
     );
   }
 }
@@ -546,10 +544,10 @@ To configure your app to reference images, modify its `pubspec.yaml` file.
    available to your code.
 
    ```yaml title="pubspec.yaml" diff
-    flutter:
-      uses-material-design: true
-   +  assets:
-   +    - images/lake.jpg
+     flutter:
+       uses-material-design: true
+   +   assets:
+   +     - images/lake.jpg
    ```
 
 :::tip
@@ -626,7 +624,7 @@ You can access the resources used in this tutorial from these locations:
 ## Next Steps
 
 To add interactivity to this layout, follow the
-[interactivity tutorial][Adding Interactivity to Your Flutter App].
+[interactivity tutorial][].
 
-[Adding Interactivity to Your Flutter App]: /ui/interactivity
+[interactivity tutorial]: /ui/interactivity
 [Unsplash]: https://unsplash.com


### PR DESCRIPTION
Fixes https://github.com/flutter/website/issues/11189 - The `f` was missing as the `diff` functionality expects a space after the + and - signs. So code should start on the 3rd column.

**Staged:** https://flutter-docs-prod--pr11190-fix-11189-v42bwqkr.web.app/ui/layout/tutorial