### PR TITLE
document how `FLUTTER_BUILD_MODE` is set during asset transformation

### DIFF
--- a/src/content/ui/assets/asset-transformation.md
+++ b/src/content/ui/assets/asset-transformation.md
@@ -79,9 +79,9 @@ fails with error message explaining that transformation of the asset failed.
 Anything written to the [`stderr`] stream of the process by the transformer is
 included in the error message.
 
-During the invocation of the transformer, the `FLUTTER_BUILD_MODE`,
+During the invocation of the transformer, the `FLUTTER_BUILD_MODE`
 environment variable will be set to the CLI name of the build mode being used.
-For example, if you run your app with `flutter run -d macos --release`,
+For example, if you run your app with `flutter run -d macos --release`, then
 `FLUTTER_BUILD_MODE` will be set to `release`.
 
 ## Sample

--- a/src/content/ui/assets/asset-transformation.md
+++ b/src/content/ui/assets/asset-transformation.md
@@ -74,10 +74,15 @@ An asset transformer is a Dart [command-line app][] that is invoked with
 the file to transform and `--output`, which is the location where the
 transformer code must write its output to.
 
-If the transformer applications finishes with a non-zero exit code, the build
+If the transformer finishes with a non-zero exit code, the application build
 fails with error message explaining that transformation of the asset failed.
 Anything written to the [`stderr`] stream of the process by the transformer is
 included in the error message.
+
+During the invocation of the transformer, the `FLUTTER_BUILD_MODE`,
+environment variable will be set to the CLI name of the build mode being used.
+For example, if you run your app with `flutter run -d macos --release`,
+`FLUTTER_BUILD_MODE` will be set to `release`.
 
 ## Sample
 


### PR DESCRIPTION
Documents the feature long-ago implemented by https://github.com/flutter/flutter/pull/144958.

**Summary**: this documents that asset-transforming Dart packages can read `FLUTTER_BUILD_MODE` from the environment to determine what mode the app is being built in. This also tries to fix what I think was a typo in the original docs.

If you are curious about what asset transformation is, read [Assets and Images (flutter.dev)](https://docs.flutter.dev/ui/assets/assets-and-images) to learn how to bundle assets (arbitrary files, such as images) into your app and then read [Asset transformation (flutter.dev)](https://docs.flutter.dev/ui/assets/asset-transformation).

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
