### PR TITLE
Remove survey announcement from the banner

### DIFF
--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -3,7 +3,6 @@
 {% endcomment -%}
 <div class="site-banner site-banner--default" role="alert">
   <a href="https://medium.com/flutter/flutter-3-24-dart-3-5-204b7d20c45d">Flutter 3.24 and Dart 3.5</a> are here!
-  Check out <a href="/release/whats-new">what's new</a> on the website.<br>
-	Help improve Flutter! Take our <a href="https://google.qualtrics.com/jfe/form/SV_4PhMtNLa6DWOGWi?Source=Website">Q4 survey</a>.
+  Check out <a href="/release/whats-new">what's new</a> on the website.
 </div>
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Removing the survey announcement from the banner, as the survey will be closed in a couple days!

_Issues fixed by this PR (if any):_ NA

_PRs or commits this PR depends on (if any):_ NA

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
