### PR TITLE
Fix image suffix mismatch in description

### DIFF
--- a/examples/get-started/flutter-for/android_devs/lib/images.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/images.dart
@@ -8,7 +8,7 @@ class MyWidget extends StatelessWidget {
     return const Image(
         image:
             // #docregion asset-image
-            AssetImage('images/my_icon.jpeg')
+            AssetImage('images/my_icon.png')
         // #enddocregion asset-image
         );
   }

--- a/examples/get-started/flutter-for/ios_devs/lib/images.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/images.dart
@@ -7,7 +7,7 @@ class MyWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return const Image(
       // #docregion asset-image
-      image: AssetImage('images/a_dot_burr.jpeg'),
+      image: AssetImage('images/a_dot_burr.png'),
       // #enddocregion asset-image
     );
   }

--- a/src/content/get-started/flutter-for/android-devs.md
+++ b/src/content/get-started/flutter-for/android-devs.md
@@ -1293,14 +1293,14 @@ Next, you'll need to declare these images in your `pubspec.yaml` file:
 
 ```yaml
 assets:
- - images/my_icon.jpeg
+ - images/my_icon.png
 ```
 
 You can then access your images using `AssetImage`:
 
 <?code-excerpt "lib/images.dart (asset-image)"?>
 ```dart
-AssetImage('images/my_icon.jpeg')
+AssetImage('images/my_icon.png')
 ```
 
 or directly in an `Image` widget:

--- a/src/content/get-started/flutter-for/android-devs.md
+++ b/src/content/get-started/flutter-for/android-devs.md
@@ -1277,30 +1277,30 @@ val flutterAssetStream = assetManager.open("flutter_assets/assets/my_flutter_ass
 
 Flutter can't access native resources or assets.
 
-To add a new image asset called `my_icon.jpeg` to our Flutter project,
+To add a new image asset called `my_icon.png` to our Flutter project,
 for example, and deciding that it should live in a folder we
 arbitrarily called `images`, you would put the base image (1.0x)
 in the `images` folder, and all the other variants in sub-folders
 called with the appropriate ratio multiplier:
 
 ```plaintext
-images/my_icon.jpeg       // Base: 1.0x image
-images/2.0x/my_icon.jpeg  // 2.0x image
-images/3.0x/my_icon.jpeg  // 3.0x image
+images/my_icon.png       // Base: 1.0x image
+images/2.0x/my_icon.png  // 2.0x image
+images/3.0x/my_icon.png  // 3.0x image
 ```
 
 Next, you'll need to declare these images in your `pubspec.yaml` file:
 
 ```yaml
 assets:
- - images/my_icon.jpeg
+ - images/my_icon.png
 ```
 
 You can then access your images using `AssetImage`:
 
 <?code-excerpt "lib/images.dart (asset-image)"?>
 ```dart
-AssetImage('images/my_icon.jpeg')
+AssetImage('images/my_icon.png')
 ```
 
 or directly in an `Image` widget:

--- a/src/content/get-started/flutter-for/android-devs.md
+++ b/src/content/get-started/flutter-for/android-devs.md
@@ -1277,30 +1277,30 @@ val flutterAssetStream = assetManager.open("flutter_assets/assets/my_flutter_ass
 
 Flutter can't access native resources or assets.
 
-To add a new image asset called `my_icon.png` to our Flutter project,
+To add a new image asset called `my_icon.jpeg` to our Flutter project,
 for example, and deciding that it should live in a folder we
 arbitrarily called `images`, you would put the base image (1.0x)
 in the `images` folder, and all the other variants in sub-folders
 called with the appropriate ratio multiplier:
 
 ```plaintext
-images/my_icon.png       // Base: 1.0x image
-images/2.0x/my_icon.png  // 2.0x image
-images/3.0x/my_icon.png  // 3.0x image
+images/my_icon.jpeg       // Base: 1.0x image
+images/2.0x/my_icon.jpeg  // 2.0x image
+images/3.0x/my_icon.jpeg  // 3.0x image
 ```
 
 Next, you'll need to declare these images in your `pubspec.yaml` file:
 
 ```yaml
 assets:
- - images/my_icon.png
+ - images/my_icon.jpeg
 ```
 
 You can then access your images using `AssetImage`:
 
 <?code-excerpt "lib/images.dart (asset-image)"?>
 ```dart
-AssetImage('images/my_icon.png')
+AssetImage('images/my_icon.jpeg')
 ```
 
 or directly in an `Image` widget:

--- a/src/content/get-started/flutter-for/uikit-devs.md
+++ b/src/content/get-started/flutter-for/uikit-devs.md
@@ -1497,7 +1497,7 @@ You can now access your images using `AssetImage`:
 
 <?code-excerpt "lib/images.dart (asset-image)"?>
 ```dart
-image: AssetImage('images/a_dot_burr.jpeg'),
+image: AssetImage('images/a_dot_burr.png'),
 ```
 
 or directly in an `Image` widget:

--- a/src/content/get-started/flutter-for/xamarin-forms-devs.md
+++ b/src/content/get-started/flutter-for/xamarin-forms-devs.md
@@ -1318,7 +1318,7 @@ Next, you'll need to declare these images in your `pubspec.yaml` file:
 
 ```yaml
 assets:
- - images/my_icon.jpeg
+ - images/my_icon.png
 ```
 
 You can directly access your images in an `Image.asset` widget:

--- a/src/content/tools/pubspec.md
+++ b/src/content/tools/pubspec.md
@@ -87,8 +87,8 @@ dev_dependencies:
   [!generate: true!] # Enables generation of localized strings from arb files
 
   [!assets:!]  # Lists assets, such as image files
-    [!- images/a_dot_burr.jpeg!]
-    [!- images/a_dot_ham.jpeg!]
+    [!- images/a_dot_burr.png!]
+    [!- images/a_dot_ham.png!]
 
   [!fonts:!]              # Required if your app uses custom fonts
     [!- family: Schyler!]


### PR DESCRIPTION
Fix image suffix mismatch in description


## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
