### PR TITLE
Fix Web support page highlighting in left nav

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -513,6 +513,7 @@
       children:
         - title: Web support in Flutter
           permalink: /platform-integration/web
+          match-page-url-exactly: true
         - title: Add web as build target
           permalink: /platform-integration/web/install-web
         - title: Build a web app

--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -512,7 +512,7 @@
       permalink: /platform-integration/web
       children:
         - title: Web support in Flutter
-          permalink: /platform-integration/web/
+          permalink: /platform-integration/web
         - title: Add web as build target
           permalink: /platform-integration/web/install-web
         - title: Build a web app


### PR DESCRIPTION
The page "Web support for Flutter" wasn't showing an active highlight in the left nav (see screenshots). Looks like there was an extraneous trailing slash.

VERY minor change

Web support for Flutter: No active highlight:
![Screenshot 2024-11-21 at 10 08 16](https://github.com/user-attachments/assets/1d1b3656-7463-4320-949a-805e993e6f8d)

Other pages have:
![Screenshot 2024-11-21 at 10 09 00](https://github.com/user-attachments/assets/92d8514a-3bca-4545-9c65-4953fbe0deaf)
