### PR TITLE
Update site for 3.35.1

### DIFF
--- a/examples/_animation/basic_hero_animation/pubspec.yaml
+++ b/examples/_animation/basic_hero_animation/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/_animation/basic_radial_hero_animation/pubspec.yaml
+++ b/examples/_animation/basic_radial_hero_animation/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/_animation/basic_staggered_animation/pubspec.yaml
+++ b/examples/_animation/basic_staggered_animation/pubspec.yaml
@@ -4,7 +4,7 @@ description: An introductory example to staggered animations.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/_animation/hero_animation/pubspec.yaml
+++ b/examples/_animation/hero_animation/pubspec.yaml
@@ -4,7 +4,7 @@ description: Shows how to create a simple Hero transition.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/_animation/radial_hero_animation/pubspec.yaml
+++ b/examples/_animation/radial_hero_animation/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/_animation/radial_hero_animation_animate_rectclip/pubspec.yaml
+++ b/examples/_animation/radial_hero_animation_animate_rectclip/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/_animation/staggered_pic_selection/pubspec.yaml
+++ b/examples/_animation/staggered_pic_selection/pubspec.yaml
@@ -4,7 +4,7 @@ description: A more complex staggered animation example.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/accessibility/pubspec.yaml
+++ b/examples/accessibility/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/animation/animate0/pubspec.yaml
+++ b/examples/animation/animate0/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/animation/animate1/pubspec.yaml
+++ b/examples/animation/animate1/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/animation/animate2/pubspec.yaml
+++ b/examples/animation/animate2/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/animation/animate3/pubspec.yaml
+++ b/examples/animation/animate3/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/animation/animate4/pubspec.yaml
+++ b/examples/animation/animate4/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/animation/animate5/pubspec.yaml
+++ b/examples/animation/animate5/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/animation/implicit/pubspec.yaml
+++ b/examples/animation/implicit/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/app-architecture/command/pubspec.yaml
+++ b/examples/app-architecture/command/pubspec.yaml
@@ -3,7 +3,7 @@ description: Example for command cookbook recipe
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/app-architecture/offline_first/pubspec.yaml
+++ b/examples/app-architecture/offline_first/pubspec.yaml
@@ -3,7 +3,7 @@ description: Example for offline_first cookbook recipe
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/app-architecture/optimistic_state/pubspec.yaml
+++ b/examples/app-architecture/optimistic_state/pubspec.yaml
@@ -3,7 +3,7 @@ description: Example for optimistic_state cookbook recipe
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/app-architecture/result/pubspec.yaml
+++ b/examples/app-architecture/result/pubspec.yaml
@@ -3,7 +3,7 @@ description: Example for result cookbook recipe
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/app-architecture/todo_data_service/pubspec.yaml
+++ b/examples/app-architecture/todo_data_service/pubspec.yaml
@@ -3,7 +3,7 @@ description: Example for key_value_data cookbook recipe
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/animation/animated_container/pubspec.yaml
+++ b/examples/cookbook/animation/animated_container/pubspec.yaml
@@ -3,7 +3,7 @@ description: Sample code for cookbook.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/animation/opacity_animation/pubspec.yaml
+++ b/examples/cookbook/animation/opacity_animation/pubspec.yaml
@@ -3,7 +3,7 @@ description: Sample code for cookbook.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/animation/page_route_animation/pubspec.yaml
+++ b/examples/cookbook/animation/page_route_animation/pubspec.yaml
@@ -3,7 +3,7 @@ description: Sample code for cookbook.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/animation/physics_simulation/pubspec.yaml
+++ b/examples/cookbook/animation/physics_simulation/pubspec.yaml
@@ -3,7 +3,7 @@ description: Sample code for cookbook.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/design/drawer/pubspec.yaml
+++ b/examples/cookbook/design/drawer/pubspec.yaml
@@ -3,7 +3,7 @@ description: Sample code for drawer cookbook recipe.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/design/fonts/pubspec.yaml
+++ b/examples/cookbook/design/fonts/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/design/orientation/pubspec.yaml
+++ b/examples/cookbook/design/orientation/pubspec.yaml
@@ -3,7 +3,7 @@ description: Sample code for orientation cookbook recipe.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/design/package_fonts/pubspec.yaml
+++ b/examples/cookbook/design/package_fonts/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/design/snackbars/pubspec.yaml
+++ b/examples/cookbook/design/snackbars/pubspec.yaml
@@ -3,7 +3,7 @@ description: Sample code for snackbars cookbook recipe.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/design/tabs/pubspec.yaml
+++ b/examples/cookbook/design/tabs/pubspec.yaml
@@ -3,7 +3,7 @@ description: Sample code for tabs cookbook recipe.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/design/themes/pubspec.yaml
+++ b/examples/cookbook/design/themes/pubspec.yaml
@@ -3,7 +3,7 @@ description: Sample code for themes cookbook recipe.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/effects/download_button/pubspec.yaml
+++ b/examples/cookbook/effects/download_button/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/effects/drag_a_widget/pubspec.yaml
+++ b/examples/cookbook/effects/drag_a_widget/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/effects/expandable_fab/pubspec.yaml
+++ b/examples/cookbook/effects/expandable_fab/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/effects/gradient_bubbles/pubspec.yaml
+++ b/examples/cookbook/effects/gradient_bubbles/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/effects/nested_nav/pubspec.yaml
+++ b/examples/cookbook/effects/nested_nav/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/effects/parallax_scrolling/pubspec.yaml
+++ b/examples/cookbook/effects/parallax_scrolling/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/effects/shimmer_loading/pubspec.yaml
+++ b/examples/cookbook/effects/shimmer_loading/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/effects/staggered_menu_animation/pubspec.yaml
+++ b/examples/cookbook/effects/staggered_menu_animation/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/effects/typing_indicator/pubspec.yaml
+++ b/examples/cookbook/effects/typing_indicator/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/forms/focus/pubspec.yaml
+++ b/examples/cookbook/forms/focus/pubspec.yaml
@@ -3,7 +3,7 @@ description: Sample code for focus cookbook recipe.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/forms/retrieve_input/pubspec.yaml
+++ b/examples/cookbook/forms/retrieve_input/pubspec.yaml
@@ -3,7 +3,7 @@ description: Sample code for retrieve_input cookbook recipe.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/forms/text_field_changes/pubspec.yaml
+++ b/examples/cookbook/forms/text_field_changes/pubspec.yaml
@@ -3,7 +3,7 @@ description: Sample code for text_field_changes
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/forms/text_input/pubspec.yaml
+++ b/examples/cookbook/forms/text_input/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/forms/validation/pubspec.yaml
+++ b/examples/cookbook/forms/validation/pubspec.yaml
@@ -3,7 +3,7 @@ description: Use Form widget to perform form validation.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/games/achievements_leaderboards/pubspec.yaml
+++ b/examples/cookbook/games/achievements_leaderboards/pubspec.yaml
@@ -3,7 +3,7 @@ description: Games services
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/games/firestore_multiplayer/pubspec.yaml
+++ b/examples/cookbook/games/firestore_multiplayer/pubspec.yaml
@@ -3,7 +3,7 @@ description: Firestore multiplayer
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/gestures/dismissible/pubspec.yaml
+++ b/examples/cookbook/gestures/dismissible/pubspec.yaml
@@ -3,7 +3,7 @@ description: Sample code for dismissible cookbook recipe.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/gestures/handling_taps/pubspec.yaml
+++ b/examples/cookbook/gestures/handling_taps/pubspec.yaml
@@ -3,7 +3,7 @@ description: Example on handling_taps cookbook recipe.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/gestures/ripples/pubspec.yaml
+++ b/examples/cookbook/gestures/ripples/pubspec.yaml
@@ -3,7 +3,7 @@ description: Example for ripples cookbook recipe
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/images/cached_images/pubspec.yaml
+++ b/examples/cookbook/images/cached_images/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/images/fading_in_images/pubspec.yaml
+++ b/examples/cookbook/images/fading_in_images/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/images/network_image/pubspec.yaml
+++ b/examples/cookbook/images/network_image/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/lists/basic_list/pubspec.yaml
+++ b/examples/cookbook/lists/basic_list/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/lists/floating_app_bar/pubspec.yaml
+++ b/examples/cookbook/lists/floating_app_bar/pubspec.yaml
@@ -3,7 +3,7 @@ description: Example for floating_app_bar cookbook recipe
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/lists/grid_lists/pubspec.yaml
+++ b/examples/cookbook/lists/grid_lists/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/lists/horizontal_list/pubspec.yaml
+++ b/examples/cookbook/lists/horizontal_list/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/lists/long_lists/pubspec.yaml
+++ b/examples/cookbook/lists/long_lists/pubspec.yaml
@@ -3,7 +3,7 @@ description: Example for long_lists cookbook recipe
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/lists/mixed_list/pubspec.yaml
+++ b/examples/cookbook/lists/mixed_list/pubspec.yaml
@@ -3,7 +3,7 @@ description: Example for mixed_lists cookbook recipe
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/lists/spaced_items/pubspec.yaml
+++ b/examples/cookbook/lists/spaced_items/pubspec.yaml
@@ -3,7 +3,7 @@ description: Example for spaced_items cookbook recipe
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/maintenance/error_reporting/pubspec.yaml
+++ b/examples/cookbook/maintenance/error_reporting/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/navigation/hero_animations/pubspec.yaml
+++ b/examples/cookbook/navigation/hero_animations/pubspec.yaml
@@ -3,7 +3,7 @@ description: Hero animations
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/navigation/named_routes/pubspec.yaml
+++ b/examples/cookbook/navigation/named_routes/pubspec.yaml
@@ -3,7 +3,7 @@ description: Named route example snippets.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/navigation/navigate_with_arguments/pubspec.yaml
+++ b/examples/cookbook/navigation/navigate_with_arguments/pubspec.yaml
@@ -3,7 +3,7 @@ description: Use Form widget to perform form validation.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/navigation/navigation_basics/pubspec.yaml
+++ b/examples/cookbook/navigation/navigation_basics/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/navigation/passing_data/pubspec.yaml
+++ b/examples/cookbook/navigation/passing_data/pubspec.yaml
@@ -3,7 +3,7 @@ description: Passing data
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/navigation/returning_data/pubspec.yaml
+++ b/examples/cookbook/navigation/returning_data/pubspec.yaml
@@ -3,7 +3,7 @@ description: Returning data
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/networking/authenticated_requests/pubspec.yaml
+++ b/examples/cookbook/networking/authenticated_requests/pubspec.yaml
@@ -3,7 +3,7 @@ description: Authenticated HTTP request example snippets.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/networking/background_parsing/pubspec.yaml
+++ b/examples/cookbook/networking/background_parsing/pubspec.yaml
@@ -3,7 +3,7 @@ description: Background parsing
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/networking/delete_data/pubspec.yaml
+++ b/examples/cookbook/networking/delete_data/pubspec.yaml
@@ -3,7 +3,7 @@ description: Delete Data
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/networking/fetch_data/pubspec.yaml
+++ b/examples/cookbook/networking/fetch_data/pubspec.yaml
@@ -3,7 +3,7 @@ description: Fetch Data
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/networking/send_data/pubspec.yaml
+++ b/examples/cookbook/networking/send_data/pubspec.yaml
@@ -3,7 +3,7 @@ description: Send data
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/networking/update_data/pubspec.yaml
+++ b/examples/cookbook/networking/update_data/pubspec.yaml
@@ -3,7 +3,7 @@ description: Update Data
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/networking/web_sockets/pubspec.yaml
+++ b/examples/cookbook/networking/web_sockets/pubspec.yaml
@@ -3,7 +3,7 @@ description: Web Sockets
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/persistence/key_value/pubspec.yaml
+++ b/examples/cookbook/persistence/key_value/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/persistence/reading_writing_files/pubspec.yaml
+++ b/examples/cookbook/persistence/reading_writing_files/pubspec.yaml
@@ -3,7 +3,7 @@ description: Reading and Writing Files
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/persistence/sqlite/pubspec.yaml
+++ b/examples/cookbook/persistence/sqlite/pubspec.yaml
@@ -3,7 +3,7 @@ description: Example of using sqflite plugin to access SQLite database.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/plugins/google_mobile_ads/pubspec.yaml
+++ b/examples/cookbook/plugins/google_mobile_ads/pubspec.yaml
@@ -3,7 +3,7 @@ description: Google mobile ads
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/plugins/picture_using_camera/pubspec.yaml
+++ b/examples/cookbook/plugins/picture_using_camera/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/plugins/play_video/pubspec.yaml
+++ b/examples/cookbook/plugins/play_video/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/testing/integration/introduction/pubspec.yaml
+++ b/examples/cookbook/testing/integration/introduction/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/testing/integration/profiling/pubspec.yaml
+++ b/examples/cookbook/testing/integration/profiling/pubspec.yaml
@@ -3,7 +3,7 @@ description: Integration test profiling examples.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/testing/unit/counter_app/pubspec.yaml
+++ b/examples/cookbook/testing/unit/counter_app/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/testing/unit/mocking/pubspec.yaml
+++ b/examples/cookbook/testing/unit/mocking/pubspec.yaml
@@ -3,7 +3,7 @@ description: Use the Mockito package to mimic the behavior of services for testi
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/testing/widget/finders/pubspec.yaml
+++ b/examples/cookbook/testing/widget/finders/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/testing/widget/introduction/pubspec.yaml
+++ b/examples/cookbook/testing/widget/introduction/pubspec.yaml
@@ -3,7 +3,7 @@ description: Widget testing example snippets.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/testing/widget/orientation_tests/pubspec.yaml
+++ b/examples/cookbook/testing/widget/orientation_tests/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/testing/widget/scrolling/pubspec.yaml
+++ b/examples/cookbook/testing/widget/scrolling/pubspec.yaml
@@ -3,7 +3,7 @@ description: Scrollable widget testing.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/cookbook/testing/widget/tap_drag/pubspec.yaml
+++ b/examples/cookbook/testing/widget/tap_drag/pubspec.yaml
@@ -3,7 +3,7 @@ description: Tap drag widget testing examples.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/data-and-backend/json/pubspec.yaml
+++ b/examples/data-and-backend/json/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   json_annotation: ^4.9.0

