### PR TITLE
Fix(docs): Use 'prop drilling' terminology and add glossary entry (fixes #12828)

### DIFF
--- a/src/content/get-started/fundamentals/state-management.md
+++ b/src/content/get-started/fundamentals/state-management.md
@@ -157,9 +157,9 @@ Column(
 
 Passing the shared data for your app through widget constructors
 makes it clear to anyone reading the code that there are shared dependencies.
-However, creating a chain of widgets that only pass data down to their children
-is often referred to as _prop drilling_.
-
+Creating a chain of widgets that only pass data down to their children
+is often referred to as [_prop drilling_](/resources/glossary#prop-drilling).
+ 
 ### Using InheritedWidget
 
 Manually passing data down the widget tree can be verbose

--- a/src/data/glossary.yml
+++ b/src/data/glossary.yml
@@ -149,11 +149,14 @@
 
 - term: "Prop drilling"
   short_description: |-
-    The process of passing data through multiple layers of widgets via constructors.
+    The process of passing data through multiple layers of widgets
+    through constructor parameters.
   long_description: |-
-    The process of passing data through multiple layers of widgets via constructors,
-    usually to reach a deeper descendant. This pattern can become verbose, which is
-    why other state management solutions (like `InheritedWidget` or `Provider`) are often used.
+    The process of passing data through multiple layers of widgets
+    through constructor pareameterss, usually to reach a deeper descendant.
+    This pattern can become verbose, which is
+    why other state management solutions
+    (like `InheritedWidget` or `Provider`) are often used.
   related_links:
     - text: "State management: Sharing state"
       link: "/get-started/fundamentals/state-management#sharing-state-between-widgets"


### PR DESCRIPTION
Resolves #12828 by updating 'state-management.md' to explicitly use the term 'prop drilling' for the constructor-based data passing pattern, replacing the confusing 'dependency injection' reference in that specific context. Also adds 'Prop drilling' to the glossary.