### PR TITLE
button border-radius added

### DIFF
--- a/src/_sass/components/_button.scss
+++ b/src/_sass/components/_button.scss
@@ -30,13 +30,12 @@ a, button {
     width: fit-content;
     white-space: nowrap;
     outline-offset: 2px;
-
+    border-radius: 24px;
     font-weight: 500;
     padding: 0.5rem 1rem;
     background-color: $site-color-primary;
     color: $site-color-white;
     text-decoration: none;
-    border-radius: 0;
     cursor: pointer;
     user-select: none;
 


### PR DESCRIPTION
In the Navbar, the 'Get Started' button has sharp angles. Instead, we should make it rounded by adding a border radius.

Fixed #11622 

Now Looks better with round shape 😊

<img width="143" alt="image" src="https://github.com/user-attachments/assets/497921b6-df79-47ba-bfb7-5a520b09cab5" />

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
