### PR TITLE
Updated incorrect file name in documentation

### DIFF
--- a/src/content/app-architecture/case-study/ui-layer.md
+++ b/src/content/app-architecture/case-study/ui-layer.md
@@ -578,7 +578,7 @@ the view wants to render. This gets at *why* the Compass app uses `Commands`.
 In the view's `Widget.build` method,
 the command is used to conditionally render different widgets.
 
-```dart title=home_viewmodel.dart
+```dart title=home_screen.dart
 // ...
 child: ListenableBuilder(
   listenable: [!viewModel.load!],


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ In the last code snippet of page `App Architecture -> Architecture case study -> UI layer` document, the last code snippet's current title is `home_viewmodel.dart` which should be `home_screen.dart`. Here's a link to the document- [UI layer | Flutter](https://docs.flutter.dev/app-architecture/case-study/ui-layer).

_Issues fixed by this PR (if any):_ Corrected the file name in the code snippet.

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
