### PR TITLE
Update site tool to support multiple sites

### DIFF
--- a/tool/dash_site/lib/dash_site.dart
+++ b/tool/dash_site/lib/dash_site.dart
@@ -15,17 +15,25 @@ import 'src/commands/refresh_excerpts.dart';
 import 'src/commands/serve.dart';
 import 'src/commands/test_dart.dart';
 import 'src/commands/verify_firebase_json.dart';
+import 'src/sites.dart';
 
-/// The root command runner of the Fluter documentation website tooling.
+/// The root command runner of the Flutter website tooling.
 ///
-/// To learn about it and its subcommands,
+/// To learn about the command, its supported options, and its subcommands,
 /// run `dart run dash_site --help`.
 final class DashSiteCommandRunner extends CommandRunner<int> {
   DashSiteCommandRunner()
     : super(
         'dart run dash_site',
-        'Infrastructure tooling for the Flutter documentation website.',
+        'Infrastructure tooling for the Flutter websites.',
       ) {
+    argParser.addOption(
+      siteOptionName,
+      defaultsTo: Site.docs.name,
+      allowed: [for (final site in Site.values) site.name],
+      help: 'The site to operate on.',
+    );
+
     addCommand(AnalyzeDartCommand());
     addCommand(BuildSiteCommand());
     addCommand(CheckAllCommand());

--- a/tool/dash_site/lib/src/commands/analyze_dart.dart
+++ b/tool/dash_site/lib/src/commands/analyze_dart.dart
@@ -36,7 +36,7 @@ int analyzeDart({bool verboseLogging = false}) {
   final directoriesToAnalyze = [
     'examples',
     'packages',
-    Site.docs.directory,
+    for (final site in Site.values) site.directory,
     path.join('tool', 'dash_site'),
   ];
 

--- a/tool/dash_site/lib/src/commands/build.dart
+++ b/tool/dash_site/lib/src/commands/build.dart
@@ -35,6 +35,7 @@ final class BuildSiteCommand extends Command<int> {
     installJasprCliIfNecessary();
 
     final productionRelease = argResults.get<bool>(_releaseFlag, false);
+    final site = selectedSite;
 
     final process = await Process.start(
       Platform.resolvedExecutable,
@@ -52,7 +53,7 @@ final class BuildSiteCommand extends Command<int> {
         r'--sitemap-exclude=\.html\.md$',
         '--dart-define=PRODUCTION=$productionRelease',
       ],
-      workingDirectory: Site.docs.directory,
+      workingDirectory: site.directory,
       mode: ProcessStartMode.inheritStdio,
     );
 
@@ -60,7 +61,7 @@ final class BuildSiteCommand extends Command<int> {
 
     final originalOutputDirectoryPath = path.join(
       repositoryRoot,
-      Site.docs.directory,
+      site.directory,
       'build',
       'jaspr',
     );

--- a/tool/dash_site/lib/src/commands/build.dart
+++ b/tool/dash_site/lib/src/commands/build.dart
@@ -19,7 +19,7 @@ final class BuildSiteCommand extends Command<int> {
       _releaseFlag,
       defaultsTo: false,
       help:
-          'Build a release build for docs.flutter.dev. '
+          'Build a production release of the site. '
           'Optimizes site resources.',
     );
   }
@@ -48,7 +48,7 @@ final class BuildSiteCommand extends Command<int> {
         // Use build_web_compiler options specified in build.yaml instead of
         // those specified by jaspr_cli.
         '--no-managed-build-options',
-        '--sitemap-domain=https://docs.flutter.dev',
+        '--sitemap-domain=${site.baseUrl}',
         // Exclude secondary Markdown output files from sitemap.
         r'--sitemap-exclude=\.html\.md$',
         '--dart-define=PRODUCTION=$productionRelease',

--- a/tool/dash_site/lib/src/commands/check_all.dart
+++ b/tool/dash_site/lib/src/commands/check_all.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:args/command_runner.dart';
 
+import '../sites.dart';
 import '../utils.dart';
 
 final class CheckAllCommand extends Command<int> {
@@ -25,6 +26,8 @@ final class CheckAllCommand extends Command<int> {
       ['refresh-excerpts', '--fail-on-update', '--dry-run'],
     ];
 
+    final siteName = selectedSite.name;
+
     var seenFailure = false;
 
     for (final task in verificationTasks) {
@@ -32,6 +35,7 @@ final class CheckAllCommand extends Command<int> {
       final process = await Process.start(Platform.resolvedExecutable, [
         'run',
         'dash_site',
+        '--$siteOptionName=$siteName',
         ...task,
       ]);
       await stdout.addStream(process.stdout);

--- a/tool/dash_site/lib/src/commands/clean.dart
+++ b/tool/dash_site/lib/src/commands/clean.dart
@@ -27,7 +27,7 @@ final class CleanSiteCommand extends Command<int> {
     final process = await Process.start(
       Platform.resolvedExecutable,
       ['pub', 'global', 'run', 'jaspr_cli:jaspr', 'clean', '--kill'],
-      workingDirectory: Site.docs.directory,
+      workingDirectory: selectedSite.directory,
       mode: ProcessStartMode.inheritStdio,
     );
 

--- a/tool/dash_site/lib/src/commands/format_dart.dart
+++ b/tool/dash_site/lib/src/commands/format_dart.dart
@@ -38,7 +38,7 @@ int formatDart({bool justCheck = false}) {
   final directoriesToFormat = [
     'examples',
     'packages',
-    Site.docs.directory,
+    for (final site in Site.values) site.directory,
     path.join('tool', 'dash_site'),
   ];
 

--- a/tool/dash_site/lib/src/commands/serve.dart
+++ b/tool/dash_site/lib/src/commands/serve.dart
@@ -44,7 +44,7 @@ final class ServeSiteCommand extends Command<int> {
         '--dart-define=PRODUCTION=false',
         if (release) '--release',
       ],
-      workingDirectory: Site.docs.directory,
+      workingDirectory: selectedSite.directory,
       runInShell: true,
       mode: ProcessStartMode.inheritStdio,
     );

--- a/tool/dash_site/lib/src/sites.dart
+++ b/tool/dash_site/lib/src/sites.dart
@@ -8,7 +8,12 @@ import 'package:path/path.dart' as path;
 /// The sites maintained in this repository.
 enum Site {
   /// The Flutter documentation site.
-  docs;
+  docs(baseUrl: 'https://docs.flutter.dev');
+
+  const Site({required this.baseUrl});
+
+  /// The canonical base URL where this site is hosted in production.
+  final String baseUrl;
 
   /// The directory where this site's content and implementation is located.
   String get directory => path.join('sites', name);

--- a/tool/dash_site/lib/src/sites.dart
+++ b/tool/dash_site/lib/src/sites.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:args/command_runner.dart';
 import 'package:path/path.dart' as path;
 
 /// The sites maintained in this repository.
@@ -9,5 +10,21 @@ enum Site {
   /// The Flutter documentation site.
   docs;
 
+  /// The directory where this site's content and implementation is located.
   String get directory => path.join('sites', name);
+}
+
+/// The name of the global `--site` option.
+const String siteOptionName = 'site';
+
+extension CommandSiteResolution<T> on Command<T> {
+  /// The [Site] selected with the global `--site` option,
+  /// defaulting to [Site.docs].
+  Site get selectedSite {
+    if (globalResults?.option(siteOptionName) case final siteName?) {
+      return Site.values.byName(siteName);
+    }
+
+    return Site.docs;
+  }
 }


### PR DESCRIPTION
Support multiple sites in commands that need to with a global `--sites=<site-id>` option that defaults to `docs`.

Contributes to https://github.com/flutter/website/issues/13148