### PR TITLE
Remove unused import in architectural overview

### DIFF
--- a/src/content/resources/architectural-overview.md
+++ b/src/content/resources/architectural-overview.md
@@ -277,7 +277,6 @@ way up to the root widget (the container that hosts the Flutter app, typically
 <?code-excerpt "lib/main.dart (main)"?>
 ```dart
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 void main() => runApp(const MyApp());
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
this change removes an unused import (`package:flutter/services.dart`) in the code example :
<img width="862" height="61" alt="Screenshot 2026-01-19 at 11 32 26" src="https://github.com/user-attachments/assets/5ca713b2-fe75-4d18-9ab2-4007d98e16fb" />
_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
