### PR TITLE
Add Flutter iOS role

### DIFF
--- a/src/content/jobs/_template.md
+++ b/src/content/jobs/_template.md
@@ -9,7 +9,6 @@ showToc: false
 3. Remove the leading underscore (_) to allow the document to be published
 4. Specify the full job title in the front matter
 5. Update the sections with a TODO, removing the TODO when complete
-6. Adjust the "To apply" link if necessary
 {% endcomment %}
 
 ## About the team
@@ -36,11 +35,6 @@ and we celebrate and support the career progression of our team members.
 
 Here on the Flutter team and at Google, we embrace our differences
 and are [committed to furthering our culture of inclusion](https://flutter.dev/culture).
-In addition to groups like the [Flutteristas](https://flutteristas.org/),
-[Employee Resource Groups (ERGs)](https://diversity.google/commitments/)
-are employee-initiated networks for supporting underrepresented employees
-and their allies with shared values of creating belonging
-across their communities and Google.
 
 ### Work-life balance
 
@@ -71,4 +65,4 @@ well-balanced life—both in and outside of work.
 
 ## To apply
 
-Please apply by [filling out the following form](https://flutter.dev/go/job).
+Please apply via [this Google Careers page](<TODO: Link>).

--- a/src/content/jobs/index.md
+++ b/src/content/jobs/index.md
@@ -6,5 +6,11 @@ description: Open job listings for the Flutter and Dart teams.
 
 ## Current openings
 
+#### Sunnyvale, CA, USA
+
+* [Software Engineer III, Flutter (iOS)](/jobs/swe_ios_iii)
+
+{% comment %}
 The Flutter and Dart SWE teams aren't currently hiring.
 Thanks for your interest!
+{% endcomment %}

--- a/src/content/jobs/swe_ios_iii.md
+++ b/src/content/jobs/swe_ios_iii.md
@@ -1,0 +1,94 @@
+---
+title: Software Engineer III, Flutter (iOS)
+showToc: false
+---
+
+## About the team
+
+This full time position is on the Flutter iOS team.
+
+## About the position
+
+Google's software engineers develop the next-generation technologies that
+change how billions of users connect, explore, and interact with information
+and one another. Our products need to handle information at massive scale,
+and extend well beyond web search. We're looking for engineers who bring
+fresh ideas from all areas, including information retrieval, distributed computing,
+large-scale system design, networking and data storage, security, artificial
+intelligence, natural language processing, UI design and mobile; the list goes on
+and is growing every day. As a software engineer, you will work on a specific
+project critical to Google’s needs with opportunities to switch teams and projects
+as you and our fast-paced business grow and evolve. We need our engineers to be
+versatile, display leadership qualities and be enthusiastic to take on new problems
+across the full-stack as we continue to push technology forward.
+
+The US base salary range for this full-time position is $141,000-$202,000 + bonus +
+equity + benefits. Our salary ranges are determined by role, level, and location. Within
+the range, individual pay is determined by work location and additional factors,
+including job-related skills, experience, and relevant education or training. Your
+recruiter can share more about the specific salary range for your preferred location
+during the hiring process.
+
+Please note that the compensation details listed in US role postings reflect the
+base salary only, and do not include bonus, equity, or benefits.
+Learn more about
+[benefits at Google](https://www.google.com/about/careers/applications/benefits/).
+
+## Our values
+
+### Mentorship
+
+Upon joining Google, you will be paired with a formal mentor,
+who will help guide you in the process of ramping up, forging relationships,
+and learning the systems you'll need to do your job.
+Your manager can also help you find mentors who can coach you
+as you navigate your career at Google. In addition to formal mentors,
+we work and train together so that we are always learning from one another,
+and we celebrate and support the career progression of our team members.
+
+### Inclusion
+
+Here on the Flutter team and at Google, we embrace our differences
+and are [committed to furthering our culture of inclusion](https://flutter.dev/culture).
+
+### Work-life balance
+
+Our team also puts a high value on work-life balance.
+Striking a healthy balance between your personal and professional life
+is crucial to your happiness and success here, which is why we aren't focused
+on how many hours you spend at work or online. Instead,
+we're happy to offer a flexible schedule so you can have a more productive and
+well-balanced life—both in and outside of work.
+
+## Job location
+
+Sunnyvale, CA, USA
+
+## Job responsibilities
+
+* Implement complex native integrations (for example, text input,
+accessibility) to achieve fidelity and responsiveness for Flutter on iOS.
+* Analyze WWDC announcements and beta releases to proactively ensure day-zero
+compatibility with emerging technologies like new versions of Swift.
+* Profile to improve Flutter startup latency, memory usage, and frame rates,
+ensuring platform parity with native applications.
+
+## Qualifications
+
+### Minimum qualifications
+
+* Bachelor’s degree or equivalent practical experience.
+* 2 years of experience with software development in Objective-C or Swift
+programming languages.
+* 2 years of experience with iOS application development.
+
+### Preferred qualifications
+
+* Master's degree or PhD in Computer Science, or a related technical field.
+* Experience building SDKs, frameworks, or contributing to open-source projects
+used by other developers.
+* Experience with iOS performance and memory profiling.
+
+## To apply
+
+Please apply via [this Google Careers page](https://www.google.com/about/careers/applications/jobs/results/101341377605837510).


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ 
1. Add link to open role on Flutter iOS team.
2. Evidently we want to retire https://flutter.dev/go/job and link to the Google Careers page instead. Update the template.
3. Update inclusion section to remove outdated info, keep reference to https://flutter.dev/culture.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
