### PR TITLE
Fix: Windows PowerShell command dash character

### DIFF
--- a/src/_includes/docs/install/flutter/download.md
+++ b/src/_includes/docs/install/flutter/download.md
@@ -16,7 +16,7 @@
    {% assign ps-dir-target='$env:USERPROFILE\\dev\\' %}
    {% capture uz -%}
      {{prompt}} Expand-Archive `
-         –Path {{ps-dir-dl}}flutter_sdk_v1.0.0.zip `
+         -Path {{ps-dir-dl}}flutter_sdk_v1.0.0.zip `
          -Destination {{ps-dir-target}}
    {%- endcapture %}
 {% when "macOS" -%}


### PR DESCRIPTION
### Issue location
Windows installation documentation - PowerShell command for extracting Flutter archive

### Problem
The PowerShell command in the Windows setup documentation uses an en-dash (–) instead of a regular hyphen (-) for the `-Path` parameter:

```powershell
PS Expand-Archive `
      –Path $env:USERPROFILE\Downloads\flutter_windows_3.35.2-stable.zip `
      -Destination $env:USERPROFILE\dev\
```

### Error result 

```powershell
Get-Process : Não é possível localizar um parâmetro que coincida com o nome de parâmetro 'Path'.
No linha:1 caractere:19
+ PS Expand-Archive –Path $env:USERPROFILE\Downloads\flutter_windows_3. ...
+                   ~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Get-Process], ParameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,Microsoft.PowerShell.Commands.GetProcessCommand
```

### Fix done
Replaced the en-dash (–) with a regular ASCII hyphen (-), resulting in:

```powershell
PS Expand-Archive `
      -Path $env:USERPROFILE\Downloads\flutter_windows_3.35.2-stable.zip `
      -Destination $env:USERPROFILE\dev\
```

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
