### PR TITLE
Add property to feedback widget to capture page location.

### DIFF
--- a/src/content/assets/js/main.js
+++ b/src/content/assets/js/main.js
@@ -416,13 +416,21 @@ function setupFeedback() {
   if (!feedbackUpButton || !feedbackDownButton) return;
 
   feedbackUpButton.addEventListener('click', (_) => {
-    window.dataLayer?.push({'event': 'inline_feedback', 'feedback_type': 'up'});
+    window.dataLayer?.push({
+      'event': 'inline_feedback',
+      'feedback_type': 'up',
+      'page_location': window.location.href
+    });
 
     feedbackContainer.classList.add('feedback-up');
   }, { once: true });
 
   feedbackDownButton.addEventListener('click', (_) => {
-    window.dataLayer?.push({'event': 'inline_feedback', 'feedback_type': 'down'});
+    window.dataLayer?.push({
+      'event': 'inline_feedback',
+      'feedback_type': 'down',
+      'page_location': window.location.href
+    });
 
     feedbackContainer.classList.add('feedback-down');
   }, { once: true });


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

We want developers to be able to rate our pages. We can do this now, but we're not capturing the page location that they want to rate. Added an additional parameter to our event tag to capture this.

@RedBrogdon are you able to take a quick look?

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
