### PR TITLE
Correct text in setting up VM acceleration

### DIFF
--- a/src/content/platform-integration/android/setup.md
+++ b/src/content/platform-integration/android/setup.md
@@ -165,7 +165,7 @@ run a Flutter app on an Android emulator, follow these steps:
 
     1. Start **Android Studio**.
 
-    1. Go to the **Settings** dialog to view the **SDK Manager**.
+    1. Go to the **Settings** dialog to view the **Device Manager**.
 
        1. If you have a project open,
           go to **Tools** <span aria-label="and then">></span>


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

The instructions for setting up VM acceleration instruct users to open the SDK Manager, wheres they should be opening the Device Manager. The text in the sub-steps is already correct.

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
