### PR TITLE
Update check links to support different sites

### DIFF
--- a/tool/dash_site/lib/src/commands/check_links.dart
+++ b/tool/dash_site/lib/src/commands/check_links.dart
@@ -9,6 +9,7 @@ import 'package:args/command_runner.dart';
 import 'package:linkcheck/linkcheck.dart' as linkcheck show run;
 import 'package:path/path.dart' as path;
 
+import '../sites.dart';
 import '../utils.dart';
 
 final class CheckLinksCommand extends Command<int> {
@@ -30,14 +31,11 @@ final class CheckLinksCommand extends Command<int> {
   String get name => 'check-links';
 
   @override
-  Future<int> run() async =>
-      _checkLinks(checkExternal: argResults.get<bool>(_externalFlag, false));
+  Future<int> run() async => _checkLinks(
+    site: selectedSite,
+    checkExternal: argResults.get<bool>(_externalFlag, false),
+  );
 }
-
-/// The port that the firebase emulator runs on by default.
-/// This must match what's declared in the `firebase.json`
-/// and can't be 5000, since Airplay uses it.
-const int _emulatorPort = 5502;
 
 /// The path from root where the linkcheck skip list lives.
 final String _skipFilePath = path.join(
@@ -46,10 +44,15 @@ final String _skipFilePath = path.join(
   'linkcheck-skip-list.txt',
 );
 
-Future<int> _checkLinks({bool checkExternal = false}) async {
-  if (await _isPortInUse(_emulatorPort)) {
+Future<int> _checkLinks({
+  required Site site,
+  bool checkExternal = false,
+}) async {
+  final emulatorPort = site.firebaseEmulatorPort;
+
+  if (await _isPortInUse(emulatorPort)) {
     stderr.writeln(
-      'Error: Port $_emulatorPort is already in use! '
+      'Error: Port $emulatorPort is already in use! '
       'Are you running the emulator elsewhere?',
     );
     return 1;
@@ -67,15 +70,27 @@ Future<int> _checkLinks({bool checkExternal = false}) async {
     'Using firebase-tools $firebaseToolsVersion to start the '
     'Firebase hosting emulator asynchronously...',
   );
-  final emulatorProcess = await Process.start('firebase', const [
-    'emulators:start',
-    '--only',
-    'hosting',
-    '--project',
-    'default',
-    '--log-verbosity',
-    'QUIET',
-  ], mode: ProcessStartMode.inheritStdio);
+  final firebaseConfigDirectory = path.join(
+    repositoryRoot,
+    site.firebaseConfigDirectory,
+  );
+  final firebaseConfigFileName = path.basename(site.firebaseConfigPath);
+  final emulatorProcess = await Process.start(
+    'firebase',
+    [
+      'emulators:start',
+      '--only',
+      'hosting',
+      '--project',
+      'default',
+      '--config',
+      firebaseConfigFileName,
+      '--log-verbosity',
+      'QUIET',
+    ],
+    workingDirectory: firebaseConfigDirectory,
+    mode: ProcessStartMode.inheritStdio,
+  );
 
   print('Connecting to the emulator...');
   // Give the emulator a few seconds to start up.
@@ -83,14 +98,14 @@ Future<int> _checkLinks({bool checkExternal = false}) async {
 
   try {
     // Check to see if the emulator is running.
-    if (!(await _isPortInUse(_emulatorPort))) {
+    if (!(await _isPortInUse(emulatorPort))) {
       stderr.writeln('Error: The Firebase hosting emulator did not start!');
       return 1;
     }
 
     try {
       final result = await linkcheck.run([
-        ':$_emulatorPort',
+        ':$emulatorPort',
         '--skip-file',
         _skipFilePath,
         if (checkExternal) 'external',

--- a/tool/dash_site/lib/src/commands/verify_firebase_json.dart
+++ b/tool/dash_site/lib/src/commands/verify_firebase_json.dart
@@ -172,7 +172,8 @@ bool _verifyHostingEmulatorPort(
   final emulatorsConfig = firebaseConfig['emulators'];
   if (emulatorsConfig is! Map<String, Object?>) {
     stderr.writeln(
-      "Error: The firebase.json file is missing a top-level 'emulators' entry.",
+      'Error: The ${site.name} Firebase config is '
+      "missing a top-level 'emulators' entry.",
     );
     return false;
   }
@@ -180,7 +181,8 @@ bool _verifyHostingEmulatorPort(
   final hostingEmulatorConfig = emulatorsConfig['hosting'];
   if (hostingEmulatorConfig is! Map<String, Object?>) {
     stderr.writeln(
-      "Error: The firebase.json file is missing an 'emulators.hosting' entry.",
+      'Error: The ${site.name} Firebase config is '
+      "missing an 'emulators.hosting' entry.",
     );
     return false;
   }
@@ -188,9 +190,8 @@ bool _verifyHostingEmulatorPort(
   final port = hostingEmulatorConfig['port'];
   if (port != site.firebaseEmulatorPort) {
     stderr.writeln(
-      "Error: The firebase.json 'emulators.hosting.port' value must be "
-      '${site.firebaseEmulatorPort} for the ${site.name} site, '
-      'but found $port.',
+      "Error: The ${site.name} Firebase config 'emulators.hosting.port' "
+      'value must be ${site.firebaseEmulatorPort}, but found $port.',
     );
     return false;
   }

--- a/tool/dash_site/lib/src/commands/verify_firebase_json.dart
+++ b/tool/dash_site/lib/src/commands/verify_firebase_json.dart
@@ -6,6 +6,10 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
+import 'package:path/path.dart' as path;
+
+import '../sites.dart';
+import '../utils.dart';
 
 final class VerifyFirebaseJsonCommand extends Command<int> {
   @override
@@ -17,15 +21,16 @@ final class VerifyFirebaseJsonCommand extends Command<int> {
   String get name => 'verify-firebase-json';
 
   @override
-  Future<int> run() async => _verifyFirebaseJson();
+  Future<int> run() async => _verifyFirebaseJson(selectedSite);
 }
 
-int _verifyFirebaseJson() {
-  final firebaseFile = File('firebase.json');
+int _verifyFirebaseJson(Site site) {
+  final firebasePath = path.join(repositoryRoot, site.firebaseConfigPath);
+  final firebaseFile = File(firebasePath);
 
   if (!firebaseFile.existsSync()) {
     stderr.writeln(
-      'Cannot find the firebase.json file in the current directory.',
+      'Cannot find the ${site.name} Firebase config at $firebasePath.',
     );
     return 1;
   }
@@ -41,6 +46,10 @@ int _verifyFirebaseJson() {
       stderr.writeln(
         "Error: The firebase.json file is missing a top-level 'hosting' entry.",
       );
+      return 1;
+    }
+
+    if (!_verifyHostingEmulatorPort(firebaseConfig, site)) {
       return 1;
     }
 
@@ -152,4 +161,39 @@ int _verifyFirebaseJson() {
   }
 
   return 0;
+}
+
+/// Returns whether the Firebase hosting emulator port in
+/// the [firebaseConfig] matches the one specified for [site].
+bool _verifyHostingEmulatorPort(
+  Map<String, Object?> firebaseConfig,
+  Site site,
+) {
+  final emulatorsConfig = firebaseConfig['emulators'];
+  if (emulatorsConfig is! Map<String, Object?>) {
+    stderr.writeln(
+      "Error: The firebase.json file is missing a top-level 'emulators' entry.",
+    );
+    return false;
+  }
+
+  final hostingEmulatorConfig = emulatorsConfig['hosting'];
+  if (hostingEmulatorConfig is! Map<String, Object?>) {
+    stderr.writeln(
+      "Error: The firebase.json file is missing an 'emulators.hosting' entry.",
+    );
+    return false;
+  }
+
+  final port = hostingEmulatorConfig['port'];
+  if (port != site.firebaseEmulatorPort) {
+    stderr.writeln(
+      "Error: The firebase.json 'emulators.hosting.port' value must be "
+      '${site.firebaseEmulatorPort} for the ${site.name} site, '
+      'but found $port.',
+    );
+    return false;
+  }
+
+  return true;
 }

--- a/tool/dash_site/lib/src/commands/verify_firebase_json.dart
+++ b/tool/dash_site/lib/src/commands/verify_firebase_json.dart
@@ -14,7 +14,7 @@ import '../utils.dart';
 final class VerifyFirebaseJsonCommand extends Command<int> {
   @override
   String get description =>
-      'Verify the firebase.json file is valid and '
+      "Verify the site's Firebase config is valid and "
       'meets the site standards.';
 
   @override
@@ -44,7 +44,8 @@ int _verifyFirebaseJson(Site site) {
 
     if (hostingConfig == null) {
       stderr.writeln(
-        "Error: The firebase.json file is missing a top-level 'hosting' entry.",
+        'Error: The ${site.name} Firebase config is '
+        "missing a top-level 'hosting' entry.",
       );
       return 1;
     }
@@ -57,14 +58,16 @@ int _verifyFirebaseJson(Site site) {
 
     if (redirects == null) {
       stdout.writeln(
-        'There are no redirects specified within the firebase.json file.',
+        'There are no redirects specified in '
+        'the ${site.name} Firebase config.',
       );
       return 0;
     }
 
     if (redirects is! List<Object?>) {
       stderr.writeln(
-        "Error: The firebase.json file's 'redirect' entry is not a list.",
+        "Error: The ${site.name} Firebase config 'hosting.redirects' "
+        'entry is not a list.',
       );
       return 1;
     }
@@ -80,8 +83,8 @@ int _verifyFirebaseJson(Site site) {
     for (final redirect in redirects) {
       if (redirect is! Map<String, Object?>) {
         stderr.writeln(
-          'Error: Each redirect must be a map containing '
-          "a 'source' or 'regex' field.",
+          'Error: Each redirect in the ${site.name} Firebase config must be '
+          "a map containing a 'source' or 'regex' field.",
         );
         return 1;
       }
@@ -89,7 +92,7 @@ int _verifyFirebaseJson(Site site) {
       final source = redirect['source'] ?? redirect['regex'];
       if (source == null) {
         stderr.writeln(
-          'Error: The firebase.json file has a '
+          'Error: The ${site.name} Firebase config has a '
           "redirect missing a 'source' or 'regex'.",
         );
         return 1;
@@ -97,7 +100,7 @@ int _verifyFirebaseJson(Site site) {
 
       if (source is! String) {
         stderr.writeln(
-          'Error: The firebase.json redirect $redirect has a '
+          'Error: The ${site.name} Firebase config redirect $redirect has a '
           "'source' or 'regex' specified which is not a string.",
         );
         return 1;
@@ -105,14 +108,17 @@ int _verifyFirebaseJson(Site site) {
 
       if (source.isEmpty) {
         stderr.writeln(
-          'Error: The firebase.json redirect $redirect has an '
+          'Error: The ${site.name} Firebase config redirect $redirect has an '
           "empty 'source' or 'regex'.",
         );
         return 1;
       }
 
       if (sources.contains(source)) {
-        stderr.writeln("Error: Multiple redirects share the '$source' source.");
+        stderr.writeln(
+          'Error: Multiple ${site.name} redirects '
+          "share the '$source' source.",
+        );
         duplicatesFound += 1;
       }
 
@@ -122,7 +128,7 @@ int _verifyFirebaseJson(Site site) {
 
       if (destination == null) {
         stderr.writeln(
-          'Error: The firebase.json file has a '
+          'Error: The ${site.name} Firebase config has a '
           "redirect missing a 'destination'.",
         );
         return 1;
@@ -130,7 +136,7 @@ int _verifyFirebaseJson(Site site) {
 
       if (destination is! String) {
         stderr.writeln(
-          'Error: The firebase.json redirect $redirect has a '
+          'Error: The ${site.name} Firebase config redirect $redirect has a '
           "'destination' specified which is not a string.",
         );
         return 1;
@@ -138,8 +144,8 @@ int _verifyFirebaseJson(Site site) {
 
       if (destination.isEmpty) {
         stderr.writeln(
-          'Error: The firebase.json redirect $redirect has '
-          "an empty 'destination'.",
+          'Error: The ${site.name} Firebase config redirect $redirect has an '
+          "empty 'destination'.",
         );
         return 1;
       }
@@ -147,14 +153,15 @@ int _verifyFirebaseJson(Site site) {
 
     if (duplicatesFound > 0) {
       stderr.writeln(
-        'Error: $duplicatesFound duplicate sources found '
-        'in the firebase.json redirects.',
+        'Error: $duplicatesFound duplicate sources found in '
+        'the ${site.name} Firebase config redirects.',
       );
       return 1;
     }
   } catch (e) {
     stderr.writeln(
-      'Error: Encountered an error when loading the firebase.json file:',
+      'Error: Encountered an error when loading '
+      'the ${site.name} Firebase config:',
     );
     stderr.writeln(e);
     return 1;

--- a/tool/dash_site/lib/src/sites.dart
+++ b/tool/dash_site/lib/src/sites.dart
@@ -8,15 +8,40 @@ import 'package:path/path.dart' as path;
 /// The sites maintained in this repository.
 enum Site {
   /// The Flutter documentation site.
-  docs(baseUrl: 'https://docs.flutter.dev');
+  docs(
+    baseUrl: 'https://docs.flutter.dev',
+    firebaseConfigPathSegments: ['firebase.json'],
+    firebaseEmulatorPort: 5502,
+  );
 
-  const Site({required this.baseUrl});
+  const Site({
+    required this.baseUrl,
+    required this.firebaseConfigPathSegments,
+    required this.firebaseEmulatorPort,
+  });
 
   /// The canonical base URL where this site is hosted in production.
   final String baseUrl;
 
+  /// The path segments for this site's Firebase config file.
+  final List<String> firebaseConfigPathSegments;
+
+  /// The hosting emulator port declared in this site's Firebase config.
+  ///
+  /// The value must match the `emulators.hosting.port` value in
+  /// the site's Firebase config (`firebase.json`) file.
+  /// Each site needs a unique port so the emulators can run concurrently,
+  /// and `5000` must be avoided since AirPlay can use it on macOS.
+  final int firebaseEmulatorPort;
+
   /// The directory where this site's content and implementation is located.
   String get directory => path.join('sites', name);
+
+  /// The location of this site's Firebase config file.
+  String get firebaseConfigPath => path.joinAll(firebaseConfigPathSegments);
+
+  /// The directory containing this site's Firebase config file.
+  String get firebaseConfigDirectory => path.dirname(firebaseConfigPath);
 }
 
 /// The name of the global `--site` option.


### PR DESCRIPTION
Update the `dart run check-links` command to support different sites.

Also add validation of the configured emulator port.

Contributes to https://github.com/flutter/website/issues/13148