### PR TITLE
fix: generate '/f/devtools-releases.json' on the Windows platform

### DIFF
--- a/site/lib/src/components/pages/devtools_release_notes_index.dart
+++ b/site/lib/src/components/pages/devtools_release_notes_index.dart
@@ -21,11 +21,11 @@ class DevToolsReleaseNotesIndex extends StatelessComponent {
       'release-notes-',
     ]);
     return context.pages
-        .where((p) => p.path.startsWith(releaseNotesPrefix))
+        .where((page) => page.path.startsWith(releaseNotesPrefix))
         .map(
-          (p) => (
-            version: Version.parse(p.data.page['breadcrumb'] as String),
-            page: p,
+          (page) => (
+            version: Version.parse(page.data.page['breadcrumb'] as String),
+            page: page,
           ),
         )
         .sortedBy((e) => e.version)


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Running the `dart run dash_site build --release` command on the Windows platform results in an error:

```bash
[SERVER] [ERROR] Error while building Builder:
[SERVER] [ERROR] Bad state: No element
[SERVER] [ERROR] #0      List.first (dart:core-patch/growable_array.dart:352:5)
[SERVER] [ERROR] #1      _devtoolsReleasesIndex.<anonymous closure> (package:docs_flutter_dev_site/src/pages/custom_pages.dart:58:26)
...
```


_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
