### PR TITLE
Add go link to "Web Development Proxy Server" design doc

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -685,6 +685,7 @@
       { "source": "/go/web-astral-projections", "destination": "https://docs.google.com/document/d/1pvH-J8opXsjntTpFf1bbsbU8N1vFd8tPKvBgcNn8UKQ", "type": 301 },
       { "source": "/go/web-cleanup-service-worker", "destination": "https://docs.google.com/document/d/1czOm3Hmy_oIq3NJStezb9AjwkKyta3NospkCy_DDv9E/edit", "type": 301 },
       { "source": "/go/web-declarative-bootstrap", "destination": "https://docs.google.com/document/d/1jVXxC0tNDW45ypfVESyHipL2lHCX32GmFyJNO0u9c6Y/edit?resourcekey=0-AQ8z_0_U8Vq3JBdyracNuQ", "type": 301 },
+      { "source": "/go/web-development-proxy-server", "destination": "https://docs.google.com/document/d/1Ud9D3F0GxB5Ocoo5NnAy7PH5oo3qxvALxUlAXMCANJ0/edit?usp=sharing", "type": 301 },
       { "source": "/go/web-multiview-js-api", "destination": "https://docs.google.com/document/d/1ixwPBG7YIHEONc15t9SOmrfgDK3gghvkk7it_8AFOmw/edit?resourcekey=0-VQC2nby6Coe5OG-R833yXw", "type": 301 },
       { "source": "/go/web-native-text-editing", "destination": "https://docs.google.com/document/d/1t6qAX46tsR1tdBS42yro6G_5Igtrj7WzmKKiUI_JC-k/edit", "type": 301 },
       { "source": "/go/web-plugins-layout", "destination": "https://docs.google.com/document/d/1PeS-QSAFydHXhjZrqkub-GRPMs83roh8VwhbUScWuGQ", "type": 301 },


### PR DESCRIPTION
This PR modifies website/firebase.json to add a new go/link to the "Web Development Proxy Server" design doc that @sydneybao and @salemiranloye are presenting on the next dash forum, following the design doc instructions.

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
