### PR TITLE
Remove flutter_gdb from docs (it's deprecated).

### DIFF
--- a/src/_includes/docs/debug/debug-flow-android.md
+++ b/src/_includes/docs/debug/debug-flow-android.md
@@ -1,12 +1,3 @@
-:::note
-If you want to use the [GNU Project Debugger][] to debug the
-Flutter engine running within an Android app process,
-check out [`flutter_gdb`][].
-:::
-
-[GNU Project Debugger]: https://www.sourceware.org/gdb/
-[`flutter_gdb`]: {{site.repo.flutter}}/blob/main/engine/src/flutter/sky/tools/flutter_gdb
-
 #### Build the Android version of the Flutter app in the Terminal
 
 To generate the needed Android platform dependencies,

--- a/src/content/testing/code-debugging.md
+++ b/src/content/testing/code-debugging.md
@@ -11,14 +11,6 @@ This guide describes which debugging features you can enable in your code.
 For a full list of debugging and profiling tools, check out the
 [Debugging][] page.
 
-:::note
-If you are looking for a way to use GDB to remotely debug the
-Flutter engine running within an Android app process,
-check out [`flutter_gdb`][].
-:::
-
-[`flutter_gdb`]: {{site.repo.flutter}}/blob/main/engine/src/flutter/sky/tools/flutter_gdb
-
 ## Add logging to your application
 
 The following list contains a few statements that you can use to log the

--- a/src/content/testing/debugging.md
+++ b/src/content/testing/debugging.md
@@ -22,12 +22,6 @@ Flutter applications. Here are some of the available tools:
   representation of the widget tree, inspect
   individual widgets and their property values,
   enable the performance overlay, and more.
-* If you are looking for a way to use GDB to remotely debug the
-  Flutter engine running within an Android app process,
-  check out [`flutter_gdb`][].
-
-
-[`flutter_gdb`]: {{site.repo.flutter}}/blob/main/engine/src/flutter/sky/tools/flutter_gdb
 
 ## Other resources
 

--- a/src/content/tools/devtools/debugger.md
+++ b/src/content/tools/devtools/debugger.md
@@ -13,15 +13,6 @@ from VS Code because VS Code has a built-in debugger.
 DevTools includes a full source-level debugger,
 supporting breakpoints, stepping, and variable inspection.
 
-:::note
-The debugger works with all Flutter and Dart applications.
-If you are looking for a way to use GDB to remotely debug the
-Flutter engine running within an Android app process,
-check out [`flutter_gdb`][].
-:::
-
-[`flutter_gdb`]: {{site.repo.flutter}}/blob/main/engine/src/flutter/sky/tools/flutter_gdb
-
 When you open the debugger tab, you should see the source for the main
 entry-point for your app loaded in the debugger.
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

I recently discovered that GDB for Android has been deprecated. Triaged the issue with the Flutter dev team and the resolution was to remove mention of the flutter_gdb tool from the docs. There is something newer called LLDB, but we don't have a tool for that.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
