### PR TITLE
Fix wrong command in flutter-plugins-configuration.md

### DIFF
--- a/src/content/release/breaking-changes/flutter-plugins-configuration.md
+++ b/src/content/release/breaking-changes/flutter-plugins-configuration.md
@@ -124,7 +124,7 @@ To smoke test whether your build relies on a `.flutter-plugins` file,
 you can use the feature flag `explicit-package-dependencies`:
 
 ```console
-$ flutter config explicit-package-dependencies
+$ flutter config --explicit-package-dependencies
 ```
 
 Any build tools or scripts that might rely on the `.flutter-plugins` file


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Fix wrong command in flutter-plugins-configuration.md

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
