### PR TITLE
Fix unclosed parentheses error on "Create a widget to make buttons" code excerpt

### DIFF
--- a/examples/layout/lakes/step3/lib/main.dart
+++ b/examples/layout/lakes/step3/lib/main.dart
@@ -132,5 +132,5 @@ class ButtonWithText extends StatelessWidget {
     );
   }
 }
-// #enddocregion button-with-text
-// #enddocregion button-section
+
+// #enddocregion button-with-text, button-section

--- a/src/content/ui/layout/tutorial.md
+++ b/src/content/ui/layout/tutorial.md
@@ -412,7 +412,6 @@ class ButtonWithText extends StatelessWidget {
       // ···
     );
   }
-
 }
 ```
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
1. Stumbled on an unclosed parentheses error while doing the tutorial
2. Added the closing parenthesis
3. No more stumbling :D

_Issues fixed by this PR (if any):_
- Presumed none

_PRs or commits this PR depends on (if any):_
- Presumed none

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
