### PR TITLE
Remove outdated mention of iOS platform view cap

### DIFF
--- a/src/content/platform-integration/ios/platform-views.md
+++ b/src/content/platform-integration/ios/platform-views.md
@@ -382,16 +382,6 @@ Widget build(BuildContext context) {
 
 Platform views in Flutter come with performance trade-offs.
 
-For example, in a typical Flutter app, the Flutter UI is 
-composed on a dedicated raster thread. 
-This allows Flutter apps to be fast, 
-as the main platform thread is rarely blocked.
-
-When a platform view is rendered with hybrid composition, 
-the Flutter UI is composed from the platform thread. 
-The platform thread competes with other tasks 
-like handling OS or plugin messages.
-
 For complex cases, there are some techniques that can be used 
 to mitigate performance issues.
 


### PR DESCRIPTION
Removing outdated mention of platform view caps. As per https://github.com/flutter/website/pull/11159#discussion_r1765693398.

Fixes https://github.com/flutter/website/issues/11161

Please review, @jonahwilliams. Is this sufficient?