### PR TITLE
[SwiftPM] Prepare guides for next stable release

### DIFF
--- a/src/_includes/docs/swift-package-manager/check-ios-project.md
+++ b/src/_includes/docs/swift-package-manager/check-ios-project.md
@@ -1,0 +1,14 @@
+<!-- TODO -->
+Apps created before Flutter version <X.Y.Z> need to be migrated to support
+Swift Package Manager.
+
+To check if your project support Swift Package Manager:
+
+1. Open your app (`ios/Runner.xcworkspace`) in Xcode.
+1. Build your app using Xcode.
+1. Ensure that **Run Prepare Flutter Framework Script** runs as a pre-action
+   and that `FlutterGeneratedPluginSwiftPackage` is a target dependency.
+
+   {% render docs/captioned-image.liquid,
+   image:"development/packages-and-plugins/swift-package-manager/flutter-pre-action-build-log.png",
+   caption:"Ensure **Run Prepare Flutter Framework Script** runs as a pre-action" %}

--- a/src/_includes/docs/swift-package-manager/check-macos-project.md
+++ b/src/_includes/docs/swift-package-manager/check-macos-project.md
@@ -1,0 +1,14 @@
+<!-- TODO -->
+Apps created before Flutter version <X.Y.Z> need to be migrated to support
+Swift Package Manager.
+
+To check if your project support Swift Package Manager:
+
+1. Open your app (`macos/Runner.xcworkspace`) in Xcode.
+1. Build your app using Xcode.
+1. Ensure that **Run Prepare Flutter Framework Script** runs as a pre-action
+   and that `FlutterGeneratedPluginSwiftPackage` is a target dependency.
+
+   {% render docs/captioned-image.liquid,
+   image:"development/packages-and-plugins/swift-package-manager/flutter-pre-action-build-log.png",
+   caption:"Ensure **Run Prepare Flutter Framework Script** runs as a pre-action" %}

--- a/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
+++ b/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
@@ -1,51 +1,25 @@
-## How to turn on Swift Package Manager
-
-Flutter's Swift Package Manager support is turned off by default.
-To turn it on:
-
-1. Upgrade to the latest Flutter SDK:
-
-   ```sh
-   flutter upgrade
-   ```
-
-1. Turn on the Swift Package Manager feature:
-
-   ```sh
-   flutter config --enable-swift-package-manager
-   ```
-
-Using the Flutter CLI to run an app [migrates the project][addSPM] to add
-Swift Package Manager integration.
-This makes your project download the Swift packages that
-your Flutter plugins depend on.
-An app with Swift Package Manager integration requires Flutter version 3.24 or
-higher.
-To use an older Flutter version,
-you will need to [remove Swift Package Manager integration][removeSPM]
-from the app.
-
-Flutter falls back to CocoaPods for dependencies that do not support Swift
-Package Manager yet.
-
 ## How to turn off Swift Package Manager
 
 :::secondary Plugin authors
-Plugin authors need to turn on and off Flutter's Swift Package Manager
+Plugin authors need to turn off and on Flutter's Swift Package Manager
 support for testing.
-App developers do not need to disable Swift Package Manager support,
+App developers do not need to turn off Swift Package Manager support
 unless they are running into issues.
 
 If you find a bug in Flutter's Swift Package Manager support,
 [open an issue][].
 :::
 
-Disabling Swift Package Manager causes Flutter to use CocoaPods for all
+Flutter's Swift Package Manager support is on by default.
+Turning off Swift Package Manager causes Flutter to use CocoaPods for all
 dependencies.
 However, Swift Package Manager remains integrated with your project.
 To remove Swift Package Manager integration completely from your project,
-follow the [How to remove Swift Package Manager integration][removeSPM]
+follow the [How to remove Swift Package Manager integration][]
 instructions.
+
+[open an issue]: {{site.github}}/flutter/flutter/issues/new?template=2_bug.yml
+[How to remove Swift Package Manager integration]: /packages-and-plugins/swift-package-manager/for-app-developers#how-to-remove-swift-package-manager-integration
 
 ### Turn off for a single project
 
@@ -71,8 +45,10 @@ flutter config --no-enable-swift-package-manager
 This turns off Swift Package Manager for the current user.
 
 If a project is incompatible with Swift Package Manager, all contributors
-need to run this command. 
+need to run this command.
 
