### PR TITLE
Remove reference to Visual Samples Index

### DIFF
--- a/src/_data/docs_cards.yml
+++ b/src/_data/docs_cards.yml
@@ -12,7 +12,7 @@
   url: /cookbook
 - name: Samples
   description: Check out the Flutter examples.
-  url: https://flutter.github.io/samples
+  url: https://github.com/flutter/samples
 - name: Videos
   description: View the many videos on the Flutter YouTube channel.
   url: https://www.youtube.com/@flutterdev

--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -55,7 +55,7 @@
     - title: Cookbook
       permalink: /cookbook
     - title: Demos and samples
-      permalink: https://flutter.github.io/samples/
+      permalink: https://github.com/flutter/samples
 
 - title: Stay up to date
   permalink: /release

--- a/src/content/get-started/fundamentals/state-management.md
+++ b/src/content/get-started/fundamentals/state-management.md
@@ -552,7 +552,7 @@ If you would like to learn more, check out the following resources:
 [List of state management approaches]: /data-and-backend/state-mgmt/options
 [Pragmatic state management]: {{site.youtube-site}}/watch?v=d_m5csmrf7I
 [Provider counter]: https://github.com/flutter/samples/tree/main/provider_counter
-[Provider shopper]: https://flutter.github.io/samples/provider_shopper.html
+[Provider shopper]: https://github.com/flutter/samples/tree/main/provider_shopper
 [State management]: /data-and-backend/state-mgmt/intro
 [StatefulWidget]: {{site.api}}/flutter/widgets/StatefulWidget-class.html
 [`StatefulWidget`]: {{site.api}}/flutter/widgets/StatefulWidget-class.html

