### PR TITLE
docs: clarify nested loop usage in layout tutorial

### DIFF
--- a/sites/docs/src/content/learn/pathway/tutorial/layout.md
+++ b/sites/docs/src/content/learn/pathway/tutorial/layout.md
@@ -253,8 +253,10 @@ Now, it looks more like the following (abridged) figure:
 :::note Challenge
 
 Add a `Tile` to each row for each letter allowed in the guess.
-The `guess` variable in the loop is a [record][] with the type
+Each element in `guess` is a [record][] with the type
 `({String char, HitType type})`.
+
+Use a nested loop to iterate over the letters in each guess.
 
 **Solution:**
 


### PR DESCRIPTION
*Description of what this PR is changing or adding, and why:*

Clarifies the challenge instructions in the layout tutorial by
correcting the description of the `guess` variable type.

The previous wording incorrectly implied that `guess` itself was a
record with the type `({String char, HitType type})`, when it is
actually a collection of records. The updated text explains that each
element in `guess` is a record and explicitly mentions using a nested
loop to iterate over the letters.

This aligns the tutorial instructions with the provided solution code
and avoids confusion for readers attempting the challenge.

*Issues fixed by this PR (if any):*

Fixes #13422


*PRs or commits this PR depends on (if any):*

None.

## Presubmit checklist

* [x] If you are unwilling, or unable, to sign the CLA, even for a *tiny*, one-word PR, please file an issue instead of a PR.
* [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
* [x] This PR follows the [[Google Developer Documentation Style Guidelines](https://developers.google.com/style)](https://developers.google.com/style)—for example, it doesn't use *i.e.* or *e.g.*, and it avoids *I* and *we* (first-person pronouns).
* [x] This PR uses [[semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.