### PR TITLE
Document how to determine if an app is a flutter app

### DIFF
--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -647,10 +647,12 @@ Example:
 returns any number greater than 0.
 
 **Why this works**
-Flutter depends on C++ code called the Flutter engine. On Android, this engine is bundled as an `.so` native library.
-Historically, this file has been named `libflutter.so`. The Flutter framework and the developer's Dart code are combined into `libapp.so`.
-The Flutter codebase names this library `flutter`; Java/Android tooling adds the `lib` prefix and handles library location across architectures.
-Many reverse engineers use this method to identify Flutter apps.
+Flutter depends on C++ code used by the Flutter engine. In Android,
+this code is bundled with the Flutter framework and the developer's
+Dart code as a native library called `libflutter.so`.
+The Java/Android tooling renames the `flutter` library with the `lib` prefix
+and handles library location across architectures.
+This is how some reverse engineer an APK to identify it as a Flutter app.
 
 #### Secondary Evaluation:
 Run `apkanalyzer manifest print <SOME-APK>` and look for a `<meta-data>` tag with `android:name="flutterEmbedding"`.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Documents how to tell from a built apk if the app uses flutter. 
Internal documentation authored by me can be seen by googlers in [go/flutter-android-detection](http://goto.google.com/flutter-android-detection)

_Issues fixed by this PR (if any):_
flutter/flutter/issues/170523

_PRs or commits this PR depends on (if any):_
n/a

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
