### PR TITLE
Ensure use of latest Jaspr and build deps

### DIFF
--- a/sites/docs/pubspec.yaml
+++ b/sites/docs/pubspec.yaml
@@ -7,12 +7,12 @@ environment:
   sdk: ^3.11.0
 
 dependencies:
-  build: ^4.0.5
+  build: ^4.0.6
   collection: ^1.19.1
   crypto: ^3.0.7
   html: ^0.15.6
   http: ^1.6.0
-  jaspr: ^0.23.0
+  jaspr: ^0.23.1
   jaspr_content: ^0.5.2
   # Used as our template engine.
   liquify: ^1.5.1
@@ -30,10 +30,10 @@ dependencies:
 dev_dependencies:
   analysis_defaults:
     path: ../../packages/analysis_defaults
-  build_runner: ^2.13.1
-  build_web_compilers: ^4.4.17
-  jaspr_builder: ^0.23.0
-  sass: ^1.97.3
+  build_runner: ^2.15.0
+  build_web_compilers: ^4.4.19
+  jaspr_builder: ^0.23.1
+  sass: ^1.99.0
   sass_builder: ^2.4.0
 
 jaspr:

--- a/tool/dash_site/lib/src/utils.dart
+++ b/tool/dash_site/lib/src/utils.dart
@@ -33,7 +33,7 @@ int installJasprCliIfNecessary() {
     'global',
     'activate',
     'jaspr_cli',
-    '^0.23.0',
+    '^0.23.1',
   ]);
 
   if (activateOutput.exitCode != 0) {


### PR DESCRIPTION
Jaspr 0.23.1 includes some fixes when running an AOT installed version of `jaspr_cli`.