### PR TITLE
Only use `<li>` as children of `<ul>` elements in sidebar

### DIFF
--- a/src/_includes/sidenav-level-2.html
+++ b/src/_includes/sidenav-level-2.html
@@ -10,7 +10,7 @@
 
 
 {% if entry == 'divider' -%}
-  <div class="sidenav-divider"></div>
+  <li aria-hidden="true"><div class="sidenav-divider"></div></li>
 {% elsif entry.header -%}
   <li class="nav-header">{{entry.header}}</li>
 {%- elsif entry.children -%}

--- a/src/_includes/sidenav-level-3.html
+++ b/src/_includes/sidenav-level-3.html
@@ -9,7 +9,7 @@
 {% endif -%}
 
 {% if entry == 'divider' -%}
-  <div class="sidenav-divider"></div>
+  <li aria-hidden="true"><div class="sidenav-divider"></div></li>
 {%- elsif entry.children -%}
   {% assign class = class | append: ' collapsible' -%}
 


### PR DESCRIPTION
Uses a hidden `<li>` for divider elements only used for visual distinction. Matches what is done at the top level of the sidebar as well.

Fixes https://github.com/flutter/website/issues/10535