### PR TITLE
Fix typo in sidenav for in Cookbook Animation "Animate a widget using a physics simulation“

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -348,7 +348,7 @@
       permalink: /ui/animations/hero-animations
     - title: Animate a page route transition
       permalink: /cookbook/animation/page-route-animation
-    - title: Animate using a physic simulation
+    - title: Animate using a physics simulation
       permalink: /cookbook/animation/physics-simulation
     - title: Staggered animations
       permalink: /ui/animations/staggered-animations


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Fixes a missing letter in the sidenav for the text "Animate a widget using a physics simulation".

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
