### PR TITLE
adds redirect for /learn restructure

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -76,6 +76,8 @@
       { "source": "/intellij-setup", "destination": "/tools/android-studio#setup", "type": 301 },
       { "source": "/ios-release", "destination": "/deployment/ios", "type": 301 },
       { "source": "/json", "destination": "/data-and-backend/serialization/json", "type": 301 },
+      { "source": "/learn/tutorial", "destination": "/learn/pathway/tutorial", "type": 301 },
+      { "source": "/learn/tutorial/:rest*", "destination": "/learn/pathway/tutorial/:rest*", "type": 301 },
       { "source": "/ui/media", "destination": "/ui/assets", "type": 301 },
       { "source": "/ui/media/:rest*", "destination": "/ui/assets/:rest*", "type": 301 },
       { "source": "/networking", "destination": "/data-and-backend/networking", "type": 301 },


### PR DESCRIPTION
Sets up a redirect for the /learn/tutorial pages, as they're now in learn/pathway

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
