### PR TITLE
Improve dark mode version and accessibility of learning index

### DIFF
--- a/src/_includes/docs/learning-resources-index/grid.md
+++ b/src/_includes/docs/learning-resources-index/grid.md
@@ -29,8 +29,8 @@
                     endcase -%}
                 <span class="pill-sm {{ pill-color }}">{{ item.type | capitalize }}</span>
                 {%- if item.link.label == "Flutter Github" -%}
-                    <svg style="color:black" width="24px" height="24px">
-                        <use href="/assets/images/social/github.svg#github"></use>
+                    <svg class="monochrome-icon" width="24px" height="24px">
+                      <use href="/assets/images/social/github.svg#github"></use>
                     </svg>
                 {%- elsif item.link.label == 'Dart Github' -%}
                     <img src="/assets/images/branding/dart/logo.svg" width="24px" alt="Dart logo" />
@@ -40,15 +40,15 @@
                     <img src='/assets/images/branding/dart/logo.svg' alt="Dart icon" width="24px"/>
                 {%- elsif item.link.label == "Google Codelab" -%}
                     <svg width="24px" height="24px">
-                        <use href="/assets/images/social/google-developers.svg#google-developers"></use>
+                      <use href="/assets/images/social/google-developers.svg#google-developers"></use>
                     </svg>
                 {%- elsif item.link.label == "YouTube" -%}
-                    <svg style="color:red" width="24px" height="24px">
-                        <use href="/assets/images/social/youtube.svg#youtube"></use>
+                    <svg style="color: red" width="24px" height="24px">
+                      <use href="/assets/images/social/youtube.svg#youtube"></use>
                     </svg>
                 {%- elsif item.link.label == "Medium" -%}
-                    <svg style="color:black" width="24px" height="24px">
-                        <use href="/assets/images/social/medium.svg#medium"></use>
+                    <svg class="monochrome-icon" width="24px" height="24px">
+                      <use href="/assets/images/social/medium.svg#medium"></use>
                     </svg>
                 {%- endif -%}
             </div>

--- a/src/_sass/pages/_learning-resources-index.scss
+++ b/src/_sass/pages/_learning-resources-index.scss
@@ -1,3 +1,5 @@
+@use '../base/mixins';
+
 #resource-index-content {
   display: flex;
   flex-direction: row;
@@ -15,7 +17,6 @@
       top: var(--site-header-height);
       bottom: 0;
       right: -15rem;
-      background-color: var(--site-inset-bgColor);
       box-shadow: 0 6px 18px 0 rgba(0, 0, 0, 0.2);
       border-radius: 0.4rem;
       width: 220px;
@@ -43,16 +44,19 @@
 
 #resource-filter-group {
   border: 1px solid var(--site-inset-borderColor);
-
-  @media (max-width: 840px) {
-    border-bottom: none;
-  }
+  background-color: var(--site-inset-bgColor);
+  border-radius: var(--site-radius);
+  overflow: hidden;
+  position: sticky;
+  top: calc(var(--site-header-height) + 1rem);
 
   .table-title {
     text-align: center;
-    color: var(--site-base-fgColor-subtle);
-    font-weight: bold;
-    font-size: .9rem;
+    color: var(--site-base-fgColor-alt);
+    background-color: var(--site-raised-bgColor);
+    font-family: var(--site-ui-fontFamily);
+    font-weight: 700;
+    font-size: .925rem;
     padding: .5rem;
     border-bottom: 1px solid var(--site-inset-borderColor);
   }
@@ -69,7 +73,7 @@
       list-style: none;
       padding-left: 0;
       padding-bottom: .25rem;
-      display:flex;
+      display: flex;
       align-items: center;
 
       label {
@@ -94,10 +98,19 @@
     }
   }
 
+  @media (max-width: 840px) {
+    border-bottom: none;
+    height: 100%;
+    border-radius: 0;
+
+    .table-title {
+      background-color: var(--site-raised-bgColor-translucent);
+    }
+  }
+
   .hidden {
     display: none;
   }
-
 }
 
 #resource-search-group {