--- a/examples/deployment/obfuscate/pubspec.yaml
+++ b/examples/deployment/obfuscate/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/get-started/flutter-for/android_devs/pubspec.yaml
+++ b/examples/get-started/flutter-for/android_devs/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/get-started/flutter-for/declarative/pubspec.yaml
+++ b/examples/get-started/flutter-for/declarative/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/get-started/flutter-for/ios_devs/pubspec.yaml
+++ b/examples/get-started/flutter-for/ios_devs/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/get-started/flutter-for/react_native_devs/my_widgets/pubspec.yaml
+++ b/examples/get-started/flutter-for/react_native_devs/my_widgets/pubspec.yaml
@@ -4,4 +4,4 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0

--- a/examples/get-started/flutter-for/react_native_devs/pubspec.yaml
+++ b/examples/get-started/flutter-for/react_native_devs/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 workspace:
   - my_widgets

--- a/examples/get-started/flutter-for/web_devs/pubspec.yaml
+++ b/examples/get-started/flutter-for/web_devs/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/get-started/flutter-for/xamarin_devs/pubspec.yaml
+++ b/examples/get-started/flutter-for/xamarin_devs/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/googleapis/pubspec.yaml
+++ b/examples/googleapis/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   collection: any # Pull the version of package:collection from Flutter.

