### PR TITLE
Add go link redirect for /go/soft-hyphens

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -701,6 +701,7 @@
       { "source": "/go/sliver-flex-and-friends", "destination": "https://docs.google.com/document/d/1W4_5oD5z7JHhUjuQYwS_NJRAv27Ih7IazcMm739O5JU/edit", "type": 301 },
       { "source": "/go/sliver-workshop", "destination": "https://dartpad.dev/workshops.html?webserver=https://dartpad-workshops-io2021.web.app/getting_started_with_slivers", "type": 301 },
       { "source": "/go/smoothing-discrete-scroll-inputs", "destination": "https://docs.google.com/document/d/136wxl8He3PF2UMOT51lPfeqKE2TWGQuQ1u1b-ZDgErM/edit?usp=sharing", "type": 301 },
+      { "source": "/go/soft-hyphens", "destination": "https://docs.google.com/document/d/1w_d53wb-RMuwXmXIPq67JrZYG97XF1mDaKEoKBDt8-E/edit?usp=sharing", "type": 301 },
       { "source": "/go/squircle-web", "destination": "https://docs.google.com/document/d/1r5BDa0GBUpq6tAg7zqcaGDPMGhjvIIsZKB7c9gpYuzo/edit?usp=sharing", "type": 301 },
       { "source": "/go/state-restoration-design", "destination": "https://docs.google.com/document/d/1KIiq5CdqnSXxQXbZIDy2Ukc-JHFyLak1JR8e2cm3eO4/edit", "type": 301 },
       { "source": "/go/stateful-macro", "destination": "https://docs.google.com/document/d/1TMVFn2jXw705px7bUggk8vTvpLrUjxEG9mzb-cSqZuo/edit?usp=sharing&resourcekey=0-0s5mvWGH3OcW8GN-Rmr36A", "type": 301 },


### PR DESCRIPTION
Adds a redirect for flutter.dev/go/soft-hyphens pointing to the design doc for soft hyphen (U+00AD) rendering support in Flutter.

Design doc: https://docs.google.com/document/d/1w_d53wb-RMuwXmXIPq67JrZYG97XF1mDaKEoKBDt8-E
Tracking issue: flutter/flutter#18443
Implementation PR: flutter/flutter#185152