### PR TITLE
Add "Open in IDX" for Flutter website development

### DIFF
--- a/.idx/dev.nix
+++ b/.idx/dev.nix
@@ -1,0 +1,51 @@
+# To learn more about how to use Nix to configure your environment
+# see: https://developers.google.com/idx/guides/customize-idx-env
+{ pkgs, ... }: {
+  # Which nixpkgs channel to use.
+  channel = "stable-24.05"; # or "unstable"
+
+  # Use https://search.nixos.org/packages to find packages
+  packages = [
+    pkgs.nodejs_22
+    pkgs.pnpm
+  ];
+
+  # Sets environment variables in the workspace
+  env = {};
+  idx = {
+    # Search for the extensions you want on https://open-vsx.org/ and use "publisher.id"
+    extensions = [
+      "Dart-Code.flutter"
+      "Dart-Code.dart-code"
+    ];
+
+    # Enable previews
+    previews = {
+      enable = true;
+      previews = {
+        web = {
+          command = ["./dash_site" "serve"];
+          manager = "web";
+          env = {
+            # Environment variables to set for your server
+            PORT = "$PORT";
+          };
+        };
+      };
+    };
+
+    # Workspace lifecycle hooks
+    workspace = {
+      # Runs when a workspace is first created
+      onCreate = {
+        get-submodule = "git submodule update --init --recursive";
+        pnpm-install = "pnpm install";
+      };
+      # Runs when the workspace is (re)started
+      onStart = {
+        # Example: start a background task to watch and re-build backend code
+        # watch-backend = "npm run watch-backend";
+      };
+    };
+  };
+}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ built with [Eleventy][] and hosted on [Firebase][].
 [Flutter]: https://docs.flutter.dev/
 [Repo on GitHub Actions]: https://github.com/flutter/website/actions?query=workflow%3Abuild+branch%3Amain
 
+<a href="https://idx.google.com/import?url=https%3A%2F%2Fgithub.com%2Fflutter%2Fwebsite">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://cdn.idx.dev/btn/open_dark_32.svg">
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://cdn.idx.dev/btn/open_light_32.svg">
+    <img
+      height="32"
+      alt="Open in IDX"
+      src="https://cdn.idx.dev/btn/open_purple_32.svg">
+  </picture>
+</a>
+
 ## Issues, bugs, and requests
 
 We welcome contributions and feedback on our website. 

--- a/tool/flutter_site/lib/src/commands/serve.dart
+++ b/tool/flutter_site/lib/src/commands/serve.dart
@@ -32,7 +32,12 @@ final class ServeSiteCommand extends Command<int> {
     final verbose = argResults.get<bool>(_verboseFlag, false);
     final process = await Process.start(
       'npx',
-      const ['eleventy', '--serve', '--incremental'],
+      [
+        'eleventy',
+        '--serve',
+        '--incremental',
+        '--port=${Platform.environment['PORT'] ?? 4000}'
+      ],
       environment: {
         'PRODUCTION': 'false',
         if (verbose) 'DEBUG': 'Eleventy*',


### PR DESCRIPTION
- Adds "Open in IDX" for dart site development

![Screenshot 2024-11-05 at 2 49 00 PM](https://github.com/user-attachments/assets/eda7c302-0543-4809-b43f-a44e320e4552)

Test here:
<a href="https://idx.google.com/import?url=https%3A%2F%2Fgithub.com%2Frodydavis%2Fflutter_website">
  <picture>
    <source
      media="(prefers-color-scheme: dark)"
      srcset="https://cdn.idx.dev/btn/open_dark_32.svg">
    <source
      media="(prefers-color-scheme: light)"
      srcset="https://cdn.idx.dev/btn/open_light_32.svg">
    <img
      height="32"
      alt="Open in IDX"
      src="https://cdn.idx.dev/btn/open_purple_32.svg">
  </picture>
</a>