--- a/examples/integration_test/pubspec.yaml
+++ b/examples/integration_test/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/integration_test_migration/pubspec.yaml
+++ b/examples/integration_test_migration/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/internationalization/add_language/pubspec.yaml
+++ b/examples/internationalization/add_language/pubspec.yaml
@@ -3,7 +3,7 @@ description: An i18n app example that adds a supported language
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/internationalization/gen_l10n_example/pubspec.yaml
+++ b/examples/internationalization/gen_l10n_example/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 # #docregion flutter-localizations
 dependencies:

--- a/examples/internationalization/intl_example/pubspec.yaml
+++ b/examples/internationalization/intl_example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Example of a Flutter app using the intl library services.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/internationalization/minimal/pubspec.yaml
+++ b/examples/internationalization/minimal/pubspec.yaml
@@ -3,7 +3,7 @@ description: A minimal example of a localized Flutter app
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/layout/base/pubspec.yaml
+++ b/examples/layout/base/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/layout/card_and_stack/pubspec.yaml
+++ b/examples/layout/card_and_stack/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/layout/constraints/pubspec.yaml
+++ b/examples/layout/constraints/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/layout/container/pubspec.yaml
+++ b/examples/layout/container/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/layout/gallery/pubspec.yaml
+++ b/examples/layout/gallery/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   animations: ^2.0.11

