### PR TITLE
Typo in Data-Layer documentation

### DIFF
--- a/src/content/app-architecture/case-study/data-layer.md
+++ b/src/content/app-architecture/case-study/data-layer.md
@@ -84,7 +84,7 @@ Some methods return data classes that are
 specifically for raw data from the API,
 such as the `BookingApiModel` class.
 As you'll soon see, repositories extract data and
-expose it to s in a different format.
+expose it in a different format.
 :::
 
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
"to s" doesn't make sense in this context.
The sentence without it makes sense, but maybe I missed the original idea.
_Issues fixed by this PR (if any):_
Removed unnecessary text.
_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
