### PR TITLE
Fix "Flutter now sets default `abiFilters` in Android builds" link

### DIFF
--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -71,7 +71,7 @@ They're sorted by release and listed in alphabetical order:
 [Redesigned the `Radio` Widget]: /release/breaking-changes/radio-api-redesign
 [Removed semantics elevation and thickness]: /release/breaking-changes/remove-semantics-elevation-and-thickness
 [The `Form` widget no longer supports being a sliver]: /release/breaking-changes/form-semantics
-[Changed how to add ABI filters on Android]: /release/breaking-changes/default-abi-filters-android
+[Flutter now sets default `abiFilters` in Android builds]: /release/breaking-changes/default-abi-filters-android
 
 <a id="released-in-flutter-332" aria-hidden="true"></a>
 ### Released in Flutter 3.32


### PR DESCRIPTION
Fixes link added in https://github.com/flutter/website/pull/12350.