### PR TITLE
Add More widgets under 'Animation and motion' in Widget Catalogue

### DIFF
--- a/src/_data/catalog/widgets.yml
+++ b/src/_data/catalog/widgets.yml
@@ -1119,6 +1119,13 @@
     - 'Text'
   subcategories: []
   link: https://api.flutter.dev/flutter/widgets/DefaultTextStyle-class.html
+- name: DefaultTextStyleTransition
+  description: >-
+    Animated version of a DefaultTextStyle that animates the different properties of its TextStyle.
+  categories:
+    - 'Animation and motion'
+  subcategories: []
+  link: https://api.flutter.dev/flutter/widgets/DefaultTextStyleTransition-class.html
 - name: Dismissible
   description: >-
     A widget that can be dismissed by dragging in the indicated direction.

--- a/src/_data/catalog/widgets.yml
+++ b/src/_data/catalog/widgets.yml
@@ -42,6 +42,13 @@
     x2='68' y2='65' stroke='#f50057' stroke-width='2'
     marker-end='url(#arrow-align)'/><line x1='40' y1='20' x2='40' y2='47'
     stroke='#f50057' stroke-width='2' marker-end='url(#arrow-align)'/></svg>
+- name: AlignTransition
+  description: >-
+    Animated version of an Align that animates its Align.alignment property.
+  categories:
+    - 'Animation and motion'
+  subcategories: []
+  link: https://api.flutter.dev/flutter/widgets/AlignTransition-class.html
 - name: AnimatedAlign
   description: >-
     Animated transition that moves the child's position over a given duration

--- a/src/_data/catalog/widgets.yml
+++ b/src/_data/catalog/widgets.yml
@@ -1512,6 +1512,13 @@
   link: https://api.flutter.dev/flutter/material/MaterialApp-class.html
   image:
     src: https://storage.googleapis.com/material-design/publish/material_v_11/assets/0Bx4BSt6jniD7Y1huOXVQdlFPMmM/materialdesign_introduction.png
+- name: MatrixTransition
+  description: >-
+    Animates the Matrix4 of a transformed widget.
+  categories:
+    - 'Animation and motion'
+  subcategories: []
+  link: https://api.flutter.dev/flutter/widgets/MatrixTransition-class.html
 - name: MediaQuery
   description: Establishes a subtree in which media queries resolve to the given data.
   categories:

--- a/src/_data/catalog/widgets.yml
+++ b/src/_data/catalog/widgets.yml
@@ -1955,6 +1955,13 @@
   subcategories:
     - 'Sliver widgets'
   link: https://api.flutter.dev/flutter/widgets/SliverChildListDelegate-class.html
+- name: SliverFadeTransition
+  description: >-
+    Animates the opacity of a sliver widget.
+  categories:
+    - 'Animation and motion'
+  subcategories: []
+  link: https://api.flutter.dev/flutter/widgets/SliverFadeTransition-class.html
 - name: SliverFixedExtentList
   description: >-
     A sliver that places multiple box children with the same main axis extent in

--- a/src/_data/catalog/widgets.yml
+++ b/src/_data/catalog/widgets.yml
@@ -1740,6 +1740,13 @@
   link: https://api.flutter.dev/flutter/material/RefreshIndicator-class.html
   image:
     src: https://storage.googleapis.com/material-design/publish/material_v_12/assets/0B7WCemMG6e0VS2kzSmZwNnNKQVk/patterns-swipe-to-refresh.png
+- name: RelativePositionedTransition
+  description: >-
+    Animated version of Positioned which transitions the child's position based on the value of rect relative to a bounding box with the specified size.
+  categories:
+    - 'Animation and motion'
+  subcategories: []
+  link: https://api.flutter.dev/flutter/widgets/RelativePositionedTransition-class.html
 - name: ReorderableListView
   description: >-
     A list whose items the user can interactively reorder by dragging.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Add More widgets under 'Animation and motion' in Widget Catalogue

_Issues fixed by this PR (if any):_ Fixes #11563 

_PRs or commits this PR depends on (if any):_ None

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
