### PR TITLE
Docs: Fix phrasing in case-study/index.md

### DIFF
--- a/src/content/app-architecture/case-study/index.md
+++ b/src/content/app-architecture/case-study/index.md
@@ -155,8 +155,8 @@ The example in this case-study demonstrates how one application abides by our
 recommended architectural rules, but there are many other example apps that
 could've been written. The UI of this app leans heavily on view models
 and `ChangeNotifier`, but it could've easily been written
-with streams, or with other libraries like provided by the [`riverpod`][],
-[`flutter_bloc`][], and [`signals`][] packages.
+with streams, or with other libraries such as [`riverpod`][],
+[`flutter_bloc`][], and [`signals`][].
 The communication between layers of this app handled
 everything with method calls, including polling for new data.
 It could've instead used streams to expose data from a repository to


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

This corrects a weird grammatical construction ("like provided by") on the "Architecture case study" page.

_Issues fixed by this PR (if any):_ 

- Fixes a grammatical typo/clunky phrasing.

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
