### PR TITLE
Dispose Animation Controller in Flutter for Android Devs Examples

### DIFF
--- a/examples/get-started/flutter-for/android_devs/lib/animation.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/animation.dart
@@ -42,6 +42,12 @@ class _MyFadeTest extends State<MyFadeTest> with TickerProviderStateMixin {
   }
 
   @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text(widget.title)),

--- a/examples/get-started/flutter-for/android_devs/lib/events.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/events.dart
@@ -63,6 +63,12 @@ class _SampleAppState extends State<SampleApp>
   }
 
   @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: Center(

--- a/sites/docs/src/content/flutter-for/android-devs.md
+++ b/sites/docs/src/content/flutter-for/android-devs.md
@@ -356,12 +356,6 @@ class _MyFadeTest extends State<MyFadeTest> with TickerProviderStateMixin {
   }
 
   @override
-  void dispose() {
-    controller.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text(widget.title)),
@@ -1675,12 +1669,6 @@ class _SampleAppState extends State<SampleApp>
       duration: const Duration(milliseconds: 2000),
     );
     curve = CurvedAnimation(parent: controller, curve: Curves.easeIn);
-  }
-
-  @override
-  void dispose() {
-    controller.dispose();
-    super.dispose();
   }
 
   @override

--- a/sites/docs/src/content/flutter-for/android-devs.md
+++ b/sites/docs/src/content/flutter-for/android-devs.md
@@ -356,6 +356,12 @@ class _MyFadeTest extends State<MyFadeTest> with TickerProviderStateMixin {
   }
 
   @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text(widget.title)),
@@ -1669,6 +1675,12 @@ class _SampleAppState extends State<SampleApp>
       duration: const Duration(milliseconds: 2000),
     );
     curve = CurvedAnimation(parent: controller, curve: Curves.easeIn);
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Animation Controller examples in the Android Dev section were missing dispose logic for the controller lifecycle.
This PR adds this logic to the examples.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
