### PR TITLE
Update plugin migration instructions

### DIFF
--- a/src/content/release/breaking-changes/uiscenedelegate.md
+++ b/src/content/release/breaking-changes/uiscenedelegate.md
@@ -579,13 +579,20 @@ sceneLifeCycleDelegate.unregisterSceneLifeCycle(with: flutterEngine)
 Not all plugins use lifecycle events. If your plugin does, though, you will
 need to migrate to UIKit's scene-based lifecycle.
 
-1. Update Flutter SDK version in your pubspec.yaml
+1. Update the Dart and Flutter SDK versions in your pubspec.yaml
+
+```yaml
+environment:
+  sdk: ^3.10.0-290.1.beta
+  flutter: ">=3.38.0-0.1.pre"
+```
 
 :::warning
 The below Flutter APIs are available in the 3.38.0-0.1.pre beta, but are not
-yet available on stable. You might consider publishing a [prerelease
-version](https://dart.dev/tools/pub/publishing#publishing-prereleases)
-of your plugin to migrate early.
+yet available on stable. You might consider publishing a
+[prerelease](https://dart.dev/tools/pub/publishing#publishing-prereleases) or
+[preview](https://dart.dev/tools/pub/publishing#publish-preview-versions)
+version of your plugin to migrate early.
 :::
 
 2. Adopt the `FlutterSceneLifeCycleDelegate` protocol
@@ -630,7 +637,7 @@ event, visit Apple's documentation on
 [`UISceneDelegate`][] and [`UIWindowSceneDelegate`][].
 
 [`UISceneDelegate`]: {{site.apple-dev}}/documentation/uikit/uiscenedelegate
-[UIWindowSceneDelegate]: {{site.apple-dev}}/documentation/uikit/uiwindowscenedelegate
+[`UIWindowSceneDelegate`]: {{site.apple-dev}}/documentation/uikit/uiwindowscenedelegate
 
 
 ```swift


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

This change moves the plugin migration guide to the bottom so app migrations are first.

This also adds a warning that plugin APIs are not available on stable yet.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
