### PR TITLE
[www] Support event date ranges

### DIFF
--- a/sites/www/content/events/data/calendar.yaml
+++ b/sites/www/content/events/data/calendar.yaml
@@ -1,6 +1,7 @@
 - title: "Google Cloud Next"
   description: "Join us in Las Vegas, NV for Google Cloud Next."
-  date: "2026-04-22"
+  startDate: "2026-04-22"
+  endDate: "2026-04-24"
   link: "https://cloud.google.com/next"
   card: "images/calendar/next26.gif"
   location: "NA"
@@ -9,7 +10,8 @@
 
 - title: "Flutterconf Spain"
   description: "Join us in Malaga, Spain for Flutterconf Spain."
-  date: "2026-05-08"
+  startDate: "2026-05-08"
+  endDate: "2026-05-09"
   link: "https://flutterconf.es/"
   card: "images/calendar/flutterconf.png"
   location: "EMEA"
@@ -18,7 +20,8 @@
 
 - title: "Google I/O"
   description: "Join us in Sunnyvale, USA for Google I/O."
-  date: "2026-05-19"
+  startDate: "2026-05-19"
+  endDate: "2026-05-20"
   link: "https://io.google/2026/?utm_source=flutter&utm_medium=embedded_marketing&utm_campaign=flutter"
   card: "images/calendar/io26.png"
   location: "NA"
@@ -27,7 +30,8 @@
 
 - title: "Flutter Flow Developers Conference"
   description: "Join us in San Francisco, CA for the Flutter Flow Developers Conference."
-  date: "2026-05-27"
+  startDate: "2026-05-27"
+  endDate: "2026-05-28"
   link: "https://www.ffdc.io/"
   card: "images/calendar/flutterflow.png"
   location: "NA"
@@ -35,7 +39,8 @@
 
 - title: "mDevCamp"
   description: "Join us in Prague, Czechia for mDevCamp."
-  date: "2026-06-03"
+  startDate: "2026-06-03"
+  endDate: "2026-06-04"
   link: "https://mdevcamp.eu/"
   card: "images/calendar/mdevcamp26.png"
   location: "EMEA"
@@ -43,7 +48,8 @@
 
 - title: "Flutter Tech Summit"
   description: "Join us in Warsaw, Poland for Flutter Tech Summit."
-  date: "2026-06-09"
+  startDate: "2026-06-09"
+  endDate: "2026-06-09"
   link: "https://www.fluttertechsummit.com/"
   card: "images/calendar/fluttertechsummit26.png"
   location: "EMEA"
@@ -52,7 +58,8 @@
 
 - title: "Config"
   description: "Join us in San Francisco, CA for Config."
-  date: "2026-06-23"
+  startDate: "2026-06-23"
+  endDate: "2026-06-25"
   link: "https://config.figma.com/"
   card: "images/calendar/config26.png"
   location: "NA"
@@ -61,7 +68,8 @@
 
 - title: "I/O Connect Berlin"
   description: "Join us in Berlin, Germany for I/O Connect."
-  date: "2026-06-25"
+  startDate: "2026-06-25"
+  endDate: "2026-06-25"
   card: "images/calendar/io26.png"
   location: "EMEA"
   host: "Google"
@@ -69,7 +77,8 @@
 
 - title: "I/O Connect Bengaluru"
   description: "Join us in Bengaluru, India for I/O Connect."
-  date: "2026-07-14"
+  startDate: "2026-07-14"
+  endDate: "2026-07-14"
   card: "images/calendar/io26.png"
   location: "APAC"
   host: "Google"
@@ -77,7 +86,8 @@
 
 - title: "Fluttercon USA"
   description: "Join us in Orlando, FL for Fluttercon USA."
-  date: "2026-07-16"
+  startDate: "2026-07-16"
+  endDate: "2026-07-17"
   link: "https://www.flutterconusa.dev/"
   card: "images/calendar/fluttercon.png"
   location: "NA"
@@ -85,7 +95,8 @@
 
 - title: "Ai4"
   description: "Join us in Las Vegas, NV for Ai4."
-  date: "2026-08-04"
+  startDate: "2026-08-04"
+  endDate: "2026-08-06"
   link: "https://ai4.io/"
   card: "images/calendar/ai426.png"
   location: "NA"
@@ -94,7 +105,8 @@
 
 - title: "I/O Connect China"
   description: "Join us in China for I/O Connect."
-  date: "2026-08-07"
+  startDate: "2026-08-07"
+  endDate: "2026-08-07"
   card: "images/calendar/io26.png"
   location: "APAC"
   host: "Google"
@@ -102,7 +114,8 @@
 
 - title: "RenderATL"
   description: "Join us in Atlanta, GA for RenderATL."
