### PR TITLE
Fixed typo of _kDartMode to _kDarkMode

### DIFF
--- a/examples/app-architecture/todo_data_service/lib/data/services/shared_preferences_service.dart
+++ b/examples/app-architecture/todo_data_service/lib/data/services/shared_preferences_service.dart
@@ -2,16 +2,16 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 // #docregion SharedPreferencesService
 class SharedPreferencesService {
-  static const String _kDartMode = 'darkMode';
+  static const String _kDarkMode = 'darkMode';
 
   Future<void> setDarkMode(bool value) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_kDartMode, value);
+    await prefs.setBool(_kDarkMode, value);
   }
 
   Future<bool> isDarkMode() async {
     final prefs = await SharedPreferences.getInstance();
-    return prefs.getBool(_kDartMode) ?? false;
+    return prefs.getBool(_kDarkMode) ?? false;
   }
 }
 

--- a/src/content/app-architecture/design-patterns/key-value-data.md
+++ b/src/content/app-architecture/design-patterns/key-value-data.md
@@ -249,16 +249,16 @@ eveloped by other developers outside your organization.
 <?code-excerpt "lib/data/services/shared_preferences_service.dart (SharedPreferencesService)"?>
 ```dart
 class SharedPreferencesService {
-  static const String _kDartMode = 'darkMode';
+  static const String _kDarkMode = 'darkMode';
 
   Future<void> setDarkMode(bool value) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_kDartMode, value);
+    await prefs.setBool(_kDarkMode, value);
   }
 
   Future<bool> isDarkMode() async {
     final prefs = await SharedPreferences.getInstance();
-    return prefs.getBool(_kDartMode) ?? false;
+    return prefs.getBool(_kDarkMode) ?? false;
   }
 }
 ```


### PR DESCRIPTION
Fixed typo of `_kDartMode` to `_kDarkMode`

## Presubmit checklist

- [X] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
