### PR TITLE
Update the "setState called during build" in common-errors.md

### DIFF
--- a/src/content/testing/common-errors.md
+++ b/src/content/testing/common-errors.md
@@ -443,46 +443,27 @@ attempting to trigger a `Dialog` from within the
 immediately show information to the user,
 but `setState` should never be called from a `build` method.
 
-The following code illustrates a common culprit of this error:
+The following snippet seems to be a common culprit of this error:
 
 <?code-excerpt "lib/set_state_build.dart (problem)"?>
 ```dart
-import 'package:flutter/material.dart';
-
-void main() => runApp(const ShowDialogExampleApp());
-
-class ShowDialogExampleApp extends StatelessWidget {
-  const ShowDialogExampleApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: DialogExample(),
-    );
-  }
-}
-
-class DialogExample extends StatelessWidget {
-  const DialogExample({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    // Don't do this:    
-    showDialog(
+Widget build(BuildContext context) {
+  // Don't do this.
+  showDialog(
       context: context,
-      builder: (BuildContext context) {
+      builder: (context) {
         return const AlertDialog(
           title: Text('Alert Dialog'),
         );
-      },
-    );
-    return Scaffold(
-      appBar: AppBar(title: const Text('This does not work')),
-      body: const Center(
-        child: Text('Does not Work'),
-      ),
-    );
-  }
+      });
+
+  return const Center(
+    child: Column(
+      children: <Widget>[
+        Text('Show Material Dialog'),
+      ],
+    ),
+  );
 }
 ```
 
@@ -496,7 +477,8 @@ framework for every frame, for example, during an animation.
 
 One way to avoid this error is instruct flutter to finish rendering the page
 before calling `showDialog()`. This can be done by using
-addPostFrameCallback() method. The following code illustrates this on the broken example just given:
+addPostFrameCallback() method. 
+The following code illustrates this on the broken example just given:
 
 <?code-excerpt "lib/set_state_build.dart (solution)"?>
 ```dart

--- a/src/content/testing/common-errors.md
+++ b/src/content/testing/common-errors.md
@@ -495,7 +495,7 @@ framework for every frame, for example, during an animation.
 **How to fix it?**
 
 One way to avoid this error is instruct flutter to finish rendering the page
-before implementing the showDialog. This can be done by using
+before calling `showDialog()`. This can be done by using
 addPostFrameCallback() method. The following code illustrates this on the broken example just given:
 
 <?code-excerpt "lib/set_state_build.dart (solution)"?>

--- a/src/content/testing/common-errors.md
+++ b/src/content/testing/common-errors.md
@@ -456,10 +456,8 @@ class ShowDialogExampleApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      theme: ThemeData(
-          colorSchemeSeed: const Color(0xff6750a4), useMaterial3: true),
-      home: const DialogExample(),
+    return const MaterialApp(
+      home: DialogExample(),
     );
   }
 }


### PR DESCRIPTION
I ran into the error "setState called during build" while writing an app which uses the pluto_grid package. I had the need to validate a cell in the onChanged callback of the grid, but got the error when I tried to do a showDialog to alert the user to an error. 
To solve it I went to the common-errors page in the flutter docs, but found a) the code describing the problem was a snippet with no obvious functionality and b) the solution code is for a different situation, not a direct solution to either my problem or the one in the given snippet.

I can see that there are different solutions in different scenarios (Navigator, FutureBuilder, addPostFrameCallback) but I feel the addPostFrameCallback is the most intuitive and direct, particularly in the showDialog scenario.

The example code I give is a bit arbitrary and useless, but I can see that including code with the pluto_grid package would be inappropriate, and I wasn't sure what else I could use for an illustration.

This is my first attempt at contributing to an Open Source project of any sort. Please let me know if I've messed up., so I can improve at the procedure.
