### PR TITLE
Add breaking changes doc for form role changes

### DIFF
--- a/src/content/release/breaking-changes/form-semantics.md
+++ b/src/content/release/breaking-changes/form-semantics.md
@@ -1,0 +1,77 @@
+---
+title: The Form widget no longer supports being a sliver.
+description: The Form widget now includes a semantics widget, which prevents it from being used directly as a sliver.
+---
+
+## Summary
+
+Previously, the Form widget essentially acted as a direct wrapper 
+around its child. This design allowed a Form containing a sliver child
+(e.g., Form(child: other sliver)) to be treated as a sliver itself
+ within a CustomScrollView or similar scrollable parent.
+
+However, This PR introduced a new semantics widget
+within the Form widget's internal structure. This change alters
+its rendering behavior, meaning Form can no longer directly
+function as a sliver.
+
+## Context
+This change is part of an ongoing effort to improve the
+accessibility and semantic understanding of Flutter widgets.
+By embedding a semantics widget directly within Form, the framework
+can provide better information to accessibility services.
+
+## Description of change
+The core change is the integration of a semantics widget 
+into the Form widget's build method.
+
+## Migration guide
+
+If your app does not currently use the Form widget directly
+as a sliver within a scrollable list
+(e.g., as a direct child of CustomScrollView's slivers property),
+then no changes are required.
+
+If your app use Form as a sliver, you will need to wrap the Form
+widget within a SliverToBoxAdapter. SliverToBoxAdapter is a
+sliver that contains a single box widget, converting a regular
+widget into a sliver that can be placed in a CustomScrollView.
+
+Code before migration:
+
+```dart
+    sliver: Form(
+        key: controller.formKey,
+        child: SomeWidgetWithFormFields(),
+    )
+```
+
+Code after migration:
+
+```dart
+    sliver: SliverToBoxAdapter(
+        child: Form(
+            key: controller.formKey,
+            child: SomeWidgetWithFormFields(),
+        )
+    )
+```
+
+## Timeline
+
+Landed in version: 3.35.0-pre
+In stable release: TBD
+
+## References
+
+API documentation:
+
+* [`Form`]({{site.api}}/flutter/widgets/Form-class.html)
+
+Relevant issues:
+
+* [Issue 161628]({{site.repo.flutter}}/issues/161628)
+
+Relevant PRs:
+
+* [PR 170709: Add semantics role for form]({{site.github}}/flutter/pull/170709)

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -49,6 +49,7 @@ They're sorted by release and listed in alphabetical order:
 * [UISceneDelegate adoption][]
 * [Component theme normalization updates][]
 * [Deprecate `DropdownButtonFormField` `value` parameter in favor of `initialValue`][]
+* [The Form widget no longer supports being a sliver.][]
 
 [Redesigned the Radio Widget]: /release/breaking-changes/radio-api-redesign
 [Removed semantics elevation and thickness]: /release/breaking-changes/remove-semantics-elevation-and-thickness
@@ -57,6 +58,7 @@ They're sorted by release and listed in alphabetical order:
 [UISceneDelegate adoption]: /release/breaking-changes/uiscenedelegate
 [Component theme normalization updates]: /release/breaking-changes/component-theme-normalization-updates
 [Deprecate `DropdownButtonFormField` `value` parameter in favor of `initialValue`]: /release/breaking-changes/deprecate-dropdownbuttonformfield-value
+[The Form widget no longer supports being a sliver.]:/release/breaking-changes/form-semantics
 
 <a id="released-in-flutter-332" aria-hidden="true"></a>
 ### Released in Flutter 3.32


### PR DESCRIPTION
noticed from a g3 code case people use form as a sliver ,
Adding breaking changes to it! 



## Presubmit checklist

- [ ] **If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.** - [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR doesn't contain automatically generated corrections (generated by Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