@@ -106,15 +119,17 @@
 
   .top-row {
     display: flex;
+    align-items: center;
+    gap: .35rem;
 
     .search-wrapper {
       display: flex;
       align-items: center;
 
       width: 100%;
-      background-color: white;
+      background-color: var(--site-inset-bgColor);
 
-      border: 1px solid var(--site-outline);
+      border: 1px solid var(--site-inset-borderColor);
       border-radius: 2rem;
       height: 3rem;
       padding: 0 .5rem;
@@ -127,13 +142,15 @@
       .leading-icon {
         padding-left: 0.25rem;
         user-select: none;
+        color: var(--site-base-fgColor-alt);
       }
 
       input {
-        background: white;
+        background: none;
         width: 100%;
         font-size: 1rem;
         cursor: text;
+        margin-left: 0.5rem;
 
         &:focus {
           outline: none;
@@ -146,7 +163,6 @@
     }
 
     button.show-filters-button {
-      padding: 1rem;
       @media (min-width: 840px) {
         display: none;
       }
@@ -156,10 +172,11 @@
   .label-row {
     display: flex;
     justify-content: space-between;
-    font-size: .9rem;
+    font-size: .925rem;
 
     label {
-      color: var(--site-base-fgColor-subtle);
+      font-family: var(--site-ui-fontFamily);
+      color: var(--site-base-fgColor-lighter);
 
       padding: .25rem 1rem 0 0;
       margin: 0;
@@ -181,31 +198,39 @@
         cursor: default;
       }
     }
-
   }
 }
 
-.resource-index-icon {
-  color: var(--site-base-fgColor);
-}
-
-
 #all-resources-grid {
+  margin-block-start: 1rem;
   grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
   grid-auto-rows: 300px;
 
   .card {
     &:hover {
-      box-shadow: 0 0 20px -5px var(--site-inset-borderColor);
       background-image: none;
       transition: .25s ease;
+
+      @include mixins.interaction-style(2%);
+    }
+
+    &:active {
+      @include mixins.interaction-style(4%);
     }
 
     .card-leading {
-      background-color: var(--site-onPrimary-color-light);
+      background-color: var(--site-filledCard-bgColor);
       justify-content: space-between !important;
       margin: -1rem;
-      padding: 1rem 1rem .5rem;
+      padding: 0.75rem 1rem 0.75rem;
+
+      .monochrome-icon {
+        color: black;
+
+        @at-root body.dark-mode & {
+          color: white;
+        }
+      }
     }
 
     .card-title {
@@ -213,7 +238,7 @@
     }
 
     .card-content {
-      gap:0;
+      gap: 0;
     }
   }
 }

--- a/src/content/reference/learning-resources.md
+++ b/src/content/reference/learning-resources.md
@@ -22,11 +22,7 @@ This page lists all of our additional learning resources:
 
 <div id="resource-index-content">
     <div class="left-col" id="resource-index-main-content">
-        <div 
-            id="resource-search-group" 
-            class="chip-filters-group" 
-            style="margin-bottom:20px"
-        >
+        <div id="resource-search-group" class="chip-filters-group">
             <div class="top-row">
                 <div class="search-wrapper" id="resource-search">
                     <span class="material-symbols leading-icon" aria-hidden="true">search</span>
@@ -34,7 +30,7 @@ This page lists all of our additional learning resources:
                         aria-label="Search learning resources by name and category">
                 </div>
                 {% comment -%}This dropdown is shown on narrow screens{% endcomment -%}
-                <button class="show-filters-button">
+                <button class="icon-button show-filters-button">
                     <span class="material-symbols" aria-hidden="true">filter_list</span>
                 </button>
             </div>


### PR DESCRIPTION
- Replace card header background with lighter color which has dark mode alternative
- Use non-white background for search bar
- Use appropriate color for search bar text for more accessible contrast in dark mode
- Add background for filter menu to improve visibility
- Use standard `icon-button` class for menu toggle in narrow view to add interaction styles (hover, active, focus)
- Standardize spacing where inconsistent or too large
- Replace usages of non-existent `-subtle` css property
- Use white instead of black for monochrome source icons in dark mode (GitHub, medium)

Fixes https://github.com/flutter/website/issues/11929

**Staged:** https://flutter-docs-prod--pr12083-feat-learning-index-dark-mo-jddzza3i.web.app/reference/learning-resources