### PR TITLE
Enhance pubspec guide

### DIFF
--- a/src/content/tools/pubspec.md
+++ b/src/content/tools/pubspec.md
@@ -302,68 +302,13 @@ a Flutter Android app, see
 ### disable-swift-package-manager field
 
 Disable the use of the Swift Package Manager (SPM) so that
-it no longer manages dependencies in your iOS Flutter
-project.
+it no longer manages dependencies in your iOS and macOS
+Flutter projects.
 
 ```yaml title="pubspec.yaml"
 flutter:
   disable-swift-package-manager: true
 ```
-
-### flavors field
-
-Include flavor-specific data in your Flutter app.
-
-The `flavors` field has this structure:
-
-```yaml title="pubspec.yaml"
-flutter:
-  flavors:
-    [flavor_field]
-    [...]
-```
-
-```yaml
-# flavor_field structure
-my_flavor:
-  name: string_expression
-  bundle_id: string_expression # Optional
-  android: # Optional
-    application_id: string_expression
-```
-
-Flavor-specific subfields:
-
-* `my_flavor`: Replace this with the flavor ID.
-* `name`: The name of the flavor.
-* `bundle_id`: Optional. The iOS bundle identifier for the
-  flavor.
-* `android`: Optional. Contains Android settings.
-* `application_id`: The Android application ID for the
-  flavor.
-
-Bundle flavor-specific data with two flavors of
-your app. For example:
-
-```yaml title="pubspec.yaml"
-flutter:
-  flavors:
-    staging:
-      name: 'My App (Staging)'
-      bundle_id: 'com.example.myapp.staging'
-      android:
-        application_id: 'com.example.myapp.staging'
-    production:
-      name: 'My App (Production)'
-      bundle_id: 'com.example.myapp.production'
-      android:
-        application_id: 'com.example.myapp.production'  
-```
-
-To learn more about flavors, see
-[Set up Flutter flavors for Android][]
-
-[Set up Flutter flavors for Android]: /deployment/flavors
 
 ### flutter field
 
@@ -468,37 +413,6 @@ Enable general localization:
 ```yaml title="pubspec.yaml"
 flutter:
   generate: true
-```
-
-Enable general localization and Material Design
-localization:
-
-```yaml title="pubspec.yaml"
-flutter:
-  generate: true
-  material:
-    generate: true
-```
-
-### material field
-
-Enable Material Design localization. This works with the
-`ARB` localization files.
-
-```yaml title="pubspec.yaml"
-flutter:
-  material:
-    generate: true
-```
-
-Enable general localization and Material Design
-localization:
-
-```yaml title="pubspec.yaml"
-flutter:
-  generate: true
-  material:
-    generate: true
 ```
 
 ### plugin field

--- a/src/content/tools/pubspec.md
+++ b/src/content/tools/pubspec.md
@@ -169,8 +169,7 @@ Subfields of `assets`:
   subfields.
 * `path`: The path to a directory.
 * `flavors`: A list of flutter flavors to use with assets
-  at a specific path. Currently, this works with
-  Android-specific Flutter flavors. To learn more about
+  at a specific path. To learn more about
   flavors, see [Set up flavors for iOS and macOS] and
   [Set up flavors for Android].
 

--- a/src/content/tools/pubspec.md
+++ b/src/content/tools/pubspec.md
@@ -214,9 +214,9 @@ flutter:
 
 ### default-flavor field
 
-Assign a default Flutter flavor for an Android app.
+Assign a default Flutter flavor for an app.
 When used, you don't need to include the name of this
-flavor in Flutter build command.
+flavor in Flutter launch command.
 
 ```yaml title="pubspec.yaml"
 flutter:
@@ -225,8 +225,8 @@ flutter:
 
 In the following example, an Android Flutter app has a
 flavor called `staging` and `production`. The `production`
-flavor is the default flavor. When that flavor is built,
-you don't need to include it in the build command.
+flavor is the default flavor. When that flavor is run,
+you don't need to include it in the launch command.
 
 ```yaml title="pubspec.yaml"
 flutter:
@@ -234,17 +234,19 @@ flutter:
 ```
 
 ```console title="console"
-// Use this command to build the default flavor (production).
-flutter build --flavor
+// Use this command to run the default flavor (production).
+flutter run
 
-// Use this command to build non-default flavors (staging).
-flutter build --flavor staging
+// Use this command to run non-default flavors (staging).
+flutter run --flavor staging
 ```
 
-To learn how to create Flutter flavors for Android apps,
-see [Set up Flutter flavors for Android][]
+To learn how to create Flutter flavors,
+see [Set up Flutter flavors for Android][] and
+[Set up Flutter flavors for iOS and macOS][].
 
 [Set up Flutter flavors for Android]: /deployment/flavors
+[Set up Flutter flavors for iOS and macOS]: /deployment/flavors-ios
 
 ### deferred-components field
 
@@ -530,16 +532,16 @@ The `plugin` field has this structure:
 flutter:
   plugin:
     platforms:
-      platform_type: # Optional
-        package: com.example.my_plugin # Platform-specific
-        pluginClass: MyPlugin # Platform-specific, optional
-        dartPluginClass: MyPluginClassName # Platform-specific, optional
-        ffiPlugin: true # Optional
-        default_package: my_plugin_name # Optional
-        fileName: hello_web.dart # Optional
-        sharedDarwinSource: true # Platform-specific, optional
+      [android | ios | linux | macos | windows | web]:
+        package: com.example.my_plugin
+        pluginClass: MyPlugin
+        dartPluginClass: MyPluginClassName
+        ffiPlugin: true
+        default_package: my_plugin_name
+        fileName: hello_web.dart
+        sharedDarwinSource: true
       [...]
-    implements: # Optional
+    implements:
       - example_platform_interface
 ```
 
