### PR TITLE
Add migration guide for moving the gradle files

### DIFF
--- a/src/content/release/breaking-changes/gradle-settings-migration.md
+++ b/src/content/release/breaking-changes/gradle-settings-migration.md
@@ -47,7 +47,7 @@ project(":app").projectDir = File(rootDir, "android/app/")
 
 #### or `build.gradle`
 
-Add the line:
+Add the following line:
 ```dart
 project(':app').projectDir = new File(rootDir, 'android/app/')
 ```

--- a/src/content/release/breaking-changes/gradle-settings-migration.md
+++ b/src/content/release/breaking-changes/gradle-settings-migration.md
@@ -29,7 +29,7 @@ The following files must be moved to the root directory of your project:
 
 #### `build.gradle.kts`
 
-The `newBuildDir` needs to be changed from:
+Change the `newBuildDir` value from:
 ```dart
 val newBuildDir: Directory = rootProject.layout.buildDirectory.dir("../../build").get()
 ```

--- a/src/content/release/breaking-changes/gradle-settings-migration.md
+++ b/src/content/release/breaking-changes/gradle-settings-migration.md
@@ -12,7 +12,7 @@ completion in Android Studio.
 
 ## Context
 
-In order to detect Flutter and Gradle modules in one IDE instance the Gradle settings need to be
+In order to detect Flutter and Gradle modules in the same IDE instance, the Gradle settings need to be
 moved so that the IDE can see both project types at once.
 
 ## Migration guide

--- a/src/content/release/breaking-changes/gradle-settings-migration.md
+++ b/src/content/release/breaking-changes/gradle-settings-migration.md
@@ -40,7 +40,7 @@ val newBuildDir: Directory = rootProject.layout.buildDirectory.dir("build").get(
 
 #### `build.gradle.kts`
 
-Add the line:
+Add the following line:
 ```dart
 project(":app").projectDir = File(rootDir, "android/app/")
 ```

--- a/src/content/release/breaking-changes/gradle-settings-migration.md
+++ b/src/content/release/breaking-changes/gradle-settings-migration.md
@@ -1,0 +1,71 @@
+---
+title: Gradle settings migration
+description: >
+  A change to enable the developer to edit Kotlin and Dart files with syntax highlighting and auto
+  completion in Android Studio.
+---
+
+## Summary
+
+A change to enable the developer to edit Kotlin and Dart files with syntax highlighting and auto
+completion in Android Studio.
+
+## Context
+
+In order to detect Flutter and Gradle modules in one IDE instance the Gradle settings need to be
+moved so that the IDE can see both project types at once.
+
+## Migration guide
+
+### Moving files
+
+The files `android/settings.gradle[.kts]` (with the `.kts` suffix when you use the Kotlin
+script), `android/build.gradle[.kts]`, `android/gradle.properties` and
+`android/local.properties` must be moved to the root directory of your project.
+
+### Changing files
+
+#### `build.gradle.kts`
+
+The `newBuildDir` needs to be changed from:
+```dart
+val newBuildDir: Directory = rootProject.layout.buildDirectory.dir("../../build").get()
+```
+to:
+```dart
+val newBuildDir: Directory = rootProject.layout.buildDirectory.dir("build").get()
+```
+
+#### `build.gradle.kts`
+
+Add the line:
+```dart
+project(":app").projectDir = File(rootDir, "android/app/")
+```
+
+#### or `build.gradle`
+
+Add the line:
+```dart
+project(':app').projectDir = new File(rootDir, 'android/app/')
+```
+
+When you have multiple modules then can add them in the `build.gradle[.kts]` too you just need to
+replace the module name and use your actual path.
+
+## Timeline
+
+In stable release: 3.34.0
+
+## References
+
+Relevant issue:
+
+* [Can't resolve symbol `io.flutter.plugin dependency`][Issue-19830]
+
+Relevant PR:
+
+* [Resolve resolve native Flutter dependencies in Android Studio][PR-167332]
+
+[PR-167332]: {{site.repo.flutter}}/pull/167332
+[Issue-19830]: {{site.repo.flutter}}/issues/19830

--- a/src/content/release/breaking-changes/gradle-settings-migration.md
+++ b/src/content/release/breaking-changes/gradle-settings-migration.md
@@ -52,8 +52,8 @@ Add the following line:
 project(':app').projectDir = new File(rootDir, 'android/app/')
 ```
 
-When you have multiple modules then can add them in the `build.gradle[.kts]` too you just need to
-replace the module name and use your actual path.
+When your project has multiple modules, add them in `build.gradle[.kts]` and
+replace the module name with the actual path.
 
 ## Timeline
 

--- a/src/content/release/breaking-changes/gradle-settings-migration.md
+++ b/src/content/release/breaking-changes/gradle-settings-migration.md
@@ -19,9 +19,11 @@ moved so that the IDE can see both project types at once.
 
 ### Moving files
 
-The files `android/settings.gradle[.kts]` (with the `.kts` suffix when you use the Kotlin
-script), `android/build.gradle[.kts]`, `android/gradle.properties` and
-`android/local.properties` must be moved to the root directory of your project.
+The following files must be moved to the root directory of your project:
+- `android/settings.gradle[.kts]` (with the `.kts` suffix when you use the Kotlin script)
+- `android/build.gradle[.kts]`
+- `android/gradle.properties`
+- `android/local.properties`
 
 ### Changing files
 


### PR DESCRIPTION
Related to [Resolve resolve native Flutter dependencies in Android Studio](https://github.com/flutter/flutter/pull/167332) and in preparation of [Extend template to resolve Dart and Kotlin](https://github.com/flutter/flutter/pull/168490) to explain how to use that fix to resolve [Can't resolve symbol io.flutter.plugin dependency](https://github.com/flutter/flutter/issues/19830)


## Presubmit checklist

- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR doesn't contain automatically generated corrections (generated by Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
