### PR TITLE
Reference alternative Linux deploy methods

### DIFF
--- a/src/content/deployment/linux.md
+++ b/src/content/deployment/linux.md
@@ -11,7 +11,8 @@ options in your IDE. By default,
 Flutter builds a _debug_ version of your app.
 
 When you're ready to prepare a _release_ version of your app,
-for example to [publish to the Snap Store][snap],
+for example to [publish to the Snap Store][snap] or an
+[alternative channel](#additional-deployment-resources),
 this page can help.
 
 ## Prerequisites
@@ -374,7 +375,7 @@ depending on how the snap was built, and if there are
 any specific security concerns. If the checks pass
 without errors, the snap becomes available in the store.
 
-## Additional resources
+## Additional snapcraft resources
 
 You can learn more from the following links on the
 [snapcraft.io][] site:
@@ -387,6 +388,20 @@ You can learn more from the following links on the
 * [Snapcraft extensions][]
 * [Supported plugins][]
 
+## Additional deployment resources
+
+### [flutter_distributor][]
+
+> An all-in-one Flutter application packaging and distribution tool,
+providing you with a one-stop solution to meet various distribution needs.
+
+Supports popular packaging formats like, appimage, deb, pacman, rpm, and more.
+
+### [flatpak-flutter][]
+
+> Flatpak manifest tooling for the offline build of Flutter apps.
+
+Supports Flatpak preparation for publishing on [Flathub][].
 
 
 [Environment variables]: https://snapcraft.io/docs/environment-variables
@@ -406,3 +421,6 @@ You can learn more from the following links on the
 [Snapcraft extensions]: https://snapcraft.io/docs/snapcraft-extensions
 [Supported plugins]: https://snapcraft.io/docs/supported-plugins
 [Ubuntu]: https://ubuntu.com/download/desktop
+[flutter_distributor]: https://pub.dev/packages/flutter_distributor
+[flatpak-flutter]: https://github.com/TheAppgineer/flatpak-flutter
+[Flathub]: https://flathub.org


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

This PR follows up on a discussion about alternative Linux deploy methods, and a comment that was made about it: https://github.com/flutter/flutter/issues/160430#issuecomment-2597270972

This is specifically about the second bullet point:

> If documentation exists elsewhere (e.g. upstream to that packaging format or a good blog post) then we should link to that from the Flutter documentation. That helps developers use these packaging formats without overcomplicating the Flutter documentation.

To be clear about my role in this play, I am the developer of the flatpak-flutter tool.

_Issues fixed by this PR (if any):_
https://github.com/flutter/website/issues/7639
https://github.com/flutter/website/issues/7641

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [X] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
