### PR TITLE
Minor Website Text Correction

### DIFF
--- a/src/content/get-started/fundamentals/index.md
+++ b/src/content/get-started/fundamentals/index.md
@@ -62,7 +62,7 @@ following subjects in the listed order.
     It also facilitates designing a UI to
     optimize any screen where your app might be used.
  4. [State management][]
-    Learn how share state between widgets and notify other parts of your app
+    Learn how to share state between widgets and notify other parts of your app
     when the state changes.
     See how to implement MVVM in Flutter to manage state effectively
     for small to medium-sized apps.


### PR DESCRIPTION
Corrected grammatical error in documentation.

_Description of what this PR is changing or adding, and why:_
Grammatical error fix where the statement is missing "to". This PR corrects this.

_Issues fixed by this PR (if any):_
Item 4 of the Introduction page of the Learn the fundamentals under the Learn Flutter page menu.

Changes from: 
`4. [State management][] Learn how share state between widgets and notify other parts of your app when the state changes....`

to 

`4. [State management][] Learn how **to** share state between widgets and notify other parts of your app when the state changes....`

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
