### PR TITLE
[SwiftPM] Allow checking-in example apps' SwiftPM integration

### DIFF
--- a/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
@@ -422,18 +422,17 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
       flutter run
       ```
 
-      :::warning
+      :::note
       Using the Flutter CLI to run the plugin's example app with the
       Swift Package Manager feature turned on migrates the project to add
       Swift Package Manager integration.
 
-      **Do not commit the migration's changes to your version control system.**
+      This raises the example app's Flutter SDK requirement to version 3.24 or
+      higher.
 
-      Otherwise, the plugin's example app won't build unless Flutter version
-      3.24 or higher is installed.
-
-      If you accidentally commit the migration's changes to the plugin's example
-      app, follow the steps to
+      If you'd like to run the example app using an older Flutter SDK version,
+      do not commit the migration's changes to your version control system.
+      If needed, you can always
       [undo the Swift Package Manager migration][removeSPM].
       :::
 

--- a/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
@@ -295,18 +295,17 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
       flutter run
       ```
 
-      :::warning
+      :::note
       Using the Flutter CLI to run the plugin's example app with the
       Swift Package Manager feature turned on migrates the project to add
       Swift Package Manager integration.
 
-      **Do not commit the migration's changes to your version control system.**
+      This raises the example app's Flutter SDK requirement to version 3.24 or
+      higher.
 
-      Otherwise, the plugin's example app won't build if the
-      Swift Package Manager feature is turned off.
-
-      If you accidentally commit the migration's changes to the plugin's example
-      app, follow the steps to
+      If you'd like to run the example app using an older Flutter SDK version,
+      do not commit the migration's changes to your version control system.
+      If needed, you can always
       [undo the Swift Package Manager migration][removeSPM].
       :::
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

The SwiftPM migration guide currently recommends **not** migrating plugins' example apps to add SwiftPM migration. This was necessary as before Flutter 3.24.0, Flutter stable did not support SwiftPM. Running the example app would cause Xcode build errors.

Flutter 3.24.0 and higher can build apps with SwiftPM integration. This updates the warning to instead notify that this raises the example app's Flutter SDK requirement to 3.24.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
