### PR TITLE
Remove redundant use material3

### DIFF
--- a/examples/app-architecture/offline_first/lib/main.dart
+++ b/examples/app-architecture/offline_first/lib/main.dart
@@ -20,7 +20,6 @@ class MyApp extends StatelessWidget {
       title: 'Flutter Demo',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
       ),
       home: UserProfileScreen(
         viewModel: UserProfileViewModel(

--- a/examples/cookbook/design/themes/lib/main.dart
+++ b/examples/cookbook/design/themes/lib/main.dart
@@ -19,8 +19,6 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: appName,
       theme: ThemeData(
-        useMaterial3: true,
-
         // Define the default brightness and colors.
         colorScheme: ColorScheme.fromSeed(
           seedColor: Colors.purple,

--- a/examples/cookbook/effects/gradient_bubbles/lib/main.dart
+++ b/examples/cookbook/effects/gradient_bubbles/lib/main.dart
@@ -18,7 +18,7 @@ class App extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Flutter Chat',
-      theme: ThemeData.dark(useMaterial3: true),
+      theme: ThemeData.dark(),
       home: home,
     );
   }

--- a/examples/cookbook/lists/spaced_items/lib/main.dart
+++ b/examples/cookbook/lists/spaced_items/lib/main.dart
@@ -15,7 +15,6 @@ class SpacedItemsList extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         cardTheme: CardTheme(color: Colors.blue.shade50),
-        useMaterial3: true,
       ),
       home: Scaffold(
         body: LayoutBuilder(builder: (context, constraints) {

--- a/examples/cookbook/testing/integration/introduction/lib/main.dart
+++ b/examples/cookbook/testing/integration/introduction/lib/main.dart
@@ -13,7 +13,6 @@ class MyApp extends StatelessWidget {
       title: 'Flutter Demo',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
       ),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );

--- a/examples/testing/native_debugging/lib/main.dart
+++ b/examples/testing/native_debugging/lib/main.dart
@@ -17,7 +17,6 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'URL Launcher',
       theme: ThemeData(
-        useMaterial3: true,
         colorSchemeSeed: Colors.purple,
       ),
       home: const MyHomePage(title: 'URL Launcher'),

--- a/src/content/cookbook/design/themes.md
+++ b/src/content/cookbook/design/themes.md
@@ -52,8 +52,6 @@ Flutter creates a default theme for you.
 MaterialApp(
   title: appName,
   theme: ThemeData(
-    useMaterial3: true,
-
     // Define the default brightness and colors.
     colorScheme: ColorScheme.fromSeed(
       seedColor: Colors.purple,
@@ -208,8 +206,6 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: appName,
       theme: ThemeData(
-        useMaterial3: true,
-
         // Define the default brightness and colors.
         colorScheme: ColorScheme.fromSeed(
           seedColor: Colors.purple,

--- a/src/content/cookbook/effects/gradient-bubbles.md
+++ b/src/content/cookbook/effects/gradient-bubbles.md
@@ -279,7 +279,7 @@ class App extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Flutter Chat',
-      theme: ThemeData.dark(useMaterial3: true),
+      theme: ThemeData.dark(),
       home: home,
     );
   }

--- a/src/content/cookbook/lists/spaced-items.md
+++ b/src/content/cookbook/lists/spaced-items.md
@@ -181,7 +181,6 @@ class SpacedItemsList extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         cardTheme: CardTheme(color: Colors.blue.shade50),
-        useMaterial3: true,
       ),
       home: Scaffold(
         body: LayoutBuilder(builder: (context, constraints) {


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
This PR removes redundant `useMaterial3` since it is true by default.

_Issues fixed by this PR (if any):_
https://github.com/flutter/flutter/issues/162818

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
