### PR TITLE
Add wrapped page header and utility button

### DIFF
--- a/site/lib/_sass/_site.scss
+++ b/site/lib/_sass/_site.scss
@@ -14,6 +14,7 @@
 @use 'components/alert';
 @use 'components/banner';
 @use 'components/books';
+@use 'components/breadcrumbs';
 @use 'components/button';
 @use 'components/card';
 @use 'components/code';

--- a/site/lib/_sass/components/_breadcrumbs.scss
+++ b/site/lib/_sass/components/_breadcrumbs.scss
@@ -1,0 +1,47 @@
+nav.breadcrumbs {
+  align-items: center;
+
+  ol.breadcrumb-list {
+    margin: 0;
+    padding: 0;
+    border-radius: var(--site-radius);
+    font-size: 0.925rem;
+
+    align-items: center;
+    list-style: none;
+
+    font-family: var(--site-ui-fontFamily);
+
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+
+    li.breadcrumb-item {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      padding: 0;
+
+      & a {
+        padding: 0.125rem;
+        border-radius: 0.125rem;
+      }
+
+      &.active a {
+        color: var(--site-base-fgColor-lighter);
+        cursor: default;
+        text-decoration: none;
+      }
+
+      &:before {
+        display: none;
+      }
+    }
+
+    .material-symbols {
+      user-select: none;
+      font-size: 1.25rem;
+      color: var(--site-base-fgColor-lighter);
+    }
+  }
+}

--- a/site/lib/_sass/components/_content.scss
+++ b/site/lib/_sass/components/_content.scss
@@ -53,10 +53,50 @@ main {
   }
 
   #site-content-title {
-    margin-block-end: 1rem;
+    position: relative;
+    font-family: var(--site-ui-fontFamily);
+    margin-block-end: 1.5rem;
+    scroll-margin-top: calc(var(--site-header-height) + var(--site-subheader-height) + 1.25rem);
+
+    &.wrap {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+
+      background-color: var(--site-raised-bgColor);
+      padding: 1rem;
+      border-radius: var(--site-radius);
+    }
 
     h1 {
-      margin-bottom: 0;
+      text-wrap: pretty;
+      padding-right: 1rem;
+    }
+
+    .page-description {
+      margin-block: 0;
+    }
+
+    #page-header-options {
+      position: absolute;
+      top: 0.75rem;
+      right: 0.75rem;
+
+      > button {
+        color: var(--site-base-fgColor-alt);
+
+        > span.material-symbols {
+          font-size: 1.5rem;
+        }
+      }
+
+      .dropdown-content {
+        right: -0.5rem;
+
+        background-color: var(--site-raised-bgColor);
+        border: var(--site-outline) 1px solid;
+        box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .15);
+      }
     }
   }
 
