### PR TITLE
New migration guide: Underdamped spring formula changed

### DIFF
--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -44,6 +44,7 @@ They're sorted by release and listed in alphabetical order:
 * [`.flutter-plugins-dependencies` replaces `.flutter-plugins`][]
 * [Changing the default `goldenFileComparator` for `integration_test`s][]
 * [Deprecate `InputDecoration.maintainHintHeight` in favor of `InputDecoration.maintainHintSize`][]
+* [Underdamped spring formula changed][]
 
 [Deprecate `SystemContextMenuController.show`]: /release/breaking-changes/system_context_menu_controller_show
 [deprecate-markForRemove]: /release/breaking-changes/navigator-complete-route
@@ -55,6 +56,7 @@ They're sorted by release and listed in alphabetical order:
 [`.flutter-plugins-dependencies` replaces `.flutter-plugins`]: /release/breaking-changes/flutter-plugins-configuration
 [Changing the default `goldenFileComparator` for `integration_test`s]: /release/breaking-changes/integration-test-default-golden-comparator
 [Deprecate `InputDecoration.maintainHintHeight` in favor of `InputDecoration.maintainHintSize`]: /release/breaking-changes/deprecate-inputdecoration-maintainhintheight
+[Underdamped spring formula changed]: /release/breaking-changes/spring-description-underdamped
 
 <a id="released-in-flutter-329" aria-hidden="true"></a>
 ### Released in Flutter 3.29

--- a/src/content/release/breaking-changes/spring-description-underdamped.md
+++ b/src/content/release/breaking-changes/spring-description-underdamped.md
@@ -1,0 +1,134 @@
+---
+title: Underdamped spring formula changed
+description: >-
+  The formula for `SpringDescription` changed to correct an earlier error,
+  affecting underdamped springs (damping ratio less than 1).
+---
+
+## Summary
+
+The formula for `SpringDescription` changed to correct an earlier error,
+affecting underdamped springs (damping ratio less than 1)
+with mass values other than 1.
+Springs created prior to this change may exhibit
+different bouncing behaviors after upgrading.
+
+## Background
+
+The [`SpringDescription`][] class describes the behavior of damped springs,
+enabling Flutter widgets to animate realistically based on provided parameters.
+The physics of damped springs are widely studied and documented. For an overview
+of damping, see [Wikipedia: Damping][].
+
+Previously, Flutter's formula for calculating underdamped spring behavior was
+incorrect, as reported in [Issue 163858][]. This error affected all springs with
+a damping ratio less than 1 and a mass other than 1. Consequently, animations
+did not match expected real-world physics, and behavior around the critical
+damping point (damping ratio of exactly 1) exhibited discontinuities.
+Specifically, when using `SpringDescription.withDampingRatio`, small
+differences, such as damping ratios of 1.0001 versus 0.9999, resulted in
+significantly different animations.
+
+The issue was corrected in PR [Fix SpringSimulation formula for underdamping][],
+which updated the underlying calculation. As a result, previously affected
+animations now behave differently, though no explicit errors are reported by the
+framework.
+
+## Migration guide
+
+Migration is necessary only for springs with damping ratios less than 1 and
+masses other than 1.
+
+To restore previous animation behavior, update your spring parameters
+accordingly. You can calculate the required parameter adjustments using the
+provided [JSFiddle for migration][]. Detailed formulas and explanations follow
+in the next sections.
+
+### Default constructor
+If the `SpringDescription` was built with the default constructor with mass `m`, stiffness `k`, and damping `c`,
+then it should be changed with the following formula:
+```
+new_m = 1
+new_c = c * m
+new_k = (4 * (k / m) - (c / m)^2 + (c * m)^2) / 4
+```
+
+Code before migration:
+
+```dart
+const spring = SpringDescription(
+  mass: 20.0,
+  stiffness: 10,
+  damping: 1,
+);
+```
+
+Code after migration:
+
+```dart
+const spring = SpringDescription(
+  mass: 1.0,
+  stiffness: 100.499375,
+  damping: 20,
+);
+```
+
+### `.withDampingRatio` constructor
+If the `SpringDescription` was built with the `.withDampingRatio` constructor with mass `m`, stiffness `k`, and ratio `z`,
+then first calculate damping
+```
+c = z * 2 * sqrt(m * k)
+```
+
+Then apply the formula above. Optionally you might convert the result back to damping ratio with
+```
+new_z = new_c / 2 / sqrt(new_m * new_k)
+```
+
+Code before migration:
+
+```dart
+const spring = SpringDescription.withDampingRatio(
+  mass: 5.0,
+  stiffness: 6.0,
+  damping: 0.03,
+);
+```
+
+Code after migration:
+
+```dart
+const spring = SpringDescription.withDampingRatio(
+  mass: 1,
+  stiffness: 1.87392,
+  ratio: 0.60017287468545,
+);
+```
+
+## Timeline
+
+Landed in version: 3.31.0-0.1.pre<br>
+In stable release: Not yet
+
+## References
+
+API documentation:
+
+* [`SpringDescription`][]
+
+Relevant issues:
+
+* [Issue 163858][], where the bug was discovered and more context can be found.
+
+Relevant PRs:
+
+* [Fix SpringSimulation formula for underdamping][]
+
+Tool:
+* [JSFiddle for migration][]
+
+[Fix SpringSimulation formula for underdamping]: {{site.repo.flutter}}/pull/165017
+[Issue 163858]: {{site.repo.flutter}}/issues/163858
+[JSFiddle for migration]: https://jsfiddle.net/6jgvbzps/30/
+[`SpringDescription`]: {{site.api}}/flutter/physics/SpringDescription-class.html
+[Wikipedia: Damping]: https://en.wikipedia.org/wiki/Damping

--- a/src/content/release/breaking-changes/spring-description-underdamped.md
+++ b/src/content/release/breaking-changes/spring-description-underdamped.md
@@ -47,7 +47,7 @@ in the next sections.
 ### Default constructor
 If the `SpringDescription` was built with the default constructor with mass `m`, stiffness `k`, and damping `c`,
 then it should be changed with the following formula:
-```
+```plaintext
 new_m = 1
 new_c = c * m
 new_k = (4 * (k / m) - (c / m)^2 + (c * m)^2) / 4
@@ -76,12 +76,12 @@ const spring = SpringDescription(
 ### `.withDampingRatio` constructor
 If the `SpringDescription` was built with the `.withDampingRatio` constructor with mass `m`, stiffness `k`, and ratio `z`,
 then first calculate damping
-```
+```plaintext
 c = z * 2 * sqrt(m * k)
 ```
 
 Then apply the formula above. Optionally you might convert the result back to damping ratio with
-```
+```plaintext
 new_z = new_c / 2 / sqrt(new_m * new_k)
 ```
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Added a new migration guide "Underdamped spring formula changed"

Correspond to https://github.com/flutter/flutter/pull/165017

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