@@ -548,16 +550,13 @@ Subfields of `plugin`:
 * `platforms`: A list of platforms that will have
   configuration settings.
 
-* `platform_type`: Replace with the platform name. This
-  can be `android`, `ios`, `linux`, `macos`, `windows` or
-  `web`.
-
-* `package`: The Android package name of the plugin.
+* `package`: The Android package name of the plugin. This
+  can be used with the Android platform and is required.
 
 * `pluginClass`: The name of the plugin class. Optional if
   `dartPluginClass` is used for the same platform. This
-  can be used with the Android, iOS, Linux macOS, Windows
-  platforms.
+  can be used with the Android, iOS, Linux macOS, and
+  Windows platforms.
 
 * `default_package`: Optional. The package that should be
   used as the default implementation of a platform
@@ -567,8 +566,8 @@ Subfields of `plugin`:
 
 * `dartPluginClass`: Optional. The Dart class that serves
   as the entry point for a Flutter plugin. This
-  can be used with the Android, iOS, Linux macOS, Windows
-  platforms.
+  can be used with the Android, iOS, Linux macOS, and
+  Windows platforms.
 
 * `sharedDarwinSource`: Optional. Indicates that the plugin
   shares native code between iOS and macOS. This

--- a/src/content/tools/pubspec.md
+++ b/src/content/tools/pubspec.md
@@ -1,15 +1,15 @@
 ---
-title: "Flutter and the pubspec file"
+title: "Flutter pubspec options"
 description: "Describes the Flutter-only fields in the pubspec file."
 ---
 
-:::note
 This page is primarily aimed at folks who write
 Flutter apps. If you write packages or plugins, 
 (perhaps you want to create a federated plugin),
 you should check out the
 [Developing packages and plugins][] page.
-:::
+
+## Overview
 
 Every Flutter project includes a `pubspec.yaml` file,
 often referred to as _the pubspec_.
@@ -21,46 +21,45 @@ needs to know. The pubspec is written in
 [YAML][], which is human readable, but be aware
 that _white space (tabs v spaces) matters_.
 
-[YAML]: https://yaml.org/
+The pubspec specifies dependencies
+that the project requires, such as:
 
-The pubspec file specifies dependencies
-that the project requires, such as particular packages
-(and their versions), fonts, or image files.
-It also specifies other requirements, such as 
-dependencies on developer packages (like
-testing or mocking packages), or particular
-constraints on the version of the Flutter SDK. 
++ Particular packages and their versions
++ Fonts
++ Images
++ Developer packages (like testing or mocking packages)
++ Particular constraints on the version of the Flutter SDK
 
 Fields common to both Dart and Flutter projects
 are described in [the pubspec file][] on [dart.dev][].
-This page lists _Flutter-specific_ fields
+This page lists _Flutter-specific_ fields and packages
 that are only valid for a Flutter project.
 
-:::note
-The first time you build your project, it
-creates a `pubspec.lock` file that contains
-specific versions of the included packages.
-This ensures that you get the same version
-the next time the project is built.
-:::
-
+[YAML]: https://yaml.org/
 [the pubspec file]: {{site.dart-site}}/tools/pub/pubspec
 [dart.dev]: {{site.dart-site}}
+
+## Example
 
 When you create a new project with the
 `flutter create` command (or by using the
 equivalent button in your IDE), it creates
 a pubspec for a basic Flutter app.
 
-Here is an example of a Flutter project pubspec file.
-The Flutter only fields are highlighted.
+The first time you build your project, it
+also creates a `pubspec.lock` file that contains
+specific versions of the included packages.
+This ensures that you get the same version
+the next time the project is built.
 
-```yaml
+Here is an example of a Flutter project pubspec file.
+The Flutter-only fields and packages are highlighted.
+
+```yaml title="pubspec.yaml"
 name: <project name>
 description: A new Flutter project.
 
 publish_to: none
-
 version: 1.0.0+1
 
 environment:
