### PR TITLE
Move "Update the plugin's pubspec.yaml" outside of tab

### DIFF
--- a/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
+++ b/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
@@ -161,6 +161,7 @@ kotlin {
 // ...
 ```
 </Tab>
+</Tabs>
 
 ### Update the plugin's `pubspec.yaml`
 

--- a/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
+++ b/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
@@ -160,6 +160,7 @@ kotlin {
 
 // ...
 ```
+</Tab>
 
 ### Update the plugin's `pubspec.yaml`
 


### PR DESCRIPTION

_Description of what this PR is changing or adding, and why:_  Move "Update the plugin's `pubspec.yaml`" outside of "legacy apply" tab. 

_Issues fixed by this PR (if any):_ https://github.com/flutter/website/issues/13315

_PRs or commits this PR depends on (if any):_ 

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
