### PR TITLE
Update developing-packages.md to the proper definition of a federated plugin

### DIFF
--- a/src/content/packages-and-plugins/developing-packages.md
+++ b/src/content/packages-and-plugins/developing-packages.md
@@ -153,7 +153,7 @@ A federated plugin requires the following:
 **app-facing interface**
 : The interface that plugin users interact with when using the
   plugin. This interface specifies the API used by the Flutter app.
-  In a package-separated federated plugin, this is the the package
+  In a package-separated federated plugin, this is the package
   that plugin users depend on to use the plugin. 
 
 **platform implementation(s)**


### PR DESCRIPTION
The currently stated definition of a federated plugin is slightly off from the [original definition](https://docs.google.com/document/d/1LD7QjmzJZLCopUrFAAE98wOUQpjmguyGTN2wd_89Srs/edit?tab=t.0#heading=h.fxi4zmto7rth](https://www.google.com/url?q=https://docs.google.com/document/d/1LD7QjmzJZLCopUrFAAE98wOUQpjmguyGTN2wd_89Srs/edit?tab%3Dt.0%23heading%3Dh.fxi4zmto7rth&sa=D&source=docs&ust=1764793986204835&usg=AOvVaw2TIxFw9HeLwzrEAKJiTO60)). "Federated Plugin" refers to the code structure, but is now typically referred to as the package structure. This adds separate phrases to separate the terms. 

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
