### PR TITLE
fixed typo

### DIFF
--- a/src/content/tools/formatting.md
+++ b/src/content/tools/formatting.md
@@ -70,6 +70,6 @@ Here is an example of automatically formatted code *with* trailing commas:
 
 ![Automatically formatted code with trailing commas](/assets/images/docs/tools/android-studio/trailing-comma-with.png){:width="100%"}
 
-And the same code automatically formatted code *without* trailing commas:
+And the same code automatically formatted *without* trailing commas:
 
 ![Automatically formatted code without trailing commas](/assets/images/docs/tools/android-studio/trailing-comma-without.png){:width="100%"}


### PR DESCRIPTION
The word "code" was mistakenly present twice in the sentence.

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
