### PR TITLE
Include a java too new path in android-java-gradle-migration

### DIFF
--- a/src/content/release/breaking-changes/android-java-gradle-migration-guide.md
+++ b/src/content/release/breaking-changes/android-java-gradle-migration-guide.md
@@ -91,7 +91,7 @@ surrounding AGP, java, and gradle.
 
 ### Solution 1: Use Android Studio 
 The easiest way to resolve this issue is to use Android Studio AGP upgrade assistant. 
-To use select your top level build.gradle file in Android Studio then select 
+To use select your top-level `build.gradle` file in Android Studio then select 
 Tools -> AGP Upgrade Assistant. 
 
 ### Solution 2: Command line

--- a/src/content/release/breaking-changes/android-java-gradle-migration-guide.md
+++ b/src/content/release/breaking-changes/android-java-gradle-migration-guide.md
@@ -83,11 +83,11 @@ Do the following from the top of your Flutter project.
    $ ./gradlew wrapper --gradle-version=7.6.1
    ```
 
-## You didnt update android studio and still have a java error
+## You didn't update Android Studio and still have a Java error
 The error appears similar to `Unsupported class file major version 65`. 
-This is an indication that your java version is newer than the version of
+This is an indication that your Java version is newer than the version of
 gradle you are running can handle. There is a non obvious set of dependencies
-surrounding AGP, java, and gradle. 
+surrounding AGP, Java, and Gradle. 
 
 ### Solution 1: Android Studio 
 The easiest way to resolve this issue is to use Android Studio AGP upgrade assistant. 
@@ -95,7 +95,7 @@ To use select your top-level `build.gradle` file in Android Studio then select
 Tools -> AGP Upgrade Assistant. 
 
 ### Solution 2: Command line
-Run `flutter analyze --suggestion` to see if your AGP, Java, and gradle versions are compatible. 
+Run `flutter analyze --suggestion` to see if your AGP, Java, and Gradle versions are compatible. 
 If Gradle needs to be updated you can update it with `./gradlew wrapper --gradle-version=SOMEGRADLEVERSION`
 where SOMEGRADLEVERSION is the version (you can use a newer version)
 suggested by `flutter analyze`. 

--- a/src/content/release/breaking-changes/android-java-gradle-migration-guide.md
+++ b/src/content/release/breaking-changes/android-java-gradle-migration-guide.md
@@ -89,7 +89,7 @@ This is an indication that your java version is newer than the version of
 gradle you are running can handle. There is a non obvious set of dependencies
 surrounding AGP, java, and gradle. 
 
-### Solution 1: Use Android Studio 
+### Solution 1: Android Studio 
 The easiest way to resolve this issue is to use Android Studio AGP upgrade assistant. 
 To use select your top-level `build.gradle` file in Android Studio then select 
 Tools -> AGP Upgrade Assistant. 

--- a/src/content/release/breaking-changes/android-java-gradle-migration-guide.md
+++ b/src/content/release/breaking-changes/android-java-gradle-migration-guide.md
@@ -100,10 +100,10 @@ If Gradle needs to be updated you can update it with `./gradlew wrapper --gradle
 where SOMEGRADLEVERSION is the version (you can use a newer version)
 suggested by `flutter analyze`. 
 
-To find the java version being used run `flutter doctor`
-On a mac you can find the versions of java the OS knows about with `/usr/libexec/java_home -V` 
-To set the version of java that all flutter projects use run `flutter config --jdk-dir=SOMEJAVAPATH`
-where SOMEJAVAPATH is a path to a java version like `/opt/homebrew/Cellar/openjdk@17/17.0.13/libexec/openjdk.jdk/Contents/Home`
+To find the Java version being used run `flutter doctor`.
+On a mac, you can find the Java versions that the OS knows about with `/usr/libexec/java_home -V`.
+To set the version of Java that all flutter projects use run `flutter config --jdk-dir=SOMEJAVAPATH`
+where SOMEJAVAPATH is a path to a Java version like `/opt/homebrew/Cellar/openjdk@17/17.0.13/libexec/openjdk.jdk/Contents/Home`
 
 ## Notes
 

