### PR TITLE
Added section on FlutterLaunchEngine and GeneratedPluginRegistrant to UISceneDelegate breaking change notice

### DIFF
--- a/src/content/release/breaking-changes/uiscenedelegate.md
+++ b/src/content/release/breaking-changes/uiscenedelegate.md
@@ -161,7 +161,7 @@ Apps that rely on Storyboards (and XIBs) to create platform channels in
   func register(with registry: any FlutterPluginRegistry) {
     let registrar = registry.registrar(forPlugin: "battery")
     let batteryChannel = FlutterMethodChannel(name: "samples.flutter.dev/battery",
-                                              binaryMessenger: registrar.messenger)
+                                              binaryMessenger: registrar!.messenger())
     batteryChannel.setMethodCallHandler({
       [weak self] (call: FlutterMethodCall, result: FlutterResult) -> Void in
       // This method is invoked on the UI thread.

--- a/src/content/release/breaking-changes/uiscenedelegate.md
+++ b/src/content/release/breaking-changes/uiscenedelegate.md
@@ -208,6 +208,56 @@ Apps that rely on Storyboards (and XIBs) to create platform channels in
 Set up the `FlutterPluginRegistrant` programmatically through the
 `FlutterAppDelegate`.
 
+### Registering plugins in `application:didFinishLaunchingWithOptions:`
+
+Most legacy Flutter projects will be registering plugins with the
+`GeneratedPluginRegistrant` at application launch. The
+`GeneratedPluginRegistrant` is registering platform channels under the hood and
+should be migrated as [platform channels
+are](#creating-platform-channels-in-applicationdidfinishlaunchingwithoptions).
+This will avoid any runtime warnings about using a `FlutterLaunchEngine`.
+
+{% tabs "darwin-language" %}
+{% tab "Swift" %}
+
+```swift
+@UIApplicationMain
+@objc class AppDelegate: FlutterAppDelegate, FlutterPluginRegistrant {
+  override func application(
+      _ application: UIApplication,
+      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    pluginRegistrant = self
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func register(with registry: any FlutterPluginRegistry) {
+    GeneratedPluginRegistrant.register(with: registry)
+  }
+}
+```
+
+{% endtab %}
+{% tab "Obj-C" %}
+
+```objc
+@interface AppDelegate () <FlutterPluginRegistrant>
+@end
+
+@implementation AppDelegate
+- (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
+  self.pluginRegistrant = self;
+  return [super application:application didFinishLaunchingWithOptions:launchOptions];
+}
+
+- (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry {
+  [GeneratedPluginRegistrant registerWithRegistry:registry];
+}
+@end
+```
+
+{% endtab %}
+{% endtabs %}
+
 ### Bespoke FlutterViewController usage
 
 For apps that use a `FlutterViewController` instantiated from Storyboards in

--- a/src/content/release/breaking-changes/uiscenedelegate.md
+++ b/src/content/release/breaking-changes/uiscenedelegate.md
@@ -214,7 +214,7 @@ Most legacy Flutter projects will be registering plugins with the
 `GeneratedPluginRegistrant` at application launch. The
 `GeneratedPluginRegistrant` is registering platform channels under the hood and
 should be migrated as [platform channels
-are](#creating-platform-channels-in-applicationdidfinishlaunchingwithoptions).
+are](#creating-platform-channels-in-application-didfinishlaunchingwithoptions).
 This will avoid any runtime warnings about using a `FlutterLaunchEngine`.
 
 {% tabs "darwin-language" %}

--- a/src/content/release/breaking-changes/uiscenedelegate.md
+++ b/src/content/release/breaking-changes/uiscenedelegate.md
@@ -212,9 +212,9 @@ Set up the `FlutterPluginRegistrant` programmatically through the
 
 Most legacy Flutter projects register plugins with
 `GeneratedPluginRegistrant` at application launch. The
-`GeneratedPluginRegistrant` is registering platform channels under the hood and
+`GeneratedPluginRegistrant` object registers platform channels under the hood and
 should be migrated as [platform channels
-are](#creating-platform-channels-in-application-didfinishlaunchingwithoptions).
+are migrating](#creating-platform-channels-in-application-didfinishlaunchingwithoptions).
 This will avoid any runtime warnings about using a `FlutterLaunchEngine`.
 
 {% tabs "darwin-language" %}

--- a/src/content/release/breaking-changes/uiscenedelegate.md
+++ b/src/content/release/breaking-changes/uiscenedelegate.md
@@ -210,7 +210,7 @@ Set up the `FlutterPluginRegistrant` programmatically through the
 
 ### Registering plugins in `application:didFinishLaunchingWithOptions:`
 
-Most legacy Flutter projects will be registering plugins with the
+Most legacy Flutter projects register plugins with
 `GeneratedPluginRegistrant` at application launch. The
 `GeneratedPluginRegistrant` is registering platform channels under the hood and
 should be migrated as [platform channels


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

This addition was made in response to @vashworth 's request in https://github.com/flutter/flutter/pull/170156#issuecomment-2950193929

This explicitly lists what to do about the GeneratedPluginRegistrant and mentions the FlutterLaunchEngine to provide extra context to future runtime warnings.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
