### PR TITLE
Fix typo about Windows path conditions

### DIFF
--- a/src/_includes/docs/install/flutter/download.md
+++ b/src/_includes/docs/install/flutter/download.md
@@ -87,7 +87,7 @@ then extract the SDK.
    * The path contains special characters or spaces.
    * The path requires elevated privileges.
 
-   As an example, `C:\Program Files` fails both conditions.
+   As an example, `C:\Program Files` meets both conditions.
    :::
 
    {% endif %}

--- a/src/_includes/docs/install/flutter/vscode.md
+++ b/src/_includes/docs/install/flutter/vscode.md
@@ -55,7 +55,7 @@ verify that you've installed
    * The path contains special characters or spaces.
    * The path requires elevated privileges.
 
-   As an example, `C:\Program Files` fails both conditions.
+   As an example, `C:\Program Files` meets both conditions.
    :::
 
    {% else -%}


### PR DESCRIPTION
[The text](https://docs.flutter.dev/get-started/install/windows/web) says that you should not use a directory "or path" that _meets_ one or both of these conditions. To use the same term, `C:\Program Files` _meets_ these conditions, not "fails" them.

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