@@ -102,13 +101,28 @@ dev_dependencies:
         [!- asset: fonts/TrajanPro_Bold.ttf!]
           [!weight: 700!]
 ```
- 
-## Assets
 
-Common types of assets include static data
-(for example, JSON files), configuration files,
-icons, and images (JPEG, WebP, GIF,
-animated WebP/GIF, PNG, BMP, and WBMP).
+## Fields
+
+Flutter-specific and Dart-specific fields can be added to
+the Flutter pubspec. To learn more about Flutter-specific
+fields, see the following sections. To learn more about
+Dart-specific fields, see [Dart's pubspec supported fields][]. 
+
+:::note
+The pubspec can have additional auto-generated Flutter
+fields that are not listed here.
+:::
+
+[Dart's pubspec supported fields]: {{site.dart-site}}/tools/pub/pubspec#supported-fields
+
+### assets field {: #assets }
+
+A list of asset paths that your app uses. These assets are
+bundled with your application. Common types of assets
+include static data (for example, `JSON`),
+configuration files, icons, and images (`JPEG`, `WebP`,
+`GIF`, animated `WebP/GIF`, `PNG`, `BMP`, and `WBMP`).
 
 Besides listing the images that are included in the
 app package, an image asset can also refer to one or more
@@ -120,26 +134,484 @@ dependencies, see the
 [asset images in package dependencies][]
 section in the same page.
 
+The `asset` field has this structure:
+
+```yaml
+flutter:
+  assets:
+    - { path_to_file | path_to_directory | flavor_path_field }
+    [...]
+```
+
+```yaml
+# path_to_file structure
+- path/to/directory/file
+```
+
+```yaml
+# path_to_directory structure
+- path/to/directory/
+```
+```yaml
+# flavor_path_field strucure
+- path: path/to/directory
+  flavors:
+  - flavor_name
+```
+
+Subfields of `assets`:
+
+* `path_to_file`: A string that represents the path to
+  a file.
+* `path_to_directory`: A string that represents the path to
+  a directory.
+* `flavor_path_field`: A path field and its flavor
+  subfields.
+* `path`: The path to a directory.
+* `flavors`: A list of flutter flavors to use with assets
+  at a specific path. Currently, this works with
+  Android-specific Flutter flavors. To learn more about
+  flavors, see [Set up flavors for iOS and macOS] and
+  [Set up flavors for Android].
+
+You can pass in a path to a file:
+
+```yaml
+flutter:
+  assets:
+    - assets/images/my_image_a.png
+    - assets/images/my_image_b.png
+```
+
+You can pass in a path to a directory:
+
+```yaml
+flutter:
+  assets:
+    - assets/images/
+    - assets/icons/
+```
+
+You can pass in a path to a directory for specific
+flavors:
+
+```yaml
+flutter:
+  assets:
+    - path: assets/flavor_a_and_b/images
+      flavors:
+      - flavor_a
+      - flavor_b
+    - path: assets/flavor_c/images
+      flavors:
+      - flavor_c
+```
+
+[Set up flavors for iOS and macOS]: /deployment/flavors-ios
+[Set up flavors for Android]: /deployment/flavors
 [Assets and images]: /ui/assets/assets-and-images
 [asset images in package dependencies]: /ui/assets/assets-and-images#from-packages
 [resolution aware]: /ui/assets/assets-and-images#resolution-aware
 
-## Fonts
+### disable-swift-package-manager field
 
-As shown in the above example,
-each entry in the fonts section should have a
-`family` key with the font family name,
-and a `fonts` key with a list specifying the
-asset and other descriptors for the font.
+Disable the use of the Swift Package Manager (SPM) so that
+it no longer manages dependencies in your iOS Flutter
+project.
+
+```yaml
+flutter:
+  disable-swift-package-manager: true
+```
+
+### flavors field
+
+Include flavor-specific data in your Flutter app.
+
+The `flavors` field has this structure:
+
+```yaml
+flutter:
+  flavors:
+    [flavor_field]
+    [...]
+```
+
+```yaml
+# flavor_field structure
+my_flavor:
+  name: string_expression
+  bundle_id: string_expression # Optional
+  android: # Optional
+    application_id: string_expression
+```
+
+Flavor-specific subfields:
+
+* `my_flavor`: Replace this with the flavor ID.
+* `name`: The name of the flavor.
+* `bundle_id`: Optional. The iOS bundle identifier for the
+  flavor.
+* `android`: Optional. Contains Android settings.
+* `application_id`: The Android application ID for the
+  flavor.
+
+Bundle flavor-specific data with two flavors of
+your app. For example:
+
+```yaml
+flutter:
+  flavors:
+    staging:
+      name: 'My App (Staging)'
+      bundle_id: 'com.example.myapp.staging'
+      android:
+        application_id: 'com.example.myapp.staging'
+    production:
+      name: 'My App (Production)'
+      bundle_id: 'com.example.myapp.production'
+      android:
+        application_id: 'com.example.myapp.production'  
+```
+
+To learn more about flavors, see
+[Set up Flutter flavors for Android][]
+
+[Set up Flutter flavors for Android]: /deployment/flavors
+
+### flutter field
+
+A field that contains Flutter-specific settings for your
+app.
+
+```yaml
+flutter:
+  [flutter_field]
+  [...]
+```
+
+### fonts field {: #fonts }
+
+Configure and include custom fonts in your Flutter
+application.
 
 For examples of using fonts
 see the [Use a custom font][] and
 [Export fonts from a package][] recipes in the
 [Flutter cookbook][].
 
+The `fonts` field has this structure:
+
+```yaml
+flutter:
+  fonts:
+    -  { font_family_field | font_asset_field }
+    [...]
+```
+
+```yaml
+# font_family_field structure
+- family: font_name
+      fonts:
+        - font_asset_field
+        [...]
+```
+
+```yaml
+# font_asset_field structure
+- asset: path/to/directory/font_name
+  weight: int_expression # Optional
+  style: string_expression # Optional
+```
+
+Subfields of `fonts`:
+
++ `family`: Optional. The font family name. Can have
+  multiple font assets.
++ `asset`: The font to use.
++ `weight`: Optional. The weight of the font. This can be
+  `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800` or
+  `900`.
++ `style`: Optional. The style of the font. This can be
+  `italic`.
+
+Use a font that is not part of a font family:
+
+```yaml
+flutter:
+  fonts:
+    - asset: fonts/Roboto-Regular.ttf
+      weight: 900 # Optional
+      style: italic # Optional  
+```
+
+Use a font family:
+
+```yaml
+flutter:
+  fonts:
+  - family: Roboto # Optional
+        fonts:
+          - asset: fonts/Roboto-Regular.ttf
+          - asset: fonts/Roboto-Bold.ttf
+            weight: 700 # Optional
+            style: italic # Optional
+```
+
+Alternatively, if you have a font that requires no family,
+weight or style requirements, you can declare it as a simple
+asset:
+
+```yaml
+flutter:
+  assets:
+    - fonts/Roboto-Regular.ttf
+```
+
 [Export fonts from a package]: /cookbook/design/package-fonts
 [Flutter cookbook]: /cookbook
 [Use a custom font]: /cookbook/design/fonts
+
+### generate field
+
+Handles localization tasks. This field can appear as a
+subfield of `flutter` and `material`.
+
+Enable general localization:
+
+```yaml
+flutter:
+  generate: true
+```
+
+Enable general localization and Material Design
+localization:
+
+```yaml
+flutter:
+  generate: true
+  material:
+    generate: true
+```
+
+### material field
+
+Enable Material Design localization. This works with the
+`ARB` localization files.
+
+```yaml
+flutter:
+  material:
+    generate: true
+```
+
+Enable general localization and Material Design
+localization:
+
+```yaml
+flutter:
+  generate: true
+  material:
+    generate: true
+```
+
+### module field
+
+Add this field if you are creating a Flutter module to
+embed in an existing native Android or iOS app. If you are
+building a standalone Flutter application, you don't need
+this field.
+
+```yaml
+flutter:
+  module:
+    androidX: true # Optional
+    androidPackage: com.example.my_module # Optional
+    iosSwiftVersion: '5.0' # Optional
+    iosBundleIdentifier: com.example.myModule # Optional
+```
+
+Subfields of `module`:
+
+* `androidX`: Optional. A boolean value that indicates
+  whether the Flutter module should use AndroidX libraries.
+* `androidPackage`: Optional. The package name of the
+  android module.
+* `iosSwiftVersion`: Optional. The minimum Swift version
+  that the iOS part of the Flutter module supports.
+* `iosBundleIdentifier`: Optional. The bundle identifier for
+  the iOS module.
+
+### plugin field
+
+Configure settings specifically for Flutter plugins.
+
+```yaml
+flutter:
+  plugin:
+    platforms:
+      android: # Optional
+        package: com.example.my_plugin
+        pluginClass: MyPlugin
+      ios: # Optional
+        pluginClass: MyPlugin
+      linux: # Optional
+        pluginClass: MyPlugin
+      macos: # Optional
+        pluginClass: MyPlugin
+      windows: # Optional
+        pluginClass: MyPlugin
+      web: # Optional
+        default_package: my_plugin_web
+```
+
+Subfields of `plugin`:
+
+* `platforms`: A list of platforms that will have
+  configuration settings.
+* `android`: Optional. The configurations settings for
+  Android.
+* `ios`: Optional. The configurations settings for iOS.
+* `linux`: Optional. The configurations settings for Linux.
+* `macos`: Optional. The configurations settings for macOS.
+* `windows`: Optional. The configurations settings for
+  Windows.
+* `web`: Optional. The configurations settings for the web.
+* `package`: The Android package name of the plugin.
+* `pluginClass`: The name of the plugin class.
+* `default_package`: The name of the package containing the
+  web implementation of the plugin.
+
+### shaders field
+
+GLSL Shaders with the `FRAG` extension, must be declared in
+the shaders section of your project's `pubspec.yaml` file.
+The Flutter command-line tool compiles the shader to its
+appropriate backend format, and generates its necessary
+runtime metadata. The compiled shader is then included in
+the application just like an asset.
+
+The `shaders` field has this structure:
+
+```yaml
+flutter:
+  shaders:
+    -  { path_to_file | path_to_directory }
+    [...]
+```
+
+```yaml
+# path_to_file structure
+- assets/shaders/file
+```
+
+```yaml
+# path_to_directory structure
+- assets/shaders/
+```
+
+Add specific shaders:
+
+```yaml
+flutter:
+  shaders:
+    - assets/shaders/shader_a.frag
+    - assets/shaders/shader_b.frag
+```
+
+Add a directory of shaders:
+
+```yaml
+flutter:
+  shaders:
+    - assets/shaders/
+```
+
+Alternatively, you can add your shader directory to the
+`assets` field:
+
+```yaml
+flutter:
+  assets:
+    - assets/shaders/my_shader.frag
+```
+
+### uses-material-design field
+
+Use Material Design components in your Flutter app.
+
+```yaml
+flutter:
+  uses-material-design: true
+```
+
+## Packages
+
+The following Flutter-specific packages can be added to the
+pubspec. If you add a package, run `flutter pub get` in your
+terminal to install the package.
+
+### flutter package
+
+A package that represents the Flutter SDK itself and
+can be added to the `dependencies` field. Use this if
+your project relies on the Flutter SDK, not a regular
+package from pub.dev.
+
+```yaml
+dependencies:
+  flutter:
+    sdk: flutter
+```
+
+### flutter_localizations package
+
+A package that represents the Flutter SDK itself and
+can be added to the `dependencies` field. Use this to
+enable the localization of `ARB` files. Often used with
+the `intl` package.
+
+```yaml
+dependencies:
+  flutter_localizations:
+    sdk: flutter
+  intl: ^0.18.0
+```
+
+### flutter_test package
+
+A package that represents the Flutter SDK itself and
+can be added to the `dependencies` field. Use this if you
+have unit, widget, or integration tests for your Flutter
+app.
+
+```yaml
+dependencies:
+  flutter_test:
+    sdk: flutter
+```
+
+### flutter_lints package
+
+A package that that provides a set of recommended lints for
+Flutter projects. This package can be added to the
+`dev_dependency` field in the pubspec.
+
+```yaml
+dev_dependencies:
+  flutter_lints: ^2.0.0
+```
+
+### cupertino_icons
+
+A package that provides a set of Apple's Cupertino icons
+for use in Flutter applications. This package can be added
+to the `dependency` field in the pubspec.
+
+```yaml
+dependencies:
+  cupertino_icons: ^1.0.0
+```
 
 ## More information
 

--- a/src/content/tools/pubspec.md
+++ b/src/content/tools/pubspec.md
@@ -139,7 +139,7 @@ The `asset` field has this structure:
 ```yaml title="pubspec.yaml"
 flutter:
   assets:
