### PR TITLE
Add breaking change doc for removing semantics elevation and thickness

### DIFF
--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -42,6 +42,7 @@ They're sorted by release and listed in alphabetical order:
 
 ### Not yet released to stable
 
+* [Removed semantics elevation and thickness][]
 * [Deprecate `ExpansionTileController` in favor of `ExpansibleController`][]
 * [Deprecate `RouteTransitionRecord.markForRemove`][deprecate-markForRemove]
    in favor of `RouteTransitionRecord.markForComplete`
@@ -55,6 +56,7 @@ They're sorted by release and listed in alphabetical order:
 * [Deprecate `InputDecoration.maintainHintHeight` in favor of `InputDecoration.maintainHintSize`][]
 * [Underdamped spring formula changed][]
 
+[Removed semantics elevation and thickness]: /release/breaking-changes/remove-semantics-elevation-and-thickness
 [Deprecate `SystemContextMenuController.show`]: /release/breaking-changes/system_context_menu_controller_show
 [Deprecate `ExpansionTileController` in favor of `ExpansibleController`]: {{site.url}}/release/breaking-changes/expansion-tile-controller
 [deprecate-markForRemove]: /release/breaking-changes/navigator-complete-route

--- a/src/content/release/breaking-changes/remove-semantics-elevation-and-thickness.md
+++ b/src/content/release/breaking-changes/remove-semantics-elevation-and-thickness.md
@@ -1,0 +1,67 @@
+---
+title: Removed semantics elevation and thickness
+description: >
+  Removed elevation and thickness from semantics properties.
+---
+
+## Summary
+
+Both elevation and thickness semantics properties and their related apis were removed
+
+## Context
+
+Both elevation and thickness semantics properties were created for fuchsia's 3D rendering.
+They were never implemented and thus remained unused. There were also no other known usage
+for these properties. These properties added unnecessary code complexity and were removed.
+
+## Description of change
+
+We removed `SemanticsConfiguration.elevation`, `SemanticsConfiguration.thickness`,
+`SemanticsNode.thickness`, `SemanticsNode.elevation`, and `SemanticsNode.elevationAdjustment`.
+
+## Migration guide
+
+If you previously assigned these properties, remove the assignments.
+
+Code before migration:
+
+```dart
+void describeSemanticsConfiguration(SemanticsConfiguration config) {
+  config.label = 'my label';
+  config.elevation = 1;
+  config.thickness = 1;
+}
+```
+
+Code after migration:
+
+```dart
+void describeSemanticsConfiguration(SemanticsConfiguration config) {
+  config.label = 'my label';
+}
+```
+
+## Timeline
+
+Landed in version: 3.32.0
+In stable release: TBD
+
+## References
+
+API documentation:
+
+* [`SemanticsConfiguration`][]
+* [`SemanticsNode`][]
+
+Relevant issue:
+
+* [Issue 166092][]
+
+Relevant PR:
+
+* [PR 168703][]
+
+[`SemanticsConfiguration`]: {{site.api}}/flutter/semantics/SemanticsConfiguration-class.html
+[`SemanticsNode`]: {{site.api}}/flutter/semantics/SemanticsNode-class.html
+[Issue 166092]: {{site.repo.flutter}}/issues/166092
+[PR 168703]: {{site.repo.flutter}}/pull/168703

--- a/src/content/release/breaking-changes/remove-semantics-elevation-and-thickness.md
+++ b/src/content/release/breaking-changes/remove-semantics-elevation-and-thickness.md
@@ -6,17 +6,18 @@ description: >
 
 ## Summary
 
-Both elevation and thickness semantics properties and their related apis were removed
+Both elevation and thickness semantics properties and their related APIs were removed.
 
 ## Context
 
-Both elevation and thickness semantics properties were created for fuchsia's 3D rendering.
-They were never implemented and thus remained unused. There were also no other known usage
-for these properties. These properties added unnecessary code complexity and were removed.
+Both elevation and thickness semantics properties were created for Fuchsia's 3D rendering.
+They were never implemented and thus remained unused. There was also no other known usage
+for these properties. These properties added unnecessary code complexity and have been removed.
 
 ## Description of change
 
-We removed `SemanticsConfiguration.elevation`, `SemanticsConfiguration.thickness`,
+The following properties are removed `SemanticsConfiguration.elevation`,
+`SemanticsConfiguration.thickness`,
 `SemanticsNode.thickness`, `SemanticsNode.elevation`, and `SemanticsNode.elevationAdjustment`.
 
 ## Migration guide


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why: breaking change

_Issues fixed by this PR (if any): https://github.com/flutter/flutter/pull/168703

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
