### PR TITLE
Added warning against migration to built-in kotlin

### DIFF
--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers.md
@@ -14,7 +14,17 @@ listed in the [Android Gradle Plugin docs][AGP block].
 :::warning
 This guide only applies to apps that already use the
 Kotlin Gradle Plugin (KGP).
-If your project doesn't currently apply KGP,
+
+To verify whether your app applies KGP,
+find the `kotlin-android` plugin
+(or the `org.jetbrains.kotlin.android` plugin).
+It is likely located in the
+`<app-src>/android/app/build.gradle` or
+`<app-src>/android/app/build.gradle.kts` file.
+To view the KGP application code,
+see [Update the Gradle file](#update-the-gradle-file).
+
+If your app doesn't currently apply KGP,
 don't migrate to built-in Kotlin.
 :::
 
@@ -306,6 +316,8 @@ kotlin {
 Before enabling built-in Kotlin,
 confirm that you have migrated your application
 and any Flutter plugins it uses.
+Also, confirm that you updated your app
+to AGP 9+, because built-in Kotlin requires AGP 9+.
 
 To enable built-in Kotlin,
 set the `android.builtInKotlin` property to `true`

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers.md
@@ -11,6 +11,13 @@ an AGP version created before 9.0.0 to an AGP version 9.0.0+.
 You should also use the minimum compatible dependency versions
 listed in the [Android Gradle Plugin docs][AGP block].
 
+:::warning
+This guide only applies to apps that already use the
+Kotlin Gradle Plugin (KGP).
+If your project doesn't currently apply KGP,
+don't migrate to built-in Kotlin.
+:::
+
 :::note
 To update Flutter plugins to use built-in Kotlin,
 follow the [migration guide for plugin authors][].

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
@@ -9,6 +9,16 @@ This guide outlines the migration steps specifically for plugin authors.
 :::warning
 This guide only applies to plugins that already use the
 Kotlin Gradle Plugin (KGP).
+
+To verify whether your plugin applies KGP,
+find the `kotlin-android` plugin
+(or the `org.jetbrains.kotlin.android` plugin).
+It is likely located in the
+`<plugin-project>/build.gradle` or
+`<plugin-project>/build.gradle.kts` file.
+To view the KGP application code,
+see [Update the Gradle file](#update-the-gradle-file).
+
 If your plugin project doesn't currently apply KGP,
 don't migrate to built-in Kotlin.
 :::
@@ -428,8 +438,9 @@ the newly released plugin version:
 
 Before enabling built-in Kotlin,
 confirm that you have migrated your plugin example app
-and any Flutter plugins it uses. Also confirm you have updated your
-plugin example app to AGP version 9.0.0+.
+and any Flutter plugins it uses.
+Also, confirm that you updated your plugin example app
+to AGP 9+, because built-in Kotlin requires AGP 9+.
 
 To enable built-in Kotlin,
 set the `android.builtInKotlin` property to `true`

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
@@ -428,7 +428,8 @@ the newly released plugin version:
 
 Before enabling built-in Kotlin,
 confirm that you have migrated your plugin example app
-and any Flutter plugins it uses.
+and any Flutter plugins it uses. Also confirm you have updated your
+plugin example app to AGP version 9.0.0+.
 
 To enable built-in Kotlin,
 set the `android.builtInKotlin` property to `true`

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
@@ -14,8 +14,8 @@ To verify whether your plugin applies KGP,
 find the `kotlin-android` plugin
 (or the `org.jetbrains.kotlin.android` plugin).
 It is likely located in the
-`<plugin-project>/build.gradle` or
-`<plugin-project>/build.gradle.kts` file.
+`<plugin-project>/android/build.gradle` or
+`<plugin-project>/android/build.gradle.kts` file.
 To view the KGP application code,
 see [Update the Gradle file](#update-the-gradle-file).
 

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
@@ -6,6 +6,13 @@ description: >-
 
 This guide outlines the migration steps specifically for plugin authors.
 
+:::warning
+This guide only applies to plugins that already use the
+Kotlin Gradle Plugin (KGP).
+If your plugin project doesn't currently apply KGP,
+don't migrate to built-in Kotlin.
+:::
+
 :::note
 To update Flutter apps to use built-in Kotlin,
 follow the [migration guide for app developers][].

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
@@ -14,8 +14,8 @@ To verify whether your plugin applies KGP,
 find the `kotlin-android` plugin
 (or the `org.jetbrains.kotlin.android` plugin).
 It is likely located in the
-`<plugin-project>/build.gradle` or
-`<plugin-project>/build.gradle.kts` file.
+`<plugin-project>/android/build.gradle` or
+`<plugin-project>/android/build.gradle.kts` file.
 To view the KGP application code,
 see [Update the Gradle file](#update-the-gradle-file).
 
@@ -41,9 +41,9 @@ follow the instructions to
 First, find the `kotlin-android` plugin
 (or the `org.jetbrains.kotlin.android` plugin).
 It is likely located in the `plugins` block of the
-`<plugin-project>/build.gradle` or the `<plugin-project>/build.gradle.kts` file.
+`<plugin-project>/android/build.gradle` or the `<plugin-project>/android/build.gradle.kts` file.
 If you use the legacy `apply` syntax,
-it will be located in the Groovy-based `<plugin-project>/build.gradle` file,
+it will be located in the Groovy-based `<plugin-project>/android/build.gradle` file,
 as this syntax isn't supported in Kotlin DSL.
 
 The following examples demonstrate how to migrate a Flutter plugin:

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/index.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/index.md
@@ -7,6 +7,13 @@ description: >-
 
 {% render "docs/breaking-changes.md" %}
 
+:::warning
+This guide only applies to apps and plugins that already use the
+Kotlin Gradle Plugin (KGP).
+If your project doesn't currently apply KGP,
+don't migrate to built-in Kotlin.
+:::
+
 ## Summary
 
 To build a Flutter app for Android,


### PR DESCRIPTION
Added warning against migrating to built-in kotlin if project does not currently use KGP. Also added apps should be on AGP 9+ when validating migration.

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