--- a/examples/layout/grid_and_list/pubspec.yaml
+++ b/examples/layout/grid_and_list/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/layout/lakes/interactive/pubspec.yaml
+++ b/examples/layout/lakes/interactive/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/layout/lakes/step2/pubspec.yaml
+++ b/examples/layout/lakes/step2/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/layout/lakes/step3/pubspec.yaml
+++ b/examples/layout/lakes/step3/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/layout/lakes/step4/pubspec.yaml
+++ b/examples/layout/lakes/step4/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/layout/lakes/step5/pubspec.yaml
+++ b/examples/layout/lakes/step5/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/layout/lakes/step6/pubspec.yaml
+++ b/examples/layout/lakes/step6/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/layout/non_material/pubspec.yaml
+++ b/examples/layout/non_material/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/layout/pavlova/pubspec.yaml
+++ b/examples/layout/pavlova/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/layout/row_column/pubspec.yaml
+++ b/examples/layout/row_column/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/layout/sizing/pubspec.yaml
+++ b/examples/layout/sizing/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/perf/concurrency/isolates/pubspec.yaml
+++ b/examples/perf/concurrency/isolates/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/perf/deferred_components/pubspec.yaml
+++ b/examples/perf/deferred_components/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/platform_integration/compose_activities/pubspec.yaml
+++ b/examples/platform_integration/compose_activities/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/platform_integration/pigeon/pubspec.yaml
+++ b/examples/platform_integration/pigeon/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/platform_integration/platform_channels/pubspec.yaml
+++ b/examples/platform_integration/platform_channels/pubspec.yaml
@@ -9,7 +9,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/platform_integration/platform_views/pubspec.yaml
+++ b/examples/platform_integration/platform_views/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/platform_integration/plugin_api_migration/pubspec.yaml
+++ b/examples/platform_integration/plugin_api_migration/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_docs_examples
 publish_to: none
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 workspace:
   - _animation/basic_hero_animation

