### PR TITLE
Fix typo List<TripSummary> to List<BookingSummary> in ui-layer.md

### DIFF
--- a/src/content/app-architecture/case-study/ui-layer.md
+++ b/src/content/app-architecture/case-study/ui-layer.md
@@ -81,7 +81,7 @@ The view model exposes state as public members.
 On the view model in the following code example,
 the exposed data is a `User` object,
 as well as the user's saved itineraries which
-are exposed as an object of type `List<TripSummary>`.
+are exposed as an object of type `List<BookingSummary>`.
 
 ```dart title=home_viewmodel.dart
 class HomeViewModel {


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Fixed a simple typo of view model exposed data is a `User` Object, as well as the user's saved  itineraries which are exposed as an object of type List<BookingSummary>

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
