### PR TITLE
Changed default reviewer to Flutter docs owner.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,13 +1,8 @@
-# Default code owners
-* @flutter/website-reviewers @sfshaza2 @antfitch @parlough
+# Default reviewer
+* @sfshaza2
 
-# Covers iOS documentation content
-**/add-to-app/ios/                @flutter/website-reviewers @sfshaza2 @parlough @jmagman
-**/deployment/ios.md              @flutter/website-reviewers @sfshaza2 @parlough @jmagman
-**/flavors.md                     @flutter/website-reviewers @sfshaza2 @parlough @jmagman
-**/flavors/                       @flutter/website-reviewers @sfshaza2 @parlough @jmagman
-**/platform-integration/ios/      @flutter/website-reviewers @sfshaza2 @parlough @jmagman
-
-# Covers macOS documentation content
-**/deployment/macos.md            @flutter/website-reviewers @sfshaza2 @parlough @jmagman
-**/platform-integration/macos/    @flutter/website-reviewers @sfshaza2 @parlough @jmagman
+## Notes
+## --------------------------------------------------
+## Default reviewer will triage to others.
+## Someone in this group requires an LGTM to push a PR: @flutter/website-reviewers
+## Include the following reviewers on any iOS or macOS or flavors changes: @jmagman


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Moving forward, the lead for the Flutter docs site (@Sfshaza) will triage PRs as needed to others.

If the person submitting the PR knows they need someone additional to look at a PR, they can always add these people after they submit the PR for review. @jmagman, I've removed iOS-specific reviewers for now. I want to try the new triaging system.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
