### PR TITLE
docs: add remote_caching to database packages list

### DIFF
--- a/src/content/get-started/fundamentals/local-caching.md
+++ b/src/content/get-started/fundamentals/local-caching.md
@@ -200,10 +200,13 @@ For a more thorough guide, see the following resources:
 * Drift, a relational database: [`drift` package][]
 * Hive, a non-relational database: [`hive` package][]
 * Isar, a non-relational database: [`isar` package][]
+* Remote Caching, a lightweight caching system for API responses: [`remote_caching` package][]
 
 [`drift` package]: {{site.pub-pkg}}/drift
 [`hive` package]: {{site.pub-pkg}}/hive
 [`isar` package]: {{site.pub-pkg}}/isar
+['remote_caching' package]: {{site.pub-pkg}}/remote_caching
+
 [Persist data with SQLite]: /cookbook/persistence/sqlite
 [`sqlite3` package]: {{site.pub-pkg}}/sqlite3
 


### PR DESCRIPTION
📝 Description of what this PR is changing or adding, and why:

Adds [remote_caching](https://pub.dev/packages/remote_caching) to the list of persistence-related packages in the Flutter documentation.

remote_caching is a lightweight and flexible package for caching remote API calls using SQLite. It offers:
	•	custom deserialization via fromJson,
	•	configurable expiration per call,
	•	support for any serializable object (Map, List, custom models…),
	•	and SQLite-backed persistence.

This package can be particularly helpful for Flutter newcomers thanks to its simple but effective API, making it a pragmatic choice for common caching needs without requiring complex setups.

Additionally, some of the previously recommended solutions—such as Hive—have been marked as deprecated or in maintenance mode ([see issue](https://github.com/isar/hive/issues/1331)). Including remote_caching offers an actively maintained alternative that aligns well with modern Flutter projects.

## Presubmit checklist

- [x] **If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.**
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR doesn't contain automatically generated corrections (generated by Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