-  date: "2026-08-12"
+  startDate: "2026-08-12"
+  endDate: "2026-08-13"
   link: "https://www.renderatl.com/"
   card: "images/calendar/render26.svg"
   location: "NA"
@@ -110,7 +123,8 @@
 
 - title: "Flutter & Friends"
   description: "Join us in Stockholm, Sweden for Flutter & Friends."
-  date: "2026-09-03"
+  startDate: "2026-09-03"
+  endDate: "2026-09-05"
   link: "https://flutterfriends.dev/"
   card: "images/calendar/flutter_friends.png"
   location: "EMEA"
@@ -118,7 +132,8 @@
 
 - title: "FlutterConf LATAM"
   description: "Join us in Cancún, México for FlutterConf LATAM."
-  date: "2026-09-22"
+  startDate: "2026-09-22"
+  endDate: "2026-09-24"
   link: "https://flutterconflatam.dev/"
   card: "images/calendar/flutterconflatam26.png"
   location: "LATAM"
@@ -127,7 +142,8 @@
 
 - title: "next.app devcon"
   description: "Join us in Berlin, Germany for next.app devcon."
-  date: "2026-10-07"
+  startDate: "2026-10-07"
+  endDate: "2026-10-09"
   link: "https://www.nextappcon.com/"
   card: "images/calendar/nextapp26.png"
   location: "EMEA"
@@ -136,7 +152,8 @@
 
 - title: "All Things Open"
   description: "Join us in Raleigh, NC for All Things Open."
-  date: "2026-10-19"
+  startDate: "2026-10-19"
+  endDate: "2026-10-20"
   link: "https://allthingsopen.org/events/all-things-open-2026"
   card: "images/calendar/allthingsopen26.svg"
   location: "NA"
@@ -144,7 +161,8 @@
 
 - title: "Flutter Kaigi/Ninjas"
   description: "Join us in Tokyo, Japan for Flutter Kaigi/Ninjas."
-  date: "2026-10-29"
+  startDate: "2026-10-29"
+  endDate: "2026-10-30"
   link: "https://medium.com/flutterkaigi/flutterkaigi-2026-%E9%96%8B%E5%82%AC%E3%81%AE%E3%81%8A%E7%9F%A5%E3%82%89%E3%81%9B-f78a1421fe08"
   card: "images/calendar/kaigi.png"
   location: "APAC"
@@ -153,7 +171,8 @@
 
 - title: "Google for Developers events (DevFest and Build with AI)"
   description: "Join us at Google for Developers events taking place throughout Fall and Winter 2026."
-  date: "2026-11-01"
+  startDate: "2026-06-15"
+  endDate: "2026-12-15"
   link: "https://developers.google.com/community"
   card: "images/calendar/gfd26.png"
   location: "Virtual"

