### PR TITLE
Fix style of leading console token in code blocks

### DIFF
--- a/site/lib/_sass/components/_code.scss
+++ b/site/lib/_sass/components/_code.scss
@@ -130,11 +130,8 @@ pre {
       }
     }
 
-    .terminal-command::before {
-      color: $margin-fgColor;
-      content: "$";
-      content: "$" / "";
-      padding-right: 0.5rem;
+    span[aria-hidden="true"] {
+      user-select: none;
     }
   }
 

--- a/site/lib/src/style_hash.dart
+++ b/site/lib/src/style_hash.dart
@@ -2,4 +2,4 @@
 // dart format off
 
 /// The generated hash of the `main.css` file.
-const generatedStylesHash = '0lnBUTa5o0lF';
+const generatedStylesHash = 'MGuX2wOew92p';


### PR DESCRIPTION
Makes console tokens (`$`) in code blocks a different color and prevents text selection.