### PR TITLE
Add migration guide for https://github.com/flutter/flutter/pull/164034

### DIFF
--- a/src/content/release/breaking-changes/RenderConstrainedLayoutBuilder-mixin.md
+++ b/src/content/release/breaking-changes/RenderConstrainedLayoutBuilder-mixin.md
@@ -1,29 +1,38 @@
 ---
 title: RenderConstrainedLayoutBuilder renamed RenderAbstractLayoutBuilderMixin
-description: >
-  `RenderConstrainedLayoutBuilder` is replaced by
-  `RenderAbstractLayoutBuilderMixin` with a new `layoutInfo` getter to implement.
+description: >-
+  'RenderConstrainedLayoutBuilder' is replaced by
+  'RenderAbstractLayoutBuilderMixin' with a
+  new 'layoutInfo' getter to implement.
 ---
 
 ## Summary
 
-`RenderConstrainedLayoutBuilder` is renamed `RenderAbstractLayoutBuilderMixin`. The same functionality can be
-achieved by using the new mixin, while a new getter `layoutInfo` will also be required of implementors.
+`RenderConstrainedLayoutBuilder` is renamed `RenderAbstractLayoutBuilderMixin`.
+The same functionality can be achieved by using the new mixin,
+while a new getter `layoutInfo` is also be required of implementors.
 
 ## Background
 
-`RenderObject`'s standard layout mechanism, optimized with re-layout boundaries, generally restricts a
-`RenderObject`'s ability to access layout information, like size or constraints, to only its direct
-children, not other descendants. This standard behavior simplified dependencies but complicated some common
-UI patterns.
+`RenderObject`'s standard layout mechanism, optimized with re-layout boundaries,
+generally restricts a`RenderObject`'s ability to access layout information,
+like size or constraints, to only its direct children, not other descendants.
+This standard behavior simplified dependencies but
+complicated some common UI patterns.
 
-The change that includes these updates overcomes that limitation by making this information more available. For example,
-it permits an `OverlayPortal.overlayChild`'s widget tree to use layout data from another `Overlay` child subtree,
+The change that includes these updates overcomes that limitation by
+making this information more available.
+For example, it permits an `OverlayPortal.overlayChild`'s widget tree to
+use layout data from another `Overlay` child subtree,
 provided that subtree lays out first.
 
 ## Migration guide
 
-To migrate, replace references to the `RenderConstrainedLayoutBuilder` with `RenderAbstractLayoutBuilderMixin`, and implement `layoutInfo`. In most `RenderObject`s, the `layoutInfo` should be implemented to return the `RenderObject.constraints`.
+To migrate, replace references to
+`RenderConstrainedLayoutBuilder` with `RenderAbstractLayoutBuilderMixin`,
+and implement `layoutInfo`.
+In most `RenderObject`s, `layoutInfo` should be
+implemented to return the `RenderObject.constraints`.
 
 Code before migration:
 
@@ -32,9 +41,10 @@ class SliverLayoutBuilder extends ConstrainedLayoutBuilder<SliverConstraints> {
   const SliverLayoutBuilder({super.key, required super.builder});
 
   @override
-  RenderObject createRenderObject(BuildContext context) => _RenderSliverLayoutBuilder();
+  RenderObject createRenderObject(BuildContext context) =>
+      _RenderSliverLayoutBuilder();
 
-  // The updateRenderObject method may be implemented as well in your own code.
+  // The `updateRenderObject` method might also be implemented in your code.
 }
 
 class _RenderSliverLayoutBuilder extends RenderSliver
@@ -53,9 +63,10 @@ class SliverLayoutBuilder extends ConstrainedLayoutBuilder<SliverConstraints> {
 
   // Updated return type to reflect the new mixin.
   @override
-  RenderAbstractLayoutBuilderMixin<SliverConstraints, RenderSliver> createRenderObject(BuildContext context) => _RenderSliverLayoutBuilder();
+  RenderAbstractLayoutBuilderMixin<SliverConstraints, RenderSliver>
+      createRenderObject(BuildContext context) => _RenderSliverLayoutBuilder();
 
-  // Change of return type name also applies if updateRenderObject is implemented.
+  // Change of return type also applies if `updateRenderObject` is implemented.
 }
 
 class _RenderSliverLayoutBuilder extends RenderSliver
@@ -75,7 +86,7 @@ class _RenderSliverLayoutBuilder extends RenderSliver
 ## Timeline
 
 Landed in version: 3.32.0-0.0.pre<br>
-In stable release: not yet
+In stable release: Not yet
 
 ## References
 

