### PR TITLE
Include site sections on mobile sidenav

### DIFF
--- a/site/lib/src/components/layout/header.dart
+++ b/site/lib/src/components/layout/header.dart
@@ -54,7 +54,7 @@ class DashHeader extends StatelessComponent {
         ul(classes: 'nav-items', [
           _NavItem(
             href: '/',
-            label: 'User Guides',
+            label: 'Guides',
             isActive: activeEntry == ActiveNavEntry.home,
           ),
           _NavItem(

--- a/site/lib/src/components/layout/sidenav.dart
+++ b/site/lib/src/components/layout/sidenav.dart
@@ -30,28 +30,26 @@ final class DashSideNav extends StatelessComponent {
     final activeEntry = activeNavEntry(context.page.url);
 
     return div(id: 'sidenav', [
-      // Only show the nav items if the tutorial is active for now.
-      if (activeEntry == ActiveNavEntry.learn)
-        ul(classes: 'navbar-nav', [
-          _TopNavItem(
-            href: '/',
-            label: 'Home',
-            iconId: 'asterisk',
-            active: activeEntry == ActiveNavEntry.home,
-          ),
-          _TopNavItem(
-            href: '/learn',
-            label: 'Learn',
-            iconId: 'play_lesson',
-            active: activeEntry == ActiveNavEntry.learn,
-          ),
-          const _TopNavItem(
-            href: 'https://api.flutter.dev',
-            label: 'Reference',
-            iconId: 'api',
-          ),
-          const _SideNavDivider(),
-        ]),
+      ul(classes: 'navbar-nav', [
+        _TopNavItem(
+          href: '/',
+          label: 'Guides',
+          iconId: 'asterisk',
+          active: activeEntry == ActiveNavEntry.home,
+        ),
+        _TopNavItem(
+          href: '/learn',
+          label: 'Learn',
+          iconId: 'play_lesson',
+          active: activeEntry == ActiveNavEntry.learn,
+        ),
+        const _TopNavItem(
+          href: 'https://api.flutter.dev',
+          label: 'Reference',
+          iconId: 'api',
+        ),
+        const _SideNavDivider(),
+      ]),
 
       nav([
         _SideNavLevel(

--- a/site/lib/src/style_hash.dart
+++ b/site/lib/src/style_hash.dart
@@ -2,4 +2,4 @@
 // dart format off
 
 /// The generated hash of the `main.css` file.
-const generatedStylesHash = 'D1OovaDfTpf7';
+const generatedStylesHash = '';

--- a/src/content/release/whats-new.md
+++ b/src/content/release/whats-new.md
@@ -39,7 +39,7 @@ significant changes:
   both Flutter and Dart, as announced in a recent [blog post][fwe].
   You can find the Flutter [learning pathway][] under the **Learn**
   tab at the top of [docs.flutter.dev][]. To return to the rest of the site,
-  select the **User Guides** tab. As always, the **Reference**
+  select the **Guides** tab. As always, the **Reference**
   tab takes you to the [Flutter API docs][].
 
 * Flutter and Dart now have an [official glossary][].


### PR DESCRIPTION
Also renames "User Guides" to just "Guides" as we prefer "Developers" over "Users" and the title case is inconsistent with what we use elsewhere.

Fixes https://github.com/flutter/website/issues/13084