### PR TITLE
Document version codes during ABI splitting

### DIFF
--- a/sites/docs/src/content/deployment/android.md
+++ b/sites/docs/src/content/deployment/android.md
@@ -663,12 +663,12 @@ Such APKs are larger in size than their split counterparts,
 causing the user to download native binaries that
 aren't applicable to their device's architecture.
 
-When using split APKs the framework will add `ABI_VERSION * 1000`
+When using split APKs, the framework adds `ABI_VERSION * 1000`
 to the version code. This is because the Google Play Store
 [doesn't allow](https://developer.android.com/studio/build/configure-apk-splits#configure-APK-versions)
 multiple APKs for the same app to have the same version code.
-You can force using the usual version code by specifying the
-`-P force-version-code-ignoring-abi=true` flag during build.
+To force the default version code, specify the
+`-P force-version-code-ignoring-abi=true` flag during the build.
 
 [obfuscating your Dart code]: /deployment/obfuscate
 

--- a/sites/docs/src/content/deployment/android.md
+++ b/sites/docs/src/content/deployment/android.md
@@ -663,6 +663,13 @@ Such APKs are larger in size than their split counterparts,
 causing the user to download native binaries that
 aren't applicable to their device's architecture.
 
+When using split APKs the framework will add `ABI_VERSION * 1000`
+to the version code. This is because the Google Play Store
+[doesn't allow](https://developer.android.com/studio/build/configure-apk-splits#configure-APK-versions)
+multiple APKs for the same app to have the same version code.
+You can force using the usual version code by specifying the
+`-P force-version-code-ignoring-abi=true` flag during build.
+
 [obfuscating your Dart code]: /deployment/obfuscate
 
 ### Install an APK on a device


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
As asked in a review of the linked pull request: This pull request updates the Android deployment documentation to explain how split APKs affect the version code and how to bypass this behavior during a build.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_
- https://github.com/flutter/flutter/pull/187742

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
