### PR TITLE
Rename onPressed to nextArticleCallback in ArticlePage

### DIFF
--- a/src/content/learn/pathway/tutorial/listenable-builder.md
+++ b/src/content/learn/pathway/tutorial/listenable-builder.md
@@ -255,10 +255,8 @@ class ArticlePage extends StatelessWidget {
     return SingleChildScrollView(
       child: Column(
         children: [
-          Flexible(
-            child: ArticleWidget(
-              summary: summary,
-            ),
+          ArticleWidget(
+            summary: summary,
           ),
           ElevatedButton(
             onPressed: nextArticleCallback,


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Rename onPressed to nextArticleCallback in ArticlePage

_Issues fixed by this PR (if any):_
Fixes https://github.com/flutter/website/issues/13067
Fixes https://github.com/flutter/website/issues/13073
Fixes https://github.com/flutter/website/issues/13068
Fixes https://github.com/flutter/website/issues/13054

_PRs or commits this PR depends on (if any):_
None

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
