### PR TITLE
Fixed typo in get-started/fundamentals/state-management page

### DIFF
--- a/src/content/get-started/fundamentals/state-management.md
+++ b/src/content/get-started/fundamentals/state-management.md
@@ -483,7 +483,7 @@ class CounterViewModel extends ChangeNotifier {
       await model.updateCountOnServer(incrementedCount);
       count = incrementedCount;
     } catch(e) {
-      errorMessage = 'Count not update count';
+      errorMessage = 'Could not update count';
     }
     notifyListeners();
   }


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Fixed typo in get-started/fundamentals/state-management page

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
