### PR TITLE
Also fix versionName in example build.gradle.kts

### DIFF
--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -470,7 +470,7 @@ android {
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
-        versionName = flutterVersionName
+        versionName = flutter.versionName
     }
 
     buildTypes {


### PR DESCRIPTION
There is a call to .toInteger() on flutter.versionCode in the example of build.gradle.kts

This does not seem right because that change throws an error when trying to build the app with that change.

Note: There is no such a call to .toInteger() with the build.gradle.kts created with flutter for a brand new app

_Description of what this PR is changing or adding, and why:_
Remove a call to to toInteger() for flutter.versionCode because it throws an error when building and does not seem necessary (builds fine without)

_Issues fixed by this PR (if any):_
See above

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
