### PR TITLE
Add storetype option to keytool command example for linux

### DIFF
--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -151,7 +151,7 @@ If not, create one using one of the following methods:
 
    ```console
    keytool -genkey -v -keystore ~/upload-keystore.jks -keyalg RSA \
-           -keysize 2048 -validity 10000 -alias upload
+           -storetype JKS -keysize 2048 -validity 10000 -alias upload
    ```
 
    On Windows, use the following command in PowerShell:


### PR DESCRIPTION
Also specify storetype of JKS for linux example

_Description of what this PR is changing or adding, and why:_
Correct the linux keytool example and add -storetype JKS to match the windows example

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
