### PR TITLE
[3.35] Rename `entryPointBaseUrl` to `entrypointBaseUrl`

### DIFF
--- a/src/content/platform-integration/web/initialization.md
+++ b/src/content/platform-integration/web/initialization.md
@@ -123,7 +123,7 @@ The `config` argument is an object that can have the following optional fields:
 |`canvasKitForceCpuOnly`| When `true`, forces CPU-only rendering in CanvasKit (the engine won't use WebGL). |`bool`|
 |`canvasKitMaximumSurfaces`| The maximum number of overlay surfaces that the CanvasKit renderer can use. |`double`|
 |`debugShowSemanticNodes`| If `true`, Flutter visibly renders the semantics tree onscreen (for debugging).  |`bool`|
-|`entryPointBaseUrl`| The base URL of your Flutter app's entrypoint. Defaults to "/".  |`String`|
+|`entrypointBaseUrl`| The base URL of your Flutter app's entrypoint. Defaults to "/".  |`String`|
 |`hostElement`| HTML Element into which Flutter renders the app. When not set, Flutter web takes over the whole page. |`HtmlElement`|
 |`renderer`| Specifies the [web renderer][web-renderers] for the current Flutter application, either `"canvaskit"` or `"skwasm"`. |`String`|
 


### PR DESCRIPTION
_**Blocked on landing in stable**_

Renaming the `entryPointBaseUrl` parameter to `entrypointBaseUrl`.

* PR in the Flutter SDK: https://github.com/flutter/flutter/pull/170166
* Issue: https://github.com/flutter/flutter/issues/168968

cc @piedcipher 

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
