### PR TITLE
Fix more engine links after monorepo

### DIFF
--- a/src/_includes/docs/debug/debug-flow-android.md
+++ b/src/_includes/docs/debug/debug-flow-android.md
@@ -5,7 +5,7 @@ check out [`flutter_gdb`][].
 :::
 
 [GNU Project Debugger]: https://www.sourceware.org/gdb/
-[`flutter_gdb`]: {{site.repo.engine}}/blob/main/sky/tools/flutter_gdb
+[`flutter_gdb`]: {{site.repo.flutter}}/blob/master/engine/src/flutter/sky/tools/flutter_gdb
 
 #### Build the Android version of the Flutter app in the Terminal
 

--- a/src/content/embedded/index.md
+++ b/src/content/embedded/index.md
@@ -38,10 +38,10 @@ resources.
 
 [community]: {{site.main-url}}/community
 [Discord]: https://discord.com/invite/N7Yshp4
-[Custom Flutter Engine Embedders]: {{site.repo.engine}}/blob/main/docs/Custom-Flutter-Engine-Embedders.md
+[Custom Flutter Engine Embedders]: {{site.repo.flutter}}/blob/master/engine/src/flutter/docs/Custom-Flutter-Engine-Embedders.md
 [Flutter architectural overview]: /resources/architectural-overview
-[Flutter engine `embedder.h` file]: {{site.repo.engine}}/blob/main/shell/platform/embedder/embedder.h
-[Flutter Embedder Engine GLFW example]: {{site.repo.engine}}/tree/main/examples/glfw#flutter-embedder-engine-glfw-example
+[Flutter engine `embedder.h` file]: {{site.repo.flutter}}/blob/master/engine/src/flutter/shell/platform/embedder/embedder.h
+[Flutter Embedder Engine GLFW example]: {{site.repo.flutter}}/tree/master/engine/src/flutter/examples/glfw#flutter-embedder-engine-glfw-example
 [embedding Flutter in a terminal]: https://github.com/jiahaog/flt
 [Issue 31043]: {{site.repo.flutter}}/issues/31043
 

--- a/src/content/perf/faq.md
+++ b/src/content/perf/faq.md
@@ -75,7 +75,7 @@ about evaluating and debugging Flutter's performance.
 * How do I query the target frames per second (of the display)?
   * [Get the display refresh rate][]
 
-[Get the display refresh rate]: {{site.repo.engine}}/blob/main/docs/Engine-specific-Service-Protocol-extensions.md#get-the-display-refresh-rate-_fluttergetdisplayrefreshrate
+[Get the display refresh rate]: {{site.repo.flutter}}/blob/master/engine/src/flutter/docs/Engine-specific-Service-Protocol-extensions.md#get-the-display-refresh-rate-_fluttergetdisplayrefreshrate
 
 * How to solve my app's poor animations caused by an expensive
   Dart async function call that is blocking the UI thread?

--- a/src/content/perf/impeller.md
+++ b/src/content/perf/impeller.md
@@ -145,15 +145,15 @@ submitting an issue for Impeller:
 To learn more details about Impeller's design and architecture,
 check out the [README.md][] file in the source tree.
 
-[README.md]: {{site.repo.engine}}/blob/main/impeller/README.md
+[README.md]: {{site.repo.flutter}}/blob/master/engine/src/flutter/impeller/README.md
 
 ## Additional information
 
