### PR TITLE
*Breaking change* Deprecate `CurvedAnimation.reverseCurve` in favor of `AsymmetricCurvedAnimation`

### DIFF
--- a/sites/docs/src/content/release/breaking-changes/deprecate-curved-animation-reverse-curve.md
+++ b/sites/docs/src/content/release/breaking-changes/deprecate-curved-animation-reverse-curve.md
@@ -12,8 +12,7 @@ description: >-
 
 [`CurvedAnimation`][]'s [`reverseCurve`][] field has been deprecated.
 
-If needed,
-switch from [`CurvedAnimation`][] to [`AsymmetricCurvedAnimation`][].
+To use distinct curves for forward and reverse directions, switch from [`CurvedAnimation`][] to [`AsymmetricCurvedAnimation`][].
 
 ## Background
 

--- a/sites/docs/src/content/release/breaking-changes/deprecate-curved-animation-reverse-curve.md
+++ b/sites/docs/src/content/release/breaking-changes/deprecate-curved-animation-reverse-curve.md
@@ -2,8 +2,8 @@
 title: Deprecate `CurvedAnimation.reverseCurve` in favor of `AsymmetricCurvedAnimation`
 description: >-
   CurvedAnimation is becoming a single-curve animation.
-  Use AsymmetricCurvedAnimation for different curves in the forward and
-  reverse directions.
+  Use AsymmetricCurvedAnimation for different curves in
+  the forward and reverse directions.
 ---
 
 {% render "docs/breaking-changes.md" %}
@@ -12,7 +12,8 @@ description: >-
 
 [`CurvedAnimation`][]'s [`reverseCurve`][] field has been deprecated.
 
-To use distinct curves for forward and reverse directions, switch from [`CurvedAnimation`][] to [`AsymmetricCurvedAnimation`][].
+To use distinct curves for forward and reverse directions,
+switch from [`CurvedAnimation`][] to [`AsymmetricCurvedAnimation`][].
 
 ## Background
 
@@ -20,8 +21,8 @@ To support its [`reverseCurve`][] functionality,
 `CurvedAnimation` had to add listeners to its [`parent`][]
 to keep track of its direction.
 If you forget to call the [`dispose`][] method when you're done,
-those listeners would stick around in memory and prevent Dart from freeing up
-unneeded resources.
+those listeners would stick around in memory and prevent Dart from
+freeing up unneeded resources.
 
 But the most common use case of `CurvedAnimation` is with a single curve,
 meaning these listeners aren't even needed most of the time.
@@ -29,14 +30,18 @@ meaning these listeners aren't even needed most of the time.
 For this reason, [`reverseCurve`][] is being removed from [`CurvedAnimation`][]
 and moved to [`AsymmetricCurvedAnimation`][].
 
-After a migration period, it will be removed from `CurvedAnimation` alongside
-its listeners. This means more memory safety with [`CurvedAnimation`][]
-and less code to write, since you won't need to dispose it.
+After a migration period,
+it will be removed from `CurvedAnimation` alongside its listeners.
+This means more memory safety with [`CurvedAnimation`][] and
+less code to write, since you won't need to dispose it.
 
-(Until the migration period is over, remember to still call [`dispose`] when
-you're done.
-If you use [`AsymmetricCurvedAnimation`][], you still need to call its
-[`dispose`][] method regardless.)
+:::note
+Until the migration period is over,
+remember to still call [`dispose`] when you're done.
+
+If you use [`AsymmetricCurvedAnimation`][],
+you still need to call its [`dispose`][] method regardless.
+:::
 
 ## Migration guide
 
@@ -46,13 +51,13 @@ switch from [`CurvedAnimation`][] to [`AsymmetricCurvedAnimation`][].
 Code before migration:
 
 ```dart
-// This doesn't use `reverseCurve` so it stays as `CurvedAnimation`.
+// This doesn't use `reverseCurve` so it stays as `CurvedAnimation`:
 final oneCurve = CurvedAnimation(
   parent: _animationController,
   curve: Curves.easeIn,
 );
 
-// This uses `reverseCurve` so migrate to `AsymmetricCurvedAnimation`.
+// This uses `reverseCurve` so migrate to `AsymmetricCurvedAnimation`:
 final twoCurves = CurvedAnimation(
   parent: _animationController,
   curve: Curves.easeIn,
@@ -63,13 +68,13 @@ final twoCurves = CurvedAnimation(
 Code after migration:
 
 ```dart
-// This doesn't use `reverseCurve` so it stays as `CurvedAnimation`.
+// This doesn't use `reverseCurve` so it stays as `CurvedAnimation`:
 final oneCurve = CurvedAnimation(
   parent: _animationController,
   curve: Curves.easeIn,
 );
 
