### PR TITLE
Fix incorrect assetBase documentation

### DIFF
--- a/src/content/platform-integration/web/initialization.md
+++ b/src/content/platform-integration/web/initialization.md
@@ -116,6 +116,7 @@ arguments to customize initialization behavior:
 
 | Name                    | Description                                                                                                                   | JS&nbsp;type |
 |-------------------------|-------------------------------------------------------------------------------------------------------------------------------|--------------|
+|`assetBase`              | The base URL of the `assets` directory of the app. Add this when Flutter loads from a different domain or subdirectory than the actual web app. You might need this when you embed Flutter web into another app, or when you deploy its assets to a CDN. |`string`|
 | `config`                | The Flutter configuration of your app.                                                                                        | `Object`     |
 | `onEntrypointLoaded`    | The function called when the engine is ready to be initialized. Receives an `engineInitializer` object as its only parameter. | `Function`   |
 | `serviceWorkerSettings` | The configuration for the `flutter_service_worker.js` loader. (If not set, the service worker isn't used.)                    | `Object`     |
@@ -126,7 +127,6 @@ The `config` argument is an object that can have the following optional fields:
 
 | Name | Description | Dart&nbsp;type |
 |---|---|---|
-|`assetBase`| The base URL of the `assets` directory of the app. Add this when Flutter loads from a different domain or subdirectory than the actual web app. You might need this when you embed Flutter web into another app, or when you deploy its assets to a CDN. |`String`|
 |`canvasKitBaseUrl`| The base URL from where `canvaskit.wasm` is downloaded. |`String`|
 |`canvasKitVariant`| The CanvasKit variant to download. Your options cover:<br><br>1. `auto`: Downloads the optimal variant for the browser. The option defaults to this value.<br>2. `full`: Downloads the full variant of CanvasKit that works in all browsers.<br>3. `chromium`: Downloads a smaller variant of CanvasKit that uses Chromium compatible APIs. **_Warning_**: Don't use the `chromium` option unless you plan on only using Chromium-based browsers. |`String`|
 |`canvasKitForceCpuOnly`| When `true`, forces CPU-only rendering in CanvasKit (the engine won't use WebGL). |`bool`|

--- a/src/content/platform-integration/web/initialization.md
+++ b/src/content/platform-integration/web/initialization.md
@@ -116,7 +116,6 @@ arguments to customize initialization behavior:
 
 | Name                    | Description                                                                                                                   | JS&nbsp;type |
 |-------------------------|-------------------------------------------------------------------------------------------------------------------------------|--------------|
-|`assetBase`              | The base URL of the `assets` directory of the app. Add this when Flutter loads from a different domain or subdirectory than the actual web app. You might need this when you embed Flutter web into another app, or when you deploy its assets to a CDN. |`string`|
 | `config`                | The Flutter configuration of your app.                                                                                        | `Object`     |
 | `onEntrypointLoaded`    | The function called when the engine is ready to be initialized. Receives an `engineInitializer` object as its only parameter. | `Function`   |
 | `serviceWorkerSettings` | The configuration for the `flutter_service_worker.js` loader. (If not set, the service worker isn't used.)                    | `Object`     |
@@ -194,8 +193,9 @@ The initialization process is split into the following stages:
 : The `onEntrypointLoaded` callback receives an
   **engine initializer** object as its only parameter.
   Use the engine initializer `initializeEngine()` function to
-  set the run-time configuration, like `multiViewEnabled: true`,
-  and start the Flutter web engine.
+  set run-time configuration options like `multiViewEnabled: true`
+  and `assetBase` (useful when Flutter loads from a different domain
+  or subdirectory than the actual web app).
 
 **Running the app**
 : The `initializeEngine()` function returns a [`Promise`][js-promise]


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Fixing a documentation bug.

_Issues fixed by this PR (if any):_ #11341 

_PRs or commits this PR depends on (if any):_ N/A

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
