### PR TITLE
Update Material 3 progress indicators and slider guides for theme migration

### DIFF
--- a/src/content/release/breaking-changes/updated-material-3-progress-indicators.md
+++ b/src/content/release/breaking-changes/updated-material-3-progress-indicators.md
@@ -55,19 +55,19 @@ LinearProgressIndicator(
 ),
 ```
 
-To opt into the updated design spec for the `LinearProgressIndicator`, for the
-entire app, set the `ProgressIndicatorThemeData.year2023` flag to `false` in
-the `MaterialApp`:
+To update your entire app to use the updated `LinearProgressIndicator` design,
+set the `ProgressIndicatorThemeData.year2023` property to `false` in your
+`MaterialApp`:
 
 ```dart highlightLines=2
 return MaterialApp(
   theme: ThemeData(progressIndicatorTheme: const ProgressIndicatorThemeData(year2023: false)),
-        /// ...
+        // ...
         LinearProgressIndicator(
           year2023: false,
           value: 0.5,
         ),
-        /// ...
+        // ...
 ```
 
 To opt into the updated design spec for the `CircularProgressIndicator`,
@@ -80,19 +80,19 @@ CircularProgressIndicator(
 ),
 ```
 
-To opt into the updated design spec for the `CircularProgressIndicator`, for the
-entire app, set the `ProgressIndicatorThemeData.year2023` flag to `false` in
-the `MaterialApp`:
+To update your entire app to use the updated `CircularProgressIndicator` design,
+set the `ProgressIndicatorThemeData.year2023` property to `false` in your
+`MaterialApp`:
 
 ```dart highlightLines=2
 return MaterialApp(
   theme: ThemeData(progressIndicatorTheme: const ProgressIndicatorThemeData(year2023: false)),
-        /// ...
+        // ...
         CircularProgressIndicator(
           year2023: false,
           value: 0.5,
         ),
-        /// ...
+        // ...
 ```
 
 ## Timeline

--- a/src/content/release/breaking-changes/updated-material-3-progress-indicators.md
+++ b/src/content/release/breaking-changes/updated-material-3-progress-indicators.md
@@ -55,6 +55,21 @@ LinearProgressIndicator(
 ),
 ```
 
+To opt into the updated design spec for the `LinearProgressIndicator`, for the
+entire app, set the `ProgressIndicatorThemeData.year2023` flag to `false` in
+the `MaterialApp`:
+
+```dart highlightLines=2
+return MaterialApp(
+  theme: ThemeData(progressIndicatorTheme: const ProgressIndicatorThemeData(year2023: false)),
+        /// ...
+        LinearProgressIndicator(
+          year2023: false,
+          value: 0.5,
+        ),
+        /// ...
+```
+
 To opt into the updated design spec for the `CircularProgressIndicator`,
 set the `year2023` flag to `false`:
 
@@ -63,6 +78,21 @@ CircularProgressIndicator(
   year2023: false,
   value: 0.5,
 ),
+```
+
+To opt into the updated design spec for the `CircularProgressIndicator`, for the
+entire app, set the `ProgressIndicatorThemeData.year2023` flag to `false` in
+the `MaterialApp`:
+
+```dart highlightLines=2
+return MaterialApp(
+  theme: ThemeData(progressIndicatorTheme: const ProgressIndicatorThemeData(year2023: false)),
+        /// ...
+        CircularProgressIndicator(
+          year2023: false,
+          value: 0.5,
+        ),
+        /// ...
 ```
 
 ## Timeline

--- a/src/content/release/breaking-changes/updated-material-3-slider.md
+++ b/src/content/release/breaking-changes/updated-material-3-slider.md
@@ -50,6 +50,24 @@ Slider(
 ),
 ```
 
+To opt into the updated design spec for the `Slider`, for the entire app, set
+the `SliderThemeData.year2023` flag to `false` in the `MaterialApp`:
+
+```dart highlightLines=2
+return MaterialApp(
+  theme: ThemeData(sliderTheme: const SliderThemeData(year2023: false)),
+        /// ...
+        Slider(
+          value: _value,
+          onChanged: (value) {
+            setState(() {
+              _value = value;
+            });
+          },
+        ),
+        /// ...
+```
+
 ## Timeline
 
 Landed in version: 3.28.0-0.1.pre<br>

--- a/src/content/release/breaking-changes/updated-material-3-slider.md
+++ b/src/content/release/breaking-changes/updated-material-3-slider.md
@@ -50,13 +50,13 @@ Slider(
 ),
 ```
 
-To opt into the updated design spec for the `Slider`, for the entire app, set
-the `SliderThemeData.year2023` flag to `false` in the `MaterialApp`:
+To update your entire app to use the updated `Slider` design, set the
+`SliderThemeData.year2023` property to `false` in your `MaterialApp`:
 
 ```dart highlightLines=2
 return MaterialApp(
   theme: ThemeData(sliderTheme: const SliderThemeData(year2023: false)),
-        /// ...
+        // ...
         Slider(
           value: _value,
           onChanged: (value) {
@@ -65,7 +65,7 @@ return MaterialApp(
             });
           },
         ),
-        /// ...
+        // ...
 ```
 
 ## Timeline


### PR DESCRIPTION
Fixes [Update slider and progress indicator migration guides with `year2023` flag from component themes](https://github.com/flutter/flutter/issues/163541)

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
