### PR TITLE
Reformat with latest formatter updates and fixes

### DIFF
--- a/examples/animation/animate3/lib/main.dart
+++ b/examples/animation/animate3/lib/main.dart
@@ -65,5 +65,4 @@ class _LogoAppState extends State<LogoApp> with SingleTickerProviderStateMixin {
 
   // #docregion print-state
 }
-
 // #enddocregion print-state

--- a/examples/animation/animate4/lib/main.dart
+++ b/examples/animation/animate4/lib/main.dart
@@ -84,5 +84,4 @@ class _LogoAppState extends State<LogoApp> with SingleTickerProviderStateMixin {
 
   // #docregion print-state
 }
-
 // #enddocregion print-state

--- a/examples/animation/animate5/lib/main.dart
+++ b/examples/animation/animate5/lib/main.dart
@@ -3,6 +3,7 @@
 import 'dart:math';
 
 // #enddocregion ShakeCurve
+
 import 'package:flutter/material.dart';
 
 void main() => runApp(const LogoApp());
@@ -133,5 +134,4 @@ class ShakeCurve extends Curve {
   @override
   double transform(double t) => sin(t * pi * 2);
 }
-
 // #enddocregion ShakeCurve

--- a/examples/app-architecture/command/lib/main.dart
+++ b/examples/app-architecture/command/lib/main.dart
@@ -81,7 +81,6 @@ class _MainAppState extends State<MainApp> {
       // Show Snackbar
     }
   }
-
   // #enddocregion _onViewModelChanged
 }
 
@@ -175,5 +174,4 @@ class Command extends ChangeNotifier {
     _completed = false;
   }
 }
-
 // #enddocregion Command

--- a/examples/app-architecture/command/lib/no_command.dart
+++ b/examples/app-architecture/command/lib/no_command.dart
@@ -69,7 +69,6 @@ class _MainAppState extends State<MainApp> {
       // Show Snackbar
     }
   }
-
   // #enddocregion _onViewModelChanged
 }
 
@@ -142,5 +141,4 @@ class HomeViewModel3 extends ChangeNotifier {
     // edit user
   }
 }
-
 // #enddocregion HomeViewModel3

--- a/examples/app-architecture/command/lib/simple_command.dart
+++ b/examples/app-architecture/command/lib/simple_command.dart
@@ -40,5 +40,4 @@ class HomeViewModel extends ChangeNotifier {
     // load user
   }
 }
-
 // #enddocregion ViewModel

--- a/examples/app-architecture/offline_first/lib/data/repositories/user_profile_repository.dart
+++ b/examples/app-architecture/offline_first/lib/data/repositories/user_profile_repository.dart
@@ -142,6 +142,5 @@ class UserProfileRepository {
       // Try again later
     }
   }
-
   // #enddocregion sync
 }

--- a/examples/app-architecture/offline_first/lib/data/services/api_client_service.dart
+++ b/examples/app-architecture/offline_first/lib/data/services/api_client_service.dart
@@ -23,5 +23,4 @@ class ApiClientService {
     // #docregion ApiClientService
   }
 }
-
 // #enddocregion ApiClientService

--- a/examples/app-architecture/offline_first/lib/data/services/database_service.dart
+++ b/examples/app-architecture/offline_first/lib/data/services/database_service.dart
@@ -24,5 +24,4 @@ class DatabaseService {
     // #docregion DatabaseService
   }
 }
-
 // #enddocregion DatabaseService

--- a/examples/app-architecture/offline_first/lib/domain/model/user_profile.dart
+++ b/examples/app-architecture/offline_first/lib/domain/model/user_profile.dart
@@ -11,5 +11,4 @@ abstract class UserProfile with _$UserProfile {
     @Default(false) bool synchronized,
   }) = _UserProfile;
 }
-
 // #enddocregion UserProfile

--- a/examples/app-architecture/offline_first/lib/ui/user_profile/user_profile_viewmodel.dart
+++ b/examples/app-architecture/offline_first/lib/ui/user_profile/user_profile_viewmodel.dart
@@ -55,5 +55,4 @@ class UserProfileViewModel extends ChangeNotifier {
     // #docregion UserProfileViewModel
   }
 }
-
 // #enddocregion UserProfileViewModel

--- a/examples/app-architecture/optimistic_state/lib/main.dart
+++ b/examples/app-architecture/optimistic_state/lib/main.dart
@@ -90,7 +90,6 @@ class _SubscribeButtonState extends State<SubscribeButton> {
       ).showSnackBar(const SnackBar(content: Text('Failed to subscribe')));
     }
   }
-
   // #enddocregion listener2
 }
 
@@ -150,7 +149,6 @@ class SubscribeButtonViewModel extends ChangeNotifier {
       notifyListeners();
     }
   }
-
   // #enddocregion subscribe
 }
 // #enddocregion ViewModelFull
@@ -166,5 +164,4 @@ class SubscriptionRepository {
     throw Exception('Failed to subscribe');
   }
 }
-
 // #enddocregion SubscriptionRepository

--- a/examples/app-architecture/optimistic_state/lib/starter.dart
+++ b/examples/app-architecture/optimistic_state/lib/starter.dart
@@ -18,5 +18,4 @@ class _SubscribeButtonState extends State<SubscribeButton> {
 class SubscribeButtonViewModel extends ChangeNotifier {}
 
 class SubscriptionRepository {}
-
 // #enddocregion Starter

--- a/examples/app-architecture/result/lib/main.dart
+++ b/examples/app-architecture/result/lib/main.dart
@@ -68,7 +68,6 @@ class UserProfileRepository {
 
     return Result.error(Exception('Failed to get user profile'));
   }
-
   // #enddocregion getUserProfile
 }
 

--- a/examples/app-architecture/result/lib/result.dart
+++ b/examples/app-architecture/result/lib/result.dart
@@ -55,5 +55,4 @@ final class Error<T> extends Result<T> {
   @override
   String toString() => 'Result<$T>.error($error)';
 }
-
 // #enddocregion Result

--- a/examples/app-architecture/todo_data_service/lib/business/model/todo.dart
+++ b/examples/app-architecture/todo_data_service/lib/business/model/todo.dart
@@ -13,5 +13,4 @@ abstract class Todo with _$Todo {
     required String task,
   }) = _Todo;
 }
-
 // #enddocregion Todo

--- a/examples/app-architecture/todo_data_service/lib/data/repositories/theme_repository.dart
+++ b/examples/app-architecture/todo_data_service/lib/data/repositories/theme_repository.dart
@@ -38,5 +38,4 @@ class ThemeRepository {
   /// ViewModels should call [isDarkMode] to get the current theme setting.
   Stream<bool> observeDarkMode() => _darkModeController.stream;
 }
-
 // #enddocregion ThemeRepository

--- a/examples/app-architecture/todo_data_service/lib/data/repositories/todo_repository.dart
+++ b/examples/app-architecture/todo_data_service/lib/data/repositories/todo_repository.dart
@@ -29,5 +29,4 @@ class TodoRepository {
     return _database.delete(id);
   }
 }
-
 // #enddocregion TodoRepository

--- a/examples/app-architecture/todo_data_service/lib/data/services/shared_preferences_service.dart
+++ b/examples/app-architecture/todo_data_service/lib/data/services/shared_preferences_service.dart
@@ -14,5 +14,4 @@ class SharedPreferencesService {
     return prefs.getBool(_kDarkMode) ?? false;
   }
 }
-
 // #enddocregion SharedPreferencesService

--- a/examples/app-architecture/todo_data_service/lib/main_app_viewmodel.dart
+++ b/examples/app-architecture/todo_data_service/lib/main_app_viewmodel.dart
@@ -37,5 +37,4 @@ class MainAppViewModel extends ChangeNotifier {
     super.dispose();
   }
 }
-
 // #enddocregion MainAppViewModel

--- a/examples/app-architecture/todo_data_service/lib/ui/theme_config/viewmodel/theme_switch_viewmodel.dart
+++ b/examples/app-architecture/todo_data_service/lib/ui/theme_config/viewmodel/theme_switch_viewmodel.dart
@@ -42,5 +42,4 @@ class ThemeSwitchViewModel extends ChangeNotifier {
     return result;
   }
 }
-
 // #enddocregion ThemeSwitchViewModel

--- a/examples/app-architecture/todo_data_service/lib/ui/theme_config/widgets/theme_switch.dart
+++ b/examples/app-architecture/todo_data_service/lib/ui/theme_config/widgets/theme_switch.dart
@@ -30,5 +30,4 @@ class ThemeSwitch extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion ThemeSwitch

--- a/examples/app-architecture/todo_data_service/lib/ui/todo_list/viewmodel/todo_list_viewmodel.dart
+++ b/examples/app-architecture/todo_data_service/lib/ui/todo_list/viewmodel/todo_list_viewmodel.dart
@@ -82,6 +82,5 @@ class TodoListViewModel extends ChangeNotifier {
       notifyListeners();
     }
   }
-
   // #enddocregion Delete
 }

--- a/examples/app-architecture/todo_data_service/lib/ui/todo_list/widgets/todo_list_screen.dart
+++ b/examples/app-architecture/todo_data_service/lib/ui/todo_list/widgets/todo_list_screen.dart
@@ -93,6 +93,5 @@ class _TodoListScreenState extends State<TodoListScreen> {
       _controller.clear();
     }
   }
-
   // #enddocregion Add
 }

--- a/examples/cookbook/animation/animated_container/lib/starter.dart
+++ b/examples/cookbook/animation/animated_container/lib/starter.dart
@@ -23,5 +23,4 @@ class _AnimatedContainerAppState extends State<AnimatedContainerApp> {
     return Container();
   }
 }
-
 // #enddocregion Starter

--- a/examples/cookbook/animation/opacity_animation/lib/starter.dart
+++ b/examples/cookbook/animation/opacity_animation/lib/starter.dart
@@ -1,6 +1,6 @@
+// ignore_for_file: prefer_final_fields, unused_field
+
 import 'package:flutter/material.dart';
-// ignore_for_file: prefer_final_fields
-// ignore_for_file: unused_field
 
 // #docregion Starter
 // The StatefulWidget's job is to take data and create a State class.
