### PR TITLE
Add explanation for edge-to-edge Google Play Console warning

### DIFF
--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -5,6 +5,18 @@ description: >-
     in to edge-to-edge mode.
 ---
 
+:::note
+You may have found this page because you have seen a warning in the Google
+Play Console concerning "Edge-to-edge may not display for all users" or "Your
+"app uses deprecated APIs or parameters for edge-to-edge". These warnings
+**will not** impact users.
+
+This warning references deprecated code used in the Flutter engine to implement
+edge-to-edge mode on devices running below Android 15 that will continue to
+work should you set edge-to-edge mode in your app. See
+https://github.com/flutter/flutter/issues/169810 for more information.
+:::
+
 ## Summary
 
 If your Flutter app targets Android SDK version 15 or later,

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -6,14 +6,14 @@ description: >-
 ---
 
 :::note
-You may have found this page because you have seen a warning in the Google
-Play Console concerning "Edge-to-edge may not display for all users" or "Your
-"app uses deprecated APIs or parameters for edge-to-edge". These warnings
-**will not** impact users.
+You might have found this page because you see a warning in the Google Play
+Console concerning "Edge-to-edge may not display for all users" or "Your app
+uses deprecated APIs or parameters for edge-to-edge". These warnings **will
+not** impact users.
 
 This warning references deprecated code used in the Flutter engine to implement
-edge-to-edge mode on devices running below Android 15 that will continue to
-work should you set edge-to-edge mode in your app. See
+edge-to-edge mode, but this code will continue to work should you set
+edge-to-edge mode in your app. See
 https://github.com/flutter/flutter/issues/169810 for more information.
 :::
 

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -12,8 +12,9 @@ uses deprecated APIs or parameters for edge-to-edge". These warnings **will
 not** impact users.
 
 This warning references deprecated code used in the Flutter engine to implement
-edge-to-edge mode, but this code will continue to work should you set
-edge-to-edge mode in your app. See [flutter#169810] for more information.
+edge-to-edge mode. The engine relies on this deprecated code to avoid breaking
+changes for users, so it will continue to work should you set edge-to-edge
+mode in your app. See [flutter#169810] for more information.
 :::
 
 ## Summary

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -13,8 +13,7 @@ not** impact users.
 
 This warning references deprecated code used in the Flutter engine to implement
 edge-to-edge mode, but this code will continue to work should you set
-edge-to-edge mode in your app. See
-https://github.com/flutter/flutter/issues/169810 for more information.
+edge-to-edge mode in your app. See [flutter#169810] for more information.
 :::
 
 ## Summary
@@ -126,3 +125,4 @@ Stable release: 3.27
 
 [The supported Flutter `SystemUiMode`s]: {{site.api}}/flutter/services/SystemUiMode.html
 [The Android 15 edge-to-edge behavior changes guide]: {{site.android-dev}}/about/versions/15/behavior-changes-15#edge-to-edge
+[flutter#169810]: https://github.com/flutter/flutter/issues/169810


### PR DESCRIPTION
Adds explanation about warnings that users may see in the Google Play Console related to edge-to-edge mode. Added the explanation to [this](https://github.com/flutter/website/blob/449f33220f4d95d05c4f942be6e21e1036cadf38/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md) page because Android added the warning to the console as part of edge-to-edge mode becoming the default on Android 15+.

This addition was prompted by https://github.com/flutter/flutter/issues/169810, which a user reported because they were seeing such warning.

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
