### PR TITLE
Make sure install help button styles take priority

### DIFF
--- a/src/_sass/components/_misc.scss
+++ b/src/_sass/components/_misc.scss
@@ -1,6 +1,6 @@
 @use '../base/variables' as *;
 
-.install-help {
+.site-content p.install-help {
   text-align: right;
   margin-block-start: -2.5rem;
 


### PR DESCRIPTION
This slightly improves the styling of "Install help" buttons on pages like https://docs.flutter.dev/get-started/install/windows/mobile, placing them more inline with the titles.

We should likely consider replacing these, but that can be revisited with later install work.