### PR TITLE
Add breaking change page for removing support for setting Flutter Android engine arguments via `Intent` extras

### DIFF
--- a/sites/docs/src/content/release/breaking-changes/index.md
+++ b/sites/docs/src/content/release/breaking-changes/index.md
@@ -37,8 +37,10 @@ They're sorted by release and listed in alphabetical order:
 ### Not yet released to stable
 
 * [Large screen orientation and resizability restrictions ignored on Android 17][]
+* [Android engine flags specified via `Intent`s no longer supported][]
 
 [Large screen orientation and resizability restrictions ignored on Android 17]: /release/breaking-changes/android-large-screens-restrictions-ignored
+[Android engine flags specified via `Intent`s no longer supported]: /release/breaking-changes/intent-extra-engine-flags-not-supported.md
 
 <a id="released-in-flutter-344" aria-hidden="true"></a>
 ### Released in Flutter 3.44

--- a/sites/docs/src/content/release/breaking-changes/intent-extra-engine-flags-not-supported.md
+++ b/sites/docs/src/content/release/breaking-changes/intent-extra-engine-flags-not-supported.md
@@ -1,0 +1,151 @@
+---
+title: Android engine flags specified via `Intent`s no longer supported
+description: >-
+  Passing Flutter engine flags on Android via `Intent` extras
+  is no longer supported for security reasons.
+---
+
+{% render "docs/breaking-changes.md" %}
+
+## Summary
+
+For security reasons,
+passing Flutter engine flags with Android `Intent` extras
+is no longer supported.
+To set engine flags, configure them statically in the manifest
+or set them from the command line.
+
+## Background
+
+Flutter previously allowed passing engine flags to the Android embedding
+with Android `Intent` extras.
+However, malicious actors can take advantage of that mechanism
+to exploit flag vulnerabilities and execute malicious code.
+
+For example,
+an attacker can specify a malicious path for the AOT library flag
+(`--aot-shared-library-name=`),
+which allows running arbitrary native C code.
+While not all engine flags present security vulnerabilities,
+allowing dynamic flag configuration with `Intent`s
+is insecure for production Flutter Android applications.
+
+To eliminate this vulnerability,
+support for setting engine flags via `Intent` extras
+has been completely removed.
+
+## Migration guide
+
+If your application relies on dynamically setting engine flags,
+migrate to one of the supported methods.
+
+Example of code before migration:
+
+```kotlin
+// Passing engine flags via Intent extras (no longer supported).
+val intent = Intent(this, MainActivity::class.java).apply {
+    putExtra("enable-software-rendering", true)
+}
+startActivity(intent)
+```
+
+Choose one of the following supported methods to configure engine flags:
+
+### Option 1: Configure statically in AndroidManifest.xml
+
+Set flags inside the `<application>` tag of your `AndroidManifest.xml` file.
+All supported flags, their manifest keys, and whether or not they are allowed in release mode can be found in [`FlutterEngineFlags.java`][].
+For boolean flags, explicitly set `android:value="true"`.
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.myapp">
+    <application>
+        <meta-data
+            android:name="io.flutter.embedding.android.TraceToFile"
+            android:value="some_file.txt" />
+        <meta-data
+            android:name="io.flutter.embedding.android.EnableFlutterGPU"
+            android:value="true" />
+    </application>
+</manifest>
+```
+
+If a disallowed flag is specified in a release build,
+the Android embedding ignores the flag.
+
+### Option 2: Pass flags from the command line
+
+For local debugging and development,
+pass engine flags directly using `flutter run`:
+
+```bash
+flutter run \
+  --trace-startup \
+  --enable-software-rendering
+```
+
+### Option 3: Initialize programmatically (Dynamic/Add-to-app)
+
+If you need per-launch or runtime-controlled flags,
+supply engine arguments directly to a cached `FlutterEngine`
+during engine initialization.
+
+To do that, supply engine arguments directly to a `FlutterEngine` with the
+desired flags from the earliest point you can control in your
+application. For example, if you are writing an add-to-app app that launches
+a `FlutterActivity` or `FlutterFragment`, then you can cache a
+`FlutterEngine` that is initialized with your desired
+engine flags:
+
+```kotlin
+class MyApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+
+        val args = arrayOf(
+            "--trace-startup",
+            "--enable-software-rendering"
+        )
+        val flutterEngine = FlutterEngine(this, args)
+        flutterEngine.dartExecutor.executeDartEntrypoint(
+            DartEntrypoint.createDefault()
+        )
+        FlutterEngineCache.getInstance().put("my_engine_id", flutterEngine)
+    }
+}
+```
+
+Then, launch the activity or fragment using the cached engine:
+
+```kotlin
+val intent = FlutterActivity.withCachedEngine("my_engine_id").build(this)
+startActivity(intent)
+```
+
+For normal Flutter Android applications,
+override `provideFlutterEngine` in your app's `FlutterActivity`
+to return the custom configured engine:
+
+```kotlin
+class MainActivity : FlutterActivity() {
+    override fun provideFlutterEngine(context: Context): FlutterEngine? {
+        return FlutterEngineCache.getInstance().get("my_engine_id")
+    }
+}
+```
+
+## Timeline
+
+Not yet released.
+
+## References
+
+Relevant issues:
+
+* [Issue 172553][]
+* [Issue 180686][]
+
+[`FlutterEngineFlags.java`]: {{site.repo.flutter}}/blob/master/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngineFlags.java
+[Issue 172553]: {{site.repo.flutter}}/issues/172553
+[Issue 180686]: {{site.repo.flutter}}/issues/180686


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Adds a breaking change page for a feature soon to be removed on Flutter Android: setting engine flags via `Intent` extras when launching a Flutter Android component. I wish to land this page before support is removed so that helpful errors can point to this page that tells developers how to migrate. See issue below for more details on why we are removing support.

_Issues fixed by this PR (if any):_
Part of https://github.com/flutter/flutter/issues/180686.

_PRs or commits this PR depends on (if any):_
https://github.com/flutter/flutter/pull/180591 must land first.

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
