### PR TITLE
Fix count variable assignment bug in code example

### DIFF
--- a/src/content/get-started/fundamentals/state-management.md
+++ b/src/content/get-started/fundamentals/state-management.md
@@ -474,13 +474,14 @@ class CounterViewModel extends ChangeNotifier {
   }
 
   Future<void> increment() async {
-    var count = this.count;
-    if (count == null) {
+    final currentCount = count;
+    if (currentCount == null) {
       throw('Not initialized');
     }
     try {
-      await model.updateCountOnServer(count + 1);
-      count++;
+      final incrementedCount = currentCount + 1;
+      await model.updateCountOnServer(incrementedCount);
+      count = incrementedCount;
     } catch(e) {
       errorMessage = 'Count not update count';
     }


### PR DESCRIPTION
There’s a bug in the increment() method.
### Issue in increment()
`var count = this.count;`
	•	Here, count (a local variable) gets a copy of this.count.
	•	This means modifying count++ only affects the local variable, not this.count.