### PR TITLE
Update WebSocket URL

### DIFF
--- a/examples/cookbook/networking/web_sockets/lib/main.dart
+++ b/examples/cookbook/networking/web_sockets/lib/main.dart
@@ -29,7 +29,7 @@ class _MyHomePageState extends State<MyHomePage> {
   final TextEditingController _controller = TextEditingController();
   // #docregion connect
   final WebSocketChannel _channel = WebSocketChannel.connect(
-    Uri.parse('wss://echo.websocket.events'),
+    Uri.parse('wss://echo.websocket.org'),
   );
   // #enddocregion connect
 

--- a/src/content/cookbook/networking/web-sockets.md
+++ b/src/content/cookbook/networking/web-sockets.md
@@ -137,7 +137,7 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   final TextEditingController _controller = TextEditingController();
   final WebSocketChannel _channel = WebSocketChannel.connect(
-    Uri.parse('wss://echo.websocket.events'),
+    Uri.parse('wss://echo.websocket.org'),
   );
 
   @override


### PR DESCRIPTION
Referencing the WebSocket documentation https://websocket.org/reference/websocket-api/, the correct echo server URL is now wss://echo.websocket.org.

Fixes: https://github.com/flutter/website/issues/13182

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
