### PR TITLE
Fix spacing in Apple platform table

### DIFF
--- a/src/content/platform-integration/ios/apple-frameworks.md
+++ b/src/content/platform-integration/ios/apple-frameworks.md
@@ -54,7 +54,7 @@ should provide details.
 
 | Use Case                                       | Apple Framework or Class                                                              | Flutter Plugin               |
 |------------------------------------------------|---------------------------------------------------------------------------------------|------------------------------|
-| Access the photo library                       | `PhotoKit`using the `Photos` and `PhotosUI ` frameworks and `UIImagePickerController` | [`image_picker`][]           |
+| Access the photo library                       | `PhotoKit` using the `Photos` and `PhotosUI ` frameworks and `UIImagePickerController`| [`image_picker`][]           |
 | Access the camera                              | `UIImagePickerController` using the `.camera` `sourceType`                            | [`image_picker`][]           |
 | Use advanced camera features                   | `AVFoundation`                                                                        | [`camera`][]                 |
 | Offer In-app purchases                         | `StoreKit`                                                                            | [`in_app_purchase`][][^1]    |


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Fix spacing between "`PhotoKit`" and "using":

![Screenshot 2025-03-07 at 1 54 03 PM](https://github.com/user-attachments/assets/12a34662-d825-48a1-baca-4674ce70aaf6)


_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
