### PR TITLE
fix: Typo in arb file name in internationalization docs

### DIFF
--- a/src/content/ui/accessibility-and-internationalization/internationalization.md
+++ b/src/content/ui/accessibility-and-internationalization/internationalization.md
@@ -593,7 +593,7 @@ Those parameters can be specified as the value
 of the placeholder's `optionalParameters` object.
 For example, to specify the optional `decimalDigits`
 parameter for `compactCurrency`,
-make the following changes to the `lib/l10n/app_en.arg` file:
+make the following changes to the `lib/l10n/app_en.arb` file:
 
 {% raw %}
 <?code-excerpt "gen_l10n_example/lib/l10n/app_en.arb" skip="34" take="13" replace="/},$/}/g"?>


### PR DESCRIPTION
There is a small typo in the docs where `app_en.arg` is mentioned instead of `app_en.arb`. This PR fixes that :)

## Presubmit checklist

- [X] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [X] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
