### PR TITLE
Fixes #11545 - Fix the null safety issue in shimmer example in cookbook

### DIFF
--- a/examples/cookbook/effects/shimmer_loading/lib/original_example.dart
+++ b/examples/cookbook/effects/shimmer_loading/lib/original_example.dart
@@ -247,8 +247,8 @@ class _ShimmerLoadingState extends State<ShimmerLoading> {
     }
 
     // Collect ancestor shimmer info.
-    final shimmer = Shimmer.of(context)!;
-    if (!shimmer.isSized) {
+    final shimmer = Shimmer.of(context);
+    if (shimmer == null || !shimmer.isSized) {
       // The ancestor Shimmer widget has not laid
       // itself out yet. Return an empty box.
       return const SizedBox();

--- a/examples/cookbook/effects/shimmer_loading/lib/shimmer_loading_state_pt2.dart
+++ b/examples/cookbook/effects/shimmer_loading/lib/shimmer_loading_state_pt2.dart
@@ -23,8 +23,8 @@ class _ShimmerLoadingState extends State<ShimmerLoading> {
     }
 
     // Collect ancestor shimmer information.
-    final shimmer = Shimmer.of(context)!;
-    if (!shimmer.isSized) {
+    final shimmer = Shimmer.of(context);
+    if (shimmer == null || !shimmer.isSized) {
       // The ancestor Shimmer widget isn't laid
       // out yet. Return an empty box.
       return const SizedBox();

--- a/src/content/cookbook/effects/shimmer-loading.md
+++ b/src/content/cookbook/effects/shimmer-loading.md
@@ -414,11 +414,11 @@ class _ShimmerLoadingState extends State<ShimmerLoading> {
       return widget.child;
     }
 
-    // Collect ancestor shimmer information.
-    final shimmer = Shimmer.of(context)!;
-    if (!shimmer.isSized) {
-      // The ancestor Shimmer widget isn't laid
-      // out yet. Return an empty box.
+    // Collect ancestor shimmer info.
+    final shimmer = Shimmer.of(context);
+    if (shimmer == null || !shimmer.isSized) {
+      // The ancestor Shimmer widget has not laid
+      // itself out yet. Return an empty box.
       return const SizedBox();
     }
     final shimmerSize = shimmer.size;
@@ -815,8 +815,8 @@ class _ShimmerLoadingState extends State<ShimmerLoading> {
     }
 
     // Collect ancestor shimmer info.
-    final shimmer = Shimmer.of(context)!;
-    if (!shimmer.isSized) {
+    final shimmer = Shimmer.of(context);
+    if (shimmer == null || !shimmer.isSized) {
       // The ancestor Shimmer widget has not laid
       // itself out yet. Return an empty box.
       return const SizedBox();


### PR DESCRIPTION
_Issues fixed by this PR (if any):_ #11545 

> I am not sure if I need to make changes in all the files that I changed or not so I'll keep this change in the Draft until someone corrects me If I made the wrong changes.

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
