### PR TITLE
Fix/update deeplinking doc

### DIFF
--- a/src/content/cookbook/navigation/set-up-app-links.md
+++ b/src/content/cookbook/navigation/set-up-app-links.md
@@ -102,7 +102,7 @@ It provides a simple API to handle complex routing scenarios.
     The metadata tag `flutter_deeplinking_enabled` opts
     into Flutter's default deeplink handler.
     If you are using the third-party plugins,
-    such as [uni_links][], setting this metadata tag will
+    such as [app_links][], setting this metadata tag will
     break these plugins. Omit this metadata tag
     if you prefer to use third-party plugins.
     :::
@@ -217,5 +217,5 @@ Source code: [deeplink_cookbook][]
 [Firebase Hosting]: {{site.firebase}}/docs/hosting
 [go_router]: {{site.pub}}/packages/go_router
 [GitHub Pages]: https://pages.github.com
-[uni_links]: {{site.pub}}/packages/uni_links
+[app_links]: {{site.pub}}/packages/app_links
 [Signing the app]: /deployment/android#signing-the-app

--- a/src/content/cookbook/navigation/set-up-universal-links.md
+++ b/src/content/cookbook/navigation/set-up-universal-links.md
@@ -112,7 +112,7 @@ It provides a simple API to handle complex routing scenarios.
    :::note
    The `FlutterDeepLinkingEnabled` property enables
    Flutter's default deeplink handler.
-   If you use a third-party plugin, such as [uni_links][],
+   If you use a third-party plugin, such as [app_links][],
    setting this property breaks the third-party plugin.
    Skip this step if you prefer to use a third-party plugin.
    :::
@@ -331,4 +331,4 @@ recipe in the GitHub repo.
 [Firebase Hosting]: {{site.firebase}}/docs/hosting
 [go_router]: {{site.pub-pkg}}/go_router
 [GitHub Pages]: https://pages.github.com
-[uni_links]: {{site.pub-pkg}}/uni_links
+[app_links]: {{site.pub-pkg}}/app_links


### PR DESCRIPTION
The `uni_links` package is no longer supported and has been replaced by the `app_links` package.

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
