### PR TITLE
[www] Support and improve formatting of narrow-layout banner

### DIFF
--- a/sites/www/content/banner.yaml
+++ b/sites/www/content/banner.yaml
@@ -1,4 +1,14 @@
+# Marketing site-wide banner content.
+#
+# Fields:
+# - text: Required, non-empty text displayed in wide layouts.
+# - mobileText: Optional non-empty concise text displayed in narrow layouts.
+#   If omitted, normal `text` field is displayed in every layout.
+# - link: Required absolute https URL that the whole banner links to.
+
 text: >-
   Flutter 3.44 is here! Everywhere, everyday, built by everyone, for everyone.
   Learn more
+mobileText: >-
+  Flutter 3.44 is here! Learn more
 link: https://blog.flutter.dev/whats-new-in-flutter-3-44-b0cc1ad3c527

--- a/sites/www/content/banner.yaml
+++ b/sites/www/content/banner.yaml
@@ -2,9 +2,9 @@
 #
 # Fields:
 # - text: Required, non-empty text displayed in wide layouts.
-# - mobileText: Optional non-empty concise text displayed in narrow layouts.
+# - mobileText: Optional, non-empty concise text displayed in narrow layouts.
 #   If omitted, normal `text` field is displayed in every layout.
-# - link: Required absolute https URL that the whole banner links to.
+# - link: Required, absolute https URL that the whole banner links to.
 
 text: >-
   Flutter 3.44 is here! Everywhere, everyday, built by everyone, for everyone.