@@ -26,5 +26,4 @@ class _MyHomePageState extends State<MyHomePage> {
     return Container();
   }
 }
-
 // #enddocregion Starter

--- a/examples/cookbook/animation/physics_simulation/lib/main.dart
+++ b/examples/cookbook/animation/physics_simulation/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 // #docregion import
 import 'package:flutter/physics.dart';
+
 // #enddocregion import
 
 void main() {

--- a/examples/cookbook/animation/physics_simulation/lib/step1.dart
+++ b/examples/cookbook/animation/physics_simulation/lib/step1.dart
@@ -51,6 +51,5 @@ class _DraggableCardState extends State<DraggableCard>
   Widget build(BuildContext context) {
     return Align(child: Card(child: widget.child));
   }
-
   // #enddocregion build
 }

--- a/examples/cookbook/animation/physics_simulation/lib/step2.dart
+++ b/examples/cookbook/animation/physics_simulation/lib/step2.dart
@@ -74,6 +74,5 @@ class _DraggableCardState extends State<DraggableCard>
     );
     // #enddocregion gesture
   }
-
   // #enddocregion build
 }

--- a/examples/cookbook/animation/physics_simulation/lib/step3.dart
+++ b/examples/cookbook/animation/physics_simulation/lib/step3.dart
@@ -92,6 +92,5 @@ class _DraggableCardState extends State<DraggableCard>
     _controller.reset();
     _controller.forward();
   }
-
   // #enddocregion runAnimation
 }

--- a/examples/cookbook/design/orientation/lib/orientation.dart
+++ b/examples/cookbook/design/orientation/lib/orientation.dart
@@ -9,5 +9,4 @@ void main() {
   SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
   runApp(const MyApp());
 }
-
 // #enddocregion PreferredOrientations

--- a/examples/cookbook/effects/download_button/lib/button_taps.dart
+++ b/examples/cookbook/effects/download_button/lib/button_taps.dart
@@ -151,5 +151,4 @@ class DownloadButton extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion TapCallbacks

--- a/examples/cookbook/effects/download_button/lib/display.dart
+++ b/examples/cookbook/effects/download_button/lib/display.dart
@@ -71,5 +71,4 @@ class ButtonShapeWidget extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion Display

--- a/examples/cookbook/effects/download_button/lib/display_text.dart
+++ b/examples/cookbook/effects/download_button/lib/display_text.dart
@@ -56,5 +56,4 @@ class ButtonShapeWidget extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion DisplayText

--- a/examples/cookbook/effects/download_button/lib/spinner.dart
+++ b/examples/cookbook/effects/download_button/lib/spinner.dart
@@ -147,6 +147,5 @@ class DownloadButton extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion Spinner
 }

--- a/examples/cookbook/effects/download_button/lib/stateful_widget.dart
+++ b/examples/cookbook/effects/download_button/lib/stateful_widget.dart
@@ -11,5 +11,4 @@ class DownloadButton extends StatelessWidget {
     return const SizedBox();
   }
 }
-
 // #enddocregion DownloadButton

--- a/examples/cookbook/effects/download_button/lib/stop.dart
+++ b/examples/cookbook/effects/download_button/lib/stop.dart
@@ -158,6 +158,5 @@ class DownloadButton extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion StopIcon
 }

--- a/examples/cookbook/effects/download_button/lib/visual_states.dart
+++ b/examples/cookbook/effects/download_button/lib/visual_states.dart
@@ -20,5 +20,4 @@ class DownloadButton extends StatelessWidget {
     return const SizedBox();
   }
 }
-
 // #enddocregion VisualStates

--- a/examples/cookbook/effects/drag_a_widget/lib/main.dart
+++ b/examples/cookbook/effects/drag_a_widget/lib/main.dart
@@ -389,5 +389,4 @@ class Customer {
     return '\$${(totalPriceCents / 100.0).toStringAsFixed(2)}';
   }
 }
-
 // #enddocregion CustomerClass

--- a/examples/cookbook/effects/expandable_fab/lib/excerpt1.dart
+++ b/examples/cookbook/effects/expandable_fab/lib/excerpt1.dart
@@ -24,5 +24,4 @@ class _ExpandableFabState extends State<ExpandableFab> {
     return const SizedBox();
   }
 }
-
 // #enddocregion ExpandableFab

--- a/examples/cookbook/effects/expandable_fab/lib/excerpt2.dart
+++ b/examples/cookbook/effects/expandable_fab/lib/excerpt2.dart
@@ -90,5 +90,4 @@ class _ExpandableFabState extends State<ExpandableFab> {
     );
   }
 }
-
 // #enddocregion ExpandableFabState

--- a/examples/cookbook/effects/nested_nav/lib/prompt_user.dart
+++ b/examples/cookbook/effects/nested_nav/lib/prompt_user.dart
@@ -86,6 +86,5 @@ class SetupFlowState extends State<SetupFlow> {
       title: const Text('Bulb Setup'),
     );
   }
-
   // #enddocregion PromptUser
 }

--- a/examples/cookbook/effects/nested_nav/lib/setupflow.dart
+++ b/examples/cookbook/effects/nested_nav/lib/setupflow.dart
@@ -16,5 +16,4 @@ class SetupFlowState extends State<SetupFlow> {
     return const SizedBox();
   }
 }
-
 // #enddocregion SetupFlow

--- a/examples/cookbook/effects/nested_nav/lib/setupflow2.dart
+++ b/examples/cookbook/effects/nested_nav/lib/setupflow2.dart
@@ -19,6 +19,5 @@ class SetupFlowState extends State<SetupFlow> {
   PreferredSizeWidget _buildFlowAppBar() {
     return AppBar(title: const Text('Bulb Setup'));
   }
-
   // #enddocregion SetupFlow2
 }

--- a/examples/cookbook/effects/parallax_scrolling/lib/excerpt1.dart
+++ b/examples/cookbook/effects/parallax_scrolling/lib/excerpt1.dart
@@ -9,5 +9,4 @@ class ParallaxRecipe extends StatelessWidget {
     return const SingleChildScrollView(child: Column(children: []));
   }
 }
-
 // #enddocregion ParallaxRecipe

--- a/examples/cookbook/effects/parallax_scrolling/lib/excerpt2.dart
+++ b/examples/cookbook/effects/parallax_scrolling/lib/excerpt2.dart
@@ -78,5 +78,4 @@ class LocationListItem extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion LocationListItem

--- a/examples/cookbook/effects/parallax_scrolling/lib/main.dart
+++ b/examples/cookbook/effects/parallax_scrolling/lib/main.dart
@@ -134,7 +134,6 @@ class ParallaxFlowDelegate extends FlowDelegate {
     required this.listItemContext,
     required this.backgroundImageKey,
   }) : super(repaint: scrollable.position);
-
   // #enddocregion SuperScrollPosition
 
   final ScrollableState scrollable;
@@ -197,7 +196,6 @@ class ParallaxFlowDelegate extends FlowDelegate {
         listItemContext != oldDelegate.listItemContext ||
         backgroundImageKey != oldDelegate.backgroundImageKey;
   }
-
   // #enddocregion ShouldRepaint
 }
 

--- a/examples/cookbook/effects/shimmer_loading/lib/main.dart
+++ b/examples/cookbook/effects/shimmer_loading/lib/main.dart
@@ -191,5 +191,4 @@ class _ExampleUiLoadingAnimationState extends State<ExampleUiLoadingAnimation> {
     );
   }
 }
-
 // #enddocregion ExampleUiAnimationState

--- a/examples/cookbook/effects/shimmer_loading/lib/shimmer_state.dart
+++ b/examples/cookbook/effects/shimmer_loading/lib/shimmer_state.dart
@@ -41,5 +41,4 @@ class ShimmerState extends State<Shimmer> {
     return widget.child ?? const SizedBox();
   }
 }
-
 // #enddocregion ShimmerState

--- a/examples/cookbook/effects/staggered_menu_animation/lib/animation_delays.dart
+++ b/examples/cookbook/effects/staggered_menu_animation/lib/animation_delays.dart
@@ -38,5 +38,4 @@ class _MenuState extends State<Menu> with SingleTickerProviderStateMixin {
 
   // #docregion delays
 }
-
 // #enddocregion delays

--- a/examples/cookbook/effects/staggered_menu_animation/lib/step1.dart
+++ b/examples/cookbook/effects/staggered_menu_animation/lib/step1.dart
@@ -83,5 +83,4 @@ class _MenuState extends State<Menu> {
     );
   }
 }
-
 // #enddocregion step1

--- a/examples/cookbook/effects/staggered_menu_animation/lib/step2.dart
+++ b/examples/cookbook/effects/staggered_menu_animation/lib/step2.dart
@@ -32,5 +32,4 @@ class _MenuState extends State<Menu> with SingleTickerProviderStateMixin {
 
   // #docregion animation-controller
 }
-
 // #enddocregion animation-controller

--- a/examples/cookbook/effects/staggered_menu_animation/lib/step3.dart
+++ b/examples/cookbook/effects/staggered_menu_animation/lib/step3.dart
@@ -74,5 +74,4 @@ class _MenuState extends State<Menu> with SingleTickerProviderStateMixin {
   ];
   // #docregion step3
 }
-
 // #enddocregion step3

--- a/examples/cookbook/effects/staggered_menu_animation/lib/step4.dart
+++ b/examples/cookbook/effects/staggered_menu_animation/lib/step4.dart
@@ -156,6 +156,5 @@ class _MenuState extends State<Menu> with SingleTickerProviderStateMixin {
       ),
     );
   }
-
   // #enddocregion build-get-started
 }

--- a/examples/cookbook/forms/focus/lib/starter.dart
+++ b/examples/cookbook/forms/focus/lib/starter.dart
@@ -37,5 +37,4 @@ class _MyCustomFormState extends State<MyCustomForm> {
     return Container();
   }
 }
-
 // #enddocregion Starter

--- a/examples/cookbook/forms/focus/lib/step2.dart
+++ b/examples/cookbook/forms/focus/lib/step2.dart
@@ -35,6 +35,5 @@ class _MyCustomFormState extends State<MyCustomForm> {
   Widget build(BuildContext context) {
     return TextField(focusNode: myFocusNode);
   }
-
   // #enddocregion Build
 }

