### PR TITLE
Correct escape character in user-input.md

### DIFF
--- a/src/content/get-started/fundamentals/user-input.md
+++ b/src/content/get-started/fundamentals/user-input.md
@@ -910,7 +910,7 @@ Widget build(BuildContext context) {
   return Column(children: [
     Text(
       date == null
-          ? 'You haven\\'t picked a date yet.'
+          ? "You haven't picked a date yet."
           : DateFormat('MM-dd-yyyy').format(date),
     ),
     ElevatedButton.icon(
@@ -960,7 +960,7 @@ Widget build(BuildContext context) {
 
   return Column(children: [
     Text(
-      time == null ? 'You haven\\'t picked a time yet.' : time.format(context),
+      time == null ? "You haven't picked a time yet." : time.format(context),
     ),
     ElevatedButton.icon(
       icon: const Icon(Icons.calendar_today),


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
- The docs misrender the escape character '\\' so that the code example still doesn't escape the ' on the `Text`

_Issues fixed by this PR (if any):_
Haven't checked, none

_PRs or commits this PR depends on (if any):_
None

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
