### PR TITLE
Omission Fix: Retain automaticallyImplyLeading default parameter

### DIFF
--- a/src/content/learn/pathway/tutorial/slivers.md
+++ b/src/content/learn/pathway/tutorial/slivers.md
@@ -390,9 +390,12 @@ default `CupertinoSliverNavigationBar` constructor:
 class _ContactListView extends StatelessWidget {
   const _ContactListView({
     required this.listId,
+    this.automaticallyImplyLeading = true,
   });
 
   final int listId;
+  final bool automaticallyImplyLeading;
+  
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Source url: https://docs.flutter.dev/learn/pathway/tutorial/slivers

**Page**: Flutter Docs
**Tutorial Scope**: Flutter UI 102
**Global Lesson number**: 15 - _Advanced scrolling and slivers_
**Lesson Section**: 07 - _Use `SliverList` for alphabetized sections_

_Description of what this PR is changing or adding, and why:_

- In Lesson 15, Section 4, Code Snippet 2 [`lib/screens/contacts.dart`], the `automaticallyImplyLeading` default, named parameter is introduced in the `_ContactListView` constructor, but it is unused.
- In the subsequent Section (5: _Add search integration with slivers_), Code Snippet 1, the `automaticallyImplyLeading` parameter is omitted from the `_ContactListView` class.
- However, by Section 7, the `automaticallyImplyLeading` parameter is referenced in the `_ContactListView` build method, but it throws an undefined name error due to intermittent omission of the `automaticallyImplyLeading` parameter:

`CupertinoSliverNavigationBar.search(
                 largeTitle: Text(contactList.title),
                 automaticallyImplyLeading: automaticallyImplyLeading, ...`


_Issues fixed by this PR (if any):_
To fix this, the `automaticallyImplyLeading` default parameter is reintroduced to the `_ContactListView` class in Section 7 as it originally was in Section 4.