### PR TITLE
Update link for Activity UI design article

### DIFF
--- a/src/content/get-started/flutter-for/android-devs.md
+++ b/src/content/get-started/flutter-for/android-devs.md
@@ -1355,7 +1355,7 @@ user interfaces for larger screens, and help scale your application UI.
 In Flutter, both of these concepts fall under the umbrella of `Widget`s.
 
 To learn more about the UI for building Activities and Fragments,
-see the community-contributed Medium article,
+see the community-contributed article,
 [Flutter for Android Developers: How to design Activity UI in Flutter][].
 
 As mentioned in the [Intents][] section,
@@ -2380,7 +2380,7 @@ see the [`firebase_messaging`][] plugin documentation.
 [Firebase Messaging]: {{site.github}}/firebase/flutterfire/tree/master/packages/firebase_messaging
 [first party plugins]: {{site.pub}}/flutter/packages?q=firebase
 [Flutter for Android Developers: How to design LinearLayout in Flutter]: https://proandroiddev.com/flutter-for-android-developers-how-to-design-linearlayout-in-flutter-5d819c0ddf1a
-[Flutter for Android Developers: How to design Activity UI in Flutter]: https://blog.usejournal.com/flutter-for-android-developers-how-to-design-activity-ui-in-flutter-4bf7b0de1e48
+[Flutter for Android Developers: How to design Activity UI in Flutter]: https://burhanrashid52.com/flutter-for-android-developers-how-to-design-activity-ui-in-flutter/
 [`geolocator`]: {{site.pub}}/packages/geolocator
 [`http` package]: {{site.pub}}/packages/http
 [`image_picker`]: {{site.pub}}/packages/image_picker


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Link on Page https://docs.flutter.dev/get-started/flutter-for/android-devs#:~:text=To%20learn%20more%20about%20the%20UI%20for%20building%20Activities%20and%20Fragments%2C%20see%20the%20community%2Dcontributed%20Medium%20article%2C%20Flutter%20for%20Android%20Developers%3A%20How%20to%20design%20Activity%20UI%20in%20Flutter.

points to a medium article no longer exists.
After searching i found this Medium blog post https://burhanrashid52.medium.com/flutter-for-android-developers-how-to-design-activity-ui-in-flutter-4bf7b0de1e48 and in its referring to his blog so i added the link to his original article here https://burhanrashid52.com/flutter-for-android-developers-how-to-design-activity-ui-in-flutter/

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
