### PR TITLE
Show set up entries in sidenav when child page is open

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -2,6 +2,44 @@
 
 - title: Set up Flutter
   permalink: /get-started/install
+  hiddenChildren: true
+  children:
+    - title: On Windows
+      permalink: /get-started/install/windows
+      children:
+        - title: Target Android
+          permalink: /get-started/install/windows/mobile
+        - title: Target web
+          permalink: /get-started/install/windows/web
+        - title: Target desktop
+          permalink: /get-started/install/windows/desktop
+    - title: On macOS
+      permalink: /get-started/install/macos
+      children:
+        - title: Target iOS
+          permalink: /get-started/install/macos/mobile-ios
+        - title: Target Android
+          permalink: /get-started/install/macos/mobile-android
+        - title: Target web
+          permalink: /get-started/install/macos/web
+        - title: Target desktop
+          permalink: /get-started/install/macos/desktop
+    - title: On Linux
+      permalink: /get-started/install/linux
+      children:
+        - title: Target Android
+          permalink: /get-started/install/linux/android
+        - title: Target web
+          permalink: /get-started/install/linux/web
+        - title: Target desktop
+          permalink: /get-started/install/linux/desktop
+    - title: On ChromeOS
+      permalink: /get-started/install/chromeos
+      children:
+        - title: Target Android
+          permalink: /get-started/install/chromeos/android
+        - title: Target web
+          permalink: /get-started/install/chromeos/web
 
 - title: Learn Flutter
   children:

--- a/src/_includes/sidenav-level-1.html
+++ b/src/_includes/sidenav-level-1.html
@@ -17,7 +17,8 @@
         {% assign isActive = false -%}
         {% assign class = '' -%}
       {% endif -%}
-      {% if entry.children -%}
+      {% assign hidingChildren = entry.hiddenChildren == true and not pageUrlPath contains entry.permalink -%}
+      {% if entry.children and not hidingChildren -%}
         {% if isActive or entry.expanded -%}
           {% assign expanded = 'true' -%}
           {% assign show = 'show' -%}


### PR DESCRIPTION
An improvement for the flow of someone navigating between the set up pages in the sidenav. Before this PR, they didn't show up at all in the sidenav, but now they do if any of the set up pages are open.

Contributes to https://github.com/flutter/website/issues/11672 as an improvement while I work on a longer term, automated solution.