### PR TITLE
docs: add Viewport to glossary

### DIFF
--- a/src/data/glossary.yml
+++ b/src/data/glossary.yml
@@ -30,7 +30,7 @@
 
 - term: "Hot reload"
   short_description: |-
-    A Flutter feature that allows you to inject updated code into 
+    A Flutter feature that allows you to inject updated code into
     a running application in the Dart VM and see the changes immediately
     while maintaining application state.
   long_description: |-
@@ -171,11 +171,12 @@
 
 - term: "Viewport"
   short_description: |-
-    A widget that displays a subset of its children based on the current scroll offset.
+    A widget that displays a subset of its children
+    based on the current scroll offset.
   long_description: |-
     A viewport is the visual component of the scrolling machinery.
     It displays a subset of its children (usually slivers)
-    based on the current scroll offset. 
+    based on the current scroll offset.
     It is often described as being "bigger on the inside"
     because it can contain more content than is visible on the screen.
   related_links:
@@ -204,7 +205,7 @@
     Widgets are composed together in a hierarchy to form the widget tree.
     When a widget's state changes, the Flutter framework
     rebuilds the necessary parts of the tree to update the UI.
-    
+
     There are two primary types of widgets,
     including [`StatelessWidget`][], which have no mutable state, and
     [`StatefulWidget`][], which have a persistent [state][] that can be updated.


### PR DESCRIPTION
Fixes #12642.

Adds a glossary entry for 'Viewport' to `src/data/glossary.yml`. defined as a widget that displays a subset of its children based on a scroll offset.