### PR TITLE
Fix(deployment): Improve Android build config docs

### DIFF
--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -444,7 +444,7 @@ Verify the following values:
 [applicationtag]: {{site.android-dev}}/guide/topics/manifest/application-element
 [permissiontag]: {{site.android-dev}}/guide/topics/manifest/uses-permission-element
 
-## Review the app's build configuration {:#review-the-gradle-build-configuration}
+## Review the Gradle build configuration {:#review-the-gradle-build-configuration}
 
 To verify the Android build configuration,
 review the `android` block in the default


### PR DESCRIPTION
Fixes #11347. Improves the 'Review the app's build configuration' section in android.md to be more actionable.