### PR TITLE
Filter by close icon added for mobile screen

### DIFF
--- a/src/_includes/docs/learning-resources-index/side-filters.liquid
+++ b/src/_includes/docs/learning-resources-index/side-filters.liquid
@@ -1,4 +1,11 @@
+<input type="checkbox" id="close-filter-toggle" hidden>
+<div id="resource-filter-group-wrapper">
 <div id="resource-filter-group">
+<div class="filter-header">
+      <label for="close-filter-toggle" class="close-icon" aria-hidden="true">
+        <span class="material-symbols">close</span>
+      </label>
+    </div>
     <div class="table-title">Filter by</div>
     <div class="table-content">
         <h4>Subject</h4>
@@ -36,4 +43,5 @@
             <span class="material-symbols" aria-hidden="true">expand_more</span>
         </button>
     </div>
+</div>
 </div>

--- a/src/_sass/pages/_learning-resources-index.scss
+++ b/src/_sass/pages/_learning-resources-index.scss
@@ -1,3 +1,41 @@
+.close-icon {
+  font-size: 1rem;
+  cursor: pointer;
+}
+// smaller screen filter by
+@media (max-width: 839px) {
+  #resource-filter-group-wrapper{
+    position: fixed;
+    top: var(--site-header-height);
+    bottom: 0;
+    right: -220px;            
+    width: 220px;
+    background-color: var(--site-inset-bgColor);
+    transition: right 0.3s ease-in-out;
+    z-index: 1000;
+  }
+
+#close-filter-toggle:not(:checked) + #resource-filter-group-wrapper { right: 0; }
+#close-filter-toggle:checked     + #resource-filter-group-wrapper { right: -220px; }
+
+// close icon in small screen
+  #resource-filter-group .filter-header {
+    display: flex;
+    justify-content: flex-end;
+    padding: 0.5rem 0.75rem;
+  }
+}
+// Large screens
+@media (min-width: 840px) {
+  #resource-filter-group {
+    position: static !important;
+    right: auto !important;
+  }
+  #resource-filter-group .filter-header {
+    display: none !important;
+  }
+}
+
 #resource-index-content {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
A close icon/button should be added to the "Filter by" wrapper on mobile screens to allow users to easily close the sidebar.

Fixed #11980

he close button works properly, but despite trying multiple times, I couldn't fix the issue where, after closing the filter once, clicking the filter icon again on a mobile screen doesn't show the filter content inside the card.

https://github.com/user-attachments/assets/cf04648c-9c11-41ba-9afa-9ff73cae7c28


## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