--- a/src/content/get-started/fundamentals/user-input.md
+++ b/src/content/get-started/fundamentals/user-input.md
@@ -227,7 +227,7 @@ Widget build(BuildContext context) {
 > [Rich Text Editor code][]
 
 [Rich Text (Widget of the Week)]: {{site.youtube-site}}/watch?v=rykDVh-QFfw
-[Rich Text Editor]: https://flutter.github.io/samples/rich_text_editor.html
+[Rich Text Editor]: https://github.com/flutter/samples/tree/main/rich_text_editor
 [Rich Text Editor code]: {{site.github}}/flutter/samples/tree/main/simplistic_editor
 
 ### `TextField`
@@ -360,7 +360,7 @@ Widget build(BuildContext context) {
 <span class="material-symbols" aria-hidden="true">menu_book</span> **API Docs**: [`TextField`][] • [`RichText`][] • [`SelectableText`][] • [`Form`][]
 
 [Build a form with validation]: /cookbook/forms/validation
-[Form app]: https://flutter.github.io/samples/web/form_app/
+[Form app]: https://github.com/flutter/samples/tree/main/form_app/
 [Form app code]: {{site.github}}/flutter/samples/tree/main/form_app
 [`Form`]: {{site.api}}/flutter/widgets/Form-class.html
 [`TextField`]: {{site.api}}/flutter/material/TextField-class.html
@@ -1110,7 +1110,7 @@ the `Dismissible` widget described in the previous section.
 
 [Material Widget Library]: /ui/widgets/material
 [Material Library API docs]: {{site.api}}/flutter/material/material-library.html
-[Material 3 Demo]: https://flutter.github.io/samples/web/material_3_demo/
+[Material 3 Demo]: https://github.com/flutter/samples/tree/main/material_3_demo
 
 [`flutter_slidable`]: {{site.pub}}/packages/flutter_slidable
 [flutter_slidable (Package of the Week)]: {{site.youtube-site}}/watch?v=QFcFEpFmNJ8

--- a/src/content/get-started/learn-flutter.md
+++ b/src/content/get-started/learn-flutter.md
@@ -53,7 +53,7 @@ Happy Fluttering!
 [Flutter for SwiftUI developers]: /get-started/flutter-for/swiftui-devs
 [Flutter for UIKit developers]: /get-started/flutter-for/uikit-devs
 [Flutter for React Native developers]: /get-started/flutter-for/react-native-devs
-[Flutter samples]: https://flutter.github.io/samples
+[Flutter samples]: https://github.com/flutter/samples
 [Flutter for web developers]: /get-started/flutter-for/web-devs
 [Flutter for Xamarin.Forms developers]: /get-started/flutter-for/xamarin-forms-devs
 [Learn the fundamentals]: /get-started/fundamentals

--- a/src/content/platform-integration/web/index.md
+++ b/src/content/platform-integration/web/index.md
@@ -90,5 +90,5 @@ The following resources can help you get started:
 [Preparing an app for web release]: /deployment/web
 [Progressive Web Application]: https://web.dev/progressive-web-apps/
 [web FAQ]: /platform-integration/web/faq
-[web samples for Flutter]: https://flutter.github.io/samples/#?platform=web
+[web samples for Flutter]: https://github.com/flutter/samples/#?platform=web
 [Web renderers]: /platform-integration/web/renderers

--- a/src/content/release/breaking-changes/material-3-default.md
+++ b/src/content/release/breaking-changes/material-3-default.md
@@ -87,7 +87,7 @@ Relevant PRs:
 * [Updated `ThemeData.useMaterial3` API doc, default is true][]
 
 
-[Material 3 gallery]: https://flutter.github.io/samples/web/material_3_demo/
+[Material 3 gallery]: https://github.com/flutter/samples/tree/main/material_3_demo
 [Material 3 umbrella issue]: {{site.repo.flutter}}/issues/91605
 [Material Design for Flutter]: /ui/design/material
 [`ThemeData.useMaterial3`]: {{site.api}}/flutter/material/ThemeData/useMaterial3.html

--- a/src/content/release/release-notes/release-notes-1.7.8.md
+++ b/src/content/release/release-notes/release-notes-1.7.8.md
@@ -152,7 +152,11 @@ This release includes a number of improvements to existing Material components, 
 
 ## Web
 
-The work on web functionality continues with merging of the code from flutter_web repo into the main flutter repo, providing a simpler developer experience for this pre-release technology. We've already [compiled many of the existing Flutter samples for web](https://github.com/flutter/samples/). Enjoy!
+The work on web functionality continues with merging of the code from the flutter_web repo
+into the main flutter repo, providing a simpler developer experience for this pre-release
+technology. We've already
+[compiled many of the existing Flutter samples for web]({{site.github}}/flutter/samples/).
+Enjoy!
 
 
 

--- a/src/content/release/release-notes/release-notes-1.7.8.md
+++ b/src/content/release/release-notes/release-notes-1.7.8.md
@@ -152,7 +152,7 @@ This release includes a number of improvements to existing Material components, 
 
 ## Web
 
-The work on web functionality continues with merging of the code from flutter_web repo into the main flutter repo, providing a simpler developer experience for this pre-release technology. We've already [compiled many of the existing Flutter samples for web](https://flutter.github.io/samples/). Enjoy!
+The work on web functionality continues with merging of the code from flutter_web repo into the main flutter repo, providing a simpler developer experience for this pre-release technology. We've already [compiled many of the existing Flutter samples for web](https://github.com/flutter/samples/). Enjoy!
 
 
 

--- a/src/content/ui/animations/index.md
+++ b/src/content/ui/animations/index.md
@@ -427,7 +427,7 @@ Learn more about Flutter animations at the following links:
 [animate1]: {{examples}}/animation/animate1
 [Animate a widget using a physics simulation]: /cookbook/animation/physics-simulation
 [`Animatable`]: {{site.api}}/flutter/animation/Animatable-class.html
-[`AnimatedList` example]: https://flutter.github.io/samples/animations.html
+[`AnimatedList` example]: https://github.com/flutter/samples/blob/main/animations
 [`Animation`]: {{site.api}}/flutter/animation/Animation-class.html
 [Animation and motion widgets]: /ui/widgets/animation
 [Animation basics with implicit animations]: {{site.yt.watch}}?v=IVTjpW3W33s&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=1
@@ -466,7 +466,7 @@ Learn more about Flutter animations at the following links:
 [`PageRoute`]: {{site.api}}/flutter/widgets/PageRoute-class.html
 [part 2]: {{site.medium}}/dartlang/zero-to-one-with-flutter-part-two-5aa2f06655cb
 [`RepaintBoundary`]: {{site.api}}/flutter/widgets/RepaintBoundary-class.html
-[Sample app catalog]: https://flutter.github.io/samples
+[Sample app catalog]: https://github.com/flutter/samples
 [`SpringSimulation`]: {{site.api}}/flutter/physics/SpringSimulation-class.html
 [Staggered Animations]: /ui/animations/staggered-animations
 [`Tween`]: {{site.api}}/flutter/animation/Tween-class.html

--- a/src/content/ui/animations/index.md
+++ b/src/content/ui/animations/index.md
@@ -427,7 +427,7 @@ Learn more about Flutter animations at the following links:
 [animate1]: {{examples}}/animation/animate1
 [Animate a widget using a physics simulation]: /cookbook/animation/physics-simulation
 [`Animatable`]: {{site.api}}/flutter/animation/Animatable-class.html
-[`AnimatedList` example]: https://github.com/flutter/samples/blob/main/animations
+[`AnimatedList` example]: {{site.github}}/flutter/samples/blob/main/animations
 [`Animation`]: {{site.api}}/flutter/animation/Animation-class.html
 [Animation and motion widgets]: /ui/widgets/animation
 [Animation basics with implicit animations]: {{site.yt.watch}}?v=IVTjpW3W33s&list=PLjxrf2q8roU2v6UqYlt_KPaXlnjbYySua&index=1

--- a/src/content/ui/animations/index.md
+++ b/src/content/ui/animations/index.md
@@ -466,7 +466,7 @@ Learn more about Flutter animations at the following links:
 [`PageRoute`]: {{site.api}}/flutter/widgets/PageRoute-class.html
 [part 2]: {{site.medium}}/dartlang/zero-to-one-with-flutter-part-two-5aa2f06655cb
 [`RepaintBoundary`]: {{site.api}}/flutter/widgets/RepaintBoundary-class.html
-[Sample app catalog]: https://github.com/flutter/samples
+[Sample app catalog]: {{site.github}}/flutter/samples
 [`SpringSimulation`]: {{site.api}}/flutter/physics/SpringSimulation-class.html
 [Staggered Animations]: /ui/animations/staggered-animations
 [`Tween`]: {{site.api}}/flutter/animation/Tween-class.html

--- a/src/content/ui/design/material/index.md
+++ b/src/content/ui/design/material/index.md
@@ -33,7 +33,7 @@ visiting the [Affected widgets][] page.
 
 [Affected widgets]: {{site.api}}/flutter/material/ThemeData/useMaterial3.html#affected-widgets
 [deprecation policy]: /release/compatibility-policy#deprecation-policy
-[demo]: https://flutter.github.io/samples/web/material_3_demo/#/
+[demo]: https://github.com/flutter/samples/blob/main/material_3_demo/
 [`NavigationBar`]: {{site.api}}/flutter/material/NavigationBar-class.html
 [`useMaterial3`]: {{site.api}}/flutter/material/ThemeData/useMaterial3.html
 
@@ -41,7 +41,7 @@ Explore the updated components, typography, color system,
 and elevation support with the
 [interactive Material 3 demo][demo]:
 
-<iframe src="https://flutter.github.io/samples/web/material_3_demo/#/" width="100%" height="600px" title="Material 3 Demo App"></iframe>
+<iframe src="https://github.com/flutter/samples/tree/main/material_3_demo" width="100%" height="600px" title="Material 3 Demo App"></iframe>
 
 ## More information {:.no_toc}
 

--- a/src/content/ui/design/material/index.md
+++ b/src/content/ui/design/material/index.md
@@ -33,7 +33,7 @@ visiting the [Affected widgets][] page.
 
 [Affected widgets]: {{site.api}}/flutter/material/ThemeData/useMaterial3.html#affected-widgets
 [deprecation policy]: /release/compatibility-policy#deprecation-policy
-[demo]: https://github.com/flutter/samples/blob/main/material_3_demo/
+[demo]: {{site.github}}/flutter/samples/blob/main/material_3_demo/
 [`NavigationBar`]: {{site.api}}/flutter/material/NavigationBar-class.html
 [`useMaterial3`]: {{site.api}}/flutter/material/ThemeData/useMaterial3.html
 

--- a/src/content/ui/widgets/material.md
+++ b/src/content/ui/widgets/material.md
@@ -25,7 +25,7 @@ check out the [Material 3 demo][] web app.
 
 [Material 3]: https://m3.material.io/get-started
 [Migrate to Material 3]: /release/breaking-changes/material-3-migration
-[Material 3 demo]: https://flutter.github.io/samples/web/material_3_demo/
+[Material 3 demo]: https://github.com/flutter/samples/tree/main/material_3_demo/
 
 {% render docs/catalog-page-material.md, categoryName:"Material components", catalog:catalog %}
 

--- a/src/content/ui/widgets/material.md
+++ b/src/content/ui/widgets/material.md
@@ -25,7 +25,7 @@ check out the [Material 3 demo][] web app.
 
 [Material 3]: https://m3.material.io/get-started
 [Migrate to Material 3]: /release/breaking-changes/material-3-migration
-[Material 3 demo]: https://github.com/flutter/samples/tree/main/material_3_demo/
+[Material 3 demo]: {{site.github}}/flutter/samples/tree/main/material_3_demo/
 
 {% render docs/catalog-page-material.md, categoryName:"Material components", catalog:catalog %}
 


### PR DESCRIPTION
This PR replaces out-going links to flutter.github.io/samples with links to the Github repository instead. The Visual Samples Index is going to be removed altogether.

Fixes flutter/samples issue [2507](https://github.com/flutter/samples/issues/2507)


## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
