### PR TITLE
Add Flutter 3.35 merged threads migration annoucement

### DIFF
--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -67,6 +67,7 @@ They're sorted by release and listed in alphabetical order:
 * [Removed semantics elevation and thickness][]
 * [The `Form` widget no longer supports being a sliver][]
 * [Flutter now sets default `abiFilters` in Android builds][]
+* [Merged threads on macOS and Windows][]
 
 [Component theme normalization updates]: /release/breaking-changes/component-theme-normalization-updates
 [Deprecate `DropdownButtonFormField` `value` parameter in favor of `initialValue`]: /release/breaking-changes/deprecate-dropdownbuttonformfield-value
@@ -74,6 +75,7 @@ They're sorted by release and listed in alphabetical order:
 [Removed semantics elevation and thickness]: /release/breaking-changes/remove-semantics-elevation-and-thickness
 [The `Form` widget no longer supports being a sliver]: /release/breaking-changes/form-semantics
 [Flutter now sets default `abiFilters` in Android builds]: /release/breaking-changes/default-abi-filters-android
+[Merged threads on macOS and Windows]: /release/breaking-changes/macos-windows-merged-threads
 
 <a id="released-in-flutter-332" aria-hidden="true"></a>
 ### Released in Flutter 3.32

--- a/src/content/release/breaking-changes/macos-windows-merged-threads.md
+++ b/src/content/release/breaking-changes/macos-windows-merged-threads.md
@@ -1,0 +1,52 @@
+---
+title: Merged threads on macOS and Windows
+description: >-
+  Learn about threading changes on macOS and Windows in Flutter 3.35.
+---
+
+## Summary
+
+Flutter 3.35 merges the UI and platform threads by default on macOS and Windows.
+
+## Context
+
+Originally, Flutter had separate threads to produce UI frames and to
+interact with the native platform.
+
+The split-thread design prevented Flutter apps and plugins from using Dart FFI
+to interoperate with native APIs that must be called on the platform thread.
+
+## Description of change
+
+Flutter 3.35 merges the UI and platform threads by default on macOS and Windows.
+
+This mirrors iOS and Android, whose threads were merged by default in
+Flutter 3.29.
+
+## Migration guide
+
+Merged threads should not affect your app.
+
+If you suspect merged threads has regressed your app, please reach out on 
+[Issue 150525][].
+
+## Timeline
+
+Landed in version: 3.33.0-0.0.pre<br>
+In stable release: 3.35
+
+## References
+
+Relevant issue:
+
+* [Issue 150525][]
+
+Relevant PRs:
+
+* [PR 166536][]
+* [PR 167472][]
+
+[Issue 150525]: {{site.repo.flutter}}/issues/150525
+[PR 166536]: {{site.repo.flutter}}/pull/166536
+[PR 167472]: {{site.repo.flutter}}/pull/167472
+


### PR DESCRIPTION
Raise awareness that Flutter 3.35 merged the UI/platform threads on macOS and Windows. This is a significant internal change that _might_ break apps. If so, we'd like customers to reach out to us on GitHub so that we can fix bugs, if any.

_Issues fixed by this PR (if any):_ None

_PRs or commits this PR depends on (if any):_ None

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
