### PR TITLE
Fix: Update URL launch method to use Uri.parse

### DIFF
--- a/examples/platform_integration/plugin_api_migration/lib/url_launcher.dart
+++ b/examples/platform_integration/plugin_api_migration/lib/url_launcher.dart
@@ -20,7 +20,7 @@ class DemoPage extends StatelessWidget {
   const DemoPage({super.key});
 
   void launchURL() {
-    launchUrl(p.toUri('https://flutter.dev'));
+    launchUrl(Uri.parse('https://flutter.dev'));
   }
 
   @override

--- a/src/content/packages-and-plugins/using-packages.md
+++ b/src/content/packages-and-plugins/using-packages.md
@@ -472,7 +472,7 @@ To use this plugin:
       const DemoPage({super.key});
     
       void launchURL() {
-        launchUrl(p.toUri('https://flutter.dev'));
+        launchUrl(Uri.parse('https://flutter.dev'));
       }
     
       @override


### PR DESCRIPTION
Refer this issue for full description #12410 

**Before:**
- Wasn't opening the website by clicking on the launch button. I don't have a screenshot of that as the app was not breaking but was just not opening the webpage. I could not find any error logs in the emulator logs (may be because I am new to this). Only thing I can verify is that this issue persist in macos and iPhone 14 emulator.

**After:**
Opened the website uccessfully
<img width="382" alt="image" src="https://github.com/user-attachments/assets/455279e2-b1f5-4d5b-b50c-fef7b4521ab5" />


## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
