### PR TITLE
Revert "iOS: bump minimum iOS version from 12 to 13 (#11958)"

### DIFF
--- a/src/_data/platforms.yml
+++ b/src/_data/platforms.yml
@@ -5,7 +5,7 @@
   unsupported: '20 and earlier'
 - platform: 'iOS'
   target-arch: 'Arm64'
-  supported: '13 to 18'
+  supported: '12 to 18'
   ci-tested: '17'
   unsupported: '11 and earlier'
 - platform: 'macOS'

--- a/src/_data/site.yml
+++ b/src/_data/site.yml
@@ -85,7 +85,7 @@ targetmin:
   linux:
     debian: 10
     ubuntu: '20.04 LTS'
-  ios: 13
+  ios: 12
   android: 'Android API level 21'
 
 ## Software current versions

--- a/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
@@ -51,7 +51,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
            // TODO: Update the platforms your plugin supports.
            // If your plugin only supports iOS, remove `.macOS(...)`.
            // If your plugin only supports macOS, remove `.iOS(...)`.
-           .iOS("13.0"),
+           .iOS("12.0"),
            .macOS("10.14")
        ],
        products: [
@@ -93,7 +93,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
            // TODO: Update the platforms your plugin supports.
            // If your plugin only supports iOS, remove `.macOS(...)`.
            // If your plugin only supports macOS, remove `.iOS(...)`.
-           [!.iOS("13.0"),!]
+           [!.iOS("12.0"),!]
            [!.macOS("10.14")!]
        ],
    ```
@@ -107,7 +107,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
        // TODO: Update your plugin name.
        name: [!"plugin_name"!],
        platforms: [
-           .iOS("13.0"),
+           .iOS("12.0"),
            .macOS("10.14")
        ],
        products: [

--- a/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
@@ -44,7 +44,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
            // TODO: Update the platforms your plugin supports.
            // If your plugin only supports iOS, remove `.macOS(...)`.
            // If your plugin only supports macOS, remove `.iOS(...)`.
-           .iOS("13.0"),
+           .iOS("12.0"),
            .macOS("10.14")
        ],
        products: [
@@ -82,7 +82,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
            // TODO: Update the platforms your plugin supports.
            // If your plugin only supports iOS, remove `.macOS(...)`.
            // If your plugin only supports macOS, remove `.iOS(...)`.
-           [!.iOS("13.0"),!]
+           [!.iOS("12.0"),!]
            [!.macOS("10.14")!]
        ],
    ```
@@ -96,7 +96,7 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
        // TODO: Update your plugin name.
        name: [!"plugin_name"!],
        platforms: [
-           .iOS("13.0"),
+           .iOS("12.0"),
            .macOS("10.14")
        ],
        products: [

--- a/src/content/deployment/ios.md
+++ b/src/content/deployment/ios.md
@@ -115,10 +115,9 @@ In the **Deployment** section of the **Build Settings** tab:
 
 `iOS Deployment Target`
 : The minimum iOS version that your app supports.
-  Flutter supports iOS {{site.targetmin.ios}} and later. If your app or plugins
+  Flutter supports iOS 12 and later. If your app or plugins
   include Objective-C or Swift code that makes use of APIs newer
-  than iOS {{site.targetmin.ios}}, update this setting to the highest required
-  version.
+  than iOS 12, update this setting to the highest required version.
 
 The **General** tab of your project settings should resemble
 the following:

--- a/src/content/platform-integration/ios/ios-app-clip.md
+++ b/src/content/platform-integration/ios/ios-app-clip.md
@@ -300,7 +300,7 @@ target '<name of your App Clip target>'
 ```
 
 At the top of the file,
-also uncomment `platform :ios, '13.0'` and set the
+also uncomment `platform :ios, '12.0'` and set the
 version to the lowest of the two target's iOS
 Deployment Target.
 


### PR DESCRIPTION
This shouldn't go live until next stable release goes live.

This reverts commit 8050cd7fad77a634a924c1fe2e966ba320045163.

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
