### PR TITLE
Pubspec > make it clear that default flavor is not Android-specific

### DIFF
--- a/src/content/tools/pubspec.md
+++ b/src/content/tools/pubspec.md
@@ -244,7 +244,7 @@ flavor in Flutter launch command.
 
 ```yaml title="pubspec.yaml"
 flutter:
-  default-flavor: flavor_name # Android-only field
+  default-flavor: flavor_name
 ```
 
 In the following example, an Android Flutter app has a


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Make it clear that the default_flavor field in the Pubspec is not limited to Android.

_Issues fixed by this PR (if any):_

Fixes #12038

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
