### PR TITLE
Add Genkit Dart to AI documentation

### DIFF
--- a/src/content/ai/create-with-ai.md
+++ b/src/content/ai/create-with-ai.md
@@ -44,12 +44,18 @@ resources:
   features directly in Flutter. Compatible with the Gemini Developer API or
   Vertex AI. To get started, check out the
   [official documentation][firebase-ai-logic-docs].
+* [Genkit Dart][] - An open-source framework for building AI-powered
+  features in Dart and Flutter with support for multiple model providers,
+  type-safe schemas, and built-in observability. To get started, check out the
+  [quickstart guide][genkit-dart-quickstart].
 * [Flutter AI Toolkit][] - A sample app with pre-built widgets to help you build
   AI-powered features in Flutter.
 
 [Firebase AI Logic]: {{site.firebase}}/docs/ai-logic
 [Firebase AI Logic Showcase]: {{site.github}}/flutter/demos/tree/main/firebase_ai_logic_showcase
 [firebase-ai-logic-docs]: {{site.firebase}}/docs/ai-logic/get-started
+[Genkit Dart]: https://genkit.dev
+[genkit-dart-quickstart]: https://genkit.dev/docs/dart/get-started
 [Flutter AI Toolkit]: /ai/ai-toolkit
 
 ## AI development tools
@@ -84,6 +90,34 @@ alpha and is likely to change.
 To learn more, visit the [GenUI SDK for Flutter][] documentation.
 
 [GenUI SDK for Flutter]: /ai/genui
+
+### Genkit Dart
+
+[Genkit Dart](https://genkit.dev) is an open-source, model-agnostic framework
+for building AI-powered applications in Dart and Flutter.
+It provides a structured way to integrate AI features into your app
+with support for multiple model providers, including
+Google Gemini, Anthropic Claude, and OpenAI.
+
+Key features include:
+
+*   **Model-agnostic API**: Switch between AI providers with minimal code changes.
+*   **Type-safe schemas**: Define strongly-typed inputs and outputs for AI
+    interactions using the [`schemantic`](https://pub.dev/packages/schemantic) package.
+*   **Flows**: Testable, observable, and deployable functions that wrap
+    AI logic with typed inputs and outputs.
+*   **Tools**: Define functions that models can invoke to fetch live data
+    or perform actions.
+*   **Developer UI**: A built-in web UI for testing prompts, viewing execution
+    traces, and debugging flows.
+
+Genkit Dart supports multiple deployment architectures for Flutter,
+including running AI logic entirely in the app,
+calling backend flows from Flutter, or proxying model requests
+through a Genkit backend.
+
+To get started, check out the
+[Genkit Dart quickstart](https://genkit.dev/docs/dart/get-started).
 
 ### Antigravity
 

--- a/src/content/llms.txt
+++ b/src/content/llms.txt
@@ -78,7 +78,8 @@ This file provides a curated list of resources to help Large Language Models und
 - [Firebase AI Logic](https://firebase.google.com/docs/ai-logic): Official documentation for Firebase AI Logic.
 - [Firebase AI Logic package](https://pub.dev/packages/firebase_ai): The pub.dev package for Firebase AI Logic.
 - [GenUI SDK for Flutter](https://docs.flutter.dev/ai/genui): Learn how to use the GenUI SDK for Flutter to build more interactive experiences in your apps.
-- [Get started with GenKit](https://genkit.dev/docs/dart/get-started/): Use GenKit to build AI-powered apps.
+- [Genkit Dart](https://genkit.dev): An open-source, model-agnostic framework for building AI-powered apps in Dart and Flutter with type-safe schemas, flows, and built-in observability.
+- [Genkit Dart quickstart](https://genkit.dev/docs/dart/get-started): Get started building AI-powered Dart and Flutter apps with Genkit.
 
 ## Testing & debugging
 

--- a/src/data/ai.yml
+++ b/src/data/ai.yml
@@ -23,6 +23,8 @@
   children:
     - title: Firebase AI Logic
       permalink: https://firebase.google.com/docs/ai-logic/get-started?platform=flutter
+    - title: Genkit Dart
+      permalink: https://genkit.dev/docs/dart/get-started
     - title: GenUI SDK for Flutter
       permalink: /ai/genui
       children:


### PR DESCRIPTION
- Add Genkit Dart to the "Build AI-powered experiences" resource list and as a dedicated subsection on the `/ai/create-with-ai` page
- Add Genkit Dart to the sidebar navigation under "Build AI-powered apps" in `ai.yml`
- Update `llms.txt` with improved Genkit Dart entries