-[addSPM]: /packages-and-plugins/swift-package-manager/for-app-developers/#how-to-add-swift-package-manager-integration
-[removeSPM]: /packages-and-plugins/swift-package-manager/for-app-developers#how-to-remove-swift-package-manager-integration
-[open an issue]: {{site.github}}/flutter/flutter/issues/new?template=2_bug.yml
+To undo this, run the following command:
+
+```sh
+flutter config --enable-swift-package-manager
+```

--- a/src/_includes/docs/swift-package-manager/migrate-ios-project-manually.md
+++ b/src/_includes/docs/swift-package-manager/migrate-ios-project-manually.md
@@ -1,6 +1,5 @@
-Once you [turn on Swift Package Manager][], the Flutter CLI tries to migrate
-your project to use Swift Package Manager the next time you run your app
-using the CLI.
+The Flutter CLI has an [automatic migration][] that tries to add Swift Package
+Manager integration to your app when you run it using the CLI.
 
 However, the Flutter CLI tool might be unable to migrate your project
 automatically if there are unexpected modifications.
@@ -81,5 +80,5 @@ the following files in your issue:
 
 1. Ensure that the app runs on the command line with `flutter run`.
 
-[turn on Swift Package Manager]: /packages-and-plugins/swift-package-manager/for-app-developers/#how-to-turn-on-swift-package-manager
+[automatic migration]: /packages-and-plugins/swift-package-manager/for-app-developers/#add-to-a-flutter-app
 [file an issue]: {{site.github}}/flutter/flutter/issues/new?template=2_bug.yml

--- a/src/_includes/docs/swift-package-manager/migrate-ios-project.md
+++ b/src/_includes/docs/swift-package-manager/migrate-ios-project.md
@@ -1,11 +1,10 @@
-Once you [turn on Swift Package Manager][], the Flutter CLI tries to migrate
-your project the next time you run your app using the CLI.
-This migration updates your Xcode project to use Swift Package Manager to
-add Flutter plugin dependencies.
+To migrate your iOS project to add Swift Package Manager integration:
 
-To migrate your project:
+1. Turn on the Swift Package Manager app migration:
 
-1. [Turn on Swift Package Manager][].
+   ```sh
+   flutter config --enable-swift-package-manager-migration
+   ```
 
 1. Run the iOS app using the Flutter CLI.
 
@@ -24,15 +23,8 @@ To migrate your project:
 1. If the Flutter CLI's automatic migration fails, follow the steps in
    [add Swift Package Manager integration manually][manualIntegration].
 
-[Optional] To check if your project is migrated:
-
-1. Run the app in Xcode.
-1. Ensure that  **Run Prepare Flutter Framework Script** runs as a pre-action
-   and that `FlutterGeneratedPluginSwiftPackage` is a target dependency.
-
-   {% render docs/captioned-image.liquid,
-   image:"development/packages-and-plugins/swift-package-manager/flutter-pre-action-build-log.png",
-   caption:"Ensure **Run Prepare Flutter Framework Script** runs as a pre-action" %}
+If your app supports macOS, you will need to repeat these steps for your
+macOS project.
 
 [Turn on Swift Package Manager]: /packages-and-plugins/swift-package-manager/for-app-developers/#how-to-turn-on-swift-package-manager
 [manualIntegration]: /packages-and-plugins/swift-package-manager/for-app-developers/#add-to-a-flutter-app-manually

--- a/src/_includes/docs/swift-package-manager/migrate-macos-project-manually.md
+++ b/src/_includes/docs/swift-package-manager/migrate-macos-project-manually.md
@@ -1,6 +1,5 @@
-Once you [turn on Swift Package Manager][], the Flutter CLI tries to migrate
-your project to use Swift Package Manager the next time you run your app
-using the CLI.
+The Flutter CLI has an [automatic migration][] that tries to add Swift Package
+Manager integration to your app when you run it using the CLI.
 
 However, the Flutter CLI tool might be unable to migrate your project
 automatically if there are unexpected modifications.
@@ -81,5 +80,5 @@ the following files in your issue:
 
 1. Ensure that the app runs on the command line with `flutter run`.
 
