### PR TITLE
Replace the type `number` with `num` in ARB files

### DIFF
--- a/src/content/ui/accessibility-and-internationalization/internationalization.md
+++ b/src/content/ui/accessibility-and-internationalization/internationalization.md
@@ -570,7 +570,7 @@ The localizations generation tool in
 class in the `intl` package to format
 numbers based on the locale and the desired format.
 
-The `int`, `double`, and `number` types can use any of the
+The `int`, `double`, and `num` types can use any of the
 following `NumberFormat` constructors:
 
 | Message "format" value   | Output for 1200000 |


### PR DESCRIPTION
This PR replaces the type `number` with `num`, because `number` is not available in the `type` field in ARB files, but `num` is.

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
