### PR TITLE
Remove Rosetta note from iOS setup page

### DIFF
--- a/sites/docs/src/content/platform-integration/ios/setup.md
+++ b/sites/docs/src/content/platform-integration/ios/setup.md
@@ -74,12 +74,6 @@ an iOS physical device or on the iOS Simulator.
     $ xcodebuild -downloadPlatform iOS
     ```
 
-    :::note
-    As of Flutter 3.41.9,
-    Rosetta is no longer required to build and run
-    iOS apps on [Apple Silicon][] Macs.
-    :::
-
  1. <h3>Install CocoaPods</h3>
 
     To support [Flutter plugins][] that use native iOS or macOS code,

--- a/sites/docs/src/content/platform-integration/ios/setup.md
+++ b/sites/docs/src/content/platform-integration/ios/setup.md
@@ -88,7 +88,6 @@ an iOS physical device or on the iOS Simulator.
 {: .steps}
 
 [xcode]: https://developer.apple.com/xcode/
-[Apple Silicon]: https://support.apple.com/en-us/116943
 [cocoapods]: https://guides.cocoapods.org/using/getting-started.html#installation
 [Flutter plugins]: /packages-and-plugins/developing-packages#types
 [CocoaPods installation guide]: https://guides.cocoapods.org/using/getting-started.html#installation


### PR DESCRIPTION
It seems the necessary commit wasn't included in 3.41.9, so we should either update this to 3.44 or remove it. I chose to remove it as new developers following the setup instructions will likely be using an up-to-date Flutter SDK and if not, the tooling should prompt them if/when the installation of Rosetta is necessary. This keeps the docs up to date and focused for the majority of developers.

Resolves https://github.com/flutter/website/issues/13369
Closes https://github.com/flutter/website/issues/12178