### PR TITLE
fix: update broken Flutter and Dart tutorial links

### DIFF
--- a/src/content/learn/tutorial/set-up-state-project.md
+++ b/src/content/learn/tutorial/set-up-state-project.md
@@ -56,8 +56,8 @@ free and accessible to everyone.
 :::
 
 [Wikipedia API]: https://en.wikipedia.org/api/rest_v1/
-[Getting started with Dart]: https://dart.dev/learn/tutorial
-[Introduction to Flutter UI]: https://docs.flutter.dev/learn/tutorial/create-an-app
+[Getting started with Dart]: {{site.dart-site}}/learn/tutorial
+[Introduction to Flutter UI]: /learn/tutorial/create-an-app
 [Wikipedia]: https://wikipedia.org/
 [donating to Wikipedia]: https://donate.wikimedia.org/
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Fixes two broken links in the documentation:

- **Getting started with Dart** → now points to the official https://dart.dev/learn/tutorial
- **Introduction to Flutter UI** → updated to the current correct URL https://docs.flutter.dev/learn/tutorial/create-an-app

Both links now work correctly and point to the latest official tutorials.

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
