### PR TITLE
Update iOS flutterEngine libraryURI

### DIFF
--- a/src/content/add-to-app/ios/add-flutter-screen.md
+++ b/src/content/add-to-app/ios/add-flutter-screen.md
@@ -646,6 +646,14 @@ not be [tree-shaken][] away when compiling:
 @pragma('vm:entry-point')
 void myOtherEntrypoint() { ... };
 ```
+
+Additionally, If your entrypoint functions are not in `lib/main.dart` file,
+you need to import them in `lib/main.dart`.
+
+```dart
+// ignore: unused_import
+import 'package:your_package_name/other_file.dart';
+```
 :::
 
 ### Dart library
@@ -660,14 +668,14 @@ in `lib/other_file.dart` instead of `main()` in `lib/main.dart`:
 {% tab "Swift" %}
 
 ```swift
-flutterEngine.run(withEntrypoint: "myOtherEntrypoint", libraryURI: "other_file.dart")
+flutterEngine.run(withEntrypoint: "myOtherEntrypoint", libraryURI: "package:your_package_name/other_file.dart")
 ```
 
 {% endtab %}
 {% tab "Objective-C" %}
 
 ```objc
-[flutterEngine runWithEntrypoint:@"myOtherEntrypoint" libraryURI:@"other_file.dart"];
+[flutterEngine runWithEntrypoint:@"myOtherEntrypoint" libraryURI:@"package:your_package_name/other_file.dart"];
 ```
 
 {% endtab %}


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
I have to import another file in main and use package prefix in libraryURI
[reference](https://stackoverflow.com/questions/68253270/why-file-not-found-when-i-invoke-runwithentrypointlibraryuri-on-a-flutterengin)
_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