--- a/examples/cookbook/forms/retrieve_input/lib/starter.dart
+++ b/examples/cookbook/forms/retrieve_input/lib/starter.dart
@@ -29,5 +29,4 @@ class _MyCustomFormState extends State<MyCustomForm> {
     return Container();
   }
 }
-
 // #enddocregion Starter

--- a/examples/cookbook/forms/text_field_changes/lib/main_step1.dart
+++ b/examples/cookbook/forms/text_field_changes/lib/main_step1.dart
@@ -30,5 +30,4 @@ class _MyCustomFormState extends State<MyCustomForm> {
     return Container();
   }
 }
-
 // #enddocregion Step1

--- a/examples/cookbook/games/firestore_multiplayer/lib/main.dart
+++ b/examples/cookbook/games/firestore_multiplayer/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
 
 import 'firebase_options.dart';
+
 // #enddocregion imports
 
 void main() async {

--- a/examples/cookbook/games/firestore_multiplayer/lib/play_session/play_session_screen.dart
+++ b/examples/cookbook/games/firestore_multiplayer/lib/play_session/play_session_screen.dart
@@ -9,6 +9,7 @@ import '../game_internals/board_state.dart';
 // #docregion imports
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../multiplayer/firestore_controller.dart';
+
 // #enddocregion imports
 
 class PlaySessionScreen extends StatefulWidget {

--- a/examples/cookbook/lists/mixed_list/lib/main.dart
+++ b/examples/cookbook/lists/mixed_list/lib/main.dart
@@ -87,5 +87,4 @@ class MessageItem implements ListItem {
   @override
   Widget buildSubtitle(BuildContext context) => Text(body);
 }
-
 // #enddocregion ListItem

--- a/examples/cookbook/navigation/navigate_with_arguments/lib/main.dart
+++ b/examples/cookbook/navigation/navigate_with_arguments/lib/main.dart
@@ -179,5 +179,4 @@ class ScreenArguments {
 
   ScreenArguments(this.title, this.message);
 }
-
 // #enddocregion ScreenArguments

--- a/examples/cookbook/navigation/navigation_basics/lib/main_step1.dart
+++ b/examples/cookbook/navigation/navigation_basics/lib/main_step1.dart
@@ -38,5 +38,4 @@ class SecondRoute extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion first-second-routes

--- a/examples/cookbook/navigation/navigation_basics/lib/main_step1_cupertino.dart
+++ b/examples/cookbook/navigation/navigation_basics/lib/main_step1_cupertino.dart
@@ -38,5 +38,4 @@ class SecondRoute extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion first-second-routes

--- a/examples/cookbook/navigation/passing_data/lib/main.dart
+++ b/examples/cookbook/navigation/passing_data/lib/main.dart
@@ -82,5 +82,4 @@ class DetailScreen extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion detail

--- a/examples/cookbook/navigation/passing_data/lib/main_routesettings.dart
+++ b/examples/cookbook/navigation/passing_data/lib/main_routesettings.dart
@@ -79,5 +79,4 @@ class DetailScreen extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion DetailScreen

--- a/examples/cookbook/navigation/passing_data/lib/main_todoscreen.dart
+++ b/examples/cookbook/navigation/passing_data/lib/main_todoscreen.dart
@@ -30,5 +30,4 @@ class TodosScreen extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion TodosScreen

--- a/examples/cookbook/navigation/returning_data/lib/main.dart
+++ b/examples/cookbook/navigation/returning_data/lib/main.dart
@@ -55,7 +55,6 @@ class _SelectionButtonState extends State<SelectionButton> {
       ..removeCurrentSnackBar()
       ..showSnackBar(SnackBar(content: Text('$result')));
   }
-
   // #enddocregion navigateAndDisplay
 }
 

--- a/examples/cookbook/navigation/returning_data/lib/main_step2.dart
+++ b/examples/cookbook/navigation/returning_data/lib/main_step2.dart
@@ -1,5 +1,6 @@
-import 'package:flutter/material.dart';
 // ignore_for_file: unused_local_variable
+
+import 'package:flutter/material.dart';
 
 void main() {
   runApp(const MaterialApp(title: 'Returning Data', home: HomeScreen()));
@@ -91,5 +92,4 @@ class SelectionScreen extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion SelectionScreen

--- a/examples/cookbook/networking/background_parsing/lib/main_step2.dart
+++ b/examples/cookbook/networking/background_parsing/lib/main_step2.dart
@@ -6,5 +6,4 @@ import 'package:http/http.dart' as http;
 Future<http.Response> fetchPhotos(http.Client client) async {
   return client.get(Uri.parse('https://jsonplaceholder.typicode.com/photos'));
 }
-
 // #enddocregion fetchPhotos

--- a/examples/cookbook/networking/background_parsing/lib/main_step3.dart
+++ b/examples/cookbook/networking/background_parsing/lib/main_step3.dart
@@ -48,5 +48,4 @@ class Photo {
     );
   }
 }
-
 // #enddocregion Photo

--- a/examples/cookbook/networking/delete_data/lib/main.dart
+++ b/examples/cookbook/networking/delete_data/lib/main.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 // #docregion Http
 import 'package:http/http.dart' as http;
+
 // #enddocregion Http
 
 Future<Album> fetchAlbum() async {

--- a/examples/cookbook/networking/delete_data/lib/main_step1.dart
+++ b/examples/cookbook/networking/delete_data/lib/main_step1.dart
@@ -13,5 +13,4 @@ Future<http.Response> deleteAlbum(String id) async {
 
   return response;
 }
-
 // #enddocregion deleteAlbum

--- a/examples/cookbook/networking/fetch_data/lib/main.dart
+++ b/examples/cookbook/networking/fetch_data/lib/main.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 // #docregion Http
 import 'package:http/http.dart' as http;
+
 // #enddocregion Http
 
 // #docregion fetchAlbum
@@ -98,5 +99,4 @@ class _MyAppState extends State<MyApp> {
 
   // #docregion State
 }
-
 // #enddocregion State

--- a/examples/cookbook/networking/fetch_data/lib/main_step1.dart
+++ b/examples/cookbook/networking/fetch_data/lib/main_step1.dart
@@ -6,5 +6,4 @@ import 'package:http/http.dart' as http;
 Future<http.Response> fetchAlbum() {
   return http.get(Uri.parse('https://jsonplaceholder.typicode.com/albums/1'));
 }
-
 // #enddocregion fetchAlbum

--- a/examples/cookbook/networking/send_data/lib/create_album.dart
+++ b/examples/cookbook/networking/send_data/lib/create_album.dart
@@ -14,5 +14,4 @@ Future<http.Response> createAlbum(String title) {
     body: jsonEncode(<String, String>{'title': title}),
   );
 }
-
 // #enddocregion CreateAlbum

--- a/examples/cookbook/networking/send_data/lib/main.dart
+++ b/examples/cookbook/networking/send_data/lib/main.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 // #docregion Http
 import 'package:http/http.dart' as http;
+
 // #enddocregion Http
 
 // #docregion createAlbum

--- a/examples/cookbook/networking/update_data/lib/main.dart
+++ b/examples/cookbook/networking/update_data/lib/main.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 // #docregion Http
 import 'package:http/http.dart' as http;
+
 // #enddocregion Http
 
 // #docregion fetchAlbum

--- a/examples/cookbook/networking/update_data/lib/main_step2.dart
+++ b/examples/cookbook/networking/update_data/lib/main_step2.dart
@@ -13,5 +13,4 @@ Future<http.Response> updateAlbum(String title) {
     body: jsonEncode(<String, String>{'title': title}),
   );
 }
-
 // #enddocregion updateAlbum

--- a/examples/cookbook/persistence/reading_writing_files/lib/main.dart
+++ b/examples/cookbook/persistence/reading_writing_files/lib/main.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 // #docregion localPath
 import 'package:path_provider/path_provider.dart';
+
 // #enddocregion localPath
 
 void main() {
@@ -54,7 +55,6 @@ class CounterStorage {
     // Write the file
     return file.writeAsString('$counter');
   }
-
   // #enddocregion writeCounter
 }
 

--- a/examples/cookbook/persistence/sqlite/lib/main.dart
+++ b/examples/cookbook/persistence/sqlite/lib/main.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
+
 // #enddocregion imports
 
 void main() async {
@@ -148,5 +149,4 @@ class Dog {
     return 'Dog{id: $id, name: $name, age: $age}';
   }
 }
-
 // #enddocregion Dog

--- a/examples/cookbook/plugins/google_mobile_ads/lib/my_banner_ad.dart
+++ b/examples/cookbook/plugins/google_mobile_ads/lib/my_banner_ad.dart
@@ -88,6 +88,5 @@ class _MyBannerAdWidgetState extends State<MyBannerAdWidget> {
     // Start loading.
     bannerAd.load();
   }
-
   // #enddocregion loadAd
 }

--- a/examples/cookbook/plugins/picture_using_camera/lib/main_step3.dart
+++ b/examples/cookbook/plugins/picture_using_camera/lib/main_step3.dart
@@ -70,5 +70,4 @@ class TakePictureScreenState extends State<TakePictureScreen> {
     return Container();
   }
 }
-
 // #enddocregion controller

--- a/examples/cookbook/plugins/play_video/lib/main_step3.dart
+++ b/examples/cookbook/plugins/play_video/lib/main_step3.dart
@@ -45,5 +45,4 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
     return Container();
   }
 }
-
 // #enddocregion VideoPlayerScreen

--- a/examples/cookbook/testing/integration/introduction/integration_test/app_test.dart
+++ b/examples/cookbook/testing/integration/introduction/integration_test/app_test.dart
@@ -31,5 +31,4 @@ void main() {
     });
   });
 }
-
 // #enddocregion integration-test

--- a/examples/cookbook/testing/integration/profiling/integration_test/scrolling_test.dart
+++ b/examples/cookbook/testing/integration/profiling/integration_test/scrolling_test.dart
@@ -28,5 +28,4 @@ void main() {
     // #enddocregion traceAction
   });
 }
-
 // #enddocregion ScrollWidgetTest

