### PR TITLE
Move animation conceptual content out of tutorial and into introduction

### DIFF
--- a/src/content/ui/animations/index.md
+++ b/src/content/ui/animations/index.md
@@ -190,7 +190,7 @@ One of the more commonly used animation types is `Animation<double>`.
 An `Animation` object sequentially generates
 interpolated numbers between two values over a certain duration.
 The output of an `Animation` object might be linear,
-a curve, a step function, or any other mapping you can devise.
+a curve, a step function, or any other mapping you can create.
 Depending on how the `Animation` object is controlled,
 it could run in reverse, or even switch directions in the
 middle.
@@ -204,7 +204,7 @@ always available in the `.value` member.
 An `Animation` object knows nothing about rendering or
 `build()` functions.
 
-### Curved&shy;Animation
+### CurvedAnimation
 
 A [`CurvedAnimation`][] defines the animation's progress
 as a non-linear curve.
@@ -237,7 +237,7 @@ are both of type `Animation<double>`, so you can pass them interchangeably.
 The `CurvedAnimation` wraps the object it's modifying&mdash;you
 don't subclass `AnimationController` to implement a curve.
 
-### Animation&shy;Controller
+### AnimationController
 
 [`AnimationController`][] is a special `Animation`
 object that generates a new value whenever the hardware
@@ -277,13 +277,13 @@ starts again (without stopping the clock, so it's as if it had
 been ticking the whole time, but without using the CPU.)
 To use your custom State object as the `vsync`, include the
 `TickerProviderStateMixin` when defining the custom State class.
-{% endcomment -%}
+{% endcomment %}
 
 :::note
 In some cases, a position might exceed the `AnimationController`'s
 0.0-1.0 range. For example, the `fling()` function
 allows you to provide velocity, force, and position
-(via the Force object). The position can be anything and
+(using the Force object). The position can be anything and
 so can be outside of the 0.0 to 1.0 range.
 
 A `CurvedAnimation` can also exceed the 0.0 to 1.0 range,
@@ -395,6 +395,10 @@ shows how to write animation code.
   that uses animation to show the user's progress
   as they fill in the fields.
 
+* [Casual games toolkit][]<br>
+  A toolkit with game templates that contain examples of how to use Flutter
+  animations.
+
 ## Other resources
 
 Learn more about Flutter animations at the following links:
@@ -446,6 +450,7 @@ Learn more about Flutter animations at the following links:
 [article4]: {{site.flutter-medium}}/directional-animations-with-built-in-explicit-animations-3e7c5e6fbbd7
 [article5]: {{site.flutter-medium}}/when-should-i-useanimatedbuilder-or-animatedwidget-57ecae0959e8
 [article6]: {{site.flutter-medium}}/animation-deep-dive-39d3ffea111f
+[Casual games toolkit]: /resources/games-toolkit/
 [Creating your own custom implicit animations with TweenAnimationBuilder]: {{site.yt.watch}}?v=6KiPEqzJIKQ&feature=youtu.be
 [Creating custom explicit animations with AnimatedBuilder and AnimatedWidget]: {{site.yt.watch}}?v=fneC7t4R_B0&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=4
 [`Curves`]: {{site.api}}/flutter/animation/Curves-class.html

--- a/src/content/ui/animations/index.md
+++ b/src/content/ui/animations/index.md
@@ -4,6 +4,8 @@ short-title: Animations
 description: How to perform animations in Flutter.
 ---
 
+{% capture examples -%} {{site.repo.this}}/tree/{{site.branch}}/examples {%- endcapture -%}
+
 Well-designed animations make a UI feel more intuitive,
 contribute to the slick look and feel of a polished app,
 and improve the user experience.
@@ -230,7 +232,7 @@ Browse the [`Curves`] documentation for a complete listing
 (with visual previews) of the `Curves` constants that ship with Flutter.
 :::
 
-`CurvedAnimation` and `AnimationController` (described in the next section)
+`CurvedAnimation` and `AnimationController` (described in the next sections)
 are both of type `Animation<double>`, so you can pass them interchangeably.
 The `CurvedAnimation` wraps the object it's modifying&mdash;you
 don't subclass `AnimationController` to implement a curve.
@@ -367,9 +369,6 @@ A `Listener` is called whenever the value of the animation changes.
 The most common behavior of a `Listener` is to call `setState()`
 to cause a rebuild. A `StatusListener` is called when an animation begins,
 ends, moves forward, or moves reverse, as defined by `AnimationStatus`.
-The next section has an example of the `addListener()` method,
-and [Monitoring the progress of the animation][] shows an
-example of `addStatusListener()`.
 
 ## Codelabs, tutorials, and articles
 
@@ -459,7 +458,6 @@ Learn more about Flutter animations at the following links:
 [Implicit animations codelab]: /codelabs/implicit-animations
 [Making your first directional animations with built-in explicit animations]: {{site.yt.watch}}?v=CunyH6unILQ&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=3
 [Material widgets]: /ui/widgets/material
-[Monitoring the progress of the animation]: #monitoring
 [`Navigator`]: {{site.api}}/flutter/widgets/Navigator-class.html
 [`PageRoute`]: {{site.api}}/flutter/widgets/PageRoute-class.html
 [part 2]: {{site.medium}}/dartlang/zero-to-one-with-flutter-part-two-5aa2f06655cb

