### PR TITLE
Fix broken link to `debugInvertOversizedImages` documentation

### DIFF
--- a/src/content/tools/devtools/inspector.md
+++ b/src/content/tools/devtools/inspector.md
@@ -520,7 +520,7 @@ void showOversizedImages() {
 
 You can learn more at the following link:
 
-- [Flutter documentation: debugInvertOversizedImages]({{site.api}}/flutter/painting/debugInvertOversizedImages.html)
+- [Flutter documentation: debugInvertOversizedImages]({{site.api}}/flutter/rendering/debugInvertOversizedImages.html)
 
 [render box]: {{site.api}}/flutter/rendering/RenderBox-class.html
 

--- a/src/content/tools/devtools/legacy-inspector.md
+++ b/src/content/tools/devtools/legacy-inspector.md
@@ -449,7 +449,7 @@ void showOversizedImages() {
 
 You can learn more at the following link:
 
-* [Flutter documentation: debugInvertOversizedImages]({{site.api}}/flutter/painting/debugInvertOversizedImages.html)
+* [Flutter documentation: debugInvertOversizedImages]({{site.api}}/flutter/rendering/debugInvertOversizedImages.html)
 
 [render box]: {{site.api}}/flutter/rendering/RenderBox-class.html
 


### PR DESCRIPTION
This PR changes the link from https://api.flutter.dev/flutter/painting/debugInvertOversizedImages.html to https://api.flutter.dev/flutter/rendering/debugInvertOversizedImages.html for the DevTools inspector documentation, according to the discussion in the linked issue. I also changed the link in the `legacy-inspector.md` page, as the issue persisted there too.

Fixes https://github.com/flutter/website/issues/12638