### PR TITLE
Add permalink to runWidget docs.

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -733,6 +733,7 @@
       { "source": "/to/wasm", "destination": "/platform-integration/web/wasm", "type": 301 },
       { "source": "/to/web-bootstrapping", "destination": "/platform-integration/web/initialization", "type": 301 },
       { "source": "/to/web-images", "destination": "/platform-integration/web/web-images", "type": 301 },
+      { "source": "/to/web-multiview-runwidget", "destination": "/platform-integration/web/embedding-flutter-web#replace-runapp-by-runwidget-in-dart", "type": 301 },
       { "source": "/to/web-renderers", "destination": "/platform-integration/web/renderers", "type": 301 },
       { "source": "/to/widget-testing", "destination": "/cookbook/testing/widget/introduction", "type": 301 },
       { "source": "/to/windows-android-setup", "destination": "/get-started/install/windows/mobile", "type": 301 },


### PR DESCRIPTION
## Description

We're adding a more descriptive error when a misconfigured multi-view web app attempts to run (flutter/flutter#155734), and we want a permalink to the relevant bit of the docs.

This PR adds a `/to/web-multiview-runwidget` redirect, pointing to the correct part of the docs.

## Issues

Needed for flutter/flutter#155734

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
