### PR TITLE
Update set-up-app-links.md

### DIFF
--- a/src/content/cookbook/navigation/set-up-app-links.md
+++ b/src/content/cookbook/navigation/set-up-app-links.md
@@ -102,7 +102,7 @@ It provides a simple API to handle complex routing scenarios.
     The metadata tag `flutter_deeplinking_enabled` opts
     into Flutter's default deeplink handler.
     If you are using the third-party plugins,
-    such as [uni_links][], setting this metadata tag will
+    such as [app_links][], setting this metadata tag will
     break these plugins. Omit this metadata tag
     if you prefer to use third-party plugins.
     :::
@@ -217,5 +217,5 @@ Source code: [deeplink_cookbook][]
 [Firebase Hosting]: {{site.firebase}}/docs/hosting
 [go_router]: {{site.pub}}/packages/go_router
 [GitHub Pages]: https://pages.github.com
-[uni_links]: {{site.pub}}/packages/uni_links
+[app_links]: {{site.pub}}/packages/app_links
 [Signing the app]: /deployment/android#signing-the-app


### PR DESCRIPTION
change uni_links package to app_links

The `uni_links` package is deprecated and has been replaced by `app_links`.


## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
