### PR TITLE
Add redirect from `/download` to `/install`

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -50,6 +50,7 @@
       { "source": "/development", "destination": "/", "type": 301 },
       { "source": "/development/:rest*", "destination": "/:rest*", "type": 301 },
       { "source": "/devtools/:rest*", "destination": "/tools/devtools/:rest*", "type": 301 },
+      { "source": "/download", "destination": "/install", "type": 301 },
       { "source": "/downloads/:resource*", "destination": "/resources/:resource*", "type": 301 },
       { "source": "/f/dart-devtools-survey-metadata.json", "destination": "https://storage.googleapis.com/flutter-uxr/surveys/devtools-survey-metadata.json", "type": 301 },
       { "source": "/f/flutter-survey-metadata.json", "destination": "https://storage.googleapis.com/flutter-uxr/surveys/flutter-survey-metadata.json", "type": 301 },


### PR DESCRIPTION
This PR adds a redirect from docs.flutter.dev/download -> /install

This is precautionary, as we're adding a /download redirect from the marketing site to docs.flutter.dev/install, which is being advertised in a FWE video, and folks might accidentally try the url on the docs site.