### PR TITLE
Add Sliver widgets to the Scrolling widget catalog

### DIFF
--- a/src/_data/catalog/index.yml
+++ b/src/_data/catalog/index.yml
@@ -87,6 +87,11 @@
   id: async
 - name: Scrolling
   description: Scroll multiple widgets as children of the parent.
+  subcategories:
+    - name: 'Sliver widgets'
+      description: >-
+        These widgets take a portion of a CustomScrollView and
+        apply a layout to that portion.
   id: scrolling
 - name: Accessibility
   description: Make your app accessible.


### PR DESCRIPTION
Currently, sliver widgets are only added to the layout widget catalog. This PR also adds the sliver widgets to the scrollable widget catalog too.

1. Layout widget catalog: https://flutter-docs-prod--pr12219-loic-sharma-patch-2-yu5u6jx5.web.app/ui/widgets/layout
2. Scrollable widget catalog: https://flutter-docs-prod--pr12219-loic-sharma-patch-2-yu5u6jx5.web.app/ui/widgets/scrolling

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
