### PR TITLE
Update wide-gamut-framework.md

### DIFF
--- a/src/content/release/breaking-changes/wide-gamut-framework.md
+++ b/src/content/release/breaking-changes/wide-gamut-framework.md
@@ -67,7 +67,7 @@ class Foo implements Color {
   int _red;
 
   @override
-  double get r => _red * 255.0;
+  double get r => _red / 255.0;
 }
 ```
 


### PR DESCRIPTION
This fixes a typo in one of the code snippets: the integer `_red` component needs to be *divided by* 255.0 to get `r`, not *multiplied*.

## Presubmit checklist

- [X] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
