### PR TITLE
Calling JetPack APIs documentation

### DIFF
--- a/src/content/platform-integration/android/call-jetpack-apis.md
+++ b/src/content/platform-integration/android/call-jetpack-apis.md
@@ -42,13 +42,13 @@ your desired native feature is not covered by a package on
 
 Not all scenarios and APIs will be supported by
 existing solutions; but luckily, you can always add whatever
-support you need. The ensuing sections describe two different
+support you need. The next sections describe two different
 ways to call native code from Dart.
 
 :::note
 Neither solution below is inherently better or worse than 
-existing plugins, because all plugins use one of the ensuing
-options.
+existing plugins, because all plugins use one of the following
+two options.
 :::
 
 ### Call native code directly via FFI
@@ -56,7 +56,7 @@ options.
 The most direct and efficient way to invoke native APIs is by
 calling it directly, via FFI. This links your Dart executable
 to any specified native code at compile-time, allowing you to 
-call it directly from the UI thread through a modicum of glue
+call it directly from the UI thread through a small amount of glue
 code. In most cases, [ffigen][ffigen] or [jnigen][jnigen] are
 helpful in writing this glue code.
 
@@ -81,7 +81,7 @@ Unlike the FFI solution outlined in the previous step,
 MethodChannels are always asychronous, which
 might or might not matter to you, depending on your use case. Like
 with FFI and direct calls to native code, using MethodChannels
-requires a modicum of glue code to translate your Dart objects
+requires a small amount of glue code to translate your Dart objects
 into native objects, and then back again. In most cases, 
 [`pkg:pigeon`][pigeon] is helpful in writing this glue code.
 

--- a/src/content/platform-integration/android/call-jetpack-apis.md
+++ b/src/content/platform-integration/android/call-jetpack-apis.md
@@ -1,6 +1,6 @@
 ---
 title: "Calling JetPack APIs"
-description: "Utilize the latest Android APIs from your Dart code"
+description: "Use the latest Android APIs from your Dart code"
 ---
 
 <?code-excerpt path-base="platform_integration"?>

--- a/src/content/platform-integration/android/call-jetpack-apis.md
+++ b/src/content/platform-integration/android/call-jetpack-apis.md
@@ -75,7 +75,7 @@ glue code.
 
 ### Add a MethodChannel
 
-[MethodChannel][methodchannels-api-docs]s are an alternate
+[`MethodChannel`][methodchannels-api-docs]s are an alternate
 way Flutter apps can invoke arbitrary native code.
 Unlike the FFI solution outlined in the previous step,
 MethodChannels are always asychronous, which

--- a/src/content/platform-integration/android/call-jetpack-apis.md
+++ b/src/content/platform-integration/android/call-jetpack-apis.md
@@ -12,11 +12,9 @@ Android-specific APIs.
 
 ## Use an existing solution
 
-In most scenarios, you can [use a plugin][use-a-plugin] to
-invoke native APIs without writing any custom boilerplate or
+In most scenarios, you can use a plugin (as shown in the next section)
+to invoke native APIs without writing any custom boilerplate or
 glue code yourself.
-
-[use-a-plugin]: /platform-integration/android/call-jetpack-apis#use-a-plugin
 
 ### Use a plugin
 

--- a/src/content/platform-integration/android/call-jetpack-apis.md
+++ b/src/content/platform-integration/android/call-jetpack-apis.md
@@ -54,7 +54,7 @@ two options.
 ### Call native code directly via FFI
 
 The most direct and efficient way to invoke native APIs is by
-calling it directly, via FFI. This links your Dart executable
+calling the API directly, via FFI. This links your Dart executable
 to any specified native code at compile-time, allowing you to 
 call it directly from the UI thread through a small amount of glue
 code. In most cases, [ffigen][ffigen] or [jnigen][jnigen] are

--- a/src/content/platform-integration/android/call-jetpack-apis.md
+++ b/src/content/platform-integration/android/call-jetpack-apis.md
@@ -79,7 +79,7 @@ glue code.
 way Flutter apps can invoke arbitrary native code.
 Unlike the FFI solution outlined in the previous step,
 MethodChannels are always asychronous, which
