### PR TITLE
Fixed Broken URL in Dart Fundamentals 

### DIFF
--- a/src/content/get-started/fundamentals/dart.md
+++ b/src/content/get-started/fundamentals/dart.md
@@ -169,7 +169,7 @@ building block of Flutter apps: widgets.
 [Deferred components]: /perf/deferred-components
 [`main`]: {{site.dart-site}}/language#hello-world
 [classes in Dart]: {{site.dart-site}}/language/classes
-[`FutureBuilder`]: {{site.api}}/flutter/widgets/FutureBuilder-class
+[`FutureBuilder`]: {{site.api}}/flutter/widgets/FutureBuilder-class.html
 [type safe]: {{site.dart-site}}/language/type-system
 [sound null safety]: {{site.dart-site}}/null-safety
 [Working with long lists]: /cookbook/lists/long-lists


### PR DESCRIPTION
Fixed a Broken URL

Issues fixed by this PR (if any): Fixes #11554 

PRs or commits this PR depends on (if any): None

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
