### PR TITLE
Fix use_null_aware_elements lint to unblock ci

### DIFF
--- a/site/lib/src/components/common/dash_image.dart
+++ b/site/lib/src/components/common/dash_image.dart
@@ -31,7 +31,7 @@ class DashImage with CustomComponentBase {
 
     final style =
         [
-              if (attributes['img-style'] case final s?) s,
+              ?attributes['img-style'],
               if (attributes['width'] case final w?) 'width: $w',
               if (attributes['height'] case final h?) 'height: $h',
             ]


### PR DESCRIPTION
Fixes CI failures in other PRs

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
