### PR TITLE
feat: add Flutter 3.44 news entry and associated featured image

### DIFF
--- a/sites/www/content/home/latest_news.yaml
+++ b/sites/www/content/home/latest_news.yaml
@@ -5,6 +5,10 @@
 # If you have some other news or posts you think should be added,
 # please first open an issue with relevant information.
 
+- title: "What's new in Flutter 3.44 and Dart 3.12"
+  url: "https://blog.flutter.dev/whats-new-in-flutter-3-44-b0cc1ad3c527"
+  image: "/news/images/featured/Flutter-344.gif"
+
 - title: "What's new in Flutter 3.41 and Dart 3.11"
   url: "https://blog.flutter.dev/whats-new-in-flutter-3-41-302ec140e632"
   image: "/news/images/featured/whats-new-flutter-3-41-dart-3-11.png"


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Updating the new section to include 3.44 Flutter release blog

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [X] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [X] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