-* [Frequently asked questions]({{site.repo.engine}}/blob/main/impeller/docs/faq.md)
-* [Impeller's coordinate system]({{site.repo.engine}}/blob/main/impeller/docs/coordinate_system.md)
-* [How to set up Xcode for GPU frame captures with metal]({{site.repo.engine}}/blob/main/impeller/docs/xcode_frame_capture.md)
-* [Learning to read GPU frame captures]({{site.repo.engine}}/blob/main/impeller/docs/read_frame_captures.md)
-* [How to enable metal validation for command line apps]({{site.repo.engine}}/blob/main/impeller/docs/metal_validation.md)
-* [How Impeller works around the lack of uniform buffers in Open GL ES 2.0]({{site.repo.engine}}/blob/main/impeller/docs/ubo_gles2.md)
-* [Guidance for writing efficient shaders]({{site.repo.engine}}/blob/main/impeller/docs/shader_optimization.md)
-* [How color blending works in Impeller]({{site.repo.engine}}/blob/main/impeller/docs/blending.md)
+* [Frequently asked questions]({{site.repo.flutter}}/blob/master/engine/src/flutter/impeller/docs/faq.md)
+* [Impeller's coordinate system]({{site.repo.flutter}}/blob/master/engine/src/flutter/impeller/docs/coordinate_system.md)
+* [How to set up Xcode for GPU frame captures with metal]({{site.repo.flutter}}/blob/master/engine/src/flutter/impeller/docs/xcode_frame_capture.md)
+* [Learning to read GPU frame captures]({{site.repo.flutter}}/blob/master/engine/src/flutter/impeller/docs/read_frame_captures.md)
+* [How to enable metal validation for command line apps]({{site.repo.flutter}}/blob/master/engine/src/flutter/impeller/docs/metal_validation.md)
+* [How Impeller works around the lack of uniform buffers in Open GL ES 2.0]({{site.repo.flutter}}/blob/master/engine/src/flutter/impeller/docs/ubo_gles2.md)
+* [Guidance for writing efficient shaders]({{site.repo.flutter}}/blob/master/engine/src/flutter/impeller/docs/shader_optimization.md)
+* [How color blending works in Impeller]({{site.repo.flutter}}/blob/master/engine/src/flutter/impeller/docs/blending.md)

--- a/src/content/resources/architectural-overview.md
+++ b/src/content/resources/architectural-overview.md
@@ -90,7 +90,7 @@ and compile toolchain.
 [Impeller]: /perf/impeller
 
 The engine is exposed to the Flutter framework through
-[`dart:ui`]({{site.repo.engine}}/tree/main/lib/ui),
+[`dart:ui`]({{site.repo.flutter}}/tree/master/engine/src/flutter/lib/ui),
 which wraps the underlying C++ code in Dart classes. This library
 exposes the lowest-level primitives, such as classes for driving input,
 graphics, and text rendering subsystems.
@@ -166,14 +166,14 @@ pieces of a Flutter app.
   accessibility, text input).
 * Composites the app's widget tree into a scene.
 
-**Engine** ([source code]({{site.repo.engine}}/tree/main/shell/common))
+**Engine** ([source code]({{site.repo.flutter}}/tree/master/engine/src/flutter/shell/common))
 * Responsible for rasterizing composited scenes.
 * Provides low-level implementation of Flutter's core APIs
   (for example, graphics, text layout, Dart runtime).
 * Exposes its functionality to the framework using the **dart:ui API**.
 * Integrates with a specific platform using the Engine's **Embedder API**.
 
-**Embedder** ([source code]({{site.repo.engine}}/tree/main/shell/platform))
+**Embedder** ([source code]({{site.repo.flutter}}/tree/master/engine/src/flutter/shell/platform))
 * Coordinates with the underlying operating system
   for access to services like rendering surfaces,
   accessibility, and input.
@@ -780,7 +780,7 @@ itself. The mechanism for obtaining the texture and participating in the app
 lifecycle of the underlying operating system inevitably varies depending on the
 unique concerns of that platform. The engine is platform-agnostic, presenting a
 [stable ABI (Application Binary
-Interface)]({{site.repo.engine}}/blob/main/shell/platform/embedder/embedder.h)
+Interface)]({{site.repo.flutter}}/blob/master/engine/src/flutter/shell/platform/embedder/embedder.h)
 that provides a _platform embedder_ with a way to set up and use Flutter.
 
 The platform embedder is the native OS application that hosts all Flutter

