### PR TITLE
Correct EdgeInsets mislabeled as widget in Flutter example

### DIFF
--- a/src/content/get-started/flutter-for/compose-devs.md
+++ b/src/content/get-started/flutter-for/compose-devs.md
@@ -56,14 +56,14 @@ Both composables and widgets only exist until they need to change.
 These languages call this property _immutability_.
 Jetpack Compose modifies UI component properties using an optional
 _modifier_ property backed by a `Modifier` object.
-By contrast, Flutter uses widgets for both UI components and
-their properties.
+By contrast, Flutter widgets configure their properties directly
+through constructor parameters.
 
 ```dart
 Padding(                         // <-- This is a Widget
-  padding: EdgeInsets.all(10.0), // <-- So is this
-  child: Text("Hello, World!"),  // <-- This, too
-)));
+  padding: EdgeInsets.all(10.0), // <-- a parameter to Padding
+  child: Text("Hello, World!"),  // <-- This is also a Widget
+);
 ```
 
 To compose layouts, both Jetpack Compose and Flutter nest UI components


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
`EdgeInsets` were incorrectly called a Widget in the docs and also it said incorrectly that 
> Flutter uses widgets for both UI components **<ins> and their properties</ins>**

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
