### PR TITLE
(fix) - the class GrowTransition compilation

### DIFF
--- a/src/content/ui/animations/tutorial.md
+++ b/src/content/ui/animations/tutorial.md
@@ -501,7 +501,6 @@ in the bullet points above.
 + 
 +   @override
 +   Widget build(BuildContext context) {
-+     final animation = listenable as Animation<double>;
 +     return Center(
 +       child: AnimatedBuilder(
 +         animation: animation,


### PR DESCRIPTION
In this Flutter animation [tutorial](https://docs.flutter.dev/ui/animations/tutorial#refactoring-with-animatedbuilder), the class `GrowTransition` extends `StatelessWidget` and doesn't have the field `listenable`, so this code doesn't compile:

![image](https://github.com/user-attachments/assets/f3023975-af08-4a87-b8b5-6495955dde75)


## Presubmit checklist

- [ X] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