-    - { path_to_file | path_to_directory | flavor_path_field }
+    - [ path_to_file | path_to_directory | flavor_path_field ]
     [...]
 ```
 
@@ -532,16 +532,44 @@ The `plugin` field has this structure:
 flutter:
   plugin:
     platforms:
-      [android | ios | linux | macos | windows | web]:
+      android: # Optional
         package: com.example.my_plugin
         pluginClass: MyPlugin
         dartPluginClass: MyPluginClassName
         ffiPlugin: true
         default_package: my_plugin_name
-        fileName: hello_web.dart
+        fileName: my_file.dart
+      ios: # Optional
+        pluginClass: MyPlugin
+        dartPluginClass: MyPluginClassName
+        ffiPlugin: true
+        default_package: my_plugin_name
+        fileName: my_file.dart
         sharedDarwinSource: true
-      [...]
-    implements:
+      macos: # Optional
+        pluginClass: MyPlugin
+        dartPluginClass: MyPluginClassName
+        ffiPlugin: true
+        default_package: my_plugin_name
+        fileName: my_file.dart
+        sharedDarwinSource: true
+      windows: # Optional
+        pluginClass: MyPlugin
+        dartPluginClass: MyPluginClassName
+        ffiPlugin: true
+        default_package: my_plugin_name
+        fileName: my_file.dart
+      linux: # Optional
+        pluginClass: MyPlugin
+        dartPluginClass: MyPluginClassName
+        ffiPlugin: true
+        default_package: my_plugin_name
+        fileName: my_file.dart
+      web: # Optional
+        ffiPlugin: true
+        default_package: my_plugin_name
+        fileName: my_file.dart
+    implements: # Optional
       - example_platform_interface
 ```
 
