### PR TITLE
Fix view source path after moving site content

### DIFF
--- a/sites/docs/lib/src/loaders/data_processor.dart
+++ b/sites/docs/lib/src/loaders/data_processor.dart
@@ -74,51 +74,59 @@ final String? _repositoryRoot = () {
 String? _lastModifiedDateForPath(String inputPath) =>
     _lastModifiedPerPath[inputPath]?.formatted;
 
+/// The most recent Git commit date for each content file path.
+///
+/// The paths are relative to the repository root.
+/// If Git metadata isn't available, the map is empty.
 final Map<String, DateTime> _lastModifiedPerPath = () {
   final fileLastModified = <String, DateTime>{};
   final repositoryRoot = _repositoryRoot;
   if (repositoryRoot == null) return fileLastModified;
 
+  final ProcessResult result;
   try {
-    final output =
-        Process.runSync(
-              'git',
-              [
-                'log',
-                '--name-only',
-                '--format=commit-date:%cI',
-                '--',
-                path.join('sites', 'docs', 'src', 'content'),
-              ],
-              workingDirectory: repositoryRoot,
-            ).stdout
-            as String;
+    result = Process.runSync(
+      'git',
+      [
+        'log',
+        '--name-only',
+        '--format=commit-date:%cI',
+        '--',
+        path.join('sites', 'docs', 'src', 'content'),
+      ],
+      workingDirectory: repositoryRoot,
+    );
+  } on FileSystemException catch (_) {
+    // Ignore and return an empty list.
+    // We just won't render the last updated time.
+    return fileLastModified;
+  } on ProcessException catch (_) {
+    // Ignore and return an empty list.
+    // We just won't render the last updated time.
+    return fileLastModified;
+  }
 
-    final lines = const LineSplitter().convert(output);
-    DateTime? currentCommitDate;
-    for (final line in lines) {
-      // Check if the line is a commit date line.
-      if (line.split('commit-date:') case [_, final dateString]) {
-        // Extract the date string and try to parse it.
-        currentCommitDate = DateTime.tryParse(dateString);
-      } else if (line.isNotEmpty) {
-        // If it's a non-empty line and a date is set, it's a file path.
-        if (currentCommitDate case final lastModifiedTime?) {
-          // Only set the last modified time for this path
-          // if we haven't already stored a later modified time.
-          fileLastModified.putIfAbsent(
-            line,
-            () => lastModifiedTime,
-          );
-        }
+  if (result.exitCode != 0) return fileLastModified;
+
+  final output = result.stdout as String;
+  final lines = const LineSplitter().convert(output);
+  DateTime? currentCommitDate;
+  for (final line in lines) {
+    // Check if the line is a commit date line.
+    if (line.split('commit-date:') case [_, final dateString]) {
+      // Extract the date string and try to parse it.
+      currentCommitDate = DateTime.tryParse(dateString);
+    } else if (line.isNotEmpty) {
+      // If it's a non-empty line and a date is set, it's a file path.
+      if (currentCommitDate case final lastModifiedTime?) {
+        // Only set the last modified time for this path
+        // if we haven't already stored a later modified time.
+        fileLastModified.putIfAbsent(
+          line,
+          () => lastModifiedTime,
+        );
       }
     }
-  } on FileSystemException catch (_) {
-    // Ignore and fall through to return an empty list.
-    // We just won't render the last updated time.
-  } on ProcessException catch (_) {
-    // Ignore and fall through to return an empty list.
-    // We just won't render the last updated time.
   }
 
   return fileLastModified;

--- a/sites/docs/lib/src/loaders/data_processor.dart
+++ b/sites/docs/lib/src/loaders/data_processor.dart
@@ -24,7 +24,7 @@ final class DataProcessor implements DataLoader {
       path.join(pageLoader.directory, page.path),
     );
 
-    final inputPath = path.relative(sourcePath, from: '..');
+    final inputPath = path.relative(sourcePath, from: _repositoryRoot);
     page.apply(
       data: {
         'page': {
@@ -39,6 +39,17 @@ final class DataProcessor implements DataLoader {
     );
   }
 }
+
+/// The root directory of this repository.
+final String _repositoryRoot = () {
+  final result = Process.runSync('git', const ['rev-parse', '--show-toplevel']);
+  if (result.exitCode != 0) {
+    throw StateError(
+      'Couldn\'t find repository root: ${result.stderr}',
+    );
+  }
+  return path.canonicalize((result.stdout as String).trim());
+}();
 
 /// Determines the last modified date for a given path
 /// in the form `yyyy-mm-dd`.
@@ -58,7 +69,7 @@ final Map<String, DateTime> _lastModifiedPerPath = () {
               '--name-only',
               '--format=commit-date:%cI',
               '--',
-              '../src/content',
+              'src/content',
             ]).stdout
             as String;
 

--- a/sites/docs/lib/src/loaders/data_processor.dart
+++ b/sites/docs/lib/src/loaders/data_processor.dart
@@ -26,8 +26,12 @@ final class DataProcessor implements DataLoader {
     );
 
     final repositoryRoot = _repositoryRoot;
+    // Use native separators for filesystem paths,
+    // then POSIX separators for Git paths and source URLs.
     final inputPath = repositoryRoot != null
-        ? path.relative(sourcePath, from: repositoryRoot)
+        ? path.posix.joinAll(
+            path.split(path.relative(sourcePath, from: repositoryRoot)),
+          )
         : null;
     final lastModifiedDate = inputPath != null
         ? _lastModifiedDateForPath(inputPath)
@@ -92,7 +96,7 @@ final Map<String, DateTime> _lastModifiedPerPath = () {
         '--name-only',
         '--format=commit-date:%cI',
         '--',
-        path.join('sites', 'docs', 'src', 'content'),
+        path.posix.join('sites', 'docs', 'src', 'content'),
       ],
       workingDirectory: repositoryRoot,
     );

--- a/sites/docs/lib/src/loaders/data_processor.dart
+++ b/sites/docs/lib/src/loaders/data_processor.dart
@@ -3,7 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:io' show FileSystemException, Process;
+import 'dart:io'
+    show FileSystemException, Process, ProcessException, ProcessResult;
 
 import 'package:jaspr_content/jaspr_content.dart';
 import 'package:path/path.dart' as path;
@@ -21,18 +22,24 @@ final class DataProcessor implements DataLoader {
     if (pageLoader is! FilesystemLoader) return;
 
     final sourcePath = path.canonicalize(
-      path.join(pageLoader.directory, page.path),
+      path.absolute(path.join(pageLoader.directory, page.path)),
     );
 
-    final inputPath = path.relative(sourcePath, from: _repositoryRoot);
+    final repositoryRoot = _repositoryRoot;
+    final inputPath = repositoryRoot != null
+        ? path.relative(sourcePath, from: repositoryRoot)
+        : null;
+    final lastModifiedDate = inputPath != null
+        ? _lastModifiedDateForPath(inputPath)
+        : null;
     page.apply(
       data: {
         'page': {
-          'date': ?_lastModifiedDateForPath(inputPath),
-          'inputPath': inputPath,
+          'date': ?lastModifiedDate,
+          'inputPath': ?inputPath,
           if (page.data.page['sitemap'] == null)
             'sitemap': {
-              'lastmod': _lastModifiedDateForPath(inputPath),
+              'lastmod': lastModifiedDate,
             },
         },
       },
@@ -40,14 +47,22 @@ final class DataProcessor implements DataLoader {
   }
 }
 
-/// The root directory of this repository.
-final String _repositoryRoot = () {
-  final result = Process.runSync('git', const ['rev-parse', '--show-toplevel']);
-  if (result.exitCode != 0) {
-    throw StateError(
-      'Couldn\'t find repository root: ${result.stderr}',
-    );
+/// The root directory of this repository, if available from Git.
+final String? _repositoryRoot = () {
+  final ProcessResult result;
+  try {
+    result = Process.runSync('git', const [
+      'rev-parse',
+      '--show-toplevel',
+    ]);
+  } on ProcessException {
+    return null;
   }
+
+  if (result.exitCode != 0) {
+    return null;
+  }
+
   return path.canonicalize((result.stdout as String).trim());
 }();
 
@@ -61,16 +76,22 @@ String? _lastModifiedDateForPath(String inputPath) =>
 
 final Map<String, DateTime> _lastModifiedPerPath = () {
   final fileLastModified = <String, DateTime>{};
+  final repositoryRoot = _repositoryRoot;
+  if (repositoryRoot == null) return fileLastModified;
 
   try {
     final output =
-        Process.runSync('git', [
-              'log',
-              '--name-only',
-              '--format=commit-date:%cI',
-              '--',
-              'src/content',
-            ]).stdout
+        Process.runSync(
+              'git',
+              [
+                'log',
+                '--name-only',
+                '--format=commit-date:%cI',
+                '--',
+                path.join('sites', 'docs', 'src', 'content'),
+              ],
+              workingDirectory: repositoryRoot,
+            ).stdout
             as String;
 
     final lines = const LineSplitter().convert(output);
@@ -93,6 +114,9 @@ final Map<String, DateTime> _lastModifiedPerPath = () {
       }
     }
   } on FileSystemException catch (_) {
+    // Ignore and fall through to return an empty list.
+    // We just won't render the last updated time.
+  } on ProcessException catch (_) {
     // Ignore and fall through to return an empty list.
     // We just won't render the last updated time.
   }

--- a/sites/docs/lib/src/loaders/data_processor.dart
+++ b/sites/docs/lib/src/loaders/data_processor.dart
@@ -101,11 +101,11 @@ final Map<String, DateTime> _lastModifiedPerPath = () {
       workingDirectory: repositoryRoot,
     );
   } on FileSystemException catch (_) {
-    // Ignore and return an empty list.
+    // Ignore and return an empty map.
     // We just won't render the last updated time.
     return fileLastModified;
   } on ProcessException catch (_) {
-    // Ignore and return an empty list.
+    // Ignore and return an empty map.
     // We just won't render the last updated time.
     return fileLastModified;
   }


### PR DESCRIPTION
Fix view source path after moving site content into the `sites/docs` directory. Also add more handling for different setups, working directories, error situations, and building on Windows.

Fixes https://github.com/flutter/website/issues/13357