--- a/src/content/ui/animations/index.md
+++ b/src/content/ui/animations/index.md
@@ -33,6 +33,18 @@ to use when implementing a Flutter animation:
 <img src='/assets/images/docs/ui/animations/animation-decision-tree.png'
     alt="The animation decision tree" class="mw-100">
 
+## Animation deep dive
+
+For a deeper understanding of just how animations work in Flutter, watch
+[Animation deep dive][].
+(Also published as a [_companion article_][article6].)
+
+{% ytEmbed 'PbcILiN8rbo', 'Take a deep dive into Flutter animation', true %}
+
+## Implicit and explicit animations
+
+### Pre-packaged implicit animations
+
 If a pre-packaged implicit animation (the easiest animation
 to implement) suits your needs, watch
 [Animation basics with implicit animations][].
@@ -40,11 +52,15 @@ to implement) suits your needs, watch
 
 {% ytEmbed 'IVTjpW3W33s', 'Flutter implicit animation basics' %}
 
+### Custom implicit animations
+
 To create a custom implicit animation, watch
 [Creating your own custom implicit animations with TweenAnimationBuilder][].
 (Also published as a [_companion article_][article3].)
 
 {% ytEmbed '6KiPEqzJIKQ', 'Create custom implicit animations with TweenAnimationBuilder' %}
+
+### Built-in implicit animations
 
 To create an explicit animation (where you control the animation,
 rather than letting the framework control it), perhaps
@@ -56,43 +72,14 @@ built-in explicit animations][].
 
 {% ytEmbed 'CunyH6unILQ', 'Making your first directional animations with built-in explicit animations', true %}
 
+### Explicit animations
+
 If you need to build an explicit animation from scratch, watch
 [Creating custom explicit animations with
 AnimatedBuilder and AnimatedWidget][].
 (Also published as a [_companion article_][article5].)
 
 {% ytEmbed 'fneC7t4R_B0', 'Creating custom explicit animations with AnimatedBuilder and AnimatedWidget', true %}
-
-For a deeper understanding of just how animations work in Flutter, watch
-[Animation deep dive][].
-(Also published as a [_companion article_][article6].)
-
-{% ytEmbed 'PbcILiN8rbo', 'Take a deep dive into Flutter animation', true %}
-
-## Codelabs, tutorials, and articles
-
-The following resources are a good place to start learning
-the Flutter animation framework. Each of these documents
-shows how to write animation code.
-
-* [Implicit animations codelab][]<br>
-  Covers how to use implicit animations
-  using step-by-step instructions and interactive examples.
-
-* [Animations tutorial][]<br>
-  Explains the fundamental classes in the Flutter animation package
-  (controllers, `Animatable`, curves, listeners, builders),
-  as it guides you through a progression of tween animations using
-  different aspects of the animation APIs. This tutorial shows
-  how to create your own custom explicit animations.
-
-* [Zero to One with Flutter, part 1][] and [part 2][]<br>
-  Medium articles showing how to create an animated chart using tweening.
-
-* [Write your first Flutter app on the web][]<br>
-  Codelab demonstrating how to create a form
-  that uses animation to show the user's progress
-  as they fill in the fields.
 
 ## Animation types
 
@@ -126,15 +113,6 @@ Similarly, dropping a ball attached to a spring falls
 * Also see the API documentation for
   [`AnimationController.animateWith`][] and
   [`SpringSimulation`][].
-
-## Pre-canned animations
-
-If you are using Material widgets, you might check
-out the [animations package][] available on pub.dev.
-This package contains pre-built animations for
-the following commonly used patterns:
-`Container` transforms, shared axis transitions,
-fade through transitions, and fade transitions.
 
 ## Common animation patterns
 
@@ -186,9 +164,246 @@ or might partially or completely overlap.
   <img src="/assets/images/docs/ic_new_releases_black_24px.svg" alt="this doc is new!"> NEW<br>
 {% endcomment -%}
 
