### PR TITLE
Update AppDelegate declaration to use new main annotation

### DIFF
--- a/src/content/platform-integration/platform-channels.md
+++ b/src/content/platform-integration/platform-channels.md
@@ -613,7 +613,7 @@ a `FlutterMethodChannel` tied to the channel name
 `samples.flutter.dev/battery`:
 
 ```swift title="AppDelegate.swift"
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ This PR updates a code sample to remove a deprecated annotation and to bring it in line with the app template that is defined in flutter_tools at https://github.com/flutter/flutter/blob/master/packages/flutter_tools/templates/app/ios.tmpl/Runner/AppDelegate.swift

_Issues fixed by this PR (if any):_ https://github.com/flutter/website/issues/12382

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
