### PR TITLE
Fix path to build directory in migration guide

### DIFF
--- a/src/content/release/breaking-changes/gradle-settings-migration.md
+++ b/src/content/release/breaking-changes/gradle-settings-migration.md
@@ -35,7 +35,7 @@ val newBuildDir: Directory = rootProject.layout.buildDirectory.dir("../../build"
 ```
 to:
 ```dart
-val newBuildDir: Directory = rootProject.layout.buildDirectory.dir("build").get()
+val newBuildDir: Directory = rootProject.layout.buildDirectory.get()
 ```
 
 #### `build.gradle.kts`


### PR DESCRIPTION
In context of adding a test of [Fix handling of generate lock files](https://github.com/flutter/flutter/pull/172124) I noticed that the migration guide had a bug. When you keep the "build" sub directory the android artifacts will land in `build/build/outputs` instead of `build/outputs` and will break the rest of the build pipeline.

_Issues fixed by this PR:_ Part of [#172124](https://github.com/flutter/flutter/pull/172124) verified via [test](https://github.com/flutter/flutter/pull/172124/files#diff-69f1017db6d0164855e2cc56f273edcca2cc4bff1d5b14b716b0259252568d52R49-R51)

## Presubmit checklist

- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
