### PR TITLE
Fix: Add missing `windowOptOutEdgeToEdgeEnforcement` to all relevant styles for SDK 35 compatibility

### DIFF
--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -101,7 +101,7 @@ Locate the style definition in:
 
 Add the following attribute to the appropriate style:
 
-```xml title="styles.xml" highlightLines=7
+```xml title="styles.xml" highlightLines=6,12
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -99,7 +99,7 @@ Modify these default styles in your manifest file:
 Locate the style definition in:
 `your_app/android/app/src/main/res/values/styles.xml`.
 
-Add the following attribute to the appropriate style:
+Add the following attribute to the appropriate styles:
 
 ```xml title="styles.xml" highlightLines=6,12
 <?xml version="1.0" encoding="utf-8"?>

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -96,13 +96,19 @@ Modify these default styles in your manifest file:
 </manifest>
 ```
 
-Find where this style is defined in
-`your_app/android/app/src/main/res/values/styles.xml`.
-There, add the following attribute to the style:
+Locate the style definition in:
+`your_app/android/app/src/main/res/values/styles.xml`
+
+Add the following attribute to the appropriate style:
 
 ```xml title="styles.xml" highlightLines=7
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
+        ...
+	      <!-- Add the following line: -->
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
     ...
     <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
         ...
@@ -111,6 +117,11 @@ There, add the following attribute to the style:
     </style>
 </resources>
 ```
+
+Make sure to apply the same change in the night mode styles file as well:
+`your_app/android/app/src/main/res/values-night/styles.xml`
+
+Ensure both styles are updated consistently in both files.
 
 This modified style opts your app out of edge-to-edge for
 apps targeting Android SDK 15.

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -119,7 +119,7 @@ Add the following attribute to the appropriate style:
 ```
 
 Make sure to apply the same change in the night mode styles file as well:
-`your_app/android/app/src/main/res/values-night/styles.xml`
+`your_app/android/app/src/main/res/values-night/styles.xml`.
 
 Ensure both styles are updated consistently in both files.
 

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -97,7 +97,7 @@ Modify these default styles in your manifest file:
 ```
 
 Locate the style definition in:
-`your_app/android/app/src/main/res/values/styles.xml`
+`your_app/android/app/src/main/res/values/styles.xml`.
 
 Add the following attribute to the appropriate style:
 

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -106,7 +106,7 @@ Add the following attribute to the appropriate style:
 <resources>
     <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
         ...
-	      <!-- Add the following line: -->
+        <!-- Add the following line: -->
         <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
     </style>
     ...


### PR DESCRIPTION
The Flutter documentation currently states that the
`<item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>`
attribute should be added only to the `NormalTheme` in
`your_app/android/app/src/main/res/values/styles.xml`.

However, this is not sufficient.

To ensure proper behavior—especially for users with dark mode enabled—this attribute must also be added to the `LaunchTheme` and be mirrored in the `values-night/styles.xml` file.

Initially, I added the attribute only to `NormalTheme` in the `values` folder, but users in dark mode continued to experience issues. This PR resolves the problem by applying the fix consistently across both `NormalTheme` and `LaunchTheme`, in both `values` and `values-night`.