### PR TITLE
Remove redundant single quotes in code 

### DIFF
--- a/src/content/cookbook/navigation/set-up-app-links.md
+++ b/src/content/cookbook/navigation/set-up-app-links.md
@@ -201,9 +201,9 @@ the devices. This ensures that the Flutter application is installed.
 To test **only** the app setup, use the adb command:
 
 ```console
-adb shell 'am start -a android.intent.action.VIEW \
+adb shell am start -a android.intent.action.VIEW \
     -c android.intent.category.BROWSABLE \
-    -d "http://<web-domain>/details"' \
+    -d "http://<web-domain>/details" \
     <package name>
 ```
 


### PR DESCRIPTION
I think the single quotes here are not needed.

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
