### PR TITLE
[SwiftPM] Update instructions to increase OS version

### DIFF
--- a/src/content/packages-and-plugins/swift-package-manager/for-app-developers.md
+++ b/src/content/packages-and-plugins/swift-package-manager/for-app-developers.md
@@ -151,8 +151,24 @@ the project, you might get an error like this:
 Target Integrity (Xcode): The package product 'plugin_name_ios' requires minimum platform version 14.0 for the iOS platform, but this target supports 12.0
 ```
 
-To use the plugin, increase the **Minimum Deployments** of your app's target.
+To use the plugin:
 
-{% render docs/captioned-image.liquid,
-image:"development/packages-and-plugins/swift-package-manager/minimum-deployments.png",
-caption:"The target's **Minimum Deployments** setting" %}
+1. Increase the **Minimum Deployments** of your app's target.
+
+   {% render docs/captioned-image.liquid,
+   image:"development/packages-and-plugins/swift-package-manager/minimum-deployments.png",
+   caption:"The target's **Minimum Deployments** setting" %}
+
+1. If you updated your iOS app's **Minimum Deployments**,
+   regenerate the iOS project's configuration files:
+
+   ```sh
+   flutter build ios --config-only
+   ```
+
+1. If you updated your macOS app's **Minimum Deployments**,
+   regenerate the macOS project's configuration files:
+
+   ```sh
+   flutter build macos --config-only
+   ```


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Tell users to build their apps using the Flutter tool after they update their app's iOS/macOS minimum deployments.

This is currently necessary due to this bug: https://github.com/flutter/flutter/issues/162196

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