--- a/examples/cookbook/testing/integration/profiling/test_driver/perf_driver.dart
+++ b/examples/cookbook/testing/integration/profiling/test_driver/perf_driver.dart
@@ -28,5 +28,4 @@ Future<void> main() {
     },
   );
 }
-
 // #enddocregion Timeline

--- a/examples/cookbook/testing/unit/mocking/test/fetch_album_test.dart
+++ b/examples/cookbook/testing/unit/mocking/test/fetch_album_test.dart
@@ -7,6 +7,7 @@ import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
 import 'fetch_album_test.mocks.dart';
+
 // #docregion mockClient
 
 // Generate a MockClient using the Mockito package.
@@ -46,5 +47,4 @@ void main() {
   });
   // #docregion mockClient
 }
-
 // #enddocregion mockClient

--- a/examples/cookbook/testing/widget/introduction/test/main_step5_test.dart
+++ b/examples/cookbook/testing/widget/introduction/test/main_step5_test.dart
@@ -1,6 +1,7 @@
+// ignore_for_file: unused_local_variable
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-// ignore_for_file: unused_local_variable
 
 // #docregion main
 void main() {

--- a/examples/cookbook/testing/widget/introduction/test/main_test.dart
+++ b/examples/cookbook/testing/widget/introduction/test/main_test.dart
@@ -38,5 +38,4 @@ class MyWidget extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion widget

--- a/examples/cookbook/testing/widget/orientation_tests/test/widget_test.dart
+++ b/examples/cookbook/testing/widget/orientation_tests/test/widget_test.dart
@@ -66,5 +66,4 @@ void main() {
     // #docregion scaffolding
   });
 }
-
 // #enddocregion scaffolding

--- a/examples/cookbook/testing/widget/scrolling/test/widget_test.dart
+++ b/examples/cookbook/testing/widget/scrolling/test/widget_test.dart
@@ -29,5 +29,4 @@ void main() {
     expect(itemFinder, findsOneWidget);
   });
 }
-
 // #enddocregion ScrollWidgetTest

--- a/examples/cookbook/testing/widget/tap_drag/test/main_test.dart
+++ b/examples/cookbook/testing/widget/tap_drag/test/main_test.dart
@@ -81,5 +81,4 @@ class _TodoListState extends State<TodoList> {
     );
   }
 }
-
 // #enddocregion TodoList

--- a/examples/fwe/birdle/lib/main.dart
+++ b/examples/fwe/birdle/lib/main.dart
@@ -155,5 +155,4 @@ class Tile extends StatelessWidget {
     // #enddocregion AnimatedContainer
   }
 }
-
 // #enddocregion Tile

--- a/examples/fwe/birdle/lib/step1_main.dart
+++ b/examples/fwe/birdle/lib/step1_main.dart
@@ -23,5 +23,4 @@ class MainApp extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion MainApp

--- a/examples/fwe/birdle/lib/step2_main.dart
+++ b/examples/fwe/birdle/lib/step2_main.dart
@@ -65,8 +65,8 @@ class Tile extends StatelessWidget {
     // #enddocregion Tile-Container
   }
 }
-
 // #enddocregion Tile
+
 void docRegionTileUsage() {
   // #docregion TileUsage
   // main.dart line ~16

--- a/examples/fwe/birdle/lib/step2a_main.dart
+++ b/examples/fwe/birdle/lib/step2a_main.dart
@@ -14,5 +14,4 @@ class Tile extends StatelessWidget {
     return Container();
   }
 }
-
 // #enddocregion Tile

--- a/examples/fwe/birdle/lib/step2b_main.dart
+++ b/examples/fwe/birdle/lib/step2b_main.dart
@@ -15,5 +15,4 @@ class Tile extends StatelessWidget {
     return Container();
   }
 }
-
 // #enddocregion Tile

--- a/examples/fwe/birdle/lib/step2c_main.dart
+++ b/examples/fwe/birdle/lib/step2c_main.dart
@@ -21,5 +21,4 @@ class Tile extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion Tile

--- a/examples/fwe/birdle/lib/step2d_main.dart
+++ b/examples/fwe/birdle/lib/step2d_main.dart
@@ -22,5 +22,4 @@ class Tile extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion Tile

--- a/examples/fwe/birdle/lib/step2e_main.dart
+++ b/examples/fwe/birdle/lib/step2e_main.dart
@@ -27,5 +27,4 @@ class Tile extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion Tile

--- a/examples/fwe/birdle/lib/step2f_main.dart
+++ b/examples/fwe/birdle/lib/step2f_main.dart
@@ -32,5 +32,4 @@ class Tile extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion Tile

--- a/examples/fwe/birdle/lib/step3_main.dart
+++ b/examples/fwe/birdle/lib/step3_main.dart
@@ -67,5 +67,4 @@ class GamePage extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion GamePage

--- a/examples/fwe/birdle/lib/step3a_main.dart
+++ b/examples/fwe/birdle/lib/step3a_main.dart
@@ -17,5 +17,4 @@ class GamePage extends StatelessWidget {
     return Container();
   }
 }
-
 // #enddocregion GamePage

--- a/examples/fwe/birdle/lib/step3b_main.dart
+++ b/examples/fwe/birdle/lib/step3b_main.dart
@@ -23,5 +23,4 @@ class GamePage extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion GamePage

--- a/examples/fwe/birdle/lib/step3c_main.dart
+++ b/examples/fwe/birdle/lib/step3c_main.dart
@@ -29,5 +29,4 @@ class GamePage extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion GamePage

--- a/examples/fwe/birdle/lib/step4_main.dart
+++ b/examples/fwe/birdle/lib/step4_main.dart
@@ -91,5 +91,4 @@ class GuessInput extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion GuessInput

--- a/examples/fwe/birdle/lib/step4a_main.dart
+++ b/examples/fwe/birdle/lib/step4a_main.dart
@@ -14,5 +14,4 @@ class GuessInput extends StatelessWidget {
     return Container(); // Placeholder
   }
 }
-
 // #enddocregion GuessInput

--- a/examples/fwe/birdle/lib/step4b_main.dart
+++ b/examples/fwe/birdle/lib/step4b_main.dart
@@ -29,5 +29,4 @@ class GuessInput extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion GuessInput

--- a/examples/fwe/birdle/lib/step4c_main.dart
+++ b/examples/fwe/birdle/lib/step4c_main.dart
@@ -33,5 +33,4 @@ class GuessInput extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion GuessInput

--- a/examples/fwe/birdle/lib/step4d_main.dart
+++ b/examples/fwe/birdle/lib/step4d_main.dart
@@ -30,5 +30,4 @@ class GuessInput extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion GuessInput

--- a/examples/fwe/birdle/lib/step4e_main.dart
+++ b/examples/fwe/birdle/lib/step4e_main.dart
@@ -34,5 +34,4 @@ class GuessInput extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion GuessInput

--- a/examples/fwe/birdle/lib/step4f_main.dart
+++ b/examples/fwe/birdle/lib/step4f_main.dart
@@ -35,5 +35,4 @@ class GuessInput extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion GuessInput

--- a/examples/fwe/birdle/lib/step4g_main.dart
+++ b/examples/fwe/birdle/lib/step4g_main.dart
@@ -35,5 +35,4 @@ class GuessInput extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion GuessInput

--- a/examples/fwe/birdle/lib/step4h_main.dart
+++ b/examples/fwe/birdle/lib/step4h_main.dart
@@ -18,5 +18,4 @@ class GuessInput extends StatelessWidget {
     return Container();
   }
 }
-
 // #enddocregion GuessInput

--- a/examples/fwe/birdle/lib/step4i_main.dart
+++ b/examples/fwe/birdle/lib/step4i_main.dart
@@ -39,5 +39,4 @@ class GuessInput extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion GuessInput

--- a/examples/fwe/birdle/lib/step4j_main.dart
+++ b/examples/fwe/birdle/lib/step4j_main.dart
@@ -39,5 +39,4 @@ class GuessInput extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion GuessInput

--- a/examples/fwe/birdle/lib/step4k_main.dart
+++ b/examples/fwe/birdle/lib/step4k_main.dart
@@ -36,8 +36,8 @@ class GamePage extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion GamePage
+
 class GuessInput extends StatelessWidget {
   GuessInput({super.key, required this.onSubmitGuess});
   final void Function(String) onSubmitGuess;

--- a/examples/fwe/birdle/lib/step4l_main.dart
+++ b/examples/fwe/birdle/lib/step4l_main.dart
@@ -25,5 +25,4 @@ class GuessInput extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion GuessInput

--- a/examples/fwe/birdle/lib/step4m_main.dart
+++ b/examples/fwe/birdle/lib/step4m_main.dart
@@ -27,5 +27,4 @@ class GuessInput extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion GuessInput

--- a/examples/fwe/birdle/lib/step5_main.dart
+++ b/examples/fwe/birdle/lib/step5_main.dart
@@ -54,5 +54,4 @@ class _GamePageState extends State<GamePage> {
     );
   }
 }
-
 // #enddocregion GamePage

--- a/examples/fwe/rolodex/lib/step1_advanced_ui/data/contact_group.dart
+++ b/examples/fwe/rolodex/lib/step1_advanced_ui/data/contact_group.dart
@@ -125,5 +125,4 @@ class ContactGroupsModel {
     _listsNotifier.dispose();
   }
 }
-
 // #enddocregion model_class

--- a/examples/fwe/rolodex/lib/step2_adaptive_layout/screens/adaptive_layout.dart
+++ b/examples/fwe/rolodex/lib/step2_adaptive_layout/screens/adaptive_layout.dart
@@ -52,6 +52,5 @@ class _AdaptiveLayoutState extends State<AdaptiveLayout> {
       ),
     );
   }
-
   // #enddocregion panel-and-divider
 }

--- a/examples/fwe/rolodex/lib/step3_slivers/screens/contact_groups.dart
+++ b/examples/fwe/rolodex/lib/step3_slivers/screens/contact_groups.dart
@@ -87,6 +87,5 @@ class _ContactGroupsView extends StatelessWidget {
       ],
     );
   }
-
   // #enddocregion build_trailing
 }

