### PR TITLE
Add timeline for breaking changes in raw-menu-anchor-close-order

### DIFF
--- a/src/content/release/breaking-changes/raw-menu-anchor-close-order.md
+++ b/src/content/release/breaking-changes/raw-menu-anchor-close-order.md
@@ -119,6 +119,11 @@ RawMenuAnchor(
 This migration is not supported by `dart fix`
 :::
 
+## Timeline
+
+Landed in version: 3.44.0-0.1.pre<br>
+In stable release: TBD
+
 ## References
 
 API documentation:


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Adds a timeline for breaking changes in raw-menu-anchor-close-order. I didn't fill in the stable version yet -- should I?

_PRs or commits this PR depends on (if any):_
https://github.com/flutter/flutter/pull/182357

@dkwingsmt 

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