+<a id="concepts"></a>
+
+## Essential animation concepts and classes
+
+The animation system in Flutter is based on typed
+[`Animation`][] objects. Widgets can either incorporate
+these animations in their build functions directly by
+reading their current value and listening to their state
+changes or they can use the animations as the basis of
+more elaborate animations that they pass along to
+other widgets.
+
+<a id="animation-class"></a>
+
+### Animation<wbr>\<double>
+
+In Flutter, an `Animation` object knows nothing about what
+is onscreen. An `Animation` is an abstract class that
+understands its current value and its state (completed or dismissed).
+One of the more commonly used animation types is `Animation<double>`.
+
+An `Animation` object sequentially generates
+interpolated numbers between two values over a certain duration.
+The output of an `Animation` object might be linear,
+a curve, a step function, or any other mapping you can devise.
+Depending on how the `Animation` object is controlled,
+it could run in reverse, or even switch directions in the
+middle.
+
+Animations can also interpolate types other than double, such as
+`Animation<Color>` or `Animation<Size>`.
+
+An `Animation` object has state. Its current value is
+always available in the `.value` member.
+
+An `Animation` object knows nothing about rendering or
+`build()` functions.
+
+### Curved&shy;Animation
+
+A [`CurvedAnimation`][] defines the animation's progress
+as a non-linear curve.
+
+<?code-excerpt "animate5/lib/main.dart (CurvedAnimation)"?>
+```dart
+animation = CurvedAnimation(parent: controller, curve: Curves.easeIn);
+```
+
+:::note
+The [`Curves`][] class defines many commonly used curves,
+or you can create your own. For example:
+
+<?code-excerpt "animate5/lib/main.dart (ShakeCurve)" plaster="none"?>
+```dart
+import 'dart:math';
+
+class ShakeCurve extends Curve {
+  @override
+  double transform(double t) => sin(t * pi * 2);
+}
+```
+
+Browse the [`Curves`] documentation for a complete listing
+(with visual previews) of the `Curves` constants that ship with Flutter.
+:::
+
+`CurvedAnimation` and `AnimationController` (described in the next section)
+are both of type `Animation<double>`, so you can pass them interchangeably.
+The `CurvedAnimation` wraps the object it's modifying&mdash;you
+don't subclass `AnimationController` to implement a curve.
+
+### Animation&shy;Controller
+
+[`AnimationController`][] is a special `Animation`
+object that generates a new value whenever the hardware
+is ready for a new frame. By default,
+an `AnimationController` linearly produces the numbers
+from 0.0 to 1.0 during a given duration.
+For example, this code creates an `Animation` object,
+but does not start it running:
+
+<?code-excerpt "animate5/lib/main.dart (animation-controller)"?>
+```dart
+controller =
+    AnimationController(duration: const Duration(seconds: 2), vsync: this);
+```
+
+`AnimationController` derives from `Animation<double>`, so it can be used
+wherever an `Animation` object is needed. However, the `AnimationController`
+has additional methods to control the animation. For example, you start
+an animation with the `.forward()` method. The generation of numbers is
+tied to the screen refresh, so typically 60 numbers are generated per
+second. After each number is generated, each `Animation` object calls the
+attached `Listener` objects. To create a custom display list for each
+child, see [`RepaintBoundary`][].
+
+When creating an `AnimationController`, you pass it a `vsync` argument.
+The presence of `vsync` prevents offscreen animations from consuming
+unnecessary resources.
+You can use your stateful object as the vsync by adding
+`SingleTickerProviderStateMixin` to the class definition.
+You can see an example of this in [animate1][] on GitHub.
+
+{% comment %}
+The `vsync` object ties the ticking of the animation controller to
+the visibility of the widget, so that when the animating widget goes
+off-screen, the ticking stops, and when the widget is restored, it
+starts again (without stopping the clock, so it's as if it had
+been ticking the whole time, but without using the CPU.)
+To use your custom State object as the `vsync`, include the
+`TickerProviderStateMixin` when defining the custom State class.
+{% endcomment -%}
+
+:::note
+In some cases, a position might exceed the `AnimationController`'s
+0.0-1.0 range. For example, the `fling()` function
+allows you to provide velocity, force, and position
+(via the Force object). The position can be anything and
+so can be outside of the 0.0 to 1.0 range.
+
+A `CurvedAnimation` can also exceed the 0.0 to 1.0 range,
+even if the `AnimationController` doesn't.
+Depending on the curve selected, the output of
+the `CurvedAnimation` can have a wider range than the input.
+For example, elastic curves such as `Curves.elasticIn`
+significantly overshoots or undershoots the default range.
+:::
+
+### Tween
+
+By default, the `AnimationController` object ranges from 0.0 to 1.0.
+If you need a different range or a different data type, you can use a
+[`Tween`][] to configure an animation to interpolate to a
+different range or data type. For example, the
+following `Tween` goes from -200.0 to 0.0:
+
+<?code-excerpt "animate5/lib/main.dart (tween)"?>
+```dart
+tween = Tween<double>(begin: -200, end: 0);
+```
+
+A `Tween` is a stateless object that takes only `begin` and `end`.
+The sole job of a `Tween` is to define a mapping from an
+input range to an output range. The input range is commonly
+0.0 to 1.0, but that's not a requirement.
+
+A `Tween` inherits from `Animatable<T>`, not from `Animation<T>`.
+An `Animatable`, like `Animation`, doesn't have to output double.
+For example, `ColorTween` specifies a progression between two colors.
+
+<?code-excerpt "animate5/lib/main.dart (colorTween)"?>
+```dart
+colorTween = ColorTween(begin: Colors.transparent, end: Colors.black54);
+```
+
+A `Tween` object doesn't store any state. Instead, it provides the
+[`evaluate(Animation<double> animation)`][] method that uses the 
+`transform` function to map the current value of the animation
+(between 0.0 and 1.0), to the actual animation value. 
+
+The current value of the `Animation` object can be found in the
+`.value` method. The evaluate function also performs some housekeeping,
+such as ensuring that begin and end are returned when the
+animation values are 0.0 and 1.0, respectively.
+
+#### Tween.animate
+
+To use a `Tween` object, call `animate()` on the `Tween`,
+passing in the controller object. For example,
+the following code generates the
+integer values from 0 to 255 over the course of 500 ms.
+
+<?code-excerpt "animate5/lib/main.dart (IntTween)"?>
+```dart
+AnimationController controller = AnimationController(
+    duration: const Duration(milliseconds: 500), vsync: this);
+Animation<int> alpha = IntTween(begin: 0, end: 255).animate(controller);
+```
+
+:::note
+The `animate()` method returns an [`Animation`][],
+not an [`Animatable`][].
+:::
+
+The following example shows a controller, a curve, and a `Tween`:
+
+<?code-excerpt "animate5/lib/main.dart (IntTween-curve)"?>
+```dart
+AnimationController controller = AnimationController(
+    duration: const Duration(milliseconds: 500), vsync: this);
+final Animation<double> curve =
+    CurvedAnimation(parent: controller, curve: Curves.easeOut);
+Animation<int> alpha = IntTween(begin: 0, end: 255).animate(curve);
+```
+
+### Animation notifications
+
+An [`Animation`][] object can have `Listener`s and `StatusListener`s,
+defined with `addListener()` and `addStatusListener()`.
+A `Listener` is called whenever the value of the animation changes.
+The most common behavior of a `Listener` is to call `setState()`
+to cause a rebuild. A `StatusListener` is called when an animation begins,
+ends, moves forward, or moves reverse, as defined by `AnimationStatus`.
+The next section has an example of the `addListener()` method,
+and [Monitoring the progress of the animation][] shows an
+example of `addStatusListener()`.
+
+## Codelabs, tutorials, and articles
+
+The following resources are a good place to start learning
+the Flutter animation framework. Each of these documents
+shows how to write animation code.
+
+* [Implicit animations codelab][]<br>
+  Covers how to use implicit animations
+  using step-by-step instructions and interactive examples.
+
+* [Animations tutorial][]<br>
+  Explains the fundamental classes in the Flutter animation package
+  (controllers, `Animatable`, curves, listeners, builders),
+  as it guides you through a progression of tween animations using
+  different aspects of the animation APIs. This tutorial shows
+  how to create your own custom explicit animations.
+
+* [Zero to One with Flutter, part 1][] and [part 2][]<br>
+  Medium articles showing how to create an animated chart using tweening.
+
+* [Write your first Flutter app on the web][]<br>
+  Codelab demonstrating how to create a form
+  that uses animation to show the user's progress
+  as they fill in the fields.
+
 ## Other resources
 
 Learn more about Flutter animations at the following links:
+
+* There are several [animations packages][] available on pub.dev that contain
+  pre-built animations for commonly used patterns, including:
+  `Container` transforms, shared axis transitions,
+  fade through transitions, and fade transitions.
 
 * [Animation samples][] from the [Sample app catalog][].
 
@@ -209,7 +424,9 @@ Learn more about Flutter animations at the following links:
   takes you to a technical overview page for the library.
 
 [Animate a widget using a physics simulation]: /cookbook/animation/physics-simulation
+[`Animatable`]: {{site.api}}/flutter/animation/Animatable-class.html
 [`AnimatedList` example]: https://flutter.github.io/samples/animations.html
+[`Animation`]: {{site.api}}/flutter/animation/Animation-class.html
 [Animation and motion widgets]: /ui/widgets/animation
 [Animation basics with implicit animations]: {{site.yt.watch}}?v=IVTjpW3W33s&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=1
 [Animation deep dive]: {{site.yt.watch}}?v=PbcILiN8rbo&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=5
@@ -219,8 +436,9 @@ Learn more about Flutter animations at the following links:
 [Animation videos]: {{site.social.youtube}}/search?query=animation
 [Animations in Flutter done right]: {{site.yt.watch}}?v=wnARLByOtKA&t=3s
 [Animations: overview]: /ui/animations/overview
-[animations package]: {{site.pub}}/packages/animations
+[animations packages]: {{site.pub}}/packages?q=topic%3Aanimation
 [Animations tutorial]: /ui/animations/tutorial
+[`AnimationController`]: {{site.api}}/flutter/animation/AnimationController-class.html
 [`AnimationController.animateWith`]: {{site.api}}/flutter/animation/AnimationController/animateWith.html
 [article1]: {{site.flutter-medium}}/how-to-choose-which-flutter-animation-widget-is-right-for-you-79ecfb7e72b5
 [article2]: {{site.flutter-medium}}/flutter-animation-basics-with-implicit-animations-95db481c5916
@@ -230,6 +448,9 @@ Learn more about Flutter animations at the following links:
 [article6]: {{site.flutter-medium}}/animation-deep-dive-39d3ffea111f
 [Creating your own custom implicit animations with TweenAnimationBuilder]: {{site.yt.watch}}?v=6KiPEqzJIKQ&feature=youtu.be
 [Creating custom explicit animations with AnimatedBuilder and AnimatedWidget]: {{site.yt.watch}}?v=fneC7t4R_B0&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=4
+[`Curves`]: {{site.api}}/flutter/animation/Curves-class.html
+[`CurvedAnimation`]: {{site.api}}/flutter/animation/CurvedAnimation-class.html
+[`evaluate(Animation<double> animation)`]: {{site.api}}/flutter/animation/Animation/value.html
 [Flutter API documentation]: {{site.api}}
 [`Hero`]: {{site.api}}/flutter/widgets/Hero-class.html
 [Hero animations]: /ui/animations/hero-animations
