### PR TITLE
Fix #13102: clarify Linux build prerequisite structure

### DIFF
--- a/src/content/platform-integration/linux/building.md
+++ b/src/content/platform-integration/linux/building.md
@@ -60,11 +60,13 @@ operating system libraries against which it's been compiled.
 To see the full list of libraries,
 use the `ldd` command on your application's directory.
 
-For example, assume you have a Flutter desktop application
-called `linux_desktop_test`.
-To inspect the its system library dependencies, use the following commands:
+For example, to create a new Flutter desktop application called
+`linux_desktop_test`, build it, and inspect its system library dependencies,
+run the following commands:
 
 ```console
+$ flutter create linux_desktop_test
+$ cd linux_desktop_test
 $ flutter build linux --release
 $ ldd build/linux/x64/release/bundle/linux_desktop_test
 ```


### PR DESCRIPTION
Resolves #13102 by adding explicit flutter create and cd instructions before the flutter build linux commands in platform-integration/linux/building.md.