-[turn on Swift Package Manager]: /packages-and-plugins/swift-package-manager/for-app-developers/#how-to-turn-on-swift-package-manager
+[automatic migration]: /packages-and-plugins/swift-package-manager/for-app-developers/#add-to-a-flutter-app
 [file an issue]: {{site.github}}/flutter/flutter/issues/new?template=2_bug.yml

--- a/src/_includes/docs/swift-package-manager/migrate-macos-project.md
+++ b/src/_includes/docs/swift-package-manager/migrate-macos-project.md
@@ -1,11 +1,10 @@
-Once you [turn on Swift Package Manager][], the Flutter CLI tries to migrate
-your project the next time you run your app using the CLI.
-This migration updates your Xcode project to use Swift Package Manager to
-add Flutter plugin dependencies.
+To migrate your macOS project to add Swift Package Manager integration:
 
-To migrate your project:
+1. Turn on the Swift Package Manager app migration:
 
-1. [Turn on Swift Package Manager][].
+   ```sh
+   flutter config --enable-swift-package-manager-migration
+   ```
 
 1. Run the macOS app using the Flutter CLI.
 
@@ -24,15 +23,7 @@ To migrate your project:
 1. If the Flutter CLI's automatic migration fails, follow the steps in
    [add Swift Package Manager integration manually][manualIntegration].
 
-[Optional] To check if your project is migrated:
+If your app supports iOS, you will need to repeat these steps for your
+iOS project.
 
-1. Run the app in Xcode.
-1. Ensure that  **Run Prepare Flutter Framework Script** runs as a pre-action
-   and that `FlutterGeneratedPluginSwiftPackage` is a target dependency.
-
-   {% render docs/captioned-image.liquid,
-   image:"development/packages-and-plugins/swift-package-manager/flutter-pre-action-build-log.png",
-   caption:"Ensure **Run Prepare Flutter Framework Script** runs as a pre-action" %}
-
-[Turn on Swift Package Manager]: /packages-and-plugins/swift-package-manager/for-app-developers/#how-to-turn-on-swift-package-manager
 [manualIntegration]: /packages-and-plugins/swift-package-manager/for-app-developers/#add-to-a-flutter-app-manually

--- a/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
@@ -1,7 +1,11 @@
 Replace `plugin_name` throughout this guide with the name of your plugin.
 The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 
-1. [Turn on the Swift Package Manager feature][enableSPM].
+1. Turn on the Swift Package Manager feature:
+
+   ```sh
+   flutter config --enable-swift-package-manager
+   ```
 
 1. Start by creating a directory under the `ios`, `macos`, and/or `darwin`
    directories.
@@ -380,6 +384,18 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
       cd path/to/plugin/example/
       ```
 
+   1. [Add Swift Package Manager integration to the plugin's example app][].
+
+      :::note
+      This raises the example app's Flutter SDK requirement to version 3.24 or
+      higher.
+
+      If you'd like to run the example app using an older Flutter SDK version,
+      do not commit the migration's changes to your version control system.
+      If needed, you can always
+      [undo the Swift Package Manager migration][removeSPM].
+      :::
+
    1. Ensure the plugin's example app builds and runs.
 
       ```sh
@@ -447,7 +463,6 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 
    * Follow instructions for [testing plugins][].
 
