### PR TITLE
Update minimum recommended CocoaPods version to support Xcode 16

### DIFF
--- a/src/_data/site.yml
+++ b/src/_data/site.yml
@@ -71,7 +71,7 @@ appmin:
   android_sdk: 21
   powershell: 5.0
   xcode: '14'
-  cocoapods: '1.10'
+  cocoapods: '1.16'
 devmin:
   windows: '64-bit version of Microsoft Windows 10'
   macos: '11 (Big Sur)'

--- a/src/_data/site.yml
+++ b/src/_data/site.yml
@@ -98,4 +98,4 @@ appnow:
   powershell: 5.1
   xcode: '15'
   ios: '17'
-  cocoapods: '1.15'
+  cocoapods: '1.16'

--- a/src/_includes/docs/add-to-app/ios-project/embed-cocoapods.md
+++ b/src/_includes/docs/add-to-app/ios-project/embed-cocoapods.md
@@ -55,12 +55,8 @@ This section presumes you called your Swift app `MyApp`.
    Use the `pod init` command to create the `Podfile` file.
 
    :::warning
-   CocoaPods (as of version 1.15.2) does not support Xcode 16.
-   If the `pod init` command errors, consider re-creating your Xcode project
-   using Xcode 15 or older.
-
-   To learn more about the CocoaPods issue, check out
-   [CocoaPods#12456](https://github.com/CocoaPods/CocoaPods/issues/12456).
+   If the `pod init` command errors,
+   check that you're on the latest version of CocoaPods.
    :::
 
 1. Update your `Podfile` config file.

--- a/src/_includes/docs/add-to-app/ios-project/embed-cocoapods.md
+++ b/src/_includes/docs/add-to-app/ios-project/embed-cocoapods.md
@@ -54,7 +54,7 @@ This section presumes you called your Swift app `MyApp`.
    navigate to the root of your app directory.
    Use the `pod init` command to create the `Podfile` file.
 
-   :::warning
+   :::tip
    If the `pod init` command errors,
    check that you're on the latest version of CocoaPods.
    :::


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Xcode 16 introduced new types to its project format. Customers should update to CocoaPods 1.16 or higher to support this new project format.

_Issues fixed by this PR (if any):_ Part of https://github.com/flutter/flutter/issues/157737

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
