### PR TITLE
[experiment] Part 2 of refactor c-interop guides to support hooks.

### DIFF
--- a/src/content/platform-integration/android/c-interop.md
+++ b/src/content/platform-integration/android/c-interop.md
@@ -1,45 +1,55 @@
 ---
-title: "Binding to native Android code using dart:ffi"
-description: "To use C code in your Flutter program, use the dart:ffi library."
+title: "Binding to native Android code"
+description: "To use C code in your Flutter program, use build hooks or the dart:ffi library."
 ---
 
 <?code-excerpt path-base="platform_integration"?>
 
-Flutter mobile and desktop apps can use the
-[dart:ffi][] library to call native C APIs.
-_FFI_ stands for [_foreign function interface._][FFI]
-Other terms for similar functionality include
-_native interface_ and _language bindings._
+This guide demonstrates how to bind your Flutter app to native Android code.
+
+## Overview
+
+Flutter mobile and desktop apps can use [build hooks][] or the the [dart:ffi][]
+library to call native C APIs. FFI stands for
+[_foreign function interface._][FFI]. Other terms for similar functionality
+include _native interface_ and _language bindings_.
 
 :::note
-This page describes using the `dart:ffi` library
-in Android apps. For information on iOS, see
-[Binding to native iOS code using dart:ffi][ios-ffi].
-For information in macOS, see
-[Binding to native macOS code using dart:ffi][macos-ffi].
 This feature is not yet supported for web plugins.
 :::
 
+Prefer using an FFI package with [build hooks][] and code assets.
 
-[ios-ffi]: /platform-integration/ios/c-interop
+**Packages with code assets**:
+*   Don't require OS-specific build scripts.
+*   Run on all OSes and on Dart standalone.
+*   Access native code in a uniform way no matter what link mode is used.
+
+**Legacy FFI plugins**:
+*   Can access the Flutter plugin API.
+*   Can use Google Play services on Android.
+
+[build hooks]: {{site.baseurl}}/packages-and-plugins/developing-packages#build-hooks
 [dart:ffi]: {{site.dart.api}}/dart-ffi/dart-ffi-library.html
-[macos-ffi]: /platform-integration/macos/c-interop
 [FFI]: https://en.wikipedia.org/wiki/Foreign_function_interface
 
-Before your library or program can use the FFI library
-to bind to native code, you must ensure that the
-native code is loaded and its symbols are visible to Dart.
-This page focuses on compiling, packaging,
-and loading Android native code within a Flutter plugin or app.
+### Accessing native code (build hooks)
 
-This tutorial demonstrates how to bundle C/C++
-sources in a Flutter plugin and bind to them using
-the Dart FFI library on both Android and iOS.
-In this walkthrough, you'll create a C function
-that implements 32-bit addition and then
-exposes it through a Dart plugin named "native_add".
+When using build hooks, you can access native code using the
+`@Native` annotation. The `@Native` annotation resolves native symbols
+automatically.
 
-## Dynamic vs static linking
+```dart
+@Native<Int32 Function(Int32, Int32)>(symbol: 'native_add')
+external int nativeAdd(int a, int b);
+```
+
+Currently, build hooks essentially use dynamic linking.
+However, the `@Native` annotation is agnostic to the linking method.
+This means that if build hooks support static linking in the future,
+your Dart code won't need to change.
+
+### Dynamic vs static linking (legacy FFI plugin) {: #static-linking }
 
 A native library can be linked into an app either
 dynamically or statically. A statically linked library
