### PR TITLE
Improve search page styling with dark mode enabled

### DIFF
--- a/sites/docs/lib/_sass/pages/_search.scss
+++ b/sites/docs/lib/_sass/pages/_search.scss
@@ -37,6 +37,7 @@
     border: none;
     border-radius: var(--site-radius);
     padding-top: 0.5rem;
+    margin-top: 0.5rem;
 
     .gsc-completion-selected {
       background-color: var(--site-primary-color-highlight);

--- a/sites/docs/lib/_sass/pages/_search.scss
+++ b/sites/docs/lib/_sass/pages/_search.scss
@@ -27,6 +27,7 @@
     input.gsc-input {
       background-color: transparent !important;
       height: 2rem !important;
+      color: var(--site-base-fgColor);
     }
   }
 
@@ -92,11 +93,13 @@
 
     .gsc-result {
       border: none;
+      background: none;
     }
   }
 
   .gsc-cursor-box {
     .gsc-cursor-page {
+      background: none;
       color: var(--site-base-fgColor-lighter);
     }
 


### PR DESCRIPTION
Overrides additional styles to improve styling of GSC results in dark mode with some smaller benefits in light mode as well.

Fixes https://github.com/flutter/website/issues/13336

**Staged:** https://flutter-docs-prod--docs-pr13488-fix-13336-4g95g227.web.app/search?q=testing