### PR TITLE
Add missing text to Prompt vesioning section in `AI > Best practices > Prompting` page

### DIFF
--- a/src/content/ai/best-practices/prompting.md
+++ b/src/content/ai/best-practices/prompting.md
@@ -168,7 +168,7 @@ final result = await _clueSolverModel.generateContent(
 
 ### Prompt versioning
 
-This simple app keeps the prompt strings in code.
+This basic app keeps the prompt strings in code.
 This makes them hard to track down and update.
 For production apps, it's better to keep your prompts separated from the code,
 perhaps bundled as Flutter assets.


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

The [Prompt versioning](https://docs.flutter.dev/ai/best-practices/prompting#prompt-versioning) section in the [AI > Best practices > Prompting](https://docs.flutter.dev/ai/best-practices/prompting) page has incomplete text. 

This PR adds the missing text from the Flutter AI best practices [Google doc](https://docs.google.com/document/d/1PsOmd9aRLzG3P7q8rYP8oaw0xZGQIaib_BPDOPnAsxU/edit?usp=sharing). 

| Before | <img width="890" height="94" alt="Screenshot 2026-01-19 at 10 36 11" src="https://github.com/user-attachments/assets/494099e3-e032-4f89-a6f6-21e6deccc717" /> |
 |:---|:---|
| After |  <img width="905" height="139" alt="Screenshot 2026-01-19 at 10 37 43" src="https://github.com/user-attachments/assets/eeddb9a8-29a6-4d55-b9f9-94f21e06412e" />  |




## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
