### PR TITLE
Update generated files location in internationalization doc

### DIFF
--- a/src/content/ui/accessibility-and-internationalization/internationalization.md
+++ b/src/content/ui/accessibility-and-internationalization/internationalization.md
@@ -266,7 +266,7 @@ complete the following instructions:
 
 6. Now, run `flutter pub get` or `flutter run` and codegen takes place automatically.
    You should find generated files in
-   `${FLUTTER_PROJECT}/.dart_tool/flutter_gen/gen_l10n`.
+   `${FLUTTER_PROJECT}/lib/l10n`.
    Alternatively, you can also run `flutter gen-l10n` to
    generate the same files without running the app.
 

--- a/src/content/ui/accessibility-and-internationalization/internationalization.md
+++ b/src/content/ui/accessibility-and-internationalization/internationalization.md
@@ -265,8 +265,8 @@ complete the following instructions:
    ```
 
 6. Now, run `flutter pub get` or `flutter run` and codegen takes place automatically.
-   You should find generated files in
-   `${FLUTTER_PROJECT}/lib/l10n`.
+   You should find generated files in the `arb-dir` directory you specified
+   or `output-dir` if you configured that property as well.
    Alternatively, you can also run `flutter gen-l10n` to
    generate the same files without running the app.
 

--- a/src/content/ui/accessibility-and-internationalization/internationalization.md
+++ b/src/content/ui/accessibility-and-internationalization/internationalization.md
@@ -265,8 +265,8 @@ complete the following instructions:
    ```
 
 6. Now, run `flutter pub get` or `flutter run` and codegen takes place automatically.
-   You should find generated files in the `arb-dir` directory you specified
-   or `output-dir` if you configured that property as well.
+   You should find generated files in the directory at the path you specified
+   with the `arb-dir` or `output-dir` options.
    Alternatively, you can also run `flutter gen-l10n` to
    generate the same files without running the app.
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

I'm using Flutter version 3.29.0.
I've created a brand new Flutter application using this command: `flutter create --platforms=android,ios my_flutter_test_lang`

I'm following all the steps from the internationalization documentation.

In the section `Adding your own localized messages` at section 6 it says

> You should find generated files in `${FLUTTER_PROJECT}/.dart_tool/flutter_gen/gen_l10n`

but previous step 3 in the` l10n.yaml` file the `arb_dir` is set to: `arb-dir: lib/l10n`

After doing `flutter pub get`, generated files are in the `${FLUTTER_PROJECT}/lib/l10n` folder and not in `${FLUTTER_PROJECT}/.dart_tool/flutter_gen/gen_l10n`

Or maybe the path for `arb_dir` in the `l10n.yaml` file is wrong.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
