### PR TITLE
Updated the "why" for the withOpacity deprecation.

### DIFF
--- a/src/content/release/breaking-changes/wide-gamut-framework.md
+++ b/src/content/release/breaking-changes/wide-gamut-framework.md
@@ -138,7 +138,7 @@ Since Flutter 3.27, alpha is stored as a floating-point value. Using `.a` and
 `.withValues()` will give the full expression of a floating-point value and
 won't be quantized (restricted to a limited range). That means "alpha" expresses
 the intent of "opacity" more correctly. Opacity is different in a subtle way
-where it's usage can result in unexpected data loss, so `.withOpacity()` and
+where its usage can result in unexpected data loss, so `.withOpacity()` and
 `.opacity` have been deprecated and their semantics have been maintained to
 avoid breaking anyone.
 


### PR DESCRIPTION
This PR expands on the "why" for the deprecation of `Color.withOpacity`.

fixes: https://github.com/flutter/flutter/issues/163007
issue: https://github.com/flutter/flutter/issues/162069

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
