### PR TITLE
:pencil2: fix typo l10n

### DIFF
--- a/src/content/release/breaking-changes/flutter-generate-i10n-source.md
+++ b/src/content/release/breaking-changes/flutter-generate-i10n-source.md
@@ -15,7 +15,7 @@ Applications or tools that referenced `package:flutter_gen` should instead
 reference source files generated into the app's source directory directly.
 
 In addition, the property `generate: true` is now required when using generated
-i10n source.
+l10n source.
 
 ## Background
 


### PR DESCRIPTION
Fixes typo for "localization".

Copied from #1091:
there is no such thing as i10n, its a typo
i18n means internationalization
l10n means localization

i10n would mean internation

Similar PR but addresses in different places: #12438 

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
