### PR TITLE
Migration guide for ExpansionTileController deprecation

### DIFF
--- a/src/content/release/breaking-changes/expansion-tile-controller.md
+++ b/src/content/release/breaking-changes/expansion-tile-controller.md
@@ -1,0 +1,92 @@
+---
+title: Deprecated ExpansionTileController
+description: >
+  `ExpansionTileController` is deprecated and replaced by
+  `ExpansibleController`.
+---
+
+## Summary
+
+`ExpansionTileController` is deprecated. The same functionality can be
+achieved by using `ExpansibleController` instead.
+
+## Background
+
+`ExpansionTileController` programmatically expands and collapses an `ExpansionTile`. A new `Expansible` widget has been added to the widgets library, which contains logic for expanding and collapsing behavior without being tied to the Material library. `ExpansibleController` complements `Expansible` and has the same functionality as `ExpansionTileController`. Additionally, `ExpansibleController` also supports adding and notifying listeners when its expansion state changes.
+
+Apps that use `ExpansionTileController` display the following error when run
+in debug mode: "Use `ExpansibleController` instead.". Specifically, this means that users should replace usage of `ExpansionTileController` with `ExpansibleController`.
+
+## Migration guide
+
+To migrate, replace the `controller` parameter of an `ExpansionTile` from an `ExpansionTileController` to an `ExpansibleController`. Unlike `ExpansionTileController`, `ExpansibleController` is a `ChangeNotifier`, so remember to dispose the new `ExpansibleController`.
+
+Code before migration:
+
+```dart
+class _MyWidgetState extends State<MyWidget> {
+  final ExpansionTileController controller = ExpansionTileController();
+  
+  @override
+  Widget build(BuildContext context) {
+    return ExpansionTile(
+      controller: controller,
+    );
+  }
+}
+```
+
+Code after migration:
+
+```dart
+class _MyWidgetState extends State<MyWidget> {
+  final ExpansibleController controller = ExpansibleController();
+  
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+  
+  @override
+  Widget build(BuildContext context) {
+    return ExpansionTile(
+      controller: controller,
+    );
+  }
+}
+```
+
+## Timeline
+
+Landed in version: 3.31.0-0.1.pre<br>
+In stable release: not yet
+
+## References
+
+API documentation:
+
+* [`ExpansionTileController`][]
+* [`ExpansibleController`][]
+* [`ExpansionTile.controller`][]
+* [`Expansible.controller`][]
+
+Relevant issues:
+
+* [Codeshare between ExpansionTile and its Cupertino variant][]
+* [Deprecate ExpansionTileController in favor of ExpansibleController][]
+
+Relevant PRs:
+
+* [Introduce Expansible, a base widget for ExpansionTile][]
+* [Deprecate ExpansionTileController][]
+
+[`ExpansionTileController`]: {{site.api}}/flutter/material/ExpansionTileController-class.html
+[`ExpansibleController`]: {{site.api}}/flutter/widgets/ExpansibleController-class.html
+[`ExpansionTile.controller`]: {{site.api}}/flutter/material/ExpansionTile/controller.html
+[`Expansible.controller`]: {{site.api}}/flutter/widgets/Expansible/controller.html
+
+[Codeshare between ExpansionTile and its Cupertino variant]: {{site.repo.flutter}}/issues/163552
+[Deprecate ExpansionTileController in favor of ExpansibleController]: {{site.repo.flutter}}/issues/165511
+[Introduce Expansible, a base widget for ExpansionTile]: {{site.repo.flutter}}/pull/164049
+[Deprecate ExpansionTileController]: {{site.repo.flutter}}/pull/166368

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -34,6 +34,7 @@ They're sorted by release and listed in alphabetical order:
 
 ### Not yet released to stable
 
+* [Deprecate `ExpansionTileController` in favor of `ExpansibleController`][]
 * [Deprecate `RouteTransitionRecord.markForRemove`][deprecate-markForRemove]
    in favor of `RouteTransitionRecord.markForComplete`
 * [Deprecate `TextField.canRequestFocus`][]
@@ -47,6 +48,7 @@ They're sorted by release and listed in alphabetical order:
 * [Underdamped spring formula changed][]
 
 [Deprecate `SystemContextMenuController.show`]: /release/breaking-changes/system_context_menu_controller_show
+[Deprecate `ExpansionTileController` in favor of `ExpansibleController`]: {{site.url}}/release/breaking-changes/expansion-tile-controller
 [deprecate-markForRemove]: /release/breaking-changes/navigator-complete-route
 [Deprecate `TextField.canRequestFocus`]: /release/breaking-changes/can-request-focus
 [Deprecate `ThemeData.indicatorColor` in favor of `TabBarThemeData.indicatorColor`]: /release/breaking-changes/deprecate-themedata-indicatorcolor


### PR DESCRIPTION
Added a migration guide for a deprecation in https://github.com/flutter/flutter/pull/166368.

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
