### PR TITLE
fix: allow inline code to wrap on mobile viewports

### DIFF
--- a/site/lib/_sass/components/_code.scss
+++ b/site/lib/_sass/components/_code.scss
@@ -9,7 +9,6 @@ samp {
 
 // Inline code spans found within the primary contents of the page.
 // Targets all <code> elements, but <pre><code> shouldn't have many of these.
-
 main code,
 main kbd {
   font-size: 0.9em;
@@ -22,7 +21,6 @@ main kbd {
   white-space: normal;
   word-wrap: break-word;
   word-break: normal;
-
 }
 
 main kbd {

--- a/site/lib/_sass/components/_code.scss
+++ b/site/lib/_sass/components/_code.scss
@@ -9,6 +9,7 @@ samp {
 
 // Inline code spans found within the primary contents of the page.
 // Targets all <code> elements, but <pre><code> shouldn't have many of these.
+
 main code,
 main kbd {
   font-size: 0.9em;
@@ -17,8 +18,11 @@ main kbd {
   background-color: var(--site-inset-bgColor-translucent);
   border: 1px solid var(--site-inset-borderColor);
   border-radius: 0.2rem;
+
+  white-space: normal;
   word-wrap: break-word;
-  white-space: nowrap;
+  word-break: normal;
+
 }
 
 main kbd {
@@ -276,7 +280,7 @@ pre {
   display: grid;
   grid-template-rows: min-content 1fr;
   grid-template-columns: 100%;
-  
+
   margin-block-start: 1rem;
   margin-block-end: 1rem;
   border: 1px solid var(--site-inset-borderColor);
@@ -288,12 +292,12 @@ pre {
     grid-template-rows: min-content 0fr;
     border-bottom-width: 0px;
 
-    .collapse-button > .material-symbols {
+    .collapse-button>.material-symbols {
       transform: rotate(180deg);
     }
   }
 
-  .collapse-button > .material-symbols {
+  .collapse-button>.material-symbols {
     transform: rotate(0deg);
     transform-origin: center;
     transition: transform 0.3s ease;
@@ -305,15 +309,15 @@ pre {
 
     background-color: var(--site-raised-bgColor);
     border-bottom: 1px solid var(--site-inset-borderColor);
-    
+
     padding: 0.75rem 0.5rem 0.67rem 1rem;
     gap: 0.5rem;
 
-    > span:first-child {
+    >span:first-child {
       flex-grow: 1;
       overflow-x: hidden;
       text-overflow: ellipsis;
-      
+
       font-size: 0.9375rem;
       font-weight: 500;
     }


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ 

This PR resolves the horizontal overflow issue reported in #13251.

By removing the rigid white-space: nowrap rule for main code and main kbd elements, the site now utilizes a fluid wrapping model. This ensures that long API identifiers (common in breaking changes documentation) wrap gracefully on mobile devices 
or on desktop viewports with an active sidebar.

_Issues fixed by this PR (if any):_ Fixes #13251 

_PRs or commits this PR depends on (if any):_

### VIsual Verification

| Before | After |
| :--- | :--- |
| ![Before - Mobile](https://github.com/user-attachments/assets/9699aa18-601e-403a-94e8-ae8566cc71c7) | ![After - Mobile](https://github.com/user-attachments/assets/90a79c47-b806-43d5-a9ac-25d0fc1ea85f) |

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
