### PR TITLE
Remove specific versions from old setup flow

### DIFF
--- a/src/_data/site.yml
+++ b/src/_data/site.yml
@@ -61,46 +61,4 @@ yt:
   watch: 'https://www.youtube.com/watch'
   playlist: 'https://www.youtube.com/playlist?list='
 
-## Software minimum versions
-
-appmin:
-  git_win: 2.27
-  git_mac: 2.27
-  vscode: 1.86
-  android_studio: '2024.1.1 (Koala)'
-  intellij_idea: '2024.1'
-  android_sdk: 21
-  powershell: 5.0
-  xcode: '15'
-  cocoapods: '1.16'
-devmin:
-  windows: '64-bit version of Microsoft Windows 10'
-  macos: '11 (Big Sur)'
-  linux:
-    debian: 11
-    ubuntu: '20.04 LTS'
-targetmin:
-  windows: 'Microsoft Windows 10'
-  macos: '10.14 (Mojave)'
-  linux:
-    debian: 10
-    ubuntu: '20.04 LTS'
-  ios: 12
-  android: 'Android API level 21'
-
-## Software current versions
-
-appnow:
-  flutter: '3.29.3'
-  vscode: '1.96'
-  android_studio: '2024.2'
-  android_sdk: '35.0.2'
-  intellij: '2024.3'
-  powershell: 5.1
-  xcode: '16'
-  ios: '17'
-  cocoapods: '1.16'
-
-platform:
-  androidApiLevel: '35'
-  minimumAndroidVersion: ''
+currentFlutterVersion: '3.29.3'

--- a/src/_includes/docs/install/compiler/android.md
+++ b/src/_includes/docs/install/compiler/android.md
@@ -20,7 +20,7 @@
 To create Android apps with Flutter, verify that the following Android
 components have been installed.
 
-* **Android SDK Platform, API {{ site.appnow.android_sdk }}**
+* **Android SDK Platform, API 35**
 * **Android SDK Command-line Tools**
 * **Android SDK Build-Tools**
 * **Android SDK Platform-Tools**
@@ -43,7 +43,7 @@ Otherwise, you can skip to the [next section][check-dev].
 
 1. Install the following components:
 
-   * **Android SDK Platform, API {{ site.appnow.android_sdk }}**
+   * **Android SDK Platform, API 35**
    * **Android SDK Command-line Tools**
    * **Android SDK Build-Tools**
    * **Android SDK Platform-Tools**
@@ -65,12 +65,12 @@ Otherwise, you can skip to the [next section][check-dev].
 
 1. Click **SDK Platforms**.
 
-1. Verify that **Android API {{ site.appnow.android_sdk }}** has been selected.
+1. Verify that **Android API 35** has been selected.
 
    If the **Status** column displays **Update available** or **Not installed**:
 
    {:type="a"}
-   1. Select **Android API {{ site.appnow.android_sdk }}**.
+   1. Select **Android API 35**.
 
    1. Click **Apply**.
 
@@ -207,7 +207,7 @@ follow these steps to create and select an emulator.
 {% render docs/help-link.md, location:'android-device', section:'#android-setup' %}
 
 To configure your Flutter app to run on a physical Android device,
-you need an Android device running {{site.targetmin.android}} or later.
+you need a [supported version of Android][supported-version].
 
 1. Enable **Developer options** and **USB debugging** on your device
    as described in the
@@ -254,6 +254,8 @@ you need an Android device running {{site.targetmin.android}} or later.
 
 {% endtab %}
 {% endtabs %}
+
+[supported-version]: /reference/supported-platforms
 
 {% if include.attempt == 'first' %}
 

--- a/src/_includes/docs/install/flutter/vscode.md
+++ b/src/_includes/docs/install/flutter/vscode.md
@@ -6,9 +6,9 @@
 
 ### Use VS Code to install Flutter {:.no_toc}
 
-To install Flutter using these instructions, verify that
-you have installed [Visual Studio Code][]
-{{site.appmin.vscode}} or later and the [Flutter extension for VS Code][].
+To install Flutter using these instructions,
+verify that you've installed
+[Visual Studio Code][] and the [Flutter extension for VS Code][].
 
 #### Prompt VS Code to install Flutter
 
