### PR TITLE
fix: remove duplicate course

### DIFF
--- a/src/content/resources/courses.md
+++ b/src/content/resources/courses.md
@@ -45,8 +45,6 @@ To include your course, [submit a PR][]:
 
 * [Flutter Zero to Hero][] by Veli Bacik
 
-* [Flutter Zero to Hero][] by Veli Bacik
-
 ## Urdu
 
 * [Tech Idara - Flutter from Basic to Advanced][] by Ishaq Hassan


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why: There is a duplicate course reference in the Turkish section. I simply removed it.

@Sfshaza I also left a comment on the PR; I don't know if there would be a real need for a new merge for this type of fix. 

PR - [#13104](https://github.com/flutter/website/pull/13104)

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