--- a/examples/fwe/rolodex/lib/step3_slivers/screens/contact_groups_v1.dart
+++ b/examples/fwe/rolodex/lib/step3_slivers/screens/contact_groups_v1.dart
@@ -56,5 +56,4 @@ class _ContactGroupsView extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion contact_groups_view

--- a/examples/fwe/rolodex/lib/step3_slivers/screens/contacts.dart
+++ b/examples/fwe/rolodex/lib/step3_slivers/screens/contacts.dart
@@ -116,5 +116,4 @@ class ContactListSection extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion contact_list_section

--- a/examples/fwe/rolodex/lib/step3_slivers/screens/contacts_v1.dart
+++ b/examples/fwe/rolodex/lib/step3_slivers/screens/contacts_v1.dart
@@ -56,5 +56,4 @@ class _ContactListView extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion contact_list_view

--- a/examples/fwe/rolodex/lib/step3_slivers/screens/contacts_v2.dart
+++ b/examples/fwe/rolodex/lib/step3_slivers/screens/contacts_v2.dart
@@ -60,5 +60,4 @@ class _ContactListView extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion search

--- a/examples/fwe/rolodex/lib/step4_navigation/screens/adaptive_layout.dart
+++ b/examples/fwe/rolodex/lib/step4_navigation/screens/adaptive_layout.dart
@@ -3,6 +3,7 @@ import 'package:flutter/cupertino.dart';
 
 import 'contact_groups.dart';
 import 'contacts.dart';
+
 // #enddocregion imports
 
 const largeScreenMinWidth = 600;
@@ -61,9 +62,7 @@ class _AdaptiveLayoutState extends State<AdaptiveLayout> {
       ),
     );
   }
-
   // #enddocregion build_large_screen
   // #docregion reverted-state
 }
-
 // #enddocregion reverted-state

--- a/examples/fwe/wikipedia_reader/lib/step1_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step1_main.dart
@@ -29,6 +29,4 @@ class MainApp extends StatelessWidget {
     );
   }
 }
-// #enddocregion MainApp
-
-// #enddocregion All
+// #enddocregion All, MainApp

--- a/examples/fwe/wikipedia_reader/lib/step2_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step2_main.dart
@@ -40,5 +40,4 @@ class ArticleModel {
     return Summary.fromJson(jsonDecode(response.body) as Map<String, Object?>);
   }
 }
-
 // #enddocregion ArticleModel

--- a/examples/fwe/wikipedia_reader/lib/step2a_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step2a_main.dart
@@ -30,5 +30,4 @@ class MainApp extends StatelessWidget {
 class ArticleModel {
   // Properties and methods will be added here.
 }
-
 // #enddocregion ArticleModel

--- a/examples/fwe/wikipedia_reader/lib/step2b_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step2b_main.dart
@@ -39,5 +39,4 @@ class ArticleModel {
     throw UnimplementedError();
   }
 }
-
 // #enddocregion ArticleModel

--- a/examples/fwe/wikipedia_reader/lib/step2c_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step2c_main.dart
@@ -43,5 +43,4 @@ class ArticleModel {
     throw UnimplementedError();
   }
 }
-
 // #enddocregion ArticleModel

--- a/examples/fwe/wikipedia_reader/lib/step3a_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step3a_main.dart
@@ -38,5 +38,4 @@ class ArticleViewModel extends ChangeNotifier {
 
   ArticleViewModel(this.model);
 }
-
 // #enddocregion ArticleViewModel

--- a/examples/fwe/wikipedia_reader/lib/step3b_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step3b_main.dart
@@ -28,5 +28,4 @@ class ArticleViewModel extends ChangeNotifier {
   // Methods will be added next.
   Future<void> fetchArticle() async {}
 }
-
 // #enddocregion ArticleViewModel

--- a/examples/fwe/wikipedia_reader/lib/step3c_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step3c_main.dart
@@ -31,5 +31,4 @@ class ArticleViewModel extends ChangeNotifier {
     notifyListeners();
   }
 }
-
 // #enddocregion ArticleViewModel

--- a/examples/fwe/wikipedia_reader/lib/step3d_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step3d_main.dart
@@ -37,5 +37,4 @@ class ArticleViewModel extends ChangeNotifier {
     notifyListeners();
   }
 }
-
 // #enddocregion ArticleViewModel

--- a/examples/fwe/wikipedia_reader/lib/step3e_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step3e_main.dart
@@ -36,6 +36,5 @@ class ArticleViewModel extends ChangeNotifier {
     isLoading = false;
     notifyListeners();
   }
-
   // #enddocregion fetchArticle
 }

--- a/examples/fwe/wikipedia_reader/lib/step4_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step4_main.dart
@@ -166,5 +166,4 @@ class ArticleWidget extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion article

--- a/examples/fwe/wikipedia_reader/lib/step4b_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step4b_main.dart
@@ -37,5 +37,4 @@ class _ArticleViewState extends State<ArticleView> {
     );
   }
 }
-
 // #enddocregion view-model

--- a/examples/fwe/wikipedia_reader/lib/step4c_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step4c_main.dart
@@ -42,5 +42,4 @@ class _ArticleViewState extends State<ArticleView> {
     );
   }
 }
-
 // #enddocregion view-model

--- a/examples/fwe/wikipedia_reader/lib/step4d_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step4d_main.dart
@@ -20,5 +20,4 @@ class ArticlePage extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion page

--- a/examples/fwe/wikipedia_reader/lib/step4e_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step4e_main.dart
@@ -22,5 +22,4 @@ class ArticlePage extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion page

--- a/examples/fwe/wikipedia_reader/lib/step4f_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step4f_main.dart
@@ -13,5 +13,4 @@ class ArticleWidget extends StatelessWidget {
     return const Text('Article content will be displayed here...');
   }
 }
-
 // #enddocregion article

--- a/examples/fwe/wikipedia_reader/lib/step4g_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step4g_main.dart
@@ -21,5 +21,4 @@ class ArticleWidget extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion article

--- a/examples/fwe/wikipedia_reader/lib/step4h_main.dart
+++ b/examples/fwe/wikipedia_reader/lib/step4h_main.dart
@@ -22,5 +22,4 @@ class ArticleWidget extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion article

--- a/examples/fwe/wikipedia_reader/lib/summary.dart
+++ b/examples/fwe/wikipedia_reader/lib/summary.dart
@@ -245,5 +245,4 @@ String? getFileExtension(String file) {
 }
 
 const acceptableImageFormats = ['png', 'jpg', 'jpeg'];
-
 // #enddocregion All

--- a/examples/get-started/flutter-for/android_devs/lib/async.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/async.dart
@@ -66,6 +66,5 @@ class _SampleAppPageState extends State<SampleAppPage> {
           .cast<Map<String, Object?>>();
     });
   }
-
   // #enddocregion load-data
 }

--- a/examples/get-started/flutter-for/android_devs/lib/custom.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/custom.dart
@@ -21,6 +21,5 @@ class MyWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return const Center(child: CustomButton('Hello'));
   }
-
   // #enddocregion use-custom-button
 }

--- a/examples/get-started/flutter-for/android_devs/lib/events.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/events.dart
@@ -15,7 +15,6 @@ class MyButton extends StatelessWidget {
       child: const Text('Button'),
     );
   }
-
   // #enddocregion on-pressed
 }
 
@@ -89,5 +88,4 @@ class _SampleAppState extends State<SampleApp>
     );
   }
 }
-
 // #enddocregion sample-app

--- a/examples/get-started/flutter-for/android_devs/lib/images.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/images.dart
@@ -22,6 +22,5 @@ class ImageExample extends StatelessWidget {
   Widget build(BuildContext context) {
     return Image.asset('images/my_image.png');
   }
-
   // #enddocregion image-asset
 }

--- a/examples/get-started/flutter-for/android_devs/lib/isolates.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/isolates.dart
@@ -121,6 +121,5 @@ class _SampleAppPageState extends State<SampleAppPage> {
     port.send([msg, response.sendPort]);
     return response.first;
   }
-
   // #enddocregion load-data
 }

--- a/examples/get-started/flutter-for/android_devs/lib/layout.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/layout.dart
@@ -79,7 +79,6 @@ class MyWidget extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion simple-widget
 }
 
@@ -99,7 +98,6 @@ class RowExample extends StatelessWidget {
       ],
     );
   }
-
   // #enddocregion row
 }
 
@@ -119,7 +117,6 @@ class ColumnExample extends StatelessWidget {
       ],
     );
   }
-
   // #enddocregion column
 }
 
@@ -138,6 +135,5 @@ class ListViewExample extends StatelessWidget {
       ],
     );
   }
-
   // #enddocregion list-view
 }

--- a/examples/get-started/flutter-for/android_devs/lib/text.dart
+++ b/examples/get-started/flutter-for/android_devs/lib/text.dart
@@ -16,6 +16,5 @@ class MyWidget extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion custom-font
 }

--- a/examples/get-started/flutter-for/ios_devs/lib/canvas.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/canvas.dart
@@ -64,5 +64,4 @@ class SignaturePainter extends CustomPainter {
   bool shouldRepaint(SignaturePainter oldDelegate) =>
       oldDelegate.points != points;
 }
-
 // #enddocregion custom-painter

--- a/examples/get-started/flutter-for/ios_devs/lib/custom.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/custom.dart
@@ -21,6 +21,5 @@ class MyWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return const Center(child: CustomButton('Hello'));
   }
-
   // #enddocregion use-custom-button
 }

--- a/examples/get-started/flutter-for/ios_devs/lib/events.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/events.dart
@@ -14,7 +14,6 @@ class MyButton extends StatelessWidget {
       child: const Text('Button'),
     );
   }
-
   // #enddocregion on-pressed
 }
 
@@ -82,5 +81,4 @@ class _SampleAppState extends State<SampleApp>
     );
   }
 }
-
 // #enddocregion sample-app

--- a/examples/get-started/flutter-for/ios_devs/lib/form.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/form.dart
@@ -62,5 +62,4 @@ class _MyFormState extends State<MyForm> {
     );
   }
 }
-
 // #enddocregion my-form-state

