### PR TITLE
Wrap widget names at camel case boundaries

### DIFF
--- a/site/lib/src/components/pages/widget_catalog.dart
+++ b/site/lib/src/components/pages/widget_catalog.dart
@@ -115,7 +115,7 @@ class WidgetCatalogCard extends StatelessComponent {
     return a(href: widget.link, classes: 'card outlined-card', [
       _buildCardImageHolder(),
       div(classes: 'card-header', [
-        span(classes: 'card-title', [.text(widget.name)]),
+        span(classes: 'card-title', _splitCamelCase(widget.name)),
       ]),
       div(classes: 'card-content', [
         p([
@@ -183,4 +183,51 @@ class WidgetCatalogCard extends StatelessComponent {
       ],
     );
   }
+}
+
+class WidgetCardGrid extends StatelessComponent {
+  const WidgetCardGrid({
+    required this.widgets,
+    required this.isMaterialCatalog,
+    this.subcategory,
+  });
+
+  final List<WidgetCatalogWidget> widgets;
+  final bool isMaterialCatalog;
+  final WidgetCatalogSubcategory? subcategory;
+
+  @override
+  Component build(BuildContext _) => div(
+    classes: [
+      'card-grid',
+      if (isMaterialCatalog) 'material-cards',
+    ].toClasses,
+    [
+      for (final widget in widgets)
+        WidgetCatalogCard(
+          widget: widget,
+          isMaterialCatalog: isMaterialCatalog,
+          subcategory: subcategory,
+        ),
+    ],
+  );
+}
+
+final RegExp _camelCaseSplitRegex = RegExp(
+  r'(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])',
+);
+
+/// Splits an UpperCamelCase [name] into its constituent parts,
+/// interleaving `<wbr>` elements to allow the browser to
+/// break long widget names across lines.
+List<Component> _splitCamelCase(String name) {
+  final parts = name.split(_camelCaseSplitRegex);
+  if (parts.length <= 1) return [.text(name)];
+  return [
+    .text(parts.first),
+    for (var partIndex = 1; partIndex < parts.length; partIndex += 1) ...[
+      const wbr(),
+      .text(parts[partIndex]),
+    ],
+  ];
 }

--- a/site/lib/src/pages/widget_catalog.dart
+++ b/site/lib/src/pages/widget_catalog.dart
@@ -66,8 +66,8 @@ List<MemoryPage> get widgetCatalogPages {
 
             // Only show main category widgets for non-material catalogs.
             if (!isMaterialCatalog && widgetsInCategory.isNotEmpty)
-              _buildCardGrid(
-                widgetsInCategory,
+              WidgetCardGrid(
+                widgets: widgetsInCategory,
                 isMaterialCatalog: isMaterialCatalog,
               ),
 
@@ -166,31 +166,10 @@ List<Component> _buildSubcategorySection(
 
   return [
     h2(id: slugify(subName), [.text(subName)]),
-    _buildCardGrid(
-      widgets,
+    WidgetCardGrid(
+      widgets: widgets,
       isMaterialCatalog: isMaterialCatalog,
       subcategory: subcategory,
     ),
   ];
-}
-
-Component _buildCardGrid(
-  List<WidgetCatalogWidget> widgets, {
-  required bool isMaterialCatalog,
-  WidgetCatalogSubcategory? subcategory,
-}) {
-  return div(
-    classes: [
-      'card-grid',
-      if (isMaterialCatalog) 'material-cards',
-    ].toClasses,
-    [
-      for (final widget in widgets)
-        WidgetCatalogCard(
-          widget: widget,
-          isMaterialCatalog: isMaterialCatalog,
-          subcategory: subcategory,
-        ),
-    ],
-  );
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/website/issues/13124 by adding word-break opportunities at the camel case word boundaries. For example: `Cupertino<wbr>Desktop<wbr>Text<wbr>Selection<wbr>Toolbar`.

**Staged:** https://flutter-docs-prod--pr13142-fix-13124-ca4f1e2i.web.app/ui/widgets/cupertino