### PR TITLE
Add redirect for the GitHub windowing example

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -920,6 +920,7 @@
       { "source": "/to/web-renderers", "destination": "/platform-integration/web/renderers", "type": 301 },
       { "source": "/to/widget-previews", "destination": "/tools/widget-previewer", "type": 301 },
       { "source": "/to/widget-testing", "destination": "/cookbook/testing/widget/introduction", "type": 301 },
+      { "source": "/to/windowing-example", "destination": "https://github.com/flutter/flutter/tree/main/examples/multiple_windows", "type": 301 },
       { "source": "/to/windows-android-setup", "destination": "/platform-integration/android/setup", "type": 301 },
       { "source": "/to/windows-ffi", "destination": "/platform-integration/windows/building#integrating-with-windows", "type": 301 },
       { "source": "/to/windows-setup", "destination": "/platform-integration/windows/setup", "type": 301 },


### PR DESCRIPTION
This adds a convenient link to the Windowing example. We will share this link at Fluttercon USA and ask users to try out the new windowing APIs.

_Issues fixed by this PR (if any):_ N/A

_PRs or commits this PR depends on (if any):_ N/A

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