--- a/src/content/release/breaking-changes/android-java-gradle-migration-guide.md
+++ b/src/content/release/breaking-changes/android-java-gradle-migration-guide.md
@@ -95,7 +95,7 @@ To use select your top-level `build.gradle` file in Android Studio then select
 Tools -> AGP Upgrade Assistant. 
 
 ### Solution 2: Command line
-Run `flutter analyze --suggestion` to see if your AGP, Java and gradle versions are compatible. 
+Run `flutter analyze --suggestion` to see if your AGP, Java, and gradle versions are compatible. 
 If Gradle needs to be updated you can update it with `./gradlew wrapper --gradle-version=SOMEGRADLEVERSION`
 where SOMEGRADLEVERSION is the version suggested by flutter analyze or newer. 
 

--- a/src/content/release/breaking-changes/android-java-gradle-migration-guide.md
+++ b/src/content/release/breaking-changes/android-java-gradle-migration-guide.md
@@ -97,7 +97,8 @@ Tools -> AGP Upgrade Assistant.
 ### Solution 2: Command line
 Run `flutter analyze --suggestion` to see if your AGP, Java, and gradle versions are compatible. 
 If Gradle needs to be updated you can update it with `./gradlew wrapper --gradle-version=SOMEGRADLEVERSION`
-where SOMEGRADLEVERSION is the version suggested by flutter analyze or newer. 
+where SOMEGRADLEVERSION is the version (you can use a newer version)
+suggested by `flutter analyze`. 
 
 To find the java version being used run `flutter doctor`
 On a mac you can find the versions of java the OS knows about with `/usr/libexec/java_home -V` 

--- a/src/content/release/breaking-changes/android-java-gradle-migration-guide.md
+++ b/src/content/release/breaking-changes/android-java-gradle-migration-guide.md
@@ -83,6 +83,27 @@ Do the following from the top of your Flutter project.
    $ ./gradlew wrapper --gradle-version=7.6.1
    ```
 
+## You didnt update android studio and still have a java error
+The error appears similar to `Unsupported class file major version 65`. 
+This is an indication that your java version is newer than the version of
+gradle you are running can handle. There is a non obvious set of dependencies
+surrounding AGP, java, and gradle. 
+
+### Solution 1: Use Android Studio 
+The easiest way to resolve this issue is to use Android Studio AGP upgrade assistant. 
+To use select your top level build.gradle file in Android Studio then select 
+Tools -> AGP Upgrade Assistant. 
+
+### Solution 2: Command line
+Run `flutter analyze --suggestion` to see if your AGP, Java and gradle versions are compatible. 
+If Gradle needs to be updated you can update it with `./gradlew wrapper --gradle-version=SOMEGRADLEVERSION`
+where SOMEGRADLEVERSION is the version suggested by flutter analyze or newer. 
+
+To find the java version being used run `flutter doctor`
+On a mac you can find the versions of java the OS knows about with `/usr/libexec/java_home -V` 
+To set the version of java that all flutter projects use run `flutter config --jdk-dir=SOMEJAVAPATH`
+where SOMEJAVAPATH is a path to a java version like `/opt/homebrew/Cellar/openjdk@17/17.0.13/libexec/openjdk.jdk/Contents/Home`
+
 ## Notes
 
 A few notes to be aware of:
@@ -104,8 +125,8 @@ A few notes to be aware of:
     shell script's `JAVA_HOME` environment variable.
   * If `JAVA_HOME` isn't defined, Flutter looks
     for any `java` executable in your path.
-    Once [issue 122609][] lands, the `flutter doctor -v`
-    command reports which version of Java is used.
+    The `flutter doctor -v` command reports which version
+    of Java is used.
 * If you upgrade Gradle to a release _newer_ than 7.6.1,
   you might (though it's unlikely) encounter issues
   that result from changes to Gradle, such as


### PR DESCRIPTION
Follow up on after some pairing with  @anderdobo and @kenzieschmoll covering android agp updates. 

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
