### PR TITLE
Remove references to Hive and Isar

### DIFF
--- a/src/content/get-started/fundamentals/local-caching.md
+++ b/src/content/get-started/fundamentals/local-caching.md
@@ -198,13 +198,11 @@ For a more thorough guide, see the following resources:
 * Cookbook: [Persist data with SQLite][]
 * SQLite alternate: [`sqlite3` package][]
 * Drift, a relational database: [`drift` package][]
-* Hive, a non-relational database: [`hive` package][]
-* Isar, a non-relational database: [`isar` package][]
+* Hive CE, a non-relational database: [`hive_ce` package][]
 * Remote Caching, a lightweight caching system for API responses: [`remote_caching` package][]
 
 [`drift` package]: {{site.pub-pkg}}/drift
-[`hive` package]: {{site.pub-pkg}}/hive
-[`isar` package]: {{site.pub-pkg}}/isar
+[`hive_ce` package]: {{site.pub-pkg}}/hive_ce
 [`remote_caching` package]: {{site.pub-pkg}}/remote_caching
 
 [Persist data with SQLite]: /cookbook/persistence/sqlite


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Hive and Isar are both dead packages. It is unadvisable to use them in new projects. For now, I have replaced Hive with Hive CE, but since I am the maintainer of Hive CE, I will leave it up to other maintainers to determine if we should remove the mention of Hive entirely instead.

_Issues fixed by this PR (if any):_

N/A

_PRs or commits this PR depends on (if any):_

N/A

## Presubmit checklist

- [x] **If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.**
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR doesn't contain automatically generated corrections (generated by Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
