### PR TITLE
Remove codelabs.flutter-io.cn

### DIFF
--- a/src/content/codelabs/index.md
+++ b/src/content/codelabs/index.md
@@ -316,11 +316,3 @@ like iOS, Android, desktop, or the web.
 [home-screen]: {{site.codelabs}}/flutter-home-screen-widgets
 [provider]: {{site.pub-pkg}}/provider
 [Write a Flutter desktop application]: {{site.codelabs}}/codelabs/flutter-github-client
-
-:::note
-If you have trouble viewing any of the codelabs
-on [`codelabs.developers.google.com`]({{site.codelabs}}), try
-[this mirror of the Flutter codelabs][].
-:::
-
-[this mirror of the Flutter codelabs]: https://codelabs.flutter-io.cn/


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

**[codelabs.flutter-io.cn](https://codelabs.flutter-io.cn)** site will be shut down in the near future ([internal discussions](https://github.com/cfug)).
We are now using **[codelabs.developers.google.cn](https://codelabs.developers.google.cn)**.

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
