### PR TITLE
Prevent long class names in widget catalog from being clipped

### DIFF
--- a/src/_11ty/filters.ts
+++ b/src/_11ty/filters.ts
@@ -30,6 +30,25 @@ export function registerFilters(eleventyConfig: UserConfig): void {
   eleventyConfig.addFilter('generate_toc', generateToc);
   eleventyConfig.addFilter('breadcrumbsForPage', breadcrumbsForPage);
   eleventyConfig.addFilter('slugify', slugify);
+  eleventyConfig.addFilter('camelCaseBreaker', camelCaseBreaker);
+}
+
+function camelCaseBreaker(stringToBreak: string): string {
+  // Only consider non-empty text.
+  if (!stringToBreak
+      || typeof stringToBreak !== 'string'
+      || stringToBreak.length === 0) {
+    return stringToBreak;
+  }
+
+  const firstCharacter = stringToBreak[0];
+  const restOfString = stringToBreak.substring(1);
+
+  // Replace all capital letters in the rest of the string with <wbr> + letter.
+  const processedRest =
+      restOfString.replace(/([A-Z])/g, '<wbr>$&');
+
+  return firstCharacter + processedRest;
 }
 
 /**

--- a/src/_includes/docs/catalog-page.md
+++ b/src/_includes/docs/catalog-page.md
@@ -17,7 +17,7 @@
       {% endif -%}
     </div>
     <div class="card-header">
-      <header class="card-title">{{comp.name}}</header>
+      <header class="card-title">{{comp.name | camelCaseBreaker}}</header>
     </div>
     <div class="card-content">
       <p>{{ comp.description | truncatewords: 25 }}</p>
@@ -47,7 +47,7 @@
           {% endif -%}
         </div>
         <div class="card-header">
-          <header class="card-title">{{comp.name}}</header>
+          <header class="card-title">{{comp.name | camelCaseBreaker}}</header>
         </div>
         <div class="card-content">
           <p>{{ comp.description | truncatewords: 25 }}</p>


### PR DESCRIPTION
Does this by inserting word break opportunities before each capital letter.

Resolves https://github.com/flutter/website/issues/11862