### PR TITLE
Update Flutter engine license location

### DIFF
--- a/src/content/resources/faq.md
+++ b/src/content/resources/faq.md
@@ -1098,8 +1098,8 @@ The framework is entirely self-contained and requires
 In addition, any Dart packages you use might have their
 own license requirements.
 
-[license file]: https://github.com/flutter/flutter/blob/master/engine/src/flutter/sky/packages/sky_engine/LICENSE
-[only one license]: {{site.repo.flutter}}/blob/master/LICENSE
+[license file]: {{site.repo.flutter}}/blob/main/engine/src/flutter/sky/packages/sky_engine/LICENSE
+[only one license]: {{site.repo.flutter}}/blob/main/LICENSE
 
 ### How can I determine the licenses my Flutter application needs to show?
 

--- a/src/content/resources/faq.md
+++ b/src/content/resources/faq.md
@@ -1098,7 +1098,7 @@ The framework is entirely self-contained and requires
 In addition, any Dart packages you use might have their
 own license requirements.
 
-[license file]: https://raw.githubusercontent.com/flutter/engine/master/sky/packages/sky_engine/LICENSE
+[license file]: https://github.com/flutter/flutter/blob/master/engine/src/flutter/sky/packages/sky_engine/LICENSE
 [only one license]: {{site.repo.flutter}}/blob/master/LICENSE
 
 ### How can I determine the licenses my Flutter application needs to show?


### PR DESCRIPTION
Flutter engine license location changed after the monorepo merge.

Part of https://github.com/flutter/website/issues/11595

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
