### PR TITLE
Update compose-devs.md to fix typo

### DIFF
--- a/src/content/get-started/flutter-for/compose-devs.md
+++ b/src/content/get-started/flutter-for/compose-devs.md
@@ -293,7 +293,7 @@ control placement in Jetpack Compose are one vertical and horizontal property
 from the following: `verticalArrangement`, `verticalAlignment`,
 `horizontalAlignment`, and `horizontalArrangement`. The trick to determine
 which is the `MainAxis` is to look for the property that ends in `arrangement`. 
-The `CrossAxis` will be the property that ends in `alightment`.
+The `CrossAxis` will be the property that ends in `alignment`.
 :::
 
 ### Displaying a list view


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why: fix typo 'alightment' -> 'alignment'

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] **If you are unwilling, or unable, to sign the CLA,
  even for a _tiny_, one-word PR,
  please file an issue instead of a PR.**
- [ ] If this PR is not meant to land until a future
  stable release, mark it as draft with an explanation.
- [ ] This PR doesn't contain automatically generated corrections
  (generated by Grammarly or similar).
- [ ] This PR follows the
  [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for
  example, it doesn't use _i.e._ or _e.g._,
  and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses
  [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