-may or may not matter to you, depending on your use case. Like
+might or might not matter to you, depending on your use case. Like
 with FFI and direct calls to native code, using MethodChannels
 requires a modicum of glue code to translate your Dart objects
 into native objects, and then back again. In most cases, 

--- a/src/content/platform-integration/android/call-jetpack-apis.md
+++ b/src/content/platform-integration/android/call-jetpack-apis.md
@@ -6,7 +6,7 @@ description: "Utilize the latest Android APIs from your Dart code"
 <?code-excerpt path-base="platform_integration"?>
 
 Flutter apps running on Android can always make use of the
-latest APIs, the first day they are released on Android, no
+latest APIs on the first day they are released on Android, no
 matter what. This page outlines available ways to invoke
 Android-specific APIs.
 

--- a/src/content/platform-integration/android/call-jetpack-apis.md
+++ b/src/content/platform-integration/android/call-jetpack-apis.md
@@ -80,7 +80,7 @@ way Flutter apps can invoke arbitrary native code.
 Unlike the FFI solution outlined in the previous step,
 MethodChannels are always asychronous, which
 might or might not matter to you, depending on your use case. As
-with FFI and direct calls to native code, using MethodChannels
+with FFI and direct calls to native code, using a `MethodChannel`
 requires a small amount of glue code to translate your Dart objects
 into native objects, and then back again. In most cases, 
 [`pkg:pigeon`][pigeon] is helpful in writing this glue code.

--- a/src/content/platform-integration/android/call-jetpack-apis.md
+++ b/src/content/platform-integration/android/call-jetpack-apis.md
@@ -1,0 +1,93 @@
+---
+title: "Calling JetPack APIs"
+description: "Utilize the latest Android APIs from your Dart code"
+---
+
+<?code-excerpt path-base="platform_integration"?>
+
+Flutter apps running on Android can always make use of the
+latest APIs, the first day they are released on Android, no
+matter what. This page outlines available ways to invoke
+Android-specific APIs.
+
+## Use an existing solution
+
+In most scenarios, you can [use a plugin][use-a-plugin] to
+invoke native APIs without writing any custom boilerplate or
+glue code yourself.
+
+[use-a-plugin]: /platform-integration/android/call-jetpack-apis#use-a-plugin
+
+### Use a plugin
+
+Using a plugin is often the easiest way to access native
+APIs, regardless of where your Flutter app is running. To
+use plugins, visit [pub.dev][pub] and search for
+the topic you need. Most native features, including accessing
+common hardware like GPS, the camera, or step counters are
+supported by robust plugins.
+
+For complete guidance on adding plugins to your Flutter app,
+see the [Using packages documentation][packages].
+
+[packages]: /packages-and-plugins/using-packages
+[pub]: {{site.pub}}
+
+Not all native featurers are supported by plugins, especially
+new features immediately after release. In any scenario where
+your desired native feature is not covered by a package on
+[pub.dev][pub], continue on to the following sections.
+
+## Creating a custom solution
+
+Not all scenarios and APIs will be supported by
+existing solutions; but luckily, you can always add whatever
+support you need. The ensuing sections describe two different
+ways to call native code from Dart.
+
+:::note
+Neither solution below is inherently better or worse than 
+existing plugins, because all plugins use one of the ensuing
+options.
+:::
+
+### Call native code directly via FFI
+
+The most direct and efficient way to invoke native APIs is by
+calling it dirrectly, via FFI. This links your Dart executable
+to any specified native code at compile-time, allowing you to 
+call it directly from the UI thread through a modicum of glue
+code. In most cases, [ffigen][ffigen] or [jnigen][jnigen] are
+helpful in writing this glue code.
+
+For complete guidance on directly calling native code from
+your Flutter app, see the [FFI documentation][ffi].
+
+In the coming months, the Dart team hopes to make this process
+easier with direct support for calling native APIs using the
+FFI approach, but without any need for the developer to write
+glue code.
+
+[ffi]: {{site.dart-site}}/interop/c-interop
+[ffigen]: {{site.pub}}/packages/ffigen
+[jnigen]: {{site.pub}}/packages/jnigen
+
+
+### Add a MethodChannel
+
+[MethodChannel][methodchannels-api-docs]s are an alternate
+way Flutter apps can invoke arbitrary native code.
+Unlike the FFI solution outlined in the previous step,
+MethodChannels are always asychronous, which
+may or may not matter to you, depending on your use case. Like
+with FFI and direct calls to native code, using MethodChannels
+requires a modicum of glue code to translate your Dart objects
+into native objects, and then back again. In most cases, 
+[`pkg:pigeon`][pigeon] is helpful in writing this glue code.
+
+For complete guidance on adding MethodChannels to your Flutter
+app, see the [MethodChannels documentation][methodchannels].
+
+[methodchannels]: /platform-integration/platform-channels
+[methodchannels-api-docs]: {{site.api}}/flutter/services/MethodChannel-class.html
+[pigeon]: {{site.pub}}/packages/pigeon

