### PR TITLE
Add 'Copy as Markdown' button to page options dropdown

### DIFF
--- a/packages/site_shared/lib/_sass/base/_mixins.scss
+++ b/packages/site_shared/lib/_sass/base/_mixins.scss
@@ -1,3 +1,18 @@
 @mixin interaction-style($percentage: 4%) {
   background-image: linear-gradient(rgb(var(--site-interaction-base-values) / $percentage) 0 0);
 }
+
+// Hide an element visually while
+// keeping it available to assistive technologies,
+// such as for a live region that announces status updates.
+@mixin visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/packages/site_shared/lib/_sass/components/_dropdown.scss
+++ b/packages/site_shared/lib/_sass/components/_dropdown.scss
@@ -24,6 +24,10 @@
       padding: 0 !important;
     }
 
+    .copy-markdown-status {
+      @include mixins.visually-hidden;
+    }
+
     .dropdown-menu {
       padding: 0.2rem;
 

--- a/packages/site_shared/lib/components/common/client/page_header_options.dart
+++ b/packages/site_shared/lib/components/common/client/page_header_options.dart
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:universal_web/js_interop.dart';
@@ -30,7 +34,12 @@ final class PageHeaderOptions extends StatefulComponent {
 }
 
 final class _PageHeaderOptionsState extends State<PageHeaderOptions> {
+  static const String _optionsId = 'page-header-options';
+  static const String _copyStatusId = '$_optionsId-copy-status';
+
   bool _isShareSupported = false;
+  _MarkdownCopyState _markdownCopyState = _MarkdownCopyState.idle;
+  Timer? _markdownCopyResetTimer;
 
   @override
   void initState() {
@@ -58,9 +67,78 @@ final class _PageHeaderOptionsState extends State<PageHeaderOptions> {
     title: component.title,
   );
 
+  /// Loads the Markdown at [markdownUrl].
+  ///
+  /// Throws if the request doesn't return a successful status code.
+  Future<String> _loadMarkdown(String markdownUrl) async {
+    final response = await http.get(Uri.parse(markdownUrl));
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw StateError(
+        'Unable to load Markdown from $markdownUrl (${response.statusCode}).',
+      );
+    }
+
+    return utf8.decode(response.bodyBytes);
+  }
+
+  /// Copies the page's Markdown at [markdownUrl] and
+  /// updates the copy button's progress state.
+  void _copyMarkdown(String markdownUrl) {
+    if (!kIsWeb || _markdownCopyState.isBusy) return;
+
+    _markdownCopyResetTimer?.cancel();
+    final Future<JSAny?> copyOperation;
+    try {
+      // Hand the clipboard the still-pending Markdown instead of awaiting it
+      // first, so the write is issued synchronously and keeps user activation.
+      final markdown = {
+        'text/plain': _loadMarkdown(markdownUrl).then((md) => md.toJS).toJS,
+      }.jsify();
+      copyOperation = web.window.navigator.clipboard
+          .write([web.ClipboardItem(markdown! as JSObject)].toJS)
+          .toDart;
+    } catch (_) {
+      setState(() => _markdownCopyState = _MarkdownCopyState.failed);
+      _scheduleMarkdownCopyReset();
+      return;
+    }
+
+    setState(() => _markdownCopyState = _MarkdownCopyState.copying);
+    unawaited(_completeMarkdownCopy(copyOperation));
+  }
+
+  Future<void> _completeMarkdownCopy(Future<JSAny?> copyOperation) async {
+    late final _MarkdownCopyState result;
+    try {
+      await copyOperation;
+      result = _MarkdownCopyState.copied;
+    } catch (_) {
+      result = _MarkdownCopyState.failed;
+    }
+
+    if (!mounted) return;
+    setState(() => _markdownCopyState = result);
+    _scheduleMarkdownCopyReset();
+  }
+
+  void _scheduleMarkdownCopyReset() {
+    _markdownCopyResetTimer = Timer(const Duration(seconds: 2), () {
+      if (!mounted) {
+        return;
+      }
+      setState(() => _markdownCopyState = _MarkdownCopyState.idle);
+    });
+  }
+
+  @override
+  void dispose() {
+    _markdownCopyResetTimer?.cancel();
+    super.dispose();
+  }
+
   @override
   Component build(BuildContext _) => Dropdown(
-    id: 'page-header-options',
+    id: _optionsId,
     toggle: const Button(icon: 'more_vert', title: 'View page options.'),
     content: nav(
       classes: 'dropdown-menu',
@@ -82,7 +160,7 @@ final class _PageHeaderOptionsState extends State<PageHeaderOptions> {
                   )
                 else
                   Button(
-                    icon: 'copy',
+                    icon: 'link',
                     content: 'Copy link',
                     onClick: () {
                       web.window.navigator.clipboard
@@ -94,6 +172,34 @@ final class _PageHeaderOptionsState extends State<PageHeaderOptions> {
               ],
             ),
             if (component.markdownUrl case final markdownUrl?) ...[
+              li(
+                [
+                  Button(
+                    icon: _markdownCopyState.icon,
+                    content: 'Copy as Markdown',
+                    title: 'Copy this page as Markdown to your clipboard.',
+                    attributes: {
+                      'aria-describedby': _copyStatusId,
+                      // Native `disabled` drops focus and closes the dropdown.
+                      if (_markdownCopyState.isBusy) ...{
+                        'aria-busy': 'true',
+                        'aria-disabled': 'true',
+                      },
+                    },
+                    onClick: () => _copyMarkdown(markdownUrl),
+                  ),
+                  span(
+                    id: _copyStatusId,
+                    classes: 'copy-markdown-status',
+                    attributes: const {
+                      'role': 'status',
+                      'aria-live': 'polite',
+                      'aria-atomic': 'true',
+                    },
+                    [.text(_markdownCopyState.announcement)],
+                  ),
+                ],
+              ),
               li(
                 [
                   Button(
@@ -142,4 +248,30 @@ final class _PageHeaderOptionsState extends State<PageHeaderOptions> {
       ],
     ),
   );
+}
+
+/// The current UI state of the "Copy as Markdown" action.
+enum _MarkdownCopyState {
+  /// The action is ready to copy Markdown.
+  idle('content_copy', ''),
+
+  /// The Markdown is being loaded and copied.
+  copying('progress_activity', 'Copying Markdown.'),
+
+  /// The Markdown was copied successfully.
+  copied('check', 'Markdown copied.'),
+
+  /// Loading or copying the Markdown failed.
+  failed('error', "Couldn't copy Markdown.");
+
+  const _MarkdownCopyState(this.icon, this.announcement);
+
+  /// The button icon to display for this state.
+  final String icon;
+
+  /// The status to announce to assistive technologies for this state.
+  final String announcement;
+
+  /// Whether the action is waiting for the copy to finish.
+  bool get isBusy => this == copying;
 }

--- a/packages/site_shared/lib/components/common/client/page_header_options.dart
+++ b/packages/site_shared/lib/components/common/client/page_header_options.dart
@@ -122,6 +122,7 @@ final class _PageHeaderOptionsState extends State<PageHeaderOptions> {
   }
 
   void _scheduleMarkdownCopyReset() {
+    _markdownCopyResetTimer?.cancel();
     _markdownCopyResetTimer = Timer(const Duration(seconds: 2), () {
       if (!mounted) {
         return;

--- a/packages/site_shared/lib/components/common/dropdown.dart
+++ b/packages/site_shared/lib/components/common/dropdown.dart
@@ -29,9 +29,10 @@ final class DropdownState extends State<Dropdown> {
   bool _expanded = false;
 
   void toggle({bool? to}) {
-    setState(() {
-      _expanded = to ?? !_expanded;
-    });
+    final expanded = to ?? !_expanded;
+    if (expanded == _expanded) return;
+
+    setState(() => _expanded = expanded);
   }
 
   @override

--- a/packages/site_shared/pubspec.yaml
+++ b/packages/site_shared/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   collection: ^1.19.1
   crypto: ^3.0.7
   html: ^0.15.6
+  http: ^1.6.0
   jaspr: ^0.23.1
   jaspr_content: ^0.5.2
   markdown: ^7.3.1


### PR DESCRIPTION
Adds a "Copy as Markdown" button to the more options dropdown in the page header.

Resolves https://github.com/flutter/website/issues/13062

**New copy button in dropdown:**
<img width="254" height="248" alt="Screenshot of new Copy as Markdown button" src="https://github.com/user-attachments/assets/64b684d8-7c93-420a-92a7-9e5d1f5104b0" />

