### PR TITLE
Fix links on FWE index page

### DIFF
--- a/src/content/tutorial/index.md
+++ b/src/content/tutorial/index.md
@@ -54,7 +54,7 @@ and thus is the quickest way to start using Flutter.
    2. [Widget fundamentals][]
    3. [Layout widgets on a screen][]
    4. [Devtools][]
-   5. [Handle User input][]
+   5. [Handle user input][]
    6. [Learn about stateful widgets][]
    7. [Add implicit animations][]
 2. State in Flutter apps


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Since the migration to Jaspr, the links on the (unlisted) FWE index page  no longer work. I believe this is a problem with permalinks, but this PR _only updates the link URLS_.  

We'll need to update the links anyway when FWE lands, so this is not creating more work.

_Issues fixed by this PR (if any):_

This is a **temporary** fix for #12628

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
