### PR TITLE
Clean up styling of 404 page

### DIFF
--- a/src/_sass/components/_content.scss
+++ b/src/_sass/components/_content.scss
@@ -1,6 +1,7 @@
 .site-content {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   min-width: 0;
   width: 100%;
 
@@ -123,6 +124,7 @@
       color: var(--site-base-fgColor-alt);
       opacity: 0;
       text-decoration: none;
+      user-select: none;
 
       &:hover {
         color: var(--site-link-fgColor);

--- a/src/_sass/pages/_not-found.scss
+++ b/src/_sass/pages/_not-found.scss
@@ -40,7 +40,7 @@ body.site-not-found main {
     }
   }
 
-  #page-github-links {
+  #trailing-content {
     display: none;
   }
 }


### PR DESCRIPTION
- Center 404 content on large screen.
- Hide all trailing content on 404 page, not just some of it.