### PR TITLE
Set canonical URL for every site page

### DIFF
--- a/packages/site_shared/lib/src/layouts/dash_layout.dart
+++ b/packages/site_shared/lib/src/layouts/dash_layout.dart
@@ -68,7 +68,10 @@ abstract class DashLayout implements PageLayout {
         ? '$pageTitle | $titleBase'
         : pageTitle;
 
-    final canonicalUrl = pageData['canonical'] as String?;
+    final canonicalUrl = switch (pageData['canonical']) {
+      final String url when url.trim().isNotEmpty => url.trim(),
+      _ => Uri.parse(siteData['url'] as String).resolve(page.url).toString(),
+    };
 
     return [
       Component.element(tag: 'title', children: [.text(windowTitle)]),
@@ -79,8 +82,7 @@ abstract class DashLayout implements PageLayout {
       if (pageData['noindex'] case final noIndex?
           when noIndex == true || noIndex == 'true')
         const meta(name: 'robots', content: 'noindex'),
-      if (canonicalUrl case final canonicalUrl? when canonicalUrl.isNotEmpty)
-        link(rel: 'canonical', href: canonicalUrl),
+      link(rel: 'canonical', href: canonicalUrl),
       if (pageData['redirectTo'] case final String redirectTo
           when redirectTo.isNotEmpty)
         RawText('<script>window.location.replace("$redirectTo");</script>'),
@@ -125,7 +127,7 @@ abstract class DashLayout implements PageLayout {
       meta(
         attributes: {
           'property': 'og:url',
-          'content': canonicalUrl ?? page.path,
+          'content': canonicalUrl,
         },
       ),
       meta(

--- a/sites/www/lib/src/layouts/default_layout.dart
+++ b/sites/www/lib/src/layouts/default_layout.dart
@@ -32,6 +32,11 @@ class DefaultLayout extends PageLayout {
       throw Exception('Page at ${page.path} can\'t have an empty description.');
     }
 
+    final canonicalUrl = switch (page.data.page['canonical']) {
+      final String url when url.trim().isNotEmpty => url.trim(),
+      _ => Uri.https('flutter.dev').resolve(page.url).toString(),
+    };
+
     return AsyncBuilder(
       builder: (context) async {
         final banner = context.decodeJsonObject(
@@ -48,12 +53,13 @@ class DefaultLayout extends PageLayout {
             ),
 
             meta(name: 'description', content: description),
+            link(rel: 'canonical', href: canonicalUrl),
             const meta(name: 'twitter:card', content: 'summary_large_image'),
             const meta(name: 'twitter:site', content: '@flutterdev'),
             meta(attributes: const {'property': 'og:title'}, content: title),
             meta(
               attributes: const {'property': 'og:url'},
-              content: '//flutter.dev${page.url}',
+              content: canonicalUrl,
             ),
             meta(
               attributes: const {'property': 'og:description'},


### PR DESCRIPTION
To comply with https://a14y.dev/scorecards/0.2.0/checks/html.canonical-link/

A page can specify a `canonical` in its YAML frontmatter to override the output canonical link.