### PR TITLE
Add Qualtrics survey link to Architecture guidance

### DIFF
--- a/src/content/app-architecture/case-study/data-layer.md
+++ b/src/content/app-architecture/case-study/data-layer.md
@@ -240,3 +240,10 @@ completing the cycle.
 [Result cookbook recipe]: /cookbook/architecture
 
 [//]: # (todo ewindmill@ - update Result link after #11444 lands)
+
+## Feedback
+
+As this section of the website is evolving,
+we [welcome your feedback][]!
+
+[welcome your feedback]: https://google.qualtrics.com/jfe/form/SV_4T0XuR9Ts29acw6?page="case-study/data-layer"

--- a/src/content/app-architecture/case-study/dependency-injection.md
+++ b/src/content/app-architecture/case-study/dependency-injection.md
@@ -176,3 +176,10 @@ example of a robust Flutter application built following these principles.
 [`package:go_router`]: {{site.pub-pkg}}/go_router
 [Compass app repository]: https://github.com/flutter/samples/tree/main/compass_app
 [dependency injection]: https://en.wikipedia.org/wiki/Dependency_injection
+
+## Feedback
+
+As this section of the website is evolving,
+we [welcome your feedback][]!
+
+[welcome your feedback]: https://google.qualtrics.com/jfe/form/SV_4T0XuR9Ts29acw6?page="case-study/dependency-injection"

--- a/src/content/app-architecture/case-study/index.md
+++ b/src/content/app-architecture/case-study/index.md
@@ -204,3 +204,10 @@ And if you squint, aren't all architectures MVVM anyway?
 [`flutter_bloc`]: {{site.pub-pkg}}/flutter_bloc 
 [`signals`]: {{site.pub-pkg}}/signals
 [package structure]: /app-architecture/case-study#package-structure
+
+## Feedback
+
+As this section of the website is evolving,
+we [welcome your feedback][]!
+
+[welcome your feedback]: https://google.qualtrics.com/jfe/form/SV_4T0XuR9Ts29acw6?page="case-study/index"

--- a/src/content/app-architecture/case-study/testing.md
+++ b/src/content/app-architecture/case-study/testing.md
@@ -224,3 +224,10 @@ read [Flutter's testing documentation][].
 [`package:mocktail`]: {{site.pub-pkg}}/mocktail
 [Flutter's testing documentation]: /testing/overview
 [Compass App `testing` directory]: https://github.com/flutter/samples/tree/main/compass_app/app/testing
+
+## Feedback
+
+As this section of the website is evolving,
+we [welcome your feedback][]!
+
+[welcome your feedback]: https://google.qualtrics.com/jfe/form/SV_4T0XuR9Ts29acw6?page="case-study/testing"

--- a/src/content/app-architecture/case-study/ui-layer.md
+++ b/src/content/app-architecture/case-study/ui-layer.md
@@ -649,3 +649,10 @@ the Command pattern. [Read about it on GitHub][].
 [package:riverpod]: {{site.pub-pkg}}/riverpod
 [package:flutter_bloc]: {{site.pub-pkg}}/flutter_bloc
 [package:signals]: {{site.pub-pkg}}/signals
+
+## Feedback
+
+As this section of the website is evolving,
+we [welcome your feedback][]!
+
+[welcome your feedback]: https://google.qualtrics.com/jfe/form/SV_4T0XuR9Ts29acw6?page="case-study/ui-layer"

--- a/src/content/app-architecture/concepts.md
+++ b/src/content/app-architecture/concepts.md
@@ -168,3 +168,10 @@ in your application's architecture.
 [getters]: {{site.dart-site}}/effective-dart/design#do-use-getters-for-operations-that-conceptually-access-properties
 [records]: {{site.dart-site}}/language/records
 [Unidirectional data flow]: https://en.wikipedia.org/wiki/Unidirectional_Data_Flow_(computer_science)
+
+## Feedback
+
+As this section of the website is evolving,
+we [welcome your feedback][]!
+
+[welcome your feedback]: https://google.qualtrics.com/jfe/form/SV_4T0XuR9Ts29acw6?page="concepts"

--- a/src/content/app-architecture/guide.md
+++ b/src/content/app-architecture/guide.md
@@ -344,3 +344,10 @@ but it requires greater diligence to maintain order.
 [State Management page]: /get-started/fwe/state-management
 [Repository]: https://martinfowler.com/eaaCatalog/repository.html
 [UI layer page]: /app-architecture/case-study/ui-layer
+
+## Feedback
+
+As this section of the website is evolving,
+we [welcome your feedback][]!
+
+[welcome your feedback]: https://google.qualtrics.com/jfe/form/SV_4T0XuR9Ts29acw6?page="guide"

--- a/src/content/app-architecture/index.md
+++ b/src/content/app-architecture/index.md
@@ -88,3 +88,11 @@ sample code that shows the recommendations in action.
 [Common architectural principles]: /app-architecture/concepts
 [recommended app architecture]: /app-architecture/guide
 [MVVM]: /app-architecture/guide#mvvm
+
+
+## Feedback
+
+As this section of the website is evolving,
+we [welcome your feedback][]!
+
+[welcome your feedback]: https://google.qualtrics.com/jfe/form/SV_4T0XuR9Ts29acw6?page="index"

--- a/src/content/app-architecture/recommendations.md
+++ b/src/content/app-architecture/recommendations.md
@@ -84,3 +84,9 @@ which reflects how strongly the Flutter team recommends it.
 [Flutter developer tools]: /tools/devtools
 [flutter_lints]: https://pub.dev/packages/flutter_lints
 
+## Feedback
+
+As this section of the website is evolving,
+we [welcome your feedback][]!
+
+[welcome your feedback]: https://google.qualtrics.com/jfe/form/SV_4T0XuR9Ts29acw6?page="recommendations"


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Add's a link to a Qualtrics survey to the bottom of each page of the architecture guidance docs

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
