### PR TITLE
Allow any attributes from markdown-attrs

### DIFF
--- a/src/_11ty/plugins/markdown.ts
+++ b/src/_11ty/plugins/markdown.ts
@@ -13,7 +13,6 @@ export const markdown = (() => {
     .use(markdownItAttrs, {
       leftDelimiter: '{:',
       rightDelimiter: '}',
-      allowedAttributes: ['id', 'class', /^data-.*$/],
     })
     .use(markdownItAnchor, {
       slugify: (s) => slugify(s),


### PR DESCRIPTION
Such as `width` when including an image, such as:

```
![Rename a Flutter flavor](/assets/images/docs/flavors/flavors-ios-app-names.png){:width="50%"}
```