### PR TITLE
Typo Fix: Rename ContactsListPage to ContactListsPage

### DIFF
--- a/src/content/learn/pathway/tutorial/slivers.md
+++ b/src/content/learn/pathway/tutorial/slivers.md
@@ -304,7 +304,7 @@ class _AdaptiveLayoutState extends State<AdaptiveLayout> {
         if (isLargeScreen) {
           return _buildLargeScreenLayout();
         } else {
-          return const ContactsListPage(listId: 0); // New, temporary
+          return const ContactListsPage(listId: 0); // New, temporary
         }
       },
     );


### PR DESCRIPTION
Source url: https://docs.flutter.dev/learn/pathway/tutorial/slivers

**Page**: Flutter Docs
**Tutorial Scope**: Flutter UI 102
**Global Lesson number**: 15 - _Advanced scrolling and slivers_
**Lesson Section**: 04 - _Create Advanced scrolling for contacts_

**Problem Description**
In the first placeholder code snippet of the specified lesson section, there is a class misnomer  (`ContactsListPage`) in the given else block:

`else {
          return const ContactsListPage(listId: 0); // New, temporary
        }`

The typo results in an error in the `adaptive_layout.dart` file during that section of the tutorial.

This commit corrects the class name to ContactListsPage, defined in the `lib/data/screens/contacts.dart` file.