### PR TITLE
Add `/go/android-built-in-kotlin-support` design doc redirect

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -306,7 +306,7 @@
       { "source": "/go/allow-datatable-row-height-to-expand", "destination": "https://docs.google.com/document/d/1qr1IgaU2z9eaM6zCa4u-Q8kJD5Zq7IcdxVyrgR7CwZc/edit?usp=sharing&resourcekey=0-1bNp0ocF4AwGBj6NvRfrEA", "type": 301 },
       { "source": "/go/analyze-flutter-in-runtime", "destination": "https://docs.google.com/document/d/1VZOv9NsmNeXaqM9h9EjKTz5cg7lEsA623XBfbojXU5U/edit?usp=sharing", "type": 301 },
       { "source": "/go/android-assets-in-flutter", "destination": "https://docs.google.com/document/d/1jymgQYxRTe5rdprt74ERh7Jsa0lfnRuMnkOmJusLWsE/edit", "type": 301 },
-      { "source": "/go/android-built-in-kotlin-support", "destination": "https://docs.google.com/document/d/1iAMVVvsHqs130hc3-49sstv7n63TgM5aUd-cqAGWHfc/edit?pli=1&tab=t.0", "type": 301 },
+      { "source": "/go/android-built-in-kotlin-support", "destination": "https://docs.google.com/document/d/1iAMVVvsHqs130hc3-49sstv7n63TgM5aUd-cqAGWHfc/edit", "type": 301 },
       { "source": "/go/android-dependency-versions", "destination": "https://docs.google.com/document/d/1qeeM5QG-jiafttSgvc7yvC19IDRggFFZQTktBVxL6sI/edit?usp=sharing&resourcekey=0-HLEAiBOMxAlQxDs-mEeffw", "type": 301 },
       { "source": "/go/android-embedding-dependencies", "destination": "https://docs.google.com/document/d/1vITp2mUZRa-cmll0sPH0zjNgPlyvOMx7awxPNRAPyic/edit", "type": 301 },
       { "source": "/go/android-embedding-move", "destination": "https://docs.google.com/document/d/1nQujwZfEe3QOHTyZn160eImpoJOYioADP09DtumcLcc/edit?ts=5d8041db#", "type": 301 },


### PR DESCRIPTION
## Description

Adds a `flutter.dev/go` redirect for the public [Support AGP’s Built-in Kotlin For the Ecosystem design doc](https://docs.google.com/document/d/1iAMVVvsHqs130hc3-49sstv7n63TgM5aUd-cqAGWHfc/edit?pli=1&tab=t.0).

This is needed so the design doc follows the Flutter design doc process and can be referenced from the tracking issue and review discussions.

## Related Issues

- https://github.com/flutter/flutter/issues/181383
- https://github.com/flutter/flutter/issues/180502
- https://github.com/flutter/flutter/issues/181557
- https://github.com/flutter/flutter/issues/183861

## Testing

- Verified the redirect entry was added in the expected location.
- Verified the destination URL points to the public Google Doc.

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
