### PR TITLE
docs: fix the diff code block

### DIFF
--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
@@ -184,11 +184,11 @@ Update the minimum Flutter version and the minimum Dart version:
 ```yaml diff title="<plugin-project>/pubspec.yaml"
 # ...
 
-environment:
--  sdk: ^<previous-dart-minimum>
-+  sdk: ^3.12.0
--  flutter: ">=<previous-flutter-minimum>"
-+  flutter: ">=3.44.0"
+  environment:
+-   sdk: ^<previous-dart-minimum>
++   sdk: ^3.12.0
+-   flutter: ">=<previous-flutter-minimum>"
++   flutter: ">=3.44.0"
 
 # ...
 ```
@@ -329,7 +329,7 @@ android {
 Next, remove the `kotlin-android` plugin and the `kotlinOptions` block:
 
 ```groovy diff title="<app-src>/android/build.gradle"
-apply plugin: 'com.android.library'
+  apply plugin: 'com.android.library'
 - apply plugin: 'kotlin-android'
 
   android {


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors

<img width="920" height="347" alt="1" src="https://github.com/user-attachments/assets/c4b7d2d5-367c-4b7a-bdbf-a5302587dc02" /> 
<img width="917" height="371" alt="2" src="https://github.com/user-attachments/assets/81301bbf-2bc3-44f3-a5f7-8c00db78d313" />


_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
