### PR TITLE
move snap doc to core24

### DIFF
--- a/src/content/deployment/linux.md
+++ b/src/content/deployment/linux.md
@@ -106,7 +106,7 @@ summary: Super Cool App
 description: Super Cool App that does everything!
 
 confinement: strict
-base: core22
+base: core24
 grade: stable
 
 slots:
@@ -151,7 +151,7 @@ This section defines how the snap is built.
 
 ```yaml
 confinement: strict
-base: core18
+base: core24
 grade: stable
 ```
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

This PR upgrades the suggested base for snaps from core22 to core24 and also fixes a typo where `core18` is mentioned.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
