### PR TITLE
Fix unbalanced parens in SwiftUI devs Padding example

### DIFF
--- a/sites/docs/src/content/flutter-for/swiftui-devs.md
+++ b/sites/docs/src/content/flutter-for/swiftui-devs.md
@@ -74,7 +74,7 @@ their properties.
 Padding(                         // <-- This is a Widget
   padding: EdgeInsets.all(10.0), // <-- So is this
   child: Text("Hello, World!"),  // <-- This, too
-)));
+)
 ```
 
 To compose layouts, both SwiftUI and Flutter nest UI components


### PR DESCRIPTION
The `Padding` example in the "Flutter for SwiftUI developers" page closes with three parens where the snippet only opens one:

```diff
 Padding(                         // <-- This is a Widget
   padding: EdgeInsets.all(10.0), // <-- So is this
   child: Text("Hello, World!"),  // <-- This, too
-)));
+)
```

`EdgeInsets.all(...)` and `Text(...)` are each self-closing on their own line, so `Padding(` is the only outstanding paren. The block goes from 3 open / 5 close to 3 / 3.

The snippet has no `<?code-excerpt?>` region, so `dash_site analyze-dart` doesn't cover it — which is presumably how it survived.
