### PR TITLE
Fix for https://github.com/flutter/website/issues/12144

### DIFF
--- a/src/content/cookbook/animation/physics-simulation.md
+++ b/src/content/cookbook/animation/physics-simulation.md
@@ -261,7 +261,7 @@ void _runAnimation(Offset pixelsPerSecond, Size size) {
   final unitsPerSecond = Offset(unitsPerSecondX, unitsPerSecondY);
   final unitVelocity = unitsPerSecond.distance;
 
-  const spring = SpringDescription(mass: 30, stiffness: 1, damping: 1);
+  const spring = SpringDescription(mass: 1, stiffness: 1, damping: 1);
 
   final simulation = SpringSimulation(spring, 0, 1, -unitVelocity);
 
@@ -342,7 +342,7 @@ class _DraggableCardState extends State<DraggableCard>
     final unitsPerSecond = Offset(unitsPerSecondX, unitsPerSecondY);
     final unitVelocity = unitsPerSecond.distance;
 
-    const spring = SpringDescription(mass: 30, stiffness: 1, damping: 1);
+    const spring = SpringDescription(mass: 1, stiffness: 1, damping: 1);
 
     final simulation = SpringSimulation(spring, 0, 1, -unitVelocity);
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Drop the animated bodies weight so it animates quicker

_Issues fixed by this PR (if any):_ https://github.com/flutter/website/issues/12144

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
