### PR TITLE
Add missing instructions for Android a2a depending on a module as source case

### DIFF
--- a/src/content/add-to-app/android/project-setup.md
+++ b/src/content/add-to-app/android/project-setup.md
@@ -202,15 +202,40 @@ host Android app, make the following changes.
 1. Add the `dependencyResolutionManagement` displayed in this step to the
    `settings.gradle` file.
 
-   ```groovy
-   dependencyResolutionManagement {
-      repositoriesMode = RepositoriesMode.PREFER_SETTINGS
-      repositories {
-          google()
-          mavenCentral()
-      }
-   }
-   ```
+{% tabs "settings.gradle.kts" %}
+{% tab "Kotlin" %}
+
+```kotlin title="settings.gradle.kts"
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+    val storageUrl: String = System.getenv("FLUTTER_STORAGE_BASE_URL") ?: "https://storage.googleapis.com"
+    repositories {
+        google()
+        mavenCentral()
+        maven("$storageUrl/download.flutter.io")
+    }
+}
+```
+
+{% endtab %}
+{% tab "Groovy" %}
+
+```groovy title="settings.gradle"
+dependencyResolutionManagement {
+    repositoriesMode = RepositoriesMode.PREFER_SETTINGS
+    String storageUrl = System.env.FLUTTER_STORAGE_BASE_URL ?: "https://storage.googleapis.com"
+    repositories {
+        google()
+        mavenCentral()
+        maven {
+            url = uri("$storageUrl/download.flutter.io")
+        }
+    }
+}
+```
+
+{% endtab %}
+{% endtabs %}
 
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

This instruction was already included in the tab for setting up depending on a module as an aar. It is also required for depending on the module as source, so I pulled it up to the preceding section (right before those tabs).

_Issues fixed by this PR (if any):_

https://github.com/flutter/flutter/issues/158583

_PRs or commits this PR depends on (if any):_

N/A

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
