### PR TITLE
Flutter doesn't follow semantic versioning

### DIFF
--- a/src/content/install/archive.md
+++ b/src/content/install/archive.md
@@ -35,8 +35,7 @@ The following information is available for each Flutter release in the
 SDK archive:
 
 *   **Flutter version**: The version number of the Flutter SDK
-    (for example, 3.0.0, 2.10.5). This follows semantic versioning, indicating
-    the significance of changes between releases.
+    (for example, 3.0.0, 2.10.5). Flutter doesn't follow semantic versioning.
 *   **Architecture**: The processor architecture the SDK is built for
     (for example, x64, arm64). This specifies the type of processor the SDK is
     compatible with.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Change the note that Flutter follow semantic versioning, since Flutter doesn't follow semantic versioning.

See [here](https://github.com/flutter/flutter/pull/167674#discussion_r2078303704)

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
