### PR TITLE
Add breaking change doc for `Visibility` widget changes

### DIFF
--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -71,7 +71,7 @@ They're sorted by release and listed in alphabetical order:
 * [The `Form` widget no longer supports being a sliver][]
 * [Flutter now sets default `abiFilters` in Android builds][]
 * [Merged threads on macOS and Windows][]
-* [The Visibility widget is no longer focusable by default when maintainState is enabled][]
+* [The `Visibility` widget is no longer focusable by default when `maintainState` is enabled][]
 
 [Component theme normalization updates]: /release/breaking-changes/component-theme-normalization-updates
 [Deprecate `DropdownButtonFormField` `value` parameter in favor of `initialValue`]: /release/breaking-changes/deprecate-dropdownbuttonformfield-value
@@ -81,7 +81,7 @@ They're sorted by release and listed in alphabetical order:
 [The `Form` widget no longer supports being a sliver]: /release/breaking-changes/form-semantics
 [Flutter now sets default `abiFilters` in Android builds]: /release/breaking-changes/default-abi-filters-android
 [Merged threads on macOS and Windows]: /release/breaking-changes/macos-windows-merged-threads
-[The Visibility widget is no longer focusable by default when maintainState is enabled]: /release/breaking-changes/visibility-maintainfocusability
+[The `Visibility` widget is no longer focusable by default when `maintainState` is enabled]: /release/breaking-changes/visibility-maintainfocusability
 
 <a id="released-in-flutter-332" aria-hidden="true"></a>
 ### Released in Flutter 3.32

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -71,6 +71,7 @@ They're sorted by release and listed in alphabetical order:
 * [The `Form` widget no longer supports being a sliver][]
 * [Flutter now sets default `abiFilters` in Android builds][]
 * [Merged threads on macOS and Windows][]
+* [The Visibility widget is no longer focusable by default when maintainState is enabled][]
 
 [Component theme normalization updates]: /release/breaking-changes/component-theme-normalization-updates
 [Deprecate `DropdownButtonFormField` `value` parameter in favor of `initialValue`]: /release/breaking-changes/deprecate-dropdownbuttonformfield-value
@@ -80,6 +81,7 @@ They're sorted by release and listed in alphabetical order:
 [The `Form` widget no longer supports being a sliver]: /release/breaking-changes/form-semantics
 [Flutter now sets default `abiFilters` in Android builds]: /release/breaking-changes/default-abi-filters-android
 [Merged threads on macOS and Windows]: /release/breaking-changes/macos-windows-merged-threads
+[The Visibility widget is no longer focusable by default when maintainState is enabled]: /release/breaking-changes/visibility-maintainfocusability
 
 <a id="released-in-flutter-332" aria-hidden="true"></a>
 ### Released in Flutter 3.32

--- a/src/content/release/breaking-changes/visibility-maintainfocusability.md
+++ b/src/content/release/breaking-changes/visibility-maintainfocusability.md
@@ -4,25 +4,25 @@ description: The Visibility widget by default no longer implicitly retains focus
 ---
 
 ## Summary
