### PR TITLE
[3.41] Add Android Content Sizing Documentation

### DIFF
--- a/src/content/add-to-app/android/add-flutter-view.md
+++ b/src/content/add-to-app/android/add-flutter-view.md
@@ -101,6 +101,16 @@ However, it's now possible to allow `FlutterView` to size itself
 based on its content. By using, `content_wrap` for either the height
 or the width a `FlutterView` can size itself, as shown in the [content sized sample project]({{site.repo.samples}}/tree/main/add_to_app/android_view/content_sizing_android_view).
 
+* To _enable_ Content-sized view when deploying your app,
+  add the following setting to your project's
+  `AndroidManifest.xml` file under the `<application>` tag:
+  
+```xml
+<meta-data
+  android:name="io.flutter.embedding.android.EnableContentSizing"
+  android:value="true" />
+```
+
 ### Restrictions
 
 Since content-sized Flutter views require your Flutter app to be able to size itself,


### PR DESCRIPTION
Add Android Content Sizing Documentation.  

This PR assumes https://github.com/flutter/samples/pull/2787 has landed. 

## Presubmit checklist

- [X] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [X] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