@@ -549,36 +577,28 @@ Subfields of `plugin`:
 
 * `platforms`: A list of platforms that will have
   configuration settings.
-
 * `package`: The Android package name of the plugin. This
   can be used with the Android platform and is required.
-
 * `pluginClass`: The name of the plugin class. Optional if
   `dartPluginClass` is used for the same platform. This
   can be used with the Android, iOS, Linux macOS, and
   Windows platforms.
-
 * `default_package`: Optional. The package that should be
   used as the default implementation of a platform
   interface. Only applicable to federated plugins, where the
   plugin's implementation is split into multiple
   platform-specific packages.
-
 * `dartPluginClass`: Optional. The Dart class that serves
   as the entry point for a Flutter plugin. This
   can be used with the Android, iOS, Linux macOS, and
   Windows platforms.
-
 * `sharedDarwinSource`: Optional. Indicates that the plugin
   shares native code between iOS and macOS. This
   can be used with the iOS and macOS platforms.
-
 * `fileName`: Optional. The file that contains the plugin
   class.
-
 * `ffiPlugin`: Optional. True if the plugin uses a
   Foreign Function Interface (FFI).
-
 * `implements`: Optional. The platform interfaces that a
   Flutter plugin implements.
 

--- a/src/content/tools/pubspec.md
+++ b/src/content/tools/pubspec.md
@@ -261,7 +261,7 @@ flutter:
   deferred-components:
     name: component_name
       libraries:
-        - package: string_expression
+        - string_expression
         [...]
       assets:
         - string_expression
@@ -275,7 +275,6 @@ Deferred component subfields:
   component.
 * `libraries`: A list of Dart libraries that are part of
   the deferred component.
-* `package`: A Dart library path.
 * `assets`: A list of asset paths that are associated with
   the deferred component.
 
@@ -286,10 +285,10 @@ flutter:
   deferred-components:
     - name: box_component
       libraries:
-        - package: path/to/box.dart
+        - package:testdeferredcomponents/box.dart
     - name: gallery_feature
       libraries:
