### PR TITLE
More accessible alert/aside style

### DIFF
--- a/src/_11ty/plugins/markdown.ts
+++ b/src/_11ty/plugins/markdown.ts
@@ -64,12 +64,11 @@ function _registerAside(markdown: MarkdownIt, id: string, defaultTitle: string |
       if (tokens[index].nesting === 1) {
         const parsedArgs = /\s+(.*)/.exec(tokens[index].info);
 
-        const title = parsedArgs?.[1] ?? defaultTitle ?? '';
+        const title = parsedArgs?.[1] ?? defaultTitle;
         return `<aside class="alert ${style}">
-<div class="alert-header">
+${title !== null ? `<div class="alert-header">
 ${icon !== null ? `<i class="material-symbols" aria-hidden="true">${icon}</i>` : ''}
-<span>${title ?? ''}</span>
-</div>
+<span>${title}</span></div>` : ''}
 <div class="alert-content">
 `;
       } else {

--- a/src/_11ty/plugins/markdown.ts
+++ b/src/_11ty/plugins/markdown.ts
@@ -100,7 +100,7 @@ function _registerAsides(markdown: MarkdownIt): void {
   );
   _registerAside(markdown, 'tip', 'Tip', 'lightbulb', 'alert-success');
   _registerAside(markdown, 'recommend', 'Recommended', 'bolt', 'alert-success');
-  _registerAside(markdown, 'important', 'Important', 'error', 'alert-warning');
+  _registerAside(markdown, 'important', 'Important', 'error', 'alert-important');
   _registerAside(
     markdown,
     'warning',

--- a/src/_sass/base/_base.scss
+++ b/src/_sass/base/_base.scss
@@ -391,15 +391,6 @@ td ol, td ul, td dl, td p {
   color: #041E3C;
 }
 
-aside {
-  .alert {
-    h2, h3, h4, h5, h6 {
-      margin: 0.5rem 0;
-      font-size: 1.5rem;
-    }
-  }
-}
-
 .card-os-bug {
   position: relative;
   ::before {

--- a/src/_sass/components/_alert.scss
+++ b/src/_sass/components/_alert.scss
@@ -28,7 +28,7 @@ aside.alert {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    margin-bottom: 0.5rem;
+    margin-block-end: 0.5rem;
     font-family: $site-font-family-alt;
     font-size: 1.125rem;
     font-weight: 500;
@@ -44,7 +44,7 @@ aside.alert {
   .alert-content {
     color: $site-color-body;
 
-    > *:last-child {
+    > :last-child {
       margin-bottom: 0;
     }
   }
@@ -74,8 +74,8 @@ aside.alert {
   }
 
   &.alert-secondary {
-    border-color: var(--site-surface-container-highest);
-    --alert-title-color: var(--site-on-surface);
+    border-color: $site-color-light-grey;
+    --alert-title-color: $site-color-body;
   }
 
   &.alert-error {

--- a/src/_sass/components/_alert.scss
+++ b/src/_sass/components/_alert.scss
@@ -1,0 +1,85 @@
+@use '../base/variables' as *;
+
+aside.alert {
+  --alert-info-color: #2058b7;
+  --alert-tip-color: #0c7927;
+  --alert-important-color: #7e5ac2;
+  --alert-warning-color: #9e6300;
+  --alert-error-color: #cd3434;
+  // Dark mode options:
+  // --alert-info-color: #308bf5;
+  // --alert-tip-color: #25c04b;
+  // --alert-important-color: #a676ff;
+  // --alert-warning-color: #cea11f;
+  // --alert-error-color: #ff4141;
+
+  // TODO(parlough): Remove these resets once bootstrap is removed.
+  margin: 0;
+  border: none;
+
+  padding: 0.75rem;
+  margin-block-start: 1rem;
+  margin-block-end: 1rem;
+  border-left: solid 0.25rem $site-color-light-grey;
+  background-color: $site-color-codeblock-bg;
+  --alert-title-color: $site-color-body;
+
+  .alert-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+    font-family: $site-font-family-alt;
+    font-size: 1.125rem;
+    font-weight: 500;
+    -webkit-font-smoothing: antialiased;
+    color: var(--alert-title-color);
+
+    .material-symbols {
+      font-size: 1.25em;
+      user-select: none;
+    }
+  }
+
+  .alert-content {
+    color: $site-color-body;
+
+    > *:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+
+  &.alert-success {
+    border-color: var(--alert-tip-color);
+    --alert-title-color: var(--alert-tip-color);
+  }
+
+  &.alert-important {
+    border-color: var(--alert-important-color);
+    --alert-title-color: var(--alert-important-color);
+  }
+
+  &.alert-warning {
+    border-color: var(--alert-warning-color);
+    --alert-title-color: var(--alert-warning-color);
+  }
+
+  &.alert-info {
+    border-color: var(--alert-info-color);
+    --alert-title-color: var(--alert-info-color);
+  }
+
+  &.alert-secondary {
+    border-color: var(--site-surface-container-highest);
+    --alert-title-color: var(--site-on-surface);
+  }
+
+  &.alert-error {
+    border-color: var(--alert-error-color);
+    --alert-title-color: var(--alert-error-color);
+  }
+}

--- a/src/_sass/site.scss
+++ b/src/_sass/site.scss
@@ -10,6 +10,7 @@
 
 // -- Components
 // (alpha ordered)
+@use 'components/alert';
 @use 'components/banner';
 @use 'components/books';
 @use 'components/code';

--- a/src/_sass/vendor/_bootstrap.scss
+++ b/src/_sass/vendor/_bootstrap.scss
@@ -55,9 +55,6 @@
 
   // Component config
 
-  $alert-padding-y: $site-spacer * 1.5,
-  $alert-padding-x: $site-spacer * 1.5,
-
   $border-radius: 0,
   $border-radius-lg: 0,
   $border-radius-sm: 0,
@@ -80,65 +77,6 @@
 @use '../../../node_modules/bootstrap-scss/bootstrap';
 
 // Bootstrap adjustments
-
-.alert {
-  border: none;
-  border-radius: 0;
-  color: $site-color-body;
-  margin-top: 1rem;
-  padding: 1.25rem;
-
-  .alert-header {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-family: $site-font-family-alt;
-    font-size: 1.125rem;
-    font-weight: 500;
-  }
-
-  .alert-content {
-    margin-top: 0.5rem;
-  }
-
-  i.material-symbols {
-    font-size: 1.25em;
-    user-select: none;
-  }
-
-  code {
-    background-color: transparent;
-  }
-
-  p:last-child {
-    margin-bottom: 0;
-  }
-
-  &.alert-success {
-    width: auto;
-    background-color: $alert-success-bg;
-  }
-
-  &.alert-info {
-    width: auto;
-    background-color: $alert-info-bg;
-  }
-
-  &.alert-secondary {
-    width: auto;
-    background-color: $flutter-color-grey-500;
-  }
-
-  &.alert-warning {
-    width: auto;
-    background-color: $alert-warning-bg;
-  }
-
-  &.alert-danger {
-    width: auto;
-    background-color: $alert-danger-bg;
-  }
-}
 
 a.card {
   color: inherit;


### PR DESCRIPTION
Only colors the title and a left border instead of the background and the text. This is more likely to be visually accessible and is the style many doc websites are adapting.

Also removes dependence on bootstrap-provided styles. Contributes to https://github.com/flutter/website/issues/8030 and https://github.com/flutter/website/issues/3632