### PR TITLE
fix: Add troubleshooting for Windows filename too long error (#12898)

### DIFF
--- a/src/content/install/upgrade.md
+++ b/src/content/install/upgrade.md
@@ -167,8 +167,6 @@ the Dart [`pub outdated` documentation]({{site.dart-site}}/tools/pub/cmd/pub-out
 $ flutter pub outdated
 ```
 
-<a id="troubleshooting" aria-hidden="true"></a>
-
 ## Troubleshooting
 
 ### Windows: "Filename too long" error


### PR DESCRIPTION
Fixes #12898. Adds a troubleshooting section to upgrade.md for the 'Filename too long' error on Windows.