### PR TITLE
style added in searchbar

### DIFF
--- a/src/_sass/components/_header.scss
+++ b/src/_sass/components/_header.scss
@@ -94,7 +94,7 @@
       font: $site-font-icon;
       pointer-events: none;
       position: absolute;
-      left: 0.25rem;
+      left: 0.75rem;
     }
 
     &:hover::before {
@@ -109,6 +109,8 @@
     transition: width .35s ease-in-out;
     width: 24px;
     cursor: pointer;
+    border-radius: 24px;
+    padding-left: 2.5rem;
 
     &:focus {
       width: 220px;


### PR DESCRIPTION
Added a round style to the search bar and adjusted the margin, padding of the search icon, and placeholder to improve the appearance of the rounded search bar.

<img width="374" alt="image" src="https://github.com/user-attachments/assets/c18a9226-3b38-4cc4-85f0-7601cf90ed4b" />


Fixed #11678 

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
