### PR TITLE
Fix errors in `RadialExpansion class` example

### DIFF
--- a/src/content/ui/animations/hero-animations.md
+++ b/src/content/ui/animations/hero-animations.md
@@ -557,12 +557,12 @@ class RadialExpansion extends StatelessWidget {
   const RadialExpansion({
     super.key,
     required this.maxRadius,
-    required this.child,
+    this.child,
   }) : [!clipRectSize = 2.0 * (maxRadius / math.sqrt2);!]
 
   final double maxRadius;
   final double clipRectSize;
-  final Widget child;
+  final Widget? child;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
This change fixes these errors  
<img width="722" height="78" alt="err_1" src="https://github.com/user-attachments/assets/cd1aef4b-2d3f-4987-a23f-b7592b4d2ebf" />

<img width="623" height="40" alt="err_2" src="https://github.com/user-attachments/assets/447e89e6-e5cf-4847-ba82-56a3bdf6e742" />

Fixes : #12761 

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
