### PR TITLE
Updated shader documentation to discuss ImageFilter.shader.

### DIFF
--- a/src/content/ui/design/graphics/fragment-shaders.md
+++ b/src/content/ui/design/graphics/fragment-shaders.md
@@ -113,6 +113,38 @@ void paint(Canvas canvas, Size size, FragmentShader shader) {
 
 ```
 
+### ImageFilter API
+
+Fragment shaders can also be used with the [`ImageFilter`][] API. This allows
+using custom fragment shaders with the [`BackdropFilter`][] class to apply
+shaders to already rendered content. [`ImageFilter`][] provides a constructor,
+[`ImageFilter.shader`][], for creating an [`ImageFilter`][] with a custom
+fragment shader.
+
+[`ImageFilter`]: {{site.api}}/flutter/dart-ui/ImageFilter-class.html
+[`BackdropFilter`]: {{site.api}}/flutter/dart-ui/BackdropFilter-class.html
+[`ImageFilter.shader`]: {{site.api}}/flutter/dart-ui/ImageFilter/ImageFilter.shader.html
+
+```dart
+Widget build(BuildContext context, FragmentShader shader) {
+  final screenSize = MediaQuery.of(context).size;
+  shader.setFloat(0, screenSize.width);
+  shader.setFloat(1, screenSize.height);
+  return ClipRect(
+    child: SizedBox(
+      width: 300,
+      height: 300,
+      child: BackdropFilter(
+        filter: ImageFilter.shader(shader),
+        child: Container(
+          color: Colors.transparent,
+        ),
+      ),
+    ),
+  );
+}
+```
+
 ## Authoring shaders
 
 Fragment shaders are authored as GLSL source files.


### PR DESCRIPTION
## Description of what this PR is changing or adding, and why:

This adds more clarity on how custom shaders can be used with Flutter.  Previously we just showed using them with the Canvas API.  This shows how to use them with the BackdropFilter API which is slightly different.

## Issues fixed by this PR (if any):

## PRs or commits this PR depends on (if any):

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
