### PR TITLE
Feat/add copy page button

### DIFF
--- a/sites/docs/lib/_sass/components/_misc.scss
+++ b/sites/docs/lib/_sass/components/_misc.scss
@@ -1,3 +1,23 @@
+.copy-page-toast {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: var(--site-primary-color, #0175c2);
+  color: #fff;
+  padding: 0.65rem 1.25rem;
+  border-radius: var(--site-radius, 0.5rem);
+  font-size: 0.9rem;
+  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+  animation: copy-page-toast-in 0.2s ease;
+}
+
+@keyframes copy-page-toast-in {
+  from { opacity: 0; transform: translateX(-50%) translateY(0.5rem); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+
 #page-content p.install-help {
   text-align: right;
   margin-block-start: -2.5rem;

--- a/sites/docs/lib/main.client.options.dart
+++ b/sites/docs/lib/main.client.options.dart
@@ -116,6 +116,7 @@ ClientOptions get defaultClientOptions => ClientOptions(
         title: p['title'] as String,
         sourceUrl: p['sourceUrl'] as String?,
         issueUrl: p['issueUrl'] as String?,
+        showCopyPage: p['showCopyPage'] as bool,
       ),
       loader: _page_header_options.loadLibrary,
     ),

--- a/sites/docs/lib/main.server.options.dart
+++ b/sites/docs/lib/main.server.options.dart
@@ -169,7 +169,12 @@ Map<String, Object?> __feedbackFeedbackComponent(
 ) => {'issueUrl': c.issueUrl};
 Map<String, Object?> __page_header_optionsPageHeaderOptions(
   _page_header_options.PageHeaderOptions c,
-) => {'title': c.title, 'sourceUrl': c.sourceUrl, 'issueUrl': c.issueUrl};
+) => {
+  'title': c.title,
+  'sourceUrl': c.sourceUrl,
+  'issueUrl': c.issueUrl,
+  'showCopyPage': c.showCopyPage,
+};
 Map<String, Object?> __simple_tooltipSimpleTooltip(
   _simple_tooltip.SimpleTooltip c,
 ) => {'target': c.target.toId(), 'content': c.content.toId()};

--- a/sites/docs/lib/src/components/common/client/page_header_options.dart
+++ b/sites/docs/lib/src/components/common/client/page_header_options.dart
@@ -17,12 +17,14 @@ final class PageHeaderOptions extends StatefulComponent {
     required this.title,
     this.sourceUrl,
     this.issueUrl,
+    this.showCopyPage = true,
     super.key,
   });
 
   final String title;
   final String? sourceUrl;
   final String? issueUrl;
+  final bool showCopyPage;
 
   @override
   State<PageHeaderOptions> createState() => _PageHeaderOptionsState();
@@ -115,7 +117,7 @@ final class _PageHeaderOptionsState extends State<PageHeaderOptions> {
                   ),
               ],
             ),
