### PR TITLE
Close And Menu Toggle

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -80,6 +80,7 @@
           aria-label="Toggle navigation"
           title="Toggle navigation">
         <span class="material-symbols" aria-hidden="true">menu</span>
+        <span class="material-symbols" aria-hidden="true">close</span>
       </button>
     </div>
   </nav>

--- a/src/_sass/components/_header.scss
+++ b/src/_sass/components/_header.scss
@@ -135,3 +135,23 @@
     }
   }
 }
+
+  body.open_menu #menu-toggle span.material-symbols {
+    &:first-child {
+    display: none;
+  }
+
+    &:last-child {
+    display: inline;
+  }
+}
+
+  #menu-toggle span.material-symbols {
+    &:first-child {
+    display: inline;
+  }
+
+    &:last-child {
+    display: none;
+  }
+}


### PR DESCRIPTION
Added Close Icon and Addd Functionality of menu and close button toggling.

Fixed : https://github.com/flutter/website/issues/11736


https://github.com/user-attachments/assets/f31a245a-98a8-4dae-a954-c540e417ddb3



## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
