### PR TITLE
Updating unworking zsh script for adding flutter into the PATH

### DIFF
--- a/src/_data/shells.yml
+++ b/src/_data/shells.yml
@@ -1,7 +1,7 @@
 - name: bash
   set-path: echo 'export PATH="~/development/flutter/bin:$PATH"' >> ~/.bash_profile
 - name: zsh
-  set-path: echo 'export PATH="~/development/flutter/bin:$PATH"' >> ~/.zshenv
+  set-path: echo 'export PATH="$HOME/development/flutter/bin:$PATH"' >> ~/.zshenv
 - name: fish
   set-path: fish_add_path -g -p ~/development/flutter/bin
 - name: csh


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ 
Changing the unworking zsh script for adding flutter into the PATH.  The only difference is changing  "~/development/flutter/bin:$PATH"  into "$HOME/development/flutter/bin:$PATH"

_Issues fixed by this PR (if any):_ 
#11139

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.