### PR TITLE
Move site switcher to icon button

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -3,63 +3,13 @@
     Skip to main content
   </a>
   <nav class="navbar">
-    <div id="site-switcher" class="dropdown">
-      <button class="dropdown-button site-wordmark" aria-expanded="false" aria-controls="site-switcher-menu" aria-label="Switch between Flutter and Dart sites">
-        <img src="/assets/images/branding/flutter/logo/default.svg" alt="Flutter logo" width="28">
-        <span class="name">Flutter</span>
-        <span class="subtype">Docs</span>
-        <span class="material-symbols" aria-hidden="true">unfold_more</span>
-      </button>
-      <div class="dropdown-content" id="site-switcher-menu">
-        <nav class="dropdown-menu" role="menu">
-          <ul>
-            <li role="presentation"><a href="{{site.main-url}}" class="site-wordmark" role="menuitem" title="Flutter homepage" aria-label="Go to the Flutter homepage">
-              <img src="/assets/images/branding/flutter/logo/default.svg" alt="Flutter logo" width="28">
-              <span>Flutter</span>
-            </a></li>
-            <li role="presentation"><a href="/" class="site-wordmark current-site" role="menuitem"  aria-current="true" title="Flutter docs homepage" aria-label="Go to the Flutter docs homepage">
-              <img src="/assets/images/branding/flutter/logo/default.svg" alt="Flutter logo" width="28">
-              <span>Flutter</span>
-              <span class="subtype">Docs</span>
-            </a></li>
-            <li role="presentation"><a href="{{site.api}}" class="site-wordmark" role="menuitem"  title="Flutter API reference" aria-label="Go to the Flutter API reference">
-              <img src="/assets/images/branding/flutter/logo/default.svg" alt="Flutter logo" width="28">
-              <span>Flutter</span>
-              <span class="subtype">API</span>
-            </a></li>
-            <li aria-hidden="true" class="dropdown-divider" role="separator"></li>
-            <li role="presentation"><a href="{{site.dart-site}}" class="site-wordmark" role="menuitem"  title="Dart homepage" aria-label="Go to the Dart homepage">
-              <img src="/assets/images/branding/dart/logo.svg" alt="Dart logo" width="28" height="28">
-              <span>Dart</span>
-            </a></li>
-            <li role="presentation"><a href="{{site.dartpad}}" class="site-wordmark" role="menuitem"  title="DartPad playground" aria-label="Go to the DartPad playground">
-              <img src="/assets/images/branding/dart/logo.svg" alt="Dart logo" width="28" height="28">
-              <span>DartPad</span>
-            </a></li>
-            <li role="presentation"><a href="{{site.pub}}" class="site-wordmark" role="menuitem" title="pub.dev homepage" aria-label="Go to the pub.dev homepage">
-              <img src="/assets/images/branding/dart/logo.svg" alt="Dart logo" width="28" height="28">
-              <span>pub.dev</span>
-            </a></li>
-          </ul>
-        </nav>
-      </div>
-    </div>
+    <a id="site-primary-logo" class="site-wordmark" href="/" aria-label="Go to the Flutter docs homepage" title="Go to the Flutter docs homepage">
+      <img src="/assets/images/branding/flutter/logo/default.svg" alt="Flutter logo" width="28">
+      <span class="name">Flutter</span>
+      <span class="subtype">Docs</span>
+    </a>
 
     <div class="navbar-contents">
-      <ul class="navbar-nav">
-        <li class="nav-item">
-          <a class="nav-link" href="{{site.main-url}}">Homepage</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{site.main-url}}/community">Community</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{site.pub}}">Packages</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{site.api}}">API reference</a>
-        </li>
-      </ul>
       <form action="/search/" class="site-header__search">
         <input
           class="site-header__searchfield search-field"
@@ -96,6 +46,44 @@
               </li>
             </ul>
           </div>
