### PR TITLE
Update FlutterLogo link to correct documentation

### DIFF
--- a/src/data/catalog/widgets.yml
+++ b/src/data/catalog/widgets.yml
@@ -1267,7 +1267,7 @@
   categories:
     - 'Basics'
   subcategories: []
-  link: https://api.flutter.dev/flutter/material/FlutterLogo-class.html
+  link: https://api.flutter.dev/flutter/widgets/FlutterLogo-class.html
 - name: Form
   description: >-
     An optional container for grouping together multiple form field widgets


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
1. Opened "widget index" and "basics" widgets
2. Click FlutterLogo card
3. Returned Firebase's "Page Not Found" 
4. Changed the path from ".../material/..." to ".../widgets/..."
5. Returned the correct FlutterLogo documentation page

_Issues fixed by this PR (if any):_
None

_PRs or commits this PR depends on (if any):_
None

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
