### PR TITLE
Rename 'toc' to 'showToc' in frontmatter

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -2,20 +2,20 @@
 layout: base
 ---
 
-{% if toc != false -%}
+{% if showToc != false -%}
 {% assign tocContents = content | generateToc %}
 {% if tocContents == null or tocContents == '' or tocContents.count < 2 -%}
-{% assign toc = false %}
+{% assign showToc = false %}
 {% endif -%}
 {% endif -%}
 
-<div id="site-main-row" class="{% if toc == false %}no-toc{% endif %}">
+<div id="site-main-row" class="{% if showToc == false %}no-toc{% endif %}">
   <div id="sidenav" class="site-sidebar">
     {% render sidenav-level-1.html, url:page.url, nav:sidenav, activeNav:activeNav %}
   </div>
 
   <main class="site-content">
-    {% if toc != false -%}
+    {% if showToc != false -%}
       {% render top-toc.html, tocContents:tocContents, title:title %}
     {% endif -%}
     {%- if site.showBanner and showBanner != false -%}
@@ -24,7 +24,7 @@ layout: base
     </div>
     {% endif -%}
     <div class="after-leading-content">
-      {% if toc != false -%}
+      {% if showToc != false -%}
       <aside id="side-menu">
         {% render side-toc.html, tocContents:tocContents %}
       </aside>

--- a/src/_layouts/toc.md
+++ b/src/_layouts/toc.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-toc: false
+showToc: false
 sitemap: false
 ---
 

--- a/src/content/404.html
+++ b/src/content/404.html
@@ -6,7 +6,7 @@ layout: default
 extraBodyClass: site-not-found
 permalink: /404.html
 sitemap: false
-toc: false
+showToc: false
 showBreadcrumbs: false
 showBanner: false
 ---

--- a/src/content/app-architecture/design-patterns.md
+++ b/src/content/app-architecture/design-patterns.md
@@ -7,7 +7,7 @@ description: >-
 prev:
   title: Recommendations
   path: /app-architecture/recommendations
-toc: false
+showToc: false
 ---
 
 If you've already read through the [architecture guide][] page,

--- a/src/content/app-architecture/index.md
+++ b/src/content/app-architecture/index.md
@@ -3,7 +3,7 @@ title: Architecting Flutter apps
 short-title: Architecture
 description: >
   Learn how to structure Flutter apps.
-toc: false
+showToc: false
 next:
   title: Architecture concepts
   path: /app-architecture/concepts

--- a/src/content/codelabs/implicit-animations.md
+++ b/src/content/codelabs/implicit-animations.md
@@ -3,7 +3,6 @@ title: "Implicit animations"
 description: >
   Learn how to use Flutter's implicitly animated widgets
   through interactive examples and exercises.
-toc: true
 js:
   - defer: true
     url: /assets/js/inject_dartpad.js

--- a/src/content/community/china/index.md
+++ b/src/content/community/china/index.md
@@ -1,7 +1,6 @@
 ---
 title: Using Flutter in China
 description: How to use, access, and learn about Flutter in China.
-toc: true
 os-list: [Windows, macOS, Linux, ChromeOS]
 ---
 

--- a/src/content/get-started/codelab.md
+++ b/src/content/get-started/codelab.md
@@ -8,7 +8,7 @@ prev:
 next:
   title: Learn more
   path: /get-started/learn-flutter
-toc: false
+showToc: false
 ---
 
 You are now ready to start the "First Flutter app" codelab.

--- a/src/content/get-started/fundamentals/index.md
+++ b/src/content/get-started/fundamentals/index.md
@@ -4,7 +4,7 @@ short-title: Fundamentals
 description: >
   You've gotten a taste of using the Flutter framework;
   now go beyond to learn the basics of Flutter.
-toc: false
+showToc: false
 ---
 
 

--- a/src/content/get-started/learn-flutter.md
+++ b/src/content/get-started/learn-flutter.md
@@ -1,7 +1,7 @@
 ---
 title: Learn Flutter
 description: Resources to help you learn Flutter.
-toc: false
+showToc: false
 ---
 
 {% ytEmbed 'W4JWeQolJsU', 'Build and ship amazing multiplatform iOS and Android apps with one codebase', true %}

--- a/src/content/get-started/quick.md
+++ b/src/content/get-started/quick.md
@@ -4,7 +4,7 @@ short-title: Set up & test drive
 description: >-
   Set up Flutter on your device with VS Code and
   get started developing your first multi-platform app with Flutter!
-toc: false
+showToc: false
 showBanner: false
 sitemap: false
 ---

--- a/src/content/install/archive.md
+++ b/src/content/install/archive.md
@@ -2,7 +2,6 @@
 title: Flutter SDK archive
 short-title: Archive
 description: "All current Flutter SDK releases: stable, beta, and main."
-toc: true
 ---
 
 {% render docs/china-notice.md %}

--- a/src/content/install/uninstall.md
+++ b/src/content/install/uninstall.md
@@ -3,7 +3,7 @@ title: Uninstall Flutter
 short-title: Uninstall
 description: >-
     How to remove the Flutter SDK and clean up its configuration files.
