### PR TITLE
Remove ios_platform_images reference

### DIFF
--- a/src/content/ui/assets/assets-and-images.md
+++ b/src/content/ui/assets/assets-and-images.md
@@ -372,28 +372,14 @@ let path = mainBundle.path(forResource: key, ofType: nil)
 For a more complete example, see the implementation of the
 Flutter [`video_player` plugin][] on pub.dev.
 
-The [`ios_platform_images`][] plugin on pub.dev wraps
-up this logic in a convenient category. You fetch
-an image as follows:
-
-**Objective-C:**
-```objc
-[UIImage flutterImageWithName:@"icons/heart.png"];
-```
-
-**Swift:**
-```swift
-UIImage.flutterImageNamed("icons/heart.png")
-```
-
 ### Loading iOS images in Flutter
 
 When implementing Flutter by
 [adding it to an existing iOS app][add-to-app],
 you might have images hosted in iOS that you
 want to use in Flutter. To accomplish
-that, use the [`ios_platform_images`][] plugin
-available on pub.dev.
+that, use [platform channels][] to pass the image
+data to Dart as `FlutterStandardTypedData`.
 
 ## Platform assets
 
@@ -515,7 +501,7 @@ For more details, see
 [`FlutterView`]: {{site.api}}/javadoc/io/flutter/view/FlutterView.html
 [`FlutterViewController`]: {{site.api}}/ios-embedder/interface_flutter_view_controller.html
 [Human Interface Guidelines]: {{site.apple-dev}}/design/human-interface-guidelines/app-icons
-[`ios_platform_images`]: {{site.pub}}/packages/ios_platform_images
+[platform channels]: /platform-integration/platform-channels
 [layer list drawable]: {{site.android-dev}}/guide/topics/resources/drawable-resource#LayerList
 [`mainBundle`]: {{site.apple-dev}}/documentation/foundation/nsbundle/1410786-mainbundle
 [`openFd`]: {{site.android-dev}}/reference/android/content/res/AssetManager#openFd(java.lang.String)


### PR DESCRIPTION
The `ios_platform_images` package has been discontinued, so remove references to it.

See https://github.com/flutter/flutter/issues/162961

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
