### PR TITLE
Update architectural-overview.md to remove web hot reload comment

### DIFF
--- a/src/content/resources/architectural-overview.md
+++ b/src/content/resources/architectural-overview.md
@@ -26,16 +26,12 @@ much code as possible.
 
 During development, Flutter apps run in a VM that offers
 stateful hot reload of changes without needing a full recompile.
-(On web, Flutter supports hot restart and
-[hot reload behind a flag][].)
 For release, Flutter apps are compiled directly to machine code,
 whether Intel x64 or ARM instructions,
 or to JavaScript if targeting the web.
 The framework is open source, with a permissive BSD license,
 and has a thriving ecosystem of third-party packages that
 supplement the core library functionality.
-
-[hot reload behind a flag]: /platform-integration/web/building#hot-reload-web
 
 This overview is divided into a number of sections:
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Small change to architectural-overview.md to remove a stale comment (as of Flutter 3.35, the current stable release) about stateful hot reload not being enabled by default.

## Presubmit checklist

- [X] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [X] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