--- a/sites/www/lib/src/models/content/events_content.dart
+++ b/sites/www/lib/src/models/content/events_content.dart
@@ -78,7 +78,9 @@ class FeaturedEvent with FeaturedEventMappable {
 /// Expected data format:
 /// - `title`: non-empty event title.
 /// - `description`: non-empty description of the event.
-/// - `date`: ISO8601 date string in `yyyy-mm-dd` format.
+/// - `startDate`: ISO8601 date string in `yyyy-mm-dd` format.
+/// - `endDate`: ISO8601 date string in `yyyy-mm-dd` format,
+///   on or after `startDate`.
 /// - `link`: optional absolute HTTP(S) URL or root-relative path.
 /// - `card`: image asset path under `images/`.
 /// - `location`: one of the [EventLocation] labels
@@ -89,7 +91,8 @@ class FeaturedEvent with FeaturedEventMappable {
 class CalendarEvent with CalendarEventMappable {
   CalendarEvent({
     required this.title,
-    required this.date,
+    required this.startDate,
+    required this.endDate,
     required this.description,
     required this.card,
     required this.location,
@@ -99,8 +102,16 @@ class CalendarEvent with CalendarEventMappable {
   }) {
     checkFormat(isNotBlank(title), 'title must be a non-empty string.');
     checkFormat(
-      date == DateTime(date.year, date.month, date.day),
-      'date must be a date-only value.',
+      startDate == DateTime(startDate.year, startDate.month, startDate.day),
+      'startDate must be a date-only value.',
+    );
+    checkFormat(
+      endDate == DateTime(endDate.year, endDate.month, endDate.day),
+      'endDate must be a date-only value.',
+    );
+    checkFormat(
+      !endDate.isBefore(startDate),
+      'endDate must be on or after startDate.',
     );
     checkFormat(
       isNotBlank(description),
@@ -129,8 +140,11 @@ class CalendarEvent with CalendarEventMappable {
   /// Event title displayed in the calendar grid.
   final String title;
 
-  /// The date of the event.
-  final DateTime date;
+  /// The first date of the event.
+  final DateTime startDate;
+
+  /// The final date of the event.
+  final DateTime endDate;
 
   /// Description of the event.
   final String description;
@@ -159,8 +173,13 @@ class CalendarEvent with CalendarEventMappable {
   }
 
   /// Parses a calendar event model from YAML/JSON data.
-  static CalendarEvent fromJson(Map<String, Object?> json) =>
-      CalendarEventMapper.fromMap(json);
+  static CalendarEvent fromJson(Map<String, Object?> json) {
+    checkFormat(
+      !json.containsKey('date'),
+      'date is not supported. Use startDate and endDate instead.',
+    );
+    return CalendarEventMapper.fromMap(json);
+  }
 }
 
 /// Supported regions used to filter events on the events page.

--- a/sites/www/lib/src/models/content/events_content.mapper.dart
+++ b/sites/www/lib/src/models/content/events_content.mapper.dart
@@ -295,8 +295,16 @@ class CalendarEventMapper extends ClassMapperBase<CalendarEvent> {
 
   static String _$title(CalendarEvent v) => v.title;
   static const Field<CalendarEvent, String> _f$title = Field('title', _$title);
-  static DateTime _$date(CalendarEvent v) => v.date;
-  static const Field<CalendarEvent, DateTime> _f$date = Field('date', _$date);
+  static DateTime _$startDate(CalendarEvent v) => v.startDate;
+  static const Field<CalendarEvent, DateTime> _f$startDate = Field(
+    'startDate',
+    _$startDate,
+  );
+  static DateTime _$endDate(CalendarEvent v) => v.endDate;
+  static const Field<CalendarEvent, DateTime> _f$endDate = Field(
+    'endDate',
+    _$endDate,
+  );
   static String _$description(CalendarEvent v) => v.description;
   static const Field<CalendarEvent, String> _f$description = Field(
     'description',
@@ -327,7 +335,8 @@ class CalendarEventMapper extends ClassMapperBase<CalendarEvent> {
   @override
   final MappableFields<CalendarEvent> fields = const {
     #title: _f$title,
-    #date: _f$date,
+    #startDate: _f$startDate,
+    #endDate: _f$endDate,
     #description: _f$description,
     #card: _f$card,
     #location: _f$location,
@@ -339,7 +348,8 @@ class CalendarEventMapper extends ClassMapperBase<CalendarEvent> {
   static CalendarEvent _instantiate(DecodingData data) {
     return CalendarEvent(
       title: data.dec(_f$title),
-      date: data.dec(_f$date),
+      startDate: data.dec(_f$startDate),
+      endDate: data.dec(_f$endDate),
       description: data.dec(_f$description),
       card: data.dec(_f$card),
       location: data.dec(_f$location),
@@ -413,7 +423,8 @@ abstract class CalendarEventCopyWith<$R, $In extends CalendarEvent, $Out>
     implements ClassCopyWith<$R, $In, $Out> {
   $R call({
     String? title,
-    DateTime? date,
+    DateTime? startDate,
+    DateTime? endDate,
     String? description,
     String? card,
     EventLocation? location,
@@ -435,7 +446,8 @@ class _CalendarEventCopyWithImpl<$R, $Out>
   @override
   $R call({
     String? title,
-    DateTime? date,
+    DateTime? startDate,
+    DateTime? endDate,
     String? description,
     String? card,
     EventLocation? location,
@@ -445,7 +457,8 @@ class _CalendarEventCopyWithImpl<$R, $Out>
   }) => $apply(
     FieldCopyWithData({
       if (title != null) #title: title,
-      if (date != null) #date: date,
+      if (startDate != null) #startDate: startDate,
+      if (endDate != null) #endDate: endDate,
       if (description != null) #description: description,
       if (card != null) #card: card,
       if (location != null) #location: location,
@@ -457,7 +470,8 @@ class _CalendarEventCopyWithImpl<$R, $Out>
   @override
   CalendarEvent $make(CopyWithData data) => CalendarEvent(
     title: data.get(#title, or: $value.title),
-    date: data.get(#date, or: $value.date),
+    startDate: data.get(#startDate, or: $value.startDate),
+    endDate: data.get(#endDate, or: $value.endDate),
     description: data.get(#description, or: $value.description),
     card: data.get(#card, or: $value.card),
     location: data.get(#location, or: $value.location),

--- a/sites/www/lib/src/pages/events_page.dart
+++ b/sites/www/lib/src/pages/events_page.dart
@@ -100,10 +100,8 @@ class EventsPage extends StatelessComponent {
       CalendarEvent.fromJson,
     );
 
-    // Events currently only have a start date,
-    // so keep them listed for a few extra days to
-    // cover multi-day events that might still be ongoing or
-    // events that recently ended and are potentially still relevant.
+    // Keep events listed for a few extra days after their end date
+    // because recently ended events might still be relevant.
     const visibleAfterDays = 3;
     final now = DateTime.now().toUtc();
     final cutoff = DateTime.utc(
@@ -114,9 +112,9 @@ class EventsPage extends StatelessComponent {
     final events = rawEvents
         .where(
           (event) => !DateTime.utc(
-            event.date.year,
-            event.date.month,
-            event.date.day,
+            event.endDate.year,
+            event.endDate.month,
+            event.endDate.day,
           ).isBefore(cutoff),
         )
         .toList(growable: false);
@@ -154,7 +152,7 @@ class EventsPage extends StatelessComponent {
           span([
             img(src: context.asset('/images/common/calendar.svg')),
             const RawText('&nbsp;'),
-            label([.text(_formatDate(event.date))]),
+            label([.text(_formatDateRange(event.startDate, event.endDate))]),
           ]),
           span([
             img(src: context.asset('/images/common/gps-location.svg')),
@@ -180,6 +178,26 @@ class EventsPage extends StatelessComponent {
   }
 
   static final DateFormat _eventDateFormat = .new('MMM d, yyyy', 'en-US');
+  static final DateFormat _eventRangeStartFormat = .new('MMM d', 'en-US');
 
+  /// Formats a single calendar date for display on event cards.
   static String _formatDate(DateTime date) => _eventDateFormat.format(date);
+
+  /// Formats an event date span, collapsing same-day events to one date.
+  static String _formatDateRange(DateTime startDate, DateTime endDate) {
+    if (_isSameDate(startDate, endDate)) return _formatDate(startDate);
+
+    if (startDate.year == endDate.year) {
+      return '${_eventRangeStartFormat.format(startDate)} - '
+          '${_formatDate(endDate)}';
+    }
+
+    return '${_formatDate(startDate)} - ${_formatDate(endDate)}';
+  }
+
+  /// Determines whether two [DateTime] values occur on the same calendar date.
+  static bool _isSameDate(DateTime startDate, DateTime endDate) =>
+      startDate.year == endDate.year &&
+      startDate.month == endDate.month &&
+      startDate.day == endDate.day;
 }

--- a/sites/www/test/models/content/content_models_test.dart
+++ b/sites/www/test/models/content/content_models_test.dart
@@ -320,7 +320,8 @@ void main() {
     final valid = <String, Object?>{
       'title': 'FlutterCon',
       'description': 'Conference',
-      'date': '2025-09-24',
+      'startDate': '2025-09-24',
+      'endDate': '2025-09-26',
       'card': 'images/calendar/fluttercon.png',
       'location': 'EMEA',
       'host': 'Community',
@@ -330,7 +331,8 @@ void main() {
     test('decodes valid data and computes derived state', () {
       final decoded = CalendarEvent.fromJson(valid);
       expect(decoded.hasExternalLink, isFalse);
-      expect(decoded.date, DateTime(2025, 9, 24));
+      expect(decoded.startDate, DateTime(2025, 9, 24));
+      expect(decoded.endDate, DateTime(2025, 9, 26));
       expect(decoded.backgroundColor, '#eebb22');
       expect(decoded.location, EventLocation.emea);
       expect(decoded.host, EventHost.community);
@@ -351,8 +353,32 @@ void main() {
       expect(() => CalendarEvent.fromJson(invalid), _throwsValidationError);
     });
 
-    test('throws when date includes a time', () {
-      final invalid = {...valid}..['date'] = DateTime(2025, 9, 24, 12);
+    test('throws when date is used', () {
+      final invalid = {
+        ...valid,
+        'date': '2025-09-24',
+      };
+      expect(() => CalendarEvent.fromJson(invalid), _throwsValidationError);
+    });
+
+    test('throws when startDate includes a time', () {
+      final invalid = {
+        ...valid,
+      }..['startDate'] = DateTime(2025, 9, 24, 12);
+      expect(() => CalendarEvent.fromJson(invalid), _throwsValidationError);
+    });
+
+    test('throws when endDate includes a time', () {
+      final invalid = {
+        ...valid,
+      }..['endDate'] = DateTime(2025, 9, 26, 12);
+      expect(() => CalendarEvent.fromJson(invalid), _throwsValidationError);
+    });
+
+    test('throws when endDate is before startDate', () {
+      final invalid = {
+        ...valid,
+      }..['endDate'] = '2025-09-23';
       expect(() => CalendarEvent.fromJson(invalid), _throwsValidationError);
     });
 


### PR DESCRIPTION
Updates events on the marketing site to have a `startDate` and `endDate`. If they are not on the same date, displays the range on the "Flutter Events Public Calendar" cards.

Helps prepare for https://github.com/flutter/website/issues/13499