### PR TITLE
Update and clarify command package suggestion

### DIFF
--- a/sites/docs/src/content/app-architecture/case-study/ui-layer.md
+++ b/sites/docs/src/content/app-architecture/case-study/ui-layer.md
@@ -530,12 +530,14 @@ the number of arguments that the underlying method expects.
 You can see examples of these implementation classes in
 the Compass app's [`utils` directory][].
 
-:::tip Package recommendation
-Instead of writing your own `Command` class,
-consider using the [`flutter_command`][] package,
-which is a robust library that implements classes like these.
+:::tip Package option
+To use this pattern without writing your own command classes,
+consider using packages such as [`command_it`][],
+which provide command types to wrap actions and
+track their running, completed, and error states.
 :::
 
+[`command_it`]: {{site.pub-pkg}}/command_it
 
 ### Ensuring views can render before data exists
 
@@ -647,7 +649,6 @@ the Command pattern. [Read about it on GitHub][].
 [`Scaffold`]: {{site.api}}/flutter/material/Scaffold-class.html
 [`Dismissible`]: {{site.api}}/flutter/widgets/Dismissible-class.html
 [`utils` directory]: https://github.com/flutter/samples/blob/main/compass_app/app/lib/utils/command.dart
-[`flutter_command`]: {{site.pub-pkg}}/flutter_command
 [streams]: {{site.api}}/flutter/dart-async/Stream-class.html
 [`StreamBuilders`]: {{site.api}}/flutter/widgets/StreamBuilder-class.html
 [`AsyncSnapshot`]: {{site.api}}/flutter/widgets/AsyncSnapshot-class.html

--- a/sites/docs/src/content/app-architecture/case-study/ui-layer.md
+++ b/sites/docs/src/content/app-architecture/case-study/ui-layer.md
@@ -532,8 +532,8 @@ the Compass app's [`utils` directory][].
 
 :::tip Package option
 To use this pattern without writing your own command classes,
-consider using packages such as [`command_it`][],
-which provide command types to wrap actions and
+consider using a package such as [`command_it`][],
+which provides command types to wrap actions and
 track their running, completed, and error states.
 :::
 


### PR DESCRIPTION
- Replaces `flutter_command` with its successor `command_it`.
- Clarify what the package provides.
- Use a softer title to present it as an option rather than requirement or even strong recommendation.

Fixes https://github.com/flutter/website/issues/12204
