### PR TITLE
Updates component theme normalization breaking changes

### DIFF
--- a/src/content/release/breaking-changes/component-theme-normalization-updates.md
+++ b/src/content/release/breaking-changes/component-theme-normalization-updates.md
@@ -30,11 +30,31 @@ final BottomAppBarTheme bottomAppBarTheme = Theme.of(context).bottomAppBarTheme;
 final BottomAppBarTheme bottomAppBarTheme = BottomAppBarTheme.of(context);
 ```
 
+```dart
+final ThemeData theme = ThemeData(
+  bottomAppBarTheme: BottomAppBarTheme(),
+);
+
+final ThemeData theme = ThemeData().copyWith(
+  bottomAppBarTheme: BottomAppBarTheme(),
+);
+```
+
 Code after migration:
 
 ```dart
 final BottomAppBarThemeData bottomAppBarTheme = Theme.of(context).bottomAppBarTheme;
 final BottomAppBarThemeData bottomAppBarTheme = BottomAppBarTheme.of(context);
+```
+
+```dart
+final ThemeData theme = ThemeData(
+  bottomAppBarTheme: BottomAppBarThemeData(),
+);
+
+final ThemeData theme = ThemeData().copyWith(
+  bottomAppBarTheme: BottomAppBarThemeData(),
+);
 ```
 
 ## Timeline

--- a/src/content/release/breaking-changes/component-theme-normalization-updates.md
+++ b/src/content/release/breaking-changes/component-theme-normalization-updates.md
@@ -1,16 +1,15 @@
 ---
 title: Component theme normalization updates
 description: >-
-  `AppBarTheme`, `BottomAppBarTheme`, and `InputDecorationTheme` have been normalized to follow
-  Flutter's convention for component themes in the Material library.
+  `BottomAppBarTheme` has been normalized to follow Flutter's convention for component themes 
+  in the Material library.
 ---
 
 ## Summary
 
-`AppBarTheme`, `BottomAppBarTheme`, and `InputDecorationTheme` were refactored to 
-conform to Flutter's conventions for component themes. 
-`AppBarThemeData`,`BottomAppBarThemeData`, and `InputDecorationThemeData` were added to
-define overrides for the defaults of the component visual properties.
+`BottomAppBarTheme` was refactored to conform to Flutter's conventions for component themes. 
+`BottomAppBarThemeData` was added to define overrides for the defaults of the component visual 
+properties.
 Releases of Flutter continue to normalize component themes like these for
 a more consistent theming experience in the material library.
 
@@ -18,12 +17,8 @@ a more consistent theming experience in the material library.
 
 In `ThemeData`:
 
-- The type of `appBarTheme` property has been
-  changed from `AppBarTheme` to `AppBarThemeData`.
 - The type of `bottomAppBarTheme` property has been
   changed from `BottomAppBarTheme` to `BottomAppBarThemeData`.
-- The type of `inputDecorationTheme` property has been
-  changed from `InputDecorationTheme` to `InputDecorationThemeData`.
 
 The return type of the component theme `xTheme.of()` methods and
 `Theme.of().xTheme` have also changed to `xThemeData` accordingly.
@@ -31,55 +26,32 @@ The return type of the component theme `xTheme.of()` methods and
 Code before migration:
 
 ```dart
-final AppBarTheme appBarTheme = Theme.of(context).appBarTheme;
-final AppBarTheme appBarTheme = AppBarTheme.of(context);
-
 final BottomAppBarTheme bottomAppBarTheme = Theme.of(context).bottomAppBarTheme;
 final BottomAppBarTheme bottomAppBarTheme = BottomAppBarTheme.of(context);
-
-final InputDecorationTheme inputDecorationTheme = Theme.of(context).inputDecorationTheme;
-final InputDecorationTheme inputDecorationTheme = InputDecorationTheme.of(context);
 ```
 
 Code after migration:
 
 ```dart
-final AppBarThemeData appBarTheme = Theme.of(context).appBarTheme;
-final AppBarThemeData appBarTheme = AppBarTheme.of(context);
-
 final BottomAppBarThemeData bottomAppBarTheme = Theme.of(context).bottomAppBarTheme;
 final BottomAppBarThemeData bottomAppBarTheme = BottomAppBarTheme.of(context);
