### PR TITLE
fix: corrected typo in documentation ("view mo" to "view model")

### DIFF
--- a/src/content/app-architecture/case-study/ui-layer.md
+++ b/src/content/app-architecture/case-study/ui-layer.md
@@ -191,7 +191,7 @@ propagates up to the UI layer and triggers a re-build of your Flutter widgets.
 3. `ViewModel.notifyListeners` is called, alerting the View of new UI State.
 4. The view (widget) re-renders.
 
-For example, when the user navigates to the Home screen and the view mo is
+For example, when the user navigates to the Home screen and the view model is
 created, the `_load` method is called.
 Until this method completes, the UI state is empty,
 the view displays a loading indicator.


### PR DESCRIPTION
The documentation had a typo in the term "view mo," which should have been written as "view model." This fix ensures clarity for readers following the Flutter architecture guide.

_Issues fixed by this PR (if any):_  
None.

_PRs or commits this PR depends on (if any):_  
None.

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.  
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).  
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).  
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.  
