### PR TITLE
Update wasm docs to be clear that additional headers are now optional

### DIFF
--- a/src/content/platform-integration/web/wasm.md
+++ b/src/content/platform-integration/web/wasm.md
@@ -91,13 +91,13 @@ final isRunningWithWasm = identical(double.nan, double.nan);
 
 ### Serve the built output with an HTTP server
 
-Flutter web WebAssembly uses multiple threads to render your application
+Flutter web WebAssembly can use multiple threads to render your application
 faster, with less jank. To do this, Flutter uses advanced browser features that
 require specific HTTP response headers.
 
-:::warning
-Flutter web applications won't run with WebAssembly unless the server is
-configured to send specific HTTP headers.
+:::important
+Flutter web applications compiled with WebAssembly won't run with multiple-threads
+unless the server is configured to send specific HTTP headers.
 :::
 
 | Name | Value |


### PR DESCRIPTION
Fixes https://github.com/flutter/website/issues/11649
