### PR TITLE
Add a breaking change notice for `integration_test` golden-file comparisons

### DIFF
--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -42,6 +42,7 @@ They're sorted by release and listed in alphabetical order:
 * [Material Theme System Updates][]
 * [Stop generating `AssetManifest.json`][]
 * [`.flutter-plugins-dependencies` replaces `.flutter-plugins`][]
+* [Changing the default `goldenFileComparator` for `integration_test`s][]
 
 [deprecate-markForRemove]: /release/breaking-changes/navigator-complete-route
 [Deprecate `TextField.canRequestFocus`]: /release/breaking-changes/can-request-focus
@@ -50,6 +51,7 @@ They're sorted by release and listed in alphabetical order:
 [Material Theme System Updates]: /release/breaking-changes/material-theme-system-updates
 [Stop generating `AssetManifest.json`]: /release/breaking-changes/asset-manifest-dot-json
 [`.flutter-plugins-dependencies` replaces `.flutter-plugins`]: /release/breaking-changes/flutter-plugins-configuration
+[Changing the default `goldenFileComparator` for `integration_test`s]: /release/breaking-changes/integration-test-default-golden-comparator
 
 <a id="released-in-flutter-329" aria-hidden="true"></a>
 ### Released in Flutter 3.29

--- a/src/content/release/breaking-changes/integration-test-default-golden-comparator.md
+++ b/src/content/release/breaking-changes/integration-test-default-golden-comparator.md
@@ -9,7 +9,7 @@ description: >-
 ## Summary
 
 Unless a user-defined [`goldenFileComparator`][] is set, either manually in a
