### PR TITLE
docs/update-solidart-documentation-link-and-description

### DIFF
--- a/src/content/data-and-backend/state-mgmt/options.md
+++ b/src/content/data-and-backend/state-mgmt/options.md
@@ -298,13 +298,14 @@ For more information, refer to the following resources:
 
 ## solidart
 
-A simple but powerful state management solution inspired by SolidJS.
+A simple and performant fine-grained reactivity state management solution for building user interfaces.
+Enjoy the automatic reactivity system with Signal, Computed, Resource and Effect.
 
 * [Official Documentation][]
 * [solidart package][]
 * [flutter_solidart package][]
 
-[Official Documentation]: https://docs.page/nank1ro/solidart
+[Official Documentation]: https://solidart.mariuti.com
 [solidart package]: {{site.pub-pkg}}/solidart
 [flutter_solidart package]: {{site.pub-pkg}}/flutter_solidart
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

The "List of state management approaches" documentation linked the deprecated solidart documentation. The documentation has been moved to `https://solidart.mariuti.com` (I'm the author of the library)

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
