### PR TITLE
Update "Obfuscate your app" topic to be more platform agnostic.

### DIFF
--- a/src/content/deployment/obfuscate.md
+++ b/src/content/deployment/obfuscate.md
@@ -14,23 +14,32 @@ compiled Dart code, replacing each symbol with
 another symbol, making it difficult for an attacker
 to reverse engineer your proprietary app.
 
+[Code obfuscation]: https://en.wikipedia.org/wiki/Obfuscation_(software)
+
+## Limitations and warnings {: #limitations}
+
 **Flutter's code obfuscation works
 only on a [release build][].**
-
-[Code obfuscation]: https://en.wikipedia.org/wiki/Obfuscation_(software)
-[release build]: /testing/build-modes#release
-
-## Limitations
-
-Note that obfuscating your code does _not_
-encrypt resources nor does it protect against
-reverse engineering.
-It only renames symbols with more obscure names.
 
 :::warning
 It is a **poor security practice** to
 store secrets in an app.
 :::
+
+Obfuscating your code does _not_
+encrypt resources nor does it protect against
+reverse engineering.
+It only renames symbols with more obscure names.
+
+Web apps don't support obfuscation.
+A web app can be [minified][], which provides a similar result.
+When you build a release version of a Flutter web app,
+the web compiler minifies the app. To learn more,
+see [Build and release a web app][].
+
+[release build]: /testing/build-modes#release
+[Build and release a web app]: /deployment/web
+[minified]: https://en.wikipedia.org/wiki/Minification_(programming)
 
 ## Supported targets
 
@@ -49,91 +58,97 @@ described on this page:
 * `macos-framework`
 * `windows`
 
-:::note
-Web apps don't support obfuscation.
-A web app can be [minified][], which provides a similar result.
-When you build a release version of a Flutter web app,
-the web compiler minifies the app. To learn more,
-see [Build and release a web app][].
-:::
+For detailed information about the command line options
+available for a build target, run the following
+command. The `--obfuscate` and  `--split-debug-info` options should
+be listed in the output. If they aren't, you'll need to
+install a newer version of Flutter to obfuscate your code.
 
-[Build and release a web app]: /deployment/web
-[minified]: https://en.wikipedia.org/wiki/Minification_(programming)
+```console
+$ flutter build <build-target> -h
+```
+   *  `<build-target>`: The build target. For example,
+      `apk`.
 
 ## Obfuscate your app
 
-To obfuscate your app, use the `flutter build` command
-in release mode
-with the `--obfuscate` and  `--split-debug-info` options.
-The `--split-debug-info` option specifies the directory
-where Flutter outputs debug files.
-In the case of obfuscation, it outputs a symbol map.
-For example:
+To obfuscate your app and create a symbol map, use the
+`flutter build` command in release mode
+with the `--obfuscate` and `--split-debug-info` options.
+If you want to debug your obfuscated
+app in the future, you will need the symbol map.
 
-```console
-$ flutter build apk --obfuscate --split-debug-info=/<project-name>/<directory>
-```
+1. Run the following command to obfuscate your app and
+   generate a SYMBOLS file:
 
-Once you've obfuscated your binary, **save
-the symbols file**. You need this if you later
-want to de-obfuscate a stack trace.
+   ```console
+   $ flutter build <build-target> \ 
+      --obfuscate \ 
+      --split-debug-info=/<symbols-directory>
+   ```
 