-test, or using a [`flutter_test_config.dart`][flutter_test] file, Android and iOS devices
+test, or using a `flutter_test_config.dart` file, Android and iOS devices
 and emulators/simulators have a new default that proxies to the local host
 filesystem, fixing a long-standing bug ([#143299][Issue 143299]).
 

--- a/src/content/release/breaking-changes/integration-test-default-golden-comparator.md
+++ b/src/content/release/breaking-changes/integration-test-default-golden-comparator.md
@@ -15,7 +15,7 @@ filesystem, fixing a long-standing bug ([#143299][Issue 143299]).
 
 ## Background
 
-The package [`integration_test`][], and it's integration with [`flutter test`][]
+The package [`integration_test`][], and it's integration with [`flutter_test`][]
 has historically had a bug where using [`matchesGoldenFile`][] or similar APIs
 where a `FileSystemException` was thrown.
 

--- a/src/content/release/breaking-changes/integration-test-default-golden-comparator.md
+++ b/src/content/release/breaking-changes/integration-test-default-golden-comparator.md
@@ -15,7 +15,7 @@ filesystem, fixing a long-standing bug ([#143299][Issue 143299]).
 
 ## Background
 
-The package [`integration_test`][], and it's integration with [`flutter_test`][]
+The package [`integration_test`][], and its integration with [`flutter_test`][]
 has historically had a bug where using [`matchesGoldenFile`][] or similar APIs
 where a `FileSystemException` was thrown.
 

--- a/src/content/release/breaking-changes/integration-test-default-golden-comparator.md
+++ b/src/content/release/breaking-changes/integration-test-default-golden-comparator.md
@@ -2,7 +2,7 @@
 title: Integration test default golden-file comparators changed on Android and iOS.
 description: >-
   When using `package:integration_test` to run a test _on_ an Android device or
-  emualtor, or an iOS device or simulator, the default [`goldenFileComparator`][]
+  emualtor, or an iOS device or simulator, the default `goldenFileComparator`
   has changed, and correctly uses the host filesystem.
 ---
 

--- a/src/content/release/breaking-changes/integration-test-default-golden-comparator.md
+++ b/src/content/release/breaking-changes/integration-test-default-golden-comparator.md
@@ -1,0 +1,95 @@
+---
+title: Integration test default golden-file comparators changed on Android and iOS.
+description: >-
+  When using `package:integration_test` to run a test _on_ an Android device or
+  emualtor, or an iOS device or simulator, the default [`goldenFileComparator`][]
+  has changed, and correctly uses the host filesystem.
+---
+
+## Summary
+
+Unless a user-defined [`goldenFileComparator`][] is set, either manually in a
+test, or using a [`flutter_test_config.dart`][flutter_test] file, Android and iOS devices
+and emulators/simulators have a new default that proxies to the local host
+filesystem, fixing a long-standing bug ([#143299][Issue 143299]).
+
+## Background
+
+The package [`integration_test`][], and it's integration with [`flutter test`][]
+has historically had a bug where using [`matchesGoldenFile`][] or similar APIs
+where a `FileSystemException` was thrown.
+
+Some users may have worked around this issue by writing and using a custom
+[`goldenFileComparator`][]:
+
+```dart
+import 'package:integration_test/integration_test.dart';
+import 'package:my_integration_test/custom_golden_file_comparator.dart';
+
+void main() {
+  goldenFileComparator = CustomGoldenFileComparatorThatWorks();
+
+  // ...
+}
+```
+
+Such workarounds are no longer necessary, and if type checking the default,
+will no longer work as before:
+
+```dart
+if (goldenFileComparator is ...) {
+  // The new default is a new (hidden) type that has not existed before.
+}
+```
+
+## Migration Guide
+
+In most cases, we expect users to have to do nothing - this will be in a sense
+_new_ functionality that replaced functionality that did not work and caused
+an unhandled exception which would fail a test.
+
+In cases where users wrote custom test infrastructure and compartors, consider
+instead removing the [`goldenFileComparator`][] overrides, and instead rely on
+the (new) default which should work as expected:
+
+```diff
+import 'package:integration_test/integration_test.dart';
+-import 'package:my_integration_test/custom_golden_file_comparator.dart';
+
+void main() {
+-  goldenFileComparator = CustomGoldenFileComparatorThatWorks();
+
+  // ...
+}
+```
+
+_Fun fact_: The existing code that was used for the _web_ platform was [reused][PR 160484].
+
+## Timeline
+
+Landed in version: Not yet<br>
+Stable release: Not yet
+
+## References
+
+Relevant APIs:
+
+- [`flutter_test`][], which talks about `flutter_test_config.dart` and its capabilities.
+- [`goldenFileComparator`][], which implements comparison, and is user-configurable.
+
+Relevant Issues:
+
+- [Issue 143299][], one of many user reports about the long-standing bug.
+- [Issue 160043][], which explains in technical detail why [`matchesGoldenFile`][] failed.
+
+Relevant PRs:
+
+- [PR 160215][], where the web tool implementation was refactored to make it generic.
+- [PR 160484][], which uses the Dart VM service protocol to proxy between device and host.
+
+[`flutter_test`]: {{site.api}}/flutter/flutter_test
+[`goldenFileComparator`]: {{site.api}}/flutter/flutter_test/goldenFileComparator.html
+[Issue 143299]: {{site.repo.flutter}}/issues/143299
+[Issue 160043]: {{site.repo.flutter}}/issues/160043
+[PR 160215]: {{site.repo.flutter}}/pull/160215
+[PR 160484]: {{site.repo.flutter}}/pull/160484

--- a/src/content/release/breaking-changes/integration-test-default-golden-comparator.md
+++ b/src/content/release/breaking-changes/integration-test-default-golden-comparator.md
@@ -89,6 +89,7 @@ Relevant PRs:
 
 [`flutter_test`]: {{site.api}}/flutter/flutter_test
 [`goldenFileComparator`]: {{site.api}}/flutter/flutter_test/goldenFileComparator.html
+[`integration_test`]: {{site.api}}/flutter/package-integration_test_integration_test/
 [Issue 143299]: {{site.repo.flutter}}/issues/143299
 [Issue 160043]: {{site.repo.flutter}}/issues/160043
 [`matchesGoldenFile`]: {{site.api}}/flutter/flutter_test/MatchesGoldenFile-class.html

--- a/src/content/release/breaking-changes/integration-test-default-golden-comparator.md
+++ b/src/content/release/breaking-changes/integration-test-default-golden-comparator.md
@@ -91,5 +91,6 @@ Relevant PRs:
 [`goldenFileComparator`]: {{site.api}}/flutter/flutter_test/goldenFileComparator.html
 [Issue 143299]: {{site.repo.flutter}}/issues/143299
 [Issue 160043]: {{site.repo.flutter}}/issues/160043
+[`matchesGoldenFile`]: {{site.api}}/flutter/flutter_test/MatchesGoldenFile-class.html
 [PR 160215]: {{site.repo.flutter}}/pull/160215
 [PR 160484]: {{site.repo.flutter}}/pull/160484


### PR DESCRIPTION
While this is more of a bug fix than a breaking change, it _could_ break users that were expecting it not to work and have implemented workarounds. At the very least it gives a canonical place to point to "this is fixed and here is what is wrong" for customers to use.