### PR TITLE
Remove CupertinoSegmentedControl from the widget catalog

### DIFF
--- a/src/_data/catalog/widgets.yml
+++ b/src/_data/catalog/widgets.yml
@@ -839,16 +839,6 @@
   link: https://api.flutter.dev/flutter/cupertino/CupertinoSearchTextField-class.html
   image:
     src: /assets/images/docs/widget-catalog/cupertino-search-field.png
-- name: CupertinoSegmentedControl
-  description: >-
-    An iOS-style segmented control. Used to select mutually exclusive options in
-    a horizontal list.
-  categories:
-    - 'Cupertino'
-  subcategories: []
-  link: https://api.flutter.dev/flutter/cupertino/CupertinoSegmentedControl-class.html
-  image:
-    src: /assets/images/docs/widget-catalog/cupertino-segmented-control.png
 - name: CupertinoSlider
   description: Used to select from a range of values.
   categories:


### PR DESCRIPTION
This removes the `CupertinoSegmentedControl` from the widget catalog. Customers should instead use `CupertinoSlidingSegmentedControl`.
 
`CupertinoSegmentedControl` is the pre-iOS 13 - released in 2019 - look for an iOS "segmented control".

Part of https://github.com/flutter/flutter/issues/152910

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
