### PR TITLE
Migration guide for semantics menu roles

### DIFF
--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -45,6 +45,7 @@ They're sorted by release and listed in alphabetical order:
 * [Changing the default `goldenFileComparator` for `integration_test`s][]
 * [Deprecate `InputDecoration.maintainHintHeight` in favor of `InputDecoration.maintainHintSize`][]
 * [Underdamped spring formula changed][]
+* [Semantics roles update on the menu system][]
 
 [Deprecate `SystemContextMenuController.show`]: /release/breaking-changes/system_context_menu_controller_show
 [deprecate-markForRemove]: /release/breaking-changes/navigator-complete-route
@@ -57,6 +58,7 @@ They're sorted by release and listed in alphabetical order:
 [Changing the default `goldenFileComparator` for `integration_test`s]: /release/breaking-changes/integration-test-default-golden-comparator
 [Deprecate `InputDecoration.maintainHintHeight` in favor of `InputDecoration.maintainHintSize`]: /release/breaking-changes/deprecate-inputdecoration-maintainhintheight
 [Underdamped spring formula changed]: /release/breaking-changes/spring-description-underdamped
+[Semantics roles update on the menu system]: /release/breaking-changes/menu-semantics-roles
 
 <a id="released-in-flutter-329" aria-hidden="true"></a>
 ### Released in Flutter 3.29

--- a/src/content/release/breaking-changes/menu-semantics-roles.md
+++ b/src/content/release/breaking-changes/menu-semantics-roles.md
@@ -1,0 +1,169 @@
+---
+title: Semantics roles update for the menu system
+description: >-
+  Menu-related button widgets should only be used as children of `MenuAnchor` or
+  `MenuBar`.
+---
+
+## Summary
+
+`MenuAnchor`, `MenuBar`, `MenuItemButton`, `SubmenuButton`, `CheckboxMenuButton`
+and `RadioMenuButton` have been wired up to `ARIA` menu roles. The menu button
+widgets should only be used as children of the menu-related widgets, such as
+`MenuAnchor` and `MenuBar`.
+
+## Background
+
+The `MenuAnchor` and `MenuBar` widgets are used to show menus or sub-menus. 
+The children of these widgets are composed of menu items, such as 
+`MenuItemButton`, `SubmenuButton`, `CheckboxMenuButton` and `RadioMenuButton`.
+
+To ensure the screen readers announce roles correctly on the web, after these
+widgets are wired up to the `ARIA` menu roles, widgets with menu item roles 
+should only be used as children of widgets with `menu` or `menuBar` roles.
+
+## Migration guide
+
+This change added a check for menu buttons.
+An error messages similar to "A menu item must be a child of a menu or a menu
+bar" might appear if the app or a test directly uses menu item buttons instead 
+of using them within widgets with a role of `SemanticsRole.menu` or 
+`SemanticsRole.menuBar`. Menu item buttons include: `MenuItemButton`, 
+`SubmenuButton`, `CheckboxMenuButton` and `RadioMenuButton`.
+
+For example, before the migration, if an app used a menu button outside of a 
+menu context:
+
+```dart
+MaterialApp(
+  home: Material(
+    child: Column(
+      children: [
+        ElevatedButton(onPressed: () {}, child: const Text('Button 0')),
+        OutlinedButton(onPressed: () {}, child: const Text('Button 1')),
+        MenuItemButton(onPressed: () {}, child: const Text('Button 2')),
+      ]
+    )
+  )
+)
+```
+
+An exception will be thrown and the error message will appear. Therefore, to 
+fix the error, replace the menu button widgets with other standard buttons, such 
+as:
+
+```dart
+MaterialApp(
+  home: Material(
+    child: Column(
+      children: [
+        ElevatedButton(onPressed: () {}, child: const Text('Button 0')),
+        OutlinedButton(onPressed: () {}, child: const Text('Button 1')),
+        TextButton(onPressed: () {}, child: const Text('Button 2')),
+      ]
+    )
+  )
+)
+```
+
+If an app has its own custom menu or menu bar widgets and needs to use the menu
+button widgets within them, the custom widgets should be assigned 
+`SemanticsRole.menu` and `SemanticsRole.menuBar` accordingly.
+
+For example, code before the migration:
+
+```dart
+MaterialApp(
+  home: CustomMenu(
+    children: [
+      MenuItemButton(onPressed: () {}, child: const Text('Menu item 0')),
+      MenuItemButton(onPressed: () {}, child: const Text('Menu item 1')),
+      SubmenuButton(
+        onPressed: () {}, 
+        child: const Text('Submenu 0'),
+      ),
+    ],
+  ),
+);
+```
+
+Code after the migration:
+
+```dart
+MaterialApp(
+  home: Semantics(
+    // Use `SemanticsRole.menuBar` if this is a custom menu bar.
+    role: SemanticsRole.menu,
+    child: CustomMenu(
+      children: [
+        MenuItemButton(onPressed: () {}, child: const Text('Menu item 0')),
+        MenuItemButton(onPressed: () {}, child: const Text('Menu item 1')),
+        SubmenuButton(
+          onPressed: () {}, 
+          child: const Text('Submenu 0'),
+        ),
+      ],
+    ),
+  ),
+);
+```
+
+In tests, if a test was constructed as follows to test some features of the
+`CheckboxMenuButton`:
+
+```dart
+await tester.pumpWidget(
+  MaterialApp(
+    home: CheckboxMenuButton(
+      onPressed: () {},
+      child: const Text('Menu Button'),
+    ),
+  )
+);
+```
+
+After the migration, the test should be updated to:
+
+```dart
+await tester.pumpWidget(
+  MaterialApp(
+    home: Semantics(
+      role: SemanticsRole.menu, // or `SemanticsRole.menuBar`,
+      child: CheckboxMenuButton(
+        onPressed: () {},
+        child: const Text('Menu Button'),
+      ),
+    ),
+  )
+);
+```
+
+## Timeline
+
+Landed in version: TBD
+In stable release: TBD
+
+## References
+
+API documentation:
+
+* [`MenuAnchor`][]
+* [`MenuBar`][]
+* [`MenuItemButton`][]
+* [`SubmenuButton`][]
+* [`CheckboxMenuButton`][]
+* [`RadioMenuButton`][]
+
+Relevant PRs:
+
+* [Add aria menu roles to menu-related widgets][]
+* [Wire up MenuAnchor, MenuBar, MenuItem-related widgets to aria roles][]
+
+[`MenuAnchor`]: {{site.api}}/flutter/material/MenuAnchor-class.html
+[`MenuBar`]: {{site.api}}/flutter/material/MenuBar-class.html
+[`MenuItemButton`]: {{site.api}}/flutter/material/MenuItemButton-class.html
+[`SubmenuButton`]: {{site.api}}/flutter/material/SubmenuButton-class.html
+[`CheckboxMenuButton`]: {{site.api}}/flutter/material/CheckboxMenuButton-class.html
+[`RadioMenuButton`]: {{site.api}}/flutter/material/RadioMenuButton-class.html
+[Add aria menu roles to menu-related widgets]: {{site.repo.flutter}}/pull/164741
+[Wire up MenuAnchor, MenuBar, MenuItem-related widgets to aria roles]: {{site.repo.flutter}}/pull/165596