--- a/src/content/release/breaking-changes/RenderConstrainedLayoutBuilder-mixin.md
+++ b/src/content/release/breaking-changes/RenderConstrainedLayoutBuilder-mixin.md
@@ -1,0 +1,98 @@
+---
+title: RenderConstrainedLayoutBuilder renamed RenderAbstractLayoutBuilderMixin
+description: >
+  `RenderConstrainedLayoutBuilder` is replaced by
+  `RenderAbstractLayoutBuilderMixin` with a new `layoutInfo` getter to implement.
+---
+
+## Summary
+
+`RenderConstrainedLayoutBuilder` is renamed `RenderAbstractLayoutBuilderMixin`. The same functionality can be
+achieved by using the new mixin, while a new getter `layoutInfo` will also be required of implementors.
+
+## Background
+
+`RenderObject`'s standard layout mechanism, optimized with re-layout boundaries, generally restricts a
+`RenderObject`'s ability to access layout information, like size or constraints, to only its direct
+children, not other descendants. This standard behavior simplified dependencies but complicated some common
+UI patterns.
+
+The change that includes these updates overcomes that limitation by making this information more available. For example,
+it permits an `OverlayPortal.overlayChild`'s widget tree to use layout data from another `Overlay` child subtree,
+provided that subtree lays out first.
+
+## Migration guide
+
+To migrate, replace references to the `RenderConstrainedLayoutBuilder` with `RenderAbstractLayoutBuilderMixin`, and implement `layoutInfo`. In most `RenderObject`s, the `layoutInfo` should be implemented to return the `RenderObject.constraints`.
+
+Code before migration:
+
+```dart
+class SliverLayoutBuilder extends ConstrainedLayoutBuilder<SliverConstraints> {
+  const SliverLayoutBuilder({super.key, required super.builder});
+
+  @override
+  RenderObject createRenderObject(BuildContext context) => _RenderSliverLayoutBuilder();
+
+  // The updateRenderObject method may be implemented as well in your own code.
+}
+
+class _RenderSliverLayoutBuilder extends RenderSliver
+    with RenderObjectWithChildMixin<RenderSliver>,
+         RenderConstrainedLayoutBuilder<SliverConstraints, RenderSliver> {
+
+  // Irrelevant implementation details not shown.
+}
+```
+
+Code after migration:
+
+```dart
+class SliverLayoutBuilder extends ConstrainedLayoutBuilder<SliverConstraints> {
+  const SliverLayoutBuilder({super.key, required super.builder});
+
+  // Updated return type to reflect the new mixin.
+  @override
+  RenderAbstractLayoutBuilderMixin<SliverConstraints, RenderSliver> createRenderObject(BuildContext context) => _RenderSliverLayoutBuilder();
+
+  // Change of return type name also applies if updateRenderObject is implemented.
+}
+
+class _RenderSliverLayoutBuilder extends RenderSliver
+    with RenderObjectWithChildMixin<RenderSliver>,
+         // Updated mixin name.
+         RenderAbstractLayoutBuilderMixin<SliverConstraints, RenderSliver> {
+
+  // Add implementation of layoutInfo getter.
+  @protected
+  @override
+  SliverConstraints get layoutInfo => constraints;
+
+  // Irrelevant implementation details not shown.
+}
+```
+
+## Timeline
+
+Landed in version: 3.32.0-0.0.pre<br>
+In stable release: not yet
+
+## References
+
+API documentation:
+
+* [`RenderAbstractLayoutBuilderMixin`][]
+* [`RenderObject`][]
+* [`Overlay`][]
+* [`OverlayPortal`][]
+
+Relevant PRs:
+
+* [OverlayPortal.overlayChildLayoutBuilder][]
+
+[`RenderAbstractLayoutBuilderMixin`]: {{site.api}}/flutter/widgets/RenderAbstractLayoutBuilderMixin-mixin.html
+[`RenderObject`]: {{site.api}}/flutter/rendering/RenderObject-class.html
+[`Overlay`]: {{site.api}}/flutter/widgets/Overlay-class.html
+[`OverlayPortal`]: {{site.api}}/flutter/widgets/OverlayPortal-class.html
+
+[OverlayPortal.overlayChildLayoutBuilder]: {{site.repo.flutter}}/issues/164034

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -64,8 +64,6 @@ They're sorted by release and listed in alphabetical order:
 [Semantics roles update on the menu system]: /release/breaking-changes/menu-semantics-roles
 [RenderConstrainedLayoutBuilder renamed RenderAbstractLayoutBuilderMixin]: /release/breaking-changes/RenderConstrainedLayoutBuilder-mixin
 
