### PR TITLE
Clarify Android ABI filtering guidance

### DIFF
--- a/sites/docs/src/content/deployment/flavors.md
+++ b/sites/docs/src/content/deployment/flavors.md
@@ -386,10 +386,9 @@ configure for a specific Android product flavor, see
 Android's [Configure build variants][].
 
 While it is possible to set `abiFilters` in product flavors, it is not
-recommended. Instead, favor `abiFilters` in build types. When setting
-`abiFilters` in product flavors, one must use the
-`-Pdisable-abi-filtering` flag when running `flutter build` or
-`flutter run`.
+recommended. Prefer configuring `abiFilters` in `defaultConfig` when possible.
+When setting `abiFilters` in product flavors, pass
+`-Pdisable-abi-filtering=true` when running `flutter build` or `flutter run`.
 
 [Configure build variants]: https://developer.android.com/build/build-variants
 

--- a/sites/docs/src/content/release/breaking-changes/default-abi-filters-android.md
+++ b/sites/docs/src/content/release/breaking-changes/default-abi-filters-android.md
@@ -37,7 +37,10 @@ by default to:
 
 Because this automatic configuration happens before your `build.gradle` files
 are processed, it might break custom `abiFilters` settings that depend on the
-set being empty.
+set being empty. Flutter can preserve `abiFilters` that you configure in
+`defaultConfig`, but it can't safely preserve every `buildTypes` or
+`productFlavors` ABI filter customization with the current Android Gradle
+Plugin APIs.
 
 ## Migration guide
 If your app doesn't customize `abiFilters`, no changes are required.
@@ -57,28 +60,32 @@ flutter build apk --splits-per-abi
 This creates separate APKs for each architecture and automatically disables
 the automatic `abiFilters` configuration.
 
-### Option 2: Clear and reconfigure abiFilters
+### Option 2: Configure abiFilters in defaultConfig
 
 If you must use a single APK with custom architecture filters, clear the
-automatically set filters and configure your own in your `build.gradle`.
+automatically set filters and configure your own in `defaultConfig`.
 For example:
 
 ```kotlin
 android {
-    buildTypes {
-        release {
+    defaultConfig {
+        ndk {
             // Clear the automatically set filters.
-            ndk.abiFilters.clear()
+            abiFilters.clear()
             // Set your custom filters.
-            ndk.abiFilters.addAll(listOf("arm64-v8a"))
+            abiFilters.addAll(listOf("arm64-v8a"))
         }
     }
 }
 ```
 
-### Disabling abiFIlters ###
-It is possible, but not recommended, to disable this abi filtering. Pass the `-Pdisable-abi-filtering`flag when running `flutter build`
-or `flutter run`.
+### Option 3: Disable Flutter's default ABI filtering
+
+If your app configures ABI filters in `buildTypes` or `productFlavors`,
+pass `-Pdisable-abi-filtering=true` when running `flutter build` or
+`flutter run`. This prevents Flutter from applying its default ABI filters,
+so your build type or product flavor configuration controls which
+architectures are included.
 
 ## Timeline
 


### PR DESCRIPTION
*Description of what this PR is changing or adding, and why:*

Updates the Android ABI filtering guidance to clarify when `-Pdisable-abi-filtering=true` is required.

The docs now distinguish between ABI filters configured in `defaultConfig`, which can be preserved automatically, and ABI filters configured under `buildTypes` or `productFlavors`, which require disabling Flutter's default ABI filtering.

*Issues fixed by this PR (if any):*

Clarifies guidance discussed in flutter/flutter#188009.

*PRs or commits this PR depends on (if any):*

Related to flutter/flutter#177753 and flutter/flutter#181828.

## Presubmit checklist

* [x] If you are unwilling, or unable, to sign the CLA, even for a *tiny* one-word PR, please file an issue instead of a PR.
* [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
* [x] This PR follows the [[Google Developer Documentation Style Guidelines](https://developers.google.com/style)](https://developers.google.com/style) — for example, it doesn't use *i.e.*, or *e.g.*, and it avoids *I* and *we* (first-person pronouns).
* [x] This PR uses [[semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.