### PR TITLE
fix: fix capitalization of view and view model

### DIFF
--- a/src/content/app-architecture/concepts.md
+++ b/src/content/app-architecture/concepts.md
@@ -106,7 +106,7 @@ this:
 3. [Data layer] The repository updates data (if necessary) and then provides the
    new data to the logic class.
 4. [Logic layer] The logic class saves its new state, which it sends to the UI.
-5. [UI layer] The UI displays the new state of the ViewModel.
+5. [UI layer] The UI displays the new state of the view model.
 
 New data can also start at the data layer. 
 For example, a repository might poll an HTTP server for new data. 

--- a/src/content/app-architecture/guide.md
+++ b/src/content/app-architecture/guide.md
@@ -36,7 +36,7 @@ boundaries and dependencies.
 This guide recommends you split your application into the following components:
 
 * Views
-* ViewModels
+* View models
 * Repositories
 * Services
 
@@ -46,16 +46,16 @@ If you've encountered the [Model-View-ViewModel design pattern][] (MVVM),
 this will be familiar. MVVM is a design pattern that separates a feature of an
 application into three parts: 
 the `Model`, the `ViewModel` and the `View`. 
-Views and ViewModels make up the UI layer of an application. 
+Views and view models make up the UI layer of an application. 
 Repositories and services represent the data of an application, 
-or the Model layer of MVVM. 
+or the model layer of MVVM. 
 Each of these components is defined in the next section.
 
 <img src='/assets/images/docs/app-architecture/guide/mvvm-intro-with-layers.png'
 alt="MVVM design pattern">
 
 Every feature in an application will contain one view to describe the UI and 
-one ViewModel to handle logic, 
+one view model to handle logic, 
 one or more repositories as the sources of truth for your application data, 
 and zero or more services that interact with external APIs, 
 like client servers and platform plugins.
@@ -96,35 +96,35 @@ design pattern:
 
 * **Views** describe how to present application data to the user. Specifically,
   it refers to a *composition of widgets *that make a feature. For instance, a
-  View is often (but not always) a screen that has a Scaffold widget, along with
+  view is often (but not always) a screen that has a Scaffold widget, along with
   all of the widgets below it in the widget tree. Views are also responsible for
-  passing events to the ViewModel in response to user interaction.
-* **ViewModels** contain the logic that converts app data into *UI State*,
+  passing events to the view model in response to user interaction.
+* **View models** contain the logic that converts app data into *UI State*,
   because data from repositories is often formatted differently from the data
   that needs to be displayed. For example, you might need to combine data from
   multiple repositories, or you might want to filter a list of data records.
 
-Views and ViewModels should have a 1:1 relationship.
+Views and view models should have a 1:1 relationship.
 
 <img src='/assets/images/docs/app-architecture/guide/feature-architecture-simplified-UI-highlighted.png'
-alt="A simplified diagram of the architecture described on this page with the View and ViewModel objects highlighted.">
+alt="A simplified diagram of the architecture described on this page with the view and view model objects highlighted.">
 
 In the simplest terms, 
-a ViewModel manages the UI state and the View displays that state. 
-Using Views and ViewModels, your UI layer can maintain state during 
+a view model manages the UI state and the view displays that state. 
+Using views and view models, your UI layer can maintain state during 
 configuration changes (like screen rotations), 
 and you can test the logic of your UI independently of Flutter widgets.
 
 :::note
-‘View' is an abstract term, and one View does not equal one widget. 
+‘View' is an abstract term, and one view does not equal one widget. 
 Widgets are composable, and several can be combined to create one view. 
-Therefore, ViewModels don't have a 1-to-1 relationship with widgets, 
+Therefore, view models don't have a 1-to-1 relationship with widgets, 
 but rather a 1-to-1 relation with a *collection* of widgets.
 :::
 
 A feature of an application is user centric, 
 and therefore defined by the UI layer. 
-Every instance of a pair of View and ViewModel defines one feature in your app. 
+Every instance of a pair of view and view model defines one feature in your app. 
 This is often a screen in your app, but it doesn't have to be. 
 For example, consider logging in and out. 
 Logging in is generally done on a specific screen whose
