### PR TITLE
Remove spurious backtick from faq.md

### DIFF
--- a/src/content/resources/faq.md
+++ b/src/content/resources/faq.md
@@ -735,7 +735,7 @@ that offer a better trade-off, such as code generation.
 
 ### Are internationalization and localization supported?
 
-Yes, Flutte`r supports internationalization (i18n) and localization (l10n) so
+Yes, Flutter supports internationalization (i18n) and localization (l10n) so
 that your apps are adaptable to different languages and cultures. You can
 learn more in the [internationalization documentation][].
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

"Flutte`r" -> "Flutter"

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