@@ -26,10 +26,10 @@ you have installed [Visual Studio Code][]
    {:type="a"}
    1. If you have the Flutter SDK installed, click **Locate SDK**.
 
-   1. If you do not have the Flutter SDK installed,
+   1. If you don't have the Flutter SDK installed,
       click **Download SDK**.
 
-      This option sends you the Flutter install page if you have not
+      This option sends you the Flutter install page if you haven't
       installed Git {% if include.os == "Windows" %}for Windows {% endif %}as
       directed in the [development tools prerequisites][].
 

--- a/src/_includes/docs/install/reqs/linux/base.md
+++ b/src/_includes/docs/install/reqs/linux/base.md
@@ -8,8 +8,8 @@ software packages.
 
 {% if include.os == 'Linux' %}
 {%- capture supported-os %}
-Debian Linux {{site.devmin.linux.debian}} or later
-and Ubuntu Linux {{site.devmin.linux.ubuntu}} or later
+Debian 11 or later
+and Ubuntu 22.04 or later LTS
 {% endcapture -%}
 {% else %}
 {% assign supported-os = 'ChromeOS' %}
@@ -73,7 +73,7 @@ To develop Flutter on {{include.os}}:
       $ sudo apt-get install libc6:amd64 libstdc++6:amd64 lib32z1 libbz2-1.0:amd64
       ```
 
-   1. Install [Android Studio][] {{site.appmin.android_studio}} or later to
+   1. Install [Android Studio][] to
       debug and compile Java or Kotlin code for Android.
       Flutter requires the full version of Android Studio.
 
@@ -106,16 +106,13 @@ syntax highlighting, widget editing assists, debugging, and other features.
 
 Popular options include:
 
-* [Visual Studio Code][vscode] {{site.appmin.vscode}} or later
-  with the [Flutter extension for VS Code][].
-* [Android Studio][] {{site.appmin.android_studio}} or later
-  with the [Flutter plugin for IntelliJ][].
-* [IntelliJ IDEA][] {{site.appmin.intellij_idea}} or later
-  with the [Flutter plugin for IntelliJ][].
+* [Visual Studio Code][vscode] with the [Flutter extension for VS Code][].
+* [Android Studio][] with the [Flutter plugin for IntelliJ][].
+* [IntelliJ IDEA][] with the [Flutter plugin for IntelliJ][].
 
 :::recommend
-The Flutter team recommends installing [Visual Studio Code][vscode]
-{{site.appmin.vscode}} or later and the [Flutter extension for VS Code][].
+The Flutter team recommends installing
+[Visual Studio Code][vscode] and the [Flutter extension for VS Code][].
 This combination simplifies installing the Flutter SDK.
 :::
 

--- a/src/_includes/docs/install/reqs/macos/base.md
+++ b/src/_includes/docs/install/reqs/macos/base.md
@@ -14,7 +14,7 @@ install the following packages.
 
 ### Operating system
 
-Flutter supports developing on macOS {{site.devmin.macos}} or later.
+Flutter supports developing on macOS 12 (Monterey) or later.
 This guide presumes your Mac runs the `zsh` as your [default shell][zsh-mac].
 
 Some Flutter components require the
@@ -35,39 +35,30 @@ $ sudo softwareupdate --install-rosetta --agree-to-license
 
 Download and install the following packages.
 
-{% assign xcode = '[Xcode][] ' | append: site.appnow.xcode | append: ' to debug and compile native Swift or ObjectiveC code.' %}
-{% assign cocoapods = '[CocoaPods][] ' | append: site.appnow.cocoapods | append: ' to compile and enable Flutter plugins in your native apps.' %}
-{% capture android -%}
-[Android Studio][] {{site.appmin.android_studio}} or later to
-debug and compile Java or Kotlin code for Android.
-Flutter requires the full version of Android Studio.
-{% endcapture %}
-{% assign chrome = "[Google Chrome][] to debug JavaScript code for web apps." %}
-{% assign git-main = '[Git][] ' | append: site.appmin.git_mac | append: ' or later to manage source code.' %}
-{% assign git-xcode = "The Xcode installation includes " %}
-{% capture git-other -%}
-To check if you have `git` installed,
-type `git version` in your Terminal.
-If you need to install `git`, type `brew install git`.
-{% endcapture %}
-
 {% case include.target %}
 {% when 'desktop','iOS' %}
 
-* {{xcode}} {{git-xcode}} {{git-main}}
-* {{cocoapods}}
+* [Xcode][] to debug and compile native Swift or Objective-C code.
+  The Xcode installation also includes Git to manage Flutter versions
+  and your own source code versioning.
+* [CocoaPods][] to compile and enable Flutter plugins in your native apps.
 
 {% when 'Android' %}
 
-* {{android}}
-* {{git-main}}
-  {{- git-other}}
+* [Android Studio][] to debug and compile Java or Kotlin code for Android.
+  Flutter requires the full version of Android Studio.
+* [Git][] to manage Flutter versions and your own source code versioning.
+  To check if you have `git` installed,
+  type `git version` in your Terminal.
+  If you need to install `git`, run `xcode-select --install`.
 
 {% when 'Web' -%}
 
-* {{chrome}}
-* {{git-main}}
-  {{- git-other}}
+* [Google Chrome][] to debug JavaScript code for web apps.
+* [Git][] to manage Flutter versions and your own source code versioning.
+  To check if you have `git` installed,
+  type `git version` in your Terminal.
+  If you need to install `git`, run `xcode-select --install`.
 
 {% endcase %}
 
@@ -78,7 +69,7 @@ To troubleshoot installation issues, consult that product's documentation.
 [Android Studio]: https://developer.android.com/studio/install#mac
 [Xcode]: {{site.apple-dev}}/xcode/
 [CocoaPods]: https://cocoapods.org/
-[Google Chrome]: https://www.google.com/chrome/dr/download/
+[Google Chrome]: https://www.google.com/chrome/
 
 ### Text editor or integrated development environment
 
@@ -91,18 +82,14 @@ syntax highlighting, widget editing assists, debugging, and other features.
 
 Popular options include:
 
-* [Visual Studio Code][] {{site.appmin.vscode}} or later
-  with the [Flutter extension for VS Code][].
-* [Android Studio][] {{site.appmin.android_studio}} or later
-  with the [Flutter plugin for IntelliJ][].
-* [IntelliJ IDEA][] {{site.appmin.intellij_idea}} or later
-  with both the [Flutter plugin for IntelliJ][] and
-  the [Android plugin for IntelliJ][].
+* [Visual Studio Code][] with the [Flutter extension for VS Code][].
+* [Android Studio][] with the [Flutter plugin for IntelliJ][].
+* [IntelliJ IDEA][] with both
+  the [Flutter plugin for IntelliJ][] and the [Android plugin for IntelliJ][].
 
 :::recommend
 The Flutter team recommends installing
-[Visual Studio Code][] {{site.appmin.vscode}} or later and the
-[Flutter extension for VS Code][].
+[Visual Studio Code][] and the [Flutter extension for VS Code][].
 This combination simplifies installing the Flutter SDK.
 :::
 

--- a/src/_includes/docs/install/reqs/windows/base.md
+++ b/src/_includes/docs/install/reqs/windows/base.md
@@ -6,25 +6,25 @@ software packages.
 
 ### Operating system
 
-Flutter supports {{site.devmin.windows}} or later.
+Flutter supports developing on 64-bit versions of Windows 10 and 11.
 
 ### Development tools
 
 Download and install the Windows version of the following packages:
 
-* [Git for Windows][] {{site.appmin.git_win}} or later to manage source code.
+* [Git for Windows][] to manage Flutter versions and
+  your own source code versioning.
 
 {% if include.target == 'desktop' -%}
 
 * [Visual Studio 2022][] to debug and compile native C++ Windows code.
   Make sure to install the **Desktop development with C++** workload.
-  This enables building Windows app including all of its default components.
+  This enables building Windows apps, including all of its default components.
   **Visual Studio** is an IDE separate from **[Visual Studio _Code_][]**.
 
 {% elsif include.target == 'Android' -%}
 
-* [Android Studio][] {{site.appmin.android_studio}} or later
-  to debug and compile Java or Kotlin code for Android.
+* [Android Studio][] to debug and compile Java or Kotlin code for Android.
 
 {% elsif include.target == 'Web' -%}
 
@@ -34,10 +34,9 @@ Download and install the Windows version of the following packages:
 
 * [Visual Studio 2022][] with the **Desktop development with C++** workload
   or [Build Tools for Visual Studio 2022][].
-  This enables building Windows app including all of its default components.
+  This enables building Windows apps, including all of its default components.
   **Visual Studio** is an IDE separate from **[Visual Studio _Code_][]**.
-* [Android Studio][] {{site.appmin.android_studio}} or later
-  to debug and compile Java or Kotlin code for Android.
+* [Android Studio][] to debug and compile Java or Kotlin code for Android.
 * The latest version of [Google Chrome][] to debug JavaScript code for web apps.
 
 {% endif -%}
@@ -62,16 +61,13 @@ syntax highlighting, widget editing assists, debugging, and other features.
 
 Popular options include:
 
-* [Visual Studio Code][] {{site.appmin.vscode}} or later
-  with the [Flutter extension for VS Code][].
-* [Android Studio][] {{site.appmin.android_studio}} or later
-  with the [Flutter plugin for IntelliJ][].
-* [IntelliJ IDEA][] {{site.appmin.intellij_idea}} or later
-  with the [Flutter plugin for IntelliJ][].
+* [Visual Studio Code][] with the [Flutter extension for VS Code][].
+* [Android Studio][] with the [Flutter plugin for IntelliJ][].
+* [IntelliJ IDEA][] with the [Flutter plugin for IntelliJ][].
 
 :::recommend
-The Flutter team recommends installing [Visual Studio Code][]
-{{site.appmin.vscode}} or later and the [Flutter extension for VS Code][].
+The Flutter team recommends installing
+[Visual Studio Code][] and the [Flutter extension for VS Code][].
 This combination simplifies installing the Flutter SDK.
 :::
 

--- a/src/content/add-to-app/ios/project-setup.md
+++ b/src/content/add-to-app/ios/project-setup.md
@@ -28,8 +28,7 @@ For an example using SwiftUI, consult the iOS directory in [News Feed App][].
 
 ## Development system requirements
 
-Flutter supports Xcode {{site.appmin.xcode}} or later and
-[CocoaPods][] {{site.appmin.cocoapods}} or later.
+Flutter requires the latest version of Xcode and [CocoaPods][].
 
 ## Create a Flutter module
 

--- a/src/content/deployment/macos.md
+++ b/src/content/deployment/macos.md
@@ -95,7 +95,8 @@ In the **Deployment info** section:
 
 `Deployment Target`
 : The minimum macOS version that your app supports.
-  Flutter supports deploying apps to macOS {{site.targetmin.macos}} and later.
+  To check which versions of macOS that Flutter supports deploying to,
+  check out Flutter's [Supported deployment platforms][].
 
 In the **Signing & Capabilities** section:
 
@@ -117,6 +118,8 @@ the following:
 
 For a detailed overview of app signing, see
 [Create, export, and delete signing certificates][appsigning].
+
+[Supported deployment platforms]: /reference/supported-platforms
 
 ## Configuring the app's name, bundle identifier and copyright
 

--- a/src/content/platform-integration/android/setup.md
+++ b/src/content/platform-integration/android/setup.md
@@ -68,7 +68,7 @@ install and set up the latest stable version of [Android Studio][].
     1. If the **SDK Platforms** tab is not open, switch to it.
 
     1. Verify that the first entry with an **API Level** of
-       **{{ site.platform.androidApiLevel }}** has been selected.
+       **35** has been selected.
 
        If the **Status** column displays
        **Update available** or **Not installed**:

--- a/src/content/reference/supported-platforms.md
+++ b/src/content/reference/supported-platforms.md
@@ -4,7 +4,7 @@ short-title: Supported platforms
 description: The platforms that Flutter supports by platform version.
 ---
 
-As of Flutter {{site.appnow.flutter}},
+As of Flutter {{site.currentFlutterVersion}},
 Flutter supports deploying apps on the following combinations of
 hardware architectures and operating system versions.
 These combinations are called _platforms_.


### PR DESCRIPTION
The work in https://github.com/flutter/website/issues/11911 will eventually supersede these docs, but to ease that transition and make it easier to review complete some preliminary cleanup and small fixes.

Contributes to https://github.com/flutter/website/issues/11911
Resolves https://github.com/flutter/website/issues/11907