### PR TITLE
Remove the link to the Q4 survey from the banner

### DIFF
--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -1,1 +1,1 @@
-
+Build high quality, feature-rich apps with the new Flutter Extension for Gemini CLI. <a href="https://blog.flutter.dev/meet-the-flutter-extension-for-gemini-cli-f8be3643eaad" target="_blank">Learn more</a><br>


### PR DESCRIPTION
They survey is closing today. Is there something else that we'd like to put in the banner instead?

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
