### PR TITLE
Update android-studio.md

### DIFF
--- a/src/content/tools/android-studio.md
+++ b/src/content/tools/android-studio.md
@@ -33,11 +33,9 @@ To install the latest version of the following IDEs, follow their instructions:
 
 
 ::note
-You still need to install the **Flutter SDK** even if the flutter plugin installed in **Android Studio**
+You still need to install the **Flutter SDK**; the Flutter plugin for **Android Studio** doesn't install it for you.
 
-* Follow this – [tutorial]({{site.android-dev}}/studio/install) to install the Flutter SDK 
-
-[tutorial]: {{site.android-dev}}/studio/install
+* To install the Flutter SDK, follow the [installation guide](/install).
 
 ### Install the Flutter plugin {: #install-plugin}
 


### PR DESCRIPTION
docs: clarify that the Flutter SDK must be installed separately from the Android Studio plugin.

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
