### PR TITLE
Use prebuilt firebase-tools for link check workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,8 @@ jobs:
           sdk: beta
       - name: Fetch Dart dependencies
         run: dart pub get
+      - name: Install firebase-tools
+        run: curl -sL https://firebase.tools | bash
       - name: Build site
         run: dart run flutter_site build
       - name: Check for broken Markdown link references

--- a/tool/flutter_site/lib/src/commands/check_links.dart
+++ b/tool/flutter_site/lib/src/commands/check_links.dart
@@ -55,12 +55,7 @@ Future<int> _checkLinks({bool checkExternal = false}) async {
     return 1;
   }
 
-  final toolVersionOutput = await Process.run('npm', const [
-    'exec',
-    '--',
-    'firebase-tools',
-    '--version',
-  ]);
+  final toolVersionOutput = await Process.run('firebase', const ['--version']);
 
   final firebaseToolsVersion = (toolVersionOutput.stdout as String?)?.trim();
   if (firebaseToolsVersion == null || firebaseToolsVersion.isEmpty) {
@@ -72,10 +67,7 @@ Future<int> _checkLinks({bool checkExternal = false}) async {
     'Using firebase-tools $firebaseToolsVersion to start the '
     'Firebase hosting emulator asynchronously...',
   );
-  final emulatorProcess = await Process.start('npm', const [
-    'exec',
-    '--',
-    'firebase-tools',
+  final emulatorProcess = await Process.start('firebase', const [
     'emulators:start',
     '--only',
     'hosting',


### PR DESCRIPTION
Mirrors https://github.com/dart-lang/site-www/pull/6877 by switching to the prebuilt firebase-tools rather than using it through npm.

Will simplify removing more usages of Node and npm in the future. Also should slightly reduce the workflow runtime.