-
-This change was introduced to fix an issue where an `IndexedStack`s hidden
-children would be focusable through keyboard events https://github.com/flutter/flutter/issues/114213
+This change was introduced to fix an issue
+where an `IndexedStack`s hidden children would be focusable with keyboard events
+(see https://github.com/flutter/flutter/issues/114213)
 due to the underlying `Visibility` widgets default behavior.
 
 ## Description of change
-The core change is that the `Visibility` widget is no longer focusable
-by default when `maintainState` is enabled. A new flag, `maintainFocusability`,
-must be set to true along with `maintainState` for a hidden widget to
-remain focusable.
+The core change is the `Visibility` widget is no longer focusable by default
+when `maintainState` is enabled.
+A new flag, `maintainFocusability`, must be set to true with `maintainState`
+for a hidden widget to remain focusable.
 
 ## Migration guide
+If your app has a `Visibility` widget that does not set `maintainState` to true, 
+then no changes are required.
 
-If your app currently has a `Visibility` widget that does not
-set `maintainState` to true, then no changes are required.
-
-If your app currently has a `Visibility` widget that sets `maintainState`
-to true and you relied on the previous default behavior that allowed you
-to focus your hidden widget, you will need to set `maintainFocusability` to true.
+If your app has a `Visibility` widget that sets `maintainState` to true
+and you relied on the previous default behavior 
+that allowed you to focus your hidden widget,
+you will need to set `maintainFocusability` to true.
 
 Code before migration:
 

--- a/src/content/release/breaking-changes/visibility-maintainfocusability.md
+++ b/src/content/release/breaking-changes/visibility-maintainfocusability.md
@@ -1,5 +1,5 @@
 ---
-title: The Visibility widget is no longer focusable by default when maintainState is enabled.
+title: The Visibility widget is no longer focusable by default when maintainState is enabled
 description: The Visibility widget by default no longer implicitly retains focusability for its child when maintainState is enabled.
 ---
 

--- a/src/content/release/breaking-changes/visibility-maintainfocusability.md
+++ b/src/content/release/breaking-changes/visibility-maintainfocusability.md
@@ -1,0 +1,63 @@
+---
+title: The Visibility widget is no longer focusable by default when maintainState is enabled.
+description: The Visibility widget by default no longer implicitly retains focusability for its child when maintainState is enabled.
+---
+
+## Summary
+
+This change was introduced to fix an issue where an `IndexedStack`s hidden
+children would be focusable through keyboard events https://github.com/flutter/flutter/issues/114213
+due to the underlying `Visibility` widgets default behavior.
+
+## Description of change
+The core change is that the `Visibility` widget is no longer focusable
+by default when `maintainState` is enabled. A new flag, `maintainFocusability`,
+must be set to true along with `maintainState` for a hidden widget to
+remain focusable.
+
+## Migration guide
+
+If your app currently has a `Visibility` widget that does not
+set `maintainState` to true, then no changes are required.
+
+If your app currently has a `Visibility` widget that sets `maintainState`
+to true and you relied on the previous default behavior that allowed you
+to focus your hidden widget, you will need to set `maintainFocusability` to true.
+
+Code before migration:
+
+```dart
+    child: Visibility(
+        maintainState: true,
+        child: SomeWidget(),
+    )
+```
+
+Code after migration:
+
+```dart
+    child: Visibility(
+        maintainState: true,
+        maintainFocusability: true,
+        child: SomeWidget(),
+    )
+```
+
+## Timeline
+
+Landed in version: 3.34.0-pre
+In stable release: 3.35
+
+## References
+
+API documentation:
+
+* [`Visibility`]({{site.api}}/flutter/widgets/Visibility-class.html)
+
+Relevant issues:
+
+* [Issue 114213]({{site.repo.flutter}}/issues/114213)
+
+Relevant PRs:
+
+* [PR 159133: Add flag to exclude focus for hidden children in Visibility, maintainFocusability. Set maintainFocusability to false in IndexedStack]({{site.github}}/flutter/pull/159133)

--- a/src/content/release/breaking-changes/visibility-maintainfocusability.md
+++ b/src/content/release/breaking-changes/visibility-maintainfocusability.md
@@ -1,6 +1,8 @@
 ---
 title: The Visibility widget is no longer focusable by default when maintainState is enabled
-description: The Visibility widget by default no longer implicitly retains focusability for its child when maintainState is enabled.
+description: >-
+  The Visibility widget by default no longer implicitly retains focusability
+  for its child when maintainState is enabled.
 ---
 
 ## Summary
@@ -27,25 +29,25 @@ you will need to set `maintainFocusability` to true.
 Code before migration:
 
 ```dart
-    child: Visibility(
-        maintainState: true,
-        child: SomeWidget(),
-    )
+child: Visibility(
+    maintainState: true,
+    child: SomeWidget(),
+)
 ```
 
 Code after migration:
 
 ```dart
-    child: Visibility(
-        maintainState: true,
-        maintainFocusability: true,
-        child: SomeWidget(),
-    )
+child: Visibility(
+    maintainState: true,
+    maintainFocusability: true,
+    child: SomeWidget(),
+)
 ```
 
 ## Timeline
 
-Landed in version: 3.34.0-pre
+Landed in version: 3.34.0-pre<br>
 In stable release: 3.35
 
 ## References

--- a/src/content/release/breaking-changes/visibility-maintainfocusability.md
+++ b/src/content/release/breaking-changes/visibility-maintainfocusability.md
@@ -6,7 +6,7 @@ description: The Visibility widget by default no longer implicitly retains focus
 ## Summary
 This change was introduced to fix an issue
 where an `IndexedStack`s hidden children would be focusable with keyboard events
-(see https://github.com/flutter/flutter/issues/114213)
+(see [issue](https://github.com/flutter/flutter/issues/114213))
 due to the underlying `Visibility` widgets default behavior.
 
 ## Description of change
@@ -60,4 +60,4 @@ Relevant issues:
 
 Relevant PRs:
 
-* [PR 159133: Add flag to exclude focus for hidden children in Visibility, maintainFocusability. Set maintainFocusability to false in IndexedStack]({{site.github}}/flutter/pull/159133)
+* [PR 159133: Add flag to exclude focus for hidden children in Visibility, maintainFocusability. Set maintainFocusability to false in IndexedStack]({{site.repo.flutter}}/pull/159133)


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
This PR adds a breaking change document around `Visibility` changes that landed in stable release 3.35.

_Issues fixed by this PR (if any):_
Fixes [#174652](https://github.com/flutter/flutter/issues/174652)

_PRs or commits this PR depends on (if any):_
Does not depend on any PRs that have not already landed in stable.

Related PRs:
https://github.com/flutter/flutter/pull/159133

## Presubmit checklist

- [] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
