### PR TITLE
added info to deployment/android signing

### DIFF
--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -189,7 +189,7 @@ The `storeFile` might be located at
 or `C:\\Users\\<user name>\\upload-keystore.jks` on Windows.
 
 :::note
-Note that the Windows path to keystore.jks must be specified with double backslashes `\\`.
+The Windows path to `keystore.jks` must be specified with double backslashes: `\\`.
 :::
 
 :::warning


### PR DESCRIPTION
Hey,
this is my first contribution to Flutter. If I'm doing something wrong please excuse me.

This PR makes it more prominent that the storeFile field in key.properties (android signing) must be specified with double backslashes not single backslashes. This has caused not easy to understand Java build issues multiple times with me, my collegues/friends and some StackOverflow users.
The markdown note box maybe will draw enough attention to avoid this.