### PR TITLE
Turn flutter_site tool into part of root workspace

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,6 +4,5 @@ publish_to: none
 environment:
   sdk: ^3.5.0
 
-dev_dependencies:
-  flutter_site:
-    path: tool/flutter_site
+workspace:
+  - tool/flutter_site

--- a/tool/flutter_site/pubspec.yaml
+++ b/tool/flutter_site/pubspec.yaml
@@ -2,6 +2,7 @@ name: flutter_site
 description: Dart-based tools for building docs.flutter.dev.
 publish_to: none
 
+resolution: workspace
 environment:
   sdk: ^3.5.0
 


### PR DESCRIPTION
This will allow us to share one package resolution for all tools on the site.

In Dart 3.6, we'll do the same for the examples directory.