### PR TITLE
Update page-route-animation.md

### DIFF
--- a/src/content/cookbook/animation/page-route-animation.md
+++ b/src/content/cookbook/animation/page-route-animation.md
@@ -108,7 +108,7 @@ full height of the page.
 
 The `transitionsBuilder` callback has an `animation` parameter. It's an
 `Animation<double>` that produces values between 0 and 1. Convert the
-Animation<double> into an Animation<Offset> using a Tween:
+`Animation<double>` into an `Animation<Offset>` using a Tween:
 
 <?code-excerpt "lib/starter.dart (step1)"?>
 ```dart


### PR DESCRIPTION
Fix typo in step 2 of page animation transition cookbook.

Add backquote to Animation<double> because it didn't render correctly.

