### PR TITLE
Remove test-drive page from get-started flow

### DIFF
--- a/src/content/get-started/codelab.md
+++ b/src/content/get-started/codelab.md
@@ -3,8 +3,8 @@ title: Write your first Flutter app
 description: How to write an app in Flutter.
 short-title: Write your first app
 prev:
-  title: Test drive
-  path: /get-started/test-drive
+  title: Set up Flutter
+  path: /get-started/install
 next:
   title: Learn more
   path: /get-started/learn-flutter

--- a/src/content/get-started/editor.md
+++ b/src/content/get-started/editor.md
@@ -2,11 +2,11 @@
 title: Set up an editor
 description: Configuring an IDE for Flutter.
 prev:
-  title: Install
+  title: Set up Flutter
   path: /get-started/install
 next:
-  title: Test drive
-  path: /get-started/test-drive
+  title: Create your first app
+  path: /get-started/codelab
 toc: false
 ---
 
@@ -33,7 +33,9 @@ Follow these procedures to add the Flutter plugin to VS Code,
 Android Studio, or IntelliJ.
 
 If you choose another IDE, skip ahead
-to the [next step: Test drive](/get-started/test-drive).
+to [Write your first Flutter app][].
+
+[Write your first Flutter app]: /get-started/codelab
 
 {% tabs %}
 {% tab "Visual Studio Code" %}

--- a/src/content/get-started/install/chromeos/android.md
+++ b/src/content/get-started/install/chromeos/android.md
@@ -6,8 +6,8 @@ target: Android
 config: ChromeOSAndroid
 devos: ChromeOS
 next:
-  title: Create a test app
-  path: /get-started/test-drive
+  title: Create your first app
+  path: /get-started/codelab
 ---
 
 {% include docs/install/reqs/linux/base.md os=devos target=target %}

--- a/src/content/get-started/install/chromeos/web.md
+++ b/src/content/get-started/install/chromeos/web.md
@@ -6,8 +6,8 @@ target: Web
 config: ChromeOSWeb
 devos: ChromeOS
 next:
-  title: Create a test app
-  path: /get-started/test-drive
+  title: Create your first app
+  path: /get-started/codelab
 ---
 
 {% include docs/install/reqs/linux/base.md os=devos target=target %}

--- a/src/content/get-started/install/linux/android.md
+++ b/src/content/get-started/install/linux/android.md
@@ -6,8 +6,8 @@ target: Android
 config: LinuxAndroid
 devos: Linux
 next:
-  title: Create a test app
-  path: /get-started/test-drive
+  title: Create your first app
+  path: /get-started/codelab
 ---
 
 {% include docs/install/reqs/linux/base.md os=devos target=target %}

--- a/src/content/get-started/install/linux/desktop.md
+++ b/src/content/get-started/install/linux/desktop.md
@@ -6,8 +6,8 @@ target: desktop
 config: LinuxDesktop
 devos: Linux
 next:
-  title: Create a test app
-  path: /get-started/test-drive
+  title: Create your first app
+  path: /get-started/codelab
 ---
 
 {% include docs/install/reqs/linux/base.md os=devos target=target %}

--- a/src/content/get-started/install/linux/web.md
+++ b/src/content/get-started/install/linux/web.md
@@ -6,8 +6,8 @@ target: Web
 config: LinuxWeb
 devos: Linux
 next:
-  title: Create a test app
-  path: /get-started/test-drive
+  title: Create your first app
+  path: /get-started/codelab
 ---
 
 {% include docs/install/reqs/linux/base.md os=devos target=target %}

--- a/src/content/get-started/install/macos/desktop.md
+++ b/src/content/get-started/install/macos/desktop.md
@@ -6,8 +6,8 @@ target: desktop
 config: macOSDesktop
 devos: macOS
 next:
-  title: Create a test app
-  path: /get-started/test-drive
+  title: Create your first app
+  path: /get-started/codelab
 ---
 
 {% include docs/install/reqs/macos/base.md os=devos target=target %}

--- a/src/content/get-started/install/macos/mobile-android.md
+++ b/src/content/get-started/install/macos/mobile-android.md
@@ -6,8 +6,8 @@ target: Android
 config: macOSAndroid
 devos: macOS
 next:
-  title: Create a test app
-  path: /get-started/test-drive
+  title: Create your first app
+  path: /get-started/codelab
 ---
 
 {% include docs/install/reqs/macos/base.md os=devos target=target %}

--- a/src/content/get-started/install/macos/mobile-ios.md
+++ b/src/content/get-started/install/macos/mobile-ios.md
@@ -6,8 +6,8 @@ target: iOS
 config: macOSiOS
 devos: macOS
 next:
-  title: Create a test app
-  path: /get-started/test-drive
+  title: Create your first app
+  path: /get-started/codelab
 ---
 
 {% include docs/install/reqs/macos/base.md os=devos target=target %}

--- a/src/content/get-started/install/macos/web.md
+++ b/src/content/get-started/install/macos/web.md
@@ -6,8 +6,8 @@ target: web
 config: macOSWeb
 devos: macOS
 next:
-  title: Create a test app
-  path: /get-started/test-drive
+  title: Create your first app
+  path: /get-started/codelab
 ---
 
 {% include docs/install/reqs/macos/base.md os=devos target=target %}

--- a/src/content/get-started/install/windows/desktop.md
+++ b/src/content/get-started/install/windows/desktop.md
@@ -6,8 +6,8 @@ target: desktop
 config: WindowsDesktop
 devos: Windows
 next:
-  title: Create a test app
-  path: /get-started/test-drive
+  title: Create your first app
+  path: /get-started/codelab
 ---
 
 {% include docs/install/reqs/windows/base.md os=devos target=target %}

--- a/src/content/get-started/install/windows/mobile.md
+++ b/src/content/get-started/install/windows/mobile.md
@@ -6,8 +6,8 @@ target: Android
 config: WindowsAndroid
 devos: Windows
 next:
-  title: Create a test app
-  path: /get-started/test-drive
+  title: Create your first app
+  path: /get-started/codelab
 ---
 
 {% include docs/install/reqs/windows/base.md os=devos target=target %}

--- a/src/content/get-started/install/windows/web.md
+++ b/src/content/get-started/install/windows/web.md
@@ -6,8 +6,8 @@ target: web
 config: WindowsWeb
 devos: Windows
 next:
-  title: Create a test app
-  path: /get-started/test-drive
+  title: Create your first app
+  path: /get-started/codelab
 ---
 
 {% include docs/install/reqs/windows/base.md os=devos target=target %}

--- a/src/content/get-started/test-drive/index.md
+++ b/src/content/get-started/test-drive/index.md
@@ -2,7 +2,7 @@
 title: Test drive
 description: How to create a templated Flutter app and use hot reload.
 prev:
-  title: Install Flutter
+  title: Set up Flutter
   path: /get-started/install
 next:
   title: Write your first Flutter app


### PR DESCRIPTION
This page was inconsistently included in prev->next flows for some old and new get started pages, and its content overlaps with the content in [Write your first Flutter app](https://docs.flutter.dev/get-started/codelab).

Contributes to https://github.com/flutter/website/issues/11301