### PR TITLE
Update SDK documentation with IDE support policy

### DIFF
--- a/src/content/tools/sdk.md
+++ b/src/content/tools/sdk.md
@@ -47,4 +47,4 @@ The [`dart` CLI tool][] is available with the Flutter SDK at `flutter/bin/dart`.
 The IDE tooling for Flutter (Android Studio and Intellij plugins, VS Code 
 extensions) supports SDK versions going back two years. This means that while
 the tools may still function with SDKs older than two years, they will no longer
-provide official support or fixes for issues specific to these older versions.
+provide fixes for issues specific to these older versions.

--- a/src/content/tools/sdk.md
+++ b/src/content/tools/sdk.md
@@ -42,9 +42,9 @@ The [`dart` CLI tool][] is available with the Flutter SDK at `flutter/bin/dart`.
 [Install]: /get-started/install
 [README file]: {{site.repo.flutter}}/blob/main/README.md
 
-## SDK support in tooling
+## SDK support for Flutter developer tools
 
 The IDE tooling for Flutter (Android Studio and Intellij plugins, VS Code 
-extensions) supports SDK versions going back two years. This means that while
-the tools might still function with SDKs older than two years, they will no longer
-provide fixes for issues specific to these older versions.
+extensions) supports Flutter SDK versions going back two years. This means that
+while the tools might still function with SDKs older than two years, they will
+no longer provide fixes for issues specific to these older versions.

--- a/src/content/tools/sdk.md
+++ b/src/content/tools/sdk.md
@@ -46,5 +46,5 @@ The [`dart` CLI tool][] is available with the Flutter SDK at `flutter/bin/dart`.
 
 The IDE tooling for Flutter (Android Studio and Intellij plugins, VS Code 
 extensions) supports SDK versions going back two years. This means that while
-the tools may still function with SDKs older than two years, they will no longer
+the tools might still function with SDKs older than two years, they will no longer
 provide fixes for issues specific to these older versions.

--- a/src/content/tools/sdk.md
+++ b/src/content/tools/sdk.md
@@ -41,3 +41,10 @@ The [`dart` CLI tool][] is available with the Flutter SDK at `flutter/bin/dart`.
 [`flutter` CLI tool]: /reference/flutter-cli
 [Install]: /get-started/install
 [README file]: {{site.repo.flutter}}/blob/main/README.md
+
+## SDK support in tooling
+
+The IDE tooling for Flutter (Android Studio and Intellij plugins, VS Code 
+extensions) supports SDK versions going back two years. This means that while
+the tools may still function with SDKs older than two years, they will no longer
+provide official support or fixes for issues specific to these older versions.


### PR DESCRIPTION
We want to have an explicit ongoing policy of sunsetting support for older versions of the Flutter/Dart SDKs as new IDE plugin/extensions are released.

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