+        </div>
+      </div>
+      <div id="site-switcher" class="dropdown">
+        <button class="dropdown-button icon-button" aria-expanded="false" aria-controls="site-switcher-menu" aria-label="Switch between Flutter and Dart sites">
+          <span class="material-symbols" aria-hidden="true">apps</span>
+        </button>
+        <div class="dropdown-content" id="site-switcher-menu">
+          <nav class="dropdown-menu" role="menu">
+            <ul>
+              <li role="presentation"><a href="{{site.main-url}}" class="site-wordmark" role="menuitem" title="Flutter homepage" aria-label="Go to the Flutter homepage">
+                <img src="/assets/images/branding/flutter/logo/default.svg" alt="Flutter logo" width="28">
+                <span class="name">Flutter</span>
+              </a></li>
+              <li role="presentation"><a href="/" class="site-wordmark current-site" role="menuitem"  aria-current="true" title="Flutter docs homepage" aria-label="Go to the Flutter docs homepage">
+                <img src="/assets/images/branding/flutter/logo/default.svg" alt="Flutter logo" width="28">
+                <span class="name">Flutter</span>
+                <span class="subtype">Docs</span>
+              </a></li>
+              <li role="presentation"><a href="{{site.api}}" class="site-wordmark" role="menuitem"  title="Flutter API reference" aria-label="Go to the Flutter API reference">
+                <img src="/assets/images/branding/flutter/logo/default.svg" alt="Flutter logo" width="28">
+                <span class="name">Flutter</span>
+                <span class="subtype">API</span>
+              </a></li>
+              <li aria-hidden="true" class="dropdown-divider" role="separator"></li>
+              <li role="presentation"><a href="{{site.dart-site}}" class="site-wordmark" role="menuitem"  title="Dart homepage" aria-label="Go to the Dart homepage">
+                <img src="/assets/images/branding/dart/logo.svg" alt="Dart logo" width="28" height="28">
+                <span class="name">Dart</span>
+              </a></li>
+              <li role="presentation"><a href="{{site.dartpad}}" class="site-wordmark" role="menuitem"  title="DartPad playground" aria-label="Go to the DartPad playground">
+                <img src="/assets/images/branding/dart/logo.svg" alt="Dart logo" width="28" height="28">
+                <span class="name">DartPad</span>
+              </a></li>
+              <li role="presentation"><a href="{{site.pub}}" class="site-wordmark" role="menuitem" title="pub.dev homepage" aria-label="Go to the pub.dev homepage">
+                <img src="/assets/images/branding/dart/logo.svg" alt="Dart logo" width="28" height="28">
+                <span class="name">pub.dev</span>
+              </a></li>
+            </ul>
+          </nav>
         </div>
       </div>
       <a id="call-to-action" class="filled-button" href="/get-started/install/">Get started</a>

--- a/src/_sass/components/_dropdown.scss
+++ b/src/_sass/components/_dropdown.scss
@@ -8,6 +8,7 @@
   border-radius: 0.4rem;
   width: max-content;
   border: var(--site-outline-variant) 1px solid;
+  z-index: var(--site-z-dropdown);
 
   &.show {
     display: block;

--- a/src/_sass/components/_header.scss
+++ b/src/_sass/components/_header.scss
@@ -22,8 +22,6 @@
     min-height: var(--site-header-height);
 
     #menu-toggle {
-      margin-left: 0.25rem;
-
       @media (min-width: 1024px) {
         display: none;
       }
@@ -43,19 +41,7 @@
       display: flex;
       flex-direction: row;
       align-items: center;
-    }
-
-    .navbar-nav {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      flex-direction: row;
-      gap: 0.5rem;
-      display: none;
-
-      @media (min-width: 1200px) {
-        display: flex;
-      }
+      gap: .5rem;
     }
 
     .nav-link {
@@ -71,8 +57,7 @@
   }
 
   #call-to-action {
-    margin-left: 0.5rem;
-    padding: 0.5rem 1rem !important;
+    padding: 0.5rem 1rem;
     display: none;
 
     @media (min-width: 1024px) {
@@ -94,14 +79,18 @@
     &::before {
       content: 'search';
       color: var(--site-base-fgColor-alt);
-      font: 24px/1 var(--site-icon-fontFamily);
+      font: 28px/1 var(--site-icon-fontFamily);
       pointer-events: none;
       position: absolute;
-      left: 0.75rem;
+      left: 1.25rem;
     }
 
     &:hover::before {
       color: var(--site-base-fgColor);
+    }
+
+    &:focus-within::before {
+      //left: 1rem;
     }
   }
 
@@ -112,7 +101,7 @@
     width: 24px;
     cursor: pointer;
     border-radius: 24px;
