### PR TITLE
Add iOS 18.4 beta warnings

### DIFF
--- a/src/_includes/docs/install/devices/ios-physical.md
+++ b/src/_includes/docs/install/devices/ios-physical.md
@@ -3,7 +3,7 @@ Flutter's debug mode is broken on iOS 18.4 beta physical devices.
 See [flutter#163984][] for details.
 
 If your physical device is on iOS 18.4 beta,
-switch to the **Virtual device** option.
+switch to the **Virtual device** tab.
 :::
 
 [flutter#163984]: {{site.github}}/flutter/flutter/issues/163984

--- a/src/_includes/docs/install/devices/ios-physical.md
+++ b/src/_includes/docs/install/devices/ios-physical.md
@@ -1,3 +1,13 @@
+:::warning
+Flutter's debug mode is broken on iOS 18.4 beta physical devices.
+See [flutter#163984][] for details.
+
+If your physical device is on iOS 18.4 beta,
+switch to the **Virtual device** option.
+:::
+
+[flutter#163984]: {{site.github}}/flutter/flutter/issues/163984
+
 #### Set up your target physical iOS device
 
 To deploy your Flutter app to a physical iPhone or iPad,

--- a/src/_includes/docs/install/devices/ios-physical.md
+++ b/src/_includes/docs/install/devices/ios-physical.md
@@ -3,7 +3,7 @@ An upcoming change to iOS has caused a temporary break in Flutter's debug mode
 on physical devices running iOS 18.4 (currently in beta).
 If your physical device is already on iOS 18.4, we recommend switching to the
 **Virtual device** tab and following the instructions for using a simulator.
-See [Flutter on latest iOS] for details.
+See [Flutter on latest iOS][] for details.
 :::
 
 [Flutter on latest iOS]: {{site.github}}/ios/ios-latest

--- a/src/_includes/docs/install/devices/ios-physical.md
+++ b/src/_includes/docs/install/devices/ios-physical.md
@@ -1,12 +1,12 @@
 :::warning
-Flutter's debug mode is broken on iOS 18.4 beta physical devices.
-See [flutter#163984][] for details.
-
-If your physical device is on iOS 18.4 beta,
-switch to the **Virtual device** tab.
+An upcoming change to iOS has caused a temporary break in Flutter's debug mode
+on physical devices running iOS 18.4 (currently in beta).
+If your physical device is already on iOS 18.4, we recommend switching to the
+**Virtual device** tab and following the instructions for using a simulator.
+See [Flutter on latest iOS] for details.
 :::
 
-[flutter#163984]: {{site.github}}/flutter/flutter/issues/163984
+[Flutter on latest iOS]: {{site.github}}/ios/ios-latest
 
 #### Set up your target physical iOS device
 

--- a/src/content/platform-integration/ios/ios-latest.md
+++ b/src/content/platform-integration/ios/ios-latest.md
@@ -5,6 +5,18 @@ description: >-
   the latest releases of iOS.
 ---
 
+:::warning
+Flutter's debug mode is broken on iOS 18.4 beta physical devices.
+See [flutter#163984][] for details.
+
+Flutter recommends you do not upgrade your devices to iOS 18.4 beta.
+
+To target iOS 18.4 beta physical devices, use
+[Flutter's release or profile build modes][].
+
+Alternatively, target an iOS simulator or iOS 18.3 or lower physical device.
+:::
+
 You can develop Flutter on the iOS platform, even on
 the latest release of iOS. The latest Flutter SDK
 already supports a number of the features in the
@@ -13,6 +25,8 @@ latest release of iOS.
 Of course, if you find a bug on Flutter,
 please [file an issue][].
 
+[flutter#163984]: {{site.github}}/flutter/flutter/issues/163984
+[Flutter's release or profile build modes]: /testing/build-modes
 [file an issue]: {{site.github}}/flutter/flutter/issues
 
 ## iOS 18 release

--- a/src/content/platform-integration/ios/ios-latest.md
+++ b/src/content/platform-integration/ios/ios-latest.md
@@ -6,15 +6,16 @@ description: >-
 ---
 
 :::warning
-Flutter's debug mode is broken on iOS 18.4 beta physical devices.
+An upcoming change to iOS has caused a temporary break in Flutter's
+debug mode on physical devices running iOS 18.4 (currently in beta).
 See [flutter#163984][] for details.
 
-Flutter recommends you do not upgrade your devices to iOS 18.4 beta.
+In the meantime, we recommend these temporary workarounds:
 
-To target iOS 18.4 beta physical devices, use
-[Flutter's release or profile build modes][].
-
-Alternatively, target an iOS simulator or iOS 18.3 or lower physical device.
+* When developing with a physical device, use one running iOS 18.3 or lower.
+* Use a simulator for development rather than a physical device.
+* If you must use a device updated to iOS 18.4,
+  use [Flutter's release or profile build modes][].
 :::
 
 You can develop Flutter on the iOS platform, even on


### PR DESCRIPTION
iOS 18.4 beta breaks Flutter's debug mode on physical devices. Until we hotfix this issue, users should not upgrade to iOS 18.4 beta. Users that have upgraded their device to iOS 18.4 beta should run their apps in release or profile modes, or, target an iOS simulator instead. 

This PR will be reverted once the issue is hotfixed.

Part of https://github.com/flutter/flutter/issues/163984

### Screenshots

https://flutter-docs-prod--pr11740-ios-18-4-warning-45b6gmsm.web.app/get-started/install/macos/mobile-ios#configure-your-target-ios-device

![image](https://github.com/user-attachments/assets/6a6c258a-ea00-4c49-93f7-aec4f91c4df0)

https://flutter-docs-prod--pr11740-ios-18-4-warning-45b6gmsm.web.app/platform-integration/ios/ios-latest

![image](https://github.com/user-attachments/assets/fd5273e2-654a-4c73-ba38-86c97b2fede3)

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
