### PR TITLE
Docs: Follow one convention for writing "one-to-one"

### DIFF
--- a/src/content/app-architecture/case-study/ui-layer.md
+++ b/src/content/app-architecture/case-study/ui-layer.md
@@ -254,8 +254,8 @@ would take up the full screen on mobile.
 :::note
 "View" is an abstract term, and one view doesn't equal one widget.
 Widgets are composable, and several can be combined to create one view.
-Therefore, view models don't have a 1-to-1 relationship with widgets,
-but rather a 1-to-1 relation with a *collection* of widgets.
+Therefore, view models don't have a one-to-one relationship with widgets,
+but rather a one-to-one relation with a *collection* of widgets.
 :::
 
 The widgets within a view have three responsibilities:

--- a/src/content/app-architecture/guide.md
+++ b/src/content/app-architecture/guide.md
@@ -107,7 +107,7 @@ based on the MVVM design pattern:
   For example, you might need to combine data from multiple repositories,
   or you might want to filter a list of data records.
 
-Views and view models should have a 1:1 relationship.
+Views and view models should have a one-to-one relationship.
 
 <img src='/assets/images/docs/app-architecture/guide/feature-architecture-simplified-UI-highlighted.png' alt="A simplified diagram of the architecture described on this page with the view and view model objects highlighted.">
 
@@ -120,8 +120,8 @@ and you can test the logic of your UI independently of Flutter widgets.
 :::note
 'View' is an abstract term, and one view doesn't equal one widget.
 Widgets are composable, and several can be combined to create one view.
-Therefore, view models don't have a 1-to-1 relationship with widgets,
-but rather a 1-to-1 relationship with a *collection* of widgets.
+Therefore, view models don't have a one-to-one relationship with widgets,
+but rather a one-to-one relationship with a *collection* of widgets.
 :::
 
 A feature of an application is user centric,


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Changed other conventions like "1:1" and "1-to-1" to "one-to-one" for consistency. (Also, "one-to-one" looks like the standardized way.)

