### PR TITLE
Add a `./dash_site clean` tool

### DIFF
--- a/tool/flutter_site/lib/flutter_site.dart
+++ b/tool/flutter_site/lib/flutter_site.dart
@@ -9,6 +9,7 @@ import 'src/commands/build.dart';
 import 'src/commands/check_all.dart';
 import 'src/commands/check_link_references.dart';
 import 'src/commands/check_links.dart';
+import 'src/commands/clean.dart';
 import 'src/commands/format_dart.dart';
 import 'src/commands/refresh_excerpts.dart';
 import 'src/commands/serve.dart';
@@ -29,6 +30,7 @@ final class FlutterSiteCommandRunner extends CommandRunner<int> {
     addCommand(CheckAllCommand());
     addCommand(CheckLinksCommand());
     addCommand(CheckLinkReferencesCommand());
+    addCommand(CleanSiteCommand());
     addCommand(FormatDartCommand());
     addCommand(RefreshExcerptsCommand());
     addCommand(ServeSiteCommand());

--- a/tool/flutter_site/lib/src/commands/clean.dart
+++ b/tool/flutter_site/lib/src/commands/clean.dart
@@ -1,0 +1,30 @@
+// Copyright 2025 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+
+import '../utils.dart';
+
+final class CleanSiteCommand extends Command<int> {
+  CleanSiteCommand();
+
+  @override
+  String get description => 'Clean the site output folder and tooling.';
+
+  @override
+  String get name => 'clean';
+
+  @override
+  Future<int> run() async {
+    print('Cleaning the site output directory...');
+    final outputDirectory = Directory(siteOutputDirectoryPath);
+    if (outputDirectory.existsSync()) {
+      outputDirectory.deleteSync(recursive: true);
+    }
+
+    return 0;
+  }
+}

--- a/tool/flutter_site/lib/src/commands/refresh_excerpts.dart
+++ b/tool/flutter_site/lib/src/commands/refresh_excerpts.dart
@@ -52,8 +52,6 @@ Future<int> _refreshExcerpts({
   bool dryRun = false,
   bool failOnUpdate = false,
 }) async {
-  final repositoryRoot = Directory.current.path;
-
   final updater = Updater(
     baseSourcePath: path.join(repositoryRoot, 'examples'),
     defaultPlasterContent: '···',

--- a/tool/flutter_site/lib/src/utils.dart
+++ b/tool/flutter_site/lib/src/utils.dart
@@ -3,9 +3,24 @@
 // found in the LICENSE file.
 
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
+
+/// The root path of the website repository.
+String get repositoryRoot {
+  final packageConfigPath = path.fromUri(Isolate.packageConfigSync);
+  final maybeRoot = path.dirname(path.dirname(packageConfigPath));
+  if (!File(path.join(maybeRoot, 'dash_site')).existsSync()) {
+    throw StateError('Try calling dash_site from the root directory.');
+  }
+
+  return maybeRoot;
+}
+
+/// The path of the site output directory.
+final String siteOutputDirectoryPath = path.join(repositoryRoot, '_site');
 
 final bool _runningInCi = Platform.environment['CI'] == 'true';
 


### PR DESCRIPTION
For now, `./dash_site clean` can delete the `_site` output directory, but in the future it will be expanded to run other clean up tasks.

Contributes to https://github.com/flutter/website/issues/12405