### PR TITLE
[website] Remove usesCleartextTraffic

### DIFF
--- a/src/content/release/breaking-changes/network-policy-ios-android.md
+++ b/src/content/release/breaking-changes/network-policy-ios-android.md
@@ -64,7 +64,7 @@ For instance, if you put your XML configuration under
 your manifest would contain the following:
 
 ```xml
-<application ...>
+<application android:networkSecurityConfig="@xml/network_security_config">
   ...
   <meta-data android:name="io.flutter.network-policy"
              android:resource="@xml/network_security_config"/>
@@ -77,7 +77,11 @@ If you would like to allow HTTP connections for Android debug
 builds, you can add the following snippet to your $project_path\android\app\src\debug\AndroidManifest.xml:
 
 ```xml
-<application android:networkSecurityConfig="@xml/network_security_config"> 
+<application android:networkSecurityConfig="@xml/network_security_config">
+  ...
+  <meta-data android:name="io.flutter.network-policy"
+             android:resource="@xml/network_security_config"/>
+</application>
 ```
 
 Then, add the network configuration to your $project_path/android/app/src/debug/res/xml/network_security_config.xml:


### PR DESCRIPTION
Removes deprecated usesCleartextTraffic. 

Addresses: https://github.com/flutter/flutter/issues/182553

## Presubmit checklist

- [X] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [X] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
