### PR TITLE
Document multiple Flutter plugin instances

### DIFF
--- a/sites/docs/src/content/packages-and-plugins/developing-packages.md
+++ b/sites/docs/src/content/packages-and-plugins/developing-packages.md
@@ -145,7 +145,8 @@ in global or static variables, and clean it up when the plugin
 detaches from its engine.
 
 If plugin instances share a native singleton or other global resource,
-coordinate access across the instances.
+coordinate access across the instances, for example by using
+reference counting.
 Release the resource only after every plugin instance
 has stopped using it.
 

--- a/sites/docs/src/content/packages-and-plugins/developing-packages.md
+++ b/sites/docs/src/content/packages-and-plugins/developing-packages.md
@@ -133,6 +133,22 @@ you need to develop a plugin package.
 The API is connected to the platform-specific
 implementation(s) using a [platform channel][].
 
+### Supporting multiple Flutter instances
+
+All Flutter platforms allow apps to create
+[multiple Flutter engines][].
+Each engine creates its own instance of every registered plugin,
+and those plugin instances can have independent lifetimes.
+Don't assume that a plugin class has only one instance.
+Keep engine-specific state on the plugin instance rather than
+in global or static variables, and clean it up when the plugin
+detaches from its engine.
+
+If plugin instances share a native singleton or other global resource,
+coordinate access across the instances.
+Release the resource only after every plugin instance
+has stopped using it.
+
 ### Federated plugins
 
 **Federated plugins** are a way of splitting the API of a plugin
@@ -1035,6 +1051,7 @@ file, like any other Dart package.
 [How to Write a Flutter Web Plugin, Part 1]: {{site.flutter-blog}}/how-to-write-a-flutter-web-plugin-5e26c689ea1
 [How To Write a Flutter Web Plugin, Part 2]: {{site.flutter-blog}}/how-to-write-a-flutter-web-plugin-part-2-afdddb69ece6
 [issue #33302]: {{site.repo.flutter}}/issues/33302
+[multiple Flutter engines]: /add-to-app/multiple-flutters
 [`LICENSE`]: #adding-licenses-to-the-license-file
 [`path`]: {{site.pub}}/packages/path
 [`package:ffigen`]: {{site.pub}}/packages/ffigen


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Documents that an app can run multiple Flutter engines, that each engine creates its own plugin instance, and that those instances can have independent lifetimes. It also adds guidance for scoping engine-specific state and coordinating shared native resources.

_Issues fixed by this PR (if any):_

Fixes flutter/flutter#150855.

_PRs or commits this PR depends on (if any):_

None.

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
