### PR TITLE
fix typo to dart-swift-concurrency.md

### DIFF
--- a/src/content/get-started/flutter-for/dart-swift-concurrency.md
+++ b/src/content/get-started/flutter-for/dart-swift-concurrency.md
@@ -88,7 +88,7 @@ Next, define the view model and mark it as an [`@Observable`][]
 that publishes the `result` of type `Weather?`. 
 Use GCD to create a background `DispatchQueue` to 
 send the work to the pool of threads, and then dispatch 
-back to the main threaad to update the `result`. 
+back to the main thread to update the `result`. 
 
 ```swift
 @Observable class ContentViewModel {


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
fix: correct spelling of "thread"

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
