### PR TITLE
updated slugify function to replace + with plus

### DIFF
--- a/src/_11ty/utils/slugify.js
+++ b/src/_11ty/utils/slugify.js
@@ -13,6 +13,7 @@ export function slugify(text) {
   return text
     .toLowerCase()
     .trim()
+    .replace(/\+/g, 'plus')
     .replace(/[:.]/g, '-')
     .replace(/[^\p{L}\p{N}\s:._-]/gu, '')
     .replace(/[\s-]+/g, '-')


### PR DESCRIPTION
This PR updates the `slugify` function to replace the '+' character with 'plus' to avoid slug collision between "C" and "C++". This change ensures unique slugs for both, resolving issues in tab navigation where both tabs were treated as the same.

Fixes #11225