### PR TITLE
Update buttons.md

### DIFF
--- a/src/content/release/breaking-changes/buttons.md
+++ b/src/content/release/breaking-changes/buttons.md
@@ -228,7 +228,7 @@ like a default `FlatButton`:
 
 ```dart
 final ButtonStyle flatButtonStyle = TextButton.styleFrom(
-  foregroundColor Colors.black87,
+  foregroundColor: Colors.black87,
   minimumSize: Size(88, 36),
   padding: EdgeInsets.symmetric(horizontal: 16),
   shape: const RoundedRectangleBorder(
@@ -248,7 +248,7 @@ Similarly, to make an `ElevatedButton` look like a default `RaisedButton`:
 ```dart
 final ButtonStyle raisedButtonStyle = ElevatedButton.styleFrom(
   foregroundColor: Colors.black87,
-  backgroundColor Colors.grey[300],
+  backgroundColor: Colors.grey[300],
   minimumSize: Size(88, 36),
   padding: EdgeInsets.symmetric(horizontal: 16),
   shape: const RoundedRectangleBorder(


### PR DESCRIPTION
Two colons were missing in the flutter docs, Whoever wrote those docs needs to be fired, this is not acceptable.

_Description of what this PR is changing or adding, and why:_

This is the most important PR ever...
Literally just two colons that were missing. 

_Issues fixed by this PR (if any):_

Fixed two missing colons.

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
