### PR TITLE
[docs] Clarify config isn't forwarded with custom onEntrypointLoaded

### DIFF
--- a/sites/docs/src/content/platform-integration/web/initialization.md
+++ b/sites/docs/src/content/platform-integration/web/initialization.md
@@ -250,8 +250,8 @@ loading.textContent = "Loading Entrypoint...";
 _flutter.loader.load({
   onEntrypointLoaded: async function(engineInitializer) {
     loading.textContent = "Initializing engine...";
-    // Pass your `config` here. Any config given to `load()` is not
-    // forwarded when you supply your own `onEntrypointLoaded` callback.
+    // If you have a `config`, pass it here. The config given to `load()`
+    // is not forwarded when you supply your own `onEntrypointLoaded`.
     const appRunner = await engineInitializer.initializeEngine();
 
     loading.textContent = "Running app...";

--- a/sites/docs/src/content/platform-integration/web/initialization.md
+++ b/sites/docs/src/content/platform-integration/web/initialization.md
@@ -211,6 +211,29 @@ The initialization process is split into the following stages:
 [embedded-mode]: {{site.docs}}/platform-integration/web/embedding-flutter-web/#embedded-mode
 [js-promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
+:::warning
+When you provide your own `onEntrypointLoaded` callback, the `config`
+that you pass to `_flutter.loader.load()` is **not** forwarded to the
+engine automatically. Flutter only applies that `config` for you when
+you omit `onEntrypointLoaded` and let the loader start the app.
+
+In a custom callback, pass the configuration to `initializeEngine()`
+yourself, otherwise it's silently ignored:
+
+```js
+_flutter.loader.load({
+  onEntrypointLoaded: async function(engineInitializer) {
+    const appRunner = await engineInitializer.initializeEngine({
+      // Set your run-time configuration here.
+      renderer: 'canvaskit',
+    });
+    await appRunner.runApp();
+  },
+});
+```
+
+:::
+
 ## Example: Display a progress indicator
 
 To give the user of your application feedback
@@ -227,6 +250,8 @@ loading.textContent = "Loading Entrypoint...";
 _flutter.loader.load({
   onEntrypointLoaded: async function(engineInitializer) {
     loading.textContent = "Initializing engine...";
+    // Pass your `config` here. Any config given to `load()` is not
+    // forwarded when you supply your own `onEntrypointLoaded` callback.
     const appRunner = await engineInitializer.initializeEngine();
 
     loading.textContent = "Running app...";


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

The web initialization docs imply that setting `config` in
`_flutter.loader.load()` is enough for it to reach the engine. That's only
true on the default auto-start path. When a custom `onEntrypointLoaded`
callback is supplied, the loader passes that callback only the engine
initializer — the `config` from `load()` is **not** forwarded, so it is
silently dropped unless it is passed to `initializeEngine(config)` directly.

The existing "Display a progress indicator" example calls
`initializeEngine()` with no arguments, which reinforces the
misunderstanding in the most commonly copied `onEntrypointLoaded` snippet.

Why this matters: the failure is silent and easy to hit in production. A
custom `onEntrypointLoaded` that sets `canvasKitForceCpuOnly: true` to work
around a CanvasKit rendering bug in an Android in-app browser has no effect,
and produces no error or warning. The only tell is an absent signal: the
engine always logs `Falling back to CPU-only rendering` when CPU-only is
active, so the missing log line is the sole hint that the config never
reached the engine. Because this failure mode is completely silent, a doc
note is the only thing that surfaces it.

This PR makes two changes to
`platform-integration/web/initialization.md`:

- Adds a `:::warning` in the *onEntrypointLoaded callback* section stating
  that `config` from `load()` is not forwarded when a custom
  `onEntrypointLoaded` is used, with a short example that passes the config
  to `initializeEngine()`.
- Adds a clarifying comment to the no-argument `initializeEngine()` call in
  the progress-indicator example.

Verified against the engine's `flutter.js` loader source: the default
`onEntrypointLoaded` closure is the only place that captures `config` and
passes it to `initializeEngine(config)` (in the minified loader the default
callback is `l => l.initializeEngine(t)`). When a custom callback is
supplied, `didCreateEngineInitializer` forwards only the engine
initializer, so the config never reaches the engine automatically. Scope is
a single Markdown file, with no code or config changes.

_Issues fixed by this PR (if any):_

None.

_PRs or commits this PR depends on (if any):_

None.

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
