### PR TITLE
Fix/tutorial quiz answer position always at second position

### DIFF
--- a/site/lib/src/models/quiz_model.dart
+++ b/site/lib/src/models/quiz_model.dart
@@ -16,7 +16,8 @@ class Question {
       json['question'] as String,
       (json['options'] as List<Object?>)
           .map((e) => AnswerOption.fromJson(e as Map<Object?, Object?>))
-          .toList(),
+          .toList()
+        ..shuffle(),
     );
   }
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

This PR introduces randomization to the quiz answer options by calling shuffle() on the options list within the Question.fromMap factory in lib/models/quiz_model.dart.

Currently, the quiz content in the source Markdown files frequently positions the correct answer as the second option (index 1). Without shuffling, this creates a predictable pattern that allows users to identify the correct answer through position rather than content. Shuffling ensures a more effective learning experience.

_Issues fixed by this PR (if any):_

Fixes positional bias in interactive quiz modules where the correct answer consistently appears in the same slot across different sections.

_PRs or commits this PR depends on (if any):_
None
## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