@@ -237,11 +458,14 @@ Learn more about Flutter animations at the following links:
 [Implicit animations codelab]: /codelabs/implicit-animations
 [Making your first directional animations with built-in explicit animations]: {{site.yt.watch}}?v=CunyH6unILQ&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=3
 [Material widgets]: /ui/widgets/material
+[Monitoring the progress of the animation]: #monitoring
 [`Navigator`]: {{site.api}}/flutter/widgets/Navigator-class.html
 [`PageRoute`]: {{site.api}}/flutter/widgets/PageRoute-class.html
 [part 2]: {{site.medium}}/dartlang/zero-to-one-with-flutter-part-two-5aa2f06655cb
+[`RepaintBoundary`]: {{site.api}}/flutter/widgets/RepaintBoundary-class.html
 [Sample app catalog]: https://flutter.github.io/samples
 [`SpringSimulation`]: {{site.api}}/flutter/physics/SpringSimulation-class.html
 [Staggered Animations]: /ui/animations/staggered-animations
+[`Tween`]: {{site.api}}/flutter/animation/Tween-class.html
 [Write your first Flutter app on the web]: /get-started/codelab-web
 [Zero to One with Flutter, part 1]: {{site.medium}}/dartlang/zero-to-one-with-flutter-43b13fd7b354

--- a/src/content/ui/animations/index.md
+++ b/src/content/ui/animations/index.md
@@ -207,7 +207,7 @@ An `Animation` object knows nothing about rendering or
 A [`CurvedAnimation`][] defines the animation's progress
 as a non-linear curve.
 
-<?code-excerpt "animate5/lib/main.dart (CurvedAnimation)"?>
+<?code-excerpt "animation/animate5/lib/main.dart (CurvedAnimation)"?>
 ```dart
 animation = CurvedAnimation(parent: controller, curve: Curves.easeIn);
 ```
@@ -216,7 +216,7 @@ animation = CurvedAnimation(parent: controller, curve: Curves.easeIn);
 The [`Curves`][] class defines many commonly used curves,
 or you can create your own. For example:
 
-<?code-excerpt "animate5/lib/main.dart (ShakeCurve)" plaster="none"?>
+<?code-excerpt "animation/animate5/lib/main.dart (ShakeCurve)" plaster="none"?>
 ```dart
 import 'dart:math';
 
@@ -245,7 +245,7 @@ from 0.0 to 1.0 during a given duration.
 For example, this code creates an `Animation` object,
 but does not start it running:
 
-<?code-excerpt "animate5/lib/main.dart (animation-controller)"?>
+<?code-excerpt "animation/animate5/lib/main.dart (animation-controller)"?>
 ```dart
 controller =
     AnimationController(duration: const Duration(seconds: 2), vsync: this);
@@ -300,7 +300,7 @@ If you need a different range or a different data type, you can use a
 different range or data type. For example, the
 following `Tween` goes from -200.0 to 0.0:
 
-<?code-excerpt "animate5/lib/main.dart (tween)"?>
+<?code-excerpt "animation/animate5/lib/main.dart (tween)"?>
 ```dart
 tween = Tween<double>(begin: -200, end: 0);
 ```
@@ -314,7 +314,7 @@ A `Tween` inherits from `Animatable<T>`, not from `Animation<T>`.
 An `Animatable`, like `Animation`, doesn't have to output double.
 For example, `ColorTween` specifies a progression between two colors.
 
-<?code-excerpt "animate5/lib/main.dart (colorTween)"?>
+<?code-excerpt "animation/animate5/lib/main.dart (colorTween)"?>
 ```dart
 colorTween = ColorTween(begin: Colors.transparent, end: Colors.black54);
 ```
@@ -336,7 +336,7 @@ passing in the controller object. For example,
 the following code generates the
 integer values from 0 to 255 over the course of 500 ms.
 
-<?code-excerpt "animate5/lib/main.dart (IntTween)"?>
+<?code-excerpt "animation/animate5/lib/main.dart (IntTween)"?>
 ```dart
 AnimationController controller = AnimationController(
     duration: const Duration(milliseconds: 500), vsync: this);
@@ -350,7 +350,7 @@ not an [`Animatable`][].
 
 The following example shows a controller, a curve, and a `Tween`:
 
-<?code-excerpt "animate5/lib/main.dart (IntTween-curve)"?>
+<?code-excerpt "animation/animate5/lib/main.dart (IntTween-curve)"?>
 ```dart
 AnimationController controller = AnimationController(
     duration: const Duration(milliseconds: 500), vsync: this);
@@ -423,6 +423,7 @@ Learn more about Flutter animations at the following links:
   The animation API for the Flutter framework. This link
   takes you to a technical overview page for the library.
 
+[animate1]: {{examples}}/animation/animate1
 [Animate a widget using a physics simulation]: /cookbook/animation/physics-simulation
 [`Animatable`]: {{site.api}}/flutter/animation/Animatable-class.html
 [`AnimatedList` example]: https://flutter.github.io/samples/animations.html

