### PR TITLE
Add release notes for DevTools 2.51.1

### DIFF
--- a/src/content/tools/devtools/release-notes/release-notes-2.51.1.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.51.1.md
@@ -37,8 +37,8 @@ To learn more about DevTools, check out the
 
 ## VS Code updates
 
-- On macOS, shortcuts like `Cmd`+`C` and `Cmd`+`V` now work when DevTools is
-  embedded inside VS Code -
+- Fixed issue preventing shortcuts like `Cmd`+`C` and `Cmd`+`V` from working when DevTools was
+  embedded inside VS Code on macOS. -
   [#9472](https://github.com/flutter/devtools/pull/9472)
 
 ## Full commit history


### PR DESCRIPTION
Add release notes for the 2.51.1 hotfix version of DevTools. This is version of DevTools that is going out with Flutter 3.38.

Includes the release notes for 2.51.0 along with the release notes for the cherry-picks included in 2.51.1 (see https://github.com/flutter/devtools/compare/v2.51.0...v2.51.1)
