### PR TITLE
Fix: Update to correct download link

### DIFF
--- a/src/content/community/china/index.md
+++ b/src/content/community/china/index.md
@@ -5,7 +5,7 @@ toc: true
 os-list: [Windows, macOS, Linux, ChromeOS]
 ---
 
-{% assign flutter-sdk = 'flutter_opsys_v3.13.0-stable.' %}
+{% assign flutter-sdk = 'flutter_opsys_3.13.0-stable.' %}
 {% capture sdk-path -%}flutter_infra_release/releases/stable/opsys/{{flutter-sdk}}{%- endcapture %}
 
 {% render docs/china-notice-cn.md %}


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

https://docs.flutter.dev/community/china#download-flutter-archives-based-on-a-mirror-site

The URL has an extra 'v'.

```diff
- https://storage.googleapis.com/flutter_infra_release/releases/stable/windows/flutter_windows_v3.13.0-stable.zip
+ https://storage.googleapis.com/flutter_infra_release/releases/stable/windows/flutter_windows_3.13.0-stable.zip
```

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
