### PR TITLE
Fix forward Add2app Android Setup Docs

### DIFF
--- a/src/content/add-to-app/android/project-setup.md
+++ b/src/content/add-to-app/android/project-setup.md
@@ -327,7 +327,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven("https://storage.googleapis.com/download.flutter.io")
-        maven(url = "<some/path/flutter_module_project>/build/host/outputs/repo")
+        maven(url = "<some/path/flutter_module>/build/host/outputs/repo")
     }
 }
 ```


### PR DESCRIPTION
Fix forward of this https://github.com/flutter/website/pull/13023 (meant to mark it drafted but got merged right after approval. my bad). Removed repetitive instruction and ensured there are no mentions of Java 11.

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