--- a/sites/www/lib/src/components/layout/banner.dart
+++ b/sites/www/lib/src/components/layout/banner.dart
@@ -15,22 +15,34 @@ class Banner extends StatelessComponent {
 
   @override
   Component build(BuildContext context) {
+    final mobileText = switch (banner.mobileText) {
+      final mobileText? when mobileText != banner.text => mobileText,
+      _ => null,
+    };
+
     return a(
       classes: 'event-bar',
       href: banner.link,
       target: Target.blank,
       id: 'event-bar',
       [
-        span(classes: 'event-bar__content', [
-          .text(banner.text),
-          const .text('\u00A0'),
-          const Icon.linkArrow(large: true),
-        ]),
-        span(classes: 'event-bar__content mobile', [
-          .text(banner.text),
-          const .text('\u00A0'),
-          const Icon.linkArrow(),
-        ]),
+        span(
+          classes: [
+            'event-bar__content',
+            if (mobileText != null) 'desktop',
+          ].join(' '),
+          [
+            .text(banner.text),
+            const .text('\u00A0'),
+            const Icon.linkArrow(large: true),
+          ],
+        ),
+        if (mobileText != null)
+          span(classes: 'event-bar__content mobile', [
+            .text(mobileText),
+            const .text('\u00A0'),
+            const Icon.linkArrow(),
+          ]),
       ],
     );
   }

--- a/sites/www/lib/src/models/content/banner_content.dart
+++ b/sites/www/lib/src/models/content/banner_content.dart
@@ -13,11 +13,22 @@ part 'banner_content.mapper.dart';
 ///
 /// Expected data format:
 /// - `text`: non-empty banner text.
+/// - `mobileText`: optional non-empty, concise text for narrow layouts.
 /// - `link`: absolute HTTP(S) URL or root-relative path the banner points to.
 @MappableClass()
 class BannerContent with BannerContentMappable {
-  BannerContent({required this.text, required this.link}) {
+  BannerContent({
+    required this.text,
+    this.mobileText,
+    required this.link,
+  }) {
     checkFormat(isNotBlank(text), 'text must be a non-empty string.');
+    if (mobileText case final mobileText?) {
+      checkFormat(
+        isNotBlank(mobileText),
+        'mobileText must be a non-empty string.',
+      );
+    }
     checkFormat(isNotBlank(link), 'link must be a non-empty string.');
     checkFormat(
       isAbsoluteHttpUrlOrBaseHrefRelativePath(link),
@@ -27,6 +38,9 @@ class BannerContent with BannerContentMappable {
 
   /// Banner copy displayed in the site header.
   final String text;
+
+  /// Concise banner copy displayed in narrow layouts.
+  final String? mobileText;
 
   /// Destination URL/path opened from the banner.
   final String link;

--- a/sites/www/lib/src/models/content/banner_content.mapper.dart
+++ b/sites/www/lib/src/models/content/banner_content.mapper.dart
@@ -24,17 +24,28 @@ class BannerContentMapper extends ClassMapperBase<BannerContent> {
 
   static String _$text(BannerContent v) => v.text;
   static const Field<BannerContent, String> _f$text = Field('text', _$text);
+  static String? _$mobileText(BannerContent v) => v.mobileText;
+  static const Field<BannerContent, String> _f$mobileText = Field(
+    'mobileText',
+    _$mobileText,
+    opt: true,
+  );
   static String _$link(BannerContent v) => v.link;
   static const Field<BannerContent, String> _f$link = Field('link', _$link);
 
   @override
   final MappableFields<BannerContent> fields = const {
     #text: _f$text,
+    #mobileText: _f$mobileText,
     #link: _f$link,
   };
 
   static BannerContent _instantiate(DecodingData data) {
-    return BannerContent(text: data.dec(_f$text), link: data.dec(_f$link));
+    return BannerContent(
+      text: data.dec(_f$text),
+      mobileText: data.dec(_f$mobileText),
+      link: data.dec(_f$link),
+    );
   }
 
   @override
@@ -99,7 +110,7 @@ extension BannerContentValueCopy<$R, $Out>
 
 abstract class BannerContentCopyWith<$R, $In extends BannerContent, $Out>
     implements ClassCopyWith<$R, $In, $Out> {
-  $R call({String? text, String? link});
+  $R call({String? text, String? mobileText, String? link});
   BannerContentCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
 
@@ -112,15 +123,17 @@ class _BannerContentCopyWithImpl<$R, $Out>
   late final ClassMapperBase<BannerContent> $mapper =
       BannerContentMapper.ensureInitialized();
   @override
-  $R call({String? text, String? link}) => $apply(
+  $R call({String? text, Object? mobileText = $none, String? link}) => $apply(
     FieldCopyWithData({
       if (text != null) #text: text,
+      if (mobileText != $none) #mobileText: mobileText,
       if (link != null) #link: link,
     }),
   );
   @override
   BannerContent $make(CopyWithData data) => BannerContent(
     text: data.get(#text, or: $value.text),
+    mobileText: data.get(#mobileText, or: $value.mobileText),
     link: data.get(#link, or: $value.link),
   );
 

--- a/sites/www/lib/src/style_hash.dart
+++ b/sites/www/lib/src/style_hash.dart
@@ -2,4 +2,4 @@
 // dart format off
 
 /// The generated hash of the `main.css` file.
-const generatedStylesHash = 'M_coaE-iMcTx';
+const generatedStylesHash = '';

--- a/sites/www/lib/styles/components/_header.scss
+++ b/sites/www/lib/styles/components/_header.scss
@@ -24,16 +24,25 @@
     font-size: var(--font-size-default);
     font-weight: var(--font-weight-bold);
     font-family: var(--font-ui);
+    line-height: 1.4;
+    padding-inline: var(--spacer-sm);
+    text-align: center;
 
     .event-bar__content {
-      display: none;
+      display: unset;
+
+      &.desktop {
+        display: none;
+      }
 
       &.mobile {
         display: unset;
       }
 
       @include breakpoints.screen(lg) {
-        display: unset;
+        &.desktop {
+          display: unset;
+        }
 
         &.mobile {
           display: none;

--- a/sites/www/test/models/content/content_models_test.dart
+++ b/sites/www/test/models/content/content_models_test.dart
@@ -468,18 +468,32 @@ void main() {
   group('BannerContent.fromJson', () {
     final valid = <String, Object?>{
       'text': 'Flutter 3.41 is here',
+      'mobileText': 'Flutter 3.41 is here',
       'link': 'https://blog.flutter.dev',
     };
 
     test('decodes valid data', () {
       final decoded = BannerContent.fromJson(valid);
       expect(decoded.text, 'Flutter 3.41 is here');
+      expect(decoded.mobileText, 'Flutter 3.41 is here');
       expect(decoded.toMap()['text'], 'Flutter 3.41 is here');
+      expect(decoded.toMap()['mobileText'], 'Flutter 3.41 is here');
+    });
+
+    test('decodes without optional mobileText', () {
+      final minimal = {...valid}..remove('mobileText');
+      final decoded = BannerContent.fromJson(minimal);
+      expect(decoded.mobileText, isNull);
     });
 
     test('throws when required field is missing', () {
       final invalid = {...valid}..remove('link');
       expect(() => BannerContent.fromJson(invalid), _throwsMapperException);
+    });
+
+    test('throws when mobileText is blank', () {
+      final invalid = {...valid}..['mobileText'] = ' ';
+      expect(() => BannerContent.fromJson(invalid), _throwsValidationError);
     });
 
     test('throws when link is not a URL or root-relative path', () {


### PR DESCRIPTION
Updates the banner implementation for the marketing site to support an optional `mobileText` for when the primary banner is too large to look great on narrow layouts. If it's not specified, the normal `text` is displayed. This is now documented in the `banner.yaml` file as well.

Also improves the styling on narrow layouts, centering text and adding horizontal padding.

---

**Banner before change:**
<img width="370" height="117" alt="Screenshot of the banner in a narrow layout before the change." src="https://github.com/user-attachments/assets/54146b43-0348-4413-a99d-dab382413dc8" />


**Banner after change:**
<img width="379" height="139" alt="Screenshot of the banner in a narrow layout after the change." src="https://github.com/user-attachments/assets/92f799c7-5552-4071-9b91-87c943a343c2" />
