### PR TITLE
Fix incorrect verbose flag in troubleshoot section

### DIFF
--- a/src/content/install/troubleshoot.md
+++ b/src/content/install/troubleshoot.md
@@ -81,7 +81,7 @@ such as `C:\src\flutter`.
 __What does this issue look like?__
 
 The command `flutter doctor --android-licenses` fails.
-Running `flutter doctor –verbose` gives an error message
+Running `flutter doctor --verbose` gives an error message
 like the following:
 
 ```plaintext


### PR DESCRIPTION
Change `-verbose` to `--verbose` in flutter doctor command to match actual CLI behavior

_Description of what this PR is changing or adding, and why:_
Fixed incorrect flag in the troubleshoot documentation.
The documentation showed "Running `flutter doctor –verbose` gives..."
but the correct flag is `flutter doctor --verbose`. This was verified by running `flutter doctor --help`:
`-v, --verbose               Noisy logging, including all shell commands executed.`
`flutter doctor -verbose` gives an error:
```
Could not find an option with short name "-e".
Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and options.
```

_Issues fixed by this PR (if any):_
None
_PRs or commits this PR depends on (if any):_
None
## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
