### PR TITLE
Update flavors-ios.md

### DIFF
--- a/src/content/deployment/flavors-ios.md
+++ b/src/content/deployment/flavors-ios.md
@@ -389,7 +389,7 @@ an iOS project called `flavors_example`.
       * **Release-production**: `AppIcon-production`
 
 1.  Launch the app for each scheme (`staging`, `production`)
-    and check to make sure that the app display name has
+    and check to make sure that the app icon has
     changed for each. To launch a scheme, see the steps in
     [Launch an Xcode scheme][].
 


### PR DESCRIPTION
Fixed an "error/ typo" in point 4 of chapter [Create distinct icons](https://docs.flutter.dev/deployment/flavors-ios#create-distinct-icons:~:text=Xcode%20scheme.-,Create%20distinct%20icons,-%23).

There the user was advised to check for the correct "app display name" instead of the app-icon.




