### PR TITLE
Issue-11599: update dart:js_interop hyperlink

### DIFF
--- a/src/content/platform-integration/web/wasm.md
+++ b/src/content/platform-integration/web/wasm.md
@@ -13,7 +13,7 @@ applications for the web.
 
 [`stable`]: {{site.github}}/flutter/flutter/blob/master/docs/releases/Flutter-build-release-channels.md#stable
 [`package:web`]: {{site.pub-pkg}}/web
-[`dart:js_interop`]: {{site.dart.api}}/{{site.dart.sdk.channel}}/dart-js_interop
+[`dart:js_interop`]: {{site.dart.api}}/{{site.dart.sdk.channel}}/dart-js_interop/dart-js_interop-library.html
 
 ## Get started
 


### PR DESCRIPTION
…o dart-js_interop/dart-js_interop-library.html

_Description of what this PR is changing or adding, and why:_

Issue: 

Hyperlink is now working of `[dart:js_interop]: {{site.dart.api}}/{{site.dart.sdk.channel}}/dart-js_interop`

![image](https://github.com/user-attachments/assets/3b0633c3-d3f7-4468-a24d-8ceddafcd4cd)

![image](https://github.com/user-attachments/assets/ac866a2f-92ee-40c2-b636-38d0a40be059)


Fix  dart:js_interop hyperlink by updating:

[dart:js_interop]: {{site.dart.api}}/{{site.dart.sdk.channel}}/dart-js_interop/dart-js_interop-library.html

_Issues fixed by this PR (if any):_

![image](https://github.com/user-attachments/assets/d4c53ede-f31d-4002-a8ec-0ea50448116a)

_PRs or commits this PR depends on (if any):_ Fixes https://github.com/flutter/website/issues/11599

## Presubmit checklist

- [X] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