--- a/examples/get-started/flutter-for/ios_devs/lib/get_started.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/get_started.dart
@@ -29,5 +29,4 @@ class HomePage extends StatelessWidget {
     return const Scaffold(body: Center(child: Text('Hello, World!')));
   }
 }
-
 // #enddocregion homepage

--- a/examples/get-started/flutter-for/ios_devs/lib/grid.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/grid.dart
@@ -41,5 +41,4 @@ class HomePage extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion grid-example

--- a/examples/get-started/flutter-for/ios_devs/lib/images.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/images.dart
@@ -21,6 +21,5 @@ class ImageExample extends StatelessWidget {
   Widget build(BuildContext context) {
     return Image.asset('images/my_image.png');
   }
-
   // #enddocregion image-asset
 }

--- a/examples/get-started/flutter-for/ios_devs/lib/layout.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/layout.dart
@@ -73,7 +73,6 @@ class MyWidget extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion simple-widget
 }
 
@@ -93,7 +92,6 @@ class RowExample extends StatelessWidget {
       ],
     );
   }
-
   // #enddocregion row
 }
 
@@ -113,7 +111,6 @@ class ColumnExample extends StatelessWidget {
       ],
     );
   }
-
   // #enddocregion column
 }
 
@@ -132,6 +129,5 @@ class ListViewExample extends StatelessWidget {
       ],
     );
   }
-
   // #enddocregion list-view
 }

--- a/examples/get-started/flutter-for/ios_devs/lib/list.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/list.dart
@@ -41,5 +41,4 @@ class HomePage extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion simple-list

--- a/examples/get-started/flutter-for/ios_devs/lib/navigation.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/navigation.dart
@@ -96,5 +96,4 @@ class DetailsPage extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion details-page

--- a/examples/get-started/flutter-for/ios_devs/lib/state.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/state.dart
@@ -42,5 +42,4 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 }
-
 // #enddocregion state

--- a/examples/get-started/flutter-for/ios_devs/lib/text.dart
+++ b/examples/get-started/flutter-for/ios_devs/lib/text.dart
@@ -16,6 +16,5 @@ class MyWidget extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion custom-font
 }

--- a/examples/get-started/flutter-for/react_native_devs/lib/best_practices.dart
+++ b/examples/get-started/flutter-for/react_native_devs/lib/best_practices.dart
@@ -30,5 +30,4 @@ class MyStatelessWidget extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion use-stateful-widget

--- a/examples/get-started/flutter-for/react_native_devs/lib/components.dart
+++ b/examples/get-started/flutter-for/react_native_devs/lib/components.dart
@@ -38,5 +38,4 @@ class UseCard extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion components

--- a/examples/get-started/flutter-for/react_native_devs/lib/examples.dart
+++ b/examples/get-started/flutter-for/react_native_devs/lib/examples.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 // #enddocregion package-import
 // #docregion shared-prefs
 import 'package:shared_preferences/shared_preferences.dart';
+
 // #enddocregion shared-prefs
 
 // #docregion main
@@ -161,7 +162,6 @@ class ThemeExample extends StatelessWidget {
       home: const StylingPage(),
     );
   }
-
   // #enddocregion theme
 }
 
@@ -199,7 +199,6 @@ class ThemeDataExample extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion theme-data
 }
 
@@ -249,7 +248,6 @@ class DrawerExample extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion drawer
 }
 
@@ -274,7 +272,6 @@ class ScaffoldExample extends StatelessWidget {
       body: Container(),
     );
   }
-
   // #enddocregion scaffold
 }
 
@@ -310,7 +307,6 @@ class GestureDetectorExample extends StatelessWidget {
       },
     );
   }
-
   // #enddocregion gesture-detector
 }
 
@@ -383,7 +379,6 @@ class _TextEditingExampleState extends State<TextEditingExample> {
       ],
     );
   }
-
   // #enddocregion text-editing-controller
 }
 
@@ -444,7 +439,6 @@ class _FormExampleState extends State<FormExample> {
       ),
     );
   }
-
   // #enddocregion form-state
 }
 

--- a/examples/get-started/flutter-for/react_native_devs/lib/main.dart
+++ b/examples/get-started/flutter-for/react_native_devs/lib/main.dart
@@ -51,5 +51,4 @@ void trueExample() {
 bool fn() {
   return true;
 }
-
 // #enddocregion function

--- a/examples/get-started/flutter-for/react_native_devs/lib/navigation.dart
+++ b/examples/get-started/flutter-for/react_native_devs/lib/navigation.dart
@@ -145,6 +145,5 @@ class DrawerExample extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion drawer
 }

--- a/examples/get-started/flutter-for/react_native_devs/lib/stateful.dart
+++ b/examples/get-started/flutter-for/react_native_devs/lib/stateful.dart
@@ -60,5 +60,4 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
     );
   }
 }
-
 // #enddocregion stateful-widget-state

--- a/examples/get-started/flutter-for/xamarin_devs/lib/custom_button.dart
+++ b/examples/get-started/flutter-for/xamarin_devs/lib/custom_button.dart
@@ -21,6 +21,5 @@ class UseCustomButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return const Center(child: CustomButton('Hello'));
   }
-
   // #enddocregion use-custom-button
 }

--- a/examples/get-started/flutter-for/xamarin_devs/lib/gestures.dart
+++ b/examples/get-started/flutter-for/xamarin_devs/lib/gestures.dart
@@ -14,7 +14,6 @@ class MyWidget extends StatelessWidget {
       child: const Text('Button'),
     );
   }
-
   // #enddocregion elevated-button
 }
 
@@ -83,5 +82,4 @@ class _RotatingFlutterDetectorState extends State<RotatingFlutterDetector>
     );
   }
 }
-
 // #enddocregion rotating-flutter-detector

--- a/examples/get-started/flutter-for/xamarin_devs/lib/images.dart
+++ b/examples/get-started/flutter-for/xamarin_devs/lib/images.dart
@@ -8,7 +8,6 @@ class ImageAssetExample extends StatelessWidget {
   Widget build(BuildContext context) {
     return Image.asset('images/my_icon.png');
   }
-
   // #enddocregion image-asset
 }
 
@@ -20,6 +19,5 @@ class AssetImageExample extends StatelessWidget {
   Widget build(BuildContext context) {
     return const Image(image: AssetImage('images/my_image.png'));
   }
-
   // #enddocregion asset-image
 }

--- a/examples/get-started/flutter-for/xamarin_devs/lib/layouts.dart
+++ b/examples/get-started/flutter-for/xamarin_devs/lib/layouts.dart
@@ -16,7 +16,6 @@ class RowExample extends StatelessWidget {
       ],
     );
   }
-
   // #enddocregion row
 }
 
@@ -60,7 +59,6 @@ class GridExample extends StatelessWidget {
       }),
     );
   }
-
   // #enddocregion grid
 }
 
@@ -80,7 +78,6 @@ class StackExample extends StatelessWidget {
       ],
     );
   }
-
   // #enddocregion stack
 }
 
@@ -92,7 +89,6 @@ class ScrollViewExample extends StatelessWidget {
   Widget build(BuildContext context) {
     return const SingleChildScrollView(child: Text('Long Content'));
   }
-
   // #enddocregion scroll-view
 }
 
@@ -111,6 +107,5 @@ class ListViewExample extends StatelessWidget {
       ],
     );
   }
-
   // #enddocregion list-view
 }

--- a/examples/get-started/flutter-for/xamarin_devs/lib/main.dart
+++ b/examples/get-started/flutter-for/xamarin_devs/lib/main.dart
@@ -18,5 +18,4 @@ class MyApp extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion my-app

--- a/examples/get-started/flutter-for/xamarin_devs/lib/padding.dart
+++ b/examples/get-started/flutter-for/xamarin_devs/lib/padding.dart
@@ -19,6 +19,5 @@ class MyWidget extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion padding
 }

--- a/examples/get-started/flutter-for/xamarin_devs/lib/page.dart
+++ b/examples/get-started/flutter-for/xamarin_devs/lib/page.dart
@@ -66,5 +66,4 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 }
-
 // #enddocregion my-home-page-state

--- a/examples/get-started/flutter-for/xamarin_devs/lib/strings.dart
+++ b/examples/get-started/flutter-for/xamarin_devs/lib/strings.dart
@@ -56,6 +56,5 @@ class CustomFontExample extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion custom-font
 }

--- a/examples/get-started/flutter-for/xamarin_devs/lib/views.dart
+++ b/examples/get-started/flutter-for/xamarin_devs/lib/views.dart
@@ -62,5 +62,4 @@ class _SampleAppPageState extends State<SampleAppPage> {
     );
   }
 }
-
 // #enddocregion add-remove-element

--- a/examples/googleapis/lib/main.dart
+++ b/examples/googleapis/lib/main.dart
@@ -17,8 +17,9 @@ import 'package:google_sign_in/google_sign_in.dart';
 // #enddocregion google-import
 
 // #docregion youtube-import
-/// Provides the `YouTubeApi` class.
+// Provides the `YouTubeApi` class.
 import 'package:googleapis/youtube/v3.dart';
+
 // #enddocregion youtube-import
 
 const _title = 'My YouTube Favorites';
@@ -37,8 +38,8 @@ class _LikedVideosWidget extends StatefulWidget {
 class _LikedVideosWidgetState extends State<_LikedVideosWidget> {
   // #docregion post-init
   GoogleSignInAccount? _currentUser;
-
   // #enddocregion post-init
+
   List<PlaylistItemSnippet>? _favoriteVideos;
 
   // #docregion init

--- a/examples/internationalization/gen_l10n_example/lib/examples.dart
+++ b/examples/internationalization/gen_l10n_example/lib/examples.dart
@@ -100,6 +100,5 @@ class _PageWithDatePickerState extends State<PageWithDatePicker> {
       ),
     );
   }
-
   // #enddocregion date-picker
 }

--- a/examples/internationalization/gen_l10n_example/lib/main.dart
+++ b/examples/internationalization/gen_l10n_example/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 
 // #docregion app-localizations-import
 import 'l10n/app_localizations.dart';
