### PR TITLE
Remove explanation for service worker settings

### DIFF
--- a/src/content/platform-integration/web/initialization.md
+++ b/src/content/platform-integration/web/initialization.md
@@ -152,8 +152,6 @@ _flutter.loader.load({
 This script evaluates the `URLSearchParams` of the page to determine whether
 the user passed a `renderer` query parameter and then
 changes the user configuration of the Flutter app.
-It also passes the service worker settings to use the flutter service worker,
-along with the service worker version.
 
 ## The onEntrypointLoaded callback
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
The explanation for the example "Customizing Flutter configuration based on URL query parameters" said that the service worker settings were set in the example, while they weren't. The code for that was removed in e47bbab78c28902b788b89fa85a46835e6510199 #11369 I would have added the correct code but #11320 had "remove serviceWorkerSettings" as a goal.

Therefore I simply removed the outdated explanation.


_Issues fixed by this PR (if any):_ None

_PRs or commits this PR depends on (if any):_ None

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
