### PR TITLE
Update os-settings.md for windows set mirror env

### DIFF
--- a/src/_includes/docs/community/china/os-settings.md
+++ b/src/_includes/docs/community/china/os-settings.md
@@ -13,8 +13,9 @@
    {% capture newdir -%}{{prompt}} New-Item -Path '{{installdirsuggestion}}' -ItemType Directory{% endcapture -%}
    {% capture unzip -%} {{prompt}} Expand-Archive .\{% endcapture -%}
    {% capture permaddexample -%}   
+# cd to flutter dir
 $currentDirectory = Get-Location   
-$newPath = "$currentDirectory\flutter\bin;$env:PATH"
+$newPath = "$currentDirectory\bin;$env:PATH"
 [System.Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
 [System.Environment]::SetEnvironmentVariable('PUB_HOSTED_URL', 'https://pub.flutter-io.cn', 'User')
 [System.Environment]::SetEnvironmentVariable('FLUTTER_STORAGE_BASE_URL', 'https://storage.flutter-io.cn', 'User')

--- a/src/_includes/docs/community/china/os-settings.md
+++ b/src/_includes/docs/community/china/os-settings.md
@@ -12,11 +12,14 @@
    {% capture setpath -%}{{envvarset}}PATH = $pwd.PATH + "/flutter/bin",$env:PATH -join ";"{% endcapture -%}
    {% capture newdir -%}{{prompt}} New-Item -Path '{{installdirsuggestion}}' -ItemType Directory{% endcapture -%}
    {% capture unzip -%} {{prompt}} Expand-Archive .\{% endcapture -%}
-   {% capture permaddexample -%}
-$newPath = "$pwd\flutter\bin;$env:PATH"
+   {% capture permaddexample -%}   
+$currentDirectory = Get-Location   
+$newPath = "$currentDirectory\flutter\bin;$env:PATH"
 [System.Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
 [System.Environment]::SetEnvironmentVariable('PUB_HOSTED_URL', 'https://pub.flutter-io.cn', 'User')
 [System.Environment]::SetEnvironmentVariable('FLUTTER_STORAGE_BASE_URL', 'https://storage.flutter-io.cn', 'User')
+
+Write-Host ". $PROFILE"
    {% endcapture -%}
 {% else -%}
    {% assign shell = 'your terminal' -%}


### PR DESCRIPTION
On Windows devices, the current document requires manual modification of the current directory. 
After modification, it can achieve the same effect as using pwd on Linux to read the current working directory.

