### PR TITLE
Update layout.md (Just a one word typo)

### DIFF
--- a/src/content/get-started/fundamentals/layout.md
+++ b/src/content/get-started/fundamentals/layout.md
@@ -287,7 +287,7 @@ before, and after each image.
 
 {% render docs/code-and-image.md,
 image:"fwe/layout/space_evenly.png",
-caption: "This figure shows a row widget with three children, which are aligned with the crossAxisAlignment.spaceEvenly constant."
+caption: "This figure shows a row widget with three children, which are aligned with the MainAxisAlignment.spaceEvenly constant."
 alt: "A screenshot of three widgets, spaced evenly from each other."
 code:"
 ```dart


### PR DESCRIPTION
It had a typo, instead of 'crossAxisAlignment' it should have been 'MainAxisAlignment'. As spaceEvenly is applied on main axis of the Row as shown in picture and not on crossAxis, as it was written in caption for that image.
Just replaced 'crossAxisAlignment.spaceEvenly' with 'MainAxisAlignment.spaceEvenly'.