### PR TITLE
Add back(?) introductory video to main docs page

### DIFF
--- a/src/content/index.md
+++ b/src/content/index.md
@@ -37,6 +37,8 @@ see [What's new][].**
 Ready to build beautiful, multiplatform apps from a single codebase?
 This video walks you through the fundamentals of Flutter and shows you how to get started.
 
+<YouTubeEmbed id="W4JWeQolJsU" title="Build and ship amazing multiplatform iOS and Android apps with one codebase" fullWidth></YouTubeEmbed>
+
 Once you've [Set up Flutter][],
 you should follow the
 [Write your first Flutter app][] codelab


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
1. Documentation landing page says "... This video walks you through the fundamentals of Flutter and shows you how to get started." yet there is no video about it at all.
2. Looked into the commits, found out that it used to exist in #12240 [here](https://github.com/flutter/website/pull/12240/changes#diff-f85e66abf994e6568cd122a87c83e2ebf24c3fa27d0b732a7cdc3eb6482789b9R32-R34) and was deleted/moved(?) on #12243 [here](https://github.com/flutter/website/pull/12243/changes#diff-f85e66abf994e6568cd122a87c83e2ebf24c3fa27d0b732a7cdc3eb6482789b9L33). 
3. I added it back to the landing page by copying the id and title to the current video embed format
4. Was it intentional to remove the video? If yes, why not remove the text too?

_Issues fixed by this PR (if any):_
- None, have checked

_PRs or commits this PR depends on (if any):_
- #12240 
- #12243 

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
