### PR TITLE
Fix new surface provider camerax PR url

### DIFF
--- a/src/content/release/breaking-changes/android-surface-plugins.md
+++ b/src/content/release/breaking-changes/android-surface-plugins.md
@@ -163,7 +163,7 @@ Relevant PRs:
 [`CameraCharacteristics.SENSOR_ORIENTATION`]: {{site.android-dev}}/reference/android/hardware/camera2/CameraCharacteristics#SENSOR_ORIENTATION
 [`RotatedBox`]: {{site.api}}/flutter/widgets/RotatedBox-class.html
 [Android orientation calculation documentation]: {{site.android-dev}}/media/camera/camera2/camera-preview#orientation_calculation
-[this `camera_android_camerax` PR]: {{site.repo.flutter}}/packages/pull/7044
+[this `camera_android_camerax` PR]: {{site.repo.packages}}/pull/7044
 [Issue 139702]: {{site.repo.flutter}}/issues/139702
 [Issue 145930]: {{site.repo.flutter}}/issues/145930
 [PR 51061]: {{site.repo.engine}}/pull/51061


### PR DESCRIPTION
The current URL `https://github.com/flutter/flutter/packages/pull/7044` does not exist, it should be `https://github.com/flutter/packages/pull/7044` instead

_Description of what this PR is changing or adding, and why:_

In page about the [new surface provider](https://docs.flutter.dev/release/breaking-changes/android-surface-plugins):
The URL of `this camera_android_camerax PR` https://github.com/flutter/flutter/packages/pull/7044 does not exist, it should be https://github.com/flutter/packages/pull/7044 instead.

_Issues fixed by this PR (if any):_

None

_PRs or commits this PR depends on (if any):_

None

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
