### PR TITLE
Adds go link for dependency package hosting design doc

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -454,7 +454,7 @@
       { "source": "/go/floating-snackbar-offset", "destination": "https://docs.google.com/document/d/1elP-y83PtvfAZHNcpHCtnOFhZO9VnnlobwfQ33QO4hg/edit", "type": 301 },
       { "source": "/go/floating-widgetspans", "destination": "https://docs.google.com/document/d/1I-VqCxvszXGAas_6EE9b6ZIzyMY3HjxDxGW9_DWWd7M/edit", "type": 301 },
       { "source": "/go/flutter-android-emulator-testing", "destination": "https://docs.google.com/document/d/10wYUcLcSTF4Epg2EUGoBqOkkOe4zxKHvYKjXFZAOgGs/edit?usp=sharing&resourcekey=0-pltjPvEtVezXDADMbUwFHQ", "type": 301 },
-      { "source": "/go/flutter-dependency-hosting", "destination": "https://docs.google.com/document/d/1EKb1VypI0ArXqwBWJKGTsiQ2WU0ruYb55JpIeKxWaDs/edit?usp=sharing", "type": 301 },
+      { "source": "/go/flutter-dependency-hosting", "destination": "https://docs.google.com/document/d/1EKb1VypI0ArXqwBWJKGTsiQ2WU0ruYb55JpIeKxWaDs/edit", "type": 301 },
       { "source": "/go/flutter-developer-tooling-plugins", "destination": "https://docs.google.com/document/d/189A-T-pcHPuds8pOtbzLS8Wl6Hr0AIAIl0aRTPvLKec/", "type": 301 },
       { "source": "/go/flutter-devtools-extensions", "destination": "https://docs.google.com/document/d/189A-T-pcHPuds8pOtbzLS8Wl6Hr0AIAIl0aRTPvLKec/", "type": 301 },
       { "source": "/go/flutter-devtools-static-extensions", "destination": "https://docs.google.com/document/d/11J4h1oEfB9wBoRYUy4KzclnKITBY-234jKpU3kq4V4w/edit?resourcekey=0-pPo85Svkb9lKdtlrhMCTbw", "type": 301 },


### PR DESCRIPTION
Adds a go link for the [Flutter Dependency Package Hosting design document](https://docs.google.com/document/d/1EKb1VypI0ArXqwBWJKGTsiQ2WU0ruYb55JpIeKxWaDs/edit?usp=sharing).

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
