### PR TITLE
Fix broken links on `describeEnum` migration guide

### DIFF
--- a/src/content/release/breaking-changes/describe-enum.md
+++ b/src/content/release/breaking-changes/describe-enum.md
@@ -89,8 +89,8 @@ Relevant PRs:
 
 * [Deprecate `describeEnum` PR][]
 
-[`describeEnum`]: {{site.api}}/flutter/lib/src/foundation/describeEnum.html
-[`EnumProperty`]: {{site.api}}/flutter/lib/src/foundation/EnumProperty.html
+[`describeEnum`]: {{site.api}}/flutter/foundation/describeEnum.html
+[`EnumProperty`]: {{site.api}}/flutter/foundation/EnumProperty-class.html
 
 [Cleanup SemanticsFlag and SemanticsAction issue]: {{site.repo.flutter}}/issues/123346
 [Deprecate `describeEnum` PR]: {{site.repo.flutter}}/pull/125016


### PR DESCRIPTION
Updated `describe-enum.md` to fix broken reference hyperlinks.

Fixes #11826 

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
