### PR TITLE
Fix(docs): Use .bashrc instead of .bash_profile for Linux install

### DIFF
--- a/src/_includes/docs/install/path/linux.md
+++ b/src/_includes/docs/install/path/linux.md
@@ -27,7 +27,7 @@
     <summary>Expand for <code>bash</code> instructions</summary>
 
     ```console
-    $ echo 'export PATH="<path-to-sdk>:$PATH"' >> ~/.bashrc
+    $ echo 'export PATH="<path-to-sdk>/bin:$PATH"' >> ~/.bashrc
     ```
 
     For example, if you downloaded Flutter into a


### PR DESCRIPTION
Fixes #12705. Uses .bashrc for interactive shell configuration on Linux.