### PR TITLE
Improve docs related to Swift Package Manager migration for plugin authors

### DIFF
--- a/sites/docs/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
+++ b/sites/docs/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
@@ -256,8 +256,9 @@ The example below uses `ios`, replace `ios` with `macos` or `darwin`, as applica
            name: "plugin_name",
            dependencies: [
                [!.product(name: "FlutterFramework", package: "FlutterFramework")!]
-           ],
-   ```
+           ]
+       )
+   ]
 
 1. If your header files are no longer in the same directory as your
    implementation files, you should update your import statements.

--- a/sites/docs/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
+++ b/sites/docs/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
@@ -259,6 +259,7 @@ The example below uses `ios`, replace `ios` with `macos` or `darwin`, as applica
            ]
        )
    ]
+   ```
 
 1. If your header files are no longer in the same directory as your
    implementation files, you should update your import statements.

--- a/sites/docs/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
+++ b/sites/docs/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
@@ -65,12 +65,16 @@ The example below uses `ios`, replace `ios` with `macos` or `darwin`, as applica
            // If the plugin name contains "_", replace with "-" for the library name
            .library(name: "plugin-name", targets: ["plugin_name"])
        ],
-       dependencies: [],
+       dependencies: [
+           .package(name: "FlutterFramework", path: "../FlutterFramework")
+       ],
        targets: [
            .target(
                // TODO: Update your target name.
                name: "plugin_name",
-               dependencies: [],
+               dependencies: [
+                   .product(name: "FlutterFramework", package: "FlutterFramework")
+               ],
                resources: [
                    // TODO: If your plugin requires a privacy manifest
                    // (in other words, if it uses any required reason APIs),
@@ -122,12 +126,16 @@ The example below uses `ios`, replace `ios` with `macos` or `darwin`, as applica
            // If the plugin name contains "_", replace with "-" for the library name
            .library(name: [!"plugin-name"!], targets: [[!"plugin_name"!]])
        ],
-       dependencies: [],
+       dependencies: [
+           .package(name: "FlutterFramework", path: "../FlutterFramework")
+       ],
        targets: [
            .target(
                // TODO: Update your target name.
                name: [!"plugin_name"!],
-               dependencies: [],
+               dependencies: [
+                   .product(name: "FlutterFramework", package: "FlutterFramework")
+               ],
                resources: [
                    // TODO: If your plugin requires a privacy manifest
                    // (for example, if it uses any required reason APIs),
@@ -233,6 +241,23 @@ The example below uses `ios`, replace `ios` with `macos` or `darwin`, as applica
 
 1. The `ios/Assets`, `ios/Resources`, and `ios/Classes` directories should now
    be empty and can be deleted.
+
+1. Add the `FlutterFramework` as a dependency.
+
+   Update `Package.swift` to include `FlutterFramework`:
+
+   ```swift title="Package.swift"
+   dependencies: [
+       [!.package(name: "FlutterFramework", path: "../FlutterFramework")!]
+   ],
+   targets: [
+       .target(
+           // TODO: Update your target name.
+           name: "plugin_name",
+           dependencies: [
+               [!.product(name: "FlutterFramework", package: "FlutterFramework")!]
+           ],
+   ```
 
 1. If your header files are no longer in the same directory as your
    implementation files, you should update your import statements.

--- a/sites/docs/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
+++ b/sites/docs/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
@@ -242,8 +242,6 @@ The example below uses `ios`, replace `ios` with `macos` or `darwin`, as applica
       This avoids conflicts with targets from other packages.
       :::
 
-[`PackageDescription`]: {{site.apple-dev}}/documentation/packagedescription
-
 1. Update your `ios/plugin_name.podspec` to point to new paths.
 
    ```ruby title="ios/plugin_name.podspec" diff
@@ -374,3 +372,4 @@ The example below uses `ios`, replace `ios` with `macos` or `darwin`, as applica
 [update unit tests in the plugin's example app]: /packages-and-plugins/swift-package-manager/for-plugin-authors/#how-to-update-unit-tests-in-a-plugins-example-app
 [testing plugins]: /testing/testing-plugins
 [Bundling resources with a Swift package]: {{site.apple-dev}}/documentation/xcode/bundling-resources-with-a-swift-package
+[`PackageDescription`]: {{site.apple-dev}}/documentation/packagedescription

--- a/sites/docs/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
+++ b/sites/docs/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
@@ -189,6 +189,8 @@ The example below uses `ios`, replace `ios` with `macos` or `darwin`, as applica
            dependencies: [
                [!.product(name: "FlutterFramework", package: "FlutterFramework")!]
            ],
+      )
+   ]
    ```
    
 1. The `ios/Assets`, `ios/Resources`, and `ios/Classes` directories should now

--- a/sites/docs/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
+++ b/sites/docs/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
@@ -115,12 +115,16 @@ The example below uses `ios`, replace `ios` with `macos` or `darwin`, as applica
            // If the plugin name contains "_", replace with "-" for the library name
            .library(name: [!"plugin-name"!], targets: [[!"plugin_name"!]])
        ],
-       dependencies: [],
+       dependencies: [
+           .package(name: "FlutterFramework", path: "../FlutterFramework")
+       ],
        targets: [
            .target(
                // TODO: Update your target name.
                name: [!"plugin_name"!],
-               dependencies: [],
+               dependencies: [
+                   .product(name: "FlutterFramework", package: "FlutterFramework")
+               ],
                resources: [
                    // TODO: If your plugin requires a privacy manifest
                    // (e.g. if it uses any required reason APIs), update the PrivacyInfo.xcprivacy file
@@ -168,11 +172,9 @@ The example below uses `ios`, replace `ios` with `macos` or `darwin`, as applica
    For more instructions, visit
    [Bundling resources with a Swift package][].
 
-[Bundling resources with a Swift package]: {{site.apple-dev}}/documentation/xcode/bundling-resources-with-a-swift-package
-
 1. Move all files from `ios/Classes` to `ios/plugin_name/Sources/plugin_name`.
 
-1. Add the `FlutterFramework` as a dependency and update Dart and Flutter versions.
+1. Add the `FlutterFramework` as a dependency.
 
    Update `Package.swift` to include `FlutterFramework`:
 
@@ -188,15 +190,7 @@ The example below uses `ios`, replace `ios` with `macos` or `darwin`, as applica
                [!.product(name: "FlutterFramework", package: "FlutterFramework")!]
            ],
    ```
-
-   In `pubspec.yaml`, update versions to:
-
-   ```yaml title="pubspec.yaml"
-   environment:
-     sdk: ^3.11.0
-     flutter: ">=3.41.0"
-   ```
-
+   
 1. The `ios/Assets`, `ios/Resources`, and `ios/Classes` directories should now
    be empty and can be deleted.
 
@@ -379,3 +373,4 @@ The example below uses `ios`, replace `ios` with `macos` or `darwin`, as applica
 [removeSPM]: /packages-and-plugins/swift-package-manager/for-app-developers#how-to-remove-swift-package-manager-integration
 [update unit tests in the plugin's example app]: /packages-and-plugins/swift-package-manager/for-plugin-authors/#how-to-update-unit-tests-in-a-plugins-example-app
 [testing plugins]: /testing/testing-plugins
+[Bundling resources with a Swift package]: {{site.apple-dev}}/documentation/xcode/bundling-resources-with-a-swift-package


### PR DESCRIPTION
Noticed a few missing pieces in the current version of docs for plugin authors and fixed them along with a few minor issues.

The addressed issues are:

1. Missing point item asking to add `dependencies` block in the part for Objective-C plugins. Initially had impression that is supposed to be like that, but noticed that in plugins that I maintain CI raises warnings about missing dependency on `FlutterFramework`. 
2. Since section about adding `FlutterFramework` to `dependencies` was introduced later (in Flutter 3.41.0) than the initial version of docs, the code for it wasn't added to all code snippets.
3. Broken line numbers in the part for Swift plugin due to a few links being inserted between points leading to the list having `1` 3 times in the current version of the doc.
4. The text about updating to Flutter 3.41.0 in the part for Swift plugins is not needed anymore as the list starts with text `Ensure that you are using Flutter 3.44 or later.`

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
