### PR TITLE
Inital example of a bare skill that gives contributors their installed mcp servers but only the skills that have been vetted

### DIFF
--- a/.agents/agents/bare-agent/agent.json
+++ b/.agents/agents/bare-agent/agent.json
@@ -1,0 +1,7 @@
+{
+  "name": "bare-agent",
+  "description": "An agent that only inherits MCP servers and only includes proven reliable skills.",
+  "configPath": {
+    "relativePathToConfig": "config.yaml"
+  }
+}

--- a/.agents/agents/bare-agent/config.yaml
+++ b/.agents/agents/bare-agent/config.yaml
@@ -1,0 +1,9 @@
+coding_agent:
+  agentic_mode: true
+  google_mode: false
+
+customization_config:
+  customization_discovery_config:
+    skills:
+      inherit_user: false
+      skills_paths: []


### PR DESCRIPTION
@gaaclarke was frustrated by a skill that was triggered when he didnt want or expect. Full context in go/flutter-website-skills-frustration-chat
We could fix that specific skill but that does not remove the class of issue, what to do when skills are triggering and making you work more complicated. Until we have resolver style tests that can regression test false positive activations then a custom agent can be a work around in the moment and as a pattern. 
<img width="202" height="157" alt="Screenshot 2026-05-08 at 7 06 05 PM" src="https://github.com/user-attachments/assets/3a65459d-916b-4251-970c-7dff88ecbcf2" />


## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
