### PR TITLE
Add collapsed code-block support for tutorial challenges

### DIFF
--- a/site/lib/src/extensions/code_block_processor.dart
+++ b/site/lib/src/extensions/code_block_processor.dart
@@ -88,6 +88,11 @@ final class CodeBlockProcessor implements PageExtension {
             );
           }
 
+          final isCollapsed = metadata.containsKey('collapsed');
+          if (isCollapsed && title == null) {
+            throw ArgumentError('Collapsed code blocks must have a title.');
+          }
+
           final isFolding = metadata.containsKey('foldable');
 
           final diffResult = isDiff
@@ -126,6 +131,7 @@ final class CodeBlockProcessor implements PageExtension {
               tag: tag != null ? CodeBlockTag.parse(tag) : null,
               initialLineNumber: initialLineNumber ?? 1,
               showLineNumbers: showLineNumbers,
+              collapsed: isCollapsed,
             ),
           );
         }

--- a/src/content/tutorial/ui/layout.md
+++ b/src/content/tutorial/ui/layout.md
@@ -91,7 +91,7 @@ class GamePage extends StatelessWidget {
 
 **Solution:**
 
-```dart
+```dart title="solution.dart" collapsed
 class MainApp extends StatelessWidget {
   const MainApp({super.key});
 

--- a/src/content/tutorial/ui/user-input.md
+++ b/src/content/tutorial/ui/user-input.md
@@ -573,9 +573,9 @@ in complexity, you probably should. That said, the callbacks
 
 Refactor the code such that the logic inside this methods isn't repeated.
 
-**Solution**
+**Solution:**
 
-```dart
+```dart title="solution.dart" collapsed
 class GuessInput extends StatelessWidget {
   GuessInput({super.key, required this.onSubmitGuess});
 


### PR DESCRIPTION
The tutorial includes a few optional challenges that provide solutions.

There we collapse the solution code by default, using a similar style and shared implementation to the existing collapsible `DownloadableSnippet`.