### PR TITLE
Refactor user input radio buttons to use RadioGroup

### DIFF
--- a/src/content/get-started/fundamentals/user-input.md
+++ b/src/content/get-started/fundamentals/user-input.md
@@ -739,17 +739,16 @@ Widget build(BuildContext context) {
 
 ### Radio
 
-A `RadioGroup` containing `Radio` buttons that allow the user to
+A `RadioGroup` contains `Radio` buttons that allow the user to
 select between mutually exclusive values.
 When the user selects a radio button in a group,
 the other radio buttons are unselected.
 
-- A particular `Radio` button's `value` represent that button's value,
-- The selected value for a group of radio buttons is identified by
+- A particular `Radio` button's `value` represent that button's value.
 - The selected value for a `RadioGroup` is identified by
-the `groupValue` parameter.
+  the `groupValue` parameter.
 - `RadioGroup` has an `onChanged` callback that
-  gets triggered when users click it, like `Switch` and `Checkbox`
+  gets triggered when users click it, like `Switch` and `Checkbox`.
 
 {% render "docs/code-and-image.md",
 image:"fwe/user-input/Radio.webp",


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
`groupValue` and `onChanged` parameter in `Radio` widget is deprecated after v3.32.0-0.0.pre

_Issues fixed by this PR (if any):_
None

_PRs or commits this PR depends on (if any):_
None

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
