### PR TITLE
Recommend upgrade to iOS 18.4 beta 2 if on beta 1

### DIFF
--- a/src/_includes/docs/install/devices/ios-physical.md
+++ b/src/_includes/docs/install/devices/ios-physical.md
@@ -1,13 +1,3 @@
-:::warning
-An upcoming change to iOS has caused a temporary break in Flutter's debug mode
-on physical devices running iOS 18.4 (currently in beta).
-If your physical device is already on iOS 18.4, we recommend switching to the
-**Virtual device** tab and following the instructions for using a simulator.
-See [Flutter on latest iOS][] for details.
-:::
-
-[Flutter on latest iOS]: /platform-integration/ios/ios-latest
-
 #### Set up your target physical iOS device
 
 To deploy your Flutter app to a physical iPhone or iPad,

--- a/src/content/platform-integration/ios/ios-latest.md
+++ b/src/content/platform-integration/ios/ios-latest.md
@@ -6,16 +6,10 @@ description: >-
 ---
 
 :::warning
-An upcoming change to iOS has caused a temporary break in Flutter's
-debug mode on physical devices running iOS 18.4 (currently in beta).
+iOS 18.4 beta 1 breaks Flutter's debug mode on physical devices.
+If you have upgraded your physical device to iOS 18.4 beta 1,
+please upgrade to iOS 18.4 beta 2.
 See [flutter#163984][] for details.
-
-In the meantime, we recommend these temporary workarounds:
-
-* When developing with a physical device, use one running iOS 18.3 or lower.
-* Use a simulator for development rather than a physical device.
-* If you must use a device updated to iOS 18.4,
-  use [Flutter's release or profile build modes][].
 :::
 
 You can develop Flutter on the iOS platform, even on
@@ -27,7 +21,6 @@ Of course, if you find a bug on Flutter,
 please [file an issue][].
 
 [flutter#163984]: {{site.github}}/flutter/flutter/issues/163984
-[Flutter's release or profile build modes]: /testing/build-modes
 [file an issue]: {{site.github}}/flutter/flutter/issues
 
 ## iOS 18 release


### PR DESCRIPTION
iOS 18.4 beta 1 breaks Flutter's debug mode on physical devices. Apple appears to have reverted the change that caused this regression in iOS 18.4 beta 2. Customers that are on iOS 18.4 beta 1 should upgrade to iOS 18.4 beta 2.

Part of: https://github.com/flutter/flutter/issues/163984#issuecomment-2677682423

Preview: https://flutter-docs-prod--pr11766-upgrade-ios-18-4-v394xkfi.web.app/platform-integration/ios/ios-latest

![image](https://github.com/user-attachments/assets/d9827ad2-5311-483a-9afb-907b2e0d05f4)

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
