### PR TITLE
Add installation steps for Flutter archive downloads

### DIFF
--- a/src/content/install/archive.md
+++ b/src/content/install/archive.md
@@ -53,6 +53,23 @@ SDK archive:
 [calendar versioning]: https://calver.org/
 [Flutter SDK versioning]: {{site.repo.flutter}}/blob/main/docs/releases/Release-versioning.md
 
+## Install from an archive
+
+After downloading a Flutter SDK archive from this page, follow these steps to install it:
+
+1. Extract the downloaded archive to a desired location on your system.
+2. Add the Flutter `bin` directory to your system's `PATH`.
+3. Run the following command to verify the installation:
+
+```bash id="yfl9s6"
+flutter doctor
+```
+
+The `flutter doctor` command checks your environment and displays a report of the status of your Flutter installation.
+
+For more detailed platform-specific setup instructions, refer to the main [Flutter installation guide](../install).
+
+
 ## Public release windows
 
 Predictability is key to landing complex features safely.

--- a/src/content/install/archive.md
+++ b/src/content/install/archive.md
@@ -55,7 +55,8 @@ SDK archive:
 
 ## Install from an archive
 
-After downloading a Flutter SDK archive from this page, follow these steps to install it:
+After downloading a Flutter SDK archive from this page,
+use the following steps to install:
 
 1. Extract the downloaded archive to a desired location on your system.
 2. Add the Flutter `bin` directory to your system's `PATH`.

--- a/src/content/install/archive.md
+++ b/src/content/install/archive.md
@@ -59,7 +59,8 @@ After downloading a Flutter SDK archive from this page,
 use the following steps to install:
 
 1. Extract the downloaded archive to a desired location on your system.
-2. Add the Flutter `bin` directory to your system's `PATH`.
+2. Add the Flutter `bin` directory to your system's `PATH`. For more information,
+   see [Add Flutter to PATH](/install/add-to-path).
 3. Run the following command to verify the installation:
 
 ```bash id="yfl9s6"

--- a/src/content/install/archive.md
+++ b/src/content/install/archive.md
@@ -70,7 +70,8 @@ flutter doctor
 The `flutter doctor` command checks your environment
 and reports on the status of your installation.
 
-For more detailed platform-specific setup instructions, refer to the main [Flutter installation guide](../install).
+For detailed platform-specific setup instructions,
+refer to the main [Flutter installation guide](../install).
 
 
 ## Public release windows

--- a/src/content/install/archive.md
+++ b/src/content/install/archive.md
@@ -67,7 +67,8 @@ use the following steps to install:
 flutter doctor
 ```
 
-The `flutter doctor` command checks your environment and displays a report of the status of your Flutter installation.
+The `flutter doctor` command checks your environment
+and reports on the status of your installation.
 
 For more detailed platform-specific setup instructions, refer to the main [Flutter installation guide](../install).
 


### PR DESCRIPTION
## Description

Adds a new section explaining how to install Flutter after downloading an SDK archive.

The archive page lists available SDK versions, but it does not clearly describe the steps required to install them after download. This change provides simple guidance to extract the archive, update the system `PATH`, and verify the installation using `flutter doctor`.

## Issues fixed by this PR

Closes #13317

## PRs or commits this PR depends on

None

## Presubmit checklist

* [x] If you are unwilling, or unable, to sign the CLA, even for a *tiny*, one-word PR, please file an issue instead of a PR.
* [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
* [x] This PR follows the [[Google Developer Documentation Style Guidelines](https://developers.google.com/style)](https://developers.google.com/style)—for example, it doesn't use *i.e.* or *e.g.*, and it avoids *I* and *we* (first-person pronouns).
* [x] This PR uses [[semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
