### PR TITLE
Move site deployment image from site-shared

### DIFF
--- a/cloud_build/firebase-ghcli/Dockerfile
+++ b/cloud_build/firebase-ghcli/Dockerfile
@@ -1,0 +1,15 @@
+FROM dart:3.12.0-327.4.beta@sha256:5306c1008b585f0fbcf23aa0d7145b8f65cd7bd8c63dce4b8038684c11c79833
+
+# Install prerequisite dependencies.
+RUN apt-get update && apt-get install -y --no-install-recommends curl gpg ca-certificates
+
+# Install the GitHub CLI.
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the latest version of firebase-tools globally.
+RUN curl -sL https://firebase.tools | bash

--- a/cloud_build/firebase-ghcli/Dockerfile
+++ b/cloud_build/firebase-ghcli/Dockerfile
@@ -1,15 +1,13 @@
 FROM dart:3.12.0-327.4.beta@sha256:5306c1008b585f0fbcf23aa0d7145b8f65cd7bd8c63dce4b8038684c11c79833
 
-# Install prerequisite dependencies.
-RUN apt-get update && apt-get install -y --no-install-recommends curl gpg ca-certificates
-
-# Install the GitHub CLI.
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-RUN apt-get update \
+RUN apt-get update && apt-get install -y --no-install-recommends curl gpg ca-certificates \
+    # Install the GitHub CLI. \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
     && apt-get install -y --no-install-recommends gh \
+    # Install the latest version of firebase-tools globally. \
+    && curl -sL https://firebase.tools | bash \
+    # Clean up unnecessary remnants after dependency installation. \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-# Install the latest version of firebase-tools globally.
-RUN curl -sL https://firebase.tools | bash

--- a/cloud_build/firebase-ghcli/README.md
+++ b/cloud_build/firebase-ghcli/README.md
@@ -17,4 +17,4 @@ to comment staged site links on GitHub PRs.
 When the `Dockerfile` file or `cloudbuild.yaml` template in this directory
 are changed in a PR, the cloud build template is triggered.
 Then a new version of the image is deployed as the latest version in
-Container Registry under the `flutter-dev` project on Google Cloud.
+Container Registry under the `flutter-dev-230821` project on Google Cloud.

--- a/cloud_build/firebase-ghcli/README.md
+++ b/cloud_build/firebase-ghcli/README.md
@@ -1,0 +1,20 @@
+# Site deployment image
+
+This directory contains a Dockerfile that provides access to
+Dart, Firebase CLI tools, and the GitHub CLI.
+This image is used to deploy various Dart/Flutter websites to
+Firebase in both production and staging and
+to comment staged site links on GitHub PRs.
+
+## Installed tools
+
+* Dart SDK
+* GitHub CLI
+* Firebase Tools
+
+## Updating image
+
+When the `Dockerfile` file or `cloudbuild.yaml` template in this directory
+are changed in a PR, the cloud build template is triggered.
+Then a new version of the image is deployed as the latest version in
+Container Registry under the `flutter-dev` project on Google Cloud.

--- a/cloud_build/firebase-ghcli/cloudbuild.yaml
+++ b/cloud_build/firebase-ghcli/cloudbuild.yaml
@@ -1,0 +1,14 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'gcr.io/$PROJECT_ID/firebase-ghcli'
+      - 'cloud_build/firebase-ghcli'
+images:
+  - 'gcr.io/$PROJECT_ID/firebase-ghcli'
+tags:
+  - 'dash-firebase-ghcli'
+timeout: 1200s
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
Moves the site deployment image configuration [from `dart-lang/site-shared](https://github.com/dart-lang/site-shared/tree/main/cloud_build/firebase-ghcli) to this repo as we work to consolidate to fewer repositories.

Contributes to https://github.com/flutter/website/issues/13327