### PR TITLE
Add root editorconfig options file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# Configures default editor settings for the repository.
+# To learn more, visit the EditorConfig website: https://editorconfig.org.
+
+# This is top-most EditorConfig file for the repository.
+root = true
+
+# Default configuration for all files in the repository.
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+
+# Configuration for common code and data file formats.
+[*.{css,dart,json,yaml,yml}]
+indent_size = 2
+trim_trailing_whitespace = true


### PR DESCRIPTION
This helps ensure contributor's editors format files in the format our repository expects, such as ending each file with a trailing new line.