### PR TITLE
Corrects Swift background threads example

### DIFF
--- a/src/content/platform-integration/platform-channels.md
+++ b/src/content/platform-integration/platform-channels.md
@@ -1318,10 +1318,10 @@ for iOS.
 
 ```swift
 public static func register(with registrar: FlutterPluginRegistrar) {
-  let taskQueue = registrar.messenger.makeBackgroundTaskQueue()
+  let taskQueue = registrar.messenger().makeBackgroundTaskQueue?()
   let channel = FlutterMethodChannel(name: "com.example.foo",
                                      binaryMessenger: registrar.messenger(),
-                                     codec: FlutterStandardMethodCodec.sharedInstance,
+                                     codec: FlutterStandardMethodCodec.sharedInstance(),
                                      taskQueue: taskQueue)
   let instance = MyPlugin()
   registrar.addMethodCallDelegate(instance, channel: channel)


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why: Corrected Swift [example](https://docs.flutter.dev/platform-integration/platform-channels#executing-channel-handlers-on-background-threads:~:text=content_copy-,In%20Swift%3A,-info)

_Issues fixed by this PR (if any): resolve [161944](https://github.com/flutter/flutter/issues/161944)

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
