### PR TITLE
Update body widget in layout.md to use Text instead of tile

### DIFF
--- a/src/content/learn/pathway/tutorial/layout.md
+++ b/src/content/learn/pathway/tutorial/layout.md
@@ -76,7 +76,7 @@ class MainApp extends StatelessWidget {
             child: Text('Birdle'),
           ),
         ),
-        body: Center(child: Text('A')),
+        body: Center(child: Text('Hello World!')),
       ),
     );
   }


### PR DESCRIPTION
Replace `Tile` widget with `Text` to match image and diagram.

Fixes https://github.com/flutter/website/issues/13038


## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
