### PR TITLE
Fix video embeds breaking when start time is configured

### DIFF
--- a/src/_11ty/shortcodes.ts
+++ b/src/_11ty/shortcodes.ts
@@ -3,6 +3,7 @@ import {slugify} from './utils/slugify.js';
 import {fromHtml} from 'hast-util-from-html';
 import {selectAll} from 'hast-util-select';
 import {toHtml} from 'hast-util-to-html';
+import {escapeHtml} from 'markdown-it/lib/common/utils.mjs';
 
 export function registerShortcodes(eleventyConfig: UserConfig): void {
   _setupTabs(eleventyConfig);
@@ -38,8 +39,21 @@ function _setupOsSelector(eleventyConfig: UserConfig): void {
 
 function _setupMedia(eleventyConfig: UserConfig): void {
   eleventyConfig.addShortcode('ytEmbed', function (id: string, title: string, fullWidth = false) {
+    const escapedTitle = title && title.length > 0 ? escapeHtml(title) : '';
+
+    let startTime = 0;
+    if (id.includes('?')) {
+      id = id.split('?')[0];
+
+      const idAndStartTime = id.split('start=');
+      if (idAndStartTime.length > 1) {
+        const startTimeString = idAndStartTime[1];
+        startTime = Number.parseInt(startTimeString);
+      }
+    }
+
     return `
-<lite-youtube videoid="${id}" videotitle="${title}" ${fullWidth ? 'class="full-width"' : ''}>
+<lite-youtube videoid="${id}" videotitle="${escapedTitle}" videoStartAt="${startTime}" ${fullWidth ? 'class="full-width"' : ''}>
   <p><a class="lite-youtube-fallback" href="https://www.youtube.com/watch/${id}" target="_blank" rel="noopener">Watch on YouTube in a new tab: "${title}"</a></p>
 </lite-youtube>`;
   });

--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -128,6 +128,6 @@
     {% endfor -%}
     {% endif -%}
 
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.7.1/lite-youtube.js" integrity="sha256-86ffB4sPsE/4qX2arBqtw6F1Ofv8lvv7AomIyHHTB5s=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.8.1/lite-youtube.js" integrity="sha256-dSKwIYLvKdlkLGLp9ZRLJilBuGFSM5beizYOSvK1LeQ=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   </body>
 </html>


### PR DESCRIPTION
The `lite-youtube` element didn't expect the `id` field to include a start time, causing the video embeds to break. Before passing the ID to the custom element, extract the start time and pass that separately.

Also update `lite-youtube` video to the latest release for some fixes on Firefox.

Fixes https://github.com/flutter/website/issues/11994
Fixes https://github.com/flutter/website/issues/11998