### PR TITLE
[hooks] Document dylib naming constraints

### DIFF
--- a/src/content/platform-integration/bind-native-code.md
+++ b/src/content/platform-integration/bind-native-code.md
@@ -195,7 +195,7 @@ target architectures and SDKs.
 
 On Apple platforms (iOS and macOS), dynamic libraries are bundled into
 frameworks. Flutter's build system relies on these names to generate metadata
-and package distributive formats like XCFrameworks.
+and package distributable formats like XCFrameworks.
 
 ### Consistency across architectures
 
@@ -247,6 +247,6 @@ target platform.
     build failures or Apple rejecting the application for including
     simulator-only binaries in a device build.
 *   **Recommended action**: Ensure that your `build.dart` hook logic handles
-    all supported SDKs consistently. If you have code that is only relevant
-    for a single SDK, include it in a dynamic library that is present in
-    both SDKs rather than creating a separate asset for it.
+    all supported SDKs consistently. If you produce an asset for one SDK, you
+    must produce a corresponding asset for all other SDKs for that platform.
+    For SDK-specific code, you can use stub implementations for other SDKs.


### PR DESCRIPTION
Context:

* https://github.com/flutter/flutter/pull/181507

Code assets reported from build hooks must have consistent naming on iOS and MacOS to support all use cases (specifically add2app) and have error messages easy to understand for developers depending on packages with code assets.

This PR adds documentation to the Flutter website to provide guidance.