### PR TITLE
Fix enabling and disabling active tabs from custom shortcode

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "firebase-tools": "^13.29.3",
     "hast-util-from-html": "^2.0.3",
     "hast-util-select": "^6.0.3",
+    "hast-util-to-html": "^9.0.4",
     "hast-util-to-text": "^4.0.2",
     "html-minifier-terser": "^7.2.0",
     "js-yaml": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       hast-util-select:
         specifier: ^6.0.3
         version: 6.0.3
+      hast-util-to-html:
+        specifier: ^9.0.4
+        version: 9.0.4
       hast-util-to-text:
         specifier: ^4.0.2
         version: 4.0.2

--- a/src/_11ty/shortcodes.ts
+++ b/src/_11ty/shortcodes.ts
@@ -36,7 +36,8 @@ function _setupMedia(eleventyConfig: UserConfig): void {
 }
 
 function _setupTabs(eleventyConfig: UserConfig) {
-  // Counter shared between all tabs to ensure each has a unique ID.
+  // Counter shared between all tabs and wrappers to
+  // ensure each has a unique ID.
   let currentTabWrapperId = 0;
   let currentTabPaneId = 0;
 
@@ -44,15 +45,16 @@ function _setupTabs(eleventyConfig: UserConfig) {
     const tabWrapperId = currentTabWrapperId++;
     let tabMarkup = `<div id="${tabWrapperId}" class="tabs-wrapper" ${saveKey ? `data-tab-save-key="${slugify(saveKey)}"` : ''}><ul class="nav-tabs" role="tablist">`;
 
-    const contentsDom = fromHtml(content);
     // Only select child tab panes that don't already have a parent wrapper.
-    const tabPanes = selectAll('.tab-pane[data-tab-wrapper-id="undefined"]', contentsDom);
+    const tabPanes = selectAll('.tab-pane[data-tab-wrapper-id="undefined"]', fromHtml(content));
     if (tabPanes.length <= 1) {
       throw new Error(`Tabs with save key of ${saveKey} needs more than one tab!`);
     }
 
     let setTabToActive = true;
     for (const tabPane of tabPanes) {
+      // Keep track of the tab wrapper ID to avoid including
+      // a duplicate of this tab's contents in a parent wrapper.
       tabPane.properties.dataTabWrapperId = tabWrapperId;
 
       const tabId = tabPane.properties.dataTabId! as string;
@@ -60,6 +62,7 @@ function _setupTabs(eleventyConfig: UserConfig) {
       const tabName = tabPane.properties.dataTabName! as string;
       const tabIsActive = setTabToActive;
 
+      // Only set the first tab of a wrapper to active initially.
       if (tabIsActive) {
         tabPane.properties['className'] += ' active';
         setTabToActive = false;

--- a/src/_includes/docs/install/deprecated/ios-setup.md
+++ b/src/_includes/docs/install/deprecated/ios-setup.md
@@ -281,7 +281,7 @@ Enabling certificates varies in different versions of iOS.
 
 1. Tap your Certificate.
 
-1. Tap **Trust "\<certificate\>"**.
+1. Tap **Trust "&lt;certificate&gt;"**.
 
 1. When the dialog displays, tap **Trust**.
 

--- a/src/_includes/docs/install/devices/ios-physical.md
+++ b/src/_includes/docs/install/devices/ios-physical.md
@@ -184,7 +184,7 @@ Enabling certificates varies in different versions of iOS.
 
 1. Tap your Certificate.
 
-1. Tap **Trust "\<certificate\>"**.
+1. Tap **Trust "&lt;certificate&gt;"**.
 
 1. When the dialog displays, tap **Trust**.
 

--- a/src/content/assets/js/tabs.js
+++ b/src/content/assets/js/tabs.js
@@ -7,7 +7,7 @@ function setupTabs() {
   tabsWrappers.forEach(function (tabWrapper) {
     const saveKey = tabWrapper.dataset.tabSaveKey;
     const localStorageKey = `tab-save-${saveKey}`;
-    const tabs = tabWrapper.querySelectorAll('a.nav-link');
+    const tabs = tabWrapper.querySelectorAll(':scope > .nav-tabs a.nav-link');
     let tabToChangeTo;
 
     tabs.forEach(function (tab) {
@@ -87,9 +87,10 @@ function _findAndActivateTabsWithSaveId(saveKey, saveId) {
 }
 
 function _activateTabWithSaveId(tabWrapper, saveId) {
-  const tabToActivate = tabWrapper.querySelector(`a.nav-link[data-tab-save-id="${saveId}"]`);
+  const tabsNav = tabWrapper.querySelector(':scope > .nav-tabs');
+  const tabToActivate = tabsNav.querySelector(`a.nav-link[data-tab-save-id="${saveId}"]`);
   if (tabToActivate) {
-    const tabs = tabWrapper.querySelectorAll('a.nav-link');
+    const tabs = tabsNav.querySelectorAll('a.nav-link');
     _clearActiveTabs(tabs);
     _setActiveTab(tabToActivate);
   }


### PR DESCRIPTION
The previous logic kept track of the tabs when building the children, but didn't account for there being nested tabs. Now children tabs are determined when building the parent wrapper and inspecting its children contents. The corresponding JS is also updated to only disable sibling tabs rather than all children when toggling between them.

Some additional tab validation is added as well.

This fixes tab logic in a few places, but particularly: https://flutter-docs-prod--pr11731-fix-nested-tabs-vn9fa1d8.web.app/get-started/install/macos/mobile-ios/#configure-ios-development