### PR TITLE
Make link check command more reliable

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -15,8 +15,8 @@
       { "regex": "^\/(flutter(\/.*)?)", "destination": "https://api.flutter.dev/:1", "type": 301 },
       { "regex": "^\/(objcdoc(\/.*)?)", "destination": "https://api.flutter.dev/:1", "type": 301 },
       { "regex": "^\/(javadoc(\/.*)?)", "destination": "https://api.flutter.dev/:1", "type": 301 },
-      { "regex": "(?P<basename>.*)\\.html$", "destination": ":basename", "type": 301 },
-      { "regex": "(?P<basename>.*)\\.$", "destination": ":basename", "type": 301 },
+      { "regex": "(.*)\\.html$", "destination": ":1", "type": 301 },
+      { "regex": "(.*)\\.$", "destination": ":1", "type": 301 },
 
       { "source": "/ads", "destination": "https://flutter.dev/monetization", "type": 301 },
       { "source": "/community", "destination": "https://flutter.dev/community", "type": 301 },

--- a/tool/flutter_site/lib/src/commands/check_links.dart
+++ b/tool/flutter_site/lib/src/commands/check_links.dart
@@ -97,11 +97,13 @@ Future<int> _checkLinks({bool checkExternal = false}) async {
     }
   } finally {
     print('Shutting down Firebase hosting emulator...');
-    // Terminate the process, first sending two sigterm signals for
-    // a chance to gracefully handle the signal.
+    // Try to gracefully terminate the process by sending two sigterm signals.
     emulatorProcess.kill(ProcessSignal.sigterm);
     emulatorProcess.kill(ProcessSignal.sigterm);
+    // Give the emulator a chance to shut down gracefully.
+    await Future<void>.delayed(const Duration(seconds: 4));
     emulatorProcess.kill(ProcessSignal.sigkill);
+    await Future<void>.delayed(const Duration(seconds: 1));
     print('Done!\n');
   }
 }

--- a/tool/flutter_site/lib/src/commands/check_links.dart
+++ b/tool/flutter_site/lib/src/commands/check_links.dart
@@ -99,9 +99,11 @@ Future<int> _checkLinks({bool checkExternal = false}) async {
     print('Shutting down Firebase hosting emulator...');
     // Try to gracefully terminate the process by sending two sigterm signals.
     emulatorProcess.kill(ProcessSignal.sigterm);
+    await Future<void>.delayed(const Duration(seconds: 1));
     emulatorProcess.kill(ProcessSignal.sigterm);
-    // Give the emulator a chance to shut down gracefully.
-    await Future<void>.delayed(const Duration(seconds: 4));
+    await Future<void>.delayed(const Duration(seconds: 3));
+
+    // If the emulator hasn't shut down by done, try to force terminate it.
     emulatorProcess.kill(ProcessSignal.sigkill);
     await Future<void>.delayed(const Duration(seconds: 1));
     print('Done!\n');

--- a/tool/flutter_site/lib/src/commands/check_links.dart
+++ b/tool/flutter_site/lib/src/commands/check_links.dart
@@ -69,8 +69,9 @@ Future<int> _checkLinks({bool checkExternal = false}) async {
     'QUIET',
   ], mode: ProcessStartMode.inheritStdio);
 
+  print('Connecting to the emulator...');
   // Give the emulator a few seconds to start up.
-  await Future<void>.delayed(const Duration(seconds: 5));
+  await Future<void>.delayed(const Duration(seconds: 6));
 
   try {
     // Check to see if the emulator is running.
@@ -96,7 +97,10 @@ Future<int> _checkLinks({bool checkExternal = false}) async {
     }
   } finally {
     print('Shutting down Firebase hosting emulator...');
-    emulatorProcess.kill();
+    // Terminate the process, first sending two sigterm signals for
+    // a chance to gracefully handle the signal.
+    emulatorProcess.kill(ProcessSignal.sigterm);
+    emulatorProcess.kill(ProcessSignal.sigterm);
     emulatorProcess.kill(ProcessSignal.sigkill);
     print('Done!\n');
   }
@@ -109,8 +113,7 @@ Future<bool> _isPortInUse(int port) async {
     final server = await ServerSocket.bind(
       InternetAddress.loopbackIPv4,
       port,
-      shared: false,
-    ).timeout(const Duration(seconds: 3)); // Ignore timeout.
+    ).timeout(const Duration(seconds: 5)); // Ignore timeout.
 
     // If we reach this line, the port was available,
     // and we know the Firebase hosting emulator is not running.

--- a/tool/flutter_site/lib/src/commands/check_links.dart
+++ b/tool/flutter_site/lib/src/commands/check_links.dart
@@ -71,7 +71,7 @@ Future<int> _checkLinks({bool checkExternal = false}) async {
 
   print('Connecting to the emulator...');
   // Give the emulator a few seconds to start up.
-  await Future<void>.delayed(const Duration(seconds: 6));
+  await Future<void>.delayed(const Duration(seconds: 8));
 
   try {
     // Check to see if the emulator is running.


### PR DESCRIPTION
- Updates two redirects to use positional capture groups to be compatible with firebase hosting emulation.
- Increases timeouts for connections as the emulator takes longer to start up now.
- Give the emulator a chance to shutdown gracefully.