### PR TITLE
Remove unnecessary configuration of tabindex

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -1,7 +1,5 @@
-{% assign route = page.url|regex_replace:'/index$|/index\.html$|\.html$|/$' %}
-
 <header class="site-header">
-  <a href="#document-title" id="skip-to-main" class="filled-button" tabindex="1">
+  <a href="#document-title" id="skip-to-main" class="filled-button">
     Skip to main content
   </a>
   <nav class="navbar">


### PR DESCRIPTION
This was called out by the lighthouse accessibility report.
