### PR TITLE
Fix unexpected raw `<style>` in the 3.32 release note

### DIFF
--- a/src/content/release/release-notes/release-notes-3.32.0.md
+++ b/src/content/release/release-notes/release-notes-3.32.0.md
@@ -52,7 +52,7 @@ check out the Flutter [CHANGELOG][].
 * Add color to CupertinoButton.filled constructor by @vizakenjack in [161660](https://github.com/flutter/flutter/pull/161660)
 * Adjust padding for Cupertino sheet content by @MitchellGoodwin in [162481](https://github.com/flutter/flutter/pull/162481)
 * Make CupertinoSheetRoute usable with Cupertino(Sliver)NavigationBar by @victorsanni in [162181](https://github.com/flutter/flutter/pull/162181)
-* [web] Only create one <style> for SelectableRegion by @mdebbar in [161682](https://github.com/flutter/flutter/pull/161682)
+* [web] Only create one `<style>` for SelectableRegion by @mdebbar in [161682](https://github.com/flutter/flutter/pull/161682)
 * fix: RangeError when selecting text in SelectionArea by @rkishan516 in [162228](https://github.com/flutter/flutter/pull/162228)
 * Added equals and hashCode for TextInputConfiguration and AutofillConfiguration by @Paulik8 in [162238](https://github.com/flutter/flutter/pull/162238)
 * Add role check in SemanticsNode._isDifferentFromCurrentSemanticAnnotation function. by @ksokolovskyi in [162578](https://github.com/flutter/flutter/pull/162578)


### PR DESCRIPTION
It seems there is a raw `<style>` element being generated and cause the page rendered incorrectly.

Fixes https://github.com/flutter/website/issues/12041
Closes https://github.com/flutter/website/pull/12043
