### PR TITLE
Update Simulator command to DeviceHub for Xcode 27+

### DIFF
--- a/sites/docs/src/content/platform-integration/ios/setup.md
+++ b/sites/docs/src/content/platform-integration/ios/setup.md
@@ -106,7 +106,7 @@ physical device.
 Start the iOS Simulator with the following command:
 
 ```console
-$ open -a Simulator
+$ open -a DeviceHub
 ```
 
 If you need to install a simulator for a different OS version,


### PR DESCRIPTION
Fixes #13490. Starting with Xcode 27, the Simulator app has been replaced by DeviceHub on macOS.