-:::tip
-The `--split-debug-info` option can also be used without `--obfuscate`
-to extract Dart program symbols, reducing code size.
-To learn more about app size, see [Measuring your app's size][].
-:::
+   *  `<build-target>`: The build target. For example,
+      `apk`.
+   *  `<symbols-directory>`: The directory where the SYMBOLS
+      file should be placed. For example,
+      `out/android`.
 
-[Measuring your app's size]: /perf/app-size
-
-For detailed information on these flags, run
-the help command for your specific target, for example:
-
-```console
-$ flutter build apk -h
-```
-
-If these flags are not listed in the output,
-run `flutter --version` to check your version of Flutter.
+1. Once you've obfuscated your binary, **backup
+   the SYMBOLS file**. You might need this if you lose
+   your original SYMBOLs file and you
+   want to de-obfuscate a stack trace.
 
 ## Read an obfuscated stack trace
 
 To debug a stack trace created by an obfuscated app,
 use the following steps to make it human readable:
 
-1. Find the matching symbols file.
+1. Find the matching SYMBOLS file.
    For example, a crash from an Android arm64
    device would need `app.android-arm64.symbols`.
 
 1. Provide both the stack trace (stored in a file)
-   and the symbols file to the `flutter symbolize` command.
-   For example:
+   and the SYMBOLS file to the `flutter symbolize` command.
 
    ```console
-   $ flutter symbolize -i <stack trace file> -d out/android/app.android-arm64.symbols
+   $ flutter symbolize \
+      -i <stack-trace-file> \
+      -d <obfuscated-symbols-file>
    ```
 
-   For more information on the `symbolize` command,
+   *  `<stack-trace-file>`: The file path for the
+      stacktrace. For example, `???`.
+   *  `<obfuscated-symbols-file>`: The file path for the
+      symbols file that contains the obfuscated symbols.
+      For example, `out/android/app.android-arm64.symbols`.
+
+   For more information about the `symbolize` command,
    run `flutter symbolize -h`.
 
 ## Read an obfuscated name
 
-To make the name that an app obfuscated human readable,
-use the following steps:
+You can generate a JSON file that contains
+an obfuscation map. An obfuscation map is a JSON array with
+pairs of original names and obfuscated names. For example,
+`["MaterialApp", "ex", "Scaffold", "ey"]`, where
+`ex` is the obfuscated name of `MaterialApp`.
 
-1. To save the name obfuscation map at app build time,
-   use `--extra-gen-snapshot-options=--save-obfuscation-map=/<your-path>`.
-   For example:
+To generate an obfuscation map, use the following command:
 
-   ```console
-   $ flutter build apk --obfuscate --split-debug-info=/<project-name>/<directory> --extra-gen-snapshot-options=--save-obfuscation-map=/<your-path>
-   ```
+```console
+$ flutter build <build-target> \
+   --obfuscate \
+   --split-debug-info=/<symbols-directory> \
+   --extra-gen-snapshot-options=--save-obfuscation-map=/<obfuscation-map-file>
+```
 
-1. To recover the name, use the generated obfuscation map.
-   The obfuscation map is a flat JSON array with pairs of
-   original names and obfuscated names. For example,
-   `["MaterialApp", "ex", "Scaffold", "ey"]`, where `ex`
-   is the obfuscated name of `MaterialApp`.
+*  `<build-target>`: The build target. For example,
+   `apk`.
+*  `<symbols-directory>`: The directory where the symbols
+   should be placed. For example, `out/android`
+*  `<obfuscation-map-file>`: The file path where the
+   JSON obfuscation map should be placed. For example,
+   `out/android/map.json`
 
 ## Caveat
 
@@ -145,9 +160,9 @@ eventually be an obfuscated binary.
   For example, the following call to `expect()` won't
   work in an obfuscated binary:
 
-<?code-excerpt "lib/main.dart (Expect)"?>
-```dart
-expect(foo.runtimeType.toString(), equals('Foo'));
-```
+   <?code-excerpt "lib/main.dart (Expect)"?>
+   ```dart
+   expect(foo.runtimeType.toString(), equals('Foo'));
+   ```
 
 * Enum names are not obfuscated currently.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

This topic only had Android code snippets. To make it easier for devs creating apps for other platforms, I reformatted the commands to be platform agnostic.

Notes:
- We had a few limitations outside of the Limitations section, so moved them there.
- Noticed we had a warning inside of the Limitations section, so updated the heading to include warnings.
- Updated some of the variable names in the commands and created a bulleted list below each command with the variable names and what they need to be replaced with.
- 'Read an obfuscated name' contents looked like they needed a revision, so took care of that. Essentially it looks like that section is about generating an obfuscation map that contains keys and values. It's still not quite right, but I hope it's closer to where things are at now. I'm also not sure if we still need the `--extra-gen-snapshot-options=` before the `--save-obfuscation-map=` command.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