--- a/src/content/platform-integration/android/call-jetpack-apis.md
+++ b/src/content/platform-integration/android/call-jetpack-apis.md
@@ -31,8 +31,8 @@ see the [Using packages documentation][packages].
 [packages]: /packages-and-plugins/using-packages
 [pub]: {{site.pub}}
 
-Not all native featurers are supported by plugins, especially
-new features immediately after release. In any scenario where
+Not all native features are supported by plugins, especially
+immediately after their release. In any scenario where
 your desired native feature is not covered by a package on
 [pub.dev][pub], continue on to the following sections.
 
@@ -75,7 +75,7 @@ glue code.
 
 [`MethodChannel`][methodchannels-api-docs]s are an alternate
 way Flutter apps can invoke arbitrary native code.
-Unlike the FFI solution outlined in the previous step,
+Unlike the FFI solution described in the previous step,
 MethodChannels are always asychronous, which
 might or might not matter to you, depending on your use case. As
 with FFI and direct calls to native code, using a `MethodChannel`

--- a/src/content/platform-integration/android/call-jetpack-apis.md
+++ b/src/content/platform-integration/android/call-jetpack-apis.md
@@ -54,7 +54,7 @@ options.
 ### Call native code directly via FFI
 
 The most direct and efficient way to invoke native APIs is by
-calling it dirrectly, via FFI. This links your Dart executable
+calling it directly, via FFI. This links your Dart executable
 to any specified native code at compile-time, allowing you to 
 call it directly from the UI thread through a modicum of glue
 code. In most cases, [ffigen][ffigen] or [jnigen][jnigen] are

--- a/src/content/platform-integration/android/call-jetpack-apis.md
+++ b/src/content/platform-integration/android/call-jetpack-apis.md
@@ -86,7 +86,7 @@ into native objects, and then back again. In most cases,
 [`pkg:pigeon`][pigeon] is helpful in writing this glue code.
 
 For complete guidance on adding MethodChannels to your Flutter
-app, see the [MethodChannels documentation][methodchannels].
+app, see the [`MethodChannel`s documentation][methodchannels].
 
 [methodchannels]: /platform-integration/platform-channels
 [methodchannels-api-docs]: {{site.api}}/flutter/services/MethodChannel-class.html

--- a/src/content/platform-integration/android/call-jetpack-apis.md
+++ b/src/content/platform-integration/android/call-jetpack-apis.md
@@ -79,7 +79,7 @@ glue code.
 way Flutter apps can invoke arbitrary native code.
 Unlike the FFI solution outlined in the previous step,
 MethodChannels are always asychronous, which
-might or might not matter to you, depending on your use case. Like
+might or might not matter to you, depending on your use case. As
 with FFI and direct calls to native code, using MethodChannels
 requires a small amount of glue code to translate your Dart objects
 into native objects, and then back again. In most cases, 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Adds a page explaining and linking out to all the various ways to access native APIs from Flutter.

_Issues fixed by this PR (if any):_

Resolves #11258

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
