### PR TITLE
Update platform-channels.md to remove 'dart:html' reference

### DIFF
--- a/src/content/platform-integration/platform-channels.md
+++ b/src/content/platform-integration/platform-channels.md
@@ -34,7 +34,7 @@ platform-specific languages:
 :::note
 * The information in this page is valid for most platforms,
   but platform-specific code for the web generally uses
-  [JS interoperability][] or the [`dart:html` library][] instead.
+  [JS interoperability][] instead.
 
 * This guide addresses using the platform channel mechanism
   if you need to use the platform's APIs in a non-Dart language.
@@ -1459,7 +1459,6 @@ in the Flutter ecosystem, see [publishing packages][].
 [`BinaryCodec`]: {{site.api}}/flutter/services/BinaryCodec-class.html
 [block]: {{site.apple-dev}}/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/WorkingwithBlocks/WorkingwithBlocks.html
 [`FirestoreMessageCodec`]: {{site.github}}/firebase/flutterfire/blob/master/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/utils/firestore_message_codec.dart
-[`dart:html` library]: {{site.dart.api}}/dart-html/dart-html-library.html
 [developing packages]: /packages-and-plugins/developing-packages
 [Engine Embedder APIs]: {{site.dart.api}}/index.html#more-documentation
 [`Pigeon`]: {{site.pub-pkg}}/pigeon


### PR DESCRIPTION

_Description of what this PR is changing or adding, and why:_ Removed reference to the 'dart:html' library in the note section.

_Issues fixed by this PR (if any):_ Fixes #12552

_PRs or commits this PR depends on (if any):_ None

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
