### PR TITLE
Change how `explicit-package-dependencies` is provided.

### DIFF
--- a/src/content/release/breaking-changes/flutter-generate-i10n-source.md
+++ b/src/content/release/breaking-changes/flutter-generate-i10n-source.md
@@ -58,10 +58,10 @@ There are two ways to migrate away from importing `package:flutter_gen`:
     output-dir: lib/src/generated/i18n
     ```
 
-2. Pass `--no-implicit-pubspec-resolution` to invocations of the `flutter` tool:
+2. Enable the `explicit-package-dependencies` feature flag:
 
     ```sh
-    flutter run --no-implicit-pubspec-resolution
+    flutter config explicit-package-dependencies
     ```
 
 ## Timeline

--- a/src/content/release/breaking-changes/flutter-plugins-configuration.md
+++ b/src/content/release/breaking-changes/flutter-plugins-configuration.md
@@ -119,10 +119,10 @@ See [Deprecated imperative apply of Flutter's Gradle plugins][imperative-apply]
 for details of switching to the newer plugin DSL.
 
 To smoke test whether your build relies on a `.flutter-plugins` file, you
-can use the flag `--no-implicit-pubspec-resolution`:
+can use the feature flag `explicit-package-dependencies`:
 
 ```sh
-flutter build apk --no-implicit-pubspec-resolution
+flutter config explicit-package-dependencies
 ```
 
 Any build tools or scripts that might rely on that file being output will now


### PR DESCRIPTION
This was recently changed in the flutter tool to be easier to opt-in/out of.