-        - package: path/to/gallery_feature.dart
+        - package:testdeferredcomponents/gallery_feature.dart
       assets:
         - assets/gallery_images/gallery_feature.png
 ```

--- a/src/content/tools/pubspec.md
+++ b/src/content/tools/pubspec.md
@@ -286,10 +286,10 @@ flutter:
   deferred-components:
     - name: box_component
       libraries:
-        - package: testdeferredcomponents/box.dart
+        - package: path/to/box.dart
     - name: gallery_feature
       libraries:
-        - package: testdeferredcomponents/gallery_feature.dart
+        - package: path/to/gallery_feature.dart
       assets:
         - assets/gallery_images/gallery_feature.png
 ```

--- a/src/content/tools/pubspec.md
+++ b/src/content/tools/pubspec.md
@@ -136,7 +136,7 @@ section in the same page.
 
 The `asset` field has this structure:
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   assets:
     - { path_to_file | path_to_directory | flavor_path_field }
@@ -175,7 +175,7 @@ Subfields of `assets`:
 
 You can pass in a path to a file:
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   assets:
     - assets/images/my_image_a.png
@@ -184,7 +184,7 @@ flutter:
 
 You can pass in a path to a directory:
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   assets:
     - assets/images/
@@ -194,7 +194,7 @@ flutter:
 You can pass in a path to a directory for specific
 flavors:
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   assets:
     - path: assets/flavor_a_and_b/images
@@ -212,13 +212,119 @@ flutter:
 [asset images in package dependencies]: /ui/assets/assets-and-images#from-packages
 [resolution aware]: /ui/assets/assets-and-images#resolution-aware
 
+### default-flavor field
+
+Assign a default Flutter flavor for an Android app.
+When used, you don't need to include the name of this
+flavor in Flutter build command.
+
+```yaml title="pubspec.yaml"
+flutter:
+  default-flavor: flavor_name # Android-only field
+```
+
+In the following example, an Android Flutter app has a
+flavor called `staging` and `production`. The `production`
+flavor is the default flavor. When that flavor is built,
+you don't need to include it in the build command.
+
+```yaml title="pubspec.yaml"
+flutter:
+  default-flavor: production
+```
+
+```console title="console"
+// Use this command to build the default flavor (production).
+flutter build --flavor
+
+// Use this command to build non-default flavors (staging).
+flutter build --flavor staging
+```
+
+To learn how to create Flutter flavors for Android apps,
+see [Set up Flutter flavors for Android][]
+
+[Set up Flutter flavors for Android]: /deployment/flavors
+
+### deferred-components field
+
+Defer initial the download size of an Android app. Most
+often used with large applications, modularized applications,
+and applications with on-demand features.
+
+The `deferred-components` field has this structure:
+
+```yaml title="pubspec.yaml"
+flutter:
+  deferred-components:
+    component_name:
+      import: string_expression
+      libraries:
+        - string_expression
+        [...]
+      assets:
+        - string_expression
+        [...]
+      android:
+        feature-name: string_expression
+    [...]
+```
+
+Deferred component subfields:
+
+* `component_name`: The unique identifier for a specific
+  deferred component.
+* `import`: The Dart library that acts as the entry point
+  for the deferred component.
+* `libraries`: A list of Dart library paths that are part of
+  the deferred component.
+* `assets`: A list of asset paths that are associated with
+  the deferred component.
+* `android`: A map that contains Android-specific
+  configurations for the deferred component.
+* `feature-name`: The name of the Android dynamic feature
+  module that corresponds to the Flutter deferred component.
+  This name is used to link the Flutter component to the
+  Android module during the build process.
+
+Example:
+
+```yaml title="pubspec.yaml"
+flutter:
+  deferred-components:
+    feature_a:
+      import: 'package:my_app/features/feature_a/feature_a.dart'
+      libraries:
+        - 'package:my_app/features/feature_a/feature_a.dart'
+        - 'package:my_app/features/feature_a/util.dart'
+      assets:
+        - 'assets/feature_a_1/'
+        - 'assets/feature_a_2/'
+      android:
+        feature-name: 'feature_a'
+    feature_b:
+      import: 'package:my_app/features/feature_b/feature_b.dart'
+      libraries:
+        - 'package:my_app/features/feature_b/feature_b.dart'
+      assets:
+        - 'assets/feature_b/'
+      android:
+        feature-name: 'feature_b'
+```
+
+To learn more about how you can use deferred components with
+a Flutter Android app, see
+[Deferred components for Android]. 
+
+[Deferred components for Android]: /perf/deferred-components
+
 ### disable-swift-package-manager field
 
 Disable the use of the Swift Package Manager (SPM) so that
 it no longer manages dependencies in your iOS Flutter
 project.
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   disable-swift-package-manager: true
 ```
@@ -229,7 +335,7 @@ Include flavor-specific data in your Flutter app.
 
 The `flavors` field has this structure:
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   flavors:
     [flavor_field]
@@ -258,7 +364,7 @@ Flavor-specific subfields:
 Bundle flavor-specific data with two flavors of
 your app. For example:
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   flavors:
     staging:
@@ -283,7 +389,7 @@ To learn more about flavors, see
 A field that contains Flutter-specific settings for your
 app.
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   [flutter_field]
   [...]
@@ -301,7 +407,7 @@ see the [Use a custom font][] and
 
 The `fonts` field has this structure:
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   fonts:
     -  { font_family_field | font_asset_field }
@@ -336,7 +442,7 @@ Subfields of `fonts`:
 
 Use a font that is not part of a font family:
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   fonts:
     - asset: fonts/Roboto-Regular.ttf
@@ -346,7 +452,7 @@ flutter:
 
 Use a font family:
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   fonts:
   - family: Roboto # Optional
@@ -361,7 +467,7 @@ Alternatively, if you have a font that requires no family,
 weight or style requirements, you can declare it as a simple
 asset:
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   assets:
     - fonts/Roboto-Regular.ttf
@@ -378,7 +484,7 @@ subfield of `flutter` and `material`.
 
 Enable general localization:
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   generate: true
 ```
