### PR TITLE
Update Android package setup instructions to include build.gradle.kts

### DIFF
--- a/src/content/packages-and-plugins/developing-packages.md
+++ b/src/content/packages-and-plugins/developing-packages.md
@@ -778,7 +778,7 @@ The native build systems that are invoked by FFI
 (and method channels) plugins are:
 
 * For Android: Gradle, which invokes the Android NDK for native builds.
-  * See the documentation in `android/build.gradle`.
+  * See the documentation in `android/build.gradle` or `android/build.gradle.kts`.
 * For iOS and macOS: Xcode, using CocoaPods.
   * See the documentation in `ios/hello.podspec`.
   * See the documentation in `macos/hello.podspec`.


### PR DESCRIPTION
This PR updates the Android package setup docs to include `build.gradle.kts`, ensuring Kotlin DSL projects are covered alongside `build.gradle`.
Fixes #12698

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
