### PR TITLE
Migration guide for InputDecoration.maintainHintHeight deprecation

### DIFF
--- a/src/content/release/breaking-changes/deprecate-inputdecoration-maintainhintheight.md
+++ b/src/content/release/breaking-changes/deprecate-inputdecoration-maintainhintheight.md
@@ -73,6 +73,6 @@ Relevant PRs:
 - [Fix TextField intrinsic width when hint is not visible][]
 
 [`InputDecoration.maintainHintHeight`]: {{site.api}}/flutter/material/InputDecoration/maintainHintHeight.html
-[`InputDecoration.maintainHintSize`]: {{site.api}}/flutter/material/InputDecoration/maintainHintSize.html
+[`InputDecoration.maintainHintSize`]: {{site.main-api}}/flutter/material/InputDecoration/maintainHintSize.html
 [Issue #93337]: {{site.repo.flutter}}/issues/93337
 [Fix TextField intrinsic width when hint is not visible]: {{site.repo.flutter}}/pull/161235

--- a/src/content/release/breaking-changes/deprecate-inputdecoration-maintainhintheight.md
+++ b/src/content/release/breaking-changes/deprecate-inputdecoration-maintainhintheight.md
@@ -1,0 +1,78 @@
+---
+title: Deprecate `InputDecoration.maintainHintHeight` in favor of
+  `InputDecoration.maintainHintSize`
+description: >-
+  The `InputDecoration.maintainHintHeight` parameter has been replaced by
+  `InputDecoration.maintainHintSize`.
+---
+
+## Summary
+
+The [`InputDecoration.maintainHintHeight`][] parameter was deprecated
+in favor of the [`InputDecoration.maintainHintSize`][] parameter.
+
+## Context
+
+The defaults intrincic size of an input decorator depends on the hint size.
+The [`InputDecoration.maintainHintSize`][] parameter can be set to false to
+make the intrincic size ignores the hint size when the hint is not visible.
+Previously, the `InputDecoration.maintainHintHeight` parameter was
+used to override the default intrinsic height and had no impact on the
+intrinsic width.
+
+## Description of change
+
+The [`InputDecoration.maintainHintHeight`][] is deprecated in
+favor of [`InputDecoration.maintainHintSize`][] which makes both the intrinsic
+width and height depend on the hint dimensions.
+
+## Migration guide
+
+Replace [`InputDecoration.maintainHintHeight`][] with
+[`InputDecoration.maintainHintSize`][] to override the default intrisic size
+computation.
+
+Code before migration:
+
+```dart highlightLines=3
+TextField(
+  indicator: InputDecoration(
+    maintainHintHeight: false,
+  ),
+),
+```
+
+Code after migration:
+
+```dart highlightLines=3
+TextField(
+  indicator: InputDecoration(
+    maintainHintSize: false,
+  ),
+),
+```
+
+## Timeline
+
+Landed in version: 3.30.0-0.0.pre<br>
+In stable release: Not yet
+
+## References
+
+API documentation:
+
+- [`InputDecoration.maintainHintHeight`][]
+- [`InputDecoration.maintainHintSize`][]
+
+Relevant issues:
+
+- [Issue #93337][]
+
+Relevant PRs:
+
+- [Fix TextField intrinsic width when hint is not visible][]
+
+[`InputDecoration.maintainHintHeight`]: {{site.api}}/flutter/material/InputDecoration/maintainHintHeight.html
+[`InputDecoration.maintainHintSize`]: {{site.api}}/flutter/material/InputDecoration/maintainHintSize.html
+[Issue #93337]: {{site.repo.flutter}}/issues/93337
+[Fix TextField intrinsic width when hint is not visible]: {{site.repo.flutter}}/pull/161235

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -43,6 +43,7 @@ They're sorted by release and listed in alphabetical order:
 * [Stop generating `AssetManifest.json`][]
 * [`.flutter-plugins-dependencies` replaces `.flutter-plugins`][]
 * [Changing the default `goldenFileComparator` for `integration_test`s][]
+* [Deprecate `InputDecoration.maintainHintHeight` in favor of `InputDecoration.maintainHintSize`][]
 
 [Deprecate `SystemContextMenuController.show`]: /release/breaking-changes/system_context_menu_controller_show
 [deprecate-markForRemove]: /release/breaking-changes/navigator-complete-route
@@ -53,6 +54,7 @@ They're sorted by release and listed in alphabetical order:
 [Stop generating `AssetManifest.json`]: /release/breaking-changes/asset-manifest-dot-json
 [`.flutter-plugins-dependencies` replaces `.flutter-plugins`]: /release/breaking-changes/flutter-plugins-configuration
 [Changing the default `goldenFileComparator` for `integration_test`s]: /release/breaking-changes/integration-test-default-golden-comparator
+[Deprecate `InputDecoration.maintainHintHeight` in favor of `InputDecoration.maintainHintSize`]: /release/breaking-changes/deprecate-inputdecoration-maintainhintheight
 
 <a id="released-in-flutter-329" aria-hidden="true"></a>
 ### Released in Flutter 3.29


### PR DESCRIPTION
This PR adds a migration guide for inputDecoration.maintainHintHeight.

Related PRs:
- https://github.com/flutter/flutter/pull/161235
- dart fix: https://github.com/flutter/flutter/pull/162600

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