-[enableSPM]: /packages-and-plugins/swift-package-manager/for-plugin-authors#how-to-turn-on-swift-package-manager
 [`PrivacyInfo.xcprivacy` file]: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
 [`public_header_files`]: https://guides.cocoapods.org/syntax/podspec.html#public_header_files
 [Swift Package Manager's documentation]: {{site.github}}/apple/swift-package-manager/blob/main/Documentation/Usage.md#creating-c-language-targets
@@ -458,6 +473,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 [Product]: https://developer.apple.com/documentation/packagedescription/product
 [Bundling resources]: https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package#Explicitly-declare-or-exclude-resources
 [Xcode resource detection]: https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package#:~:text=Xcode%20detects%20common%20resource%20types%20for%20Apple%20platforms%20and%20treats%20them%20as%20a%20resource%20automatically
+[Add Swift Package Manager integration to the plugin's example app]: /packages-and-plugins/swift-package-manager/for-app-developers/#add-to-a-flutter-app
 [removeSPM]: /packages-and-plugins/swift-package-manager/for-app-developers#how-to-remove-swift-package-manager-integration
 [update unit tests in the plugin's example app]: /packages-and-plugins/swift-package-manager/for-plugin-authors/#how-to-update-unit-tests-in-a-plugins-example-app
 [testing plugins]: https://docs.flutter.dev/testing/testing-plugins

--- a/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
@@ -1,7 +1,11 @@
 Replace `plugin_name` throughout this guide with the name of your plugin.
 The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 
-1. [Turn on the Swift Package Manager feature][enableSPM].
+1. Turn on the Swift Package Manager feature:
+
+   ```sh
+   flutter config --enable-swift-package-manager
+   ```
 
 1. Start by creating a directory under the `ios`, `macos`, and/or `darwin`
    directories.
@@ -289,17 +293,9 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
       cd path/to/plugin/example/
       ```
 
-   1. Ensure the plugin's example app builds and runs.
-
-      ```sh
-      flutter run
-      ```
+   1. [Add Swift Package Manager integration to the plugin's example app][].
 
       :::note
-      Using the Flutter CLI to run the plugin's example app with the
-      Swift Package Manager feature turned on migrates the project to add
-      Swift Package Manager integration.
-
       This raises the example app's Flutter SDK requirement to version 3.24 or
       higher.
 
@@ -308,6 +304,12 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
       If needed, you can always
       [undo the Swift Package Manager migration][removeSPM].
       :::
+
+   1. Ensure the plugin's example app builds and runs.
+
+      ```sh
+      flutter run
+      ```
 
    1. Open the plugin's example app in Xcode.
       Ensure that **Package Dependencies** shows in the left
@@ -320,7 +322,6 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 
    * Follow instructions for [testing plugins][].
 
-[enableSPM]: /packages-and-plugins/swift-package-manager/for-plugin-authors#how-to-turn-on-swift-package-manager
 [`PrivacyInfo.xcprivacy` file]: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
 [Pigeon]: https://pub.dev/packages/pigeon
 [CocoaPods `dependency`]: https://guides.cocoapods.org/syntax/podspec.html#dependency
@@ -330,6 +331,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 [`Bundle.module`]: https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package#Access-a-resource-in-code
 [Bundling resources]: https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package#Explicitly-declare-or-exclude-resources
 [Xcode resource detection]: https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package#:~:text=Xcode%20detects%20common%20resource%20types%20for%20Apple%20platforms%20and%20treats%20them%20as%20a%20resource%20automatically
+[Add Swift Package Manager integration to the plugin's example app]: /packages-and-plugins/swift-package-manager/for-app-developers/#add-to-a-flutter-app
 [removeSPM]: /packages-and-plugins/swift-package-manager/for-app-developers#how-to-remove-swift-package-manager-integration
 [update unit tests in the plugin's example app]: /packages-and-plugins/swift-package-manager/for-plugin-authors/#how-to-update-unit-tests-in-a-plugins-example-app
 [testing plugins]: https://docs.flutter.dev/testing/testing-plugins

--- a/src/content/packages-and-plugins/swift-package-manager/for-app-developers.md
+++ b/src/content/packages-and-plugins/swift-package-manager/for-app-developers.md
@@ -6,14 +6,12 @@ description: How to use Swift Package Manager for native iOS or macOS dependenci
 :::warning
 Flutter is migrating to [Swift Package Manager][] to manage iOS and macOS native
 dependencies.
-Flutter's support of Swift Package Manager is under development.
 If you find a bug in Flutter's Swift Package Manager support,
 [open an issue][].
-Swift Package Manager support is [off by default][].
 Flutter continues to support CocoaPods.
 :::
 
-Flutter's Swift Package Manager integration has several benefits:
+Flutter's Swift Package Manager feature has several benefits:
 
 1. **Provides access to the Swift package ecosystem**.
    Flutter plugins can use the growing ecosystem of [Swift packages][]. 
@@ -23,11 +21,23 @@ Flutter's Swift Package Manager integration has several benefits:
    Swift Package Manager.
 
 [Swift Package Manager]: https://www.swift.org/documentation/package-manager/
-[off by default]: #how-to-turn-on-swift-package-manager
 [Swift packages]: https://swiftpackageindex.com/
 [open an issue]: {{site.github}}/flutter/flutter/issues/new?template=2_bug.yml
 
-{% include docs/swift-package-manager/how-to-enable-disable.md %}
+## How to check if your app supports Swift Package Manager
+
+{% tabs %}
+{% tab "iOS project" %}
+
+{% include docs/swift-package-manager/check-ios-project.md %}
+
+{% endtab %}
+{% tab "macOS project" %}
+
+{% include docs/swift-package-manager/check-ios-project.md %}
+
+{% endtab %}
+{% endtabs %}
 
 ## How to add Swift Package Manager integration
 
@@ -91,7 +101,7 @@ of the `Flutter` target.
 
 ## How to remove Swift Package Manager integration
 
-To add Swift Package Manager integration, the Flutter CLI migrates your project.
+The Flutter CLI migrates your project to add Swift Package Manager integration.
 This migration updates your Xcode project to add Flutter plugin dependencies.
 
 To undo this migration:
@@ -141,6 +151,8 @@ To undo this migration:
    caption:"The build pre-action to remove" %}
 
 [Turn off Swift Package Manager]: /packages-and-plugins/swift-package-manager/for-app-developers/#how-to-turn-off-swift-package-manager
+
+{% include docs/swift-package-manager/how-to-enable-disable.md %}
 
 ## How to use a Swift Package Manager Flutter plugin that requires a higher OS version
 

--- a/src/content/packages-and-plugins/swift-package-manager/for-plugin-authors.md
+++ b/src/content/packages-and-plugins/swift-package-manager/for-plugin-authors.md
@@ -4,12 +4,10 @@ description: How to add Swift Package Manager compatibility to iOS and macOS plu
 ---
 
 :::warning
-Flutter is migrating to [Swift Package Manager][]
-to manage iOS and macOS native dependencies.
-Flutter's support of Swift Package Manager is under development.
+Flutter is migrating to [Swift Package Manager][] to manage iOS and macOS
+native dependencies.
 If you find a bug in Flutter's Swift Package Manager support,
 [open an issue][].
-Swift Package Manager support is [off by default][].
 Flutter continues to support CocoaPods.
 :::
 
@@ -22,13 +20,17 @@ Flutter's Swift Package Manager integration has several benefits:
    In the future, you won’t need to install Ruby and CocoaPods to target iOS or
    macOS.
 
+Plugin authors are encouraged to add support for Swift Package Manager to their
+plugins.
+Many popular plugins — including [Firebase], [plus plugins][], and [more][] —
+have already migrated to Swift Package Manager!
 
 [Swift Package Manager]: https://www.swift.org/documentation/package-manager/
-[off by default]: #how-to-turn-on-swift-package-manager
 [Swift packages]: https://swiftpackageindex.com/
 [open an issue]: {{site.github}}/flutter/flutter/issues/new?template=2_bug.yml
-
-{% include docs/swift-package-manager/how-to-enable-disable.md %}
+[Firebase]: https://github.com/firebase/flutterfire/issues/13205
+[plus plugins]: https://github.com/fluttercommunity/plus_plugins/issues/3152
+[more]: https://pub.dev/packages?q=is%3Aswiftpm-plugin
 
 ## How to add Swift Package Manager support to an existing Flutter plugin
 
@@ -119,7 +121,7 @@ To update your unit tests:
 
    1. Ensure `RunnerTests` **Build Phases** has a **Link Binary With Libraries**
       build phase:
-   
+
       {% render docs/captioned-image.liquid,
       image:"development/packages-and-plugins/swift-package-manager/runner-tests-link-binary-with-libraries.png",
       caption:"The `Link Binary With Libraries` Build Phase in the `RunnerTests` target" %}
@@ -147,3 +149,5 @@ To update your unit tests:
 1. Ensure tests pass **Product > Test**.
 
 [library type recommendations]: https://developer.apple.com/documentation/packagedescription/product/library(name:type:targets:)
+
+{% include docs/swift-package-manager/how-to-enable-disable.md %}


### PR DESCRIPTION
⚠️ Please do not merge this until after the next stable release

_Description of what this PR is changing or adding, and why:_

In the next stable release, SwiftPM will be on by default. However, users will need to opt-in to the SwiftPM app migration using `flutter config --enable-swift-package-manager-migration`. This updates our guides accordingly.

Part of: https://github.com/flutter/flutter/issues/151567

_Issues fixed by this PR (if any):_ N/A

_PRs or commits this PR depends on (if any):_

https://github.com/flutter/flutter/pull/158897
https://github.com/flutter/flutter/pull/159309

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
