### PR TITLE
fix: typo in /get-started/fundamentals/state-management.md

### DIFF
--- a/src/content/get-started/fundamentals/state-management.md
+++ b/src/content/get-started/fundamentals/state-management.md
@@ -482,7 +482,7 @@ class CounterViewModel extends ChangeNotifier {
       await model.updateCountOnServer(count + 1);
       count++;
     } catch(e) {
-      errorMessage = 'Count not update count';
+      errorMessage = 'Could not update count';
     }
     notifyListeners();
   }


### PR DESCRIPTION
This PR fixes a minor typo in https://docs.flutter.dev/get-started/fundamentals/state-management#defining-the-viewmodel

The example used in this section mistakenly assigned 'Cou**nt** not update count' to an error message instead of 'Cou**ld** not update count'

## Presubmit checklist
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