-<a id="]:
-
 <a id="released-in-flutter-329" aria-hidden="true"></a>
 ### Released in Flutter 3.29
 

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -47,7 +47,7 @@ They're sorted by release and listed in alphabetical order:
 * [Deprecate `InputDecoration.maintainHintHeight` in favor of `InputDecoration.maintainHintSize`][]
 * [Underdamped spring formula changed][]
 * [Semantics roles update on the menu system][]
-* [RenderConstrainedLayoutBuilder renamed RenderAbstractLayoutBuilderMixin][]
+* [`RenderConstrainedLayoutBuilder` renamed `RenderAbstractLayoutBuilderMixin`][]
 
 [Deprecate `SystemContextMenuController.show`]: /release/breaking-changes/system_context_menu_controller_show
 [Deprecate `ExpansionTileController` in favor of `ExpansibleController`]: {{site.url}}/release/breaking-changes/expansion-tile-controller
@@ -62,7 +62,7 @@ They're sorted by release and listed in alphabetical order:
 [Deprecate `InputDecoration.maintainHintHeight` in favor of `InputDecoration.maintainHintSize`]: /release/breaking-changes/deprecate-inputdecoration-maintainhintheight
 [Underdamped spring formula changed]: /release/breaking-changes/spring-description-underdamped
 [Semantics roles update on the menu system]: /release/breaking-changes/menu-semantics-roles
-[RenderConstrainedLayoutBuilder renamed RenderAbstractLayoutBuilderMixin]: /release/breaking-changes/RenderConstrainedLayoutBuilder-mixin
+[`RenderConstrainedLayoutBuilder` renamed `RenderAbstractLayoutBuilderMixin`]: /release/breaking-changes/RenderConstrainedLayoutBuilder-mixin
 
 <a id="released-in-flutter-329" aria-hidden="true"></a>
 ### Released in Flutter 3.29

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -47,6 +47,7 @@ They're sorted by release and listed in alphabetical order:
 * [Deprecate `InputDecoration.maintainHintHeight` in favor of `InputDecoration.maintainHintSize`][]
 * [Underdamped spring formula changed][]
 * [Semantics roles update on the menu system][]
+* [RenderConstrainedLayoutBuilder renamed RenderAbstractLayoutBuilderMixin][]
 
 [Deprecate `SystemContextMenuController.show`]: /release/breaking-changes/system_context_menu_controller_show
 [Deprecate `ExpansionTileController` in favor of `ExpansibleController`]: {{site.url}}/release/breaking-changes/expansion-tile-controller
@@ -61,6 +62,9 @@ They're sorted by release and listed in alphabetical order:
 [Deprecate `InputDecoration.maintainHintHeight` in favor of `InputDecoration.maintainHintSize`]: /release/breaking-changes/deprecate-inputdecoration-maintainhintheight
 [Underdamped spring formula changed]: /release/breaking-changes/spring-description-underdamped
 [Semantics roles update on the menu system]: /release/breaking-changes/menu-semantics-roles
+[RenderConstrainedLayoutBuilder renamed RenderAbstractLayoutBuilderMixin]: /release/breaking-changes/RenderConstrainedLayoutBuilder-mixin.md
+
+<a id="]:
 
 <a id="released-in-flutter-329" aria-hidden="true"></a>
 ### Released in Flutter 3.29

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -62,7 +62,7 @@ They're sorted by release and listed in alphabetical order:
 [Deprecate `InputDecoration.maintainHintHeight` in favor of `InputDecoration.maintainHintSize`]: /release/breaking-changes/deprecate-inputdecoration-maintainhintheight
 [Underdamped spring formula changed]: /release/breaking-changes/spring-description-underdamped
 [Semantics roles update on the menu system]: /release/breaking-changes/menu-semantics-roles
-[RenderConstrainedLayoutBuilder renamed RenderAbstractLayoutBuilderMixin]: /release/breaking-changes/RenderConstrainedLayoutBuilder-mixin.md
+[RenderConstrainedLayoutBuilder renamed RenderAbstractLayoutBuilderMixin]: /release/breaking-changes/RenderConstrainedLayoutBuilder-mixin
 
 <a id="]:
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Adds a migration guide for https://github.com/flutter/flutter/pull/164034, whcih was identified as breaking in beta testing in https://github.com/flutter/flutter/issues/167247

_Issues fixed by this PR (if any):_

Fixes https://github.com/flutter/flutter/issues/167247


## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
