### PR TITLE
Advise Running VS Code as Administrator on Windows for Flutter Installation

### DIFF
--- a/src/_includes/docs/install/quick.md
+++ b/src/_includes/docs/install/quick.md
@@ -175,6 +175,11 @@ follow the instructions in [Install Flutter manually][].
     If not already open, open VS Code by searching for it with Spotlight
     or opening it manually from the directory where it's installed.
 
+    :::note Windows users
+    If the Flutter installation fails or the command palette doesn't respond,
+    try relaunching VS Code as **Administrator** and repeat this step.
+    :::
+
  1. <h3>Add the Flutter extension to VS Code</h3>
 
     To add the Dart and Flutter extensions to VS Code,


### PR DESCRIPTION
On Windows, Flutter installation via the VS Code command palette can silently fail without elevated privileges. Updated the launch step to instruct Windows users to run VS Code as Administrator. I encountered this problem every time when installing Flutter on Windows.