### PR TITLE
Update first widgets example to work with both themes

### DIFF
--- a/examples/ui/widgets_intro/lib/main.dart
+++ b/examples/ui/widgets_intro/lib/main.dart
@@ -3,7 +3,11 @@ import 'package:flutter/material.dart';
 void main() {
   runApp(
     const Center(
-      child: Text('Hello, world!', textDirection: TextDirection.ltr),
+      child: Text(
+        'Hello, world!',
+        textDirection: TextDirection.ltr,
+        style: TextStyle(color: Colors.blue),
+      ),
     ),
   );
 }

--- a/src/content/ui/index.md
+++ b/src/content/ui/index.md
@@ -38,7 +38,11 @@ import 'package:flutter/material.dart';
 void main() {
   runApp(
     const Center(
-      child: Text('Hello, world!', textDirection: TextDirection.ltr),
+      child: Text(
+        'Hello, world!',
+        textDirection: TextDirection.ltr,
+        style: TextStyle(color: Colors.blue),
+      ),
     ),
   );
 }


### PR DESCRIPTION
Sets the text style to blue so the text is visible in both the light and dark mode versions of DartPad.

<img width="318" alt="Screenshot of the more visible text" src="https://github.com/user-attachments/assets/a9d693ed-988e-4442-aca9-f6eafd57de86" />


Fixes https://github.com/flutter/website/issues/11923