--- a/src/content/release/breaking-changes/menu-semantics-roles.md
+++ b/src/content/release/breaking-changes/menu-semantics-roles.md
@@ -7,32 +7,34 @@ description: >-
 
 ## Summary
 
-`MenuAnchor`, `MenuBar`, `MenuItemButton`, `SubmenuButton`, `CheckboxMenuButton`
-and `RadioMenuButton` have been wired up to `ARIA` menu roles. The menu button
-widgets should only be used as children of the menu-related widgets, such as
-`MenuAnchor` and `MenuBar`.
+To support accessibility and ensure that screen readers announce roles correctly
+on the web, `MenuAnchor`, `MenuBar`, `MenuItemButton`, `SubmenuButton`, 
+`CheckboxMenuButton`, and `RadioMenuButton` have been wired up to `ARIA` menu 
+roles. These menu button widgets should only be used as children of menu-related
+widgets, such as `MenuAnchor` and `MenuBar`.
 
 ## Background
 
 The `MenuAnchor` and `MenuBar` widgets are used to show menus or sub-menus. 
 The children of these widgets are composed of menu items, such as 
-`MenuItemButton`, `SubmenuButton`, `CheckboxMenuButton` and `RadioMenuButton`.
+`MenuItemButton`, `SubmenuButton`, `CheckboxMenuButton`, and `RadioMenuButton`.
 
-To ensure the screen readers announce roles correctly on the web, after these
-widgets are wired up to the `ARIA` menu roles, widgets with menu item roles 
-should only be used as children of widgets with `menu` or `menuBar` roles.
+After these widgets are wired up to the `ARIA` menu roles, widgets with menu 
+item roles should only be used as children of widgets with `menu` or `menuBar` 
+roles.
 
 ## Migration guide
 
 This change added a check for menu buttons.
 An error messages similar to "A menu item must be a child of a menu or a menu
-bar" might appear if the app or a test directly uses menu item buttons instead 
+bar" might appear if the menu item buttons are used directly instead 
 of using them within widgets with a role of `SemanticsRole.menu` or 
 `SemanticsRole.menuBar`. Menu item buttons include: `MenuItemButton`, 
 `SubmenuButton`, `CheckboxMenuButton` and `RadioMenuButton`.
 
-For example, before the migration, if an app used a menu button outside of a 
-menu context:
+Before migration:
+
+The following example uses a menu button outside of a menu context:
 
 ```dart
 MaterialApp(
@@ -48,9 +50,10 @@ MaterialApp(
 )
 ```
 
-An exception will be thrown and the error message will appear. Therefore, to 
-fix the error, replace the menu button widgets with other standard buttons, such 
-as:
+After migration:
+
+The previous code now throws an exception and displays an error message. To 
+fix the error, replace the menu button widgets with other standard buttons:
 
 ```dart
 MaterialApp(
@@ -108,8 +111,7 @@ MaterialApp(
 );
 ```
 
-In tests, if a test was constructed as follows to test some features of the
-`CheckboxMenuButton`:
+An example test, before migration:
 
 ```dart
 await tester.pumpWidget(
@@ -122,7 +124,7 @@ await tester.pumpWidget(
 );
 ```
 
-After the migration, the test should be updated to:
+The same test, after migration:
 
 ```dart
 await tester.pumpWidget(


### PR DESCRIPTION
This PR is to add a breaking change page for https://github.com/flutter/flutter/pull/165596.

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