--- a/src/content/ui/animations/tutorial.md
+++ b/src/content/ui/animations/tutorial.md
@@ -16,10 +16,10 @@ description: A tutorial showing how to build explicit animations in Flutter.
 :::
 
 This tutorial shows you how to build explicit animations in Flutter.
-After introducing some of the essential concepts, classes,
-and methods in the animation library, it walks you through 5
-animation examples. The examples build on each other,
-introducing you to different aspects of the animation library.
+The examples build on each other, introducing you to different aspects of the
+animation library. The tutorial is built on essential concepts, classes,
+and methods in the animation library that you can learn about in
+[Introduction to animations][].
 
 The Flutter SDK also provides built-in explicit animations,
 such as [`FadeTransition`][], [`SizeTransition`][],
@@ -28,236 +28,10 @@ triggered by setting a beginning and ending point.
 They are simpler to implement
 than custom explicit animations, which are described here.
 
-<a id="concepts"></a>
-## Essential animation concepts and classes
-
-:::secondary What's the point?
-* [`Animation`][], a core class in Flutter's animation library,
-  interpolates the values used to guide an animation.
-* An `Animation` object knows the current state of an animation
-  (for example, whether it's started, stopped,
-  or moving forward or in reverse),
-  but doesn't know anything about what appears onscreen.
-* An [`AnimationController`][] manages the `Animation`.
-* A [`CurvedAnimation`][] defines progression as a non-linear curve.
-* A [`Tween`][] interpolates between the range of data as used by the
-  object being animated.
-  For example, a `Tween` might define an interpolation
-  from red to blue, or from 0 to 255.
-* Use `Listener`s and `StatusListener`s to monitor
-  animation state changes.
-:::
-
-The animation system in Flutter is based on typed
-[`Animation`][] objects. Widgets can either incorporate
-these animations in their build functions directly by
-reading their current value and listening to their state
-changes or they can use the animations as the basis of
-more elaborate animations that they pass along to
-other widgets.
-
-<a id="animation-class"></a>
-### Animation<wbr>\<double>
-
-In Flutter, an `Animation` object knows nothing about what
-is onscreen. An `Animation` is an abstract class that
-understands its current value and its state (completed or dismissed).
-One of the more commonly used animation types is `Animation<double>`.
-
-An `Animation` object sequentially generates
-interpolated numbers between two values over a certain duration.
-The output of an `Animation` object might be linear,
-a curve, a step function, or any other mapping you can devise.
-Depending on how the `Animation` object is controlled,
-it could run in reverse, or even switch directions in the
-middle.
-
-Animations can also interpolate types other than double, such as
-`Animation<Color>` or `Animation<Size>`.
-
-An `Animation` object has state. Its current value is
-always available in the `.value` member.
-
-An `Animation` object knows nothing about rendering or
-`build()` functions.
-
-### Curved&shy;Animation
-
-A [`CurvedAnimation`][] defines the animation's progress
-as a non-linear curve.
-
-<?code-excerpt "animate5/lib/main.dart (CurvedAnimation)"?>
-```dart
-animation = CurvedAnimation(parent: controller, curve: Curves.easeIn);
-```
-
-:::note
-The [`Curves`][] class defines many commonly used curves,
-or you can create your own. For example:
-
-<?code-excerpt "animate5/lib/main.dart (ShakeCurve)" plaster="none"?>
-```dart
-import 'dart:math';
-
-class ShakeCurve extends Curve {
-  @override
-  double transform(double t) => sin(t * pi * 2);
-}
-```
-
-Browse the [`Curves`] documentation for a complete listing
-(with visual previews) of the `Curves` constants that ship with Flutter.
-:::
-
-`CurvedAnimation` and `AnimationController` (described in the next section)
-are both of type `Animation<double>`, so you can pass them interchangeably.
-The `CurvedAnimation` wraps the object it's modifying&mdash;you
-don't subclass `AnimationController` to implement a curve.
-
-### Animation&shy;Controller
-
-[`AnimationController`][] is a special `Animation`
-object that generates a new value whenever the hardware
-is ready for a new frame. By default,
-an `AnimationController` linearly produces the numbers
-from 0.0 to 1.0 during a given duration.
-For example, this code creates an `Animation` object,
-but does not start it running:
-
-<?code-excerpt "animate5/lib/main.dart (animation-controller)"?>
-```dart
-controller =
-    AnimationController(duration: const Duration(seconds: 2), vsync: this);
-```
-
-`AnimationController` derives from `Animation<double>`, so it can be used
-wherever an `Animation` object is needed. However, the `AnimationController`
-has additional methods to control the animation. For example, you start
-an animation with the `.forward()` method. The generation of numbers is
-tied to the screen refresh, so typically 60 numbers are generated per
-second. After each number is generated, each `Animation` object calls the
-attached `Listener` objects. To create a custom display list for each
-child, see [`RepaintBoundary`][].
-
-When creating an `AnimationController`, you pass it a `vsync` argument.
-The presence of `vsync` prevents offscreen animations from consuming
-unnecessary resources.
-You can use your stateful object as the vsync by adding
-`SingleTickerProviderStateMixin` to the class definition.
-You can see an example of this in [animate1][] on GitHub.
-
-{% comment %}
-The `vsync` object ties the ticking of the animation controller to
-the visibility of the widget, so that when the animating widget goes
-off-screen, the ticking stops, and when the widget is restored, it
-starts again (without stopping the clock, so it's as if it had
-been ticking the whole time, but without using the CPU.)
-To use your custom State object as the `vsync`, include the
-`TickerProviderStateMixin` when defining the custom State class.
-{% endcomment -%}
-
-:::note
-In some cases, a position might exceed the `AnimationController`'s
-0.0-1.0 range. For example, the `fling()` function
-allows you to provide velocity, force, and position
-(via the Force object). The position can be anything and
-so can be outside of the 0.0 to 1.0 range.
-
-A `CurvedAnimation` can also exceed the 0.0 to 1.0 range,
-even if the `AnimationController` doesn't.
-Depending on the curve selected, the output of
-the `CurvedAnimation` can have a wider range than the input.
-For example, elastic curves such as `Curves.elasticIn`
-significantly overshoots or undershoots the default range.
-:::
-
-### Tween
-
-By default, the `AnimationController` object ranges from 0.0 to 1.0.
-If you need a different range or a different data type, you can use a
-[`Tween`][] to configure an animation to interpolate to a
-different range or data type. For example, the
-following `Tween` goes from -200.0 to 0.0:
-
-<?code-excerpt "animate5/lib/main.dart (tween)"?>
-```dart
-tween = Tween<double>(begin: -200, end: 0);
-```
-
-A `Tween` is a stateless object that takes only `begin` and `end`.
-The sole job of a `Tween` is to define a mapping from an
-input range to an output range. The input range is commonly
-0.0 to 1.0, but that's not a requirement.
-
-A `Tween` inherits from `Animatable<T>`, not from `Animation<T>`.
-An `Animatable`, like `Animation`, doesn't have to output double.
-For example, `ColorTween` specifies a progression between two colors.
-
-<?code-excerpt "animate5/lib/main.dart (colorTween)"?>
-```dart
-colorTween = ColorTween(begin: Colors.transparent, end: Colors.black54);
-```
-
-A `Tween` object doesn't store any state. Instead, it provides the
-[`evaluate(Animation<double> animation)`][] method that uses the 
-`transform` function to map the current value of the animation
-(between 0.0 and 1.0), to the actual animation value. 
-
-The current value of the `Animation` object can be found in the
-`.value` method. The evaluate function also performs some housekeeping,
-such as ensuring that begin and end are returned when the
-animation values are 0.0 and 1.0, respectively.
-
-#### Tween.animate
-
-To use a `Tween` object, call `animate()` on the `Tween`,
-passing in the controller object. For example,
-the following code generates the
-integer values from 0 to 255 over the course of 500 ms.
-
-<?code-excerpt "animate5/lib/main.dart (IntTween)"?>
-```dart
-AnimationController controller = AnimationController(
-    duration: const Duration(milliseconds: 500), vsync: this);
-Animation<int> alpha = IntTween(begin: 0, end: 255).animate(controller);
-```
-
-:::note
-The `animate()` method returns an [`Animation`][],
-not an [`Animatable`][].
-:::
-
-The following example shows a controller, a curve, and a `Tween`:
-
-<?code-excerpt "animate5/lib/main.dart (IntTween-curve)"?>
-```dart
-AnimationController controller = AnimationController(
-    duration: const Duration(milliseconds: 500), vsync: this);
-final Animation<double> curve =
-    CurvedAnimation(parent: controller, curve: Curves.easeOut);
-Animation<int> alpha = IntTween(begin: 0, end: 255).animate(curve);
-```
-
-### Animation notifications
-
-An [`Animation`][] object can have `Listener`s and `StatusListener`s,
-defined with `addListener()` and `addStatusListener()`.
-A `Listener` is called whenever the value of the animation changes.
-The most common behavior of a `Listener` is to call `setState()`
-to cause a rebuild. A `StatusListener` is called when an animation begins,
-ends, moves forward, or moves reverse, as defined by `AnimationStatus`.
-The next section has an example of the `addListener()` method,
-and [Monitoring the progress of the animation][] shows an
-example of `addStatusListener()`.
-
----
-
-## Animation examples
-
-This section walks you through 5 animation examples.
+The following sections walks you through several animation examples.
 Each section provides a link to the source code for that example.
 
