### PR TITLE
Update set-up-app-links.md (add missing line)

### DIFF
--- a/src/content/cookbook/navigation/set-up-app-links.md
+++ b/src/content/cookbook/navigation/set-up-app-links.md
@@ -88,6 +88,7 @@ It provides a simple API to handle complex routing scenarios.
     Replace `example.com` with your own web domain.
 
     ```xml
+    <meta-data android:name="flutter_deeplinking_enabled" android:value="true" />
     <intent-filter android:autoVerify="true">
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
`<meta-data android:name="flutter_deeplinking_enabled" android:value="true" />`

This one line of code took me 3 days.
Without this, deep linking doesn't work.

