### PR TITLE
fix: action lookup stops when matching action has isEnabled set to false

### DIFF
--- a/sites/docs/src/content/ui/interactivity/actions-and-shortcuts.md
+++ b/sites/docs/src/content/ui/interactivity/actions-and-shortcuts.md
@@ -321,9 +321,8 @@ Widget build(BuildContext context) {
 
 The `Actions` widget only invokes actions when `isEnabled(Intent intent)`
 returns true, allowing the action to decide if the dispatcher should consider it
-for invocation.  If the action isn't enabled, then the `Actions` widget gives
-another enabled action higher in the widget hierarchy (if it exists) a chance to
-execute.
+for invocation. If the action isn't enabled, the action is not invoked and the
+framework stops searching for matching actions at that point.
 
 The previous example uses a `Builder` because `Actions.handler` and
 `Actions.invoke` (for example) only finds actions in the provided `context`, and


### PR DESCRIPTION
Fix site documentation's note on what happens when an action's `isEnabled` is set to false. The documentation said that search for a matching action continues up in the tree, but it actually stops.

Relevant source code:
- [actions.dart#L959-L967](https://github.com/flutter/flutter/blob/815c4373454bfc0553d487335dfe0974c8755f58/packages/flutter/lib/src/widgets/actions.dart#L959-L967)
- [actions.dart#L873-L882](https://github.com/flutter/flutter/blob/815c4373454bfc0553d487335dfe0974c8755f58/packages/flutter/lib/src/widgets/actions.dart#L873-L882)

The `maybeFind` (second one) is the one used by shortcuts (per [shortcuts.dart#L922-L938](https://github.com/flutter/flutter/blob/969aa847e564c97483464b4ce68b6f8b9128a3ac/packages/flutter/lib/src/widgets/shortcuts.dart#L922-L938)).

A side example: `DismissIntent` from modals is handled by `_DismissModalAction` ([routes.dart#L975-L984](https://github.com/flutter/flutter/blob/e8f1e18166fa9610c6f4bfbefaf6a118a5eb4121/packages/flutter/lib/src/widgets/routes.dart#L975-L984)), and `isEnabled` is set to false if the modal is not `barrierDismissible`. Actions that handle the dismiss intent above in the widget tree do not get invoked in that case.

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
