### PR TITLE
[fwe] Clean up `game.dart`, fix lints, add more doc comments

### DIFF
--- a/examples/fwe/birdle/lib/game.dart
+++ b/examples/fwe/birdle/lib/game.dart
@@ -142,7 +142,8 @@ class Game {
   ///
   /// UIs can call this method before [guess] to
   /// show players a message when they enter an invalid word.
-  bool isLegalGuess(String guess) => Word.fromString(guess).isLegalGuess;
+  bool isLegalGuess(String guess) =>
+      guess.length == 5 && Word.fromString(guess).isLegalGuess;
 
   /// Evaluates [guess] against the hidden word without advancing the game.
   Word matchGuessOnly(String guess) =>
@@ -150,7 +151,12 @@ class Game {
 
   /// Stores [guess] in the next empty slot of [guesses].
   void addGuessToList(Word guess) {
-    _guesses[activeIndex] = guess;
+    final guessIndex = activeIndex;
+    if (guessIndex == -1) {
+      throw StateError('No guesses remaining.');
+    }
+
+    _guesses[guessIndex] = guess;
   }
 
   /// Returns the starting hidden word for a new round.
@@ -175,6 +181,14 @@ class Word with IterableMixin<Letter> {
   /// Each character is lowercased,
   /// every [Letter] starts as [HitType.none].
   factory Word.fromString(String guess) {
+    if (guess.length != 5) {
+      throw ArgumentError.value(
+        guess,
+        'guess',
+        'Must be exactly 5 characters long.',
+      );
+    }
+
     final letters = guess
         .toLowerCase()
         .split('')
@@ -203,6 +217,9 @@ class Word with IterableMixin<Letter> {
   /// Whether every [Letter] in this word has no character.
   @override
   bool get isEmpty => every((letter) => letter.char.isEmpty);
+
+  @override
+  int get length => _letters.length;
 
   /// The [Letter] at index [i] in word.
   Letter operator [](int i) => _letters[i];

--- a/examples/fwe/birdle/lib/game.dart
+++ b/examples/fwe/birdle/lib/game.dart
@@ -1,17 +1,40 @@
+/// Game logic and supporting types for Birdle,
+/// a five-letter word-guessing game similar to Wordle.
+///
+/// Defines the [Game] state machine and the
+/// [Word], [Letter], and [HitType] data model used to
+/// represent guesses and their evaluation against a hidden word.
+library;
+
 import 'dart:collection';
 import 'dart:math';
 
-const List<String> allLegalGuesses = [...legalWords, ...legalGuesses];
-const defaultNumGuesses = 5;
+/// The result of evaluating a [Letter] of a guess against the hidden word.
+enum HitType {
+  /// The letter hasn't yet been evaluated.
+  none,
 
-enum HitType { none, hit, partial, miss, removed }
+  /// The letter matches the hidden word's letter at the same position.
+  hit,
 
+  /// The letter is in the hidden word, but at a different position.
+  partial,
+
+  /// The letter doesn't appear in the hidden word.
+  miss,
+}
+
+/// A single character paired with its [HitType] against the hidden word.
 typedef Letter = ({String char, HitType type});
 
-const legalWords = <String>['aback', 'abase', 'abate', 'abbey', 'abbot'];
+/// Every word that can be legally entered as a guess.
+const List<String> allLegalGuesses = [...legalWords, ...legalGuesses];
 
-/// Legal guesses minus legal wordles
-const legalGuesses = <String>[
+/// Words that can be chosen as the hidden word.
+const List<String> legalWords = ['aback', 'abase', 'abate', 'abbey', 'abbot'];
+
+/// Additional words accepted as guesses beyond those in [legalWords].
+const List<String> legalGuesses = [
   'aback',
   'abase',
   'abate',
@@ -24,55 +47,67 @@ const legalGuesses = <String>[
   'abort',
 ];
 
-/// This class holds game state for a single round of Bulls and Cows,
-/// and exposes methods that a UI would need to manage the game state.
+/// Game state of a single round of Birdle,
+/// a five-letter word-guessing game similar to Wordle.
 ///
-/// On its own, this class won't manage a game.
-/// For example, it won't call [resetGame] on its own.
-/// It assumes that a client will use its methods to progress through a game.
+/// Exposes the state and methods a UI needs to
+/// evaluate guesses and track progress,
+/// but doesn't advance play on its own.
+///
+/// Clients drive each round by calling [guess] to submit an attempt and
+/// [resetGame] to start over.
 class Game {
-  Game({this.numAllowedGuesses = defaultNumGuesses, this.seed}) {
-    _wordToGuess = seed == null ? Word.random() : Word.fromSeed(seed!);
-    _guesses = List<Word>.filled(numAllowedGuesses, Word.empty());
-  }
+  /// The default maximum number of guesses allowed in a [Game].
+  static const int defaultMaxGuesses = 5;
 
-  late final int numAllowedGuesses;
-  late List<Word> _guesses;
-  late Word _wordToGuess;
-  int? seed;
+  /// Creates a new game with [maxGuesses] guesses allowed.
+  ///
+  /// If [seed] is provided, the hidden word is
+  /// chosen deterministically from [legalWords],
+  /// otherwise it is selected at random.
+  Game({this.maxGuesses = defaultMaxGuesses, this.seed})
+    : _wordToGuess = _generateInitialWord(seed),
+      _guesses = List<Word>.filled(maxGuesses, Word.empty());
 
+  /// The maximum number of guesses allowed in this game.
+  final int maxGuesses;
+
+  /// The seed used to choose the hidden word,
+  /// or `null` if it was selected at random.
+  final int? seed;
+
+  /// The current hidden word, exposed publicly through [hiddenWord].
+  Word _wordToGuess;
+
+  /// Backing storage for [guesses].
+  ///
+  /// Holds every guess slot in order,
+  /// with unfilled slots represented by empty [Word]s.
+  List<Word> _guesses;
+
+  /// The word the player is trying to guess.
   Word get hiddenWord => _wordToGuess;
 
+  /// An unmodifiable view of every guess slot, including those still empty.
   UnmodifiableListView<Word> get guesses => UnmodifiableListView(_guesses);
 
+  /// The most recently submitted guess,
+  /// or an empty [Word] if no guesses have been made.
   Word get previousGuess {
     final index = _guesses.lastIndexWhere((word) => word.isNotEmpty);
     return index == -1 ? Word.empty() : _guesses[index];
   }
 
-  int get activeIndex {
-    return _guesses.indexWhere((word) => word.isEmpty);
-  }
+  /// The index of the next empty guess slot, or `-1` if every slot is full.
+  int get activeIndex => _guesses.indexWhere((word) => word.isEmpty);
 
+  /// The number of guesses still available to the player.
   int get guessesRemaining {
     if (activeIndex == -1) return 0;
-    return numAllowedGuesses - activeIndex;
+    return maxGuesses - activeIndex;
   }
 
-  void resetGame() {
-    _wordToGuess = seed == null ? Word.random() : Word.fromSeed(seed!);
-    _guesses = List.filled(numAllowedGuesses, Word.empty());
-  }
-
-  // Most common entry-point for handling guess logic.
-  // For finer control over logic, use other methods such as [isGuessLegal]
-  // and [matchGuess]
-  Word guess(String guess) {
-    final result = matchGuessOnly(guess);
-    addGuessToList(result);
-    return result;
-  }
-
+  /// Whether the most recent guess matches the hidden word.
   bool get didWin {
     if (_guesses.first.isEmpty) return false;
 
@@ -83,136 +118,154 @@ class Game {
     return true;
   }
 
+  /// Whether all allowed guesses have been used without winning.
   bool get didLose => guessesRemaining == 0 && !didWin;
 
-  // UIs can call this method before calling [guess] if they want
-  // to show users messages based incorrect words
-  bool isLegalGuess(String guess) {
-    return Word.fromString(guess).isLegalGuess;
+  /// Picks a new hidden word and clears every submitted guess.
+  void resetGame() {
+    _wordToGuess = _generateInitialWord(seed);
+    _guesses = List<Word>.filled(maxGuesses, Word.empty());
   }
 
-  // Doesn't move the game forward, only executes match logic.
-  Word matchGuessOnly(String guess) {
-    // The hidden word will be used by subsequent guesses.
-    final hiddenCopy = Word.fromString(_wordToGuess.toString());
-    return Word.fromString(guess).evaluateGuess(hiddenCopy);
+  /// Evaluates [guess] against the hidden word,
+  /// records the result in [guesses], and returns it.
+  ///
+  /// For finer control, use [isLegalGuess] to validate input or
+  /// [matchGuessOnly] to evaluate without recording the result.
+  Word guess(String guess) {
+    final result = matchGuessOnly(guess);
+    addGuessToList(result);
+    return result;
   }
 
+  /// Whether [guess] is a legal word to guess.
+  ///
+  /// UIs can call this method before [guess] to
+  /// show players a message when they enter an invalid word.
+  bool isLegalGuess(String guess) => Word.fromString(guess).isLegalGuess;
+
+  /// Evaluates [guess] against the hidden word without advancing the game.
+  Word matchGuessOnly(String guess) =>
+      Word.fromString(guess).evaluateGuess(_wordToGuess);
+
+  /// Stores [guess] in the next empty slot of [guesses].
   void addGuessToList(Word guess) {
-    final i = _guesses.indexWhere((word) => word.isEmpty);
-    _guesses[i] = guess;
+    _guesses[activeIndex] = guess;
   }
+
+  /// Returns the starting hidden word for a new round.
+  ///
+  /// Picks a deterministic word from [legalWords] when [seed] is provided,
+  /// or one at random otherwise.
+  static Word _generateInitialWord(int? seed) =>
+      seed == null ? Word.random() : Word.fromSeed(seed);
 }
 
+/// A five-letter word made up of [Letter]s, each tracking its [HitType].
 class Word with IterableMixin<Letter> {
+  /// Creates a word backed by the specified list of [Letter]s.
   Word(this._letters);
 
-  factory Word.empty() {
-    return Word(List.filled(5, (char: '', type: HitType.none)));
-  }
+  /// Creates a word with five blank letters of [HitType.none].
+  factory Word.empty() =>
+      Word(List<Letter>.filled(5, (char: '', type: HitType.none)));
 
+  /// Creates a [Word] from [guess].
+  ///
+  /// Each character is lowercased,
+  /// every [Letter] starts as [HitType.none].
   factory Word.fromString(String guess) {
-    final list = guess.toLowerCase().split('');
-    final letters = list
+    final letters = guess
+        .toLowerCase()
+        .split('')
         .map((char) => (char: char, type: HitType.none))
         .toList();
     return Word(letters);
   }
 
+  /// Creates a word chosen at random from [legalWords].
   factory Word.random() {
-    final rand = Random();
-    final nextWord = legalWords[rand.nextInt(legalWords.length)];
+    final random = Random();
+    final nextWord = legalWords[random.nextInt(legalWords.length)];
     return Word.fromString(nextWord);
   }
 
-  factory Word.fromSeed(int seed) {
-    return Word.fromString(legalWords[seed % legalWords.length]);
-  }
+  /// Creates a word chosen from [legalWords] using [seed] as an index.
+  factory Word.fromSeed(int seed) =>
+      Word.fromString(legalWords[seed % legalWords.length]);
 
+  /// An unmodifiable list of [Letter]s that make up this word.
   final List<Letter> _letters;
 
-  /// Loop over the Letters in this word
   @override
   Iterator<Letter> get iterator => _letters.iterator;
 
+  /// Whether every [Letter] in this word has no character.
   @override
-  bool get isEmpty {
-    return every((letter) => letter.char.isEmpty);
-  }
+  bool get isEmpty => every((letter) => letter.char.isEmpty);
 
-  @override
-  bool get isNotEmpty => !isEmpty;
-
+  /// The [Letter] at index [i] in word.
   Letter operator [](int i) => _letters[i];
-  void operator []=(int i, Letter value) => _letters[i] = value;
 
   @override
-  String toString() {
-    return _letters.map((c) => c.char).join().trim();
-  }
+  String toString() => _letters.map((letter) => letter.char).join().trim();
 
-  // Used to play game in the CLI implementation
-  String toStringVerbose() {
-    return _letters.map((l) => '${l.char} - ${l.type.name}').join('\n');
-  }
+  /// Returns a multi-line string showing each [Letter] alongside its [HitType].
+  ///
+  /// Used to play the game from the command line.
+  String toStringVerbose() => _letters
+      .map((letter) => '${letter.char} - ${letter.type.name}')
+      .join('\n');
 }
 
-// Domain specific methods that contain word related logic.
+/// Validation and guess-evaluation logic on [Word].
 extension WordUtils on Word {
-  bool get isLegalGuess {
-    if (!allLegalGuesses.contains(toString())) {
-      return false;
-    }
+  /// Whether this word appears in [allLegalGuesses].
+  bool get isLegalGuess => allLegalGuesses.contains(toString());
 
-    return true;
-  }
-
-  /// Compares two [Word] objects and returns a new [Word] that
-  /// has the same letters as this word, but each [Letter]
-  /// has new a [HitType] of either [HitType.hit],
-  /// [HitType.partial], or [HitType.miss].
-  Word evaluateGuess(Word other) {
+  /// Compares this [Word] against the specified [hiddenWord]
+  /// and returns a new [Word] with the same letters,
+  /// but where each [Letter] has new a [HitType] of
+  /// [HitType.hit], [HitType.partial], or [HitType.miss].
+  Word evaluateGuess(Word hiddenWord) {
     assert(isLegalGuess);
 
-    // Find exact hits. Mark them as hits, and mark letters in the hidden word
-    // as removed.
+    final result = List<Letter>.filled(length, (char: '', type: HitType.none));
+    // Counts hidden-word letters that can still be claimed as partial matches.
+    final unmatchedHiddenLetterCounts = <String, int>{};
+
+    // Reserve exact matches before scoring partial matches.
     for (var i = 0; i < length; i++) {
-      if (other[i].char == this[i].char) {
-        this[i] = (char: this[i].char, type: HitType.hit);
-        other[i] = (char: other[i].char, type: HitType.removed);
+      final guessChar = this[i].char;
+      final hiddenChar = hiddenWord[i].char;
+
+      if (guessChar == hiddenChar) {
+        result[i] = (char: guessChar, type: HitType.hit);
+      } else {
+        // Track non-hit hidden letters for the partial-match pass.
+        final unmatchedCount = unmatchedHiddenLetterCounts[hiddenChar] ?? 0;
+        unmatchedHiddenLetterCounts[hiddenChar] = unmatchedCount + 1;
       }
     }
 
-    // Find the partial matches
-    // The outer loop is through the hidden word
-    for (var i = 0; i < other.length; i++) {
-      // If a letter in the hidden word is already marked as "removed",
-      // then it's already an exact match, so skip it
-      final targetLetter = other[i];
-      if (targetLetter.type != HitType.none) continue;
-
-      // loop through the guessed word onces for each letter in the hidden word
-      for (var j = 0; j < length; j++) {
-        final guessedLetter = this[j];
-        // skip letters that have already been marked as exact matches
-        if (guessedLetter.type != HitType.none) continue;
-        // If this letter, which must not be in the same position, is the same,
-        // it's a partial match
-        if (guessedLetter.char == targetLetter.char) {
-          this[j] = (char: guessedLetter.char, type: HitType.partial);
-          other[i] = (char: targetLetter.char, type: HitType.removed);
-          break;
-        }
-      }
-    }
-
-    // Mark remaining letters in guessed word as misses
+    // Spend each remaining hidden letter only once for partial matches.
     for (var i = 0; i < length; i++) {
-      if (this[i].type == HitType.none) {
-        this[i] = (char: this[i].char, type: HitType.miss);
+      if (result[i].type == HitType.hit) continue;
+
+      final guessChar = this[i].char;
+      final unmatchedCount = unmatchedHiddenLetterCounts[guessChar] ?? 0;
+      final isPartial = unmatchedCount > 0;
+      if (isPartial) {
+        // Use one available hidden letter for this partial match.
+        unmatchedHiddenLetterCounts[guessChar] = unmatchedCount - 1;
       }
+
+      result[i] = (
+        char: guessChar,
+        type: isPartial ? HitType.partial : HitType.miss,
+      );
     }
 
-    return this;
+    return Word(result);
   }
 }

--- a/src/_snippets/tutorial/game-code.dart
+++ b/src/_snippets/tutorial/game-code.dart
@@ -1,218 +1,271 @@
+/// Game logic and supporting types for Birdle,
+/// a five-letter word-guessing game similar to Wordle.
+///
+/// Defines the [Game] state machine and the
+/// [Word], [Letter], and [HitType] data model used to
+/// represent guesses and their evaluation against a hidden word.
+library;
+
 import 'dart:collection';
 import 'dart:math';
 
-const List<String> allLegalGuesses = [...legalWords, ...legalGuesses];
-const defaultNumGuesses = 5;
+/// The result of evaluating a [Letter] of a guess against the hidden word.
+enum HitType {
+  /// The letter hasn't yet been evaluated.
+  none,
 
-enum HitType { none, hit, partial, miss, removed }
+  /// The letter matches the hidden word's letter at the same position.
+  hit,
 
+  /// The letter is in the hidden word, but at a different position.
+  partial,
+
+  /// The letter doesn't appear in the hidden word.
+  miss,
+}
+
+/// A single character paired with its [HitType] against the hidden word.
 typedef Letter = ({String char, HitType type});
 
-const legalWords = <String>["aback", "abase", "abate", "abbey", "abbot"];
+/// Every word that can be legally entered as a guess.
+const List<String> allLegalGuesses = [...legalWords, ...legalGuesses];
 
-/// Legal guesses minus legal wordles
-const legalGuesses = <String>[
-  "aback",
-  "abase",
-  "abate",
-  "abbey",
-  "abbot",
-  "abhor",
-  "abide",
-  "abled",
-  "abode",
-  "abort",
+/// Words that can be chosen as the hidden word.
+const List<String> legalWords = ['aback', 'abase', 'abate', 'abbey', 'abbot'];
+
+/// Additional words accepted as guesses beyond those in [legalWords].
+const List<String> legalGuesses = [
+  'aback',
+  'abase',
+  'abate',
+  'abbey',
+  'abbot',
+  'abhor',
+  'abide',
+  'abled',
+  'abode',
+  'abort',
 ];
 
-/// This class holds game state for a single round of Bulls and Cows,
-/// and exposes methods that a UI would need to manage the game state.
+/// Game state of a single round of Birdle,
+/// a five-letter word-guessing game similar to Wordle.
 ///
-/// On its own, this class won't manage a game.
-/// For example, it won't call [resetGame] on its own.
-/// It assumes that a client will use its methods to progress through a game.
+/// Exposes the state and methods a UI needs to
+/// evaluate guesses and track progress,
+/// but doesn't advance play on its own.
+///
+/// Clients drive each round by calling [guess] to submit an attempt and
+/// [resetGame] to start over.
 class Game {
-  Game({this.numAllowedGuesses = defaultNumGuesses, this.seed}) {
-    _wordToGuess = seed == null ? Word.random() : Word.fromSeed(seed!);
-    _guesses = List<Word>.filled(numAllowedGuesses, Word.empty());
-  }
+  /// The default maximum number of guesses allowed in a [Game].
+  static const int defaultMaxGuesses = 5;
 
-  late final int numAllowedGuesses;
-  late List<Word> _guesses;
-  late Word _wordToGuess;
-  int? seed;
+  /// Creates a new game with [maxGuesses] guesses allowed.
+  ///
+  /// If [seed] is provided, the hidden word is
+  /// chosen deterministically from [legalWords],
+  /// otherwise it is selected at random.
+  Game({this.maxGuesses = defaultMaxGuesses, this.seed})
+    : _wordToGuess = _generateInitialWord(seed),
+      _guesses = List<Word>.filled(maxGuesses, Word.empty());
 
+  /// The maximum number of guesses allowed in this game.
+  final int maxGuesses;
+
+  /// The seed used to choose the hidden word,
+  /// or `null` if it was selected at random.
+  final int? seed;
+
+  /// The current hidden word, exposed publicly through [hiddenWord].
+  Word _wordToGuess;
+
+  /// Backing storage for [guesses].
+  ///
+  /// Holds every guess slot in order,
+  /// with unfilled slots represented by empty [Word]s.
+  List<Word> _guesses;
+
+  /// The word the player is trying to guess.
   Word get hiddenWord => _wordToGuess;
 
+  /// An unmodifiable view of every guess slot, including those still empty.
   UnmodifiableListView<Word> get guesses => UnmodifiableListView(_guesses);
 
+  /// The most recently submitted guess,
+  /// or an empty [Word] if no guesses have been made.
   Word get previousGuess {
     final index = _guesses.lastIndexWhere((word) => word.isNotEmpty);
     return index == -1 ? Word.empty() : _guesses[index];
   }
 
-  int get activeIndex {
-    return _guesses.indexWhere((word) => word.isEmpty);
-  }
+  /// The index of the next empty guess slot, or `-1` if every slot is full.
+  int get activeIndex => _guesses.indexWhere((word) => word.isEmpty);
 
+  /// The number of guesses still available to the player.
   int get guessesRemaining {
     if (activeIndex == -1) return 0;
-    return numAllowedGuesses - activeIndex;
+    return maxGuesses - activeIndex;
   }
 
-  void resetGame() {
-    _wordToGuess = seed == null ? Word.random() : Word.fromSeed(seed!);
-    _guesses = List.filled(numAllowedGuesses, Word.empty());
-  }
-
-  // Most common entry-point for handling guess logic.
-  // For finer control over logic, use other methods such as [isGuessLegal]
-  // and [matchGuess]
-  Word guess(String guess) {
-    final result = matchGuessOnly(guess);
-    addGuessToList(result);
-    return result;
-  }
-
+  /// Whether the most recent guess matches the hidden word.
   bool get didWin {
     if (_guesses.first.isEmpty) return false;
 
-    for (var letter in previousGuess) {
+    for (final letter in previousGuess) {
       if (letter.type != HitType.hit) return false;
     }
 
     return true;
   }
 
+  /// Whether all allowed guesses have been used without winning.
   bool get didLose => guessesRemaining == 0 && !didWin;
 
-  // UIs can call this method before calling [guess] if they want
-  // to show users messages based incorrect words
-  bool isLegalGuess(String guess) {
-    return Word.fromString(guess).isLegalGuess;
+  /// Picks a new hidden word and clears every submitted guess.
+  void resetGame() {
+    _wordToGuess = _generateInitialWord(seed);
+    _guesses = List<Word>.filled(maxGuesses, Word.empty());
   }
 
-  // Doesn't move the game forward, only executes match logic.
-  Word matchGuessOnly(String guess) {
-    // The hidden word will be used by subsequent guesses.
-    var hiddenCopy = Word.fromString(_wordToGuess.toString());
-    return Word.fromString(guess).evaluateGuess(hiddenCopy);
+  /// Evaluates [guess] against the hidden word,
+  /// records the result in [guesses], and returns it.
+  ///
+  /// For finer control, use [isLegalGuess] to validate input or
+  /// [matchGuessOnly] to evaluate without recording the result.
+  Word guess(String guess) {
+    final result = matchGuessOnly(guess);
+    addGuessToList(result);
+    return result;
   }
 
+  /// Whether [guess] is a legal word to guess.
+  ///
+  /// UIs can call this method before [guess] to
+  /// show players a message when they enter an invalid word.
+  bool isLegalGuess(String guess) => Word.fromString(guess).isLegalGuess;
+
+  /// Evaluates [guess] against the hidden word without advancing the game.
+  Word matchGuessOnly(String guess) =>
+      Word.fromString(guess).evaluateGuess(_wordToGuess);
+
+  /// Stores [guess] in the next empty slot of [guesses].
   void addGuessToList(Word guess) {
-    final i = _guesses.indexWhere((word) => word.isEmpty);
-    _guesses[i] = guess;
+    _guesses[activeIndex] = guess;
   }
+
+  /// Returns the starting hidden word for a new round.
+  ///
+  /// Picks a deterministic word from [legalWords] when [seed] is provided,
+  /// or one at random otherwise.
+  static Word _generateInitialWord(int? seed) =>
+      seed == null ? Word.random() : Word.fromSeed(seed);
 }
 
+/// A five-letter word made up of [Letter]s, each tracking its [HitType].
 class Word with IterableMixin<Letter> {
+  /// Creates a word backed by the specified list of [Letter]s.
   Word(this._letters);
 
-  factory Word.empty() {
-    return Word(List.filled(5, (char: '', type: HitType.none)));
-  }
+  /// Creates a word with five blank letters of [HitType.none].
+  factory Word.empty() =>
+      Word(List<Letter>.filled(5, (char: '', type: HitType.none)));
 
+  /// Creates a [Word] from [guess].
+  ///
+  /// Each character is lowercased,
+  /// every [Letter] starts as [HitType.none].
   factory Word.fromString(String guess) {
-    var list = guess.toLowerCase().split('');
-    var letters = list
-        .map((String char) => (char: char, type: HitType.none))
+    final letters = guess
+        .toLowerCase()
+        .split('')
+        .map((char) => (char: char, type: HitType.none))
         .toList();
     return Word(letters);
   }
 
+  /// Creates a word chosen at random from [legalWords].
   factory Word.random() {
-    var rand = Random();
-    var nextWord = legalWords[rand.nextInt(legalWords.length)];
+    final random = Random();
+    final nextWord = legalWords[random.nextInt(legalWords.length)];
     return Word.fromString(nextWord);
   }
 
-  factory Word.fromSeed(int seed) {
-    return Word.fromString(legalWords[seed % legalWords.length]);
-  }
+  /// Creates a word chosen from [legalWords] using [seed] as an index.
+  factory Word.fromSeed(int seed) =>
+      Word.fromString(legalWords[seed % legalWords.length]);
 
+  /// An unmodifiable list of [Letter]s that make up this word.
   final List<Letter> _letters;
 
-  /// Loop over the Letters in this word
   @override
   Iterator<Letter> get iterator => _letters.iterator;
 
+  /// Whether every [Letter] in this word has no character.
   @override
-  bool get isEmpty {
-    return every((letter) => letter.char.isEmpty);
-  }
+  bool get isEmpty => every((letter) => letter.char.isEmpty);
 
-  @override
-  bool get isNotEmpty => !isEmpty;
-
+  /// The [Letter] at index [i] in word.
   Letter operator [](int i) => _letters[i];
-  operator []=(int i, Letter value) => _letters[i] = value;
 
   @override
-  String toString() {
-    return _letters.map((Letter c) => c.char).join().trim();
-  }
+  String toString() => _letters.map((letter) => letter.char).join().trim();
 
-  // Used to play game in the CLI implementation
-  String toStringVerbose() {
-    return _letters.map((l) => '${l.char} - ${l.type.name}').join('\n');
-  }
+  /// Returns a multi-line string showing each [Letter] alongside its [HitType].
+  ///
+  /// Used to play the game from the command line.
+  String toStringVerbose() => _letters
+      .map((letter) => '${letter.char} - ${letter.type.name}')
+      .join('\n');
 }
 
-// Domain specific methods that contain word related logic.
+/// Validation and guess-evaluation logic on [Word].
 extension WordUtils on Word {
-  bool get isLegalGuess {
-    if (!allLegalGuesses.contains(toString())) {
-      return false;
-    }
+  /// Whether this word appears in [allLegalGuesses].
+  bool get isLegalGuess => allLegalGuesses.contains(toString());
 
-    return true;
-  }
-
-  /// Compares two [Word] objects and returns a new [Word] that
-  /// has the same letters as the [this], but each [Letter]
-  /// has new a [HitType] of either [HitType.hit],
-  /// [HitType.partial], or [HitType.miss].
-  Word evaluateGuess(Word other) {
+  /// Compares this [Word] against the specified [hiddenWord]
+  /// and returns a new [Word] with the same letters,
+  /// but where each [Letter] has new a [HitType] of
+  /// [HitType.hit], [HitType.partial], or [HitType.miss].
+  Word evaluateGuess(Word hiddenWord) {
     assert(isLegalGuess);
 
-    // Find exact hits. Mark them as hits, and mark letters in the hidden word
-    // as removed.
+    final result = List<Letter>.filled(length, (char: '', type: HitType.none));
+    // Counts hidden-word letters that can still be claimed as partial matches.
+    final unmatchedHiddenLetterCounts = <String, int>{};
+
+    // Reserve exact matches before scoring partial matches.
     for (var i = 0; i < length; i++) {
-      if (other[i].char == this[i].char) {
-        this[i] = (char: this[i].char, type: HitType.hit);
-        other[i] = (char: other[i].char, type: HitType.removed);
+      final guessChar = this[i].char;
+      final hiddenChar = hiddenWord[i].char;
+
+      if (guessChar == hiddenChar) {
+        result[i] = (char: guessChar, type: HitType.hit);
+      } else {
+        // Track non-hit hidden letters for the partial-match pass.
+        final unmatchedCount = unmatchedHiddenLetterCounts[hiddenChar] ?? 0;
+        unmatchedHiddenLetterCounts[hiddenChar] = unmatchedCount + 1;
       }
     }
 
-    // Find the partial matches
-    // The outer loop is through the hidden word
-    for (var i = 0; i < other.length; i++) {
-      // If a letter in the hidden word is already marked as "removed",
-      // then it's already an exact match, so skip it
-      Letter targetLetter = other[i];
-      if (targetLetter.type != HitType.none) continue;
-
-      // loop through the guessed word onces for each letter in the hidden word
-      for (var j = 0; j < length; j++) {
-        Letter guessedLetter = this[j];
-        // skip letters that have already been marked as exact matches
-        if (guessedLetter.type != HitType.none) continue;
-        // If this letter, which must not be in the same position, is the same,
-        // it's a partial match
-        if (guessedLetter.char == targetLetter.char) {
-          this[j] = (char: guessedLetter.char, type: HitType.partial);
-          other[i] = (char: targetLetter.char, type: HitType.removed);
-          break;
-        }
-      }
-    }
-
-    // Mark remaining letters in guessed word as misses
+    // Spend each remaining hidden letter only once for partial matches.
     for (var i = 0; i < length; i++) {
-      if (this[i].type == HitType.none) {
-        this[i] = (char: this[i].char, type: HitType.miss);
+      if (result[i].type == HitType.hit) continue;
+
+      final guessChar = this[i].char;
+      final unmatchedCount = unmatchedHiddenLetterCounts[guessChar] ?? 0;
+      final isPartial = unmatchedCount > 0;
+      if (isPartial) {
+        // Use one available hidden letter for this partial match.
+        unmatchedHiddenLetterCounts[guessChar] = unmatchedCount - 1;
       }
+
+      result[i] = (
+        char: guessChar,
+        type: isPartial ? HitType.partial : HitType.miss,
+      );
     }
 
-    return this;
+    return Word(result);
   }
 }

--- a/src/_snippets/tutorial/game-code.dart
+++ b/src/_snippets/tutorial/game-code.dart
@@ -150,7 +150,12 @@ class Game {
 
   /// Stores [guess] in the next empty slot of [guesses].
   void addGuessToList(Word guess) {
-    _guesses[activeIndex] = guess;
+    final guessIndex = activeIndex;
+    if (guessIndex == -1) {
+      throw StateError('No guesses remaining.');
+    }
+
+    _guesses[guessIndex] = guess;
   }
 
   /// Returns the starting hidden word for a new round.
@@ -175,6 +180,14 @@ class Word with IterableMixin<Letter> {
   /// Each character is lowercased,
   /// every [Letter] starts as [HitType.none].
   factory Word.fromString(String guess) {
+    if (guess.length != 5) {
+      throw ArgumentError.value(
+        guess,
+        'guess',
+        'Must be exactly 5 characters long.',
+      );
+    }
+
     final letters = guess
         .toLowerCase()
         .split('')
@@ -203,6 +216,9 @@ class Word with IterableMixin<Letter> {
   /// Whether every [Letter] in this word has no character.
   @override
   bool get isEmpty => every((letter) => letter.char.isEmpty);
+
+  @override
+  int get length => _letters.length;
 
   /// The [Letter] at index [i] in word.
   Letter operator [](int i) => _letters[i];


### PR DESCRIPTION
Cleans up the `game.dart` file for Birdle. It's duplicated in this PR as one is used for the excerpts and the other is used for downloading.

- Fixes all instances of our enabled lints.
- Cleans up and simplifies some code.
- Renames some members to follow Effective Dart guidelines.
- Adds and updates API doc comments to follow Effective Dart guidelines.
- Updates `evaluateGuess` to return a new `Word` rather than modifying an existing one. This is the behavior the doc comment described, but the behavior didn't match.