### PR TITLE
fix: move child to right widget in dependency injection page

### DIFF
--- a/src/content/app-architecture/case-study/dependency-injection.md
+++ b/src/content/app-architecture/case-study/dependency-injection.md
@@ -92,8 +92,8 @@ runApp(
       ),
       // In the Compass app, additional service and repository providers live here.
     ],
+    child: const MainApp(),
   ),
-  child: const MainApp(),
 );
 ```
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

The `dependencies.dart` code snippet has the `child: const MainApp(),` line within the scope of `runApp` instead of `MultiProvider`. `runApp` doesn't have a named parameter `child`, while `MultiProvider` does.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
