### PR TITLE
Improve styling for `kbd` element

### DIFF
--- a/src/_sass/components/_code.scss
+++ b/src/_sass/components/_code.scss
@@ -18,9 +18,16 @@ main code, main kbd {
 }
 
 main kbd {
-  background-color: var(--site-base-fgColor);
-  border: none;
-  color: var(--site-inset-borderColor);
+  font-weight: 500;
+  padding: 0.05rem 0.35rem;
+
+  border-width: 1.5px;
+  border-bottom-width: 3px;
+  border-radius: 0.35rem;
+  box-shadow: inset 0 1px 1px rgb(var(--site-interaction-base-values) / 5%);
+
+  // Reduce word spacing so the + combinator is closer.
+  word-spacing: -0.25em;
 }
 
 pre {


### PR DESCRIPTION
Updates the styling for the `kbd` element to be more consistent in dark mode. Also uses a slightly button-like style for both light and dark mode.

Fixes https://github.com/flutter/website/issues/12015

---

**Dark mode:**

<img width="320" alt="Screenshot of new kbd element in dark mode" src="https://github.com/user-attachments/assets/1a9370ad-3c3e-4cf1-92b3-45f3ce47f04e" />

**Light mode:**

<img width="320" alt="Screenshot of new kbd element in light mode" src="https://github.com/user-attachments/assets/1e278a05-403f-4395-9a33-6f66967727d0" />