-### Rendering animations
+## Rendering animations
 
 :::secondary What's the point?
 * How to add basic animation to a widget using `addListener()` and
@@ -401,7 +175,7 @@ check out [Cascade notation][]
 in the [Dart language documentation][].
 :::
 
-###  Simplifying with Animated&shy;Widget
+##  Simplifying with Animated&shy;Widget
 
 :::secondary What's the point?
 * How to use the [`AnimatedWidget`][] helper class
@@ -513,7 +287,8 @@ and it passes the `Animation` object to `AnimatedLogo`:
 **App source:** [animate2][]
 
 <a id="monitoring"></a>
-### Monitoring the progress of the animation
+
+## Monitoring the progress of the animation
 
 :::secondary What's the point?
 * Use `addStatusListener()` for notifications of changes
@@ -580,7 +355,7 @@ at the beginning or the end. This creates a "breathing" effect:
 
 **App source:** [animate3][]
 
-### Refactoring with AnimatedBuilder
+## Refactoring with AnimatedBuilder
 
 :::secondary What's the point?
 * An [`AnimatedBuilder`][] understands how to render the transition.
@@ -765,7 +540,7 @@ in the bullet points above.
 
 **App source:** [animate4][]
 
-### Simultaneous animations
+## Simultaneous animations
 
 :::secondary What's the point?
 * The [`Curves`][] class defines an array of
