### PR TITLE
chore: update broken xz link in Linux documentation

### DIFF
--- a/src/_includes/docs/install/reqs/linux/base.md
+++ b/src/_includes/docs/install/reqs/linux/base.md
@@ -90,7 +90,7 @@ To troubleshoot installation issues, consult that product's documentation.
 [curl]: https://curl.se/
 [git]: https://git-scm.com/
 [unzip]: https://linux.die.net/man/1/unzip
-[xz]: https://xz.tukaani.org/xz-utils/
+[xz]: https://tukaani.org/xz/
 [zip]: https://linux.die.net/man/1/zip
 [Android Studio]: https://developer.android.com/studio/
 [Google Chrome]: https://www.google.com/chrome/dr/download/


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
This PR updates the URL for the [xz] reference in the Flutter documentation. The previous link was not working, and it seems the maintainer changed the URL to point to a new location. The updated link is now https://tukaani.org/xz/.

_Issues fixed by this PR (if any):_
This PR addresses the broken link issue by updating the URL to the correct one.

_PRs or commits this PR depends on (if any):_
No other PRs or commits are required for this change.

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a tiny, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)
—for example, it doesn't use i.e. or e.g., and it avoids I and we (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
 of 80 characters or fewer.


### Old URL
<img width="1147" height="576" alt="image" src="https://github.com/user-attachments/assets/a6829e46-a02d-4255-930f-2d76527bf4d6" />

### New URL
<img width="1436" height="963" alt="image" src="https://github.com/user-attachments/assets/f8557c3a-c1c4-49e0-8de7-8da5eba2e688" />
