### PR TITLE
Updated Doc: changes Center to Container

### DIFF
--- a/src/content/ui/layout/index.md
+++ b/src/content/ui/layout/index.md
@@ -252,7 +252,7 @@ or you can build your own set of custom widgets.
 
 #### Non-Material apps
 
-For a non-Material app, you can add the `Center` widget to the app's
+For a non-Material app, you can add the `Container` widget to the app's
 `build()` method:
 
 <?code-excerpt path-base="layout/non_material"?>


### PR DESCRIPTION
it was wrongly written as a Center widget when in the code its Container