### PR TITLE
Add back other install pages to sidenav

### DIFF
--- a/src/data/sidenav.yml
+++ b/src/data/sidenav.yml
@@ -9,6 +9,19 @@
       permalink: /install/quick
     - title: Custom setup
       permalink: /install/custom
+    - divider
+    - title: SDK archive
+      permalink: /install/archive
+    - title: Manage install
+      children:
+        - title: Upgrade SDK
+          permalink: /install/upgrade
+        - title: Add to path
+          permalink: /install/add-to-path
+        - title: Troubleshoot
+          permalink: /install/troubleshoot
+        - title: Uninstall SDK
+          permalink: /install/uninstall
 
 - title: Learn Flutter
   icon: school


### PR DESCRIPTION
@ericwindmill Do you have concerns with adding these back? It's a bit awkward if they aren't in the sidenav and also hard to find them.

Another option would be for this existing section to be "Set up Flutter" and have a separate "Manage installation" section, perhaps at the bottom of the sidenav.