### PR TITLE
Add `/blog` redirects

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -19,6 +19,8 @@
       { "regex": "(.*)\\.$", "destination": ":1", "type": 301 },
 
       { "source": "/ads", "destination": "https://flutter.dev/monetization", "type": 301 },
+      { "source": "/blog", "destination": "https://flutter.dev/blog", "type": 301 },
+      { "source": "/blog/:rest*", "destination": "https://flutter.dev/blog/:rest*", "type": 301 },
       { "source": "/community", "destination": "https://flutter.dev/community", "type": 301 },
       { "source": "/gallery", "destination": "https://github.com/flutter/gallery#flutter-gallery", "type": 301 },
       { "source": "/showcase", "destination": "https://flutter.dev/showcase", "type": 301 },

--- a/sites/www/firebase.json
+++ b/sites/www/firebase.json
@@ -25,6 +25,8 @@
 
       { "source": "/adoptawidget", "destination": "https://docs.flutter.dev/adoptawidget", "type": 301 },
       { "source": "/ads", "destination": "/monetization", "type": 301 },
+      { "source": "/blog", "destination": "https://blog.flutter.dev/", "type": 302 },
+      { "source": "/blog/:rest*", "destination": "https://blog.flutter.dev/:rest*", "type": 302 },
       { "source": "/clock", "destination": "https://docs.flutter.dev/clock", "type": 302 },
       { "source": "/community/china", "destination": "https://docs.flutter.dev/community/china", "type": 301 },
       { "source": "/desktop", "destination": "/development/desktop", "type": 301 },


### PR DESCRIPTION
- Updates `docs.flutter.dev/blog` to redirect to `flutter.dev/blog`.
- Updates `flutter.dev/blog` to redirect to `blog.flutter.dev` for now.

Contributes to https://github.com/flutter/website/issues/13507 by reserving these paths for the blog and making them point to the currently live blog. Eventually the `flutter.dev/blog` redirects will be removed. 