-// This uses `reverseCurve` so migrate to `AsymmetricCurvedAnimation`.
+// This uses `reverseCurve` so migrate to `AsymmetricCurvedAnimation`:
 final twoCurves = AsymmetricCurvedAnimation(
   parent: _animationController,
   curve: Curves.easeIn,
@@ -78,20 +83,6 @@ final twoCurves = AsymmetricCurvedAnimation(
 ```
 
 ## Timeline
-
-{% comment %}
-  The version # of the SDK where this change was
-  introduced.  If there is a deprecation window,
-  the version # to which we guarantee to maintain
-  the old API. Use the following template:
-
-  If a breaking change has been reverted in a
-  subsequent release, move that item to the
-  "Reverted" section of the index.md file.
-  Also add the "Reverted in version" line,
-  shown as optional below. Otherwise, delete
-  that line.
-{% endcomment %}
 
 Landed in version: Not yet<br>
 In stable release: Not yet

--- a/sites/docs/src/content/release/breaking-changes/deprecate-curved-animation-reverse-curve.md
+++ b/sites/docs/src/content/release/breaking-changes/deprecate-curved-animation-reverse-curve.md
@@ -35,8 +35,10 @@ In the future, the `reverseCurve` field will be removed from
 
 :::note
 Until the deprecation period is over, you must continue to
-call [`dispose`][] on [`CurvedAnimation`]. If you switch to [`AsymmetricCurvedAnimation`][], you must always call its
-[`dispose`][] method to clean up its active direction listeners.
+call [`dispose`][] on [`CurvedAnimation`].
+If you switch to [`AsymmetricCurvedAnimation`][], you must always call its
+[`dispose`][AsymmetricCurvedAnimation.dispose] method to clean up its
+active direction listeners.
 :::
 
 ## Migration guide
@@ -103,9 +105,10 @@ Relevant PRs:
 
 [`AsymmetricCurvedAnimation`]: {{site.main-api}}/flutter/animation/AsymmetricCurvedAnimation-class.html
 [`CurvedAnimation`]: {{site.main-api}}/flutter/animation/CurvedAnimation-class.html
-[`dispose`]: {{site.main-api}}/flutter/animation/AsymmetricCurvedAnimation/dispose.html
+[`dispose`]: {{site.main-api}}/flutter/animation/CurvedAnimation/dispose.html
+[AsymmetricCurvedAnimation.dispose]: {{site.main-api}}/flutter/animation/AsymmetricCurvedAnimation/dispose.html
 [`parent`]: {{site.main-api}}/flutter/animation/CurvedAnimation/parent.html
-[`reverseCurve`]: {{site.main-api}}/flutter/animation/AsymmetricCurvedAnimation/reverseCurve.html
+[`reverseCurve`]: {{site.main-api}}/flutter/animation/CurvedAnimation/reverseCurve.html
 
 [Disambiguate CurvedAnimation and CurveTween]: {{site.repo.flutter}}/issues/185468
 [Docs should instruct user to dispose `CurvedAnimation`]: {{site.repo.flutter}}/issues/183292

--- a/sites/docs/src/content/release/breaking-changes/deprecate-curved-animation-reverse-curve.md
+++ b/sites/docs/src/content/release/breaking-changes/deprecate-curved-animation-reverse-curve.md
@@ -1,0 +1,126 @@
+---
+title: Deprecate `CurvedAnimation.reverseCurve` in favor of `AsymmetricCurvedAnimation`
+description: >-
+  CurvedAnimation is becoming a single-curve animation.
+  Use AsymmetricCurvedAnimation for different curves in the forward and
+  reverse directions.
+---
+
+{% render "docs/breaking-changes.md" %}
+
+## Summary
+
+[`CurvedAnimation`][]'s [`reverseCurve`][] field has been deprecated.
+
+If needed,
+switch from [`CurvedAnimation`][] to [`AsymmetricCurvedAnimation`][].
+
+## Background
+
+To support its [`reverseCurve`][] functionality,
+`CurvedAnimation` had to add listeners to its [`parent`][]
+to keep track of its direction.
+If you forget to call the [`dispose`][] method when you're done,
+those listeners would stick around in memory and prevent Dart from freeing up
+unneeded resources.
+
+But the most common use case of `CurvedAnimation` is with a single curve,
+meaning these listeners aren't even needed most of the time.
+
+For this reason, [`reverseCurve`][] is being removed from [`CurvedAnimation`][]
+and moved to [`AsymmetricCurvedAnimation`][].
+
+After a migration period, it will be removed from `CurvedAnimation` alongside
+its listeners. This means more memory safety with [`CurvedAnimation`][]
+and less code to write, since you won't need to dispose it.
+
+(Until the migration period is over, remember to still call [`dispose`] when
+you're done.
+If you use [`AsymmetricCurvedAnimation`][], you still need to call its
+[`dispose`][] method regardless.)
+
+## Migration guide
+
+If you need [`CurvedAnimation`][]'s [`reverseCurve`][] field,
+switch from [`CurvedAnimation`][] to [`AsymmetricCurvedAnimation`][].
+
+Code before migration:
+
+```dart
+// This doesn't use `reverseCurve` so it stays as `CurvedAnimation`.
+final oneCurve = CurvedAnimation(
+  parent: _animationController,
+  curve: Curves.easeIn,
+);
+
+// This uses `reverseCurve` so migrate to `AsymmetricCurvedAnimation`.
+final twoCurves = CurvedAnimation(
+  parent: _animationController,
+  curve: Curves.easeIn,
+  reverseCurve: Curves.easeOut,
+);
+```
+
+Code after migration:
+
+```dart
+// This doesn't use `reverseCurve` so it stays as `CurvedAnimation`.
+final oneCurve = CurvedAnimation(
+  parent: _animationController,
+  curve: Curves.easeIn,
+);
+
+// This uses `reverseCurve` so migrate to `AsymmetricCurvedAnimation`.
+final twoCurves = AsymmetricCurvedAnimation(
+  parent: _animationController,
+  curve: Curves.easeIn,
+  reverseCurve: Curves.easeOut,
+);
+```
+
+## Timeline
+
+{% comment %}
+  The version # of the SDK where this change was
+  introduced.  If there is a deprecation window,
+  the version # to which we guarantee to maintain
+  the old API. Use the following template:
+
+  If a breaking change has been reverted in a
+  subsequent release, move that item to the
+  "Reverted" section of the index.md file.
+  Also add the "Reverted in version" line,
+  shown as optional below. Otherwise, delete
+  that line.
+{% endcomment %}
+
+Landed in version: Not yet<br>
+In stable release: Not yet
+
+## References
+
+{% render "docs/main-api.md", site: site %}
+
+API documentation:
+
+* [`CurvedAnimation`][]
+* [`AsymmetricCurvedAnimation`][]
+
+Relevant issues:
+
+* [Disambiguate CurvedAnimation and CurveTween][]
+* [Docs should instruct user to dispose `CurvedAnimation`][]
+
+Relevant PRs:
+
+* [Deprecate `CurvedAnimation.reverseCurve` for `AsymmetricCurvedAnimation`][]
+
+[`AsymmetricCurvedAnimation`]: {{site.main-api}}/flutter/animation/AsymmetricCurvedAnimation-class.html
+[`CurvedAnimation`]: {{site.main-api}}/flutter/animation/CurvedAnimation-class.html
+[`dispose`]: {{site.main-api}}/flutter/animation/AsymmetricCurvedAnimation/dispose.html
+[`parent`]: {{site.main-api}}/flutter/animation/CurvedAnimation/parent.html
+[`reverseCurve`]: {{site.main-api}}/flutter/animation/AsymmetricCurvedAnimation/reverseCurve.html
+
+[Disambiguate CurvedAnimation and CurveTween]: {{site.repo.flutter}}/issues/185468
+[Docs should instruct user to dispose `CurvedAnimation`]: {{site.repo.flutter}}/issues/183292
+[Deprecate `CurvedAnimation.reverseCurve` for `AsymmetricCurvedAnimation`]: {{site.repo.flutter}}/pull/185797

--- a/sites/docs/src/content/release/breaking-changes/deprecate-curved-animation-reverse-curve.md
+++ b/sites/docs/src/content/release/breaking-changes/deprecate-curved-animation-reverse-curve.md
@@ -21,26 +21,22 @@ To support its [`reverseCurve`][] functionality,
 `CurvedAnimation` had to add listeners to its [`parent`][]
 to keep track of its direction.
 If you forget to call the [`dispose`][] method when you're done,
-those listeners would stick around in memory and prevent Dart from
-freeing up unneeded resources.
+those listeners would leak.
 
-But the most common use case of `CurvedAnimation` is with a single curve,
-meaning these listeners aren't even needed most of the time.
+However, most animations use the same curve for the forward
+and reverse directions.
 
-For this reason, [`reverseCurve`][] is being removed from [`CurvedAnimation`][]
-and moved to [`AsymmetricCurvedAnimation`][].
+To make the common case leak-proof, `CurvedAnimation`'s
+`reverseCurve` functionality is moving to a separate class:
+[`AsymmetricCurvedAnimation`][].
 
-After a migration period,
-it will be removed from `CurvedAnimation` alongside its listeners.
-This means more memory safety with [`CurvedAnimation`][] and
-less code to write, since you won't need to dispose it.
+In the future, the `reverseCurve` field will be removed from
+`CurvedAnimation`.
 
 :::note
-Until the migration period is over,
-remember to still call [`dispose`] when you're done.
-
-If you use [`AsymmetricCurvedAnimation`][],
-you still need to call its [`dispose`][] method regardless.
+Until the deprecation period is over, you must continue to
+call [`dispose`][] on [`CurvedAnimation`]. If you switch to [`AsymmetricCurvedAnimation`][], you must always call its
+[`dispose`][] method to clean up its active direction listeners.
 :::
 
 ## Migration guide

--- a/sites/docs/src/content/release/breaking-changes/index.md
+++ b/sites/docs/src/content/release/breaking-changes/index.md
@@ -49,6 +49,7 @@ They're sorted by release and listed in alphabetical order:
 
 * [Changing RawMenuAnchor close order][]
 * [Deprecate `onReorder` callback][]
+* [Deprecate `CurvedAnimation.reverseCurve` in favor of `AsymmetricCurvedAnimation`][]
 * [Deprecate `TextInputConnection.setStyle`][]
 * [Deprecated `cacheExtent` and `cacheExtentStyle`][]
 * [`IconData` class marked as `final`][]
@@ -59,6 +60,7 @@ They're sorted by release and listed in alphabetical order:
 [Changing RawMenuAnchor close order]: /release/breaking-changes/raw-menu-anchor-close-order
 [Deprecate `onReorder` callback]: /release/breaking-changes/deprecate-onreorder-callback
 [Deprecated `cacheExtent` and `cacheExtentStyle`]: /release/breaking-changes/scroll-cache-extent
+[Deprecate `CurvedAnimation.reverseCurve` in favor of `AsymmetricCurvedAnimation`]: /release/breaking-changes/deprecate-curved-animation-reverse-curve
 [Deprecate `TextInputConnection.setStyle`]: /release/breaking-changes/deprecate-text-input-connection-set-style
 [`IconData` class marked as `final`]: /release/breaking-changes/icondata-class-marked-final
 [ListTile reports an error in debug when wrapped in a colored widget]: /release/breaking-changes/list-tile-color-warning

--- a/sites/docs/src/content/release/breaking-changes/index.md
+++ b/sites/docs/src/content/release/breaking-changes/index.md
@@ -37,10 +37,12 @@ They're sorted by release and listed in alphabetical order:
 ### Not yet released to stable
 
 * [Added enabled property and made onChanged optional for DropdownButton][]
+* [Deprecate `CurvedAnimation.reverseCurve` in favor of `AsymmetricCurvedAnimation`][]
 * [Large screen orientation and resizability restrictions ignored on Android 17][]
 * [Update semantics header and headingLevel behavior on iOS and Android][]
 
 [Added enabled property and made onChanged optional for DropdownButton]: /release/breaking-changes/dropdownbutton-enabled-property
+[Deprecate `CurvedAnimation.reverseCurve` in favor of `AsymmetricCurvedAnimation`]: /release/breaking-changes/deprecate-curved-animation-reverse-curve
 [Large screen orientation and resizability restrictions ignored on Android 17]: /release/breaking-changes/android-large-screens-restrictions-ignored
 [Update semantics header and headingLevel behavior on iOS and Android]: /release/breaking-changes/semantics-header-heading-level
 
@@ -49,7 +51,6 @@ They're sorted by release and listed in alphabetical order:
 
 * [Changing RawMenuAnchor close order][]
 * [Deprecate `onReorder` callback][]
-* [Deprecate `CurvedAnimation.reverseCurve` in favor of `AsymmetricCurvedAnimation`][]
 * [Deprecate `TextInputConnection.setStyle`][]
 * [Deprecated `cacheExtent` and `cacheExtentStyle`][]
 * [`IconData` class marked as `final`][]
@@ -60,7 +61,6 @@ They're sorted by release and listed in alphabetical order:
 [Changing RawMenuAnchor close order]: /release/breaking-changes/raw-menu-anchor-close-order
 [Deprecate `onReorder` callback]: /release/breaking-changes/deprecate-onreorder-callback
 [Deprecated `cacheExtent` and `cacheExtentStyle`]: /release/breaking-changes/scroll-cache-extent
-[Deprecate `CurvedAnimation.reverseCurve` in favor of `AsymmetricCurvedAnimation`]: /release/breaking-changes/deprecate-curved-animation-reverse-curve
 [Deprecate `TextInputConnection.setStyle`]: /release/breaking-changes/deprecate-text-input-connection-set-style
 [`IconData` class marked as `final`]: /release/breaking-changes/icondata-class-marked-final
 [ListTile reports an error in debug when wrapped in a colored widget]: /release/breaking-changes/list-tile-color-warning


### PR DESCRIPTION


_Description of what this PR is changing or adding, and why:_

Adds a migration guide for a breaking change in https://github.com/flutter/flutter/pull/185797.

_PRs or commits this PR depends on (if any):_
- https://github.com/flutter/flutter/pull/185797

## Presubmit checklist

- [X] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [X] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