-toc: false
+showToc: false
 ---
 
 To remove the Flutter SDK from your development machine,

--- a/src/content/jobs/_template.md
+++ b/src/content/jobs/_template.md
@@ -1,6 +1,6 @@
 ---
 title: <Job Title>
-toc: false
+showToc: false
 ---
 
 {% comment %}

--- a/src/content/jobs/tech_writer_ii.md
+++ b/src/content/jobs/tech_writer_ii.md
@@ -1,6 +1,6 @@
 ---
 title: Technical Writer, Languages
-toc: false
+showToc: false
 description: Learn about and apply to this technical writer role!
 ---
 

--- a/src/content/platform-integration/ios/launch-screen.md
+++ b/src/content/platform-integration/ios/launch-screen.md
@@ -2,7 +2,7 @@
 title: Adding a launch screen to your iOS app
 short-title: Launch screen
 description: Learn how to add a launch screen to your iOS app.
-toc: false
+showToc: false
 ---
 
 {% comment %}

--- a/src/content/platform-integration/linux/building.md
+++ b/src/content/platform-integration/linux/building.md
@@ -1,7 +1,6 @@
 ---
 title: Build Linux apps with Flutter
 description: Platform-specific considerations when building for Linux with Flutter.
-toc: true
 short-title: Linux development
 ---
 

--- a/src/content/platform-integration/macos/building.md
+++ b/src/content/platform-integration/macos/building.md
@@ -1,7 +1,6 @@
 ---
 title: Building macOS apps with Flutter
 description: Platform-specific considerations for building for macOS with Flutter.
-toc: true
 short-title: macOS development
 ---
 

--- a/src/content/platform-integration/windows/building.md
+++ b/src/content/platform-integration/windows/building.md
@@ -1,7 +1,6 @@
 ---
 title: Building Windows apps with Flutter
 description: Platform-specific considerations for building for Windows with Flutter.
-toc: true
 short-title: Windows development
 ---
 

--- a/src/content/reference/learning-resources.md
+++ b/src/content/reference/learning-resources.md
@@ -4,7 +4,7 @@ description: A catalog of Flutter sample applications, codelabs, and tutorials.
 short-title: Learning resources
 showBreadcrumbs: false
 extraBodyClass: wide-site-content
-toc: false
+showToc: false
 js: [ { url: '/assets/js/learning-resources-index.js', defer: true } ]
 ---
 

--- a/src/content/resources/books.md
+++ b/src/content/resources/books.md
@@ -1,7 +1,7 @@
 ---
 title: Books about Flutter
 description: Extra, extra! Here's a collection of books about Flutter.
-toc: false
+showToc: false
 ---
 
 Here's a collection of books about Flutter,

--- a/src/content/search-all.html
+++ b/src/content/search-all.html
@@ -1,7 +1,7 @@
 ---
 title: Search Flutter-related sites
 description: Search docs.flutter.dev, api.flutter.dev, dart.dev, and more.
-toc: false
+showToc: false
 showBreadcrumbs: false
 showBanner: false
 ---

--- a/src/content/search.html
+++ b/src/content/search.html
@@ -2,7 +2,7 @@
 title: Search Flutter docs
 short-title: Search
 description: The search page for docs.flutter.dev.
-toc: false
+showToc: false
 showBreadcrumbs: false
 showBanner: false
 ---

--- a/src/content/tools/devtools/release-notes/index.md
+++ b/src/content/tools/devtools/release-notes/index.md
@@ -1,7 +1,7 @@
 ---
 title: DevTools release notes
 description: Learn about the latest changes in Dart and Flutter DevTools.
-toc: false
+showToc: false
 ---
 
 This page summarizes the changes in official stable releases of DevTools.

