### PR TITLE
Add iOS 26 beta warnings

### DIFF
--- a/src/content/platform-integration/ios/ios-latest.md
+++ b/src/content/platform-integration/ios/ios-latest.md
@@ -6,10 +6,16 @@ description: >-
 ---
 
 :::warning
-iOS 18.4 beta 1 breaks Flutter's debug mode on physical devices.
-If you have upgraded your physical device to iOS 18.4 beta 1,
-please upgrade to iOS 18.4 beta 2.
+An upcoming change to iOS has caused a temporary break in Flutter's
+debug mode on physical devices running iOS 26 (currently in beta).
 See [flutter#163984][] for details.
+
+In the meantime, we recommend these temporary workarounds:
+
+* When developing with a physical device, use one running iOS 18.5 or lower.
+* Use a simulator for development rather than a physical device.
+* If you must use a device updated to iOS 26,
+  use [Flutter's release or profile build modes][].
 :::
 
 You can develop Flutter on the iOS platform, even on
@@ -21,6 +27,7 @@ Of course, if you find a bug on Flutter,
 please [file an issue][].
 
 [flutter#163984]: {{site.github}}/flutter/flutter/issues/163984
+[Flutter's release or profile build modes]: /testing/build-modes
 [file an issue]: {{site.github}}/flutter/flutter/issues
 
 ## iOS 18 release

--- a/src/content/platform-integration/ios/setup.md
+++ b/src/content/platform-integration/ios/setup.md
@@ -133,12 +133,11 @@ on the Apple Developer site.
 An upcoming change to iOS has caused a temporary break in Flutter's debug mode
 on physical devices running iOS 26 (currently in beta).
 If your physical device is already on iOS 26, we recommend switching to the
-**Virtual device** tab and following the instructions for using a simulator.
+**Simulator** tab and following the instructions.
 See [Flutter on latest iOS][] for details.
 :::
 
 [Flutter on latest iOS]: /platform-integration/ios/ios-latest
-
 
 Set up each iOS device on which you want to test.
 

--- a/src/content/platform-integration/ios/setup.md
+++ b/src/content/platform-integration/ios/setup.md
@@ -129,6 +129,17 @@ on the Apple Developer site.
 {% endtab %}
 {% tab "Physical device" %}
 
+:::warning
+An upcoming change to iOS has caused a temporary break in Flutter's debug mode
+on physical devices running iOS 26 (currently in beta).
+If your physical device is already on iOS 26, we recommend switching to the
+**Virtual device** tab and following the instructions for using a simulator.
+See [Flutter on latest iOS][] for details.
+:::
+
+[Flutter on latest iOS]: /platform-integration/ios/ios-latest
+
+
 Set up each iOS device on which you want to test.
 
  1. <h3>Configure your physical iOS device</h3>


### PR DESCRIPTION
The lastest iOS beta is broken in the same way as described in https://github.com/flutter/website/pull/11740.
Update warnings back to the wording in that PR, but updated iOS 18.4 to iOS 26.

These docs were refactored in #12026, put the physical device warning in the new place.

Part of https://github.com/flutter/flutter/issues/163984

## Screenshots
https://flutter-docs-prod--pr12112-26-warning-jxoxrcy1.web.app/platform-integration/ios/setup
![Screenshot 2025-06-09 at 7 30 30 PM](https://github.com/user-attachments/assets/d5e09536-761e-4351-b2d1-403ca07c3ba6)

__________

https://flutter-docs-prod--pr12112-26-warning-jxoxrcy1.web.app/platform-integration/ios/ios-latest
![Screenshot 2025-06-09 at 7 31 03 PM](https://github.com/user-attachments/assets/00697c1e-f0ec-41c3-9729-6d8d48228243)


## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