-
-final InputDecorationThemeData inputDecorationTheme = Theme.of(context).inputDecorationTheme;
-final InputDecorationThemeData inputDecorationTheme = InputDecorationTheme.of(context);
 ```
 
 ## Timeline
 
-Landed in version: 3.33.0-1.0.pre<br>
-Stable release: 3.33
+Landed in version: Not yet<br>
+Stable release: Not yet
 
 ## References
 
 API documentation:
 
-* [`AppBarTheme`][]
 * [`BottomAppBarTheme`][]
-* [`InputDecorationTheme`][]
 
 Relevant PRs:
-
-* [Normalize ThemeData.appBarTheme][]
-
-[`AppBarTheme`]: {{site.api}}/flutter/material/AppBarTheme-class.html
-[Normalize ThemeData.appBarTheme]: {{site.repo.flutter}}/pull/169130
 
 * [Normalize ThemeData.bottomAppBarTheme][]
 
 [`BottomAppBarTheme`]: {{site.api}}/flutter/material/BottomAppBarTheme-class.html
 [Normalize ThemeData.bottomAppBarTheme]: {{site.repo.flutter}}/pull/168586
 
-* [Normalize ThemeData.inputDecorationTheme][]
-
-[`InputDecorationTheme`]: {{site.api}}/flutter/material/InputDecorationTheme-class.html
-[Normalize ThemeData.inputDecorationTheme]: {{site.repo.flutter}}/pull/168981

--- a/src/content/release/breaking-changes/component-theme-normalization-updates.md
+++ b/src/content/release/breaking-changes/component-theme-normalization-updates.md
@@ -1,0 +1,85 @@
+---
+title: Component theme normalization updates
+description: >-
+  `AppBarTheme`, `BottomAppBarTheme`, and `InputDecorationTheme` have been normalized to follow
+  Flutter's convention for component themes in the Material library.
+---
+
+## Summary
+
+`AppBarTheme`, `BottomAppBarTheme`, and `InputDecorationTheme` were refactored to 
+conform to Flutter's conventions for component themes. 
+`AppBarThemeData`,`BottomAppBarThemeData`, and `InputDecorationThemeData` were added to
+define overrides for the defaults of the component visual properties.
+Releases of Flutter continue to normalize component themes like these for
+a more consistent theming experience in the material library.
+
+## Migration guide
+
+In `ThemeData`:
+
+- The type of `appBarTheme` property has been
+  changed from `AppBarTheme` to `AppBarThemeData`.
+- The type of `bottomAppBarTheme` property has been
+  changed from `BottomAppBarTheme` to `BottomAppBarThemeData`.
+- The type of `inputDecorationTheme` property has been
+  changed from `InputDecorationTheme` to `InputDecorationThemeData`.
+
+The return type of the component theme `xTheme.of()` methods and
+`Theme.of().xTheme` have also changed to `xThemeData` accordingly.
+
+Code before migration:
+
+```dart
+final AppBarTheme appBarTheme = Theme.of(context).appBarTheme;
+final AppBarTheme appBarTheme = AppBarTheme.of(context);
+
+final BottomAppBarTheme bottomAppBarTheme = Theme.of(context).bottomAppBarTheme;
+final BottomAppBarTheme bottomAppBarTheme = BottomAppBarTheme.of(context);
+
+final InputDecorationTheme inputDecorationTheme = Theme.of(context).inputDecorationTheme;
+final InputDecorationTheme inputDecorationTheme = InputDecorationTheme.of(context);
+```
+
+Code after migration:
+
+```dart
+final AppBarThemeData appBarTheme = Theme.of(context).appBarTheme;
+final AppBarThemeData appBarTheme = AppBarTheme.of(context);
+
+final BottomAppBarThemeData bottomAppBarTheme = Theme.of(context).bottomAppBarTheme;
+final BottomAppBarThemeData bottomAppBarTheme = BottomAppBarTheme.of(context);
+
+final InputDecorationThemeData inputDecorationTheme = Theme.of(context).inputDecorationTheme;
+final InputDecorationThemeData inputDecorationTheme = InputDecorationTheme.of(context);
+```
+
+## Timeline
+
+Landed in version: 3.33.0-1.0.pre<br>
+Stable release: 3.33
+
+## References
+
+API documentation:
+
+* [`AppBarTheme`][]
+* [`BottomAppBarTheme`][]
+* [`InputDecorationTheme`][]
+
+Relevant PRs:
+
+* [Normalize ThemeData.appBarTheme][]
+
+[`AppBarTheme`]: {{site.api}}/flutter/material/AppBarTheme-class.html
+[Normalize ThemeData.appBarTheme]: {{site.repo.flutter}}/pull/169130
+
+* [Normalize ThemeData.bottomAppBarTheme][]
+
+[`BottomAppBarTheme`]: {{site.api}}/flutter/material/BottomAppBarTheme-class.html
+[Normalize ThemeData.bottomAppBarTheme]: {{site.repo.flutter}}/pull/168586
+
+* [Normalize ThemeData.inputDecorationTheme][]
+
+[`InputDecorationTheme`]: {{site.api}}/flutter/material/InputDecorationTheme-class.html
+[Normalize ThemeData.inputDecorationTheme]: {{site.repo.flutter}}/pull/168981

--- a/src/content/release/breaking-changes/component-theme-normalization-updates.md
+++ b/src/content/release/breaking-changes/component-theme-normalization-updates.md
@@ -21,7 +21,7 @@ In `ThemeData`:
   changed from `BottomAppBarTheme` to `BottomAppBarThemeData`.
 
 The return type of the component theme `xTheme.of()` methods and
-`Theme.of().xTheme` have also changed to `xThemeData` accordingly.
+`Theme.of().xTheme` have also changed to `xThemeData`.
 
 Code before migration:
 

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -68,6 +68,7 @@ They're sorted by release and listed in alphabetical order:
 * [Changing the default `goldenFileComparator` for `integration_test`s][]
 * [Deprecate `InputDecoration.maintainHintHeight` in favor of `InputDecoration.maintainHintSize`][]
 * [Underdamped spring formula changed][]
+* [Component theme normalization updates][]
 
 [Deprecate `SystemContextMenuController.show`]: /release/breaking-changes/system_context_menu_controller_show
 [Deprecate `ExpansionTileController` in favor of `ExpansibleController`]: /release/breaking-changes/expansion-tile-controller
@@ -79,7 +80,7 @@ They're sorted by release and listed in alphabetical order:
 [Changing the default `goldenFileComparator` for `integration_test`s]: /release/breaking-changes/integration-test-default-golden-comparator
 [Deprecate `InputDecoration.maintainHintHeight` in favor of `InputDecoration.maintainHintSize`]: /release/breaking-changes/deprecate-inputdecoration-maintainhintheight
 [Underdamped spring formula changed]: /release/breaking-changes/spring-description-underdamped
-
+[Component theme normalization updates]: /release/breaking-changes/component-theme-normalization-updates
 <a id="released-in-flutter-329" aria-hidden="true"></a>
 ### Released in Flutter 3.29
 

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -47,12 +47,14 @@ They're sorted by release and listed in alphabetical order:
 * [Deprecate `TextField.canRequestFocus`][]
 * [Stop generating `AssetManifest.json`][]
 * [UISceneDelegate adoption][]
+* [Component theme normalization updates][]
 
 [Redesigned the Radio Widget]: /release/breaking-changes/radio-api-redesign
 [Removed semantics elevation and thickness]: /release/breaking-changes/remove-semantics-elevation-and-thickness
 [Deprecate `TextField.canRequestFocus`]: /release/breaking-changes/can-request-focus
 [Stop generating `AssetManifest.json`]: /release/breaking-changes/asset-manifest-dot-json
 [UISceneDelegate adoption]: /release/breaking-changes/uiscenedelegate
+[Component theme normalization updates]: /release/breaking-changes/component-theme-normalization-updates
 
 <a id="released-in-flutter-332" aria-hidden="true"></a>
 ### Released in Flutter 3.32


### PR DESCRIPTION
Add `BottomAppBarTheme` normalization update to align with Flutter Material's component theme conventions.

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
