### PR TITLE
Update flavors-ios.md

### DIFF
--- a/src/content/deployment/flavors-ios.md
+++ b/src/content/deployment/flavors-ios.md
@@ -309,7 +309,7 @@ names in Xcode for two schemes called `staging` and
     * Under **Information Property List**, find the
       following key and update the value for it:
 
-      * **Key**: `Bundle display name`
+      * **Key**: `CFBundleDisplayName`
       * **Value**: `$(APP_DISPLAY_NAME)`
 
 1.  Launch the app for each scheme (`staging`, `production`)


### PR DESCRIPTION
Use the correct name for distinct app display name per flavor

This PR is changing the key for the app display name on iOS and refers to the correct one

it fixes issue #11834 

## Presubmit checklist

- [x] This PR is marked as ready.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
