### PR TITLE
Remove broken link in FWE user input

### DIFF
--- a/src/content/get-started/fundamentals/user-input.md
+++ b/src/content/get-started/fundamentals/user-input.md
@@ -220,14 +220,10 @@ Widget build(BuildContext context) {
 > <span class="material-symbols" aria-hidden="true" translate="no">slideshow</span> **Video**: 
 > [Rich Text (Widget of the Week)][]
 
-> <span class="material-symbols" aria-hidden="true" translate="no">flutter</span> **Demo**: 
-> [Rich Text Editor][]
-
 > <span class="material-symbols" aria-hidden="true" translate="no">code</span> **Code**: 
 > [Rich Text Editor code][]
 
 [Rich Text (Widget of the Week)]: {{site.youtube-site}}/watch?v=rykDVh-QFfw
-[Rich Text Editor]: https://github.com/flutter/samples/tree/main/rich_text_editor
 [Rich Text Editor code]: {{site.github}}/flutter/samples/tree/main/simplistic_editor
 
 ### `TextField`


### PR DESCRIPTION



_Description of what this PR is changing or adding, and why:_

I don't know what this link was supposed to point to. Regardless, there isn't a "Rich Text Demo" sample, so the link should be removed.

_Issues fixed by this PR (if any):_

Resolves #12426 
## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