--- a/src/content/testing/build-modes.md
+++ b/src/content/testing/build-modes.md
@@ -130,7 +130,7 @@ For more information on the build modes, see
 [dart2js]: {{site.dart-site}}/tools/dart2js
 [dartdevc]: {{site.dart-site}}/tools/dartdevc
 [DevTools]: /tools/devtools
-[Flutter's build modes]: {{site.repo.engine}}/blob/main/docs/Flutter's-modes.md
+[Flutter's build modes]: {{site.repo.flutter}}/blob/master/engine/src/flutter/docs/Flutter's-modes.md
 [generate timeline events]: {{site.developers}}/web/tools/chrome-devtools/evaluate-performance/performance-reference
 [hot reload]: /tools/hot-reload
 [iOS]: /deployment/ios

--- a/src/content/testing/code-debugging.md
+++ b/src/content/testing/code-debugging.md
@@ -17,7 +17,7 @@ Flutter engine running within an Android app process,
 check out [`flutter_gdb`][].
 :::
 
-[`flutter_gdb`]: {{site.repo.engine}}/blob/main/sky/tools/flutter_gdb
+[`flutter_gdb`]: {{site.repo.flutter}}/blob/master/engine/src/flutter/sky/tools/flutter_gdb
 
 ## Add logging to your application
 

--- a/src/content/testing/debugging.md
+++ b/src/content/testing/debugging.md
@@ -27,7 +27,7 @@ Flutter applications. Here are some of the available tools:
   check out [`flutter_gdb`][].
 
 
-[`flutter_gdb`]: {{site.repo.engine}}/blob/main/sky/tools/flutter_gdb
+[`flutter_gdb`]: {{site.repo.flutter}}/blob/master/engine/src/flutter/sky/tools/flutter_gdb
 
 ## Other resources
 

--- a/src/content/tools/devtools/debugger.md
+++ b/src/content/tools/devtools/debugger.md
@@ -20,7 +20,7 @@ Flutter engine running within an Android app process,
 check out [`flutter_gdb`][].
 :::
 
-[`flutter_gdb`]: {{site.repo.engine}}/blob/main/sky/tools/flutter_gdb
+[`flutter_gdb`]: {{site.repo.flutter}}/blob/master/engine/src/flutter/sky/tools/flutter_gdb
 
 When you open the debugger tab, you should see the source for the main
 entry-point for your app loaded in the debugger.

--- a/src/content/tools/devtools/memory.md
+++ b/src/content/tools/devtools/memory.md
@@ -376,7 +376,7 @@ The quantities plotted on the y-axis are as follows:
   For more information, see [Dart VM internals][].
 
 [Command-line and server apps]: {{site.dart-site}}/server
-[Custom Flutter engine embedders]: {{site.repo.engine}}/blob/main/docs/Custom-Flutter-Engine-Embedders.md
+[Custom Flutter engine embedders]: {{site.repo.flutter}}/blob/master/engine/src/flutter/docs/Custom-Flutter-Engine-Embedders.md
 [Dart VM internals]: https://mrale.ph/dartvm/
 [DevTools Performance view]: /tools/devtools/performance
 [Flutter architectural overview]: /resources/architectural-overview

--- a/src/content/ui/design/graphics/fragment-shaders.md
+++ b/src/content/ui/design/graphics/fragment-shaders.md
@@ -275,7 +275,7 @@ this is more efficient than creating a new
 For a more detailed guide on writing performant shaders,
 check out [Writing efficient shaders][] on GitHub.
 
-[Writing efficient shaders]: {{site.repo.engine}}/blob/main/impeller/docs/shader_optimization.md
+[Writing efficient shaders]: {{site.repo.flutter}}/blob/master/engine/src/flutter/impeller/docs/shader_optimization.md
 
 ### Other resources
 


### PR DESCRIPTION
Flutter engine license location changed after the monorepo merge.

Part of https://github.com/flutter/website/issues/11595

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
