### PR TITLE
Add redirect for texture-to-image proposal

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -735,6 +735,7 @@
       { "source": "/go/text-selection-programatically", "destination": "https://docs.google.com/document/d/1NK4GJ0Wk5eJ3IUw_9oAtz1oYgZ-Sn-kAKHxTvsgr75o/edit?usp=sharing", "type": 301 },
       { "source": "/go/text-selection-theme", "destination": "https://docs.google.com/document/d/1sCe7Y_lhREljtn6m0Uu_EycbS82zRvWnNtkfEwFX9W0", "type": 301 },
       { "source": "/go/texttheme-m3", "destination": "https://docs.google.com/document/d/1y3K08vL9rMTsGmF_T65fXmWJbsPZohvaVB3T6JuqgjM/edit?resourcekey=0-Gnl-tX58L4yPdV3NgeXFBg", "type": 301 },
+      { "source": "/go/texture-to-image", "destination": "https://docs.google.com/document/d/12nRNRFRAxikkG8ojIR1a_x8FR7c99TVdFstuRt8kiEQ/edit?usp=sharing", "type": 301 },
       { "source": "/go/theme-extensions", "destination": "https://docs.google.com/document/d/1LbD4JqBgAfHex02oR3r2jyu9lTBBNBmyec2ovT59Kr8/edit?usp=sharing", "type": 301 },
       { "source": "/go/tool-announcements", "destination": "https://docs.google.com/document/d/1Lv9pkmouTPz5BoRJn441tNdVaLvw8pEtZqLUW4u0HLo/edit?resourcekey=0-8TKBpp9OgxmqvJSqLgtyoQ", "type": 301 },
       { "source": "/go/tool-integration-test-support", "destination": "https://docs.google.com/document/d/1jMMZpRAiQC2XTUFnzFsBrWwMsf7KyMuCScYgrJQJOV0/edit?resourcekey=0-ne9HbH1hXCHcIglomNfwtw", "type": 301 },


### PR DESCRIPTION
This adds a design doc entry for a proposal to efficiently convert textures to `ui.Image`s.

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
