### PR TITLE
Add a breaking change doc about deep links flag change to the flutter website

### DIFF
--- a/src/content/release/breaking-changes/deep-links-flag-change.md
+++ b/src/content/release/breaking-changes/deep-links-flag-change.md
@@ -21,7 +21,8 @@ However, if you’re using third-party plugins for deep links, such as:
 [firebase dynamic links][https://firebase.google.com/docs/dynamic-links]
 [uni_link][https://pub.dev/packages/uni_links]
 [app_links][https://pub.dev/packages/app_links]
-This update will introduce a breaking change. In this case, you’ll need to manually reset the Flutter deep linking flag to false.
+
+In this case, you must manually reset the Flutter deep linking flag to `false`.
 
 Before: non-op
 

--- a/src/content/release/breaking-changes/deep-links-flag-change.md
+++ b/src/content/release/breaking-changes/deep-links-flag-change.md
@@ -16,7 +16,8 @@ meaning that deep linking is now opt-in by default.
 
 If you’re using Flutter’s default deep linking setup, this is not a breaking change for you. 
 
-However, if you’re using third-party plugins for deep links, such as:
+However, if you’re using a third-party plugin for deep links,
+such as the following, this update introduces a breaking change:
 
 [firebase dynamic links][https://firebase.google.com/docs/dynamic-links]
 [uni_link][https://pub.dev/packages/uni_links]

--- a/src/content/release/breaking-changes/deep-links-flag-change.md
+++ b/src/content/release/breaking-changes/deep-links-flag-change.md
@@ -1,0 +1,61 @@
+---
+title: Deep links flag change
+description: >-
+
+---
+
+## Summary
+
+The default value for Flutter’s deep linking flag has changed from false to true, meaning deep linking is now opt-in by default.  
+
+## Migration guide
+
+
+If you’re using Flutter’s default deep linking setup, there’s no need to manually set the flag to true anymore.
+
+However, if you’re using third-party plugins for deep links, such as:
+
+[firebase dynamic links][https://firebase.google.com/docs/dynamic-links]
+[uni_link][https://pub.dev/packages/uni_links]
+[app_links][https://pub.dev/packages/app_links]
+This update will introduce a breaking change. In this case, you’ll need to manually reset the Flutter deep linking flag to false.
+
+Before: non-op
+
+After:
+
+Manually disable the deep linking flag if you're using third-party plugins:
+
+* Android Manifest file
+
+```dart
+<manifest>
+   <application
+       <activity>
+<meta-data android:name="flutter_deeplinking_enabled" android:value="false" />
+       </activity>
+   </application>
+</manifest>
+```
+
+* iOS info.plist file
+
+```
+   <key>FlutterDeepLinkingEnabled</key>
+   <false/>
+```
+
+## Timeline
+
+Landed in version: 3.27.0-0.0.pre<br>
+Stable release: 3.27
+
+## References
+
+Design documentation:
+flutter.dev/go/deep-link-flag-migration.
+
+Relevant PR:
+
+* [Set deep linking flag to true by defaulte][https://github.com/flutter/engine/pull/52350]
+

--- a/src/content/release/breaking-changes/deep-links-flag-change.md
+++ b/src/content/release/breaking-changes/deep-links-flag-change.md
@@ -1,6 +1,8 @@
 ---
 title: Deep links flag change
-
+description: >
+  If you use a third party deep linking plugin package for mobile apps,
+  set Flutter's deep linking flag to false.
 ---
 
 ## Summary

--- a/src/content/release/breaking-changes/deep-links-flag-change.md
+++ b/src/content/release/breaking-changes/deep-links-flag-change.md
@@ -21,9 +21,9 @@ If you’re using Flutter’s default deep linking setup, this is not a breaking
 However, if you’re using a third-party plugin for deep links,
 such as the following, this update introduces a breaking change:
 
-[firebase dynamic links][https://firebase.google.com/docs/dynamic-links]
-[uni_link][https://pub.dev/packages/uni_links]
-[app_links][https://pub.dev/packages/app_links]
+[firebase dynamic links](https://firebase.google.com/docs/dynamic-links)
+[uni_link](https://pub.dev/packages/uni_links)
+[app_links](https://pub.dev/packages/app_links)
 
 In this case, you must manually reset the Flutter deep linking flag to `false`.
 

--- a/src/content/release/breaking-changes/deep-links-flag-change.md
+++ b/src/content/release/breaking-changes/deep-links-flag-change.md
@@ -1,6 +1,5 @@
 ---
 title: Deep links flag change
-description: >-
 
 ---
 

--- a/src/content/release/breaking-changes/deep-links-flag-change.md
+++ b/src/content/release/breaking-changes/deep-links-flag-change.md
@@ -5,7 +5,11 @@ title: Deep links flag change
 
 ## Summary
 
-The default value for Flutter’s deep linking flag has changed from false to true, meaning deep linking is now opt-in by default.  
+<b>This (potential) breaking change only affects mobile apps and only if you
+use a third party deep linking plugin package.</b>
+
+The default value for Flutter’s deep linking flag has changed from `false` to `true`,
+meaning that deep linking is now opt-in by default.  
 
 ## Migration guide
 

--- a/src/content/release/breaking-changes/deep-links-flag-change.md
+++ b/src/content/release/breaking-changes/deep-links-flag-change.md
@@ -10,7 +10,7 @@ The default value for Flutter’s deep linking flag has changed from false to tr
 ## Migration guide
 
 
-If you’re using Flutter’s default deep linking setup, there’s no need to manually set the flag to true anymore.
+If you’re using Flutter’s default deep linking setup, this is not a breaking change for you. 
 
 However, if you’re using third-party plugins for deep links, such as:
 

--- a/src/content/release/breaking-changes/deep-links-flag-change.md
+++ b/src/content/release/breaking-changes/deep-links-flag-change.md
@@ -62,5 +62,5 @@ flutter.dev/go/deep-link-flag-migration.
 
 Relevant PR:
 
-* [Set deep linking flag to true by defaulte][https://github.com/flutter/engine/pull/52350]
+* [Set deep linking flag to true by defaulte]({{site.github}}/flutter/engine/pull/52350)
 

--- a/src/content/release/breaking-changes/deep-links-flag-change.md
+++ b/src/content/release/breaking-changes/deep-links-flag-change.md
@@ -29,7 +29,7 @@ Before: non-op
 
 After:
 
-Manually disable the deep linking flag if you're using third-party plugins:
+Manually disable the deep linking flag if you use a third-party plugin:
 
 * Android Manifest file
 

--- a/src/content/release/breaking-changes/deep-links-flag-change.md
+++ b/src/content/release/breaking-changes/deep-links-flag-change.md
@@ -35,7 +35,7 @@ Manually disable the deep linking flag if you use a third-party plugin:
 
 * Android Manifest file
 
-```dart
+```yaml
 <manifest>
    <application
        <activity>
@@ -47,7 +47,7 @@ Manually disable the deep linking flag if you use a third-party plugin:
 
 * iOS info.plist file
 
-```
+```yaml
    <key>FlutterDeepLinkingEnabled</key>
    <false/>
 ```

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -54,6 +54,7 @@ release, and listed in alphabetical order:
 * [`Color` wide gamut support][]
 * [Remove invalid parameters for `InputDecoration.collapsed`][]
 * [Stop generating `AssetManifest.json`][]
+* [Deep links flag change][]
 * [Deprecate `TextField.canRequestFocus`][]
 * [Set default for SystemUiMode to Edge-to-Edge][]
 * [Material 3 Tokens Update in Flutter][]
@@ -62,6 +63,7 @@ release, and listed in alphabetical order:
 [`Color` wide gamut support]: /release/breaking-changes/wide-gamut-framework
 [Remove invalid parameters for `InputDecoration.collapsed`]: /release/breaking-changes/input-decoration-collapsed
 [Stop generating `AssetManifest.json`]: /release/breaking-changes/asset-manifest-dot-json
+[Deep links flag change`]: /release/breaking-changes/deep-links-flag-change
 [Deprecate `TextField.canRequestFocus`]: /release/breaking-changes/can-request-focus
 [Set default for SystemUiMode to Edge-to-Edge]: /release/breaking-changes/default-systemuimode-edge-to-edge
 [Material 3 Tokens Update in Flutter]: /release/breaking-changes/material-design-3-token-update

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -63,7 +63,7 @@ release, and listed in alphabetical order:
 [`Color` wide gamut support]: /release/breaking-changes/wide-gamut-framework
 [Remove invalid parameters for `InputDecoration.collapsed`]: /release/breaking-changes/input-decoration-collapsed
 [Stop generating `AssetManifest.json`]: /release/breaking-changes/asset-manifest-dot-json
-[Deep links flag change`]: /release/breaking-changes/deep-links-flag-change
+[Deep links flag change]: /release/breaking-changes/deep-links-flag-change
 [Deprecate `TextField.canRequestFocus`]: /release/breaking-changes/can-request-focus
 [Set default for SystemUiMode to Edge-to-Edge]: /release/breaking-changes/default-systemuimode-edge-to-edge
 [Material 3 Tokens Update in Flutter]: /release/breaking-changes/material-design-3-token-update


### PR DESCRIPTION
Add doc about the breaking change and migration guide.
Related PR: https://github.com/flutter/engine/pull/52350
## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
