### PR TITLE
Exclude secondary Markdown files from sitemap

### DIFF
--- a/tool/dash_site/lib/src/commands/build.dart
+++ b/tool/dash_site/lib/src/commands/build.dart
@@ -47,6 +47,8 @@ final class BuildSiteCommand extends Command<int> {
         // those specified by jaspr_cli.
         '--no-managed-build-options',
         '--sitemap-domain=https://docs.flutter.dev',
+        // Exclude secondary Markdown output files from sitemap.
+        r'--sitemap-exclude=\.html\.md$',
         '--dart-define=PRODUCTION=$productionRelease',
       ],
       workingDirectory: 'site',


### PR DESCRIPTION
As their original HTML version is already present and these being indexed results in odd search results as seen by https://github.com/dart-lang/site-www/issues/7017.