+
 // #enddocregion app-localizations-import
 
 class MyApp extends StatelessWidget {

--- a/examples/layout/base/lib/cupertino.dart
+++ b/examples/layout/base/lib/cupertino.dart
@@ -31,5 +31,4 @@ class MyApp extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion my-app

--- a/examples/layout/base/lib/main.dart
+++ b/examples/layout/base/lib/main.dart
@@ -29,5 +29,4 @@ class MyApp extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion my-app, all

--- a/examples/layout/card_and_stack/lib/main.dart
+++ b/examples/layout/card_and_stack/lib/main.dart
@@ -79,6 +79,5 @@ class MyApp extends StatelessWidget {
       ],
     );
   }
-
   // #enddocregion stack
 }

--- a/examples/layout/grid_and_list/lib/main.dart
+++ b/examples/layout/grid_and_list/lib/main.dart
@@ -71,6 +71,5 @@ class MyApp extends StatelessWidget {
       leading: Icon(icon, color: Colors.blue[500]),
     );
   }
-
   // #enddocregion list
 }

--- a/examples/layout/lakes/interactive/lib/main.dart
+++ b/examples/layout/lakes/interactive/lib/main.dart
@@ -209,5 +209,4 @@ class _FavoriteWidgetState extends State<FavoriteWidget> {
 
   // #docregion favorite-state-build
 }
-
 // #enddocregion favorite-state, favorite-state-build

--- a/examples/layout/lakes/step2/lib/main.dart
+++ b/examples/layout/lakes/step2/lib/main.dart
@@ -67,5 +67,4 @@ class TitleSection extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion title-section

--- a/examples/layout/lakes/step3/lib/main.dart
+++ b/examples/layout/lakes/step3/lib/main.dart
@@ -132,5 +132,4 @@ class ButtonWithText extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion button-with-text, button-section

--- a/examples/layout/lakes/step4/lib/main.dart
+++ b/examples/layout/lakes/step4/lib/main.dart
@@ -150,5 +150,4 @@ class TextSection extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion text-section

--- a/examples/layout/lakes/step5/lib/main.dart
+++ b/examples/layout/lakes/step5/lib/main.dart
@@ -162,5 +162,4 @@ class ImageSection extends StatelessWidget {
     // #enddocregion image-asset
   }
 }
-
 // #enddocregion image-section

--- a/examples/layout/lakes/step6/lib/main.dart
+++ b/examples/layout/lakes/step6/lib/main.dart
@@ -219,5 +219,4 @@ class _FavoriteWidgetState extends State<FavoriteWidget> {
 
   // #docregion favorite-state-fields
 }
-
 // #enddocregion favorite-state, favorite-state-fields, favorite-state-build

--- a/examples/layout/non_material/lib/main.dart
+++ b/examples/layout/non_material/lib/main.dart
@@ -25,5 +25,4 @@ class MyApp extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion my-app

--- a/examples/platform_integration/pigeon/lib/pigeon_source.dart
+++ b/examples/platform_integration/pigeon/lib/pigeon_source.dart
@@ -22,5 +22,4 @@ abstract class Api {
   @async
   SearchReply search(SearchRequest request);
 }
-
 // #enddocregion search

--- a/examples/platform_integration/platform_channels/lib/platform_channels.dart
+++ b/examples/platform_integration/platform_channels/lib/platform_channels.dart
@@ -2,6 +2,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+
 // #enddocregion import
 
 class MyHomePage extends StatefulWidget {
@@ -52,6 +53,5 @@ class _MyHomePageState extends State<MyHomePage> {
       ),
     );
   }
-
   // #enddocregion build
 }

--- a/examples/platform_integration/platform_views/lib/native_view_example_1.dart
+++ b/examples/platform_integration/platform_views/lib/native_view_example_1.dart
@@ -4,6 +4,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+
 // #enddocregion import
 
 class HybridCompositionWidget extends StatelessWidget {
@@ -42,6 +43,5 @@ class HybridCompositionWidget extends StatelessWidget {
       },
     );
   }
-
   // #enddocregion hybrid-composition
 }

--- a/examples/platform_integration/platform_views/lib/native_view_example_2.dart
+++ b/examples/platform_integration/platform_views/lib/native_view_example_2.dart
@@ -1,6 +1,7 @@
 // #docregion import
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+
 // #enddocregion import
 
 class VirtualDisplayWidget extends StatelessWidget {
@@ -21,6 +22,5 @@ class VirtualDisplayWidget extends StatelessWidget {
       creationParamsCodec: const StandardMessageCodec(),
     );
   }
-
   // #enddocregion virtual-display
 }

--- a/examples/platform_integration/platform_views/lib/native_view_example_3.dart
+++ b/examples/platform_integration/platform_views/lib/native_view_example_3.dart
@@ -24,7 +24,6 @@ class IOSCompositionWidget extends StatelessWidget {
       creationParamsCodec: const StandardMessageCodec(),
     );
   }
-
   // #enddocregion ios-composition
 }
 
@@ -50,6 +49,5 @@ class TogetherWidget extends StatelessWidget {
         throw UnsupportedError('Unsupported platform view');
     }
   }
-
   // #enddocregion together-widget
 }

--- a/examples/platform_integration/platform_views/lib/native_view_example_4.dart
+++ b/examples/platform_integration/platform_views/lib/native_view_example_4.dart
@@ -24,7 +24,6 @@ class MacOSCompositionWidget extends StatelessWidget {
       creationParamsCodec: const StandardMessageCodec(),
     );
   }
-
   // #enddocregion macos-composition
 }
 
@@ -50,6 +49,5 @@ class TogetherWidget extends StatelessWidget {
         throw UnsupportedError('Unsupported platform view');
     }
   }
-
   // #enddocregion together-widget
 }

--- a/examples/platform_integration/plugin_api_migration/lib/english_words.dart
+++ b/examples/platform_integration/plugin_api_migration/lib/english_words.dart
@@ -25,5 +25,4 @@ class DemoPage extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion english-words

--- a/examples/platform_integration/plugin_api_migration/lib/test.dart
+++ b/examples/platform_integration/plugin_api_migration/lib/test.dart
@@ -12,5 +12,4 @@ void main() {
     expect(batteryLevel, isNotNull);
   });
 }
-
 // #enddocregion test

--- a/examples/platform_integration/plugin_api_migration/lib/url_launcher.dart
+++ b/examples/platform_integration/plugin_api_migration/lib/url_launcher.dart
@@ -34,5 +34,4 @@ class DemoPage extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion url-launcher

--- a/examples/resources/architectural_overview/lib/main.dart
+++ b/examples/resources/architectural_overview/lib/main.dart
@@ -93,7 +93,6 @@ class LayoutBuilderExample extends StatelessWidget {
       },
     );
   }
-
   // #enddocregion layout-builder
 }
 

--- a/examples/resources/dart_swift_concurrency/lib/async_weather.dart
+++ b/examples/resources/dart_swift_concurrency/lib/async_weather.dart
@@ -56,5 +56,4 @@ class HomePage extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion home-page-widget

--- a/examples/state_mgmt/simple/lib/src/passing_callbacks.dart
+++ b/examples/state_mgmt/simple/lib/src/passing_callbacks.dart
@@ -16,7 +16,6 @@ class CallbackPasser extends StatelessWidget {
   void myTapCallback(Item item) {
     print('user tapped on $item');
   }
-
   // #enddocregion methods
 }
 

--- a/examples/state_mgmt/simple/lib/src/provider.dart
+++ b/examples/state_mgmt/simple/lib/src/provider.dart
@@ -75,7 +75,6 @@ class MyCartUsingWidget extends StatelessWidget {
       // #docregion build
     );
   }
-
   // #enddocregion build
 }
 
@@ -118,7 +117,6 @@ class MyCatalogItem extends StatelessWidget {
     var cartModel = somehowGetMyCartModel(context);
     cartModel.add(item);
   }
-
   // #enddocregion my-tap-handler
 }
 

--- a/examples/state_mgmt/simple/lib/src/set_state.dart
+++ b/examples/state_mgmt/simple/lib/src/set_state.dart
@@ -40,5 +40,4 @@ class _MyHomepageState extends State<MyHomepage> {
     );
   }
 }
-
 // #enddocregion ephemeral

--- a/examples/testing/common_errors/lib/renderflex_overflow.dart
+++ b/examples/testing/common_errors/lib/renderflex_overflow.dart
@@ -26,7 +26,6 @@ class ProblemWidget extends StatelessWidget {
       ],
     );
   }
-
   // #enddocregion problem
 }
 

--- a/examples/testing/common_errors/lib/set_state_build.dart
+++ b/examples/testing/common_errors/lib/set_state_build.dart
@@ -18,7 +18,6 @@ class ProblemWidget extends StatelessWidget {
       child: Column(children: <Widget>[Text('Show Material Dialog')]),
     );
   }
-
   // #enddocregion problem
 }
 

--- a/examples/testing/common_errors/lib/unbounded_height.dart
+++ b/examples/testing/common_errors/lib/unbounded_height.dart
@@ -20,7 +20,6 @@ class ProblemWidget extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion problem
 }
 
@@ -46,6 +45,5 @@ class SolutionWidget extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion solution
 }

--- a/examples/testing/common_errors/lib/unbounded_width.dart
+++ b/examples/testing/common_errors/lib/unbounded_width.dart
@@ -13,7 +13,6 @@ class ProblemWidget extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion problem
 }
 
@@ -30,6 +29,5 @@ class SolutionWidget extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion solution
 }

--- a/examples/testing/errors/lib/main.dart
+++ b/examples/testing/errors/lib/main.dart
@@ -36,5 +36,4 @@ class MyApp extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion all-errors

--- a/examples/testing/integration_tests/how_to/integration_test/counter_test.dart
+++ b/examples/testing/integration_tests/how_to/integration_test/counter_test.dart
@@ -31,5 +31,4 @@ void main() {
     });
   });
 }
-
 // #enddocregion initial

--- a/examples/tools/lib/hot-reload/after.dart
+++ b/examples/tools/lib/hot-reload/after.dart
@@ -61,5 +61,4 @@ void onClick() {
   print(foo);
   print(bar);
 }
-
 // #enddocregion const

