### PR TITLE
Fix markdown usage in aside titles

### DIFF
--- a/src/_11ty/plugins/markdown.ts
+++ b/src/_11ty/plugins/markdown.ts
@@ -67,7 +67,7 @@ function _registerAside(markdown: MarkdownIt, id: string, defaultTitle: string |
         return `<aside class="alert ${style}">
 ${title !== null ? `<div class="alert-header">
 ${icon !== null ? `<i class="material-symbols" aria-hidden="true">${icon}</i>` : ''}
-<span>${title}</span></div>` : ''}
+<span>${markdown.renderInline(title)}</span></div>` : ''}
 <div class="alert-content">
 `;
       } else {


### PR DESCRIPTION
Previously custom aside titles were used as raw text, but a few usages expected inline Markdown syntax to work. That's a fair assumption and sometimes useful, so this PR updates the aside rendering to use markdown-it to render the title to HTML.

**Before:**

<img width="918" alt="A screenshot of an aside title including unrendered markdown" src="https://github.com/user-attachments/assets/efe61242-1580-4382-8fc2-7ba9bb184334" />

**After:**

<img width="760" alt="A screenshot of an aside title being properly rendered to HTML" src="https://github.com/user-attachments/assets/27e2d16a-6dfe-472b-8793-9d925259f98a" />
