### PR TITLE
Clarify usage of the ImageFilter API for fragment shaders.

### DIFF
--- a/src/content/ui/design/graphics/fragment-shaders.md
+++ b/src/content/ui/design/graphics/fragment-shaders.md
@@ -122,13 +122,12 @@ to apply shaders to already rendered content.
 [`ImageFilter`][] provides a constructor, [`ImageFilter.shader`][],
 for creating an [`ImageFilter`][] with a custom fragment shader.
 
-Fragment shaders that use the [`ImageFilter`][] API must have
-at least one sampler2D uniform value and at least one vec2 uniform value.
-The sampler2D uniform value at index 0 and
-the float uniform values at index 0 and 1
-should not be set in Dart.
-These values are automatically set to contain
-the filter input image and the image size.
+Fragment shaders that use the `ImageFilter` API receive some
+values automatically from the engine. The `sampler2D` value at index 0
+is set to the filter input image, and the `float` values at indices 0
+and 1 are set to the image's width and height.
+Your shader must specify this constructor to accept these values (for example,
+a `sampler2D` and a `vec2`), but you should not set them from your Dart code.
 
 [`ImageFilter`]: {{site.api}}/flutter/dart-ui/ImageFilter-class.html
 [`ImageFiltered`]: {{site.api}}/flutter/widgets/ImageFiltered-class.html

--- a/src/content/ui/design/graphics/fragment-shaders.md
+++ b/src/content/ui/design/graphics/fragment-shaders.md
@@ -115,21 +115,28 @@ void paint(Canvas canvas, Size size, FragmentShader shader) {
 
 ### ImageFilter API
 
-Fragment shaders can also be used with the [`ImageFilter`][] API. This allows
-using custom fragment shaders with the [`BackdropFilter`][] class to apply
-shaders to already rendered content. [`ImageFilter`][] provides a constructor,
-[`ImageFilter.shader`][], for creating an [`ImageFilter`][] with a custom
-fragment shader.
+Fragment shaders can also be used with the [`ImageFilter`][] API.
+This allows using custom fragment shaders with the
+[`ImageFiltered`][] class or the [`BackdropFilter`][] class
+to apply shaders to already rendered content.
+[`ImageFilter`][] provides a constructor, [`ImageFilter.shader`][],
+for creating an [`ImageFilter`][] with a custom fragment shader.
+
+Fragment shaders that use the [`ImageFilter`][] API must have
+at least one sampler2D uniform value and at least one vec2 uniform value.
+The sampler2D uniform value at index 0 and
+the float uniform values at index 0 and 1
+should not be set in Dart.
+These values are automatically set to contain
+the filter input image and the image size.
 
 [`ImageFilter`]: {{site.api}}/flutter/dart-ui/ImageFilter-class.html
-[`BackdropFilter`]: {{site.api}}/flutter/dart-ui/BackdropFilter-class.html
+[`ImageFiltered`]: {{site.api}}/flutter/widgets/ImageFiltered-class.html
+[`BackdropFilter`]: {{site.api}}/flutter/widgets/BackdropFilter-class.html
 [`ImageFilter.shader`]: {{site.api}}/flutter/dart-ui/ImageFilter/ImageFilter.shader.html
 
 ```dart
 Widget build(BuildContext context, FragmentShader shader) {
-  final screenSize = MediaQuery.of(context).size;
-  shader.setFloat(0, screenSize.width);
-  shader.setFloat(1, screenSize.height);
   return ClipRect(
     child: SizedBox(
       width: 300,


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

- Suggest using the ImageFiltered class in addition to the BackdropFilter class.
- Fix broken link to BackdropFilter page.
- Call out the automatically-filled uniform values when using ImageFilter.shader.
- Change the example code to not set a size uniform value. As called out above, this is incorrect and these set values are ignored.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
