### PR TITLE
Remove unused import in widgets.md

### DIFF
--- a/src/content/get-started/fundamentals/widgets.md
+++ b/src/content/get-started/fundamentals/widgets.md
@@ -40,7 +40,6 @@ widget, as this trivial example shows:
 
 ```dart
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 void main() => runApp(const MyApp());
 


### PR DESCRIPTION

<img width="634" height="307" alt="2025-12-21 21-22-47-792 main dart_-_homepage_-_Visual_Studio_Code" src="https://github.com/user-attachments/assets/cd948894-de7b-4717-ac87-b2402338b7bd" />

Removed unused import statement for 'package:flutter/services.dart'.

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
