### PR TITLE
Update ~ to $HOME to fix issues with programs using dart/flutter executables

### DIFF
--- a/src/_data/shells.yml
+++ b/src/_data/shells.yml
@@ -1,14 +1,14 @@
 - name: bash
-  set-path: echo 'export PATH="~/development/flutter/bin:$PATH"' >> ~/.bash_profile
+  set-path: echo 'export PATH="$HOME/development/flutter/bin:$PATH"' >> ~/.bash_profile
 - name: zsh
   set-path: echo 'export PATH="$HOME/development/flutter/bin:$PATH"' >> ~/.zshenv
 - name: fish
   set-path: fish_add_path -g -p ~/development/flutter/bin
 - name: csh
-  set-path: echo 'setenv PATH "~/development/flutter/bin:$PATH"' >> ~/.cshrc
+  set-path: echo 'setenv PATH "$HOME/development/flutter/bin:$PATH"' >> ~/.cshrc
 - name: tcsh
-  set-path: echo 'setenv PATH "~/development/flutter/bin:$PATH"' >> ~/.tcshrc
+  set-path: echo 'setenv PATH "$HOME/development/flutter/bin:$PATH"' >> ~/.tcshrc
 - name: ksh
-  set-path: echo 'export PATH="~/development/flutter/bin:$PATH"' >> ~/.profile
+  set-path: echo 'export PATH="$HOME/development/flutter/bin:$PATH"' >> ~/.profile
 - name: sh
-  set-path: echo 'export PATH="~/development/flutter/bin:$PATH"' >> ~/.profile
+  set-path: echo 'export PATH="$HOME/development/flutter/bin:$PATH"' >> ~/.profile


### PR DESCRIPTION

_Description of what this PR is changing or adding, and why:_
Updating the path to the shell profile to use $HOME rather than ~.

_Issues fixed by this PR (if any):_

I ran into issues while using rinf with it not being able to find dart. Updated my bash_profile from ~ to $HOME for this which solved the issue.

Before when running rinf message
```
ProcessException: No such file or directory
  Command: dart pub global activate protoc_plugin
```

It succeeded with this change.

_PRs or commits this PR depends on (if any):_
None

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
