### PR TITLE
Fix typo in physics animation docs

### DIFF
--- a/src/content/cookbook/animation/physics-simulation.md
+++ b/src/content/cookbook/animation/physics-simulation.md
@@ -279,7 +279,7 @@ onPanEnd: (details) {
 ```
 
 :::note
-Now that the animation controller uses a simulation it's `duration` argument
+Now that the animation controller uses a simulation, its `duration` argument
 is no longer required.
 :::
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] **If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.**
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR doesn't contain automatically generated corrections (generated by Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
