### PR TITLE
Fix broken GitHub URL by adding missing slash

### DIFF
--- a/src/content/tools/pubspec.md
+++ b/src/content/tools/pubspec.md
@@ -222,7 +222,7 @@ A map of keys to flags (`true` or `false`) that influences how the `flutter` CLI
 is executed.
 
 > NOTE: This feature is only available as of
-> [#167953]({{site.github}}flutter/flutter/pull/167953) on the `main`
+> [#167953]({{site.github}}/flutter/flutter/pull/167953) on the `main`
 > channel.
 
 The available keys mirror those available in `flutter config --list`.


### PR DESCRIPTION
This PR fixes a broken GitHub link by adding a missing / in the URL.

Incorrect: https://github.comflutter/flutter/pull/167953
Correct: https://github.com/flutter/flutter/pull/167953
_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_
None

_PRs or commits this PR depends on (if any):_
None
## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
