### PR TITLE
Clarify Dart VM terminology in hot-reload documentation

### DIFF
--- a/src/content/tools/hot-reload.md
+++ b/src/content/tools/hot-reload.md
@@ -9,7 +9,7 @@ Flutter's hot reload feature helps you quickly and
 easily experiment, build UIs, add features, and fix bugs.
 Hot reload works by injecting updated source code files
 into the [Dart runtime][].
-After the VM updates classes with the new versions of fields and functions,
+After the Dart runtime updates classes with the new versions of fields and functions,
 the Flutter framework automatically rebuilds the widget tree,
 allowing you to quickly view the effects of your changes.
 

--- a/src/content/tools/hot-reload.md
+++ b/src/content/tools/hot-reload.md
@@ -8,7 +8,7 @@ description: Speed up development using Flutter's hot reload feature.
 Flutter's hot reload feature helps you quickly and
 easily experiment, build UIs, add features, and fix bugs.
 Hot reload works by injecting updated source code files
-into the running [Dart Virtual Machine (VM)][].
+into the [Dart runtime][].
 After the VM updates classes with the new versions of fields and functions,
 the Flutter framework automatically rebuilds the widget tree,
 allowing you to quickly view the effects of your changes.
@@ -430,7 +430,7 @@ widgets and render objects.
 
 [static-variables]: {{site.dart-site}}/language/classes#static-variables
 [const-new]: {{site.dart-site}}/language/variables#final-and-const
-[Dart Virtual Machine (VM)]: {{site.dart-site}}/overview#platform
+[Dart runtime]: {{site.dart-site}}/overview#platform
 [Flutter editor]: /tools/editors
 [Issue 43574]: {{site.repo.flutter}}/issues/43574
 [kernel files]: {{site.github}}/dart-lang/sdk/tree/main/pkg/kernel


### PR DESCRIPTION
Updated terminology from 'Dart Virtual Machine (VM)' to 'Dart runtime' for clarity now that we also have hot reload on the web

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_ Contributes to https://github.com/dart-lang/site-www/issues/6883

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
