### PR TITLE
Predictive back transition

### DIFF
--- a/src/content/release/breaking-changes/default-android-page-transition.md
+++ b/src/content/release/breaking-changes/default-android-page-transition.md
@@ -1,0 +1,196 @@
+---
+title: Replace with title of breaking change
+description: Brief description similar to the "context" section below. The description shouldn't have any linebreaks - let it go long and wrap. Text below should break at 80 chars or less.
+---
+
+{% comment %}
+  PLEASE READ THESE GENERAL INSTRUCTIONS:
+  * All lines of text should be 80 chars OR LESS.
+    The writers strongly prefer semantic line breaks:
+    https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks
+  * DON'T SUBMIT a PR weeks and weeks in advance.
+    Doing this causes it to get stanky in the website
+    repo and usually develops conflicts in the index file.
+    Ideally, submit a PR once you have confirmed
+    info on the version number where the breaking
+    change landed.
+  * One of the most important things to fill out 
+    in this template is the *Timeline* section.
+    I won't approve/merge the PR until the "landed in"
+    release info is provided. For example:
+    `Landed in version: 1.21.0-5.0.pre<br>`.
+    Do NOT list the PR in this section. Also, don't
+    fill in the "stable" release info unless it's
+    already in a published stable release.
+    After a stable release, I go through and confirm
+    that updates have made it to stable and I then
+    update the breaking change and the index file.
+  * The text in this page should be backwards looking,
+    so write about previous behavior in past tense,
+    not future tense. People are reading this months
+    from now when the change is likely in the stable
+    release, not today. Don't say "in a month" or
+    talk about your plan to do something next week.
+    Assume you've done it, and that they're looking
+    back to figure out how to migrate their code.
+  * Use sentence case for headings and titles.
+    (`## Migration guide`, NOT `Migration Guide`)
+  * DON'T use the abbreviation `i.e.` or `e.g.`.
+    Use "for example" or "such as", and similar.
+  * For links, use the macros where possible.
+    See the examples at the end of this template,
+    but don't use "github.com" or "api.flutter.dev" or
+    "pub.dev" in your URLs. Use the {{site.github}},
+    {{site.api}}, or {{site.pub}} macros.
+  * AVOID "will" when possible, in other words,
+    stay in the present tense. For example:
+    Bad: "When encountering an xxx value,
+          the code will throw an exception."
+    Good: "When encountering an xxx value,
+           the code throws an exception."
+    Good use of "will": "In release 2.0, the xxx API
+          will be deprecated."
+  * If your included Dart code won't pass analysis
+    on its own (using the analyzer from the latest
+    stable release), then preface that code with an
+    HTML `<!-- skip -->` tag.
+  * Finally, delete the comment tags and text from the
+    final PR.
+{% endcomment %}
+
+## Summary
+
+{% comment %}
+  A brief (one- to three-line) summary that gives
+  context as to what changed so that someone can
+  find it when browsing through an index of
+  breaking changes, ideally using keywords from
+  the symptoms you would see if you had not yet
+  migrated (for example, the text from probable
+  error messages).
+{% endcomment %}
+
+## Context
+
+{% comment %}
+  High-level description of what API changed and why.
+  Should be clear enough to be understandable to someone
+  who has no context about this breaking change,
+  such as someone who doesn't know the underlying API.
+  This section should also answer the question
+  "what is the problem that led to considering making
+  a breaking change?"
+{% endcomment %}
+
+## Description of change
+
+{% comment %}
+A technical description of the actual change,
+with code samples showing how the API changed.
+
+Include examples of the error messages that are produced
+in code that has not been migrated. This helps the search
+engine find the migration guide when people search for those
+error messages.
+{% endcomment %}
+
+## Migration guide
+
+{% comment %}
+  A description of how to make the change.
+  If a migration tool is available,
+  discuss it here. Even if there is a tool,
+  a description of how to make the change manually
+  must be provided. This section needs before and
+  after code examples that are relevant to the
+  developer.
+{% endcomment %}
+
+Code before migration:
+
+<!-- skip -->
+```dart
+// Example of code before the change.
+```
+
+Code after migration:
+
+<!-- skip -->
+```dart
+// Example of code after the change.
+```
+
+## Timeline
+
+{% comment %}
+  The version # of the SDK where this change was
+  introduced.  If there is a deprecation window,
+  the version # to which we guarantee to maintain
+  the old API. Use the following template:
+
+  If a breaking change has been reverted in a
+  subsequent release, move that item to the
+  "Reverted" section of the index.md file.
+  Also add the "Reverted in version" line,
+  shown as optional below. Otherwise, delete
+  that line.
+{% endcomment %}
+
+Landed in version: xxx<br>
+In stable release: not yet
+Reverted in version: xxx  (OPTIONAL, delete if not used)
+
+## References
+
+{% comment %}
+  These links are commented out because they
+  cause the GitHubActions (GHA) linkcheck to fail.
+  Remove the comment tags once you fill this in with
+  real links. Only use the "master-api" include if
+  you link to "master-api.flutter.dev".
+
+{% include master-api.md %}
+
+API documentation:
+
+* [`ClassName`][]
+
+Relevant issues:
+
+* [Issue xxxx][]
+* [Issue yyyy][]
+
+Relevant PRs:
+
+* [PR title #1][]
+* [PR title #2][]
+{% endcomment %}
+
+{% comment %}
+  Add the links to the end of the file in alphabetical order.
+  The following links are commented out because they make
+  the GitHubActions (GHA) link checker believe they are broken links,
+  but please remove the comment tags before you commit!
+
+  If you are sharing new API that hasn't landed in
+  the stable channel yet, use the master channel link.
+  To link to docs on the master channel,
+  include the following note and make sure that
+  the URL includes the master link (as shown below).
+
+  Here's an example of defining a stable (site.api) link
+  and a master channel (master-api) link.
+
+<!-- Stable channel link: -->
+[`ClassName`]: {{site.api}}/flutter/[link_to_relevant_page].html
+
+<!-- Master channel link: -->
+{% include master-api.md %}
+
+[`ClassName`]: https://master-api.flutter.dev/flutter/[link_to_relevant_page].html
+
+[Issue xxxx]: {{site.github}}/flutter/flutter/issues/[link_to_actual_issue]
+[Issue yyyy]: {{site.github}}/flutter/flutter/issues/[link_to_actual_issue]
+[PR title #1]: {{site.github}}/flutter/flutter/pull/[link_to_actual_pr]
+[PR title #2]: {{site.github}}/flutter/flutter/pull/[link_to_actual_pr]
+{% endcomment %}

--- a/src/content/release/breaking-changes/default-android-page-transition.md
+++ b/src/content/release/breaking-changes/default-android-page-transition.md
@@ -1,6 +1,7 @@
 ---
-title: Replace with title of breaking change
-description: Brief description similar to the "context" section below. The description shouldn't have any linebreaks - let it go long and wrap. Text below should break at 80 chars or less.
+title: The default page transition on Android is now PredictiveBackPageTransitionBuilder
+description: Android's default page transition has been updated to match the
+platform and to support predictive back.
 ---
 
 {% comment %}

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -50,6 +50,7 @@ They're sorted by release and listed in alphabetical order:
 * [Component theme normalization updates][]
 * [Deprecate `DropdownButtonFormField` `value` parameter in favor of `initialValue`][]
 * [The Form widget no longer supports being a sliver.][]
+* [The default page transition on Android is now PredictiveBackPageTransitionBuilder][]
 
 [Redesigned the Radio Widget]: /release/breaking-changes/radio-api-redesign
 [Removed semantics elevation and thickness]: /release/breaking-changes/remove-semantics-elevation-and-thickness
@@ -59,6 +60,7 @@ They're sorted by release and listed in alphabetical order:
 [Component theme normalization updates]: /release/breaking-changes/component-theme-normalization-updates
 [Deprecate `DropdownButtonFormField` `value` parameter in favor of `initialValue`]: /release/breaking-changes/deprecate-dropdownbuttonformfield-value
 [The Form widget no longer supports being a sliver.]:/release/breaking-changes/form-semantics
+[The default page transition on Android is now PredictiveBackPageTransitionBuilder]:/release/breaking-changes/default-android-page-transition
 
 <a id="released-in-flutter-332" aria-hidden="true"></a>
 ### Released in Flutter 3.32


### PR DESCRIPTION
This PR spawned out of https://github.com/flutter/flutter/pull/165832#issuecomment-3074903719. That PR will change the default page transition and turn on predictive back by default. While there is no API breakage, users may encounter test breakages in tests that indirectly depend on the default page transition and/or its duration. Several of these kinds of breakages were encountered in https://github.com/flutter/flutter/pull/165832 in the framework tests, customer tests, and Google tests.

This PR should explain:

 * What predictive back is.
 * How to make sure an app supports predictive back.
 * What the new Fade Fowards page transition looks like.
 * How to manually change the page transition back to the old one.
 * How to write tests that don't depend on the page transition and its duration.

_Issues fixed by this PR (if any):_ n/a

_PRs or commits this PR depends on (if any):_ https://github.com/flutter/flutter/pull/165832

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
