### PR TITLE
Update AI rules by environment table

### DIFF
--- a/site/lib/src/components/pages/devtools_release_notes_index.dart
+++ b/site/lib/src/components/pages/devtools_release_notes_index.dart
@@ -5,6 +5,7 @@
 import 'package:collection/collection.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_content/jaspr_content.dart';
+import 'package:path/path.dart' as path;
 import 'package:pub_semver/pub_semver.dart';
 
 class DevToolsReleaseNotesIndex extends StatelessComponent {
@@ -13,13 +14,18 @@ class DevToolsReleaseNotesIndex extends StatelessComponent {
   static List<({Version version, Page page})> findDevToolsReleases(
     BuildContext context,
   ) {
-    const releaseNotesPrefix = 'tools/devtools/release-notes/release-notes-';
+    final releaseNotesPrefix = path.joinAll([
+      'tools',
+      'devtools',
+      'release-notes',
+      'release-notes-',
+    ]);
     return context.pages
-        .where((p) => p.path.startsWith(releaseNotesPrefix))
+        .where((page) => page.path.startsWith(releaseNotesPrefix))
         .map(
-          (p) => (
-            version: Version.parse(p.data.page['breadcrumb'] as String),
-            page: p,
+          (page) => (
+            version: Version.parse(page.data.page['breadcrumb'] as String),
+            page: page,
           ),
         )
         .sortedBy((e) => e.version)


### PR DESCRIPTION
- Mention which parent directory is expected such as `.idx/airules.md`
- Expand section to support directories for environments that support generic directories like Antigravity and Windsurf
- Add Antigravity and Claude Code
- Add a note that this support is evolving since each environment keeps changing it
- Update the documentation links for a few of the environments