### PR TITLE
Change description in constructor to a named parameter (as it is mentioned later on that page)

### DIFF
--- a/src/content/get-started/fundamentals/dart.md
+++ b/src/content/get-started/fundamentals/dart.md
@@ -48,7 +48,7 @@ class Package {
   final String latestVersion; 
   final String? description;
 
-  Package(this.name, this.latestVersion, this.description);
+  Package(this.name, this.latestVersion, {this.description});
 
   @override
   String toString() {
@@ -64,7 +64,11 @@ void main() async {
     return;
   }
   final json = jsonDecode(httpPackageResponse.body);
-  final package = Package(json['name'], json['latestVersion'], json['description']);
+  final package = Package(
+    json['name'],
+    json['latestVersion'],
+    description: json['description'],
+  );
   print(package);
 }
 ```


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Later on description says:
"You can see this demonstrated in the constructor for the Package class. It takes two required, positional arguments and **one optional, named argument**."

However, code had 3 required positional arguments.

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
