### PR TITLE
Document Impeller is unavailable on < Android API 29

### DIFF
--- a/src/content/perf/impeller.md
+++ b/src/content/perf/impeller.md
@@ -74,8 +74,9 @@ Flutter **enables Impeller by default** on iOS.
 
 ### Android
 
-Flutter **enables Impeller by default** on Android.
-On devices that don't support Vulkan,
+Impeller is **available and enabled by default on
+**Android API 29+**.
+On devices running lower versions of Android or don't support Vulkan,
 Impeller falls back to the the legacy OpenGL renderer.
 No action on your part is necessary for this fallback behavior.
 

--- a/src/content/perf/impeller.md
+++ b/src/content/perf/impeller.md
@@ -74,8 +74,7 @@ Flutter **enables Impeller by default** on iOS.
 
 ### Android
 
-Impeller is **available and enabled by default on
-**Android API 29+**.
+Impeller is **available and enabled by default on Android API 29+**.
 On devices running lower versions of Android or don't support Vulkan,
 Impeller falls back to the the legacy OpenGL renderer.
 No action on your part is necessary for this fallback behavior.

--- a/src/content/perf/impeller.md
+++ b/src/content/perf/impeller.md
@@ -5,7 +5,7 @@ description: What is Impeller and how to enable it?
 
 :::note
 As of the 3.27 release, Impeller is the default
-rendering engine for both iOS and Android.
+rendering engine for both iOS and Android API 29+.
 To see _detailed_ info on where Impeller is currently supported,
 check out the [Can I use Impeller?][] page.
 :::


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Update the documentation https://docs.flutter.dev/perf/impeller to note Impeller is unavailable on < Android API 29

_Issues fixed by this PR (if any):_ https://github.com/flutter/website/issues/11887

_PRs or commits this PR depends on (if any):_ None

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
