### PR TITLE
Add /go/onmaploaded design doc redirect

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -627,6 +627,7 @@
       { "source": "/go/null-safety-workshop", "destination": "https://dartpad.dev/workshops.html?webserver=https://dartpad-workshops-io2021.web.app/null_safety_workshop", "type": 301 },
       { "source": "/go/nullable-cupertinothemedata-brightness", "destination": "https://docs.google.com/document/d/1qivq0CdkWGst5LU5iTLFUe_LTfLY84679-NxWiDgJXg/edit", "type": 301 },
       { "source": "/go/ondirtycallbacks", "destination": "https://docs.google.com/document/d/1Vk_QWC92fFGxx2oIrIjkCL0ZZFHxmrprlLedyQsnkus/edit?usp=sharing", "type": 301 },
+      { "source": "/go/onmaploaded", "destination": "https://docs.google.com/document/d/1ogwmAQOjbX6UoHnsQ1sQG2P0LRU2KRBED64jnjtBpIQ/edit?usp=sharing", "type": 301 },
       { "source": "/go/opengl-on-ios", "destination":"https://docs.google.com/document/d/1kvrb6HeTRN4noAKO82o6x-Ii61PW-BQ-8s9YNtLgosM", "type": 301 },
       { "source": "/go/optimized-platform-view-layers", "destination": "https://docs.google.com/document/d/1YHwVz7-F03psEzHxByGka_lIFaDV5K90BJMbNxQeK4k/edit?resourcekey=0-n4_VcUnMU-99sjJ6C1_Ycw#", "type": 301 },
       { "source": "/go/os-adaptive-shortcut-activator", "destination": "https://docs.google.com/document/d/11NWj13MSDw1XQg4MpYIeqzcCFGuzQ_Cz7tYXW7fqzPY/edit?usp=sharing", "type": 301 },


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Adds a `flutter.dev/go` redirect for the public [onMapLoaded Cross-Platform Semantics](https://docs.google.com/document/d/1ogwmAQOjbX6UoHnsQ1sQG2P0LRU2KRBED64jnjtBpIQ/edit?usp=sharing).

This is needed so the design doc follows the Flutter design doc process and can be referenced from the tracking issue and review discussions.

_Issues fixed by this PR (if any):_

https://github.com/flutter/flutter/issues/99610

_PRs or commits this PR depends on (if any):_

https://github.com/flutter/packages/pull/10714

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
