### PR TITLE
Remove `skipTemplateRendering` from release notes front matter

### DIFF
--- a/src/content/release/release-notes/release-notes-3.0.0.md
+++ b/src/content/release/release-notes/release-notes-3.0.0.md
@@ -9,7 +9,7 @@ This page has release notes for 3.0.0.
 For information about subsequent bug-fix releases,
 see our [CHANGELOG][].
 
-[CHANGELOG]: {{site.repo.flutter}}/blob/main/CHANGELOG.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/main/CHANGELOG.md
 
 ## If you see warnings about bindings
 

--- a/src/content/release/release-notes/release-notes-3.10.0.md
+++ b/src/content/release/release-notes/release-notes-3.10.0.md
@@ -9,7 +9,7 @@ This page has release notes for 3.10.0.
 For information about subsequent bug-fix releases,
 see our [CHANGELOG][].
 
-[CHANGELOG]: {{site.repo.flutter}}/blob/main/CHANGELOG.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/main/CHANGELOG.md
 
 ## Framework
 

--- a/src/content/release/release-notes/release-notes-3.13.0.md
+++ b/src/content/release/release-notes/release-notes-3.13.0.md
@@ -9,7 +9,7 @@ This page has release notes for 3.13.0.
 For information about subsequent bug-fix releases,
 see our [CHANGELOG][].
 
-[CHANGELOG]: {{site.repo.flutter}}/blob/main/CHANGELOG.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/main/CHANGELOG.md
 
 ## Framework
 

--- a/src/content/release/release-notes/release-notes-3.16.0.md
+++ b/src/content/release/release-notes/release-notes-3.16.0.md
@@ -9,7 +9,7 @@ This page has release notes for 3.16.0.
 For information about subsequent bug-fix releases,
 see our [CHANGELOG][].
 
-[CHANGELOG]: {{site.repo.flutter}}/blob/main/CHANGELOG.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/main/CHANGELOG.md
 
 ## Flutter
 

--- a/src/content/release/release-notes/release-notes-3.19.0.md
+++ b/src/content/release/release-notes/release-notes-3.19.0.md
@@ -9,7 +9,7 @@ This page has release notes for 3.19.0.
 For information about subsequent bug-fix releases,
 see our [CHANGELOG][].
 
-[CHANGELOG]: {{site.repo.flutter}}/blob/main/CHANGELOG.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/main/CHANGELOG.md
 
 ## Flutter
 

--- a/src/content/release/release-notes/release-notes-3.22.0.md
+++ b/src/content/release/release-notes/release-notes-3.22.0.md
@@ -9,7 +9,7 @@ This page has release notes for 3.22.0.
 For information about subsequent bug-fix releases,
 see our [CHANGELOG][].
 
-[CHANGELOG]: {{site.repo.flutter}}/blob/main/CHANGELOG.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/main/CHANGELOG.md
 
 ## Flutter
 

--- a/src/content/release/release-notes/release-notes-3.24.0.md
+++ b/src/content/release/release-notes/release-notes-3.24.0.md
@@ -9,7 +9,7 @@ This page has release notes for 3.24.0.
 For information about subsequent bug-fix releases,
 check out the Flutter [CHANGELOG][].
 
-[CHANGELOG]: {{site.repo.flutter}}/blob/main/CHANGELOG.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/main/CHANGELOG.md
 
 ## Flutter framework
 

--- a/src/content/release/release-notes/release-notes-3.27.0.md
+++ b/src/content/release/release-notes/release-notes-3.27.0.md
@@ -9,7 +9,7 @@ This page has release notes for 3.27.0.
 For information about subsequent bug-fix releases,
 check out the Flutter [CHANGELOG][].
 
-[CHANGELOG]: {{site.repo.flutter}}/blob/main/CHANGELOG.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/main/CHANGELOG.md
 
 ## Flutter framework
 

--- a/src/content/release/release-notes/release-notes-3.29.0.md
+++ b/src/content/release/release-notes/release-notes-3.29.0.md
@@ -9,7 +9,7 @@ This page has release notes for 3.29.0.
 For information about subsequent bug-fix releases,
 check out the Flutter [CHANGELOG][].
 
-[CHANGELOG]: {{site.repo.flutter}}/blob/main/CHANGELOG.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/main/CHANGELOG.md
 
 ## Flutter framework
 

--- a/src/content/release/release-notes/release-notes-3.3.0.md
+++ b/src/content/release/release-notes/release-notes-3.3.0.md
@@ -9,7 +9,7 @@ This page has release notes for 3.3.0.
 For information about subsequent bug-fix releases,
 see our [CHANGELOG][].
 
-[CHANGELOG]: {{site.repo.flutter}}/blob/main/CHANGELOG.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/main/CHANGELOG.md
 
 ## What's changed
 

--- a/src/content/release/release-notes/release-notes-3.32.0.md
+++ b/src/content/release/release-notes/release-notes-3.32.0.md
@@ -9,7 +9,7 @@ This page has release notes for 3.32.0.
 For information about subsequent bug-fix releases,
 check out the Flutter [CHANGELOG][].
 
-[CHANGELOG]: {{site.repo.flutter}}/blob/main/CHANGELOG.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/main/CHANGELOG.md
 
 ## Flutter framework
 

--- a/src/content/release/release-notes/release-notes-3.35.0.md
+++ b/src/content/release/release-notes/release-notes-3.35.0.md
@@ -9,7 +9,7 @@ This page has release notes for 3.35.0.
 For information about subsequent bug-fix releases,
 check out the Flutter [CHANGELOG][].
 
-[CHANGELOG]: {{site.repo.flutter}}/blob/main/CHANGELOG.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/main/CHANGELOG.md
 
 ## What's changed
 

--- a/src/content/release/release-notes/release-notes-3.7.0.md
+++ b/src/content/release/release-notes/release-notes-3.7.0.md
@@ -9,7 +9,7 @@ This page has release notes for 3.7.0.
 For information about subsequent bug-fix releases,
 see our [CHANGELOG][].
 
-[CHANGELOG]: {{site.repo.flutter}}/blob/main/CHANGELOG.md
+[CHANGELOG]: https://github.com/flutter/flutter/blob/main/CHANGELOG.md
 
 ## What's changed
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ The problem that is described in the linked issue seems to occur due to the Templating system not working for the snippet `{{site.repo.flutter}}`. What differentiates the release notes pages from others is the option `skipTemplateRendering` in the front matter, which is set to `true`. While testing, removing the option from the front matter makes the link open as expected.

_Issues fixed by this PR (if any):_ https://github.com/flutter/website/issues/12660

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
