### PR TITLE
fix: #11433 broken link

### DIFF
--- a/src/content/cookbook/architecture/key-value-data.md
+++ b/src/content/cookbook/architecture/key-value-data.md
@@ -359,4 +359,4 @@ ListenableBuilder(
 [Flutter architecture design]: /app-architecture
 [Store key-value data on disk]: /cookbook/persistence/key-value
 [Persistent Storage Architecture: SQL]: /cookbook/architecture/sql
-[`/examples/cookbook/architecture/todo_data_service/`]: {{site.repo.flutter}}/tree/main/examples/cookbook/architecture/todo_data_service/
+[`/examples/cookbook/architecture/todo_data_service/`]: {{site.repo.this}}/tree/main/examples/cookbook/architecture/todo_data_service/

--- a/src/content/cookbook/architecture/sql.md
+++ b/src/content/cookbook/architecture/sql.md
@@ -478,7 +478,7 @@ TodoListScreen(
 [MVVM pattern]:/get-started/fundamentals/state-management#using-mvvm-for-your-applications-architecture
 [Persist data with SQLite]:/cookbook/persistence/sqlite
 [Persistent storage architecture: Key-value data]:/cookbook/architecture/key-value-data
-[`/examples/cookbook/architecture/todo_data_service/`]: {{site.repo.flutter}}/tree/main/examples/cookbook/architecture/todo_data_service/
+[`/examples/cookbook/architecture/todo_data_service/`]: {{site.repo.this}}/tree/main/examples/cookbook/architecture/todo_data_service/
 [`sqflite_common_ffi_web`]:{{site.pub}}/packages/sqflite_common_ffi_web
 [`sqflite_common_ffi`]:{{site.pub}}/packages/sqflite_common_ffi
 [`sqflite`]:{{site.pub}}/packages/sqflite


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Fixed broken links to sample. Should point to `flutter/website` not `flutter/flutter`.

_Issues fixed by this PR (if any):_

Closes #11433 

_PRs or commits this PR depends on (if any):_

None

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