@@ -386,7 +492,7 @@ flutter:
 Enable general localization and Material Design
 localization:
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   generate: true
   material:
@@ -398,7 +504,7 @@ flutter:
 Enable Material Design localization. This works with the
 `ARB` localization files.
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   material:
     generate: true
@@ -407,79 +513,80 @@ flutter:
 Enable general localization and Material Design
 localization:
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   generate: true
   material:
     generate: true
 ```
 
-### module field
-
-Add this field if you are creating a Flutter module to
-embed in an existing native Android or iOS app. If you are
-building a standalone Flutter application, you don't need
-this field.
-
-```yaml
-flutter:
-  module:
-    androidX: true # Optional
-    androidPackage: com.example.my_module # Optional
-    iosSwiftVersion: '5.0' # Optional
-    iosBundleIdentifier: com.example.myModule # Optional
-```
-
-Subfields of `module`:
-
-* `androidX`: Optional. A boolean value that indicates
-  whether the Flutter module should use AndroidX libraries.
-* `androidPackage`: Optional. The package name of the
-  android module.
-* `iosSwiftVersion`: Optional. The minimum Swift version
-  that the iOS part of the Flutter module supports.
-* `iosBundleIdentifier`: Optional. The bundle identifier for
-  the iOS module.
-
 ### plugin field
 
 Configure settings specifically for Flutter plugins.
 
-```yaml
+The `plugin` field has this structure:
+
+```yaml title="pubspec.yaml"
 flutter:
   plugin:
     platforms:
-      android: # Optional
-        package: com.example.my_plugin
-        pluginClass: MyPlugin
-      ios: # Optional
-        pluginClass: MyPlugin
-      linux: # Optional
-        pluginClass: MyPlugin
-      macos: # Optional
-        pluginClass: MyPlugin
-      windows: # Optional
-        pluginClass: MyPlugin
-      web: # Optional
-        default_package: my_plugin_web
+      platform_type: # Optional
+        package: com.example.my_plugin # Platform-specific
+        pluginClass: MyPlugin # Platform-specific, optional
+        dartPluginClass: MyPluginClassName # Platform-specific, optional
+        ffiPlugin: true # Optional
+        default_package: my_plugin_name # Optional
+        fileName: hello_web.dart # Optional
+        sharedDarwinSource: true # Platform-specific, optional
+      [...]
+    implements: # Optional
+      - example_platform_interface
 ```
 
 Subfields of `plugin`:
 
 * `platforms`: A list of platforms that will have
   configuration settings.
-* `android`: Optional. The configurations settings for
-  Android.
-* `ios`: Optional. The configurations settings for iOS.
-* `linux`: Optional. The configurations settings for Linux.
-* `macos`: Optional. The configurations settings for macOS.
-* `windows`: Optional. The configurations settings for
-  Windows.
-* `web`: Optional. The configurations settings for the web.
+
+* `platform_type`: Replace with the platform name. This
+  can be `android`, `ios`, `linux`, `macos`, `windows` or
+  `web`.
+
 * `package`: The Android package name of the plugin.
-* `pluginClass`: The name of the plugin class.
-* `default_package`: The name of the package containing the
-  web implementation of the plugin.
+
+* `pluginClass`: The name of the plugin class. Optional if
+  `dartPluginClass` is used for the same platform. This
+  can be used with the Android, iOS, Linux macOS, Windows
+  platforms.
+
+* `default_package`: Optional. The package that should be
+  used as the default implementation of a platform
+  interface. Only applicable to federated plugins, where the
+  plugin's implementation is split into multiple
+  platform-specific packages.
+
+* `dartPluginClass`: Optional. The Dart class that serves
+  as the entry point for a Flutter plugin. This
+  can be used with the Android, iOS, Linux macOS, Windows
+  platforms.
+
+* `sharedDarwinSource`: Optional. Indicates that the plugin
+  shares native code between iOS and macOS. This
+  can be used with the iOS and macOS platforms.
+
+* `fileName`: Optional. The file that contains the plugin
+  class.
+
+* `ffiPlugin`: Optional. True if the plugin uses a
+  Foreign Function Interface (FFI).
+
+* `implements`: Optional. The platform interfaces that a
+  Flutter plugin implements.
+
+To learn more about plugins, see
+[Developing packages & plugins][].
+
+[Developing packages & plugins]: /packages-and-plugins/developing-packages
 
 ### shaders field
 
@@ -492,7 +599,7 @@ the application just like an asset.
 
 The `shaders` field has this structure:
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   shaders:
     -  { path_to_file | path_to_directory }
@@ -511,7 +618,7 @@ flutter:
 
 Add specific shaders:
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   shaders:
     - assets/shaders/shader_a.frag
@@ -520,7 +627,7 @@ flutter:
 
 Add a directory of shaders:
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   shaders:
     - assets/shaders/
