### PR TITLE
Reference `EnableImpeller` not `DisableImpeller`.

### DIFF
--- a/src/content/perf/impeller.md
+++ b/src/content/perf/impeller.md
@@ -92,8 +92,8 @@ No action on your part is necessary for this fallback behavior.
 
 ```xml
 <meta-data
-    android:name="io.flutter.embedding.android.DisableImpeller"
-    android:value="true" />
+    android:name="io.flutter.embedding.android.EnableImpeller"
+    android:value="false" />
 ```
 
 ### macOS


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/160595.

The latter never existed.

Side-note: We should never have _negative_ flags (they are confusing to parse).