### PR TITLE
refactor: use the new image provider from `transparent_image` package

### DIFF
--- a/examples/cookbook/images/fading_in_images/lib/memory_main.dart
+++ b/examples/cookbook/images/fading_in_images/lib/memory_main.dart
@@ -21,9 +21,9 @@ class MyApp extends StatelessWidget {
             const Center(child: CircularProgressIndicator()),
             Center(
               // #docregion MemoryNetwork
-              child: FadeInImage.memoryNetwork(
-                placeholder: kTransparentImage,
-                image: 'https://picsum.photos/250?image=9',
+              child: FadeInImage(
+                placeholder: const TransparentImage(),
+                image: NetworkImage('https://picsum.photos/250?image=9'),
               ),
               // #enddocregion MemoryNetwork
             ),

--- a/src/content/cookbook/images/fading-in-images.md
+++ b/src/content/cookbook/images/fading-in-images.md
@@ -23,9 +23,9 @@ package for a simple transparent placeholder.
 
 <?code-excerpt "lib/memory_main.dart (MemoryNetwork)" replace="/^child\: //g"?>
 ```dart
-FadeInImage.memoryNetwork(
-  placeholder: kTransparentImage,
-  image: 'https://picsum.photos/250?image=9',
+FadeInImage(
+  placeholder: const TransparentImage(),
+  image: NetworkImage('https://picsum.photos/250?image=9'),
 ),
 ```
 
@@ -55,9 +55,9 @@ class MyApp extends StatelessWidget {
           children: <Widget>[
             const Center(child: CircularProgressIndicator()),
             Center(
-              child: FadeInImage.memoryNetwork(
-                placeholder: kTransparentImage,
-                image: 'https://picsum.photos/250?image=9',
+              child: FadeInImage(
+                placeholder: const TransparentImage(),
+                image: NetworkImage('https://picsum.photos/250?image=9'),
               ),
             ),
           ],


### PR DESCRIPTION
The latest 3.0.0 version of the `transparent_image` package removes the hardcoded PNG bytes and instead provides a custom image provider which renders the same transparent 1x1 pixel image, but without the PNG decoding overhead (which is quite significant, as noted in the upstream pull request).

This PR should not be merged until brianegan/transparent_image#15 is merged and the new package version is released on the pub.

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
