### PR TITLE
docs: note scrollbar differences between Material and Cupertino

### DIFF
--- a/src/content/ui/adaptive-responsive/platform-adaptations.md
+++ b/src/content/ui/adaptive-responsive/platform-adaptations.md
@@ -151,11 +151,16 @@ On **iOS**, scrolling past the edge of a scrollable
 
 ### Scrollbars
 
-On **Material-based platforms** (such as Android and web), scrollbars are typically visible during scrolling and may remain visible depending on the platform and theme.
+On **Material-based platforms** (such as Android and web),
+scrollbars are typically visible during scrolling
+and may remain visible depending on the platform and theme.
 
-On **Cupertino-based platforms** (such as iOS), scrollbars are more minimal and generally only appear briefly while the user is actively scrolling, fading out when interaction stops.
+On **Cupertino-based platforms** (such as iOS),
+scrollbars are more minimal and generally only appear briefly
+while the user is actively scrolling, fading out when interaction stops.
 
-This difference reflects each platform’s visual conventions and helps maintain a native look and feel across devices.
+This difference reflects each platform’s visual conventions
+and helps maintain a native look and feel across devices.
 
 ### Momentum
 


### PR DESCRIPTION
Description of what this PR is changing or adding, and why:

Adds a short note in the Scrolling section describing visual scrollbar differences
between Material and Cupertino platforms. This clarifies platform adaptation
behavior and addresses the request in flutter/website#4306.

Issues fixed by this PR (if any):

Fixes flutter/website#4306

PRs or commits this PR depends on (if any):

None.

## Presubmit checklist

- [ X] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [X ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
