### PR TITLE
Add index of platform vulnerabilities that Flutter developers should be aware of

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -860,6 +860,8 @@
     - title: Reference
       permalink: /reference
       children:
+        - title: Platform Vulnerabilities
+          permalink: /reference/vulnerabilities
         - title: Who is Dash?
           permalink: /dash
         - title: Widget index

--- a/src/content/reference/supported-platforms.md
+++ b/src/content/reference/supported-platforms.md
@@ -4,6 +4,10 @@ short-title: Supported platforms
 description: The platforms that Flutter supports by platform version.
 ---
 
+**Note**: For important security considerations related to different platforms
+and SDK versions, please refer to the [Platform Vulnerabilities][]
+documentation.
+
 As of Flutter {{site.appnow.flutter}},
 Flutter supports deploying apps on the following combinations of
 hardware architectures and operating system versions.
@@ -27,3 +31,5 @@ Flutter supports deploying to the following platforms.
 {%- endfor %}
 
 {:.table .table-striped}
+
+[Platform Vulnerabilities]: /reference/vulnerabilities

--- a/src/content/reference/vulnerabilities.md
+++ b/src/content/reference/vulnerabilities.md
@@ -1,0 +1,31 @@
+---
+title: Platform Vulnerabilities
+description: Known vulnerabilities and important considerations for Flutter developers on different platforms and versions.
+---
+
+**Important**: The list of supported platforms and versions below is not
+exhaustive and may change over time with new platform updates. Developers
+should always refer to the most up-to-date official documentation for the
+specific platform they are targeting.
+
+## Android
+
+* **StrandHogg Attack / Task Affinity Vulnerability**
+    * **Description**: On Android SDK versions less than 30
+     (Android 11), a vulnerability related to "taskAffinity" allowed
+     malicious applications to potentially intercept user interactions
+     and data from legitimate applications running in the foreground.
+     This attack, known as StrandHogg, could occur when a malicious app
+     with a carefully crafted taskAffinity was launched and then brought
+     to the foreground, potentially masking itself as the legitimate app.
+    * **Affected Versions**: Android SDK versions < 30 (Android 10 and below).
+    * **Impact**: Potential interception of sensitive data (e.g., login
+    credentials, personal information), unauthorized actions performed on
+    behalf of the user.
+    * **Mitigation**:
+        * **Target SDK Version 30 or higher**: Setting `minSdkVersion` to 30
+        or higher on Android projects applies restrictions that mitigate this
+        vulnerability. Android 11 introduced changes to how tasks are managed,
+        limiting the ability of apps to manipulate task affinity in this way.
+    * **References**:
+        * <https://developer.android.com/privacy-and-security/risks/strandhogg>


### PR DESCRIPTION
Adds documentation for an Android specific vulnerability ([StrandHogg](https://developer.android.com/privacy-and-security/risks/strandhogg) in a new index of platform-specific vulnerabilities.

Resolves https://github.com/flutter/website/issues/11828

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
