### PR TITLE
Fix indentation for onSubmitGuess callback

### DIFF
--- a/sites/docs/src/content/learn/pathway/tutorial/stateful-widget.md
+++ b/sites/docs/src/content/learn/pathway/tutorial/stateful-widget.md
@@ -191,7 +191,7 @@ class _GamePageState extends State<GamePage> {
               ],
             ),
           GuessInput(
-           onSubmitGuess: (String guess) {
+            onSubmitGuess: (String guess) {
               setState(() { // NEW
                 _game.guess(guess);
               });


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Fixes the indentation of the `onSubmitGuess` callback so it aligns with the surrounding code.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
