### PR TITLE
The cursor needs to change when the mouse hovers over each blog category

### DIFF
--- a/packages/site_shared/lib/_sass/components/_blog.scss
+++ b/packages/site_shared/lib/_sass/components/_blog.scss
@@ -84,6 +84,7 @@
   &:hover button {
     color: var(--site-base-fgColor);
     background-color: transparent;
+    cursor: pointer;
   }
 
   &.active {

--- a/packages/site_shared/lib/_sass/components/_blog.scss
+++ b/packages/site_shared/lib/_sass/components/_blog.scss
@@ -84,7 +84,6 @@
   &:hover button {
     color: var(--site-base-fgColor);
     background-color: transparent;
-    cursor: pointer;
   }
 
   &.active {
@@ -98,11 +97,11 @@
 
   button {
     padding: 0.75rem 0.5rem;
-
     font-size: 1rem;
     font-weight: 500;
     background-color: transparent;
     color: var(--site-base-fgColor-alt);
+    cursor: pointer;
   }
 }
 


### PR DESCRIPTION
The new Flutter blog has been merged into the main branch, but the cursor icon doesn't change when the mouse hovers over each blog category tag. I think it should be a pointer, which would be a more user-friendly design.

This is my first PR submission, and I'm not sure if the solution is correct, but it works fine. Thank you.

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