@@ -876,20 +651,23 @@ class _LogoAppState extends State<LogoApp> with SingleTickerProviderStateMixin {
 }
 ```
 
-**App source:** [animate5][]
+**App source:** [animate5][] object knows the current state of an animation
+  (for example, whether it's started, stopped,
+  or moving forward or in reverse),
+  but doesn't know anything about what appears onscreen.
+* An [`AnimationController`][] manages the `Animation`.
+* A [`CurvedAnimation`][] defines progression as a non-linear curve.
+* A [`Tween`][] interpolates between the range of data as used by the
+  object be
 
 ## Next steps
 
 This tutorial gives you a foundation for creating animations in
 Flutter using `Tweens`, but there are many other classes to explore.
 You might investigate the specialized `Tween` classes,
-animations specific to Material Design,
-`ReverseAnimation`,
+animations specific to your design system type, `ReverseAnimation`,
 shared element transitions (also known as Hero animations),
 physics simulations and `fling()` methods.
-See the [animations landing page][]
-for the latest available documents and examples.
-
 
 [animate0]: {{examples}}/animation/animate0
 [animate1]: {{examples}}/animation/animate1
@@ -898,23 +676,18 @@ for the latest available documents and examples.
 [animate4]: {{examples}}/animation/animate4
 [animate5]: {{examples}}/animation/animate5
 [`AnimatedWidget`]: {{site.api}}/flutter/widgets/AnimatedWidget-class.html
-[`Animatable`]: {{site.api}}/flutter/animation/Animatable-class.html
-[`Animation`]: {{site.api}}/flutter/animation/Animation-class.html
 [`AnimatedBuilder`]: {{site.api}}/flutter/widgets/AnimatedBuilder-class.html
-[animations landing page]: /ui/animations
+[Introduction to animations]: /ui/animations
 [`AnimationController`]: {{site.api}}/flutter/animation/AnimationController-class.html
 [`AnimationController` section]: #animationcontroller
 [`Curves`]: {{site.api}}/flutter/animation/Curves-class.html
 [`CurvedAnimation`]: {{site.api}}/flutter/animation/CurvedAnimation-class.html
 [Cascade notation]: {{site.dart-site}}/language/operators#cascade-notation
 [Dart language documentation]: {{site.dart-site}}/language
-[`evaluate(Animation<double> animation)`]: {{site.api}}/flutter/animation/Animation/value.html
 [`FadeTransition`]: {{site.api}}/flutter/widgets/FadeTransition-class.html
 [Monitoring the progress of the animation]: #monitoring
 [Refactoring with AnimatedBuilder]: #refactoring-with-animatedbuilder
-[`RepaintBoundary`]: {{site.api}}/flutter/widgets/RepaintBoundary-class.html
 [`SlideTransition`]: {{site.api}}/flutter/widgets/SlideTransition-class.html
 [Simplifying with AnimatedWidget]: #simplifying-with-animatedwidget
 [`SizeTransition`]: {{site.api}}/flutter/widgets/SizeTransition-class.html
 [`Tween`]: {{site.api}}/flutter/animation/Tween-class.html
-

--- a/src/content/ui/animations/tutorial.md
+++ b/src/content/ui/animations/tutorial.md
@@ -679,7 +679,7 @@ physics simulations and `fling()` methods.
 [`AnimatedBuilder`]: {{site.api}}/flutter/widgets/AnimatedBuilder-class.html
 [Introduction to animations]: /ui/animations
 [`AnimationController`]: {{site.api}}/flutter/animation/AnimationController-class.html
-[`AnimationController` section]: #animationcontroller
+[`AnimationController` section]: /ui/animations/index#animationcontroller
 [`Curves`]: {{site.api}}/flutter/animation/Curves-class.html
 [`CurvedAnimation`]: {{site.api}}/flutter/animation/CurvedAnimation-class.html
 [Cascade notation]: {{site.dart-site}}/language/operators#cascade-notation


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Small clean up of `Introduction to animations` and `Animations tutorial`.

While preparing to work on #2003, I noticed that we had conceptual topics in the tutorial and that the tutorial didn't read like a tutorial. To hopefully make things more clear, I've done the following:

- Moved `Essential animation concepts and classes` from the tutorial into the introduction.
-  In the introduction, moved `Animation deep dive` into its own section and moved it up.
- In the introduction, moved several videos about implicit and explicit animations into their own section.
- Moved codelabs, tutorials, and articles to the bottom (since this is supplemental material).
- Removed the section called `Pre-canned animations`, which was specifically about one animation package, but added a link to animation packages on pub.dev. 
- Small changes to wording in the tutorial introduction.

Once this PR is submitted (if you're all okay with the changes), I'm going to add additional items to the `Essential animation concepts and classes` section.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
