### PR TITLE
Add cupertino examples to the Floating App Bar recipe.

### DIFF
--- a/examples/cookbook/lists/floating_app_bar/lib/main_cupertino.dart
+++ b/examples/cookbook/lists/floating_app_bar/lib/main_cupertino.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/cupertino.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    const title = 'Floating Navigation Bar';
+
+    return CupertinoApp(
+      title: title,
+      home: CupertinoPageScaffold(
+        // No navigation bar provided to CupertinoPageScaffold,
+        // only a body with a CustomScrollView.
+        child: CustomScrollView(
+          slivers: [
+            // Add the navigation bar to the CustomScrollView.
+            const CupertinoSliverNavigationBar(
+              // Provide a standard title.
+              largeTitle: Text(title),
+            ),
+            // #docregion SliverList
+            // Next, create a SliverList
+            SliverList(
+              // Use a delegate to build items as they're scrolled on screen.
+              delegate: SliverChildBuilderDelegate(
+                // The builder function returns a ListTile with a title that
+                // displays the index of the current item.
+                (context, index) =>
+                    CupertinoListTile(title: Text('Item #$index')),
+                // Builds 50 ListTiles
+                childCount: 50,
+              ),
+            ),
+            // #enddocregion SliverList
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/examples/cookbook/lists/floating_app_bar/lib/main_cupertino.dart
+++ b/examples/cookbook/lists/floating_app_bar/lib/main_cupertino.dart
@@ -24,12 +24,12 @@ class MyApp extends StatelessWidget {
             // #docregion SliverList
             // Next, create a SliverList
             SliverList.builder(
-              // The builder function returns a ListTile with a title that
-              // displays the index of the current item.
+              // The builder function returns a CupertinoListTile with a title
+              // that displays the index of the current item.
               itemBuilder:
                   (context, index) =>
                       CupertinoListTile(title: Text('Item #$index')),
-              // Builds 50 ListTiles
+              // Builds 50 CupertinoListTile
               itemCount: 50,
             ),
             // #enddocregion SliverList

--- a/examples/cookbook/lists/floating_app_bar/lib/main_cupertino.dart
+++ b/examples/cookbook/lists/floating_app_bar/lib/main_cupertino.dart
@@ -23,16 +23,14 @@ class MyApp extends StatelessWidget {
             ),
             // #docregion SliverList
             // Next, create a SliverList
-            SliverList(
-              // Use a delegate to build items as they're scrolled on screen.
-              delegate: SliverChildBuilderDelegate(
-                // The builder function returns a ListTile with a title that
-                // displays the index of the current item.
-                (context, index) =>
-                    CupertinoListTile(title: Text('Item #$index')),
-                // Builds 50 ListTiles
-                childCount: 50,
-              ),
+            SliverList.builder(
+              // The builder function returns a ListTile with a title that
+              // displays the index of the current item.
+              itemBuilder:
+                  (context, index) =>
+                      CupertinoListTile(title: Text('Item #$index')),
+              // Builds 50 ListTiles
+              itemCount: 50,
             ),
             // #enddocregion SliverList
           ],

--- a/examples/cookbook/lists/floating_app_bar/lib/main_material.dart
+++ b/examples/cookbook/lists/floating_app_bar/lib/main_material.dart
@@ -12,7 +12,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: title,
       home: Scaffold(
-        // No appbar provided to the Scaffold, only a body with a
+        // No app bar provided to Scaffold, only a body with a
         // CustomScrollView.
         body: CustomScrollView(
           slivers: [
@@ -20,6 +20,8 @@ class MyApp extends StatelessWidget {
             const SliverAppBar(
               // Provide a standard title.
               title: Text(title),
+              // Allows the user to reveal the app bar if they begin scrolling
+              pinned: true,
               // Allows the user to reveal the app bar if they begin scrolling
               // back up the list of items.
               floating: true,
@@ -36,8 +38,8 @@ class MyApp extends StatelessWidget {
                 // The builder function returns a ListTile with a title that
                 // displays the index of the current item.
                 (context, index) => ListTile(title: Text('Item #$index')),
-                // Builds 1000 ListTiles
-                childCount: 1000,
+                // Builds 50 ListTiles
+                childCount: 50,
               ),
             ),
             // #enddocregion SliverList

--- a/examples/cookbook/lists/floating_app_bar/lib/main_material.dart
+++ b/examples/cookbook/lists/floating_app_bar/lib/main_material.dart
@@ -20,11 +20,8 @@ class MyApp extends StatelessWidget {
             const SliverAppBar(
               // Provide a standard title.
               title: Text(title),
-              // Allows the user to reveal the app bar if they begin scrolling
+              // Pin the app bar when scrolling
               pinned: true,
-              // Allows the user to reveal the app bar if they begin scrolling
-              // back up the list of items.
-              floating: true,
               // Display a placeholder widget to visualize the shrinking size.
               flexibleSpace: Placeholder(),
               // Make the initial height of the SliverAppBar larger than normal.
@@ -32,15 +29,13 @@ class MyApp extends StatelessWidget {
             ),
             // #docregion SliverList
             // Next, create a SliverList
-            SliverList(
-              // Use a delegate to build items as they're scrolled on screen.
-              delegate: SliverChildBuilderDelegate(
-                // The builder function returns a ListTile with a title that
-                // displays the index of the current item.
-                (context, index) => ListTile(title: Text('Item #$index')),
-                // Builds 50 ListTiles
-                childCount: 50,
-              ),
+            SliverList.builder(
+              // The builder function returns a ListTile with a title that
+              // displays the index of the current item.
+              itemBuilder:
+                  (context, index) => ListTile(title: Text('Item #$index')),
+              // Builds 50 ListTiles
+              itemCount: 50,
             ),
             // #enddocregion SliverList
           ],

--- a/examples/cookbook/lists/floating_app_bar/lib/starter_cupertino.dart
+++ b/examples/cookbook/lists/floating_app_bar/lib/starter_cupertino.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/cupertino.dart';
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // #docregion CustomScrollView
+    return const CupertinoApp(
+      home: CupertinoPageScaffold(
+        // No navigation bar property provided yet.
+        child: CustomScrollView(
+          // Add the navigation bar and list of items as slivers in the next steps.
+          slivers: <Widget>[],
+        ),
+      ),
+    );
+    // #enddocregion CustomScrollView
+  }
+}

--- a/examples/cookbook/lists/floating_app_bar/lib/starter_cupertino.dart
+++ b/examples/cookbook/lists/floating_app_bar/lib/starter_cupertino.dart
@@ -7,6 +7,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     // #docregion CustomScrollView
     return const CupertinoApp(
+      title: 'Floating Navigation Bar',
       home: CupertinoPageScaffold(
         // No navigation bar property provided yet.
         child: CustomScrollView(

--- a/examples/cookbook/lists/floating_app_bar/lib/starter_material.dart
+++ b/examples/cookbook/lists/floating_app_bar/lib/starter_material.dart
@@ -6,11 +6,14 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // #docregion CustomScrollView
-    return const Scaffold(
-      // No app bar property provided yet.
-      body: CustomScrollView(
-        // Add the app bar and list of items as slivers in the next steps.
-        slivers: <Widget>[],
+    return const MaterialApp(
+      title: 'Floating App Bar',
+      home: Scaffold(
+        // No app bar property provided yet.
+        body: CustomScrollView(
+          // Add the app bar and list of items as slivers in the next steps.
+          slivers: <Widget>[],
+        ),
       ),
     );
     // #enddocregion CustomScrollView

--- a/examples/cookbook/lists/floating_app_bar/lib/starter_material.dart
+++ b/examples/cookbook/lists/floating_app_bar/lib/starter_material.dart
@@ -7,7 +7,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     // #docregion CustomScrollView
     return const Scaffold(
-      // No appBar property provided, only the body.
+      // No app bar property provided yet.
       body: CustomScrollView(
         // Add the app bar and list of items as slivers in the next steps.
         slivers: <Widget>[],

--- a/examples/cookbook/lists/floating_app_bar/lib/step2_cupertino.dart
+++ b/examples/cookbook/lists/floating_app_bar/lib/step2_cupertino.dart
@@ -7,24 +7,22 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const title = 'Floating Navigation Bar';
-
-    return CupertinoApp(
-      title: title,
+    return const CupertinoApp(
+      title: 'Floating App Bar',
       home: CupertinoPageScaffold(
         // No navigation bar provided to CupertinoPageScaffold,
         // only a body with a CustomScrollView.
-        // #docregion SliverAppBar
         child: CustomScrollView(
+          // #docregion SliverAppBar
           slivers: [
             // Add the navigation bar to the CustomScrollView.
             const CupertinoSliverNavigationBar(
               // Provide a standard title.
-              largeTitle: Text(title),
+              largeTitle: Text('Floating App Bar'),
             ),
           ],
+          // #enddocregion SliverAppBar
         ),
-        // #enddocregion SliverAppBar
       ),
     );
   }

--- a/examples/cookbook/lists/floating_app_bar/lib/step2_cupertino.dart
+++ b/examples/cookbook/lists/floating_app_bar/lib/step2_cupertino.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/cupertino.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    const title = 'Floating Navigation Bar';
+
+    return CupertinoApp(
+      title: title,
+      home: CupertinoPageScaffold(
+        // No navigation bar provided to CupertinoPageScaffold,
+        // only a body with a CustomScrollView.
+        // #docregion SliverAppBar
+        child: CustomScrollView(
+          slivers: [
+            // Add the navigation bar to the CustomScrollView.
+            const CupertinoSliverNavigationBar(
+              // Provide a standard title.
+              largeTitle: Text(title),
+            ),
+          ],
+        ),
+        // #enddocregion SliverAppBar
+      ),
+    );
+  }
+}

--- a/examples/cookbook/lists/floating_app_bar/lib/step2_cupertino.dart
+++ b/examples/cookbook/lists/floating_app_bar/lib/step2_cupertino.dart
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
           // #docregion SliverAppBar
           slivers: [
             // Add the navigation bar to the CustomScrollView.
-            const CupertinoSliverNavigationBar(
+            CupertinoSliverNavigationBar(
               // Provide a standard title.
               largeTitle: Text('Floating App Bar'),
             ),

--- a/examples/cookbook/lists/floating_app_bar/lib/step2_material.dart
+++ b/examples/cookbook/lists/floating_app_bar/lib/step2_material.dart
@@ -7,33 +7,28 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const title = 'Floating App Bar';
-
     return const MaterialApp(
-      title: title,
+      title: 'Floating App Bar',
       home: Scaffold(
         // No appbar provided to the Scaffold, only a body with a
         // CustomScrollView.
-        // #docregion SliverAppBar
         body: CustomScrollView(
+          // #docregion SliverAppBar
           slivers: [
             // Add the app bar to the CustomScrollView.
             SliverAppBar(
               // Provide a standard title.
-              title: Text(title),
-              // Allows the user to reveal the app bar if they begin scrolling
+              title: Text('Floating App Bar'),
+              // Pin the app bar when scrolling.
               pinned: true,
-              // Allows the user to reveal the app bar if they begin scrolling
-              // back up the list of items.
-              floating: true,
               // Display a placeholder widget to visualize the shrinking size.
               flexibleSpace: Placeholder(),
               // Make the initial height of the SliverAppBar larger than normal.
               expandedHeight: 200,
             ),
           ],
+          // #enddocregion SliverAppBar
         ),
-        // #enddocregion SliverAppBar
       ),
     );
   }

--- a/examples/cookbook/lists/floating_app_bar/lib/step2_material.dart
+++ b/examples/cookbook/lists/floating_app_bar/lib/step2_material.dart
@@ -22,6 +22,8 @@ class MyApp extends StatelessWidget {
               // Provide a standard title.
               title: Text(title),
               // Allows the user to reveal the app bar if they begin scrolling
+              pinned: true,
+              // Allows the user to reveal the app bar if they begin scrolling
               // back up the list of items.
               floating: true,
               // Display a placeholder widget to visualize the shrinking size.

--- a/src/content/cookbook/lists/floating-app-bar.md
+++ b/src/content/cookbook/lists/floating-app-bar.md
@@ -1,6 +1,6 @@
 ---
 title: Place a floating app bar above a list
-description: How to place a floating app bar above a list.
+description: How to place a floating app bar or navigation bar above a list.
 js:
   - defer: true
     url: /assets/js/inject_dartpad.js
@@ -8,51 +8,57 @@ js:
 
 <?code-excerpt path-base="cookbook/lists/floating_app_bar/"?>
 
+This guide describes how to place a floating app bar or
+navigation bar above a list in a Flutter app.
+
+## Overview
+
 To make it easier for users to view a list of items,
-you might want to hide the app bar as the user scrolls down the list.
-This is especially true if your app displays a "tall"
-app bar that occupies a lot of vertical space.
+you might want to minimize the app bar (navigation bar), as
+the user scrolls down the list.
 
-Typically, you create an app bar by providing an `appBar` property to the
-`Scaffold` widget. This creates a fixed app bar that always remains above
-the `body` of the `Scaffold`.
+Moving the app bar into a [`CustomScrollView`][] allows you
+to create an app bar that can be minimized or scroll
+offscreen as you scroll through a list of items contained
+inside the `CustomScrollView`.
 
-Moving the app bar from a `Scaffold` widget into a
-[`CustomScrollView`][] allows you to create an app bar
-that scrolls offscreen as you scroll through a
-list of items contained inside the `CustomScrollView`.
-
-This recipe demonstrates how to use a `CustomScrollView` to display a list of
-items with an app bar on top that scrolls offscreen as the user scrolls
-down the list using the following steps:
+This recipe demonstrates how to use a `CustomScrollView` to
+display a list of items with an app bar on top that
+minimizes as the user scrolls down the list using the
+following steps:
 
   1. Create a `CustomScrollView`.
-  2. Use `SliverAppBar` to add a floating app bar.
-  3. Add a list of items using a `SliverList`.
+  2. Add a floating app bar to `CustomScrollView`.
+  3. Add a list of items to `CustomScrollView`.
 
 ## 1. Create a `CustomScrollView`
 
 To create a floating app bar, place the app bar inside a
 `CustomScrollView` that also contains the list of items.
-This synchronizes the scroll position of the app bar and the list of items.
-You might think of the `CustomScrollView` widget as a `ListView`
-that allows you to mix and match different types of scrollable lists
-and widgets together.
+This synchronizes the scroll position of the app bar and the
+list of items. You might think of the `CustomScrollView`
+widget as a `ListView` that allows you to mix and match
+different types of scrollable lists and widgets together.
 
 The scrollable lists and widgets provided to the
-`CustomScrollView` are known as _slivers_. There are several types
-of slivers, such as `SliverList`, `SliverGrid`, and `SliverAppBar`.
-In fact, the `ListView` and `GridView` widgets use the `SliverList` and
-`SliverGrid` widgets to implement scrolling.
+`CustomScrollView` are known as _slivers_. There are several
+types of slivers, such as `SliverList`, `SliverGrid`, and
+`SliverAppBar`. In fact, the `ListView` and `GridView`
+widgets use the `SliverList` and `SliverGrid` widgets to
+implement scrolling.
 
-For this example, create a `CustomScrollView` that contains a
-`SliverAppBar` and a `SliverList`. In addition, remove any app bars
-that you provide to the `Scaffold` widget.
+For this example, create a `CustomScrollView` that contains
+a `SliverList`. Also, remove the app bar property from your
+code if it exists.
 
-<?code-excerpt "lib/starter.dart (CustomScrollView)" replace="/^return const //g"?>
+{% tabs "device-type-tabs" %}
+
+{% tab "Material widgets" %}
+
+<?code-excerpt "lib/starter_material.dart (CustomScrollView)" replace="/^return const //g"?>
 ```dart
 Scaffold(
-  // No appBar property provided, only the body.
+  // No app bar property provided yet.
   body: CustomScrollView(
     // Add the app bar and list of items as slivers in the next steps.
     slivers: <Widget>[],
@@ -60,29 +66,55 @@ Scaffold(
 );
 ```
 
-### 2. Use `SliverAppBar` to add a floating app bar
+{% endtab %}
+
+{% tab "Cupertino widgets" %}
+
+<?code-excerpt "lib/starter_cupertino.dart (CustomScrollView)" replace="/^return const //g"?>
+```dart
+CupertinoApp(
+  home: CupertinoPageScaffold(
+    // No navigation bar property provided yet.
+    child: CustomScrollView(
+      // Add the navigation bar and list of items as slivers in the next steps.
+      slivers: <Widget>[],
+    ),
+  ),
+);
+```
+
+{% endtab %}
+
+{% endtabs %}
+
+
+## 2. Add a floating app bar
 
 Next, add an app bar to the [`CustomScrollView`][].
+
+{% tabs "device-type-tabs" %}
+
+{% tab "Material widgets" %}
+
 Flutter provides the [`SliverAppBar`][] widget which,
 much like the normal `AppBar` widget,
 uses the `SliverAppBar` to display a title,
 tabs, images and more.
 
-However, the `SliverAppBar` also gives you the ability to create a "floating"
-app bar that scrolls offscreen as the user scrolls down the list.
-Furthermore, you can configure the `SliverAppBar` to shrink and
-expand as the user scrolls.
+However, the `SliverAppBar` also gives you the ability to
+create a "floating" app bar that scrolls offscreen as the
+user scrolls down the list. Furthermore, you can configure
+the `SliverAppBar` to shrink and expand as the user scrolls.
 
 To create this effect:
 
   1. Start with an app bar that displays only a title.
+  2. Set the `pinned` property to `true`.
   2. Set the `floating` property to `true`.
-     This allows users to quickly reveal the app bar when
-     they scroll up the list.
   3. Add a `flexibleSpace` widget that fills the available
      `expandedHeight`.
 
-<?code-excerpt "lib/step2.dart (SliverAppBar)" replace="/^body: //g;/^\),$/)/g"?>
+<?code-excerpt "lib/step2_material.dart (SliverAppBar)" replace="/^body: //g;/^\),$/)/g"?>
 ```dart
 CustomScrollView(
   slivers: [
@@ -90,6 +122,8 @@ CustomScrollView(
     SliverAppBar(
       // Provide a standard title.
       title: Text(title),
+      // Allows the user to reveal the app bar if they begin scrolling
+      pinned: true,
       // Allows the user to reveal the app bar if they begin scrolling
       // back up the list of items.
       floating: true,
@@ -105,28 +139,66 @@ CustomScrollView(
 :::tip
 Play around with the
 [various properties you can pass to the `SliverAppBar` widget][],
-and use hot reload to see the results. For example, use an `Image`
-widget for the `flexibleSpace` property to create a background image that
-shrinks in size as it's scrolled offscreen.
+and use hot reload to see the results. For example, use an
+`Image` widget for the `flexibleSpace` property to create a
+background image that shrinks in size as it's scrolled
+offscreen.
 :::
 
+{% endtab %}
 
-### 3. Add a list of items using a `SliverList`
+{% tab "Cupertino widgets" %}
 
-Now that you have the app bar in place, add a list of items to the
-`CustomScrollView`. You have two options: a [`SliverList`][]
-or a [`SliverGrid`][].  If you need to display a list of items one after the other,
-use the `SliverList` widget.
-If you need to display a grid list, use the `SliverGrid` widget.
+Flutter provides the [`CupertinoSliverNavigationBar`][]
+widget, which you can use to add a navigation bar for your
+list. When used inside of a `CustomScrollView`,
+the title shrinks when you scroll down and floats when
+you're not at the top of the page.
 
-The `SliverList` and `SliverGrid` widgets take one required parameter: a
-[`SliverChildDelegate`][], which provides a list
-of widgets to `SliverList` or `SliverGrid`.
-For example, the [`SliverChildBuilderDelegate`][]
-allows you to create a list of items that are built lazily as you scroll,
-just like the `ListView.builder` widget.
+For this example, add `CupertinoSliverNavigationBar` to
+`CustomScrollView`.
 
-<?code-excerpt "lib/main.dart (SliverList)" replace="/^\),$/)/g"?>
+<?code-excerpt "lib/step2_cupertino.dart (SliverAppBar)" replace="/^body: //g;/^\),$/)/g"?>
+```dart
+child: CustomScrollView(
+  slivers: [
+    // Add the navigation bar to the CustomScrollView.
+    const CupertinoSliverNavigationBar(
+      // Provide a standard title.
+      largeTitle: Text(title),
+    ),
+  ],
+)
+```
+
+{% endtab %}
+
+{% endtabs %}
+
+
+## 3. Add a list of items
+
+Now that you have the app bar in place, add a list of items
+to the `CustomScrollView`. You have two options: a
+[`SliverList`][] or a [`SliverGrid`][].  If you need to
+display a list of items one after the other, use the
+`SliverList` widget. If you need to display a grid list, use
+the `SliverGrid` widget.
+
+The `SliverList` and `SliverGrid` widgets take one required
+parameter: a sliver delegate, which provides a
+list of widgets to `SliverList` or `SliverGrid`.
+
+There are many types of sliver delegates. In the following
+example, the [`SliverChildBuilderDelegate`][] is used to
+to create a list of items that are built lazily as you
+scroll, just like the `ListView.builder` widget.
+
+{% tabs "device-type-tabs" %}
+
+{% tab "Material widgets" %}
+
+<?code-excerpt "lib/main_material.dart (SliverList)" replace="/^\),$/)/g"?>
 ```dart
 // Next, create a SliverList
 SliverList(
@@ -135,16 +207,44 @@ SliverList(
     // The builder function returns a ListTile with a title that
     // displays the index of the current item.
     (context, index) => ListTile(title: Text('Item #$index')),
-    // Builds 1000 ListTiles
-    childCount: 1000,
+    // Builds 50 ListTiles
+    childCount: 50,
   ),
 )
 ```
 
+{% endtab %}
+
+{% tab "Cupertino widgets" %}
+
+<?code-excerpt "lib/main_cupertino.dart (SliverList)" replace="/^\),$/)/g"?>
+```dart
+// Next, create a SliverList
+SliverList(
+  // Use a delegate to build items as they're scrolled on screen.
+  delegate: SliverChildBuilderDelegate(
+    // The builder function returns a ListTile with a title that
+    // displays the index of the current item.
+    (context, index) =>
+        CupertinoListTile(title: Text('Item #$index')),
+    // Builds 50 ListTiles
+    childCount: 50,
+  ),
+)
+```
+
+{% endtab %}
+
+{% endtabs %}
+
 ## Interactive example
 
-<?code-excerpt "lib/main.dart"?>
-```dartpad title="Flutter Floating AppBar hands-on example in DartPad" run="true"
+{% tabs "device-type-tabs" %}
+
+{% tab "Material widgets" %}
+
+<?code-excerpt "lib/main_material.dart"?>
+```dartpad title="Flutter floating app bar hands-on example in DartPad" run="false"
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());
@@ -159,7 +259,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: title,
       home: Scaffold(
-        // No appbar provided to the Scaffold, only a body with a
+        // No app bar provided to Scaffold, only a body with a
         // CustomScrollView.
         body: CustomScrollView(
           slivers: [
@@ -167,6 +267,8 @@ class MyApp extends StatelessWidget {
             const SliverAppBar(
               // Provide a standard title.
               title: Text(title),
+              // Allows the user to reveal the app bar if they begin scrolling
+              pinned: true,
               // Allows the user to reveal the app bar if they begin scrolling
               // back up the list of items.
               floating: true,
@@ -182,8 +284,8 @@ class MyApp extends StatelessWidget {
                 // The builder function returns a ListTile with a title that
                 // displays the index of the current item.
                 (context, index) => ListTile(title: Text('Item #$index')),
-                // Builds 1000 ListTiles
-                childCount: 1000,
+                // Builds 50 ListTiles
+                childCount: 50,
               ),
             ),
           ],
@@ -195,10 +297,67 @@ class MyApp extends StatelessWidget {
 ```
 
 <noscript>
-  <img src="/assets/images/docs/cookbook/floating-app-bar.gif" alt="Use list demo" class="site-mobile-screenshot"/> 
+  <img src="/assets/images/docs/cookbook/floating-app-bar.gif" alt="Use floating app bar demo" class="site-mobile-screenshot"/> 
 </noscript>
 
+{% endtab %}
 
+{% tab "Cupertino widgets" %}
+
+<?code-excerpt "lib/main_cupertino.dart"?>
+```dartpad title="Flutter floating navigation bar hands-on example in DartPad" run="false"
+import 'package:flutter/cupertino.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    const title = 'Floating Navigation Bar';
+
+    return CupertinoApp(
+      title: title,
+      home: CupertinoPageScaffold(
+        // No navigation bar provided to CupertinoPageScaffold,
+        // only a body with a CustomScrollView.
+        child: CustomScrollView(
+          slivers: [
+            // Add the navigation bar to the CustomScrollView.
+            const CupertinoSliverNavigationBar(
+              // Provide a standard title.
+              largeTitle: Text(title),
+            ),
+            // Next, create a SliverList
+            SliverList(
+              // Use a delegate to build items as they're scrolled on screen.
+              delegate: SliverChildBuilderDelegate(
+                // The builder function returns a ListTile with a title that
+                // displays the index of the current item.
+                (context, index) =>
+                    CupertinoListTile(title: Text('Item #$index')),
+                // Builds 50 ListTiles
+                childCount: 50,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+```
+
+<noscript>
+  <img src="/assets/images/docs/cookbook/floating-app-bar.gif" alt="Use floating nav bar demo" class="site-mobile-screenshot"/> 
+</noscript>
+
+{% endtab %}
+
+{% endtabs %}
+
+[`CupertinoSliverNavigationBar`]: {{site.api}}/flutter/cupertino/CupertinoSliverNavigationBar-class.html
 [`CustomScrollView`]: {{site.api}}/flutter/widgets/CustomScrollView-class.html
 [`SliverAppBar`]: {{site.api}}/flutter/material/SliverAppBar-class.html
 [`SliverChildBuilderDelegate`]: {{site.api}}/flutter/widgets/SliverChildBuilderDelegate-class.html

--- a/src/content/cookbook/lists/floating-app-bar.md
+++ b/src/content/cookbook/lists/floating-app-bar.md
@@ -207,12 +207,12 @@ SliverList.builder(
 ```dart
 // Next, create a SliverList
 SliverList.builder(
-  // The builder function returns a ListTile with a title that
-  // displays the index of the current item.
+  // The builder function returns a CupertinoListTile with a title
+  // that displays the index of the current item.
   itemBuilder:
       (context, index) =>
           CupertinoListTile(title: Text('Item #$index')),
-  // Builds 50 ListTiles
+  // Builds 50 CupertinoListTile
   itemCount: 50,
 )
 ```
@@ -310,12 +310,12 @@ class MyApp extends StatelessWidget {
             ),
             // Next, create a SliverList
             SliverList.builder(
-              // The builder function returns a ListTile with a title that
-              // displays the index of the current item.
+              // The builder function returns a CupertinoListTile with a title
+              // that displays the index of the current item.
               itemBuilder:
                   (context, index) =>
                       CupertinoListTile(title: Text('Item #$index')),
-              // Builds 50 ListTiles
+              // Builds 50 CupertinoListTile
               itemCount: 50,
             ),
           ],

--- a/src/content/cookbook/lists/floating-app-bar.md
+++ b/src/content/cookbook/lists/floating-app-bar.md
@@ -57,11 +57,14 @@ code if it exists.
 
 <?code-excerpt "lib/starter_material.dart (CustomScrollView)" replace="/^return const //g"?>
 ```dart
-Scaffold(
-  // No app bar property provided yet.
-  body: CustomScrollView(
-    // Add the app bar and list of items as slivers in the next steps.
-    slivers: <Widget>[],
+MaterialApp(
+  title: 'Floating App Bar',
+  home: Scaffold(
+    // No app bar property provided yet.
+    body: CustomScrollView(
+      // Add the app bar and list of items as slivers in the next steps.
+      slivers: <Widget>[],
+    ),
   ),
 );
 ```
@@ -73,6 +76,7 @@ Scaffold(
 <?code-excerpt "lib/starter_cupertino.dart (CustomScrollView)" replace="/^return const //g"?>
 ```dart
 CupertinoApp(
+  title: 'Floating Navigation Bar',
   home: CupertinoPageScaffold(
     // No navigation bar property provided yet.
     child: CustomScrollView(
@@ -102,38 +106,31 @@ uses the `SliverAppBar` to display a title,
 tabs, images and more.
 
 However, the `SliverAppBar` also gives you the ability to
-create a "floating" app bar that scrolls offscreen as the
-user scrolls down the list. Furthermore, you can configure
-the `SliverAppBar` to shrink and expand as the user scrolls.
+create a "floating" app bar that shrinks and floats when
+you're not at the top of the page.
 
 To create this effect:
 
   1. Start with an app bar that displays only a title.
   2. Set the `pinned` property to `true`.
-  2. Set the `floating` property to `true`.
   3. Add a `flexibleSpace` widget that fills the available
      `expandedHeight`.
 
 <?code-excerpt "lib/step2_material.dart (SliverAppBar)" replace="/^body: //g;/^\),$/)/g"?>
 ```dart
-CustomScrollView(
-  slivers: [
-    // Add the app bar to the CustomScrollView.
-    SliverAppBar(
-      // Provide a standard title.
-      title: Text(title),
-      // Allows the user to reveal the app bar if they begin scrolling
-      pinned: true,
-      // Allows the user to reveal the app bar if they begin scrolling
-      // back up the list of items.
-      floating: true,
-      // Display a placeholder widget to visualize the shrinking size.
-      flexibleSpace: Placeholder(),
-      // Make the initial height of the SliverAppBar larger than normal.
-      expandedHeight: 200,
-    ),
-  ],
-)
+slivers: [
+  // Add the app bar to the CustomScrollView.
+  SliverAppBar(
+    // Provide a standard title.
+    title: Text('Floating App Bar'),
+    // Pin the app bar when scrolling.
+    pinned: true,
+    // Display a placeholder widget to visualize the shrinking size.
+    flexibleSpace: Placeholder(),
+    // Make the initial height of the SliverAppBar larger than normal.
+    expandedHeight: 200,
+  ),
+],
 ```
 
 :::tip
@@ -150,25 +147,25 @@ offscreen.
 {% tab "Cupertino widgets" %}
 
 Flutter provides the [`CupertinoSliverNavigationBar`][]
-widget, which you can use to add a navigation bar for your
-list. When used inside of a `CustomScrollView`,
-the title shrinks when you scroll down and floats when
+widget, which lets you have a "floating" navigation
+bar that shrinks when you scroll down and floats when
 you're not at the top of the page.
 
-For this example, add `CupertinoSliverNavigationBar` to
-`CustomScrollView`.
+To create this effect: 
+
+  1. Add `CupertinoSliverNavigationBar` to
+     `CustomScrollView`. 
+  2. Start with an app bar that displays only a title.
 
 <?code-excerpt "lib/step2_cupertino.dart (SliverAppBar)" replace="/^body: //g;/^\),$/)/g"?>
 ```dart
-child: CustomScrollView(
-  slivers: [
-    // Add the navigation bar to the CustomScrollView.
-    const CupertinoSliverNavigationBar(
-      // Provide a standard title.
-      largeTitle: Text(title),
-    ),
-  ],
-)
+slivers: [
+  // Add the navigation bar to the CustomScrollView.
+  const CupertinoSliverNavigationBar(
+    // Provide a standard title.
+    largeTitle: Text('Floating App Bar'),
+  ),
+],
 ```
 
 {% endtab %}
@@ -185,15 +182,6 @@ display a list of items one after the other, use the
 `SliverList` widget. If you need to display a grid list, use
 the `SliverGrid` widget.
 
-The `SliverList` and `SliverGrid` widgets take one required
-parameter: a sliver delegate, which provides a
-list of widgets to `SliverList` or `SliverGrid`.
-
-There are many types of sliver delegates. In the following
-example, the [`SliverChildBuilderDelegate`][] is used to
-to create a list of items that are built lazily as you
-scroll, just like the `ListView.builder` widget.
-
 {% tabs "device-type-tabs" %}
 
 {% tab "Material widgets" %}
@@ -201,15 +189,13 @@ scroll, just like the `ListView.builder` widget.
 <?code-excerpt "lib/main_material.dart (SliverList)" replace="/^\),$/)/g"?>
 ```dart
 // Next, create a SliverList
-SliverList(
-  // Use a delegate to build items as they're scrolled on screen.
-  delegate: SliverChildBuilderDelegate(
-    // The builder function returns a ListTile with a title that
-    // displays the index of the current item.
-    (context, index) => ListTile(title: Text('Item #$index')),
-    // Builds 50 ListTiles
-    childCount: 50,
-  ),
+SliverList.builder(
+  // The builder function returns a ListTile with a title that
+  // displays the index of the current item.
+  itemBuilder:
+      (context, index) => ListTile(title: Text('Item #$index')),
+  // Builds 50 ListTiles
+  itemCount: 50,
 )
 ```
 
@@ -220,16 +206,14 @@ SliverList(
 <?code-excerpt "lib/main_cupertino.dart (SliverList)" replace="/^\),$/)/g"?>
 ```dart
 // Next, create a SliverList
-SliverList(
-  // Use a delegate to build items as they're scrolled on screen.
-  delegate: SliverChildBuilderDelegate(
-    // The builder function returns a ListTile with a title that
-    // displays the index of the current item.
-    (context, index) =>
-        CupertinoListTile(title: Text('Item #$index')),
-    // Builds 50 ListTiles
-    childCount: 50,
-  ),
+SliverList.builder(
+  // The builder function returns a ListTile with a title that
+  // displays the index of the current item.
+  itemBuilder:
+      (context, index) =>
+          CupertinoListTile(title: Text('Item #$index')),
+  // Builds 50 ListTiles
+  itemCount: 50,
 )
 ```
 
@@ -267,26 +251,21 @@ class MyApp extends StatelessWidget {
             const SliverAppBar(
               // Provide a standard title.
               title: Text(title),
-              // Allows the user to reveal the app bar if they begin scrolling
+              // Pin the app bar when scrolling
               pinned: true,
-              // Allows the user to reveal the app bar if they begin scrolling
-              // back up the list of items.
-              floating: true,
               // Display a placeholder widget to visualize the shrinking size.
               flexibleSpace: Placeholder(),
               // Make the initial height of the SliverAppBar larger than normal.
               expandedHeight: 200,
             ),
             // Next, create a SliverList
-            SliverList(
-              // Use a delegate to build items as they're scrolled on screen.
-              delegate: SliverChildBuilderDelegate(
-                // The builder function returns a ListTile with a title that
-                // displays the index of the current item.
-                (context, index) => ListTile(title: Text('Item #$index')),
-                // Builds 50 ListTiles
-                childCount: 50,
-              ),
+            SliverList.builder(
+              // The builder function returns a ListTile with a title that
+              // displays the index of the current item.
+              itemBuilder:
+                  (context, index) => ListTile(title: Text('Item #$index')),
+              // Builds 50 ListTiles
+              itemCount: 50,
             ),
           ],
         ),
@@ -330,16 +309,14 @@ class MyApp extends StatelessWidget {
               largeTitle: Text(title),
             ),
             // Next, create a SliverList
-            SliverList(
-              // Use a delegate to build items as they're scrolled on screen.
-              delegate: SliverChildBuilderDelegate(
-                // The builder function returns a ListTile with a title that
-                // displays the index of the current item.
-                (context, index) =>
-                    CupertinoListTile(title: Text('Item #$index')),
-                // Builds 50 ListTiles
-                childCount: 50,
-              ),
+            SliverList.builder(
+              // The builder function returns a ListTile with a title that
+              // displays the index of the current item.
+              itemBuilder:
+                  (context, index) =>
+                      CupertinoListTile(title: Text('Item #$index')),
+              // Builds 50 ListTiles
+              itemCount: 50,
             ),
           ],
         ),

--- a/src/content/cookbook/lists/floating-app-bar.md
+++ b/src/content/cookbook/lists/floating-app-bar.md
@@ -161,7 +161,7 @@ To create this effect:
 ```dart
 slivers: [
   // Add the navigation bar to the CustomScrollView.
-  const CupertinoSliverNavigationBar(
+  CupertinoSliverNavigationBar(
     // Provide a standard title.
     largeTitle: Text('Floating App Bar'),
   ),


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

- Added code sample for a Cupertino floating navigation bar (thanks @loic-sharma!)
- Added Cupertino code excerpts.
- Updated the Material code example to pin the app bar, but in a minimized style (matches Cupertino example and looks nice, imo)
- Added tabs & moved Material and Cupertino specific content into tabs.
- In some cases, I reduced text in the intro section to be style agnostic.
- Moved some content into an Overview so that we can easily get to that content through the right-pane TOC.

Note: It's not easy to tell when content belongs to a tab. We might consider adding some shading back to our tabs. Just a thought for the future.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
