### PR TITLE
Add /to/template link

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -827,6 +827,7 @@
       { "source": "/to/state-management-sample", "destination": "/data-and-backend/state-mgmt/simple", "type": 301 },
       { "source": "/to/switch-flutter-version", "destination": "/install/upgrade#switch-to-a-specific-flutter-version", "type": 301 },
       { "source": "/to/team-infra", "destination": "https://github.com/flutter/flutter/blob/main/docs/triage/Infra-Triage.md", "type": 301 },
+      { "source": "/to/template", "destination": "https://flutter.dev/go/template", "type": 301 },
       { "source": "/to/test-drive", "destination": "/get-started/quick", "type": 301 },
       { "source": "/to/track-widget-creation", "destination": "/tools/devtools/inspector#track-widget-creation", "type": 301 },
       { "source": "/to/troubleshoot-devices", "destination": "/install/troubleshoot", "type": 301 },


### PR DESCRIPTION
I keep forgetting if the design doc template is [flutter.dev/to/template](https://flutter.dev/to/template) or [flutter.dev/go/template](https://flutter.dev/go/template). This supports both through daisy chaining.