### PR TITLE
Fix typo in proxy config docs

### DIFF
--- a/src/content/platform-integration/web/web-dev-config-file.md
+++ b/src/content/platform-integration/web/web-dev-config-file.md
@@ -80,7 +80,7 @@ server:
 *   A request to `/users/names` is
     forwarded to `http://localhost:5000/users/names`.
 *   A request to `/data/2023/` is
-    forwarded to `http://localhost:4000/report/2023`
+    forwarded to `http://localhost:3000/report/2023`
     because `replace: “/report/”` replaces the `/data/` prefix.
 *   A request to `/products/item/123` is
     forwarded to `http://localhost:4000/item/123` because `replace: ""`


### PR DESCRIPTION
The section of the example configuration with the replacement of `/data/` to `/report/` points to port `:3000`.

cc @kevmoo 