### PR TITLE
Add breaking change page for Android 17 orientation and resizability restrictions

### DIFF
--- a/src/content/release/breaking-changes/android-large-screens-restrictions-ignored.md
+++ b/src/content/release/breaking-changes/android-large-screens-restrictions-ignored.md
@@ -10,33 +10,39 @@ description: >-
 
 ## Summary
 
-For apps targeting Android 17 or higher, orientation, resizability, and
-aspect ratio restrictions no longer apply on displays with width 600dp or
-greater. This means that [`SystemChrome.setPreferredOrientations`][] is
-ignored on these devices.
+For apps targeting Android 17 or higher,
+orientation, resizability, and aspect ratio restrictions no longer apply
+on displays with width 600dp or greater.
+This means that [`SystemChrome.setPreferredOrientations`][] is ignored
+on these devices.
 
 ## Background
 
-Android is shifting toward a model where apps are expected to adapt to various
-orientations, display sizes, and aspect ratios.
+Android is shifting toward a model where apps are expected to adapt
+to various orientations, display sizes, and aspect ratios.
 Restrictions like fixed orientation or limited resizability hinder app
-adaptability. See  [Android 17 behavior changes][] for more details.
+adaptability.
+See [Android 17 behavior changes][] for more details.
 
-In Android 16, this behavior was introduced as a default but allowed apps to
-temporarily opt out using the `PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY`
-manifest property. Android 17 removes this opt-out.
+In Android 16, this behavior was introduced as a default
+but allowed apps to temporarily opt out
+using the `PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY` manifest property.
+Android 17 removes this opt-out.
 
 ## Description of change
 
-If you rely on [`SystemChrome.setPreferredOrientations`][] to lock your app to a
-specific orientation, it is ignored on large screens (widths 600dp and larger) if
-your app targets Android 17 or higher. If your app supports Android 16
-and you did not opt out of this behavior, then it behaves the same
-on Android 17.
+If you rely on [`SystemChrome.setPreferredOrientations`][]
+to lock your app to a specific orientation,
+it is ignored on large screens (widths 600dp and larger)
+if your app targets Android 17 or higher.
+If your app supports Android 16
+and you did not opt out of this behavior,
+then it behaves the same on Android 17.
 
-If your app relies on locking orientation, make your app adaptive to support
-different screen sizes and orientations. See the guidance for how to do this
-for large screens in [Adaptive and responsive UI][].
+If your app relies on locking orientation,
+make your app adaptive to support different screen sizes and orientations.
+See the guidance for how to do this for large screens
+in [Adaptive and responsive UI][].
 
 ## References
 

--- a/src/content/release/breaking-changes/android-large-screens-restrictions-ignored.md
+++ b/src/content/release/breaking-changes/android-large-screens-restrictions-ignored.md
@@ -1,5 +1,5 @@
 ---
