### PR TITLE
fix(ui): correct ColorLabel enum - rename yellow entry to orange

### DIFF
--- a/src/content/get-started/fundamentals/user-input.md
+++ b/src/content/get-started/fundamentals/user-input.md
@@ -560,7 +560,7 @@ enum ColorLabel {
   blue('Blue', Colors.blue),
   pink('Pink', Colors.pink),
   green('Green', Colors.green),
-  yellow('Orange', Colors.orange),
+  orange('Orange', Colors.orange),
   grey('Grey', Colors.grey);
 
   const ColorLabel(this.label, this.color);


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Renamed the `ColorLabel.yellow` enum entry to `ColorLabel.orange` to align the enum name with its actual color value (`Colors.orange`) and display label (`'Orange'`). This improves code readability and maintains consistency across the enum definition.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
