### PR TITLE
Update internationalization documents and gen_l10n example.

### DIFF
--- a/examples/internationalization/gen_l10n_example/lib/main.dart
+++ b/examples/internationalization/gen_l10n_example/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 // #docregion app-localizations-import
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'l10n/app_localizations.dart';
 // #enddocregion app-localizations-import
 
 // #docregion localization-delegates-import

--- a/src/content/ui/accessibility-and-internationalization/internationalization.md
+++ b/src/content/ui/accessibility-and-internationalization/internationalization.md
@@ -266,7 +266,7 @@ complete the following instructions:
 
 6. Now, run `flutter pub get` or `flutter run` and codegen takes place automatically.
    You should find generated files in the directory at the path you specified
-   with the `arb-dir` or `output-dir` options.
+   with the `output-dir` option (or `arb-dir`, if you don't specify `output-dir`).
    Alternatively, you can also run `flutter gen-l10n` to
    generate the same files without running the app.
 
@@ -276,7 +276,7 @@ complete the following instructions:
 
    <?code-excerpt "gen_l10n_example/lib/main.dart (app-localizations-import)"?>
    ```dart
-   import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+   import 'l10n/app_localizations.dart';
    ```
 
    <?code-excerpt "gen_l10n_example/lib/main.dart (material-app)"?>


### PR DESCRIPTION
Update internationalization documents and gen_l10n example to align with deprecation of synthetic packages.
From flutter 3.32.0 [breaking changes](https://docs.flutter.dev/release/breaking-changes/flutter-generate-i10n-source), localized messages are generated into source, not a synthetic package.
This PR should be merged in the future stable release.
Issues fixed by this PR (if any):

- https://github.com/flutter/website/issues/11765

Relative links:

- https://groups.google.com/g/flutter-announce/c/ZWtR2h6QAZk
- https://flutter.dev/to/flutter-gen-deprecation
- https://github.com/flutter/flutter/issues/102983
- https://github.com/flutter/flutter/pull/157934

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
