### PR TITLE
Fix case of autofocus property in user-input.md

### DIFF
--- a/src/content/learn/tutorial/user-input.md
+++ b/src/content/learn/tutorial/user-input.md
@@ -732,7 +732,7 @@ items:
       explanation: TextField doesn't have a focus method; you use a FocusNode.
     - text: "Set the `autofocus` property to true at runtime."
       correct: false
-      explanation: `autofocus` only works on initial build, not for moving focus later.
+      explanation: The 'autofocus' property only works on initial build, not for moving focus later.
     - text: "Use a FocusNode and call `requestFocus()` on it."
       correct: true
       explanation: "A FocusNode gives you control over focus, and calling `requestFocus()` moves focus to its associated widget."


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
changed `autoFocus` to `autofocus`. Verified that `autofocus` is correct in https://docs.flutter.dev/cookbook/forms/focus

_Issues fixed by this PR (if any):_
Copy paste of tutorial code produces an error due to incorrect casing of the `autofocus` property.

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
