### PR TITLE
Typo in implicit-animations.md

### DIFF
--- a/src/content/learn/pathway/tutorial/implicit-animations.md
+++ b/src/content/learn/pathway/tutorial/implicit-animations.md
@@ -62,7 +62,7 @@ class Tile extends StatelessWidget {
       ),
       child: Center(
         child: Text(
-          letter.char.toUpperCase(),
+          letter.toUpperCase(),
           style: Theme.of(context).textTheme.titleLarge,
         ),
       ),
@@ -107,7 +107,7 @@ class Tile extends StatelessWidget {
       ),
       child: Center(
         child: Text(
-          letter.char.toUpperCase(),
+          letter.toUpperCase(),
           style: Theme.of(context).textTheme.titleLarge,
         ),
       ),
@@ -173,7 +173,7 @@ class Tile extends StatelessWidget {
       ),
       child: Center(
         child: Text(
-          letter.char.toUpperCase(),
+          letter.toUpperCase(),
           style: Theme.of(context).textTheme.titleLarge,
         ),
       ),


### PR DESCRIPTION
Inside the "Tile" class the member variable is defined as a "String" and inside the "Text" widget we are using it as a Record "letter.char.toUpperCase()" . But we extracted the String from the record when we were creating multiple tiles inside the "Row" widget of "GamePage" class by using "Collection for"

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
