### PR TITLE
docs: update migrate swift plugin docs with `.gitignore`

### DIFF
--- a/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
@@ -237,7 +237,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
    Otherwise, using `Bundle.module` results in an error.
    :::
 
-1. If your `.gitignore` does not contain a `.build/` and `.swiftpm/` directories,
+1. If your `.gitignore` doesn't include `.build/` and `.swiftpm/` directories,
    you'll want to update your `.gitignore` to include:
 
     ```text title=".gitignore"

--- a/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
@@ -237,7 +237,15 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
    Otherwise, using `Bundle.module` results in an error.
    :::
 
-1. Commit your plugin's changes to your version control system.
+1. If your `.gitignore` does not contain a `.build/` and `.swiftpm/` directories,
+   you'll want to update your `.gitignore` to include:
+
+    ```text title=".gitignore"
+    .build/
+    .swiftpm/
+    ```
+
+    Commit your plugin's changes to your version control system.
 
 1. Verify the plugin still works with CocoaPods.
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

This PR adds notes about new `.gitignore` entries for those who want to migrate their old packages to SPM.

_Issues fixed by this PR (if any):_

Without this step - the guide suggests _"Commit your plugin's changes to your version control system"_ with those `.build/` and `.swiftpm/` directories newly created in previous steps.

_PRs or commits this PR depends on (if any):_

https://github.com/flutter/packages/pull/6705

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.