### PR TITLE
Fix ValueNotifier example in state-management.md

### DIFF
--- a/src/content/get-started/fundamentals/state-management.md
+++ b/src/content/get-started/fundamentals/state-management.md
@@ -354,7 +354,7 @@ Column(
   children: [
     ValueListenableBuilder(
       valueListenable: counterNotifier,
-      builder: (context, child, value) {
+      builder: (context, value, child) {
         return Text('counter: $value');
       },
     ),


### PR DESCRIPTION
"value" and "child" were swapped in the ValueWidgetBuilder function

_Description of what this PR is changing or adding, and why:_ This is a correction in the order of parameters passed to a function, in the ValueNotifier usage example.

_Issues fixed by this PR (if any):_ 
![Screenshot 2024-12-27 223344](https://github.com/user-attachments/assets/b1c1603c-19f2-4be8-b8f3-cb52a3d8e380)


_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