-            if (_rawMarkdownUrl != null)
+            if (component.showCopyPage && _rawMarkdownUrl != null)
               li(
                 [
                   Button(

--- a/sites/docs/lib/src/components/common/client/page_header_options.dart
+++ b/sites/docs/lib/src/components/common/client/page_header_options.dart
@@ -30,6 +30,7 @@ final class PageHeaderOptions extends StatefulComponent {
 
 final class _PageHeaderOptionsState extends State<PageHeaderOptions> {
   bool _isShareSupported = false;
+  bool _copied = false;
 
   @override
   void initState() {
@@ -66,6 +67,10 @@ final class _PageHeaderOptionsState extends State<PageHeaderOptions> {
     final response = await http.get(Uri.parse(rawUrl));
     if (response.statusCode == 200) {
       await web.window.navigator.clipboard.writeText(response.body).toDart;
+      setState(() => _copied = true);
+      Future<void>.delayed(const Duration(seconds: 2), () {
+        if (mounted) setState(() => _copied = false);
+      });
     }
   }
 
@@ -75,7 +80,8 @@ final class _PageHeaderOptionsState extends State<PageHeaderOptions> {
   );
 
   @override
-  Component build(BuildContext _) => Dropdown(
+  Component build(BuildContext _) => .fragment([
+    Dropdown(
     id: 'page-header-options',
     toggle: const Button(icon: 'more_vert', title: 'View page options.'),
     content: nav(
@@ -113,8 +119,8 @@ final class _PageHeaderOptionsState extends State<PageHeaderOptions> {
               li(
                 [
                   Button(
-                    icon: 'content_copy',
-                    content: 'Copy page',
+                    icon: _copied ? 'check' : 'content_copy',
+                    content: _copied ? 'Copied!' : 'Copy page',
                     onClick: () => _copyPageContent().ignore(),
                   ),
                 ],
@@ -151,5 +157,11 @@ final class _PageHeaderOptionsState extends State<PageHeaderOptions> {
         ),
       ],
     ),
-  );
+  ),
+  if (_copied)
+    div(
+      classes: 'copy-page-toast',
+      [.text('Page copied to clipboard!')],
+    ),
+]);
 }

--- a/sites/docs/lib/src/components/common/client/page_header_options.dart
+++ b/sites/docs/lib/src/components/common/client/page_header_options.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:http/http.dart' as http;
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:universal_web/js_interop.dart';
@@ -51,6 +52,23 @@ final class _PageHeaderOptionsState extends State<PageHeaderOptions> {
   String get _currentBaseUrl =>
       web.window.location.origin + web.window.location.pathname;
 
+  String? get _rawMarkdownUrl {
+    final sourceUrl = component.sourceUrl;
+    if (sourceUrl == null) return null;
+    return sourceUrl
+        .replaceFirst('github.com', 'raw.githubusercontent.com')
+        .replaceFirst('/blob/', '/');
+  }
+
+  Future<void> _copyPageContent() async {
+    final rawUrl = _rawMarkdownUrl;
+    if (rawUrl == null) return;
+    final response = await http.get(Uri.parse(rawUrl));
+    if (response.statusCode == 200) {
+      await web.window.navigator.clipboard.writeText(response.body).toDart;
+    }
+  }
+
   web.ShareData get _shareData => web.ShareData(
     url: _currentBaseUrl,
     title: component.title,
@@ -91,6 +109,16 @@ final class _PageHeaderOptionsState extends State<PageHeaderOptions> {
                   ),
               ],
             ),
+            if (_rawMarkdownUrl != null)
+              li(
+                [
+                  Button(
+                    icon: 'content_copy',
+                    content: 'Copy page',
+                    onClick: () => _copyPageContent().ignore(),
+                  ),
+                ],
+              ),
             if (component.sourceUrl case final sourceUrl?)
               li(
                 [

--- a/sites/docs/lib/src/components/common/page_header.dart
+++ b/sites/docs/lib/src/components/common/page_header.dart
@@ -19,12 +19,14 @@ final class PageHeader extends StatelessComponent {
     this.description,
     this.wrap = true,
     this.showBreadcrumbs = true,
+    this.showCopyPage = true,
   });
 
   final String title;
   final String? description;
   final bool wrap;
   final bool showBreadcrumbs;
+  final bool showCopyPage;
 
   @override
   Component build(BuildContext context) {
@@ -49,6 +51,7 @@ final class PageHeader extends StatelessComponent {
           title: title,
           sourceUrl: sourceInfo.sourceUrl,
           issueUrl: sourceInfo.issueUrl,
+          showCopyPage: showCopyPage,
         ),
       ],
     );

--- a/sites/docs/lib/src/layouts/doc_layout.dart
+++ b/sites/docs/lib/src/layouts/doc_layout.dart
@@ -45,6 +45,14 @@ class DocLayout extends FlutterDocsLayout {
     );
   }
 
+  static final _htmlTagPattern = RegExp(r'<[^>]+>');
+
+  bool _hasSubstantialContent(Page page) {
+    final text = page.content.replaceAll(_htmlTagPattern, ' ');
+    final wordCount = text.trim().split(RegExp(r'\s+')).where((w) => w.isNotEmpty).length;
+    return wordCount > 150;
+  }
+
   @override
   Component buildBody(Page page, Component child) {
     final pageData = page.data.page;
@@ -94,6 +102,7 @@ class DocLayout extends FlutterDocsLayout {
                 showBreadcrumbs:
                     allowBreadcrumbs &&
                     (pageData['showBreadcrumbs'] as bool? ?? true),
+                showCopyPage: _hasSubstantialContent(page),
               ),
 
               child,


### PR DESCRIPTION
Closes #13062

cc @johnpryan

## Summary

Adds a **"Copy page"** button to the options dropdown (`⋮`) in the header of documentation pages, making it easy to copy the full page content to paste into an AI agent prompt.

## How it works

- Clicking "Copy page" fetches the raw Markdown from GitHub (`raw.githubusercontent.com`) using the page's existing `sourceUrl` and writes it to the clipboard.
- On success, the button label changes to **"Copied!"** with a checkmark icon, and a toast notification appears at the bottom of the screen. Both reset after 2 seconds.
- The button only appears on pages with **more than 150 words** of body content (front matter and HTML tags excluded), hiding it from navigation/index pages that have no meaningful content to copy.

## Test plan

- [ ] Click "Copy page" on a content page and paste into a text editor — confirm raw Markdown is copied
- [ ] Confirm the button label changes to "Copied!" and the toast appears on success
- [ ] Confirm the button is absent on navigation/index pages (e.g. `/ui`, `/cookbook`, `/tools`)
- [ ] Confirm the button is present on content pages (e.g. `/ui/layout/constraints`, `/cookbook/networking/fetch-data`)