--- a/examples/tools/lib/hot-reload/before.dart
+++ b/examples/tools/lib/hot-reload/before.dart
@@ -59,5 +59,4 @@ void onClick() {
   print(foo);
   print(bar);
 }
-
 // #enddocregion const

--- a/examples/tools/lib/hot-reload/foo_const.dart
+++ b/examples/tools/lib/hot-reload/foo_const.dart
@@ -7,5 +7,4 @@ void onClick() {
   print(foo);
   print(bar);
 }
-
 // #enddocregion const

--- a/examples/tools/lib/hot-reload/getter.dart
+++ b/examples/tools/lib/hot-reload/getter.dart
@@ -7,5 +7,4 @@ void onClick() {
   print(foo);
   print(bar);
 }
-
 // #enddocregion const

--- a/examples/ui/actions_and_shortcuts/lib/samples.dart
+++ b/examples/ui/actions_and_shortcuts/lib/samples.dart
@@ -29,7 +29,6 @@ class ShortcutsExample extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion shortcuts
 }
 
@@ -88,7 +87,6 @@ class SelectAllExample extends StatelessWidget {
       child: child,
     );
   }
-
   // #enddocregion select-all-usage
 }
 
@@ -142,7 +140,6 @@ class HandlerExample extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion handler
 }
 
@@ -192,7 +189,6 @@ class LoggingActionDispatcherExample extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion logging-action-dispatcher-usage
 }
 
@@ -231,6 +227,5 @@ class _CallbackShortcutsExampleState extends State<CallbackShortcutsExample> {
       ),
     );
   }
-
   // #enddocregion callback-shortcuts
 }

--- a/examples/ui/focus/lib/samples.dart
+++ b/examples/ui/focus/lib/samples.dart
@@ -15,7 +15,6 @@ class AbsorbKeysExample extends StatelessWidget {
       child: child,
     );
   }
-
   // #enddocregion absorb-keys
 }
 
@@ -34,7 +33,6 @@ class NoAExample extends StatelessWidget {
       child: const TextField(),
     );
   }
-
   // #enddocregion no-letter-a
 }
 
@@ -54,7 +52,6 @@ class BuilderExample extends StatelessWidget {
       ),
     );
   }
-
   // #enddocregion builder
 }
 
@@ -89,5 +86,4 @@ class OrderedButtonRow extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion ordered-button-row

--- a/examples/visual_debugging/lib/highlight_repaints.dart
+++ b/examples/visual_debugging/lib/highlight_repaints.dart
@@ -36,5 +36,4 @@ class AreaRepaintsPage extends StatelessWidget {
     );
   }
 }
-
 // #enddocregion area-repaints

--- a/examples/visual_debugging/lib/oversized_images.dart
+++ b/examples/visual_debugging/lib/oversized_images.dart
@@ -15,5 +15,4 @@ class ResizedImage extends StatelessWidget {
     return Image.asset('dash.png', cacheHeight: 213, cacheWidth: 392);
   }
 }
-
 // #enddocregion resized-image

--- a/packages/excerpter/test_data/example/plaster.dart
+++ b/packages/excerpter/test_data/example/plaster.dart
@@ -40,5 +40,4 @@ void template() {
   print('Templated plaster here.');
   // #docregion template
 }
-
 // #enddocregion template

--- a/packages/excerpter/test_data/example/transforms.dart
+++ b/packages/excerpter/test_data/example/transforms.dart
@@ -2,5 +2,4 @@
 void indent() {
   print('indent');
 }
-
 // #enddocregion indent

--- a/sites/docs/src/content/app-architecture/design-patterns/optimistic-state.md
+++ b/sites/docs/src/content/app-architecture/design-patterns/optimistic-state.md
@@ -285,7 +285,6 @@ class SubscribeButtonViewModel extends ChangeNotifier {
       notifyListeners();
     }
   }
-
 }
 ```
 
@@ -515,7 +514,6 @@ class _SubscribeButtonState extends State<SubscribeButton> {
       ).showSnackBar(const SnackBar(content: Text('Failed to subscribe')));
     }
   }
-
 }
 
 class SubscribeButtonStyle {
@@ -566,7 +564,6 @@ class SubscribeButtonViewModel extends ChangeNotifier {
       notifyListeners();
     }
   }
-
 }
 
 /// Repository of subscriptions.

--- a/sites/docs/src/content/cookbook/effects/parallax-scrolling.md
+++ b/sites/docs/src/content/cookbook/effects/parallax-scrolling.md
@@ -542,7 +542,6 @@ class ParallaxFlowDelegate extends FlowDelegate {
     required this.listItemContext,
     required this.backgroundImageKey,
   }) : super(repaint: scrollable.position);
-}
 ```
 
 Congratulations!
@@ -693,7 +692,6 @@ class ParallaxFlowDelegate extends FlowDelegate {
     required this.backgroundImageKey,
   }) : super(repaint: scrollable.position);
 
-
   final ScrollableState scrollable;
   final BuildContext listItemContext;
   final GlobalKey backgroundImageKey;
@@ -751,7 +749,6 @@ class ParallaxFlowDelegate extends FlowDelegate {
         listItemContext != oldDelegate.listItemContext ||
         backgroundImageKey != oldDelegate.backgroundImageKey;
   }
-
 }
 
 class Parallax extends SingleChildRenderObjectWidget {

--- a/sites/docs/src/content/cookbook/navigation/returning-data.md
+++ b/sites/docs/src/content/cookbook/navigation/returning-data.md
@@ -254,7 +254,6 @@ class _SelectionButtonState extends State<SelectionButton> {
       ..removeCurrentSnackBar()
       ..showSnackBar(SnackBar(content: Text('$result')));
   }
-
 }
 
 class SelectionScreen extends StatelessWidget {

--- a/sites/docs/src/content/cookbook/persistence/reading-writing-files.md
+++ b/sites/docs/src/content/cookbook/persistence/reading-writing-files.md
@@ -60,6 +60,7 @@ You can find the path to the documents directory as follows:
 <?code-excerpt "lib/main.dart (localPath)"?>
 ```dart
 import 'package:path_provider/path_provider.dart';
+
   // ···
   Future<String> get _localPath async {
     final directory = await getApplicationDocumentsDirectory();
@@ -173,7 +174,6 @@ class CounterStorage {
     // Write the file
     return file.writeAsString('$counter');
   }
-
 }
 
 class FlutterDemo extends StatefulWidget {

--- a/sites/docs/src/content/cookbook/plugins/google-mobile-ads.md
+++ b/sites/docs/src/content/cookbook/plugins/google-mobile-ads.md
@@ -406,7 +406,6 @@ class _MyBannerAdWidgetState extends State<MyBannerAdWidget> {
     // Start loading.
     bannerAd.load();
   }
-
 }
 ```
 

--- a/sites/docs/src/content/data-and-backend/google-apis.md
+++ b/sites/docs/src/content/data-and-backend/google-apis.md
@@ -72,7 +72,7 @@ YouTube data, authenticate the user with
 
 <?code-excerpt "lib/main.dart (youtube-import)"?>
 ```dart
-/// Provides the `YouTubeApi` class.
+// Provides the `YouTubeApi` class.
 import 'package:googleapis/youtube/v3.dart';
 ```
 
@@ -129,7 +129,6 @@ listen to authentication events to determine if a user signed in.
 <?code-excerpt "lib/main.dart (post-init)" plaster="none"?>
 ```dart highlightLines=1,7,9-12
 GoogleSignInAccount? _currentUser;
-
 @override
 void initState() {
   super.initState();

--- a/sites/docs/src/content/flutter-for/android-devs.md
+++ b/sites/docs/src/content/flutter-for/android-devs.md
@@ -851,7 +851,6 @@ class _SampleAppPageState extends State<SampleAppPage> {
           .cast<Map<String, Object?>>();
     });
   }
-
 }
 ```
 
@@ -1090,7 +1089,6 @@ class _SampleAppPageState extends State<SampleAppPage> {
     port.send([msg, response.sendPort]);
     return response.first;
   }
-
 }
 ```
 

--- a/tool/dash_site/lib/src/commands/refresh_excerpts.dart
+++ b/tool/dash_site/lib/src/commands/refresh_excerpts.dart
@@ -71,7 +71,7 @@ Future<int> _refreshExcerpts({
       // to remove extra new lines after block close.
       SimpleReplaceTransform(RegExp(r'[\r\n]+$'), ''),
       // Compress extra empty lines, working around formatting oddities.
-      SimpleReplaceTransform('\n\n\n', '\n\n'),
+      SimpleReplaceTransform(RegExp(r'\n{3,}'), '\n\n'),
     ],
   );
 

--- a/tool/dash_site/lib/src/commands/refresh_excerpts.dart
+++ b/tool/dash_site/lib/src/commands/refresh_excerpts.dart
@@ -70,6 +70,8 @@ Future<int> _refreshExcerpts({
       // Workaround for https://github.com/dart-lang/dart_style/issues/1644
       // to remove extra new lines after block close.
       SimpleReplaceTransform(RegExp(r'[\r\n]+$'), ''),
+      // Compress extra empty lines, working around formatting oddities.
+      SimpleReplaceTransform('\n\n\n', '\n\n'),
     ],
   );
 

--- a/tool/dash_site/lib/src/commands/stage_preview.dart
+++ b/tool/dash_site/lib/src/commands/stage_preview.dart
@@ -201,18 +201,14 @@ Future<String?> _deploySiteToStaging(
     'preview channel $channel...',
   );
 
-  final result = await Process.run(
-    firebaseCliExecutable,
-    [
-      'hosting:channel:deploy',
-      channel,
-      '--project=$project',
-      '--expires',
-      expires,
-      '--json',
-    ],
-    workingDirectory: path.join(repositoryRoot, site.firebaseConfigDirectory),
-  );
+  final result = await Process.run(firebaseCliExecutable, [
+    'hosting:channel:deploy',
+    channel,
+    '--project=$project',
+    '--expires',
+    expires,
+    '--json',
+  ], workingDirectory: path.join(repositoryRoot, site.firebaseConfigDirectory));
 
   if (result.exitCode != 0) {
     stderr.writeln(result.stderr);


### PR DESCRIPTION
This fixes most cases of the `#enddocregion` comments after block bodies being unnecessarily moved during formatting.