### PR TITLE
Fix(docs): Add Groovy syntax tabs to Android deployment guide (fixes #12793)

### DIFF
--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -78,7 +78,7 @@ For example:
 <Tabs key="android-material-dependency">
 <Tab name="Kotlin">
 
-```groovy
+```kotlin
 dependencies {
     // ...
     implementation("com.google.android.material:material:<version>")


### PR DESCRIPTION
Resolves #12793 by adding Tabs to 'deployment/android.md' that provide Groovy syntax examples alongside the existing Kotlin (KTS) examples. This ensures users with older Flutter projects or those preferring Groovy can follow the Material dependency, Keystore, and Signing configuration steps.