### PR TITLE
Update Swift Package Manager docs to reflect on-by-default behavior

### DIFF
--- a/sites/docs/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
+++ b/sites/docs/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
@@ -1,7 +1,10 @@
 ## How to turn on Swift Package Manager
 
-Flutter's Swift Package Manager support is turned off by default.
-To turn it on:
+As of Flutter 3.44, Flutter's Swift Package Manager support is turned on by
+default. You don't need to do anything to enable it.
+
+If you're using an older Flutter version, or you previously turned Swift Package
+Manager support off, turn it on:
 
 1. Upgrade to the latest Flutter SDK:
 

--- a/sites/docs/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
+++ b/sites/docs/src/_includes/docs/swift-package-manager/how-to-enable-disable.md
@@ -1,10 +1,10 @@
 ## How to turn on Swift Package Manager
 
-As of Flutter 3.44, Flutter's Swift Package Manager support is turned on by
-default. You don't need to do anything to enable it.
+As of Flutter 3.44, Flutter's Swift Package Manager support is enabled by
+default. No additional steps are required to use it.
 
-If you're using an older Flutter version, or you previously turned Swift Package
-Manager support off, turn it on:
+If you're using an older Flutter version, or you previously disabled Swift Package
+Manager support, you can enable it:
 
 1. Upgrade to the latest Flutter SDK:
 

--- a/sites/docs/src/content/packages-and-plugins/swift-package-manager/for-app-developers.md
+++ b/sites/docs/src/content/packages-and-plugins/swift-package-manager/for-app-developers.md
@@ -6,11 +6,10 @@ description: How to use Swift Package Manager for native iOS or macOS dependenci
 :::warning
 Flutter is migrating to [Swift Package Manager][] to manage iOS and macOS native
 dependencies.
-Flutter's support of Swift Package Manager is under development.
+As of Flutter 3.44, Swift Package Manager support is [on by default][].
 If you find a bug in Flutter's Swift Package Manager support,
 [open an issue][].
-Swift Package Manager support is [off by default][].
-Flutter continues to support CocoaPods.
+Flutter continues to support CocoaPods as a fallback.
 :::
 
 Flutter's Swift Package Manager integration has several benefits:
@@ -23,7 +22,7 @@ Flutter's Swift Package Manager integration has several benefits:
    Swift Package Manager.
 
 [Swift Package Manager]: https://www.swift.org/documentation/package-manager/
-[off by default]: #how-to-turn-on-swift-package-manager
+[on by default]: #how-to-turn-on-swift-package-manager
 [Swift packages]: https://swiftpackageindex.com/
 [open an issue]: {{site.github}}/flutter/flutter/issues/new?template=2_bug.yml
 

--- a/sites/docs/src/content/packages-and-plugins/swift-package-manager/for-app-developers.md
+++ b/sites/docs/src/content/packages-and-plugins/swift-package-manager/for-app-developers.md
@@ -6,7 +6,7 @@ description: How to use Swift Package Manager for native iOS or macOS dependenci
 :::warning
 Flutter is migrating to [Swift Package Manager][] to manage iOS and macOS native
 dependencies.
-As of Flutter 3.44, Swift Package Manager support is [on by default][].
+As of Flutter 3.44, Swift Package Manager support is [enabled by default][].
 If you find a bug in Flutter's Swift Package Manager support,
 [open an issue][].
 Flutter continues to support CocoaPods as a fallback.
@@ -22,7 +22,7 @@ Flutter's Swift Package Manager integration has several benefits:
    Swift Package Manager.
 
 [Swift Package Manager]: https://www.swift.org/documentation/package-manager/
-[on by default]: #how-to-turn-on-swift-package-manager
+[enabled by default]: #how-to-turn-on-swift-package-manager
 [Swift packages]: https://swiftpackageindex.com/
 [open an issue]: {{site.github}}/flutter/flutter/issues/new?template=2_bug.yml
 

--- a/sites/docs/src/content/packages-and-plugins/swift-package-manager/for-plugin-authors.md
+++ b/sites/docs/src/content/packages-and-plugins/swift-package-manager/for-plugin-authors.md
@@ -6,11 +6,10 @@ description: How to add Swift Package Manager compatibility to iOS and macOS plu
 :::warning
 Flutter is migrating to [Swift Package Manager][]
 to manage iOS and macOS native dependencies.
-Flutter's support of Swift Package Manager is under development.
+As of Flutter 3.44, Swift Package Manager support is [on by default][].
 If you find a bug in Flutter's Swift Package Manager support,
 [open an issue][].
-Swift Package Manager support is [off by default][].
-Flutter continues to support CocoaPods.
+Flutter continues to support CocoaPods as a fallback.
 :::
 
 Flutter's Swift Package Manager integration has several benefits:
@@ -24,7 +23,7 @@ Flutter's Swift Package Manager integration has several benefits:
 
 
 [Swift Package Manager]: https://www.swift.org/documentation/package-manager/
-[off by default]: #how-to-turn-on-swift-package-manager
+[on by default]: #how-to-turn-on-swift-package-manager
 [Swift packages]: https://swiftpackageindex.com/
 [open an issue]: {{site.github}}/flutter/flutter/issues/new?template=2_bug.yml
 

--- a/sites/docs/src/content/packages-and-plugins/swift-package-manager/for-plugin-authors.md
+++ b/sites/docs/src/content/packages-and-plugins/swift-package-manager/for-plugin-authors.md
@@ -6,7 +6,7 @@ description: How to add Swift Package Manager compatibility to iOS and macOS plu
 :::warning
 Flutter is migrating to [Swift Package Manager][]
 to manage iOS and macOS native dependencies.
-As of Flutter 3.44, Swift Package Manager support is [on by default][].
+As of Flutter 3.44, Swift Package Manager support is [enabled by default][].
 If you find a bug in Flutter's Swift Package Manager support,
 [open an issue][].
 Flutter continues to support CocoaPods as a fallback.
@@ -23,7 +23,7 @@ Flutter's Swift Package Manager integration has several benefits:
 
 
 [Swift Package Manager]: https://www.swift.org/documentation/package-manager/
-[on by default]: #how-to-turn-on-swift-package-manager
+[enabled by default]: #how-to-turn-on-swift-package-manager
 [Swift packages]: https://swiftpackageindex.com/
 [open an issue]: {{site.github}}/flutter/flutter/issues/new?template=2_bug.yml
 


### PR DESCRIPTION
## Summary

Fixes #13447. The Swift Package Manager docs stated SPM support is "off by default", but as of Flutter 3.44 stable it is on by default. This updates the two SPM pages and the shared enable/disable partial to reflect the new default.

## Changes

- `for-app-developers.md` / `for-plugin-authors.md`: reword the warning box (on by default as of 3.44; CocoaPods remains a fallback) and rename the `[off by default]` reference label to `[on by default]` (anchor unchanged).
- `_includes/docs/swift-package-manager/how-to-enable-disable.md`: reframe "How to turn on" to note SPM is on by default as of 3.44 and scope the manual enable steps to older versions or previously-disabled cases. The "How to turn off" opt-out section is unchanged.

## Notes

The `#how-to-turn-on-swift-package-manager` heading is preserved (it is referenced by several migration partials), so there is no link churn. The plugin-author testing workflow is left intact.