--- a/examples/resources/architectural_overview/pubspec.yaml
+++ b/examples/resources/architectural_overview/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/resources/dart_swift_concurrency/pubspec.yaml
+++ b/examples/resources/dart_swift_concurrency/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/state_mgmt/simple/pubspec.yaml
+++ b/examples/state_mgmt/simple/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/testing/code_debugging/pubspec.yaml
+++ b/examples/testing/code_debugging/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/testing/common_errors/pubspec.yaml
+++ b/examples/testing/common_errors/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/testing/errors/pubspec.yaml
+++ b/examples/testing/errors/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/testing/integration_tests/how_to/pubspec.yaml
+++ b/examples/testing/integration_tests/how_to/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/testing/native_debugging/pubspec.yaml
+++ b/examples/testing/native_debugging/pubspec.yaml
@@ -1,12 +1,12 @@
 name: native_debugging
 description: Demonstration of native code debugging
-sdk: ^3.9.0-0
+sdk: ^3.9.0
 
 version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/tools/pubspec.yaml
+++ b/examples/tools/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/ui/actions_and_shortcuts/pubspec.yaml
+++ b/examples/ui/actions_and_shortcuts/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/ui/adaptive_app_demos/pubspec.yaml
+++ b/examples/ui/adaptive_app_demos/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/ui/assets_and_images/pubspec.yaml
+++ b/examples/ui/assets_and_images/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/ui/focus/pubspec.yaml
+++ b/examples/ui/focus/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/ui/interactive/pubspec.yaml
+++ b/examples/ui/interactive/pubspec.yaml
@@ -3,7 +3,7 @@ description: Sample code for interactive.md
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/ui/navigation/pubspec.yaml
+++ b/examples/ui/navigation/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/ui/widgets_intro/pubspec.yaml
+++ b/examples/ui/widgets_intro/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/examples/visual_debugging/pubspec.yaml
+++ b/examples/visual_debugging/pubspec.yaml
@@ -4,7 +4,7 @@ description: Examples of visual debugging.
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: docs_flutter_dev
 publish_to: none
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 workspace:
   - tool/flutter_site

--- a/src/_data/site.yml
+++ b/src/_data/site.yml
@@ -59,4 +59,4 @@ yt:
   watch: 'https://www.youtube.com/watch'
   playlist: 'https://www.youtube.com/playlist?list='
 
-currentFlutterVersion: '3.35.0'
+currentFlutterVersion: '3.35.1'

--- a/tool/flutter_site/pubspec.yaml
+++ b/tool/flutter_site/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 resolution: workspace
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.9.0
 
 dependencies:
   args: ^2.7.0


### PR DESCRIPTION
- Mark documented version as Flutter 3.35.1.
- Update SDK constraints to `^3.9.0` now that a later beta has been released as well.
