### PR TITLE
Update Swift Package Manager pubspec.yaml syntax to use config section

### DIFF
--- a/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
+++ b/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
@@ -50,15 +50,22 @@ instructions.
 ### Turn off for a single project
 
 In the project's `pubspec.yaml` file, under the `flutter` section,
-add `disable-swift-package-manager: true`.
+set `enable-swift-package-manager` to `false` in the `config` subsection.
 
 ```yaml title="pubspec.yaml"
 # The following section is specific to Flutter packages.
 flutter:
-  disable-swift-package-manager: true
+  config:
+    enable-swift-package-manager: false
 ```
 
 This turns off Swift Package Manager for all contributors to this project.
+
+:::note Migrating from deprecated syntax
+If you were previously using `disable-swift-package-manager: true`,
+update your `pubspec.yaml` to use the new `config` section format shown above.
+The old syntax is deprecated and will produce an error in Flutter 3.38 and later.
+:::
 
 ### Turn off globally for all projects
 


### PR DESCRIPTION
## Description

Updates the Swift Package Manager documentation to use the new `flutter: config:` section format for pubspec.yaml configuration, replacing the deprecated `disable-swift-package-manager` field.

## Changes

**File:** `src/_includes/docs/swift-package-manager/how-to-enable-disable.md`

### Before (deprecated)
```yaml
flutter:
  disable-swift-package-manager: true
```

### After (current)
```yaml
flutter:
  config:
    enable-swift-package-manager: false
```

## Additional Changes

- Added a migration note to help users who were using the deprecated syntax
- The note explains that the old syntax produces an error in Flutter 3.38 and later

## Context

This change aligns the Swift Package Manager documentation with:
- The [pubspec options documentation](https://docs.flutter.dev/tools/pubspec) which already uses the new syntax
- [flutter/flutter#168433](https://github.com/flutter/flutter/pull/168433) which moved the config to the `config` section
- [flutter/flutter#167953](https://github.com/flutter/flutter/pull/167953) which introduced the `flutter: config:` section

## Testing

- Verified the new syntax matches what's documented in `src/content/tools/pubspec.md`
- Confirmed the markdown formatting follows existing patterns in the file

## Related Issues

Fixes #12924

## Pre-launch Checklist

- [x] I read the [Contributor Guide](https://github.com/flutter/website/blob/main/CONTRIBUTING.md)
- [x] I signed the [CLA](https://cla.developers.google.com/clas)
- [x] I listed at least one issue that this PR fixes in the description above