### PR TITLE
docs: update file reference to build.gradle.kts for Kotlin DSL projects

### DIFF
--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -73,7 +73,7 @@ Material Components by following the steps described in the
 
 For example:
 
-1. Add the dependency on Android's Material in `<my-app>/android/app/build.gradle`:
+1. Add the dependency on Android's Material in `<my-app>/android/app/build.gradle.kts`:
 
    ```groovy
    dependencies {


### PR DESCRIPTION
Replaced references to build.gradle with build.gradle.kts to align with Kotlin DSL-based Flutter Android projects.

This change ensures consistency for developers using the Kotlin DSL, helping avoid confusion when adding Material dependencies to their Flutter apps. The original instruction was accurate for Groovy-based projects but outdated for Kotlin-based configurations.

No functional changes—documentation only.

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
