### PR TITLE
Update header in `using-packages` for better readability

### DIFF
--- a/src/content/packages-and-plugins/using-packages.md
+++ b/src/content/packages-and-plugins/using-packages.md
@@ -142,7 +142,7 @@ To add the package `css_colors` to an app:
      so a full restart of the app might be required to avoid
      errors like `MissingPluginException` when using the package.
 
-### Removing a package dependency to an app using `flutter pub remove`
+### Removing a package dependency from an app using `flutter pub remove`
 
 To remove the package `css_colors` from an app:
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why: Changing wording of "Removing a package dependency to an app using flutter pub remove" to "Removing a package dependency **from** an app using flutter pub remove" to improve readability

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
