### PR TITLE
Customize ports used by Jaspr during serving

### DIFF
--- a/tool/dash_site/lib/src/commands/serve.dart
+++ b/tool/dash_site/lib/src/commands/serve.dart
@@ -33,6 +33,7 @@ final class ServeSiteCommand extends Command<int> {
 
     final release = argResults!.flag('release');
     final selectedSite = this.selectedSite;
+    final jasprPorts = selectedSite.jasprPorts;
 
     final process = await Process.start(
       Platform.resolvedExecutable,
@@ -42,6 +43,9 @@ final class ServeSiteCommand extends Command<int> {
         'run',
         'jaspr_cli:jaspr',
         'serve',
+        '--port=${jasprPorts.serve}',
+        '--web-port=${jasprPorts.webDev}',
+        '--proxy-port=${jasprPorts.proxy}',
         // Use build_web_compiler options specified in build.yaml instead of
         // those specified by jaspr_cli.
         '--no-managed-build-options',

--- a/tool/dash_site/lib/src/sites.dart
+++ b/tool/dash_site/lib/src/sites.dart
@@ -74,10 +74,26 @@ enum Site {
 
   /// The directory containing this site's Firebase config file.
   String get firebaseConfigDirectory => path.dirname(firebaseConfigPath);
+
+  /// The ports Jaspr uses when serving this site locally.
+  ///
+  /// Each port is derived from this site's declaration order in [Site] so
+  /// that multiple sites can be served concurrently without port conflicts.
+  /// Each is offset by one past Jaspr's default to avoid colliding with a
+  /// separate Jaspr project running with default port configuration.
+  ({int serve, int webDev, int proxy}) get jasprPorts => (
+    serve: _jasprDefaultSitePort + index + 1,
+    webDev: _jasprDefaultWebDevPort + index + 1,
+    proxy: _jasprDefaultProxyPort + index + 1,
+  );
 }
 
 /// The name of the global `--site` option.
 const String siteOptionName = 'site';
+
+const int _jasprDefaultSitePort = 8080;
+const int _jasprDefaultWebDevPort = 5467;
+const int _jasprDefaultProxyPort = 5567;
 
 extension CommandSiteResolution<T> on Command<T> {
   /// The [Site] selected with the global `--site` option,


### PR DESCRIPTION
This helps avoid conflicting with any other Jaspr sites you might happen to have running and additionally enables you to serve multiple of our own sites at the same time :D

Contributes to https://github.com/flutter/website/issues/13148