### PR TITLE
Add missing redirect from old get-started/install links

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -149,6 +149,7 @@
       { "source": "/get-started/fundamentals/*", "destination": "/learn/pathway", "type": 301 },
       { "source": "/get-started/install", "destination": "/install", "type": 301 },
       { "source": "/get-started/install/help", "destination": "/install/troubleshoot", "type": 301 },
+      { "source": "/get-started/install/*", "destination": "/install", "type": 301 },
       { "source": "/get-started/learn-flutter", "destination": "/learn", "type": 301 },
       { "source": "/get-started/learn-more", "destination": "/learn", "type": 301 },
       { "source": "/get-started/test-drive*", "destination": "/learn/pathway", "type": 301 },


### PR DESCRIPTION
Adds missing redirect from child links of `/get-started/install`, such as `/get-started/install/windows` that were used in the past.

Fixes https://github.com/flutter/website/issues/13114