@@ -88,9 +128,9 @@ main {
 
   h1 {
     font-size: 2.75rem;
+    font-weight: 500;
     margin-top: 0;
     margin-bottom: 0;
-    scroll-margin-top: 8rem;
   }
 
   h2 {
@@ -165,53 +205,6 @@ main {
     border: 2px solid var(--site-outline-variant);
     background-color: var(--site-inset-bgColor);
     max-width: 100%;
-  }
-}
-
-nav.breadcrumbs {
-  align-items: center;
-  margin-block-end: 1rem;
-
-  >ol {
-    border-radius: 0.375rem;
-    margin-block-start: 0;
-    padding: 0.375rem 0;
-
-    align-items: center;
-    list-style: none;
-
-    font-family: var(--site-ui-fontFamily);
-
-    display: flex;
-    flex-wrap: wrap;
-    flex-direction: row;
-
-    li.breadcrumb-item {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      padding: 0;
-
-      & a {
-        padding: 0.125rem;
-        border-radius: 0.125rem;
-      }
-
-      &.active a {
-        color: var(--site-base-fgColor-alt);
-        cursor: default;
-        text-decoration: none;
-      }
-
-      &:before {
-        display: none;
-      }
-    }
-
-    .child-icon {
-      user-select: none;
-      color: var(--site-base-fgColor-lighter);
-    }
   }
 }
 

--- a/site/lib/_sass/components/_dropdown.scss
+++ b/site/lib/_sass/components/_dropdown.scss
@@ -12,6 +12,10 @@
     border: var(--site-outline-variant) 1px solid;
     z-index: var(--site-z-dropdown);
 
+    .text-button {
+      color: var(--site-base-fgColor-lighter);
+    }
+
     .dropdown-divider {
       background-color: var(--site-outline-variant);
       border-radius: 0.5rem;
@@ -37,6 +41,7 @@
           button {
             display: flex;
             align-items: center;
+            justify-content: flex-start;
             flex-direction: row;
             width: 100%;
             gap: 0.4rem;

--- a/site/lib/jaspr_options.dart
+++ b/site/lib/jaspr_options.dart
@@ -23,29 +23,31 @@ import 'package:docs_flutter_dev_site/src/components/common/client/on_this_page_
     as prefix7;
 import 'package:docs_flutter_dev_site/src/components/common/client/os_selector.dart'
     as prefix8;
-import 'package:docs_flutter_dev_site/src/components/common/client/simple_tooltip.dart'
+import 'package:docs_flutter_dev_site/src/components/common/client/page_header_options.dart'
     as prefix9;
-import 'package:docs_flutter_dev_site/src/components/dartpad/dartpad_injector.dart'
+import 'package:docs_flutter_dev_site/src/components/common/client/simple_tooltip.dart'
     as prefix10;
-import 'package:docs_flutter_dev_site/src/components/layout/client/pagenav.dart'
+import 'package:docs_flutter_dev_site/src/components/dartpad/dartpad_injector.dart'
     as prefix11;
-import 'package:docs_flutter_dev_site/src/components/layout/menu_toggle.dart'
+import 'package:docs_flutter_dev_site/src/components/layout/client/pagenav.dart'
     as prefix12;
-import 'package:docs_flutter_dev_site/src/components/layout/site_switcher.dart'
+import 'package:docs_flutter_dev_site/src/components/layout/menu_toggle.dart'
     as prefix13;
-import 'package:docs_flutter_dev_site/src/components/layout/theme_switcher.dart'
+import 'package:docs_flutter_dev_site/src/components/layout/site_switcher.dart'
     as prefix14;
-import 'package:docs_flutter_dev_site/src/components/pages/archive_table.dart'
+import 'package:docs_flutter_dev_site/src/components/layout/theme_switcher.dart'
     as prefix15;
-import 'package:docs_flutter_dev_site/src/components/pages/glossary_search_section.dart'
+import 'package:docs_flutter_dev_site/src/components/pages/archive_table.dart'
     as prefix16;
-import 'package:docs_flutter_dev_site/src/components/pages/learning_resource_filters.dart'
+import 'package:docs_flutter_dev_site/src/components/pages/glossary_search_section.dart'
     as prefix17;
-import 'package:docs_flutter_dev_site/src/components/pages/learning_resource_filters_sidebar.dart'
+import 'package:docs_flutter_dev_site/src/components/pages/learning_resource_filters.dart'
     as prefix18;
-import 'package:docs_flutter_dev_site/src/components/tutorial/client/quiz.dart'
+import 'package:docs_flutter_dev_site/src/components/pages/learning_resource_filters_sidebar.dart'
     as prefix19;
-import 'package:jaspr_content/components/file_tree.dart' as prefix20;
+import 'package:docs_flutter_dev_site/src/components/tutorial/client/quiz.dart'
+    as prefix20;
+import 'package:jaspr_content/components/file_tree.dart' as prefix21;
 
 /// Default [JasprOptions] for use with your jaspr project.
 ///
@@ -106,59 +108,64 @@ JasprOptions get defaultJasprOptions => JasprOptions(
       'src/components/common/client/os_selector',
     ),
 
-    prefix9.SimpleTooltip: ClientTarget<prefix9.SimpleTooltip>(
+    prefix9.PageHeaderOptions: ClientTarget<prefix9.PageHeaderOptions>(
+      'src/components/common/client/page_header_options',
+      params: _prefix9PageHeaderOptions,
+    ),
+
+    prefix10.SimpleTooltip: ClientTarget<prefix10.SimpleTooltip>(
       'src/components/common/client/simple_tooltip',
-      params: _prefix9SimpleTooltip,
+      params: _prefix10SimpleTooltip,
     ),
 
-    prefix10.DartPadInjector: ClientTarget<prefix10.DartPadInjector>(
+    prefix11.DartPadInjector: ClientTarget<prefix11.DartPadInjector>(
       'src/components/dartpad/dartpad_injector',
-      params: _prefix10DartPadInjector,
+      params: _prefix11DartPadInjector,
     ),
 
-    prefix11.PageNav: ClientTarget<prefix11.PageNav>(
+    prefix12.PageNav: ClientTarget<prefix12.PageNav>(
       'src/components/layout/client/pagenav',
-      params: _prefix11PageNav,
+      params: _prefix12PageNav,
     ),
 
-    prefix12.MenuToggle: ClientTarget<prefix12.MenuToggle>(
+    prefix13.MenuToggle: ClientTarget<prefix13.MenuToggle>(
       'src/components/layout/menu_toggle',
     ),
 
-    prefix13.SiteSwitcher: ClientTarget<prefix13.SiteSwitcher>(
+    prefix14.SiteSwitcher: ClientTarget<prefix14.SiteSwitcher>(
       'src/components/layout/site_switcher',
     ),
 
-    prefix14.ThemeSwitcher: ClientTarget<prefix14.ThemeSwitcher>(
+    prefix15.ThemeSwitcher: ClientTarget<prefix15.ThemeSwitcher>(
       'src/components/layout/theme_switcher',
     ),
 
-    prefix15.ArchiveTable: ClientTarget<prefix15.ArchiveTable>(
+    prefix16.ArchiveTable: ClientTarget<prefix16.ArchiveTable>(
       'src/components/pages/archive_table',
-      params: _prefix15ArchiveTable,
+      params: _prefix16ArchiveTable,
     ),
 
-    prefix16.GlossarySearchSection:
-        ClientTarget<prefix16.GlossarySearchSection>(
+    prefix17.GlossarySearchSection:
+        ClientTarget<prefix17.GlossarySearchSection>(
           'src/components/pages/glossary_search_section',
         ),
 
-    prefix17.LearningResourceFilters:
-        ClientTarget<prefix17.LearningResourceFilters>(
+    prefix18.LearningResourceFilters:
+        ClientTarget<prefix18.LearningResourceFilters>(
           'src/components/pages/learning_resource_filters',
         ),
 
-    prefix18.LearningResourceFiltersSidebar:
-        ClientTarget<prefix18.LearningResourceFiltersSidebar>(
+    prefix19.LearningResourceFiltersSidebar:
+        ClientTarget<prefix19.LearningResourceFiltersSidebar>(
           'src/components/pages/learning_resource_filters_sidebar',
         ),
 
-    prefix19.InteractiveQuiz: ClientTarget<prefix19.InteractiveQuiz>(
+    prefix20.InteractiveQuiz: ClientTarget<prefix20.InteractiveQuiz>(
       'src/components/tutorial/client/quiz',
-      params: _prefix19InteractiveQuiz,
+      params: _prefix20InteractiveQuiz,
     ),
   },
-  styles: () => [...prefix20.FileTree.styles],
+  styles: () => [...prefix21.FileTree.styles],
 );
 
 Map<String, dynamic> _prefix1CollapseButton(prefix1.CollapseButton c) => {
@@ -179,27 +186,32 @@ Map<String, dynamic> _prefix5DownloadLatestButton(
 Map<String, dynamic> _prefix6FeedbackComponent(prefix6.FeedbackComponent c) => {
   'issueUrl': c.issueUrl,
 };
-Map<String, dynamic> _prefix9SimpleTooltip(prefix9.SimpleTooltip c) => {
+Map<String, dynamic> _prefix9PageHeaderOptions(prefix9.PageHeaderOptions c) => {
+  'title': c.title,
+  'sourceUrl': c.sourceUrl,
+  'issueUrl': c.issueUrl,
+};
+Map<String, dynamic> _prefix10SimpleTooltip(prefix10.SimpleTooltip c) => {
   'target': c.target.toId(),
   'content': c.content.toId(),
 };
-Map<String, dynamic> _prefix10DartPadInjector(prefix10.DartPadInjector c) => {
+Map<String, dynamic> _prefix11DartPadInjector(prefix11.DartPadInjector c) => {
   'title': c.title,
   'theme': c.theme,
   'height': c.height,
   'runAutomatically': c.runAutomatically,
 };
-Map<String, dynamic> _prefix11PageNav(prefix11.PageNav c) => {
+Map<String, dynamic> _prefix12PageNav(prefix12.PageNav c) => {
   'breadcrumbs': c.breadcrumbs,
   'pageNumber': c.pageNumber,
   'initialHeading': c.initialHeading,
   'content': c.content.toId(),
 };
-Map<String, dynamic> _prefix15ArchiveTable(prefix15.ArchiveTable c) => {
+Map<String, dynamic> _prefix16ArchiveTable(prefix16.ArchiveTable c) => {
   'os': c.os,
   'channel': c.channel,
 };
-Map<String, dynamic> _prefix19InteractiveQuiz(prefix19.InteractiveQuiz c) => {
+Map<String, dynamic> _prefix20InteractiveQuiz(prefix20.InteractiveQuiz c) => {
   'title': c.title,
   'questions': c.questions.map((i) => i.toJson()).toList(),
 };

--- a/site/lib/src/components/common/client/page_header_options.dart
+++ b/site/lib/src/components/common/client/page_header_options.dart
@@ -1,0 +1,126 @@
+// Copyright 2025 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:jaspr/jaspr.dart';
+import 'package:universal_web/js_interop.dart';
+import 'package:universal_web/web.dart' as web;
+
+import '../button.dart';
+import '../dropdown.dart';
+
+@client
+final class PageHeaderOptions extends StatefulComponent {
+  const PageHeaderOptions({
+    required this.title,
+    this.sourceUrl,
+    this.issueUrl,
+    super.key,
+  });
+
+  final String title;
+  final String? sourceUrl;
+  final String? issueUrl;
+
+  @override
+  State<PageHeaderOptions> createState() => _PageHeaderOptionsState();
+}
+
+final class _PageHeaderOptionsState extends State<PageHeaderOptions> {
+  bool _isShareSupported = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkShareSupport();
+  }
+
+  void _checkShareSupport() {
+    if (kIsWeb) {
+      try {
+        // Check if the share API is available.
+        _isShareSupported = web.window.navigator.canShare(_shareData);
+      } catch (_) {
+        _isShareSupported = false;
+      }
+      setState(() {});
+    }
+  }
+
+  String get _currentBaseUrl =>
+      web.window.location.origin + web.window.location.pathname;
+
+  web.ShareData get _shareData => web.ShareData(
+    url: _currentBaseUrl,
+    title: component.title,
+  );
+
+  @override
+  Component build(BuildContext _) => Dropdown(
+    id: 'page-header-options',
+    toggle: const Button(icon: 'more_vert', title: 'View page options.'),
+    content: nav(
+      classes: 'dropdown-menu',
+      attributes: {
+        'role': 'menu',
+      },
+      [
+        ul(
+          [
+            li(
+              [
+                if (_isShareSupported)
+                  Button(
+                    icon: 'share',
+                    content: 'Share page',
+                    onClick: () {
+                      web.window.navigator.share(_shareData).toDart.ignore();
+                    },
+                  )
+                else
+                  Button(
+                    icon: 'copy',
+                    content: 'Copy link',
+                    onClick: () {
+                      web.window.navigator.clipboard
+                          .writeText(_currentBaseUrl)
+                          .toDart
+                          .ignore();
+                    },
+                  ),
+              ],
+            ),
+            if (component.sourceUrl case final sourceUrl?)
+              li(
+                [
+                  Button(
+                    icon: 'docs',
+                    content: 'View source',
+                    href: sourceUrl,
+                    attributes: const {
+                      'target': '_blank',
+                      'rel': 'noopener',
+                    },
+                  ),
+                ],
+              ),
+            if (component.issueUrl case final issueUrl?)
+              li(
+                [
+                  Button(
+                    icon: 'bug_report',
+                    content: 'Report issue',
+                    href: issueUrl,
+                    attributes: const {
+                      'target': '_blank',
+                      'rel': 'noopener',
+                    },
+                  ),
+                ],
+              ),
+          ],
+        ),
+      ],
+    ),
+  );
+}

--- a/site/lib/src/components/common/page_header.dart
+++ b/site/lib/src/components/common/page_header.dart
@@ -1,0 +1,55 @@
+// Copyright 2025 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:jaspr/jaspr.dart';
+import 'package:jaspr_content/jaspr_content.dart';
+
+import '../../markdown/markdown_parser.dart';
+import '../../util.dart';
+import '../../utils/page_source_info.dart';
+import 'breadcrumbs.dart';
+import 'client/page_header_options.dart';
+
+final class PageHeader extends StatelessComponent {
+  const PageHeader({
+    super.key,
+    required this.title,
+    this.description,
+    this.wrap = true,
+    this.showBreadcrumbs = true,
+  });
+
+  final String title;
+  final String? description;
+  final bool wrap;
+  final bool showBreadcrumbs;
+
+  @override
+  Component build(BuildContext context) {
+    final sourceInfo = context.page.sourceInfo;
+
+    return header(
+      id: 'site-content-title',
+      classes: [if (wrap) 'wrap'].toClasses,
+      [
+        if (showBreadcrumbs) const PageBreadcrumbs(),
+        h1(id: 'document-title', [
+          DashMarkdown(content: title, inline: true),
+        ]),
+        if (description case final description? when description.isNotEmpty)
+          p(
+            classes: ['page-description'].toClasses,
+            [
+              text(description),
+            ],
+          ),
+        PageHeaderOptions(
+          title: title,
+          sourceUrl: sourceInfo.sourceUrl,
+          issueUrl: sourceInfo.issueUrl,
+        ),
+      ],
+    );
+  }
+}

--- a/site/lib/src/components/layout/trailing_content.dart
+++ b/site/lib/src/components/layout/trailing_content.dart
@@ -5,47 +5,27 @@
 import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_content/jaspr_content.dart';
 
+import '../../utils/page_source_info.dart';
 import '../common/client/feedback.dart';
 
 /// The trailing content of a content documentation page, such as
 /// its last updated information, report an issue links, and similar.
 class TrailingContent extends StatelessComponent {
-  const TrailingContent({super.key, this.repo});
-
-  final String? repo;
+  const TrailingContent({super.key});
 
   @override
   Component build(BuildContext context) {
     final page = context.page;
-    final pageUrl = page.url;
     final pageData = page.data.page;
     final siteData = page.data.site;
-    final branch = siteData['branch'] as String? ?? 'main';
-    final repoLinks = siteData['repo'] as Map<String, Object?>? ?? {};
-    final repoUrl =
-        repo ??
-        repoLinks['this'] as String? ??
-        'https://github.com/dart-lang/site-www';
-    final inputPath = pageData['inputPath'] as String?;
     final pageDate = pageData['date'] as String?;
 
     final currentFlutterVersion =
         siteData['currentFlutterVersion'] as String? ?? '';
-    final siteUrl = siteData['url'] as String? ?? 'https://docs.flutter.dev';
 
-    final fullPageUrl = '$siteUrl$pageUrl';
-    final String issueUrl;
-    final String? pageSource;
-
-    if (inputPath != null) {
-      pageSource = '$repoUrl/blob/$branch/${inputPath.replaceAll('./', '')}';
-      issueUrl =
-          '$repoUrl/issues/new?template=1_page_issue.yml&page-url=$fullPageUrl&page-source=$pageSource';
-    } else {
-      pageSource = null;
-      issueUrl =
-          '$repoUrl/issues/new?template=1_page_issue.yml&page-url=$fullPageUrl';
-    }
+    final sourceInfo = page.sourceInfo;
+    final issueUrl = sourceInfo.issueUrl;
+    final pageSource = sourceInfo.sourceUrl;
 
     return div(
       id: 'trailing-content',

--- a/site/lib/src/layouts/doc_layout.dart
+++ b/site/lib/src/layouts/doc_layout.dart
@@ -5,13 +5,12 @@
 import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_content/jaspr_content.dart';
 
-import '../components/common/breadcrumbs.dart';
+import '../components/common/page_header.dart';
 import '../components/common/prev_next.dart';
 import '../components/layout/banner.dart';
 import '../components/layout/toc.dart';
 import '../components/layout/trailing_content.dart';
 import '../models/page_navigation_model.dart';
-import '../util.dart';
 import 'dash_layout.dart';
 
 /// The Jaspr Content layout to use for normal docs pages,
@@ -30,6 +29,7 @@ class DocLayout extends FlutterDocsLayout {
     final siteData = page.data.site;
 
     final pageTitle = pageData['title'] as String;
+    final pageDescription = (pageData['description'] as String?)?.trim();
     final showBanner =
         (pageData['showBanner'] as bool?) ??
         (siteData['showBanner'] as bool?) ??
@@ -66,16 +66,11 @@ class DocLayout extends FlutterDocsLayout {
                 DashTableOfContents(toc),
               ]),
             article([
-              div(id: 'site-content-title', [
-                h1(id: 'document-title', [
-                  if (pageData['underscore_breaker_titles'] == true)
-                    ...splitByUnderscore(pageTitle)
-                  else
-                    text(pageTitle),
-                ]),
-                if (allowBreadcrumbs && pageData['showBreadcrumbs'] != false)
-                  const PageBreadcrumbs(),
-              ]),
+              PageHeader(
+                title: pageTitle,
+                description: pageDescription,
+                showBreadcrumbs: pageData['showBreadcrumbs'] as bool? ?? true,
+              ),
 
               child,
 

--- a/site/lib/src/style_hash.dart
+++ b/site/lib/src/style_hash.dart
@@ -2,4 +2,4 @@
 // dart format off
 
 /// The generated hash of the `main.css` file.
-const generatedStylesHash = 'NTjkkEUUtAQJ';
+const generatedStylesHash = '5eXkrWDGsAxO';

--- a/site/lib/src/utils/page_source_info.dart
+++ b/site/lib/src/utils/page_source_info.dart
@@ -1,0 +1,58 @@
+// Copyright 2025 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:jaspr_content/jaspr_content.dart';
+
+/// Information about a page's source location and related URLs.
+final class PageSourceInfo {
+  const PageSourceInfo({
+    required this.issueUrl,
+    this.sourceUrl,
+  });
+
+  /// The URL to create a new issue for this page.
+  final String issueUrl;
+
+  /// The URL to view the source of this page on GitHub.
+  ///
+  /// This will be `null` if the page doesn't have an `inputPath`.
+  final String? sourceUrl;
+}
+
+extension PageSourceInfoExtension on Page {
+  /// Returns the source information for this page.
+  PageSourceInfo get sourceInfo {
+    final pageUrl = url;
+    final pageData = data.page;
+    final siteData = data.site;
+    final branch = siteData['branch'] as String? ?? 'main';
+    final repoLinks = siteData['repo'] as Map<String, Object?>? ?? {};
+    final repoUrl =
+        repoLinks['this'] as String? ?? 'https://github.com/flutter/website';
+    final inputPath = pageData['inputPath'] as String?;
+    final siteUrl = siteData['url'] as String? ?? 'https://docs.flutter.dev';
+
+    final fullPageUrl = '$siteUrl$pageUrl';
+    final String? pageSourceUrl;
+    final String issueUrl;
+
+    if (inputPath != null) {
+      pageSourceUrl = '$repoUrl/blob/$branch/${inputPath.replaceAll('./', '')}';
+      issueUrl =
+          '$repoUrl/issues/new?template=1_page_issue.yml&'
+          'page-url=$fullPageUrl&'
+          'page-source=$pageSourceUrl';
+    } else {
+      pageSourceUrl = null;
+      issueUrl =
+          '$repoUrl/issues/new?template=1_page_issue.yml&'
+          'page-url=$fullPageUrl';
+    }
+
+    return PageSourceInfo(
+      issueUrl: issueUrl,
+      sourceUrl: pageSourceUrl,
+    );
+  }
+}


### PR DESCRIPTION
Begin each doc with a wrapped card of the breadcrumbs (if they exist), the page title, the page description, and a more options button to share the page.

Example on [`/ui/layout`](https://flutter-docs-prod--pr12797-feat-wrapped-page-header-an-rccxfb0l.web.app/ui/layout):

<img width="835" height="215" alt="Screenshot of wrapped page header" src="https://github.com/user-attachments/assets/1f34b9a7-6c3c-4bb0-b30f-d6e5872eac18" />


As follow-up, we can explore adding other operations to the more options dropdown, such as "View as Markdown", "Open in AI Studio", etc.

**Staged:** https://flutter-docs-prod--pr12797-feat-wrapped-page-header-an-rccxfb0l.web.app/ui/layout

Closes https://github.com/flutter/website/issues/12103