### PR TITLE
feat: Add introductory video to main docs page

### DIFF
--- a/src/content/index.md
+++ b/src/content/index.md
@@ -26,6 +26,12 @@ see [What's new][].**
 
 ## New to Flutter?
 
+Ready to build beautiful, multiplatform apps from a single codebase? This video will walk you through the fundamentals of Flutter and show you how to get started.
+
+{% videoWrapper 'Build and ship amazing multiplatform iOS and Android apps with one codebase' %}
+{% ytEmbed 'W4JWeQolJsU', 'Build and ship amazing multiplatform iOS and Android apps with one codebase' %}
+{% endvideoWrapper %}
+
 Once you've [Set up Flutter][],
 you should follow the 
 [Write your first Flutter app][] codelab 

--- a/src/content/index.md
+++ b/src/content/index.md
@@ -26,7 +26,8 @@ see [What's new][].**
 
 ## New to Flutter?
 
-Ready to build beautiful, multiplatform apps from a single codebase? This video will walk you through the fundamentals of Flutter and show you how to get started.
+Ready to build beautiful, multiplatform apps from a single codebase?
+This video walks you through the fundamentals of Flutter and shows you how to get started.
 
 {% videoWrapper 'Build and ship amazing multiplatform iOS and Android apps with one codebase' %}
 {% ytEmbed 'W4JWeQolJsU', 'Build and ship amazing multiplatform iOS and Android apps with one codebase' %}


### PR DESCRIPTION
This PR adds a new introductory video to the main documentation landing page (`index.md`). The video provides a hands-on demo of Flutter for new users, helping them get started before diving into the codelab.