### PR TITLE
Add breaking changes doc for CupertinoDynamicColor wide gamut changes.

### DIFF
--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -50,6 +50,7 @@ They're sorted by release and listed in alphabetical order:
 * [Component theme normalization updates][]
 * [Deprecate `DropdownButtonFormField` `value` parameter in favor of `initialValue`][]
 * [The Form widget no longer supports being a sliver.][]
+* [Migration guide for wide gamut CupertinoDynamicColor][]
 
 [Redesigned the Radio Widget]: /release/breaking-changes/radio-api-redesign
 [Removed semantics elevation and thickness]: /release/breaking-changes/remove-semantics-elevation-and-thickness
@@ -58,7 +59,8 @@ They're sorted by release and listed in alphabetical order:
 [UISceneDelegate adoption]: /release/breaking-changes/uiscenedelegate
 [Component theme normalization updates]: /release/breaking-changes/component-theme-normalization-updates
 [Deprecate `DropdownButtonFormField` `value` parameter in favor of `initialValue`]: /release/breaking-changes/deprecate-dropdownbuttonformfield-value
-[The Form widget no longer supports being a sliver.]:/release/breaking-changes/form-semantics
+[The Form widget no longer supports being a sliver.]: /release/breaking-changes/form-semantics
+[Migration guide for wide gamut CupertinoDynamicColor]: /release/breaking-changes/wide-gamut-cupertino-dynamic-color
 
 <a id="released-in-flutter-332" aria-hidden="true"></a>
 ### Released in Flutter 3.32

--- a/src/content/release/breaking-changes/wide-gamut-cupertino-dynamic-color.md
+++ b/src/content/release/breaking-changes/wide-gamut-cupertino-dynamic-color.md
@@ -1,0 +1,119 @@
+---
+title: Migration guide for wide gamut CupertinoDynamicColor
+description: >-
+  Addressing previously missed deprecations in CupertinoDynamicColor to align with wide gamut Color API.
+---
+
+## Summary
+
+Certain properties and methods in [`CupertinoDynamicColor`][] were deprecated 
+to align with [`Color`][] class due to [wide gamut color spaces][] support 
+added in [Flutter 3.27][Migration guide for wide gamut Color].
+
+## Context
+
+The `Color` class was updated to support wide gamut color spaces, but some 
+corresponding deprecations were not initially applied to 
+`CupertinoDynamicColor` due to its implementation rather than extension of 
+`Color`.
+
+## Description of change
+
+1. The [`CupertinoDynamicColor.red`][] is deprecated in favor of 
+  [`CupertinoDynamicColor.r`].
+1. The [`CupertinoDynamicColor.green`][] is deprecated in favor of 
+  [`CupertinoDynamicColor.g`].
+1. The [`CupertinoDynamicColor.blue`][] is deprecated in favor of 
+  [`CupertinoDynamicColor.b`].
+1. The [`CupertinoDynamicColor.opacity`][] is deprecated in favor of 
+  [`CupertinoDynamicColor.a`].
+1. The [`CupertinoDynamicColor.withOpacity()`][] is deprecated in favor of 
+  [`CupertinoDynamicColor.withValues()`].
+
+
+## Migration guide
+
+### Access color components
+
+If your app accesses a single color component, consider
+taking advantage of the floating-point components.
+In the short term, you can scale the components themselves.
+
+```dart
+int _floatToInt8(double x) {
+  return (x * 255.0).round().clamp(0, 255);
+}
+
+const CupertinoDynamicColor color = CupertinoColors.systemBlue;
+final intRed = _floatToInt8(color.r);
+final intGreen = _floatToInt8(color.g);
+final intBlue = _floatToInt8(color.b);
+```
+
+### Opacity
+
+Before Flutter 3.27, Color had the concept of "opacity" which showed up in the
+methods `opacity` and `withOpacity()`. Since Flutter 3.27, alpha is stored as a 
+floating-point value. Using `.a` and `.withValues()` will give the full 
+expression of a floating-point value and won't be quantized (restricted to a 
+limited range). That means "alpha" expresses the intent of "opacity" more 
+correctly.
+
+#### Migrate `opacity`
+
+```dart
+// Before: Access the alpha channel as a (converted) floating-point value.
+final x = color.opacity;
+
+// After: Access the alpha channel directly.
+final x = color.a;
+```
+
+#### Migrate `withOpacity`
+
+```dart
+// Before: Create a new color with the specified opacity.
+final x = color.withOpacity(0.5);
+
+// After: Create a new color with the specified alpha channel value,
+// accounting for the current or specified color space.
+final x = color.withValues(alpha: 0.5);
+```
+
+## Timeline
+
+Landed in version: 3.33.0-1.0.pre<br>
+Stable release: Not yet
+
+## References
+
+Relevant guides:
+
+* [Migration guide for wide gamut Color][]
+
+Relevant issues:
+
+* [Implement wide gamut color support in the Framework][]
+* [CupertinoDynamicColor is missing deprecation notices][]
+
+Relevant PRs:
+
+* [Add missing deprecations to CupertinoDynamicColor][]
+
+[`Color`]: {{site.api}}/flutter/dart-ui/Color-class.html
+[`CupertinoDynamicColor`]: {{site.api}}/flutter/cupertino/CupertinoDynamicColor-class.html
+[wide gamut color spaces]: https://en.wikipedia.org/wiki/RGB_color_spaces
+[`CupertinoDynamicColor.red`]: {{site.api}}/flutter/cupertino/CupertinoDynamicColor/red.html
+[`CupertinoDynamicColor.r`]: {{site.api}}/flutter/cupertino/CupertinoDynamicColor/r.html
+[`CupertinoDynamicColor.green`]: {{site.api}}/flutter/cupertino/CupertinoDynamicColor/green.html
+[`CupertinoDynamicColor.g`]: {{site.api}}/flutter/cupertino/CupertinoDynamicColor/g.html
+[`CupertinoDynamicColor.blue`]: {{site.api}}/flutter/cupertino/CupertinoDynamicColor/blue.html
+[`CupertinoDynamicColor.b`]: {{site.api}}/flutter/cupertino/CupertinoDynamicColor/b.html
+[`CupertinoDynamicColor.opacity`]: {{site.api}}/flutter/cupertino/CupertinoDynamicColor/opacity.html
+[`CupertinoDynamicColor.a`]: {{site.api}}/flutter/cupertino/CupertinoDynamicColor/a.html
+[`CupertinoDynamicColor.withOpacity()`]: {{site.api}}/flutter/cupertino/CupertinoDynamicColor/withOpacity.html
+[`CupertinoDynamicColor.withValues()`]: {{site.api}}/flutter/cupertino/CupertinoDynamicColor/withValues.html
+[Migration guide for wide gamut Color]: /release/breaking-changes/wide-gamut-framework
+[Implement wide gamut color support in the Framework]: {{site.repo.flutter}}/issues/127855
+[CupertinoDynamicColor is missing deprecation notices]: {{site.repo.flutter}}/issues/171059
+[Add missing deprecations to CupertinoDynamicColor]: {{site.repo.engine}}/pull/171160

