### PR TITLE
Fix broken link in `fragment-shaders.md`

### DIFF
--- a/src/content/ui/design/graphics/fragment-shaders.md
+++ b/src/content/ui/design/graphics/fragment-shaders.md
@@ -366,7 +366,7 @@ this is more efficient than creating a new
 For a more detailed guide on writing performant shaders,
 check out [Writing efficient shaders][] on GitHub.
 
-[Writing efficient shaders]: {{site.repo.flutter}}/blob/main/engine/src/flutter/impeller/docs/shader_optimization.md
+[Writing efficient shaders]: {{site.repo.flutter}}/blob/main/docs/engine/impeller/docs/shader_optimization.md
 
 ### Other resources
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ This PR changes the link to _Writing efficient shaders_ that is found under https://docs.flutter.dev/ui/design/graphics/fragment-shaders#performance-considerations. It seems that after relocating the engine docs (https://github.com/flutter/flutter/commit/e068a3e6c4c1dd57a5db474c30eb1988f794bee7), this link didn't change accordingly.

_Issues fixed by this PR (if any):_ https://github.com/flutter/website/issues/12665

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