--- a/src/content/tools/devtools/release-notes/release-notes-2.10.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.10.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.10.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.10.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.10.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.11.2.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.11.2.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.11.2 release notes
 description: Release notes for Dart and Flutter DevTools version 2.11.2.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.11.2-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.12.1.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.12.1.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.12.1 release notes
 description: Release notes for Dart and Flutter DevTools version 2.12.1.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.12.1-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.12.2.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.12.2.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.12.2 release notes
 description: Release notes for Dart and Flutter DevTools version 2.12.2.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.12.2-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.13.1.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.13.1.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.13.1 release notes
 description: Release notes for Dart and Flutter DevTools version 2.13.1.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.13.1-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.14.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.14.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.14.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.14.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.14.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.15.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.15.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.15.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.15.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.15.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.16.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.16.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.16.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.16.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.16.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.17.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.17.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.17.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.17.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.17.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.18.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.18.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.18.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.18.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.18.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.19.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.19.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.19.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.19.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.19.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.20.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.20.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.20.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.20.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.20.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.21.1.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.21.1.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.21.1 release notes
 description: Release notes for Dart and Flutter DevTools version 2.21.1.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.21.1-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.22.2.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.22.2.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.22.2 release notes
 description: Release notes for Dart and Flutter DevTools version 2.22.2.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.22.2-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.23.1.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.23.1.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.23.1 release notes
 description: Release notes for Dart and Flutter DevTools version 2.23.1.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.23.1-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.24.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.24.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.24.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.24.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.24.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.25.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.25.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.25.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.25.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.25.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.26.1.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.26.1.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.26.1 release notes
 description: Release notes for Dart and Flutter DevTools version 2.26.1.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.26.1-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.27.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.27.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.27.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.27.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.27.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.28.1.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.28.1.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.28.1 release notes
 description: Release notes for Dart and Flutter DevTools version 2.28.1.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.28.1-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.28.2.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.28.2.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.28.2 release notes
 description: Release notes for Dart and Flutter DevTools version 2.28.2.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.28.2-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.28.3.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.28.3.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.28.3 release notes
 description: Release notes for Dart and Flutter DevTools version 2.28.3.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.28.3-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.28.4.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.28.4.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.28.4 release notes
 description: Release notes for Dart and Flutter DevTools version 2.28.4.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.28.4-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.28.5.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.28.5.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.28.5 release notes
 description: Release notes for Dart and Flutter DevTools version 2.28.5.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.28.5-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.29.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.29.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.29.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.29.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.29.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.30.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.30.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.30.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.30.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.30.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.31.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.31.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.31.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.31.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.31.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.32.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.32.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.32.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.32.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.32.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.33.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.33.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.33.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.33.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.33.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.34.1.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.34.1.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.34.1 release notes
 description: Release notes for Dart and Flutter DevTools version 2.34.1.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.34.1-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.35.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.35.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.35.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.35.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.35.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.36.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.36.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.36.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.36.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.36.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.37.2.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.37.2.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.37.2 release notes
 description: Release notes for Dart and Flutter DevTools version 2.37.2.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.37.2-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.38.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.38.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.38.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.38.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.38.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.39.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.39.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.39.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.39.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.39.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.40.2.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.40.2.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.40.2 release notes
 description: Release notes for Dart and Flutter DevTools version 2.40.2.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.40.2-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.41.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.41.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.41.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.41.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.41.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.42.3.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.42.3.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.42.3 release notes
 description: Release notes for Dart and Flutter DevTools version 2.42.3.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.42.3-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.44.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.44.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.44.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.44.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.44.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.45.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.45.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.45.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.45.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.45.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.46.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.46.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.46.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.46.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.46.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.47.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.47.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.47.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.47.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.47.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.48.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.48.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.48.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.48.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.48.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.49.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.49.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.49.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.49.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.49.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.7.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.7.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.7.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.7.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.7.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.8.0.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.8.0.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.8.0 release notes
 description: Release notes for Dart and Flutter DevTools version 2.8.0.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.8.0-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.9.1.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.9.1.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.9.1 release notes
 description: Release notes for Dart and Flutter DevTools version 2.9.1.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.9.1-src.md %}

--- a/src/content/tools/devtools/release-notes/release-notes-2.9.2.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.9.2.md
@@ -1,7 +1,7 @@
 ---
 short-title: 2.9.2 release notes
 description: Release notes for Dart and Flutter DevTools version 2.9.2.
-toc: false
+showToc: false
 ---
 
 {% include ./release-notes-2.9.2-src.md %}

--- a/src/content/tools/editors.md
+++ b/src/content/tools/editors.md
@@ -3,7 +3,7 @@ title: Flutter editor support
 short-title: Editors
 description: >-
   Editor support for Dart and Flutter.
-toc: false
+showToc: false
 ---
 
 You can build apps with Flutter using any text editor or

--- a/src/content/tutorial/index.md
+++ b/src/content/tutorial/index.md
@@ -1,7 +1,7 @@
 ---
 title: Learn Flutter
 description: Resources to help you learn Flutter.
-toc: false
+showToc: false
 ---
 
 ## Welcome! 

--- a/src/content/ui/layout/constraints.md
+++ b/src/content/ui/layout/constraints.md
@@ -1,7 +1,7 @@
 ---
 title: Understanding constraints
 description: Flutter's model for widget constraints, sizing, positioning, and how they interact.
-toc: false
+showToc: false
 js:
   - defer: true
     url: /assets/js/inject_dartpad.js

--- a/src/content/ui/layout/scrolling/slivers.md
+++ b/src/content/ui/layout/scrolling/slivers.md
@@ -3,7 +3,7 @@ title: Using slivers to achieve fancy scrolling
 description: >-
   Where to find information on using slivers to
   implement fancy scrolling effects, like elastic scrolling, in Flutter.
-toc: false
+showToc: false
 ---
 
 A sliver is a portion of a scrollable area that you

--- a/src/content/ui/widgets/index.md
+++ b/src/content/ui/widgets/index.md
@@ -2,7 +2,7 @@
 title: Widget catalog
 description: A catalog of some of Flutter's rich set of widgets.
 short-title: Widgets
-toc: false
+showToc: false
 ---
 
 Create beautiful apps faster with Flutter's collection of visual, structural,


### PR DESCRIPTION
This will help enable the site infrastructure migration, which reserves the `toc` variable for other purposes.