@@ -142,41 +142,41 @@ only contains a single button that can be dropped into other widgets.
 
 ### Views
 
-In Flutter, Views are the widget classes of your application. 
+In Flutter, views are the widget classes of your application. 
 Views are the primary method of rendering UI, 
 and shouldn't contain any business logic. 
-They should be passed all data they need to render from the ViewModel.
+They should be passed all data they need to render from the view model.
 
 <img src='/assets/images/docs/app-architecture/guide/feature-architecture-simplified-View-highlighted.png'
-alt="A simplified diagram of the architecture described on this page with the View object highlighted.">
+alt="A simplified diagram of the architecture described on this page with the view object highlighted.">
 
 The only logic a view should contain is:
 
 * Simple if-statements to show and hide widgets based on a flag or nullable
-  field in the ViewModel
+  field in the view model
 * Animation logic
 * Layout logic based on device information, like screen size or orientation.
 * Simple routing logic
 
-All logic related to data should be handled in the ViewModel.
+All logic related to data should be handled in the view model.
 
-### ViewModels
+### View models
 
-A ViewModel exposes the application data necessary to render a View. 
+A view model exposes the application data necessary to render a view. 
 In the architecture design described on this page, 
-most of the logic in your Flutter application lives in ViewModels.
+most of the logic in your Flutter application lives in view models.
 
 <img src='/assets/images/docs/app-architecture/guide/feature-architecture-simplified-ViewModel-highlighted.png'
-alt="A simplified diagram of the architecture described on this page with the ViewModel object highlighted.">
+alt="A simplified diagram of the architecture described on this page with the view model object highlighted.">
 
-A ViewModels main responsibilities include:
+A view model's main responsibilities include:
 
 * Retrieving application data from repositories and transforming it into a
   format suitable for presentation in the view. For example, it may filter, sort
   or aggregate data.
 * Maintaining the current state needed in the view, so that the view can rebuild
   without losing data. For example, it may contain boolean flags to
-  conditionally render widgets in the View, or a field that tracks which section
+  conditionally render widgets in the view, or a field that tracks which section
   of a carousel is active on screen.
 * Exposes callbacks (called **commands**) to the view that can be attached to an
   event handler, like a button press or form submission.
@@ -184,10 +184,10 @@ A ViewModels main responsibilities include:
 Commands are named for the [Command Pattern][], 
 and are Dart functions that allow the views to 
 execute complex logic without knowledge of its implementation. 
-Commands are written as members of the ViewModel class to
-be called by the gesture handlers in the View class.
+Commands are written as members of the view model class to
+be called by the gesture handlers in the view class.
 
-You can find examples of Views, ViewModels and Commands on
+You can find examples of views, view models and Commands on
 the [UI layer page][].
 
 For a gentle introduction to MVVM in Flutter, 
@@ -211,7 +211,7 @@ Using MVVM language, services and repositories make up your *model layer*.
 They're responsible for polling data from services, 
 and transforming that raw data into **domain models**. 
 Domain models represent the data that the application needs, 
-formatted in a way that your ViewModel classes can consume. 
+formatted in a way that your view model classes can consume. 
 There should be a repository class for 
 each different type of data handled in your app.
 
@@ -232,15 +232,15 @@ a social media app might have a `UserProfileRepository` class that exposes
 a `Stream<UserProfile?>`, 
 which emits a new value whenever the user signs in or out.
 
-The models output by repositories are consumed by ViewModels. 
-Repositories and ViewModels have a many-to-many relationship. 
-A ViewModel can use many repositories to get the data it needs, 
-and a repository can be used by many ViewModels.
+The models output by repositories are consumed by view models. 
+Repositories and view models have a many-to-many relationship. 
+A view model can use many repositories to get the data it needs, 
+and a repository can be used by many view models.
 
 Repositories should never be aware of each other. 
 If your application has business logic that needs data from two repositories, 
