### PR TITLE
Include Arch-based installation commands

### DIFF
--- a/sites/docs/src/content/install/manual.md
+++ b/sites/docs/src/content/install/manual.md
@@ -89,6 +89,14 @@ first complete the following setup.
     $ sudo apt-get update -y && sudo apt-get upgrade -y
     $ sudo apt-get install -y curl git unzip xz-utils zip libglu1-mesa
     ```
+    
+    On Arch-based distros with `pacman`, such as CachyOS,
+    install these packages using the following commands:
+
+    ```console
+    $ sudo pacman -Syu
+    $ sudo pacman -S --needed curl git unzip xz zip glu
+    ```
 
 1. <h3>Set up an editor or IDE</h3>
 


### PR DESCRIPTION
Added installation instructions for Arch-based distros.

_Description of what this PR is changing or adding, and why:_
Just adds installation commands for arch based distros. I find myself looking for arch equivalent for the package names that are given for debian when installing on an arch based distro 

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
