### PR TITLE
Update wide-gamut-framework.md

### DIFF
--- a/src/content/release/breaking-changes/wide-gamut-framework.md
+++ b/src/content/release/breaking-changes/wide-gamut-framework.md
@@ -113,10 +113,14 @@ In the short term, you can scale the components themselves.
 
 ```dart
 extension IntColorComponents on Color {
-  int get intAlpha => this.a ~/ 255;
-  int get intRed => this.r ~/ 255;
-  int get intGreen => this.g ~/ 255;
-  int get intBlue => this.b ~/ 255;
+  int get intAlpha => _floatToInt8(this.a);
+  int get intRed => _floatToInt8(this.r);
+  int get intGreen => _floatToInt8(this.g);
+  int get intBlue => _floatToInt8(this.b);
+
+  int _floatToInt8(double x) {
+    return (x * 255.0).round() & 0xff;
+  }
 }
 ```
 


### PR DESCRIPTION
Fixed the `IntColorComponents` extension logic.

This PR is updating the `IntColorComponents` logic to convert correctly between floating-point and int `Color` component values.

Fixes #11504 

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
