### PR TITLE
Add `/go/video-player-drm` design doc redirect

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -755,6 +755,7 @@
       { "source": "/go/vector-graphics", "destination": "https://docs.google.com/document/d/1YWffrlc6ZqRwfIiR1qwp1AOkS9JyA_lEURI8p5PsZlg/edit", "type": 301 },
       { "source": "/go/verbatim-logical-keys-for-non-latin-layout", "destination": "https://docs.google.com/document/d/1ZNgNxito-NVUS1JKlcjdzHUcKyyiupy8Za-jb131dD4/edit?usp=sharing&resourcekey=0-eeEZ5X0jAzuqSTdmPWlv0w", "type": 301 },
       { "source": "/go/video-player-background-playback", "destination": "https://docs.google.com/document/d/12WgZg2qzpCGyCRgZbG4Jr8msAV8Jd4_MTzqWimhg56M/edit?usp=sharing", "type": 301 },
+      { "source": "/go/video-player-drm", "destination": "https://docs.google.com/document/d/1T4LRRsicr_JuSkXBAXEcv7-9BnYPhmwgYnr1d6G6_o8/edit?usp=sharing", "type": 301 },
       { "source": "/go/web-add-to-app", "destination": "https://docs.google.com/document/d/1rFM0qmYds1JkntTruBh8eO72xbT2KoP9JdbizucAAwQ/edit", "type": 301 },
       { "source": "/go/web-astral-projections", "destination": "https://docs.google.com/document/d/1pvH-J8opXsjntTpFf1bbsbU8N1vFd8tPKvBgcNn8UKQ", "type": 301 },
       { "source": "/go/web-cleanup-service-worker", "destination": "https://docs.google.com/document/d/1czOm3Hmy_oIq3NJStezb9AjwkKyta3NospkCy_DDv9E/edit", "type": 301 },
@@ -780,7 +781,6 @@
       { "source": "/go/wrap-layout", "destination": "https://docs.google.com/document/d/1auZtWT1T5CkUKOUTUld8rF91iN7PvQoOF0IlBNXiDSo/edit?usp=sharing", "type": 301 },
       { "source": "/go/wrap-popupmenu-with-safearea", "destination": "https://docs.google.com/document/d/15uBmyEKiOeYGYt1PuBVf4SFK5YhH07EP9ylWP-H9mVE/edit?usp=sharing", "type": 301 },
       { "source": "/go/zero-rebuilds", "destination": "https://docs.google.com/document/d/1MfU6gkgIgXCxa5E25sPYuAP5Bmgehyl3Hk7yDH24zl0/edit?usp=sharing", "type": 301 },
-      { "source": "/go/video-player-drm", "destination": "https://docs.google.com/document/d/1T4LRRsicr_JuSkXBAXEcv7-9BnYPhmwgYnr1d6G6_o8/edit?usp=sharing", "type": 301 },
 
       { "source": "/to/actions-shortcuts", "destination": "/ui/interactivity/actions-and-shortcuts", "type": 301 },
       { "source": "/to/add-desktop-support", "destination": "/platform-integration/desktop#add-desktop-support-to-an-existing-flutter-app", "type": 301 },


### PR DESCRIPTION
## Description

Adds a `flutter.dev/go` redirect for the DRM support design document for `video_player`.

The new go link points to the public design doc covering proposed first-party DRM support for:
- Android Widevine
- iOS FairPlay

This is needed so the design doc follows the Flutter design doc process and can be referenced from the tracking issue and review discussions.

## Related Issues

- Design doc tracking issue: flutter/flutter#182894
- Related implementation PR: flutter/packages#11115

## Testing

- Verified the redirect entry was added in the expected location.
- Verified the destination URL points to the public Google Doc.

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