@@ -529,7 +636,7 @@ flutter:
 Alternatively, you can add your shader directory to the
 `assets` field:
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   assets:
     - assets/shaders/my_shader.frag
@@ -539,7 +646,7 @@ flutter:
 
 Use Material Design components in your Flutter app.
 
-```yaml
+```yaml title="pubspec.yaml"
 flutter:
   uses-material-design: true
 ```
@@ -557,7 +664,7 @@ can be added to the `dependencies` field. Use this if
 your project relies on the Flutter SDK, not a regular
 package from pub.dev.
 
-```yaml
+```yaml title="pubspec.yaml"
 dependencies:
   flutter:
     sdk: flutter
@@ -570,7 +677,7 @@ can be added to the `dependencies` field. Use this to
 enable the localization of `ARB` files. Often used with
 the `intl` package.
 
-```yaml
+```yaml title="pubspec.yaml"
 dependencies:
   flutter_localizations:
     sdk: flutter
@@ -584,7 +691,7 @@ can be added to the `dependencies` field. Use this if you
 have unit, widget, or integration tests for your Flutter
 app.
 
-```yaml
+```yaml title="pubspec.yaml"
 dependencies:
   flutter_test:
     sdk: flutter
@@ -596,7 +703,7 @@ A package that that provides a set of recommended lints for
 Flutter projects. This package can be added to the
 `dev_dependency` field in the pubspec.
 
-```yaml
+```yaml title="pubspec.yaml"
 dev_dependencies:
   flutter_lints: ^2.0.0
 ```
@@ -607,7 +714,7 @@ A package that provides a set of Apple's Cupertino icons
 for use in Flutter applications. This package can be added
 to the `dependency` field in the pubspec.
 
-```yaml
+```yaml title="pubspec.yaml"
 dependencies:
   cupertino_icons: ^1.0.0
 ```

--- a/src/content/tools/pubspec.md
+++ b/src/content/tools/pubspec.md
@@ -259,59 +259,39 @@ The `deferred-components` field has this structure:
 ```yaml title="pubspec.yaml"
 flutter:
   deferred-components:
-    component_name:
-      import: string_expression
+    name: component_name
       libraries:
-        - string_expression
+        - package: string_expression
         [...]
       assets:
         - string_expression
         [...]
-      android:
-        feature-name: string_expression
     [...]
 ```
 
 Deferred component subfields:
 
-* `component_name`: The unique identifier for a specific
-  deferred component.
-* `import`: The Dart library that acts as the entry point
-  for the deferred component.
-* `libraries`: A list of Dart library paths that are part of
+* `name`: The unique identifier for a specific deferred
+  component.
+* `libraries`: A list of Dart libraries that are part of
   the deferred component.
+* `package`: A Dart library path.
 * `assets`: A list of asset paths that are associated with
   the deferred component.
-* `android`: A map that contains Android-specific
-  configurations for the deferred component.
-* `feature-name`: The name of the Android dynamic feature
-  module that corresponds to the Flutter deferred component.
-  This name is used to link the Flutter component to the
-  Android module during the build process.
 
 Example:
 
 ```yaml title="pubspec.yaml"
 flutter:
   deferred-components:
-    feature_a:
-      import: 'package:my_app/features/feature_a/feature_a.dart'
+    - name: box_component
       libraries:
-        - 'package:my_app/features/feature_a/feature_a.dart'
-        - 'package:my_app/features/feature_a/util.dart'
-      assets:
-        - 'assets/feature_a_1/'
-        - 'assets/feature_a_2/'
-      android:
-        feature-name: 'feature_a'
-    feature_b:
-      import: 'package:my_app/features/feature_b/feature_b.dart'
+        - package: testdeferredcomponents/box.dart
+    - name: gallery_feature
       libraries:
-        - 'package:my_app/features/feature_b/feature_b.dart'
+        - package: testdeferredcomponents/gallery_feature.dart
       assets:
-        - 'assets/feature_b/'
-      android:
-        feature-name: 'feature_b'
+        - assets/gallery_images/gallery_feature.png
 ```
 
 To learn more about how you can use deferred components with

--- a/src/content/tools/pubspec.md
+++ b/src/content/tools/pubspec.md
@@ -139,7 +139,8 @@ The `asset` field has this structure:
 ```yaml title="pubspec.yaml"
 flutter:
   assets:
-    - [ path_to_file | path_to_directory | flavor_path_field ]
+    - [ path_to_file | path_to_directory ]
+      [ flavor_path_field ]
     [...]
 ```
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

The existing guide was missing some supported fields and listing some packages as fields. The guide has a very nice robust example, but no robust documentation about the fields and packages in the example. To address this, I added a section called `Fields` and a section called `Packages` that goes over the Flutter-specific field and packages, and more specifically, the various data structures that can exist for each field.

@Sfshaza if you think this idea works and you like the general design, @andrewkolos, @vashworth, and @reidbaker can you look closely over the technical details? Am I missing any fields or packages? I have no idea how large the package list is and wasn't sure if we should document this here.

Notes:
* Values that are directories seem to be treated differently in some fields. In some fields, a directory can end with `/`, and in some fields the `/` will produce an error.
* Shams, if you like this change, I'll create an issue to link to this PR.

Preview:
* https://flutter-docs-prod--pr11833-conditionally-build-assets-4acsj9hk.web.app/tools/pubspec

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