@@ -66,13 +76,12 @@ On Android, only dynamic libraries are supported
 (because the main executable is the JVM,
 which we don't link to statically).
 
-
 [Dart API reference documentation]: {{site.dart.api}}
 [`DynamicLibrary.executable`]: {{site.dart.api}}/dart-ffi/DynamicLibrary/DynamicLibrary.executable.html
 [`DynamicLibrary.open`]: {{site.dart.api}}/dart-ffi/DynamicLibrary/DynamicLibrary.open.html
 [`DynamicLibrary.process`]: {{site.dart.api}}/dart-ffi/DynamicLibrary/DynamicLibrary.process.html
 
-## Create an FFI package {: #create-an-ffi-plugin }
+## Create an FFI package (build hooks) {: #create-an-ffi-package }
 
 To create an FFI package called "native_add",
 do the following:
@@ -82,45 +91,84 @@ $ flutter create --template=package_ffi native_add
 $ cd native_add
 ```
 
-:::note
-You can exclude platforms from `--platforms` that you don't want
-to build to. However, you need to include the platform of
-the device you are testing on.
-:::
-
 This creates a package with C/C++ sources in `native_add/src`.
 These sources are built by the `hook/build.dart` file.
 
 The FFI library can only bind against C symbols,
 so in C++ these symbols are marked `extern "C"`.
 
+:::note
+If you are using the legacy `plugin_ffi`,
 You should also add attributes to indicate that the
 symbols are referenced from Dart,
 to prevent the linker from discarding the symbols
 during link-time optimization.
 `__attribute__((visibility("default"))) __attribute__((used))`.
+:::
 
 The native code is invoked from dart in `lib/native_add_bindings_generated.dart`.
 
 The bindings are generated with [package:ffigen]({{site.pub-pkg}}/ffigen).
 
-### Legacy FFI plugin
+### Platform library (build hooks) {: #platform-library }
+
+To link against a platform library, use the `DynamicLoadingSystem` in your
+`hook/build.dart`.
+
+For example, to load OpenGL ES (v3):
+
+```dart
+      output.assets.code.add(
+        CodeAsset(
+          package: 'my_package',
+          name: 'libGLES_v3',
+          linkMode: DynamicLoadingSystem(Uri.file('libGLES_v3.so')),
+        ),
+      );
+```
+
+You might need to update the Android manifest
+file of the app or plugin if indicated by
+the documentation.
+
+### First-party support
+
+The process for including native code in source
+code or binary form is the same for an app or
+plugin.
+
+### Open-source third-party support
+
+For open source, build the C/C++ sources in your build hook. Or build the
+sources on GitHub actions and download the binary from github artifacts on
+the build hook.
+
+### Closed-source third-party support
+
+For closed source, build the dynamic library somewhere, and download it in
+your build hook.
+
+## Create an FFI plugin (legacy) {: #create-an-ffi-plugin }
+
+Before your library or program can use the FFI library
+to bind to native code, you must ensure that the
+native code is loaded and its symbols are visible to Dart.
+This page focuses on compiling, packaging,
+and loading Android native code within a Flutter plugin or app.
 
 If you need to access the Flutter Plugin API in Swift/Kotlin,
 or if you need to configure a Google Play services runtime on Android,
 you should use the legacy `plugin_ffi` template:
 
 ```console
-$ flutter create --platforms=android,ios,macos,windows,linux --template=plugin_ffi native_add
+$ flutter create --platforms=android --template=plugin_ffi native_add
 ```
 
 This creates a plugin with C/C++ sources in `native_add/src`,
 but uses platform-specific build files (like `android/build.gradle`)
 to build the native code.
 
-## Other use cases
-
-### Platform library
+### Platform library (legacy FFI plugin)
 
 To link against a platform library,
 use the following instructions:
@@ -138,26 +186,18 @@ You might need to update the Android manifest
 file of the app or plugin if indicated by
 the documentation.
 
-
 [Android NDK Native APIs]: {{site.android-dev}}/ndk/guides/stable_apis
 
-#### First-party library
-
-The process for including native code in source
-code or binary form is the same for an app or
-plugin.
-
-#### Open-source third-party
+### Open-source third-party support (legacy)
 
 Follow the [Add C and C++ code to your project][]
 instructions in the Android docs to
 add native code and support for the native
 code toolchain (either CMake or `ndk-build`).
 
-
 [Add C and C++ code to your project]: {{site.android-dev}}/studio/projects/add-native-code
 
-#### Closed-source third-party library
+### Closed-source third-party library support (legacy)
 
 To create a Flutter plugin that includes Dart
 source code, but distribute the C/C++ library
@@ -170,7 +210,6 @@ in binary form, use the following instructions:
    Flutter package. Instead, it should be
    downloaded from a repository, such as
    JCenter.
-
 
 ## Android APK size (shared object compression)
 

--- a/src/content/platform-integration/macos/c-interop.md
+++ b/src/content/platform-integration/macos/c-interop.md
@@ -1,31 +1,39 @@
 ---
-title: "Binding to native macOS code using dart:ffi"
-description: "To use C code in your Flutter program, use the dart:ffi library."
+title: "Binding to native macOS code"
+description: "To use C code in your Flutter program, use build hooks or the dart:ffi library."
 ---
 
 <?code-excerpt path-base="platform_integration"?>
 
-Flutter mobile and desktop apps can use the
-[dart:ffi][] library to call native C APIs.
-_FFI_ stands for [_foreign function interface._][FFI]
-Other terms for similar functionality include
-_native interface_ and _language bindings._
+This guide demonstrates how to bind your Flutter app to native macOS code.
+
+## Overview
+
+Flutter mobile and desktop apps can use [build hooks][] or the the [dart:ffi][]
+library to call native C APIs. FFI stands for
+[_foreign function interface._][FFI]. Other terms for similar functionality
+include _native interface_ and _language bindings_.
 
 :::note
-This page describes using the `dart:ffi` library
-in macOS desktop apps.
-For information on Android, see
-[Binding to native Android code using dart:ffi][android-ffi].
-For information on iOS, see
-[Binding to native iOS code using dart:ffi][ios-ffi].
 This feature is not yet supported for web plugins.
 :::
 
+Prefer using an FFI package with [build hooks][] and code assets.
 
-[android-ffi]: /platform-integration/android/c-interop
-[ios-ffi]: /platform-integration/ios/c-interop
+**Packages with code assets**:
+*   Don't require OS-specific build scripts.
+*   Run on all OSes and on Dart standalone.
+*   Access native code in a uniform way no matter what link mode is used.
+
+**Legacy FFI plugins**:
+*   Can access the Flutter plugin API.
+*   Can use static linking on iOS.
+
+[build hooks]: {{site.baseurl}}/packages-and-plugins/developing-packages#build-hooks
 [dart:ffi]: {{site.dart.api}}/dart-ffi/dart-ffi-library.html
 [FFI]: https://en.wikipedia.org/wiki/Foreign_function_interface
+
+### Accessing native code (build hooks)
 
 Before your library or program can use the FFI library
 to bind to native code, you must ensure that the
@@ -33,14 +41,20 @@ native code is loaded and its symbols are visible to Dart.
 This page focuses on compiling, packaging,
 and loading macOS native code within a Flutter plugin or app.
 
-This tutorial demonstrates how to bundle C/C++
-sources in a Flutter plugin and bind to them using
-the Dart FFI library on macOS.
-In this walkthrough, you'll create a C function
-that implements 32-bit addition and then
-exposes it through a Dart plugin named "native_add".
+When using build hooks, you can access native code using the `@Native` annotation.
+The `@Native` annotation resolves native symbols automatically.
 
-## Dynamic vs static linking
+```dart
+@Native<Int32 Function(Int32, Int32)>(symbol: 'native_add')
+external int nativeAdd(int a, int b);
+```
+
+Currently, build hooks essentially use dynamic linking.
+However, the `@Native` annotation is agnostic to the linking method.
+This means that if build hooks support static linking in the future,
+your Dart code won't need to change.
+
+### Dynamic vs static linking (legacy FFI plugin)
 
 A native library can be linked into an app either
 dynamically or statically. A statically linked library
@@ -62,10 +76,9 @@ Dart using `DynamicLibrary.open`.
 API documentation is available from the
 [Dart API reference documentation][].
 
-
 [Dart API reference documentation]: {{site.dart.api}}
 
-## Create an FFI package {: #create-an-ffi-plugin }
+## Create an FFI package (build hooks) {: #create-an-ffi-package }
 
 If you already have a package, skip this step.
 
@@ -77,29 +90,55 @@ $ flutter create --template=package_ffi native_add
 $ cd native_add
 ```
 
-:::note
-You can exclude platforms from `--platforms` that you don't want
-to build to. However, you need to include the platform of
-the device you are testing on.
-:::
-
 This creates a package with C/C++ sources in `native_add/src`.
 These sources are built by the `hook/build.dart` file.
 
 The FFI library can only bind against C symbols,
 so in C++ these symbols are marked `extern "C"`.
 
+:::note
+If you are using the legacy `plugin_ffi`,
 You should also add attributes to indicate that the
 symbols are referenced from Dart,
 to prevent the linker from discarding the symbols
 during link-time optimization.
 `__attribute__((visibility("default"))) __attribute__((used))`.
+:::
 
 The native code is invoked from dart in `lib/native_add_bindings_generated.dart`.
 
 The bindings are generated with [package:ffigen]({{site.pub-pkg}}/ffigen).
 
-### Legacy FFI plugin
+### Platform library
+
+To link against a platform library,
+use the following instructions:
+
+1. In Xcode, open `Runner.xcworkspace`.
+1. Select the target platform.
+1. Click **+** in the **Linked Frameworks and Libraries**
+   section.
+1. Select the system library to link against.
+
+### First-party support
+
+A first-party native library can be included either
+as source or as a (signed) `.framework` file.
+It's probably possible to include statically linked
+archives as well, but it requires testing.
+
+### Open-source third-party support
+
+For open source, build the C/C++ sources in your build hook. Or build the
+sources on GitHub actions and download the binary from github artifacts on
+the build hook.
+
+### Closed-source third-party support
+
+For closed source, build the dynamic library somewhere, and download it in
+your build hook.
+
+## Create an FFI plugin (legacy) {: #create-an-ffi-plugin }
 
 If you need to access the Flutter Plugin API in Swift/Objective-C,
 you should use the legacy `plugin_ffi` template:
@@ -112,46 +151,50 @@ This creates a plugin with C/C++ sources in `native_add/src`,
 but uses platform-specific build files (like `macos/native_add.podspec`)
 to build the native code.
 
-## Other use cases
-
-### iOS and macOS
-
-Dynamically linked libraries are automatically loaded by
-the dynamic linker when the app starts. Their constituent
-symbols can be resolved using [`DynamicLibrary.process`][].
-You can also get a handle to the library with
-[`DynamicLibrary.open`][] to restrict the scope of
-symbol resolution, but it's unclear how Apple's
-review process handles this.
-
-Symbols statically linked into the application binary
-can be resolved using [`DynamicLibrary.executable`][] or
-[`DynamicLibrary.process`][].
-
-
-[`DynamicLibrary.executable`]: {{site.dart.api}}/dart-ffi/DynamicLibrary/DynamicLibrary.executable.html
-[`DynamicLibrary.open`]: {{site.dart.api}}/dart-ffi/DynamicLibrary/DynamicLibrary.open.html
-[`DynamicLibrary.process`]: {{site.dart.api}}/dart-ffi/DynamicLibrary/DynamicLibrary.process.html
-
-#### Platform library
-
-To link against a platform library,
-use the following instructions:
-
-1. In Xcode, open `Runner.xcworkspace`.
-1. Select the target platform.
-1. Click **+** in the **Linked Frameworks and Libraries**
-   section.
-1. Select the system library to link against.
-
-#### First-party library
+### First-party support
 
 A first-party native library can be included either
 as source or as a (signed) `.framework` file.
 It's probably possible to include statically linked
 archives as well, but it requires testing.
 
-#### Source code
+### Open-source third-party support
+
+To create a Flutter plugin that includes both
+C/C++/Objective-C _and_ Dart code,
+use the following instructions:
+
+1. In your plugin project,
+   open `macos/<myproject>.podspec`.
+1. Add the native code to the `source_files`
+   field.
+
+The native code is then statically linked into
+the application binary of any app that uses
+this plugin.
+
+### Closed-source third-party support
+
+To create a Flutter plugin that includes Dart
+source code, but distribute the C/C++ library
+in binary form, use the following instructions:
+
+1. In your plugin project,
+   open `macos/<myproject>.podspec`.
+1. Add a `vendored_frameworks` field.
+   See the [CocoaPods example][].
+
+:::warning
+**Do not** upload this plugin
+(or any plugin containing binary code) to pub.dev.
+Instead, this plugin should be downloaded
+from a trusted third-party,
+as shown in the CocoaPods example.
+:::
+
+[CocoaPods example]: {{site.github}}/CocoaPods/CocoaPods/blob/master/examples/Vendored%20Framework%20Example/Example%20Pods/VendoredFrameworkExample.podspec
+
+## Link to source code
 
 To link directly to source code,
 use the following instructions:
@@ -175,19 +218,7 @@ use the following instructions:
     @_cdecl("myFunctionName")
     ```
 
-#### Compiled (dynamic) library
-
-To link to a compiled dynamic library,
-use the following instructions:
-
-1. If a properly signed `Framework` file is present,
-   open `Runner.xcworkspace`.
-1. Add the framework file to the **Embedded Binaries**
-   section.
-1. Also add it to the **Linked Frameworks & Libraries**
-   section of the target in Xcode.
-
-#### Compiled (dynamic) library (macOS)
+## Compiled (dynamic) library
 
 To add a closed source library to a
 [Flutter macOS Desktop][] app,
@@ -225,41 +256,24 @@ use the following instructions:
 
 {% comment %}
 
-#### Open-source third-party library
+## Work with symbols
 
-To create a Flutter plugin that includes both
-C/C++/Objective-C _and_ Dart code,
-use the following instructions:
+Dynamically linked libraries are automatically loaded by
+the dynamic linker when the app starts. Their constituent
+symbols can be resolved using [`DynamicLibrary.process`][].
+You can also get a handle to the library with
+[`DynamicLibrary.open`][] to restrict the scope of
+symbol resolution, but it's unclear how Apple's
+review process handles this.
 
-1. In your plugin project,
-   open `macos/<myproject>.podspec`.
-1. Add the native code to the `source_files`
-   field.
+Symbols statically linked into the application binary
+can be resolved using [`DynamicLibrary.executable`][] or
+[`DynamicLibrary.process`][].
 
-The native code is then statically linked into
-the application binary of any app that uses
-this plugin.
 
-#### Closed-source third-party library
-
-To create a Flutter plugin that includes Dart
-source code, but distribute the C/C++ library
-in binary form, use the following instructions:
-
-1. In your plugin project,
-   open `macos/<myproject>.podspec`.
-1. Add a `vendored_frameworks` field.
-   See the [CocoaPods example][].
-
-:::warning
-**Do not** upload this plugin
-(or any plugin containing binary code) to pub.dev.
-Instead, this plugin should be downloaded
-from a trusted third-party,
-as shown in the CocoaPods example.
-:::
-
-[CocoaPods example]: {{site.github}}/CocoaPods/CocoaPods/blob/master/examples/Vendored%20Framework%20Example/Example%20Pods/VendoredFrameworkExample.podspec
+[`DynamicLibrary.executable`]: {{site.dart.api}}/dart-ffi/DynamicLibrary/DynamicLibrary.executable.html
+[`DynamicLibrary.open`]: {{site.dart.api}}/dart-ffi/DynamicLibrary/DynamicLibrary.open.html
+[`DynamicLibrary.process`]: {{site.dart.api}}/dart-ffi/DynamicLibrary/DynamicLibrary.process.html
 
 ## Stripping macOS symbols
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Refactor the layout of the c-interop guides to make it clear what hooks support and what they don't.

Required reviewer: @dcharkes 
