### PR TITLE
Fixing the agent skills

### DIFF
--- a/.agents/skills/proofread_markdown/SKILL.md
+++ b/.agents/skills/proofread_markdown/SKILL.md
@@ -17,6 +17,7 @@ Google Developer Documentation Style Guide.
 
 - [ ] Wrap lines semantically and keep them generally under 80 characters using
       [scripts/wrap_lines.dart](scripts/wrap_lines.dart)
+- [ ] **Never touch the front matter.** Do not modify the content between the first two `---` lines at the top of the file.
 - [ ] Verify that the file was wrapped correctly, preserving headings and
       code blocks
 

--- a/.agents/skills/proofread_markdown/SKILL.md
+++ b/.agents/skills/proofread_markdown/SKILL.md
@@ -17,20 +17,21 @@ Google Developer Documentation Style Guide.
 
 - [ ] Wrap lines semantically and keep them generally under 80 characters using
       [scripts/wrap_lines.dart](scripts/wrap_lines.dart)
-- [ ] **Never touch the front matter.** Do not modify the content between the first two `---` lines at the top of the file.
-- [ ] Verify that the file was wrapped correctly, preserving headings and
-      code blocks
+- [ ] **Never touch the front matter.**
+      Do not modify the content between the first two `---` lines at the top of the file.
+- [ ] Verify that the file was wrapped correctly,
+      preserving headings and code blocks
 
 ### 2. Fix voice and tone
 
 - [ ] Use active voice.
 - [ ] Use present tense.
-- [ ] Use second person ("you"). No "we".
+- [ ] Use second person ("you"). No "we" or "I".
 
 ### 3. Check word choice
 
 - [ ] Replace forbidden terms: "e.g.", "i.e.", "etc.", "should", "would",
-      "could".
+      "could", "via", "may".
 - [ ] Use Oxford comma and American spelling.
 
 ### 4. Check style of headings

--- a/.agents/skills/proofread_markdown/scripts/wrap_lines.dart
+++ b/.agents/skills/proofread_markdown/scripts/wrap_lines.dart
@@ -26,9 +26,28 @@ String wrapMarkdown(String content, {int width = 80}) {
   final lines = content.split('\n');
   final output = <String>[];
   bool inCodeBlock = false;
+  bool inFrontMatter = false;
+  bool firstLine = true;
 
   for (final line in lines) {
     final stripped = line.trim();
+
+    if (firstLine) {
+      firstLine = false;
+      if (stripped == '---') {
+        inFrontMatter = true;
+        output.add(line);
+        continue;
+      }
+    }
+
+    if (inFrontMatter) {
+      output.add(line);
+      if (stripped == '---') {
+        inFrontMatter = false;
+      }
+      continue;
+    }
 
     // Handle code blocks
     if (stripped.startsWith('```') || stripped.startsWith('~~~')) {

--- a/.agents/skills/validate-pr/SKILL.md
+++ b/.agents/skills/validate-pr/SKILL.md
@@ -5,11 +5,7 @@ description: >-
   verifying excerpts, updating formatting, and serving the dev site.
 ---
 
-# Stage the Flutter site
-
-Before committing changes or reviewing a PR locally,
-it is important to stage the site and ensure everything works correctly. 
-Follow these steps to stage the site:
+Do the following to validate the site
 
 ## 1. Sync code excerpts
 
@@ -40,10 +36,3 @@ dart run dash_site check-link-references
 
 If any broken links are found, try to patch them or alert the user.
 
-## 4. Stage the site locally
-
-Finally, serve a local development server of the site so the user can preview the changes:
-
-```bash
-dart run dash_site serve
-```

--- a/.agents/skills/validate-pr/SKILL.md
+++ b/.agents/skills/validate-pr/SKILL.md
@@ -5,9 +5,9 @@ description: >-
   verifying excerpts, updating formatting, and serving the dev site.
 ---
 
-Do the following to validate the site
+# Validate the site
 
-## 1. Sync code excerpts
+## Sync code excerpts
 
 Ensure that any changed code excerpts are properly run and synced to the
 Markdown files:
@@ -16,7 +16,7 @@ Markdown files:
 dart run dash_site refresh-excerpts
 ```
 
-## 2. Update formatting
+## Update formatting
 
 Update the formatting of the site examples and tools to ensure
 they follow the official Dart format:
@@ -25,7 +25,7 @@ they follow the official Dart format:
 dart run dash_site format-dart
 ```
 
-## 3. Check for broken links
+## Check for broken links
 
 Run the following command to check for any unlinked or broken
 Markdown link references in the site output:


### PR DESCRIPTION
The `proofread-markdown` skill broke build because it tried to wrap the front matter. The front matter at the top of every markdown file should not be dorked with. That is meta information and has a very specific format.

The `validatePR` skill was problematic because it caused Jetski to stage the site and therefore "hid" issues. When I tried to stage the site manually, after making further changes, I couldn't.