### PR TITLE
Add a runtime switch guide to control Impeller usage

### DIFF
--- a/src/content/perf/impeller.md
+++ b/src/content/perf/impeller.md
@@ -96,7 +96,8 @@ No action on your part is necessary for this fallback behavior.
     android:value="false" />
 ```
 
-* To _enable_ or _disable_ Impeller on runtime, use `getFlutterShellArgs()` method in `FlutterActivity` or `FlutterFragment`:
+* To _enable_ or _disable_ Impeller on runtime, use  `getFlutterShellArgs()`
+  method in `FlutterActivity` or `FlutterFragment`:
 
 ```kotlin
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig

--- a/src/content/perf/impeller.md
+++ b/src/content/perf/impeller.md
@@ -96,6 +96,40 @@ No action on your part is necessary for this fallback behavior.
     android:value="false" />
 ```
 
+* To _enable_ or _disable_ Impeller on runtime, use `getFlutterShellArgs()` method in `FlutterActivity` or `FlutterFragment`:
+
+```kotlin
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterShellArgs
+
+class MainActivity : FlutterActivity() {
+
+    // Initialize Firebase Remote Config in your Activity
+    private lateinit var remoteConfig: FirebaseRemoteConfig
+
+    // Override getFlutterShellArgs() method to disable Impeller based
+    // on Firebase Remote Config. Useful for problematic Devices/SOCs
+    override fun getFlutterShellArgs(): FlutterShellArgs {
+        // For debug builds, use Flutter's default behavior
+        if (BuildConfig.DEBUG) {
+            return super.getFlutterShellArgs()
+        }
+        val args = mutableListOf<String>()
+        val disableImpeller = try {
+            // Example of getting a boolean value from Firebase Remote Config
+            remoteConfig.getBoolean("AndroidDisableImpeller")
+        } catch (e: Exception) {
+            false
+        }
+        if (disableImpeller) {
+            args.add(FlutterShellArgs.ARG_DISABLE_IMPELLER)
+        }
+        return FlutterShellArgs(args)
+    }
+}
+```
+
 ### macOS
 
 You can try out Impeller for macOS behind a flag.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Impeller has been causing issues on lower-end or older devices.
While stabilizing Impeller remains a priority, it is essential
to provide app developers with runtime control over its usage.
This allows decisions to be made on a per-device or per-SoC basis.

This patch introduces a guide for controlling Impeller usage at runtime
using the `getFlutterShellArgs()` method.

_Issues fixed by this PR (if any):_
Partially fixes https://github.com/flutter/flutter/issues/160902

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
