### PR TITLE
Fixed links to Flutter issues in iOS 26 support document

### DIFF
--- a/src/content/platform-integration/ios/ios-latest.md
+++ b/src/content/platform-integration/ios/ios-latest.md
@@ -23,13 +23,13 @@ visit the following issues in the flutter/flutter repo.
 * Virtual trackpad feature: [Issue 152715][]
 * Writing tools text input feature: [Issue 150965][], [Issue 150452][]
 
-[Issue 150068]: {{site.repo.flutter}}/flutter/flutter/issues/150068
-[Issue 150392]: {{site.repo.flutter}}/flutter/flutter/issues/150392
-[Issue 150452]: {{site.repo.flutter}}/flutter/flutter/issues/150452
-[Issue 150588]: {{site.repo.flutter}}/flutter/flutter/issues/150588
-[Issue 150950]: {{site.repo.flutter}}/flutter/flutter/issues/150590
-[Issue 150965]: {{site.repo.flutter}}/flutter/flutter/issues/150965
-[Issue 152711]: {{site.repo.flutter}}/flutter/flutter/issues/152711
-[Issue 152715]: {{site.repo.flutter}}/flutter/flutter/issues/152715
-[Issue 153573]: {{site.repo.flutter}}/flutter/flutter/issues/153573
-[Issue 170310]: {{site.repo.flutter}}/flutter/flutter/issues/170310
+[Issue 150068]: {{site.repo.flutter}}/issues/150068
+[Issue 150392]: {{site.repo.flutter}}/issues/150392
+[Issue 150452]: {{site.repo.flutter}}/issues/150452
+[Issue 150588]: {{site.repo.flutter}}/issues/150588
+[Issue 150950]: {{site.repo.flutter}}/issues/150590
+[Issue 150965]: {{site.repo.flutter}}/issues/150965
+[Issue 152711]: {{site.repo.flutter}}/issues/152711
+[Issue 152715]: {{site.repo.flutter}}/issues/152715
+[Issue 153573]: {{site.repo.flutter}}/issues/153573
+[Issue 170310]: {{site.repo.flutter}}/issues/170310


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ The links to the flutter issues did not work because of a duplication of the `flutter/flutter` part of the path. I removed that part from the URLs.

That page ends up on [this location](https://docs.flutter.dev/platform-integration/ios/ios-latest), and you'll find the dead links if you look at the current (2025/09/29) version.

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
