### PR TITLE
Update performance profiling docs.

### DIFF
--- a/src/content/perf/ui-performance.md
+++ b/src/content/perf/ui-performance.md
@@ -18,7 +18,7 @@ Flutter offers several tools for performance analysis. Here are a few of them:
 
 * **The Performance View**: A web-based interface that connects to your app and
   displays detailed performance metrics. Part of the DevTools utility. To learn
-  more, see the [Use the Performance View][].
+  more, see [Use the Performance View][].
 
 * **Performance tracing within Dart**: Add tracing directly into your app's
   Dart code, using the `dart:developer package`, and then track your app's
@@ -43,6 +43,11 @@ significantly longer to render and are dropped, resulting in a visible stutter
 in animations. For example, if a frame occasionally takes 10 times longer than
 usual to render, it will likely be dropped, causing the animation to appear
 jerky.
+
+[Use the Performance View]: /tools/devtools/performance
+[Tracing Dart code]: /testing/code-debugging#trace-dart-code-performance
+[Show performance data]: /tools/android-studio#show-performance-data
+[Integration testing]: /testing/integration-tests
 
 ## Connect to a physical device
 
@@ -114,6 +119,9 @@ see [Flutter's build modes][].
 You'll begin by opening DevTools and viewing
 the performance overlay, as discussed in the next section.
 
+[Flutter's build modes]: /testing/build-modes
+[generate timeline events]: {{site.developers}}/web/tools/chrome-devtools/evaluate-performance/performance-reference
+
 ## Launch DevTools
 
 DevTools provides features like profiling, examining the heap,
@@ -125,21 +133,28 @@ UI performance of your application on a frame-by-frame basis.
 Once your app is running in profile mode,
 [launch DevTools][].
 
+[Timeline view]: /tools/devtools/performance
+[launch DevTools]: /tools/devtools
+
 ## Display the performance overlay {:#displaying-the-performance-overlay}
 
-You can toggle display of the performance overlay as follows:
+You can toggle the display of the performance overlay as
+follows:
 
-* **Flutter inspector**: The easiest way to enable the PerformanceOverlay widget
-  is from the Flutter inspector, which is available in the [Inspector view][] in
-  [DevTools][]. Simply click the **Performance Overlay** button to toggle the
-  overlay on your running app.
+* **DevTools Performance view**: The easiest way to enable the
+  PerformanceOverlay widget is from the [Performance view][] in [DevTools][].
+  Simply click the **Performance Overlay** button to toggle the overlay on your
+  running app.
 
 * **command line**: Toggle the performance overlay using the **P** key from
-the command line.
+  the command line.
 
 * **programmatically**: To enable the overlay programmatically, see
-[Performance overlay][], a section in the
-[Debugging Flutter apps programmatically][] page.
+  [Performance overlay][], a section in the
+  [Debugging Flutter apps programmatically][] page.
+
+[Performance overlay]: /testing/code-debugging#add-performance-overlay
+[Debugging Flutter apps programmatically]: /testing/code-debugging
 
 <a id="the-performance-overlay" aria-hidden="true"></a>
 
@@ -239,6 +254,13 @@ see [The Framework architecture][] in the
 [Flutter wiki][], and the community article,
 [The Layer Cake][].
 
+[debug mode]: /testing/build-modes#debug
+[Flutter wiki]: {{site.repo.flutter}}/tree/main/docs
+[UIKit]: {{site.apple-dev}}/documentation/uikit
+[The Layer Cake]: {{site.medium}}/flutter-community/the-layer-cake-widgets-elements-renderobjects-7644c3142401
+[The Framework architecture]: {{site.repo.flutter}}/blob/main/docs/about/The-Framework-architecture.md
+[MainThread]: {{site.android-dev}}/reference/android/support/annotation/MainThread
+
 ## Identify problems
 
 ### Review the UI graph {:#identifying-problems-in-the-ui-graph}
@@ -272,6 +294,8 @@ instead of clipping to a rounded rectangle.
 If it's a static scene that's being faded, rotated, or otherwise
 manipulated, a [`RepaintBoundary`][] might help.
 
+[programmatically]: /testing/code-debugging#debug-animation-issues
+
 #### Checking for offscreen layers
 
 The [`saveLayer`][] method is one of the most expensive methods in
@@ -302,6 +326,8 @@ ask yourself these questions:
 * Can any of these calls be eliminated?
 * Can I apply the same effect to an individual element instead of a group?
 
+[`Clip.antiAliasWithSaveLayer`]: {{site.api}}/flutter/dart-ui/Clip.html
+
 #### Checking for non-cached images
 
 Caching an image with [`RepaintBoundary`][] is good,
@@ -328,6 +354,7 @@ The following resources provide more information on using
 Flutter's tools and debugging in Flutter:
 
 * [Debugging][]
+* [Performance view][]
 * [Flutter inspector][]
 * [Flutter inspector talk][], presented at DartConf 2018
 * [Why Flutter Uses Dart][], an article on Hackernoon
@@ -336,35 +363,16 @@ Flutter's tools and debugging in Flutter:
 * [Flutter API][] docs, particularly the [`PerformanceOverlay`][] class,
   and the [dart:developer][] package
 
-
-[`Clip.antiAliasWithSaveLayer`]: {{site.api}}/flutter/dart-ui/Clip.html
 [`PerformanceOverlay`]: {{site.api}}/flutter/widgets/PerformanceOverlay-class.html
 [`RepaintBoundary`]: {{site.api}}/flutter/widgets/RepaintBoundary-class.html
 [`saveLayer`]: {{site.api}}/flutter/dart-ui/Canvas/saveLayer.html
 [dart:developer]: {{site.api}}/flutter/dart-developer/dart-developer-library.html
-[debug mode]: /testing/build-modes#debug
-[Debugging Flutter apps programmatically]: /testing/code-debugging
 [Debugging]: /testing/debugging
 [devtools]: /tools/devtools
 [Flutter API]: {{site.api}}
 [Flutter inspector talk]: {{site.yt.watch}}?v=JIcmJNT9DNI
 [Flutter inspector]: /tools/devtools/inspector
-[Flutter wiki]: {{site.repo.flutter}}/tree/main/docs
-[Flutter's build modes]: /testing/build-modes
-[generate timeline events]: {{site.developers}}/web/tools/chrome-devtools/evaluate-performance/performance-reference
-[Inspector view]: /tools/devtools/inspector
-[Integration testing]: /testing/integration-tests
-[launch DevTools]: /tools/devtools
-[MainThread]: {{site.android-dev}}/reference/android/support/annotation/MainThread
-[Performance overlay]: /testing/code-debugging#add-performance-overlay
+[Performance view]: /tools/devtools/performance
 [profile mode]: /testing/build-modes#profile
-[programmatically]: /testing/code-debugging#debug-animation-issues
-[Show performance data]: /tools/android-studio#show-performance-data
-[The Framework architecture]: {{site.repo.flutter}}/blob/main/docs/about/The-Framework-architecture.md
-[The Layer Cake]: {{site.medium}}/flutter-community/the-layer-cake-widgets-elements-renderobjects-7644c3142401
-[Timeline view]: /tools/devtools/performance
-[Tracing Dart code]: /testing/code-debugging#trace-dart-code-performance
-[UIKit]: {{site.apple-dev}}/documentation/uikit
-[Use the Performance View]: /tools/devtools/performance
 [video]: {{site.yt.watch}}?v=5F-6n_2XWR8
 [Why Flutter Uses Dart]: https://hackernoon.com/why-flutter-uses-dart-dd635a054ebf

--- a/src/content/perf/ui-performance.md
+++ b/src/content/perf/ui-performance.md
@@ -4,50 +4,47 @@ subtitle: Where to look when your Flutter app drops frames in the UI.
 description: Diagnosing UI performance issues in Flutter.
 ---
 
-{% render docs/performance.md %}
+## Overview
 
-:::secondary What you'll learn
-* Flutter aims to provide 60 frames per second (fps) performance,
-  or 120 fps performance on devices capable of 120Hz updates.
-* For 60fps, frames need to render approximately every 16ms.
-* Jank occurs when the UI doesn't render smoothly. For example,
-  every so often, a frame takes 10 times longer to render,
-  so it gets dropped, and the animation visibly jerks.
-:::
+App performance encompasses various aspects, from raw speed and I/O throughput
+to the smoothness of the user interface. While this page primarily focuses on UI
+smoothness (lack of stutter or jank), the tools described here can often be used
+to diagnose other performance issues as well.
 
-It's been said that "a _fast_ app is great,
-but a _smooth_ app is even better."
-If your app isn't rendering smoothly,
-how do you fix it? Where do you begin?
-This guide shows you where to start,
-steps to take, and tools that can help.
+Flutter offers several tools for performance analysis. Here are a few of them:
 
-:::note
-* An app's performance is determined by more than one measure.
-  Performance sometimes refers to raw speed, but also to the UI's
-  smoothness and lack of stutter. Other examples of performance
-  include I/O or network speed. This page primarily focuses on the
-  second type of performance (UI smoothness), but you can use most
-  of the same tools to diagnose other performance problems.
-* To perform tracing inside your Dart code, see [Tracing Dart code][]
-  in the [Debugging][] page.
-:::
+* **The Performance Overlay**: Displays a simplified set of metrics directly
+  within your running app. To learn more, see the sections in this topic.
 
-[Debugging]: /testing/debugging
-[Tracing Dart code]: /testing/code-debugging#trace-dart-code-performance
+* **The Performance View**: A web-based interface that connects to your app and
+  displays detailed performance metrics. Part of the DevTools utility. To learn
+  more, see the [Use the Performance View][].
 
-## Diagnosing performance problems
+* **Performance tracing within Dart**: Add tracing directly into your app's
+  Dart code, using the `dart:developer package`, and then track your app's
+  performance in the DevTools utility. To learn more, see [Tracing Dart code][].
 
-To diagnose an app with performance problems, you'll enable
-the performance overlay to look at the UI and raster threads.
-Before you begin, make sure that you're running in
-[profile mode][], and that you're not using an emulator.
-For best results, you might choose the slowest device that
-your users might use.
+* **Benchmarking**: You can measure and track your app's performance by writing
+  benchmark tests. The Flutter Driver library provides support
+  for benchmarking. Using this integration test framework,
+  you can generate metrics that track jank, download size, battery efficiency,
+  and startup time. For more information, check out [Integration testing][].
 
-[profile mode]: /testing/build-modes#profile
+* **Widget rebuild profiler (IntelliJ for Android Studio)**: Jank often arises
+  from unnecessary UI rebuilds. If you are using IntelliJ for Android Studio,
+  the Widget Rebuild Profiler helps pinpoint and fix these issues by showing
+  widget rebuild counts for the current screen and frame. For more information,
+  see [Show performance data][].
 
-### Connect to a physical device
+Flutter aims to provide 60 frames per second (fps) performance,
+or 120 fps on devices that support it. To achieve the 60fps, each frame must
+render approximately every 16ms to avoid jank. Jank occurs when frames take
+significantly longer to render and are dropped, resulting in a visible stutter
+in animations. For example, if a frame occasionally takes 10 times longer than
+usual to render, it will likely be dropped, causing the animation to appear
+jerky.
+
+## Connect to a physical device
 
 Almost all performance debugging for Flutter applications
 should be conducted on a physical Android or iOS device,
@@ -72,7 +69,7 @@ on the slowest device that your users might reasonably use._
   compilation, which itself can cause jank.
 :::
 
-### Run in profile mode
+## Run in profile mode
 
 Flutter's profile mode compiles and launches your application
 almost identically to release mode, but with just enough additional
@@ -86,9 +83,6 @@ Flutter web app running in profile mode.
 Use Chrome DevTools to
 [generate timeline events][] for a web app.
 :::
-
-[generate timeline events]: {{site.developers}}/web/tools/chrome-devtools/evaluate-performance/performance-reference
-
 
 Launch the app in profile mode as follows:
 
@@ -120,8 +114,6 @@ see [Flutter's build modes][].
 You'll begin by opening DevTools and viewing
 the performance overlay, as discussed in the next section.
 
-[Flutter's build modes]: /testing/build-modes
-
 ## Launch DevTools
 
 DevTools provides features like profiling, examining the heap,
@@ -133,12 +125,25 @@ UI performance of your application on a frame-by-frame basis.
 Once your app is running in profile mode,
 [launch DevTools][].
 
-[launch DevTools]: /tools/devtools
-[Timeline view]: /tools/devtools/performance
+## Display the performance overlay {:#displaying-the-performance-overlay}
+
+You can toggle display of the performance overlay as follows:
+
+* **Flutter inspector**: The easiest way to enable the PerformanceOverlay widget
+  is from the Flutter inspector, which is available in the [Inspector view][] in
+  [DevTools][]. Simply click the **Performance Overlay** button to toggle the
+  overlay on your running app.
+
+* **command line**: Toggle the performance overlay using the **P** key from
+the command line.
+
+* **programmatically**: To enable the overlay programmatically, see
+[Performance overlay][], a section in the
+[Debugging Flutter apps programmatically][] page.
 
 <a id="the-performance-overlay" aria-hidden="true"></a>
 
-## The performance overlay {:#performance-overlay}
+## Observe the performance overlay {:#performance-overlay}
 
 The performance overlay displays statistics in two graphs
 that show where time is being spent in your app. If the UI
@@ -158,7 +163,7 @@ on the Flutter Gallery example:
 and UI thread (bottom).<br>The vertical green bars
 represent the current frame.
 
-## Interpreting the graphs
+### Review the graphs {:#interpreting-the-graphs}
 
 The top graph (marked "GPU") shows the time spent by 
 the raster thread, the bottom one graph shows the time 
@@ -188,9 +193,7 @@ the scene is too complicated to render quickly.
 expensive to both render and paint.<br>When both graphs
 display red, start by diagnosing the UI thread.
 
-[debug mode]: /testing/build-modes#debug
-
-## Flutter's threads
+### Review the threads {:#flutters-threads}
 
 Flutter uses several threads to do its work, though
 only two of the threads are shown in the overlay.
@@ -203,7 +206,7 @@ on other threads.
 : The platform's main thread. Plugin code runs here.
   For more information, see the [UIKit][] documentation for iOS,
   or the [MainThread][] documentation for Android.
-  This thread is not shown in the performance overlay.
+  _This thread is not shown in the performance overlay._
 
 **UI thread**
 : The UI thread executes Dart code in the Dart VM.
@@ -229,58 +232,22 @@ on other threads.
 **I/O thread**
 : Performs expensive tasks (mostly I/O) that would
   otherwise block either the UI or raster threads.
-  This thread is not shown in the performance overlay.
+  _This thread is not shown in the performance overlay._
     
 For links to more information and videos,
 see [The Framework architecture][] in the
 [Flutter wiki][], and the community article,
 [The Layer Cake][].
 
-[Flutter wiki]: {{site.repo.flutter}}/tree/main/docs
-[MainThread]: {{site.android-dev}}/reference/android/support/annotation/MainThread
-[The Framework architecture]: {{site.repo.flutter}}/blob/main/docs/about/The-Framework-architecture.md
-[The Layer Cake]: {{site.medium}}/flutter-community/the-layer-cake-widgets-elements-renderobjects-7644c3142401
-[UIKit]: {{site.apple-dev}}/documentation/uikit
+## Identify problems
 
-### Displaying the performance overlay
-
-You can toggle display of the performance overlay as follows:
-
-* Using the Flutter inspector
-* From the command line
-* Programmatically
-
-#### Using the Flutter inspector
-
-The easiest way to enable the PerformanceOverlay widget is
-from the Flutter inspector, which is available in the
-[Inspector view][] in [DevTools][]. Simply click the
-**Performance Overlay** button to toggle the overlay
-on your running app.
-
-[Inspector view]: /tools/devtools/inspector
-
-#### From the command line
-
-Toggle the performance overlay using the **P** key from
-the command line.
-
-#### Programmatically
-
-To enable the overlay programmatically, see
-[Performance overlay][], a section in the
-[Debugging Flutter apps programmatically][] page.
-
-[Debugging Flutter apps programmatically]: /testing/code-debugging
-[Performance overlay]: /testing/code-debugging#add-performance-overlay
-
-## Identifying problems in the UI graph
+### Review the UI graph {:#identifying-problems-in-the-ui-graph}
 
 If the performance overlay shows red in the UI graph,
 start by profiling the Dart VM, even if the GPU graph
 also shows red.
 
-## Identifying problems in the GPU graph
+### Review the GPU graph {:#identifying-problems-in-the-gpu-graph}
 
 Sometimes a scene results in a layer tree that is easy to construct,
 but expensive to render on the raster thread. When this happens,
@@ -304,10 +271,6 @@ use clipping. For example, overlay opaque corners onto a square
 instead of clipping to a rounded rectangle.
 If it's a static scene that's being faded, rotated, or otherwise
 manipulated, a [`RepaintBoundary`][] might help.
-
-[programmatically]: /testing/code-debugging#debug-animation-issues
-[`RepaintBoundary`]: {{site.api}}/flutter/widgets/RepaintBoundary-class.html
-[`saveLayer`]: {{site.api}}/flutter/dart-ui/Canvas/saveLayer.html
 
 #### Checking for offscreen layers
 
@@ -339,8 +302,6 @@ ask yourself these questions:
 * Can any of these calls be eliminated?
 * Can I apply the same effect to an individual element instead of a group?
 
-[`Clip.antiAliasWithSaveLayer`]: {{site.api}}/flutter/dart-ui/Clip.html
-
 #### Checking for non-cached images
 
 Caching an image with [`RepaintBoundary`][] is good,
@@ -361,40 +322,6 @@ _Because raster cache entries are expensive to
 construct and take up loads of GPU memory,
 cache images only where absolutely necessary._
 
-### Viewing the widget rebuild profiler
-
-The Flutter framework is designed to make it hard to create
-applications that are not 60fps and smooth. Often, if you have jank,
-it's because there is a simple bug causing more of the UI to be
-rebuilt each frame than required. The Widget rebuild profiler
-helps you debug and fix performance problems due to these sorts
-of bugs.
-
-You can view the widget rebuilt counts for the current screen and
-frame in the Flutter plugin for Android Studio and IntelliJ.
-For details on how to do this, see [Show performance data][]
-
-[Show performance data]: /tools/android-studio#show-performance-data
-
-## Benchmarking
-
-You can measure and track your app's performance by writing
-benchmark tests. The Flutter Driver library provides support
-for benchmarking. Using this integration test framework,
-you can generate metrics to track the following:
-
-* Jank
-* Download size
-* Battery efficiency
-* Startup time
-
-Tracking these benchmarks allows you to be informed when a
-regression is introduced that adversely affects performance.
-
-For more information, check out [Integration testing][].
-
-[Integration testing]: /testing/integration-tests
-
 ## Other resources
 
 The following resources provide more information on using
@@ -409,11 +336,35 @@ Flutter's tools and debugging in Flutter:
 * [Flutter API][] docs, particularly the [`PerformanceOverlay`][] class,
   and the [dart:developer][] package
 
+
+[`Clip.antiAliasWithSaveLayer`]: {{site.api}}/flutter/dart-ui/Clip.html
+[`PerformanceOverlay`]: {{site.api}}/flutter/widgets/PerformanceOverlay-class.html
+[`RepaintBoundary`]: {{site.api}}/flutter/widgets/RepaintBoundary-class.html
+[`saveLayer`]: {{site.api}}/flutter/dart-ui/Canvas/saveLayer.html
 [dart:developer]: {{site.api}}/flutter/dart-developer/dart-developer-library.html
+[debug mode]: /testing/build-modes#debug
+[Debugging Flutter apps programmatically]: /testing/code-debugging
+[Debugging]: /testing/debugging
 [devtools]: /tools/devtools
 [Flutter API]: {{site.api}}
-[Flutter inspector]: /tools/devtools/inspector
 [Flutter inspector talk]: {{site.yt.watch}}?v=JIcmJNT9DNI
-[`PerformanceOverlay`]: {{site.api}}/flutter/widgets/PerformanceOverlay-class.html
+[Flutter inspector]: /tools/devtools/inspector
+[Flutter wiki]: {{site.repo.flutter}}/tree/main/docs
+[Flutter's build modes]: /testing/build-modes
+[generate timeline events]: {{site.developers}}/web/tools/chrome-devtools/evaluate-performance/performance-reference
+[Inspector view]: /tools/devtools/inspector
+[Integration testing]: /testing/integration-tests
+[launch DevTools]: /tools/devtools
+[MainThread]: {{site.android-dev}}/reference/android/support/annotation/MainThread
+[Performance overlay]: /testing/code-debugging#add-performance-overlay
+[profile mode]: /testing/build-modes#profile
+[programmatically]: /testing/code-debugging#debug-animation-issues
+[Show performance data]: /tools/android-studio#show-performance-data
+[The Framework architecture]: {{site.repo.flutter}}/blob/main/docs/about/The-Framework-architecture.md
+[The Layer Cake]: {{site.medium}}/flutter-community/the-layer-cake-widgets-elements-renderobjects-7644c3142401
+[Timeline view]: /tools/devtools/performance
+[Tracing Dart code]: /testing/code-debugging#trace-dart-code-performance
+[UIKit]: {{site.apple-dev}}/documentation/uikit
+[Use the Performance View]: /tools/devtools/performance
 [video]: {{site.yt.watch}}?v=5F-6n_2XWR8
 [Why Flutter Uses Dart]: https://hackernoon.com/why-flutter-uses-dart-dd635a054ebf


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

This is part of one of our goals to make it easier for iOS developers to work with our docs. iOS devs are having a particularly difficult time with debugging and performance. This guide is full of great information, but it's been added to over the years by many contributors and looks like it has started to lose its original form.

I've taken a shot at condensing all of the materials that have been added over the years and making this doc easier to parse in a linear fashion. I worked on it a bit more than intended, so if the changes are too much in one PR, no worries at all. I can always split this up.

Changes:

- Created an overview and moved the various notes and conceptual details into this overview.
- The overview now has a list of performance analysis tools that the developer can browse with links to the documentation elsewhere.
- Tried to make it more clear that this page is specifically about the Performance Overlay tool, but more might be needed.
- A few sections in the doc weren't about the Performance Overlay tool, so I moved them into the bulleted list in the overview with links to their documentation (the sections were very small, so this was pretty easy).
- Changed some headings, and moved some sections around.
- Moved all of the links to the bottom of the topic and alphabetically sorted them (to match the pattern i've seen elsewhere the most often.)

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
