### PR TITLE
Fix layout of side-by-side code and content on mobile

### DIFF
--- a/src/_sass/base/_utils.scss
+++ b/src/_sass/base/_utils.scss
@@ -23,9 +23,16 @@ main {
     display: grid;
     grid-template-columns: 1fr;
     column-gap: 1.5rem;
+    margin-block-end: 0.5rem;
 
     @media (min-width: 768px) {
       grid-template-columns: minmax(60%, 1fr) auto;
+      margin-block-end: 0;
+    }
+
+    > * {
+      max-width: 100%;
+      min-width: 0;
     }
   }
 


### PR DESCRIPTION
Prevents code blocks from overflowing out of the page contents.
