### PR TITLE
Update documentation to reflect widget tests terminology

### DIFF
--- a/sites/docs/src/content/cookbook/testing/widget/scrolling.md
+++ b/sites/docs/src/content/cookbook/testing/widget/scrolling.md
@@ -11,7 +11,7 @@ To verify that lists contain the expected content
 using widget tests,
 you need a way to scroll through lists to search for particular items.
 
-To scroll through lists via integration tests,
+To scroll through lists via widget tests,
 use the methods provided by the [`WidgetTester`][] class,
 which is included in the [`flutter_test`][] package:
 
@@ -34,7 +34,7 @@ If you're unsure of how to work with long lists,
 see that recipe for an introduction.
 
 Add keys to the widgets you want to interact with
-inside the integration tests.
+inside the widget tests.
 
 <?code-excerpt "lib/main.dart"?>
 ```dart

--- a/sites/docs/src/content/cookbook/testing/widget/scrolling.md
+++ b/sites/docs/src/content/cookbook/testing/widget/scrolling.md
@@ -11,7 +11,7 @@ To verify that lists contain the expected content
 using widget tests,
 you need a way to scroll through lists to search for particular items.
 
-To scroll through lists via widget tests,
+To scroll through lists using the widget tests,
 use the methods provided by the [`WidgetTester`][] class,
 which is included in the [`flutter_test`][] package:
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
Since we are writing widget test on this page. The correct terminology should be widget test rather than integration test.

_Issues fixed by this PR (if any):_
No

_PRs or commits this PR depends on (if any):_
No

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
