### PR TITLE
Use unicode box-drawing characters for code organization

### DIFF
--- a/src/content/app-architecture/case-study/index.md
+++ b/src/content/app-architecture/case-study/index.md
@@ -84,45 +84,45 @@ The following is how the code is organized within the Compass application.
 
 ```plaintext
 lib
-|____ui
-| |____core
-| | |____ui
-| | | |____<shared widgets>
-| | |____themes
-| |____<FEATURE NAME>
-| | |____view_model
-| | | |_____<view_model class>.dart
-| | |____widgets
-| | | |____<feature name>_screen.dart
-| | | |____<other widgets>
-|____domain
-| |____models
-| | |____<model name>.dart
-|____data
-| |____repositories
-| | |____<repository class>.dart
-| |____services
-| | |____<service class>.dart
-| |____model
-| | |____<api model class>.dart
-|____config
-|____utils
-|____routing
-|____main_staging.dart
-|____main_development.dart
-|____main.dart
+├─┬─ ui
+│ ├─┬─ core
+│ │ ├─┬─ ui
+│ │ │ └─── <shared widgets>
+│ │ └─ themes
+│ └─┬─ <FEATURE NAME>
+│   ├─┬─ view_model
+│   │ └─── <view_model class>.dart
+│   └─┬─widgets
+│     ├── <feature name>_screen.dart
+│     └── <other widgets>
+├─┬─ domain
+│ └─┬─ models
+│   └─── <model name>.dart
+├─┬─ data
+│ ├─┬─ repositories
+│ │ └─── <repository class>.dart
+│ ├─┬─ services
+│ │ └─── <service class>.dart
+│ └─┬─ model
+│   └─── <api model class>.dart
+├─── config
+├─── utils
+├─── routing
+├─── main_staging.dart
+├─── main_development.dart
+└─── main.dart
 
 // The test folder contains unit and widget tests
 test
-|____data
-|____domain
-|____ui
-|____utils
+├─── data
+├─── domain
+├─── ui
+└─── utils
 
 // The testing folder contains mocks other classes need to execute tests
 testing
-|____fakes
-|____models
+├─── fakes
+└─── models
 ```
 
 Most of the application code lives in the

--- a/src/content/app-architecture/case-study/index.md
+++ b/src/content/app-architecture/case-study/index.md
@@ -88,11 +88,11 @@ lib
 │ ├─┬─ core
 │ │ ├─┬─ ui
 │ │ │ └─── <shared widgets>
-│ │ └─ themes
+│ │ └─── themes
 │ └─┬─ <FEATURE NAME>
 │   ├─┬─ view_model
 │   │ └─── <view_model class>.dart
-│   └─┬─widgets
+│   └─┬─ widgets
 │     ├── <feature name>_screen.dart
 │     └── <other widgets>
 ├─┬─ domain


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

This PR changes the example of code organization to use unicode box-drawing characters instead of `|` and `-`.

It makes the example more readable.

_Issues fixed by this PR (if any):_ none.

_PRs or commits this PR depends on (if any):_ none.

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
