### PR TITLE
Fix integration_test command syntax in documentation

### DIFF
--- a/src/content/testing/integration-tests/index.md
+++ b/src/content/testing/integration-tests/index.md
@@ -132,7 +132,7 @@ To add `integration_test` and `flutter_test` packages as
 `dev_dependencies` using `sdk: flutter`, run following command.
 
 ```console
-$ flutter pub add 'dev:integration_test:{"sdk":"flutter"}'
+$ flutter pub add "dev:integration_test:{sdk: flutter}"
 ```
 
 Output:


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

> Change a commad. The original command is outdated and does not work properly.

_Issues fixed by this PR (if any):_

> None.

_PRs or commits this PR depends on (if any):_

> None.

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
