### PR TITLE
Fixed markdown formatting for file names in documentation

### DIFF
--- a/src/content/app-architecture/case-study/index.md
+++ b/src/content/app-architecture/case-study/index.md
@@ -83,7 +83,7 @@ There are two popular means of organizing code:
 
 1. By feature - The classes needed for each feature are grouped together. For
    example, you might have an `auth` directory, which would contain files
-   like `auth_viewmodel.dart`, `login_usecase.dart`, `logout_usecase.dart,
+   like `auth_viewmodel.dart`, `login_usecase.dart`, `logout_usecase.dart`,
    `login_screen.dart`, `logout_button.dart`, etc.
 2. By type - Each "type" of architecture is grouped together.
    For example, you might have directories such as


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Fixed the incorrect markdown formatting in the document  `App Architecture/Architecture case study/Overview`. Here's the link to the specified section- [Architecture case study | Flutter](https://docs.flutter.dev/app-architecture/case-study#package-structure).

_Issues fixed by this PR (if any):_ Markdown formatting.

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
