### PR TITLE
Keep quotes when minifying HTML attributes

### DIFF
--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -100,6 +100,7 @@ export default function (eleventyConfig: UserConfig) {
           removeRedundantAttributes: 'smart',
           minifyCss: true,
           minifyConditionalComments: true,
+          quotes: true,
         });
 
         return minifiedHtml.code;


### PR DESCRIPTION
https://github.com/flutter/website/commit/99d9296b22b7e3703e917fdb86fe4f982b823960 switched to a different HTML minifier which stripped quotes from HTML attributes when technically browsers could parse it, but generally shouldn't be dropped.