### PR TITLE
Update deep link guide with a note for version earlier than 3.27

### DIFF
--- a/src/content/cookbook/navigation/set-up-app-links.md
+++ b/src/content/cookbook/navigation/set-up-app-links.md
@@ -96,7 +96,13 @@ It provides a simple API to handle complex routing scenarios.
         <data android:scheme="https" />
     </intent-filter>
     ```
-   
+    :::note
+      If you use a flutter version earlier than 3.27,
+      you need to manually opt in to flutter deep link by  
+      adding the following metadata tag to `<activity>`: 
+    ```<meta-data android:name="flutter_deeplinking_enabled" android:value="true" />```
+    :::
+
     :::note
     If you use a third-party plugin to handle deep links,
     such as [app_links][], 
@@ -104,9 +110,8 @@ It provides a simple API to handle complex routing scenarios.
     break these plugins. 
     
     To opt out of using Flutter's default deep link handler,
-     add the following metadata tag:
+     add the following metadata tag to `<activity>`:
     ```<meta-data android:name="flutter_deeplinking_enabled" android:value="false" />```
-    to opt out of Flutter's default deeplink handler 
     :::
 
 ## 3. Hosting assetlinks.json file

--- a/src/content/cookbook/navigation/set-up-app-links.md
+++ b/src/content/cookbook/navigation/set-up-app-links.md
@@ -96,22 +96,29 @@ It provides a simple API to handle complex routing scenarios.
         <data android:scheme="https" />
     </intent-filter>
     ```
-    :::note
-      If you use a flutter version earlier than 3.27,
-      you need to manually opt in to flutter deep link by  
-      adding the following metadata tag to `<activity>`: 
-    ```<meta-data android:name="flutter_deeplinking_enabled" android:value="true" />```
+
+    :::version-note
+    If you use a Flutter version earlier than 3.27,
+    you need to manually opt in to deep linking by
+    adding the following metadata tag to `<activity>`:
+
+    ```xml
+    <meta-data android:name="flutter_deeplinking_enabled" android:value="true" />
+    ```
     :::
 
     :::note
     If you use a third-party plugin to handle deep links,
-    such as [app_links][], 
+    such as [app_links][],
     Flutter's default deeplink handler will
-    break these plugins. 
-    
+    break these plugins.
+
     To opt out of using Flutter's default deep link handler,
-     add the following metadata tag to `<activity>`:
-    ```<meta-data android:name="flutter_deeplinking_enabled" android:value="false" />```
+    add the following metadata tag to `<activity>`:
+
+    ```xml
+    <meta-data android:name="flutter_deeplinking_enabled" android:value="false" />
+    ```
     :::
 
 ## 3. Hosting assetlinks.json file

--- a/src/content/cookbook/navigation/set-up-universal-links.md
+++ b/src/content/cookbook/navigation/set-up-universal-links.md
@@ -83,6 +83,11 @@ It provides a simple API to handle complex routing scenarios.
    Flutter project's `ios` folder.
 
   :::note
+  If you use a flutter version earlier than 3.27,
+  you need to manually opt in to flutter deep link by 
+  adding the key and value pair `FlutterDeepLinkingEnabled` and `YES` to info.Plist.
+  :::
+  :::note
   If you are using third-party plugins to handle deep links, 
   such as [app_links][],
   Flutter's default deeplink handler will

--- a/src/content/cookbook/navigation/set-up-universal-links.md
+++ b/src/content/cookbook/navigation/set-up-universal-links.md
@@ -82,20 +82,21 @@ It provides a simple API to handle complex routing scenarios.
 1. Open the `ios/Runner.xcworkspace` file inside the
    Flutter project's `ios` folder.
 
-  :::note
-  If you use a flutter version earlier than 3.27,
-  you need to manually opt in to flutter deep link by 
-  adding the key and value pair `FlutterDeepLinkingEnabled` and `YES` to info.Plist.
-  :::
-  :::note
-  If you are using third-party plugins to handle deep links, 
-  such as [app_links][],
-  Flutter's default deeplink handler will
-  break these plugins. 
+   :::version-note
+   If you use a Flutter version earlier than 3.27,
+   you need to manually opt in to deep linking by adding the
+   key and value pair `FlutterDeepLinkingEnabled` and `YES` to `info.Plist`.
+   :::
 
-  If you use a third-party plugin,
-  add the key and value pair `FlutterDeepLinkingEnabled` and `NO` to info.Plist.
-  :::
+   :::note
+   If you're using third-party plugins to handle deep links, 
+   such as [app_links][],
+   Flutter's default deeplink handler will
+   break these plugins.
+
+   If you use a third-party plugin, add the
+   key and value pair `FlutterDeepLinkingEnabled` and `NO` to `info.Plist`.
+   :::
 
 ### Add associated domains
 


### PR DESCRIPTION
Follow up on https://github.com/flutter/website/pull/11526.

This PR added a note for flutter version earlier than 3.27, you need to manually add code to opt-in to flutter deep link. 

Related PR: https://github.com/flutter/website/pull/11461. 
