### PR TITLE
[SwiftPM] Update guides after 3.27 release

### DIFF
--- a/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
+++ b/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
@@ -3,13 +3,7 @@
 Flutter's Swift Package Manager support is turned off by default.
 To turn it on:
 
-1. Switch to Flutter's `main` channel:
-
-   ```sh
-   flutter channel main --no-cache-artifacts
-   ```
-
-1. Upgrade to the latest Flutter SDK and download artifacts:
+1. Upgrade to the latest Flutter SDK:
 
    ```sh
    flutter upgrade

--- a/src/content/packages-and-plugins/swift-package-manager/for-app-developers.md
+++ b/src/content/packages-and-plugins/swift-package-manager/for-app-developers.md
@@ -7,8 +7,9 @@ description: How to use Swift Package Manager for native iOS or macOS dependenci
 Flutter is migrating to [Swift Package Manager][] to manage iOS and macOS native
 dependencies.
 Flutter's support of Swift Package Manager is under development.
-The implementation might change in the future.
-Swift Package Manager support is only available on the [`main` channel][].
+If you find a bug in Flutter's Swift Package Manager support,
+[open an issue][].
+Swift Package Manager support is [off by default][].
 Flutter continues to support CocoaPods.
 :::
 
@@ -21,11 +22,8 @@ Flutter's Swift Package Manager integration has several benefits:
    You don't need to install Ruby and CocoaPods if your project uses
    Swift Package Manager.
 
-If you find a bug in Flutter's Swift Package Manager support,
-[open an issue][].
-
 [Swift Package Manager]: https://www.swift.org/documentation/package-manager/
-[`main` channel]: /release/upgrade#switching-flutter-channels
+[off by default]: #how-to-turn-on-swift-package-manager
 [Swift packages]: https://swiftpackageindex.com/
 [open an issue]: {{site.github}}/flutter/flutter/issues/new?template=2_bug.yml
 

--- a/src/content/packages-and-plugins/swift-package-manager/for-plugin-authors.md
+++ b/src/content/packages-and-plugins/swift-package-manager/for-plugin-authors.md
@@ -7,25 +7,24 @@ description: How to add Swift Package Manager compatibility to iOS and macOS plu
 Flutter is migrating to [Swift Package Manager][]
 to manage iOS and macOS native dependencies.
 Flutter's support of Swift Package Manager is under development.
-The implementation might change in the future.
-Swift Package Manager support is only available on the [`main` channel][].
+If you find a bug in Flutter's Swift Package Manager support,
+[open an issue][].
+Swift Package Manager support is [off by default][].
 Flutter continues to support CocoaPods.
 :::
 
 Flutter's Swift Package Manager integration has several benefits:
 
-1. **Access to the Swift package ecosystem**.
+1. **Provides access to the Swift package ecosystem**.
    Flutter plugins can use the growing ecosystem of [Swift packages][]! 
 1. **Simplifies Flutter installation**.
    Swift Package Manager is bundled with Xcode.
    In the future, you won’t need to install Ruby and CocoaPods to target iOS or
    macOS.
 
-If you find a bug in Flutter's Swift Package Manager support,
-[open an issue][].
 
 [Swift Package Manager]: https://www.swift.org/documentation/package-manager/
-[`main` channel]: /release/upgrade#switching-flutter-channels
+[off by default]: #how-to-turn-on-swift-package-manager
 [Swift packages]: https://swiftpackageindex.com/
 [open an issue]: {{site.github}}/flutter/flutter/issues/new?template=2_bug.yml
 


### PR DESCRIPTION
After the 3.27 release, Swift Package Manager feature is now available on the "beta" and "stable" branches (but defaults to off). This updates the SwiftPM guides accordingly.

Depends on: https://github.com/flutter/flutter/pull/155964
Part of: https://github.com/flutter/flutter/issues/153449

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
