### PR TITLE
Update url-strategies.md

### DIFF
--- a/src/content/ui/navigation/url-strategies.md
+++ b/src/content/ui/navigation/url-strategies.md
@@ -17,8 +17,15 @@ For example, `flutterexample.dev/#/path/to/screen`.
 ## Configuring the URL strategy
 
 To configure Flutter to use the path instead, use the
-[usePathUrlStrategy][] function provided by the [flutter_web_plugins][] library
-in the SDK:
+[usePathUrlStrategy][] function provided by the [flutter_web_plugins][] library,
+which is part of the Flutter SDK.
+
+You cannot directly add `flutter_web_plugins` via `pub add`,
+as it is only available through dependencies like `go_router`. 
+When you add the `go_router` package, it automatically includes
+`flutter_web_plugins`. 
+
+Here's an example of how to use it:
 
 ```dart
 import 'package:flutter_web_plugins/url_strategy.dart';

--- a/src/content/ui/navigation/url-strategies.md
+++ b/src/content/ui/navigation/url-strategies.md
@@ -20,10 +20,16 @@ To configure Flutter to use the path instead, use the
 [usePathUrlStrategy][] function provided by the [flutter_web_plugins][] library,
 which is part of the Flutter SDK.
 
-You cannot directly add `flutter_web_plugins` via `pub add`,
-as it is only available through dependencies like `go_router`. 
-When you add the `go_router` package, it automatically includes
-`flutter_web_plugins`. 
+You cannot directly add `flutter_web_plugins` using `pub add`.
+Include it as a Flutter SDK dependency in your `pubspec.yaml` file:
+
+```dart
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_web_plugins:
+    sdk: flutter
+```
 
 Here's an example of how to use it:
 

--- a/src/content/ui/navigation/url-strategies.md
+++ b/src/content/ui/navigation/url-strategies.md
@@ -20,7 +20,7 @@ To configure Flutter to use the path instead, use the
 [usePathUrlStrategy][] function provided by the [flutter_web_plugins][] library,
 which is part of the Flutter SDK.
 
-You cannot directly add `flutter_web_plugins` using `pub add`.
+You can't directly add `flutter_web_plugins` using `pub add`.
 Include it as a Flutter SDK dependency in your `pubspec.yaml` file:
 
 ```dart


### PR DESCRIPTION
You can't add flutter_web_plugins directly using pub add. Its only included as part of the project if required by other dependencies like go_router.

_Description of what this PR is changing or adding, and why:_

Added additional information on how to add flutter_web_plugins to project to use usePathUrlStrategy() function.  

_Issues fixed by this PR (if any):_

You can't add flutter_web_plugins directly using pub add or other methods. 

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
