### PR TITLE
Improve link

### DIFF
--- a/src/content/release/breaking-changes/v1-android-embedding.md
+++ b/src/content/release/breaking-changes/v1-android-embedding.md
@@ -69,7 +69,9 @@ public static void registerWith(@NonNull io.flutter.plugin.common.PluginRegistry
 
 For an example of this migration,
 check out the pull request to remove this method from the
-Flutter team-owned plugins: https://github.com/flutter/packages/pull/6494.
+Flutter team-owned plugins: [flutter/packages#6494][].
+
+[flutter/packages#6494]: {{site.github}}/flutter/packages/pull/6494
 
 ## Timeline
 


### PR DESCRIPTION
Currently the PR isn't a link:

https://docs.flutter.dev/release/breaking-changes/v1-android-embedding#plugin-authors

![image](https://github.com/user-attachments/assets/e0294029-8b9d-48ff-9725-b951855db12c)
