### PR TITLE
Help guide users to orientation best practices.

### DIFF
--- a/src/content/cookbook/design/orientation.md
+++ b/src/content/cookbook/design/orientation.md
@@ -9,10 +9,13 @@ js:
 <?code-excerpt path-base="cookbook/design/orientation"?>
 
 In some situations,
-you want to update the display of an app when the user
-rotates the screen from portrait mode to landscape mode. For example,
+you want to update the display of an app when the shape of the
+available space changes like when a user rotates
+the screen from portrait mode to landscape mode. For example,
 the app might show one item after the next in portrait mode,
 yet put those same items side-by-side in landscape mode.
+Expanded docs covering this and more can be found
+in the [adaptive ui documenation][].
 
 In Flutter, you can build different layouts depending
 on a given [`Orientation`][].
@@ -69,8 +72,10 @@ body: OrientationBuilder(
 :::note
 If you're interested in the orientation of the screen,
 rather than the amount of space available to the parent,
-use `MediaQuery.of(context).orientation` instead of an
+use `MediaQuery.orientationOf(context)` instead of an
 `OrientationBuilder` widget.
+Using `MediaQuery.orientationOf` as a way to orignize ui
+is [discouraged][]. Instead use `MediaQuery.sizeOf(context)`
 :::
 
 ## Interactive example
@@ -168,3 +173,5 @@ void main() {
 [`OrientationBuilder`]: {{site.api}}/flutter/widgets/OrientationBuilder-class.html
 [`Orientation`]: {{site.api}}/flutter/widgets/Orientation.html
 [`SystemChrome.setPreferredOrientations()`]: {{site.api}}/flutter/services/SystemChrome/setPreferredOrientations.html
+[adaptive ui documenation]: {{site.api}}/ui/adaptive-responsive
+[discouraged]: {{site.api}}/ui/adaptive-responsive/best-practices

--- a/src/content/ui/adaptive-responsive/best-practices.md
+++ b/src/content/ui/adaptive-responsive/best-practices.md
@@ -116,14 +116,15 @@ To summarize:
 [lowest level]:  {{site.android-dev}}/docs/quality-guidelines/large-screen-app-quality#T3-8
 [override a locked screen]: {{site.android-dev}}/guide/topics/large-screens/large-screen-compatibility-mode#per-app_overrides
 
-### Avoid orientation-based layouts
+### Avoid device orientation-based layouts
 
 Avoid using `MediaQuery`'s orientation field
-or `OrientationBuilder` to switch between
-different app layouts. This is similar to the
-guidance of not checking device types to determine
-screen size. The device's orientation also doesn't
-necessarily inform you of how much space your app window has.
+or `OrientationBuilder` near the top of your widget tree
+to switch between different app layouts. This is
+similar to the guidance of not checking device types
+to determine screen size. The device's orientation also
+doesn't necessarily inform you of how much space your
+app window has.
 
 Instead, use `MediaQuery`'s `sizeOf` or `LayoutBuilder`,
 as discussed in the [General approach][] page.


### PR DESCRIPTION
I reviewed a pr that was modifying accessibility and wound my way to these pages of documentation which I think should be updated to reflect our current known best practices. 

Primarily, do not use MediaQuery.of instead use one of the more specific property builders. Second do not rely on device orientation for determining ui use LayoutBuilder and MediaQuery.sizeOf. 

https://docs.flutter.dev/ui/adaptive-responsive/best-practices


## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
