### PR TITLE
Add flutter_branch_sdk to deep-links-flag-change

### DIFF
--- a/src/content/release/breaking-changes/deep-links-flag-change.md
+++ b/src/content/release/breaking-changes/deep-links-flag-change.md
@@ -24,6 +24,7 @@ such as the following, this update introduces a breaking change:
 - [Firebase dynamic links](https://firebase.google.com/docs/dynamic-links)
 - [`package:uni_link`]({{site.pub-pkg}}/uni_links)
 - [`package:app_links`]({{site.pub-pkg}}/app_links)
+- [`package:flutter_branch_sdk`]({{site.pub-pkg}}/flutter_branch_sdk)
 
 In this case, you must manually reset the
 Flutter deep linking option to `false`.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Add flutter_branch_sdk like package that is affected by 3.27 deep link breaking change

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
