### PR TITLE
make stepper titles selectable

### DIFF
--- a/site/lib/_sass/components/_stepper.scss
+++ b/site/lib/_sass/components/_stepper.scss
@@ -102,6 +102,7 @@
   // Non-collapsible variant: all steps stay open, no toggle interaction
   &.non-collapsible > details > summary {
     pointer-events: none;
+    user-select: initial;
     cursor: default;
 
     span.material-symbols {


### PR DESCRIPTION
Fixes the issue that non-collapsible stepper titles are not selectable.

E.g. on https://docs.flutter.dev/learn/pathway