### PR TITLE
Update a few deep link notes to support iOS

### DIFF
--- a/src/content/cookbook/navigation/set-up-app-links.md
+++ b/src/content/cookbook/navigation/set-up-app-links.md
@@ -9,21 +9,15 @@ Deep linking is a mechanism for launching an app with a URI.
 This URI contains scheme, host, and path,
 and opens the app to a specific screen.
 
-:::note
-Did you know that Flutter DevTools provides a
-deep link validation tool for Android?
-An iOS version of the tool is in the works.
-Learn more and see a demo at [Validate deep links][].
-:::
-
-[Validate deep links]: /tools/devtools/deep-links
-
 An _app link_ is a type of deep link that uses
 `http` or `https` and is exclusive to Android devices.
 
 Setting up app links requires one to own a web domain.
 Otherwise, consider using [Firebase Hosting][]
 or [GitHub Pages][] as a temporary solution.
+
+Once you've set up your deep links, you can validate them.
+To learn more, see [Validate deep links][].
 
 ## 1. Customize a Flutter application
 
@@ -233,3 +227,4 @@ Source code: [deeplink_cookbook][]
 [GitHub Pages]: https://pages.github.com
 [app_links]: {{site.pub}}/packages/app_links
 [Signing the app]: /deployment/android#signing-the-app
+[Validate deep links]: /tools/devtools/deep-links

--- a/src/content/cookbook/navigation/set-up-universal-links.md
+++ b/src/content/cookbook/navigation/set-up-universal-links.md
@@ -9,21 +9,15 @@ Deep linking allows an app user to launch an app with a URI.
 This URI contains scheme, host, and path,
 and opens the app to a specific screen.
 
-:::note
-Did you know that Flutter DevTools provides a
-deep link validation tool for Android?
-An iOS version of the tool is in the works.
-Learn more and see a demo at [Validate deep links][].
-:::
-
-[Validate deep links]: /tools/devtools/deep-links
-
 A _universal link_, a type of deep link exclusive to iOS devices,
 uses only the `http` or `https` protocols.
 
 To set up universal links, you need to own a web domain.
 As a temporary solution,
 consider using [Firebase Hosting][] or [GitHub Pages][].
+
+Once you've set up your deep links, you can validate them.
+To learn more, see [Validate deep links][].
 
 ## Create or modify a Flutter app
 
@@ -313,3 +307,4 @@ recipe in the GitHub repo.
 [go_router]: {{site.pub-pkg}}/go_router
 [GitHub Pages]: https://pages.github.com
 [app_links]: {{site.pub-pkg}}/app_links
+[Validate deep links]: /tools/devtools/deep-links

--- a/src/content/tools/devtools/index.md
+++ b/src/content/tools/devtools/index.md
@@ -32,7 +32,7 @@ Here are some of the things you can do with DevTools:
   about a running Flutter or Dart
   command-line app.
 * Analyze code and app size.
-* Validate deep links in your Android app.
+* Validate deep links in your Android or iOS app.
 
 We expect you to use DevTools in conjunction with
 your existing IDE or command-line based development workflow.
@@ -42,8 +42,11 @@ your existing IDE or command-line based development workflow.
 
 ## How to launch DevTools {:#start}
 
-See the [VS Code][], [Android Studio/IntelliJ][], or
-[command line][] pages for instructions on how to launch DevTools.
+You can launch DevTools with the following tools:
+
+* [VS Code][]
+* [Android Studio/IntelliJ][]
+* [command line][]
 
 ## Troubleshooting some standard issues
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

We had a few places in the documentation that still suggestion deep link validation was only supported by Android. Updated these to include iOS.

Notes:
Updated the section called How to launch DevTools so that it's easier to parse, but feel free to revert that change if meaning is lost.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
