### PR TITLE
Update accessibility doc with Semantics roles information

### DIFF
--- a/src/content/ui/accessibility-and-internationalization/accessibility.md
+++ b/src/content/ui/accessibility-and-internationalization/accessibility.md
@@ -243,9 +243,12 @@ Flutter provides the [`Semantics` widget][] with the [`SemanticsRole` enum][] to
 
 **1. Automatic Semantics from Standard Widgets:**
 
-Many standard Flutter widgets, like `TabBar`, `MenuAnchor`, and `Table`, automatically include semantic information, including their roles. Whenever possible, prefer using these standard widgets as they handle many accessibility aspects out-of-the-box.
+Many standard Flutter widgets, like `TabBar`, `MenuAnchor`, and `Table`,
+automatically include semantic information along with their roles.
+Whenever possible, prefer using these standard widgets
+as they handle many accessibility aspects out-of-the-box.
 
-**2. Explicitly Adding or Overriding Roles:**
+**2. Explicitly adding or overriding roles:**
 
 For custom components or when the default semantics aren't sufficient, use the `Semantics` widget to define the role:
 

--- a/src/content/ui/accessibility-and-internationalization/accessibility.md
+++ b/src/content/ui/accessibility-and-internationalization/accessibility.md
@@ -235,7 +235,7 @@ By assigning appropriate roles, you ensure that:
 * Users can navigate your application more effectively using assistive technologies.
 * Your application adheres to web accessibility standards, improving usability.
 
-### Using `SemanticsRole` in Flutter for Web
+### Using `SemanticsRole` in Flutter for web
 
 Flutter provides the [`Semantics` widget][] with the [`SemanticsRole` enum][] to allow developers to assign specific roles to their widgets. When your Flutter web app is rendered, these Flutter-specific roles are translated into corresponding ARIA roles in the web page's HTML structure.
 

--- a/src/content/ui/accessibility-and-internationalization/accessibility.md
+++ b/src/content/ui/accessibility-and-internationalization/accessibility.md
@@ -220,7 +220,7 @@ widgets to offer a dramatically more accessible experience.
 
 {% ytEmbed 'bWbBgbmAdQs', 'Building Flutter apps with accessibility in mind' %}
 
-## Enhancing Accessibility with Semantic Roles in Flutter
+## Enhancing Accessibility with Semantic Roles
 
 ### What are Semantic Roles?
 

--- a/src/content/ui/accessibility-and-internationalization/accessibility.md
+++ b/src/content/ui/accessibility-and-internationalization/accessibility.md
@@ -224,9 +224,14 @@ widgets to offer a dramatically more accessible experience.
 
 ### What are Semantic Roles?
 
-Semantic roles define the purpose of a UI element, helping screen readers and other assistive tools interpret and present your application effectively to users. For example, a role can indicate if a widget is a button, a link, a heading, a slider, or part of a table. 
+Semantic roles define the purpose of a UI element, helping screen readers
+and other assistive tools interpret and present your application effectively
+to users. For example, a role can indicate if a widget is a button, a link,
+a heading, a slider, or part of a table. 
 
-While Flutter's standard widgets often provide these semantics automatically, a custom component without a clearly defined role can be incomprehensible to a screen reader user.
+While Flutter's standard widgets often provide these semantics automatically,
+a custom component without a clearly defined role can be incomprehensible
+to a screen reader user.
 
 
 By assigning appropriate roles, you ensure that:
@@ -237,7 +242,10 @@ By assigning appropriate roles, you ensure that:
 
 ### Using `SemanticsRole` in Flutter for web
 
-Flutter provides the [`Semantics` widget][] with the [`SemanticsRole` enum][] to allow developers to assign specific roles to their widgets. When your Flutter web app is rendered, these Flutter-specific roles are translated into corresponding ARIA roles in the web page's HTML structure.
+Flutter provides the [`Semantics` widget][] with the [`SemanticsRole` enum][]
+to allow developers to assign specific roles to their widgets. When your
+Flutter web app is rendered, these Flutter-specific roles are translated into
+corresponding ARIA roles in the web page's HTML structure.
 
 [`SemanticsRole` enum]: {{site.api}}/flutter/dart-ui/SemanticsRole.html
 
@@ -250,7 +258,8 @@ as they handle many accessibility aspects out-of-the-box.
 
 **2. Explicitly adding or overriding roles:**
 
-For custom components or when the default semantics aren't sufficient, use the `Semantics` widget to define the role:
+For custom components or when the default semantics aren't sufficient,
+use the `Semantics` widget to define the role:
 
 Here's an example of how you might explicitly define a list and its items:
 

--- a/src/content/ui/accessibility-and-internationalization/accessibility.md
+++ b/src/content/ui/accessibility-and-internationalization/accessibility.md
@@ -220,6 +220,76 @@ widgets to offer a dramatically more accessible experience.
 
 {% ytEmbed 'bWbBgbmAdQs', 'Building Flutter apps with accessibility in mind' %}
 
+## Enhancing Accessibility with Semantic Roles in Flutter
+
+### What are Semantic Roles?
+
+Semantic roles define the purpose of a UI element, helping screen readers and other assistive tools interpret and present your application effectively to users. For example, a role can indicate if a widget is a button, a link, a heading, a slider, or part of a table. 
+
+While Flutter's standard widgets often provide these semantics automatically, a custom component without a clearly defined role can be incomprehensible to a screen reader user.
+
+
+By assigning appropriate roles, you ensure that:
+
+* Screen readers can announce the type and purpose of elements correctly.
+* Users can navigate your application more effectively using assistive technologies.
+* Your application adheres to web accessibility standards, improving usability.
+
+### Using `SemanticsRole` in Flutter for Web
+
+Flutter provides the [`Semantics` widget][] with the [`SemanticsRole` enum][] to allow developers to assign specific roles to their widgets. When your Flutter web app is rendered, these Flutter-specific roles are translated into corresponding ARIA roles in the web page's HTML structure.
+
+[`SemanticsRole` enum]: {{site.api}}/flutter/dart-ui/SemanticsRole.html
+
+**1. Automatic Semantics from Standard Widgets:**
+
+Many standard Flutter widgets, like `TabBar`, `MenuAnchor`, and `Table`, automatically include semantic information, including their roles. Whenever possible, prefer using these standard widgets as they handle many accessibility aspects out-of-the-box.
+
+**2. Explicitly Adding or Overriding Roles:**
+
+For custom components or when the default semantics aren't sufficient, use the `Semantics` widget to define the role:
+
+Here's an example of how you might explicitly define a list and its items:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+
+
+class MyCustomListWidget extends StatelessWidget {
+  const MyCustomListWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    // This example shows how to explicitly assign list and listitem roles
+    // when building a custom list structure. 
+    return Semantics(
+      role: SemanticsRole.list,
+      explicitChildNodes: true,
+      child: Column( 
+        children: <Widget>[
+          Semantics(
+            role: SemanticsRole.listItem, 
+            child: const Padding(
+              padding: EdgeInsets.all(8.0),
+              child: Text('Content of the first custom list item.'),
+            ),
+          ),
+          Semantics(
+            role: SemanticsRole.listItem, 
+            child: const Padding(
+              padding: EdgeInsets.all(8.0),
+              child: Text('Content of the second custom list item.'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+```
+
 ## Testing accessibility on mobile
 
 Test your app using Flutter's [Accessibility Guideline API][].


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why: Update Semantics roles doc for a11y

_Issues fixed by this PR (if any): https://github.com/issues/assigned?issue=flutter%7Cwebsite%7C11942

_PRs or commits this PR depends on (if any):

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
