### PR TITLE
Fix link to Very Good Engineering architecture documentation

### DIFF
--- a/src/content/app-architecture/recommendations.md
+++ b/src/content/app-architecture/recommendations.md
@@ -85,7 +85,7 @@ It also makes it straightforward and low risk to add new logic and new UI.
 
 [Compass app source code]: https://github.com/flutter/samples/tree/main/compass_app
 [very_good_cli]: https://cli.vgv.dev/
-[Very Good Engineering architecture documentation]: https://engineering.verygood.ventures/architecture/
+[Very Good Engineering architecture documentation]: https://engineering.verygood.ventures/architecture/architecture/
 [State Management with ChangeNotifier walkthrough]: /get-started/fwe/state-management
 [Flutter developer tools]: /tools/devtools
 [flutter_lints]: https://pub.dev/packages/flutter_lints


### PR DESCRIPTION
broken link: Page Not Found : the page / resource doesn't exist on the server

_Issues fixed by this PR (if any):_

Fixed link of broken architecture documentation website

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
