### PR TITLE
add OverflowBar to Multi-Child Layout widgets

### DIFF
--- a/sites/docs/src/data/catalog/widgets.yml
+++ b/sites/docs/src/data/catalog/widgets.yml
@@ -1624,6 +1624,15 @@
   link: https://api.flutter.dev/flutter/material/OutlinedButton-class.html
   image:
     src: /assets/images/docs/widget-catalog/material-outlined-button.png
+- name: OverflowBar
+  description: >-
+    A widget that lays out its children in a row unless they
+    "overflow" the available horizontal space, in which case
+    it lays them out in a column instead.
+  categories: []
+  subcategories:
+    - 'Multi-child layout widgets'
+  link: https://api.flutter.dev/flutter/widgets/OverflowBar-class.html
 - name: OverflowBox
   description: >-
     A widget that imposes different constraints on its child than it gets from


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ 
Adds the 'OverflowBar' Widget to the [Multi-chlid layout widgets](https://docs.flutter.dev/ui/widgets/layout)

_Issues fixed by this PR (if any):_

Resolves https://github.com/flutter/website/issues/13433

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [X] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [X] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