-you should combine the data in the ViewModel or in the domain layer,
-especially if your repository-to-ViewModel relationship is complex.
+you should combine the data in the view model or in the domain layer,
+especially if your repository-to-view-model relationship is complex.
 
 ### Services
 
@@ -269,7 +269,7 @@ alt="A simplified diagram of the architecture described on this page with the Se
 ## Optional: Domain layer
 
 As your app grows and adds features, you may need to abstract away logic that
-adds too much complexity to your ViewModels. 
+adds too much complexity to your view models. 
 These classes are often called interactors or **use-cases**.
 
 Use-cases are responsible for making interactions between 
@@ -280,11 +280,11 @@ They take data from repositories and make it suitable for the UI layer.
 alt="MVVM design pattern with an added domain layer object">
 
 Use-cases are primarily used to encapsulate business logic that would otherwise
-live in the ViewModel and meets one or more of the following conditions:
+live in the view model and meets one or more of the following conditions:
 
 1. Requires merging data from multiple repositories
 2. Is exceedingly complex
-3. The logic will be reused by different ViewModels
+3. The logic will be reused by different view models
 
 This layer is optional because not all applications or features within an
 application have these requirements. If you suspect your application would
@@ -293,20 +293,20 @@ benefit from this additional layer, consider the pros and cons:
 
 | Pros                                                                     | Cons                                                                                       |
 |--------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
-| ✅ Avoid code duplication in ViewModels                                   | ❌ Increases complexity of your architecture, adding more classes and higher cognitive load |
+| ✅ Avoid code duplication in view models                                  | ❌ Increases complexity of your architecture, adding more classes and higher cognitive load |
 | ✅ Improve testability by separating complex business logic from UI logic | ❌ Testing requires additional mocks                                                        |
-| ✅ Improve code readability in ViewModels                                 | ❌ Adds additional boilerplate to your code                                                 |
+| ✅ Improve code readability in view models                                | ❌ Adds additional boilerplate to your code                                                 |
 
 {:.table .table-striped}
 
 ### Data access with use-cases
 
-Another consideration when adding a Domain layer is whether ViewModels will
+Another consideration when adding a Domain layer is whether view models will
 continue to have access to repository data directly, or if you'll enforce
-ViewModels to go through use-cases to get their data. Put another way, 
+view models to go through use-cases to get their data. Put another way, 
 will you add use-cases as you need them? 
-Perhaps when you notice repeated logic in your ViewModels? 
-Or, will you create a use-case each time a ViewModel needs data,
+Perhaps when you notice repeated logic in your view models? 
+Or, will you create a use-case each time a view model needs data,
 even if the logic in the use-case is simple?
 
 If you choose to do the latter, 
@@ -315,11 +315,11 @@ Your application code will be extremely modular and testable,
 but it also adds a significant amount of unnecessary overhead.
 
 A good approach is to add use-cases only when needed. 
-If you find that your ViewModels are 
+If you find that your view models are 
 accessing data through use-cases most of the time, 
 you can always refactor your code to utilize use-cases exclusively. 
 The example app used later in this guide uses use-cases for some features, 
-but also has ViewModels that interact with repositories directly. 
+but also has view models that interact with repositories directly. 
 A complex feature may ultimately end up looking like this:
 
 <img src='/assets/images/docs/app-architecture/guide/feature-architecture-simplified-with-logic-layer.png'
@@ -329,7 +329,7 @@ This method of adding use-cases is defined by the following rules:
 
 * Use-cases depend on repositories
 * Use-cases and repositories have a many-to-many relationship
-* ViewModels depend on one or more use-cases *and* one or more repositories
+* view models depend on one or more use-cases *and* one or more repositories
 
 This method of using use-cases ends up looking less like a layered lasagna, 
 and more like a plated dinner with two mains (UI and data layers) and 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

As mentioned in https://github.com/flutter/website/pull/11444, "View" and "ViewModel" should be not capitalized and instead be "view" and "view model".

In this PR, I changed the App Architecture "guide" and "concepts" documents to follow that format.

fyi @ericwindmill 

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_


## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
