### PR TITLE
typo: `gen-i10n` isn't a valid flutter command

### DIFF
--- a/src/content/release/breaking-changes/flutter-generate-i10n-source.md
+++ b/src/content/release/breaking-changes/flutter-generate-i10n-source.md
@@ -37,7 +37,7 @@ flutter:
   generate: true
 ```
 
-If your app previously used `gen-i10n` without this property, it is now
+If your app previously used `gen-l10n` without this property, it is now
 required.
 
 A synthetic package (`package:flutter_gen`) is


### PR DESCRIPTION
In [this page](https://docs.flutter.dev/release/breaking-changes/flutter-generate-i10n-source#migration-guide), the author probably meant `gen-l10n`.

_Description of what this PR is changing or adding, and why:_ A typo in the docs leads folks to a non-existent command.

_Issues fixed by this PR (if any):_ N.A.

_PRs or commits this PR depends on (if any):_ N.A.

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
