### PR TITLE
Update app-extensions.md

### DIFF
--- a/src/content/platform-integration/ios/app-extensions.md
+++ b/src/content/platform-integration/ios/app-extensions.md
@@ -80,6 +80,23 @@ an existing project.
     *   Drag **Embed Foundation Extensions** above
         **Run Script**.
 
+
+1.  Make sure your **Minimum Deployments** iOS value is properly
+    set and matches in both **Runner** and **ShareExtension**
+
+    *   Open the **project navigator**
+        (**View** > **Navigators** > **Project**).
+    
+    *   In the **project navigator**, at the top, select
+        **Runner**.
+
+    *   In the main window under **TARGETS**, select
+        **Runner**.
+
+    *   On the **General** tab check your **Minimum Deployments**
+        dropdown value to match the one you have on
+        **ShareExtension** > **General** tab.
+
 1.  In the console, run the following command to rebuild your
     iOS app:
 


### PR DESCRIPTION
**Description:**

In some environments the value of the Minimum Deployments is not set for the Runner Target, and the ShareExtension one takes the latest one it can, so they not match causing the Extension not to be shown on the Photos Share sheet.

So I added an extra step for people following the tutorial to check that small detail that can cause frustration.

**Issues solved**: None
**Commits dependency**: None