-title: Orientation and resizability restrictions ignored on Android 17
+title: Large screen orientation and resizability restrictions ignored on Android 17
 description: >-
   For apps targeting Android 17 or higher, orientation, resizability, and
   aspect ratio restrictions no longer apply on large displays (widths 600dp or

--- a/src/content/release/breaking-changes/android-large-screens-restrictions-ignored.md
+++ b/src/content/release/breaking-changes/android-large-screens-restrictions-ignored.md
@@ -1,0 +1,51 @@
+---
+title: Orientation and resizability restrictions ignored on Android 17
+description: >-
+  For apps targeting Android 17 or higher, orientation, resizability, and
+  aspect ratio restrictions no longer apply on large displays (widths 600dp or
+  larger).
+---
+
+{% render "docs/breaking-changes.md" %}
+
+## Summary
+
+For apps targeting Android 17 or higher, orientation, resizability, and
+aspect ratio restrictions no longer apply on displays with width 600dp or
+greater. This means that [`SystemChrome.setPreferredOrientations`][] is
+ignored on these devices.
+
+## Background
+
+Android is shifting toward a model where apps are expected to adapt to various
+orientations, display sizes, and aspect ratios.
+Restrictions like fixed orientation or limited resizability hinder app
+adaptability. See  [Android 17 behavior changes][] for more details.
+
+In Android 16, this behavior was introduced as a default but allowed apps to
+temporarily opt out using the `PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY`
+manifest property. Android 17 removes this opt-out.
+
+## Description of change
+
+If you rely on [`SystemChrome.setPreferredOrientations`][] to lock your app to a
+specific orientation, it is ignored on large screens (widths 600dp and larger) if
+your app targets Android 17 or higher. If your app supports Android 16
+and you did not opt out of this behavior, then it behaves the same
+on Android 17.
+
+If your app relies on locking orientation, make your app adaptive to support
+different screen sizes and orientations. See the guidance for how to do this
+for large screens in [Adaptive and responsive UI][].
+
+## References
+
+* [Android 17 behavior changes][]
+* [Android 16 behavior changes][]
+* [`SystemChrome.setPreferredOrientations`][]
+* [Adaptive and responsive UI][]
+
+[Android 17 behavior changes]: https://developer.android.com/about/versions/17/changes/ff-restrictions-ignored
+[Android 16 behavior changes]: https://developer.android.com/about/versions/16/behavior-changes-16#ignore-orientation
+[`SystemChrome.setPreferredOrientations`]: {{site.api}}/flutter/services/SystemChrome/setPreferredOrientations.html
+[Adaptive and responsive UI]: /ui/adaptive-responsive/large-screens

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -36,12 +36,12 @@ They're sorted by release and listed in alphabetical order:
 
 ### Not yet released to stable
 
-* [Large screen orientation and resizability restrictions ignored on Android 17][]
 * [Changing RawMenuAnchor close order][]
 * [Deprecate `onReorder` callback][]
 * [Deprecated `cacheExtent` and `cacheExtentStyle`][]
 * [Deprecate `TextInputConnection.setStyle`][]
 * [`IconData` class marked as `final`][]
+* [Large screen orientation and resizability restrictions ignored on Android 17][]
 * [ListTile reports error in debug when wrapped in a colored widget][]
 * [Migrating Flutter Android projects to built-in Kotlin][]
 * [Page transition builders reorganization][]

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -36,6 +36,7 @@ They're sorted by release and listed in alphabetical order:
 
 ### Not yet released to stable
 
+* [Android large screens restrictions ignored][]
 * [Changing RawMenuAnchor close order][]
 * [Deprecate `onReorder` callback][]
 * [Deprecated `cacheExtent` and `cacheExtentStyle`][]
@@ -45,6 +46,7 @@ They're sorted by release and listed in alphabetical order:
 * [Migrating Flutter Android projects to built-in Kotlin][]
 * [Page transition builders reorganization][]
 
+[Orientation and resizability restrictions ignored on Android 17]: /release/breaking-changes/android-large-screens-restrictions-ignored
 [Changing RawMenuAnchor close order]: /release/breaking-changes/raw-menu-anchor-close-order
 [Deprecate `onReorder` callback]: /release/breaking-changes/deprecate-onreorder-callback
 [Deprecated `cacheExtent` and `cacheExtentStyle`]: /release/breaking-changes/scroll-cache-extent

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -36,7 +36,7 @@ They're sorted by release and listed in alphabetical order:
 
 ### Not yet released to stable
 
-* [Android large screens restrictions ignored][]
+* [Large screen orientation and resizability restrictions ignored on Android 17][]
 * [Changing RawMenuAnchor close order][]
 * [Deprecate `onReorder` callback][]
 * [Deprecated `cacheExtent` and `cacheExtentStyle`][]
@@ -46,7 +46,7 @@ They're sorted by release and listed in alphabetical order:
 * [Migrating Flutter Android projects to built-in Kotlin][]
 * [Page transition builders reorganization][]
 
-[Orientation and resizability restrictions ignored on Android 17]: /release/breaking-changes/android-large-screens-restrictions-ignored
+[Large screen orientation and resizability restrictions ignored on Android 17]: /release/breaking-changes/android-large-screens-restrictions-ignored
 [Changing RawMenuAnchor close order]: /release/breaking-changes/raw-menu-anchor-close-order
 [Deprecate `onReorder` callback]: /release/breaking-changes/deprecate-onreorder-callback
 [Deprecated `cacheExtent` and `cacheExtentStyle`]: /release/breaking-changes/scroll-cache-extent


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Adds a breaking change page for orientation and resizability restrictions coming with Android 17, which will impact Flutter developers because `SystemChrome.setPreferredOrientations` will be ignored.

Details on the change can be found [here](https://developer.android.com/about/versions/17/changes/ff-restrictions-ignored). `SystemChrome.setPreferredOrientations` documentation has already been updated to reflect this breaking change: https://api.flutter.dev/flutter/services/SystemChrome/setPreferredOrientations.html 

_Issues fixed by this PR (if any):_
N/A but related to https://github.com/flutter/flutter/issues/162724

_PRs or commits this PR depends on (if any):_
N/A

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
