### PR TITLE
Fix Preview class broken url in widget-previewer.md

### DIFF
--- a/src/content/tools/widget-previewer.md
+++ b/src/content/tools/widget-previewer.md
@@ -116,7 +116,7 @@ use to customize the preview:
 *   **`localizations`**: A function to apply a localization
     configuration.
 
-[`@Preview`]: {{site.api}}/flutter/widgets/Preview-class.html
+[`@Preview`]: {{site.api}}/flutter/widget_previews/Preview-class.html
 
 ## Restrictions and limitations
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_


## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
