### PR TITLE
Fix widget catalog category pages being empty due to liquidjs regression

### DIFF
--- a/src/_includes/docs/catalog-page-material.md
+++ b/src/_includes/docs/catalog-page-material.md
@@ -1,9 +1,4 @@
-{% for section in catalog.index %}
-  {% if section.name == categoryName %}
-    {% assign category = section %}
-    {% break %}
-  {% endif %}
-{% endfor %}
+{% assign category = catalog.index | find: "name", categoryName %}
 
 {% if category.subcategories -%}
 {% for sub in category.subcategories -%}

--- a/src/_includes/docs/catalog-page.md
+++ b/src/_includes/docs/catalog-page.md
@@ -1,9 +1,4 @@
-{% for section in catalog.index %}
-  {% if section.name == categoryName %}
-    {% assign category = section %}
-    {% break %}
-  {% endif %}
-{% endfor %}
+{% assign category = catalog.index | find: "name", categoryName %}
 
 {{category.description}}
 


### PR DESCRIPTION
A regression to `break` in the latest liquidjs release caused each category page's contents to not be rendered. This fixes this by instead relying on the built-in `find` filter which is simpler and works in versions with and without the behavior change.

Fixes https://github.com/flutter/website/issues/11533
Fixes https://github.com/flutter/website/issues/11534
Fixes https://github.com/flutter/website/issues/11535
Fixes https://github.com/flutter/website/issues/11536
Fixes https://github.com/flutter/website/issues/11537
Fixes https://github.com/flutter/website/issues/11538
Fixes https://github.com/flutter/website/issues/11539
Fixes https://github.com/flutter/website/issues/11540
Fixes https://github.com/flutter/website/issues/11541
Fixes https://github.com/flutter/website/issues/11543
Fixes https://github.com/flutter/website/issues/11547
Fixes https://github.com/flutter/website/issues/11548
Fixes https://github.com/flutter/website/issues/11550
Fixes https://github.com/flutter/website/issues/11551