--- a/src/content/release/breaking-changes/wide-gamut-cupertino-dynamic-color.md
+++ b/src/content/release/breaking-changes/wide-gamut-cupertino-dynamic-color.md
@@ -14,8 +14,8 @@ added in [Flutter 3.27][Migration guide for wide gamut Color].
 
 The `Color` class was updated to support wide gamut color spaces, but some 
 corresponding deprecations were not initially applied to 
-`CupertinoDynamicColor` due to its implementation rather than extension of 
-`Color`.
+`CupertinoDynamicColor` due to its implementation rather than due to
+the extension of `Color`.
 
 ## Description of change
 

--- a/src/content/release/breaking-changes/wide-gamut-cupertino-dynamic-color.md
+++ b/src/content/release/breaking-changes/wide-gamut-cupertino-dynamic-color.md
@@ -116,4 +116,4 @@ Relevant PRs:
 [Migration guide for wide gamut Color]: /release/breaking-changes/wide-gamut-framework
 [Implement wide gamut color support in the Framework]: {{site.repo.flutter}}/issues/127855
 [CupertinoDynamicColor is missing deprecation notices]: {{site.repo.flutter}}/issues/171059
-[Add missing deprecations to CupertinoDynamicColor]: {{site.repo.engine}}/pull/171160
+[Add missing deprecations to CupertinoDynamicColor]: {{site.repo.flutter}}/pull/171160

--- a/src/content/release/breaking-changes/wide-gamut-cupertino-dynamic-color.md
+++ b/src/content/release/breaking-changes/wide-gamut-cupertino-dynamic-color.md
@@ -52,7 +52,7 @@ final intBlue = _floatToInt8(color.b);
 
 ### Opacity
 
-Before Flutter 3.27, Color had the concept of "opacity" which showed up in the
+Before Flutter 3.27, `Color` had the concept of "opacity", which showed up in the
 methods `opacity` and `withOpacity()`. Since Flutter 3.27, alpha is stored as a 
 floating-point value. Using `.a` and `.withValues()` will give the full 
 expression of a floating-point value and won't be quantized (restricted to a 

--- a/src/content/release/breaking-changes/wide-gamut-cupertino-dynamic-color.md
+++ b/src/content/release/breaking-changes/wide-gamut-cupertino-dynamic-color.md
@@ -7,7 +7,7 @@ description: >-
 ## Summary
 
 Certain properties and methods in [`CupertinoDynamicColor`][] were deprecated 
-to align with [`Color`][] class due to [wide gamut color spaces][] support 
+to align with the [`Color`][] class due to [wide gamut color spaces][] support 
 added in [Flutter 3.27][Migration guide for wide gamut Color].
 
 ## Context


### PR DESCRIPTION
Adds breaking changes doc for deprecations introduced in `CupertinoDynamicColor` after wide gamut changes.

Depends on https://github.com/flutter/flutter/pull/171160

## Presubmit checklist

- [X] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [X] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
