### PR TITLE
Updating the page that discusses Flutter support for iOS features

### DIFF
--- a/src/content/platform-integration/ios/ios-latest.md
+++ b/src/content/platform-integration/ios/ios-latest.md
@@ -24,7 +24,7 @@ visit the following issues in the flutter/flutter repo.
 * Writing tools text input feature: [Issue 150965][], [Issue 150452][]
 
 [Issue 150068]: {{site.repo.flutter}}/flutter/flutter/issues/150068
-[Issue 105392]: {{site.repo.flutter}}/flutter/flutter/issues/105392
+[Issue 150392]: {{site.repo.flutter}}/flutter/flutter/issues/150392
 [Issue 150452]: {{site.repo.flutter}}/flutter/flutter/issues/150452
 [Issue 150588]: {{site.repo.flutter}}/flutter/flutter/issues/150588
 [Issue 150950]: {{site.repo.flutter}}/flutter/flutter/issues/150590


### PR DESCRIPTION
Trying to make the iOS feature page a tad more evergreen, as discussed on an internal chat list

fixes #12335

Staged:  https://flutter-docs-prod--pr12459-ios18-21t2yru6.web.app/platform-integration/ios/ios-latest



@jmagman @chunhtai 