### PR TITLE
added enabling built-in kotlin in 3.47

### DIFF
--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers.md
@@ -296,11 +296,13 @@ kotlin {
 
 ## Validate
 
-Before enabling Built-in Kotlin, confirm that you have migrated your application
+Before enabling Built-in Kotlin,
+confirm that you have migrated your application
 and any Flutter plugins it uses.
 
-To enable Built-in Kotlin, set the `android.builtInKotlin` property
-to `true` in your gradle.properties file:
+To enable Built-in Kotlin,
+set the `android.builtInKotlin` property to `true`
+in your `gradle.properties` file:
 
 ```properties diff title="<flutter-project>/android/gradle.properties"
 # ...

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers.md
@@ -308,8 +308,9 @@ in your `gradle.properties` file:
 # ...
 + android.builtInKotlin=true
 ```
-> [!NOTE]
-> Enabling Built-in Kotlin requires Flutter 3.47 or later.
+::::note
+Enabling Built-in Kotlin requires Flutter 3.47 or later.
+::::
 
 After enabling Built-in Kotlin, execute `flutter run` or `flutter build apk` to
 confirm that your app builds and

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers.md
@@ -312,9 +312,10 @@ in your `gradle.properties` file:
 Enabling Built-in Kotlin requires Flutter 3.47 or later.
 ::::
 
-After enabling Built-in Kotlin, execute `flutter run` or `flutter build apk` to
-confirm that your app builds and
-launches on a connected Android device or emulator.
+After enabling Built-in Kotlin,
+execute `flutter run` or `flutter build apk`
+to confirm that your app builds and launches
+on a connected Android device or emulator.
 
 If your app fails to build because
 you are using an unmigrated Flutter plugin,

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers.md
@@ -296,7 +296,20 @@ kotlin {
 
 ## Validate
 
-Execute `flutter run` or `flutter build apk` to
+Before enabling Built-in Kotlin, confirm that you have migrated your application
+and any Flutter plugins it uses.
+
+To enable Built-in Kotlin, set the `android.builtInKotlin` property
+to `true` in your gradle.properties file:
+
+```properties diff title="<flutter-project>/android/gradle.properties"
+# ...
++ android.builtInKotlin=true
+```
+> [!NOTE]
+> Enabling Built-in Kotlin requires Flutter 3.47 or later.
+
+After enabling Built-in Kotlin, execute `flutter run` or `flutter build apk` to
 confirm that your app builds and
 launches on a connected Android device or emulator.
 

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers.md
@@ -296,11 +296,11 @@ kotlin {
 
 ## Validate
 
-Before enabling Built-in Kotlin,
+Before enabling built-in Kotlin,
 confirm that you have migrated your application
 and any Flutter plugins it uses.
 
-To enable Built-in Kotlin,
+To enable built-in Kotlin,
 set the `android.builtInKotlin` property to `true`
 in your `gradle.properties` file:
 
@@ -310,10 +310,10 @@ in your `gradle.properties` file:
 ```
 
 :::version-note
-Enabling Built-in Kotlin requires Flutter 3.47 or later.
+Enabling built-in Kotlin requires Flutter 3.47 or later.
 :::
 
-After enabling Built-in Kotlin,
+After enabling built-in Kotlin,
 execute `flutter run` or `flutter build apk`
 to confirm that your app builds and launches
 on a connected Android device or emulator.

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers.md
@@ -308,9 +308,10 @@ in your `gradle.properties` file:
 # ...
 + android.builtInKotlin=true
 ```
-::::note
+
+:::version-note
 Enabling Built-in Kotlin requires Flutter 3.47 or later.
-::::
+:::
 
 After enabling Built-in Kotlin,
 execute `flutter run` or `flutter build apk`

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
@@ -419,7 +419,21 @@ the newly released plugin version:
 
 ## Validate
 
-Execute `flutter run` or `flutter build apk` to
+Before enabling Built-in Kotlin, confirm that you have migrated
+your plugin example app and any Flutter plugins it uses.
+
+To enable Built-in Kotlin, set the `android.builtInKotlin` property
+to `true` in your gradle.properties file:
+
+```properties diff title="<flutter-project>/android/gradle.properties"
+# ...
++ android.builtInKotlin=true
+```
+
+> [!NOTE]
+> Enabling Built-in Kotlin requires Flutter 3.47 or later.
+
+After enabling Built-in Kotlin, execute `flutter run` or `flutter build apk` to
 confirm that your plugin example app builds and launches
 on a connected Android device or emulator.
 

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
@@ -435,8 +435,9 @@ in your `gradle.properties` file:
 > [!NOTE]
 > Enabling Built-in Kotlin requires Flutter 3.47 or later.
 
-After enabling Built-in Kotlin, execute `flutter run` or `flutter build apk` to
-confirm that your plugin example app builds and launches
+After enabling Built-in Kotlin,
+execute `flutter run` or `flutter build apk`
+to confirm that your plugin example app builds and launches
 on a connected Android device or emulator.
 
 If your plugin example app also applies KGP,

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
@@ -419,11 +419,13 @@ the newly released plugin version:
 
 ## Validate
 
-Before enabling Built-in Kotlin, confirm that you have migrated
-your plugin example app and any Flutter plugins it uses.
+Before enabling Built-in Kotlin,
+confirm that you have migrated your plugin example app
+and any Flutter plugins it uses.
 
-To enable Built-in Kotlin, set the `android.builtInKotlin` property
-to `true` in your gradle.properties file:
+To enable Built-in Kotlin,
+set the `android.builtInKotlin` property to `true`
+in your `gradle.properties` file:
 
 ```properties diff title="<flutter-project>/android/gradle.properties"
 # ...

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
@@ -432,8 +432,9 @@ in your `gradle.properties` file:
 + android.builtInKotlin=true
 ```
 
-> [!NOTE]
-> Enabling Built-in Kotlin requires Flutter 3.47 or later.
+::::note
+Enabling Built-in Kotlin requires Flutter 3.47 or later.
+::::
 
 After enabling Built-in Kotlin,
 execute `flutter run` or `flutter build apk`

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
@@ -432,9 +432,9 @@ in your `gradle.properties` file:
 + android.builtInKotlin=true
 ```
 
-::::note
+:::version-note
 Enabling Built-in Kotlin requires Flutter 3.47 or later.
-::::
+:::
 
 After enabling Built-in Kotlin,
 execute `flutter run` or `flutter build apk`

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
@@ -419,11 +419,11 @@ the newly released plugin version:
 
 ## Validate
 
-Before enabling Built-in Kotlin,
+Before enabling built-in Kotlin,
 confirm that you have migrated your plugin example app
 and any Flutter plugins it uses.
 
-To enable Built-in Kotlin,
+To enable built-in Kotlin,
 set the `android.builtInKotlin` property to `true`
 in your `gradle.properties` file:
 
@@ -433,10 +433,10 @@ in your `gradle.properties` file:
 ```
 
 :::version-note
-Enabling Built-in Kotlin requires Flutter 3.47 or later.
+Enabling built-in Kotlin requires Flutter 3.47 or later.
 :::
 
-After enabling Built-in Kotlin,
+After enabling built-in Kotlin,
 execute `flutter run` or `flutter build apk`
 to confirm that your plugin example app builds and launches
 on a connected Android device or emulator.


### PR DESCRIPTION
Adding docs to help developers validate their Flutter project works when built-in kotlin is enabled. Built-in Kotlin can only be successfully enabled when a developer is on >= Flutter 3.47 and has migrated their app and any Flutter plugins the app uses.

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
