### PR TITLE
fix: typo at set-up-universal-links.md

### DIFF
--- a/src/content/cookbook/navigation/set-up-universal-links.md
+++ b/src/content/cookbook/navigation/set-up-universal-links.md
@@ -83,7 +83,7 @@ It provides a simple API to handle complex routing scenarios.
    Flutter project's `ios` folder.
 
   :::note
-  If you are use a third-party plugins to handle deep links, 
+  If you are using third-party plugins to handle deep links, 
   such as [app_links][],
   Flutter's default deeplink handler will
   break these plugins. 
@@ -191,7 +191,7 @@ Apple formats the `appID` as `<team id>.<bundle id>`.
 
 **For example:** Given a team ID of `S8QB4VV633`
 and a bundle ID of `com.example.deeplinkCookbook`,
-You would enter an `appID` entry of
+you would enter an `appID` entry of
 `S8QB4VV633.com.example.deeplinkCookbook`.
 
 ### Create and host `apple-app-site-association` JSON file


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:
Fixing two typos at set-up-universal-links.md

_Issues fixed by this PR (if any):
Not applicable

_PRs or commits this PR depends on (if any):_
Not applicable

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