-    padding: 0.5rem 0.5rem 0.5rem 2.5rem;
+    padding: 0.5rem 0.5rem 0.5rem 3rem;
     background: none;
 
     &:focus {
@@ -152,5 +141,33 @@ body.open_menu #menu-toggle span.material-symbols {
 
   &:last-child {
     display: inline;
+  }
+}
+
+#site-primary-logo {
+  text-decoration: none;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.25rem;
+
+  &:hover {
+    text-decoration: none;
+  }
+
+  > span {
+    &.name {
+      display: none;
+
+      @media (min-width: 420px) {
+        display: unset;
+      }
+    }
+
+    &.subtype {
+      margin-left: 0;
+
+      @media (min-width: 420px) {
+        margin-left: 0.4rem;
+      }
+    }
   }
 }

--- a/src/_sass/components/_site-switcher.scss
+++ b/src/_sass/components/_site-switcher.scss
@@ -2,86 +2,55 @@
 
 #site-switcher {
   position: relative;
-  display: inline-flex;
-  justify-content: center;
 
   .dropdown-content {
-    z-index: var(--site-z-dropdown);
     transform: scale(0.9);
-    top: 2.25rem;
-    left: -0.75rem;
+    top: 1.25rem;
+    right: -0.75rem;
 
     @media (min-width: 420px) {
-      left: unset;
+      right: 0;
     }
   }
 
+  display: none;
+  @media (min-width: 320px) {
+    display: block;
+  }
+}
 
-  button.dropdown-button {
-    padding: 0.4rem 0.6rem;
-    border-radius: 0.25rem;
+#site-primary-logo, #site-switcher .site-wordmark {
+  padding: 0.4rem 0.6rem;
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  cursor: pointer;
+  gap: 0;
 
-    .material-symbols:last-child {
-      margin-left: 0.4rem;
-      color: rgba(85, 85, 85, 0.6);
-      font-size: 1rem;
-      width: 0.7rem;
-    }
+  font-variant-ligatures: none;
+  font-size: 1.75rem;
+  line-height: 1.25em;
+  letter-spacing: 0.015em;
+  font-family: 'Google Sans', sans-serif;
+  user-select: none;
 
-    &:hover {
-      .material-symbols {
-        color: rgba(85, 85, 85, 0.8);
-      }
-    }
-
-    > span {
-      &.name {
-        display: none;
-
-        @media (min-width: 420px) {
-          display: unset;
-        }
-      }
-
-      &.subtype {
-        margin-left: 0;
-
-        @media (min-width: 420px) {
-          margin-left: 0.4rem;
-        }
-      }
-    }
+  > img {
+    width: 28px;
+    margin-right: 0.25rem;
   }
 
-  .site-wordmark {
-    padding: 0.4rem 0.6rem;
-    align-items: center;
-    display: flex;
-    flex-direction: row;
-    cursor: pointer;
-    gap: 0;
+  &.current-site {
+    background-color: var(--site-primary-color-highlight);
+  }
 
-    font-variant-ligatures: none;
-    font-size: 1.75rem;
-    line-height: 1.25em;
-    letter-spacing: 0.015em;
-    font-family: 'Google Sans', sans-serif;
-    user-select: none;
+  span {
+    color: var(--site-wordmark-fgColor);
 
-    > img {
-      width: 28px;
-      margin-right: 0.75rem;
+    &.name {
+      margin-left: 0.5rem;
     }
 
-    &.current-site {
-      background-color: var(--site-primary-color-highlight);
-    }
-
-    span {
-      color: var(--site-wordmark-fgColor);
-    }
-
-    span.subtype {
+    &.subtype {
       padding: 0 0.3rem;
       font-size: 1.25rem;
       font-weight: 500;

--- a/src/_sass/components/_theming.scss
+++ b/src/_sass/components/_theming.scss
@@ -1,6 +1,5 @@
 #theme-switcher {
   position: relative;
-  margin-left: 0.1rem;
 
   > .dropdown-content {
     right: -0.5rem;


### PR DESCRIPTION
I kept finding myself wishing the current logo lead to the docs homepage. So this PR moves the site switcher to a separate button alongside the theme and search buttons, using an icon similar to other Google sites with similar functionality.