### PR TITLE
Add Disco to List of state management approaches

### DIFF
--- a/src/content/data-and-backend/state-mgmt/options.md
+++ b/src/content/data-and-backend/state-mgmt/options.md
@@ -94,6 +94,21 @@ Other useful docs include:
 [Using Flutter Inherited Widgets Effectively]: https://ericwindmill.com/articles/inherited_widget/
 [Widget - State - Context - InheritedWidget]: https://www.didierboelens.com/2018/06/widget---state---context---inheritedwidget/
 
+## Disco
+
+A library focused solely on dependency injection.
+It sits between Provider and Riverpod — respecting the widget tree like
+Provider, while supporting multiple providers of the same type and
+encouraging business logic separation like Riverpod. Unlike both,
+it purposefully avoids built-in reactivity, making it a natural
+complement to any state-management solution.
+
+* [Official Documentation][]
+* [Disco package][]
+
+[Official Documentation]: https://disco.mariuti.com/
+[disco package]: {{site.pub-pkg}}/disco
+
 ## June
 
 A lightweight and modern state management library that focuses on providing


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Adds Disco to the list of state management approaches.
However, since Disco is actually a DI-only library (it complements state-management solutions, but it is not include any form of state management/reactivity), would it make more sense to include a new section under https://docs.flutter.dev/app-architecture/case-study/dependency-injection instead of adding Disco to the List of state management approaches?

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
