### PR TITLE
Fixed swift code

### DIFF
--- a/src/content/release/breaking-changes/uiscenedelegate.md
+++ b/src/content/release/breaking-changes/uiscenedelegate.md
@@ -161,7 +161,7 @@ Apps that rely on Storyboards (and XIBs) to create platform channels in
   func register(with registry: any FlutterPluginRegistry) {
     let registrar = registry.registrar(forPlugin: "battery")
     let batteryChannel = FlutterMethodChannel(name: "samples.flutter.dev/battery",
-                                              binaryMessenger: registrar.messenger)
+                                              binaryMessenger: registrar!.messenger())
     batteryChannel.setMethodCallHandler({
       [weak self] (call: FlutterMethodCall, result: FlutterResult) -> Void in
       // This method is invoked on the UI thread.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Updated the swift example code to match the compiled swift example: https://github.com/flutter/flutter/blob/1b9502b007d01e1cc79dd86fc3300061522803a5/examples/platform_channel_swift/ios/Runner/AppDelegate.swift#L33

There were syntactic errors in the swift code which isn't checked like the dart code.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
