### PR TITLE
Migration guide for `ThemeData.dialogBackgroundColor` deprecation

### DIFF
--- a/src/content/release/breaking-changes/deprecate-themedata-dialogbackgroundcolor.md
+++ b/src/content/release/breaking-changes/deprecate-themedata-dialogbackgroundcolor.md
@@ -9,7 +9,7 @@ description: >-
 ## Summary
 
 The [`ThemeData.dialogBackgroundColor`][] parameter was deprecated in favor of
-[`DialogThemeData.backgroundColor`][] parameter.
+the [`DialogThemeData.backgroundColor`][] parameter.
 
 ## Context
 

--- a/src/content/release/breaking-changes/deprecate-themedata-dialogbackgroundcolor.md
+++ b/src/content/release/breaking-changes/deprecate-themedata-dialogbackgroundcolor.md
@@ -22,7 +22,7 @@ override the default dialog background color, which was made redundant by
 ## Description of change
 
 The [`ThemeData.dialogBackgroundColor`][] is deprecated in favor of
-component-specific theme. Use [`DialogThemeData`][] to override the default
+a component-specific theme. Use [`DialogThemeData`][] to override the default
 background color.
 
 ## Migration guide

--- a/src/content/release/breaking-changes/deprecate-themedata-dialogbackgroundcolor.md
+++ b/src/content/release/breaking-changes/deprecate-themedata-dialogbackgroundcolor.md
@@ -1,0 +1,79 @@
+---
+title: Deprecate `ThemeData.dialogBackgroundColor` in favor of
+  `DialogThemeData.backgroundColor`
+description: >-
+  The `ThemeData.dialogBackgroundColor` parameter has been replaced by
+  `DialogThemeData.backgroundColor`.
+---
+
+## Summary
+
+The [`ThemeData.dialogBackgroundColor`][] parameter was deprecated in favor of
+[`DialogThemeData.backgroundColor`][] parameter.
+
+## Context
+
+The defaults for the [`Dialog`][] and [`AlertDialog`][] widgets can be
+overridden with component-specific theme like [`DialogThemeData`][].
+Previously, the `ThemeData.dialogBackgroundColor` parameter was used to
+override the default dialog background color, which was made redundant by
+[`DialogThemeData`][].
+
+## Description of change
+
+The [`ThemeData.dialogBackgroundColor`][] is deprecated in favor of
+component-specific theme. Use [`DialogThemeData`][] to override the default
+background color.
+
+## Migration guide
+
+Replace [`ThemeData.dialogBackgroundColor`][] with
+[`DialogThemeData.backgroundColor`][] to override the default dialog background
+color.
+
+Code before migration:
+
+```dart
+theme: ThemeData(
+  dialogBackgroundColor: Colors.orange,
+),
+```
+
+Code after migration:
+
+```dart
+theme: ThemeData(
+  dialogTheme: const DialogThemeData(backgroundColor: Colors.orange),
+),
+```
+
+## Timeline
+
+Landed in version: v3.27.0-0.1.pre<br>
+In stable release: TBD
+
+## References
+
+API documentation:
+
+- [`ThemeData.dialogBackgroundColor`][]
+- [`DialogThemeData.backgroundColor`][]
+- [`DialogThemeData`][]
+- [`Dialog`][]
+- [`AlertDialog`][]
+
+Relevant issues:
+
+- [Issue #91772][]
+
+Relevant PRs:
+
+- [Deprecate `ThemeData.dialogBackgroundColor` in favor of `DialogTheme.backgroundColor`][]
+
+[`ThemeData.dialogBackgroundColor`]: {{site.api}}/flutter/material/ThemeData/dialogBackgroundColor.html
+[`DialogThemeData.backgroundColor`]: {{site.api}}/flutter/material/DialogThemeData/backgroundColor.html
+[`DialogThemeData`]: {{site.api}}/flutter/material/DialogThemeData-class.html
+[`Dialog`]: {{site.api}}/flutter/material/Dialog-class.html
+[`AlertDialog`]: {{site.api}}/flutter/material/AlertDialog-class.html
+[Issue #91772]: {{site.repo.flutter}}/issues/91772
+[Deprecate `ThemeData.dialogBackgroundColor` in favor of `DialogTheme.backgroundColor`]: {{site.repo.flutter}}/pull/155072

--- a/src/content/release/breaking-changes/deprecate-themedata-dialogbackgroundcolor.md
+++ b/src/content/release/breaking-changes/deprecate-themedata-dialogbackgroundcolor.md
@@ -14,7 +14,7 @@ the [`DialogThemeData.backgroundColor`][] parameter.
 ## Context
 
 The defaults for the [`Dialog`][] and [`AlertDialog`][] widgets can be
-overridden with component-specific theme like [`DialogThemeData`][].
+overridden with a component-specific theme like [`DialogThemeData`][].
 Previously, the `ThemeData.dialogBackgroundColor` parameter was used to
 override the default dialog background color, which was made redundant by
 [`DialogThemeData`][].

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -38,12 +38,14 @@ release, and listed in alphabetical order:
 * [Stop generating `AssetManifest.json`][]
 * [Deprecate `TextField.canRequestFocus`][]
 * [Set default for SystemUiMode to Edge-to-Edge][]
+* [Deprecate `ThemeData.dialogBackgroundColor` in favor of `DialogThemeData.backgroundColor`][]
 
 [`Color` wide gamut support]: /release/breaking-changes/wide-gamut-framework
 [Remove invalid parameters for `InputDecoration.collapsed`]: /release/breaking-changes/input-decoration-collapsed
 [Stop generating `AssetManifest.json`]: /release/breaking-changes/asset-manifest-dot-json
 [Deprecate `TextField.canRequestFocus`]: /release/breaking-changes/can-request-focus
 [Set default for SystemUiMode to Edge-to-Edge]: /release/breaking-changes/default-systemuimode-edge-to-edge
+[Deprecate `ThemeData.dialogBackgroundColor` in favor of `DialogThemeData.backgroundColor`]: /release/breaking-changes/deprecate-themedata-dialogbackgroundcolor
 
 <a id="released-in-flutter-324" aria-hidden="true"></a>
 ### Released in Flutter 3.24


### PR DESCRIPTION
Related to https://github.com/flutter/flutter/pull/155072

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
