### PR TITLE
Fix wrong method channels link in `uiscenedelegate.md`

### DIFF
--- a/src/content/release/breaking-changes/uiscenedelegate.md
+++ b/src/content/release/breaking-changes/uiscenedelegate.md
@@ -118,7 +118,7 @@ sequence, plugin registration must now be handled in a new callback called
 2. Create method channels and platform views in
 `didInitializeImplicitFlutterEngine`, if applicable.
 
-If you previously created [method channels][platform-integration/platform-channels] or
+If you previously created [method channels][method-channels-docs] or
 [platform views][platform-views-docs] in
 `application:didFinishLaunchingWithOptions:`,
 move that logic to `didInitializeImplicitFlutterEngine`.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:

This change fixes a wrong link to `method channels` in `uiscenedelegate migration docs` because right now both  `method channels and platform views` point to [platform-views](https://docs.flutter.dev/platform-integration/ios/platform-views) which is incorrect.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
