### PR TITLE
Adjust theme toggle icon

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -71,7 +71,7 @@
       </a>
       <div id="theme-switcher" class="dropdown">
         <button class="dropdown-button icon-button" title="Select a theme" aria-label="Select a theme" aria-expanded="false" aria-controls="site-switcher-menu">
-          <span class="material-symbols" aria-hidden="true">contrast</span>
+          <span class="material-symbols" aria-hidden="true">routine</span>
         </button>
         <div class="dropdown-content" id="theme-menu" >
           <div class="dropdown-menu">


### PR DESCRIPTION
Switch to an icon that's more obviously related to light and dark mode. This new icon is also used by a few other Google sites, like the Gemini web app.

<img width="120" alt="Screenshot of the new theme select toggle" src="https://github.com/user-attachments/assets/7aec546e-e5be-4981-851a-2b2dc66b4d65" />
