### PR TITLE
[ios]use weak registar for swift example to be consistent with objc

### DIFF
--- a/sites/docs/src/content/release/breaking-changes/uiscenedelegate.md
+++ b/sites/docs/src/content/release/breaking-changes/uiscenedelegate.md
@@ -932,7 +932,7 @@ migrate it to UIKit's scene-based lifecycle as follows:
 
     ```swift diff
       public class MyPlugin: NSObject, FlutterPlugin {
-    +   var registrar: FlutterPluginRegistrar
+    +   weak var registrar: FlutterPluginRegistrar?
 
     +   init(registrar: FlutterPluginRegistrar) {
     +     self.registrar = registrar
@@ -945,21 +945,21 @@ migrate it to UIKit's scene-based lifecycle as follows:
 
         func someMethod() {
     -     let screen = UIScreen.main
-    +     let screen = self.registrar.viewController?.view.window?.windowScene?.screen
+    +     let screen = self.registrar?.viewController?.view.window?.windowScene?.screen
 
     -     let window = UIApplication.shared.delegate?.window
-    +     let window = self.registrar.viewController?.view.window
+    +     let window = self.registrar?.viewController?.view.window
 
     -     let keyWindow = UIApplication.shared.keyWindow
     +     if #available(iOS 15.0, *) {
-    +       let keyWindow = self.registrar.viewController?.view.window?.windowScene?.keyWindow
+    +       let keyWindow = self.registrar?.viewController?.view.window?.windowScene?.keyWindow
     +     } else {
-    +       let keyWindow = self.registrar.viewController?.view.window?.windowScene?.windows
+    +       let keyWindow = self.registrar?.viewController?.view.window?.windowScene?.windows
     +         .filter({ $0.isKeyWindow }).first
     +     }
 
     -     let windows = UIApplication.shared.windows
-    +     let windows = self.registrar.viewController?.view.window?.windowScene?.windows
+    +     let windows = self.registrar?.viewController?.view.window?.windowScene?.windows
         }
       }
     ```


### PR DESCRIPTION
The ObjC version uses weak reference for FlutterPluginRegistrar: 

https://github.com/flutter/website/blob/374a2b6526b503d4fa80571ec969db0d093e717f/sites/docs/src/content/release/breaking-changes/uiscenedelegate.md?plain=1#L959


But Swift version uses strong reference: 

https://github.com/flutter/website/blob/374a2b6526b503d4fa80571ec969db0d093e717f/sites/docs/src/content/release/breaking-changes/uiscenedelegate.md?plain=1#L922

let's be consistent here, and choose `weak` for both. 

For a normal Flutter app, this won't make a difference.

For add-to-app, developers control when to deallocate flutter VC (and its engine). If the plugin has a `shared` singleton, this will keep this registrar alive unnecessarily (the registrar itself contains a `weak` reference to the engine, so we won't have a retain cycle)


Fixes https://github.com/flutter/website/issues/13626

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
