### PR TITLE
Add Dart & Flutter Course by Rivaan Ranawat

### DIFF
--- a/src/content/resources/courses.md
+++ b/src/content/resources/courses.md
@@ -9,6 +9,7 @@ up-to-date information, such as null-safe Dart code.
 These courses are listed alphabetically.
 To include your course, [submit a PR][]:
 
+* [20 Hour Dart & Flutter YT Course For Beginners][] by Rivaan Ranawat
 * [The Best Flutter Course on the Internet][] by Tadas Petra & Robert Brunhage
 * [Flutter in Production][] by Andrea Bizzotto
 * [Flutter Foundations][] by Andrea Bizzotto
@@ -27,6 +28,7 @@ To include your course, [submit a PR][]:
 * [Sticky Grouped Headers in Flutter][] by Marco Napoli
 * [Flutter University - From Zero to Mastery][] by Fudeo (Italian)
 
+[20 Hour Dart & Flutter YT Course For Beginners]: https://youtu.be/CzRQ9mnmh44
 [The Best Flutter Course on the Internet]: https://www.hungrimind.com/learn/flutter
 [Flutter in Production]: https://codewithandrea.com/courses/flutter-in-production/
 [Flutter Foundations]: https://codewithandrea.com/courses/flutter-foundations/


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Adding the 20 hour Dart & Flutter Course by Rivaan Ranawat present on YouTube.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
