### PR TITLE
[docs] Add instructions for installing the Claude plugin

### DIFF
--- a/sites/docs/src/content/ai/agent-skills.md
+++ b/sites/docs/src/content/ai/agent-skills.md
@@ -52,12 +52,12 @@ tailored specifically for our frameworks.
 ## Getting started
 
 You can install official Flutter and Dart agent skills into your AI agent or
-coding assistant. Select your tool below for installation instructions:
+coding assistant. Select your agent below for installation instructions:
 
 <Tabs key="ai-client-tabs">
 <Tab name="Claude Code">
 
-If you use Claude Code, you can install the official Flutter plugin.
+If you use Claude Code, install the official Flutter plugin.
 This installs the Flutter and Dart agent skills alongside the
 [Dart and Flutter MCP server](/ai/mcp-server):
 

--- a/sites/docs/src/content/ai/agent-skills.md
+++ b/sites/docs/src/content/ai/agent-skills.md
@@ -83,8 +83,8 @@ downloads the requested skills into your project.
 
 ### Using the Claude Code plugin
 
-If you use Claude Code, you can install the official Flutter plugin directly
-from GitHub. This installs Flutter and Dart agent skills alongside the
+If you use Claude Code, you can install the official Flutter plugin. This
+installs the Flutter and Dart agent skills alongside the
 [Dart and Flutter MCP server](/ai/mcp-server):
 
 1.  Add the Flutter marketplace for Claude plugins:

--- a/sites/docs/src/content/ai/agent-skills.md
+++ b/sites/docs/src/content/ai/agent-skills.md
@@ -15,16 +15,16 @@ with domain-specific capabilities using Agent Skills.
 AI agents can write Flutter and Dart code, but they sometimes are unaware of
 tools and best practices that professional developers use.
 
-[Agent Skills](https://agentskills.io/) help solve this problem by providing a
+[Agent skills](https://agentskills.io/) help solve this problem by providing a
 standardized way to give your AI agent a set of task-oriented blueprints to
 follow. By giving the agent actual domain expertise and repeatable workflows,
 you drastically reduce mistakes and can enforce consistent patterns.
 
-To understand how Agent Skills fit into your workflow, consider how they compare
+To understand how agent skills fit into your workflow, consider how they compare
 to other AI capabilities:
 
 *   **Rules files:** While [rules files](/ai/ai-rules) configure the agent's
-    general behavior across all tasks, Agent Skills give the AI step-by-step
+    general behavior across all tasks, agent skills give the AI step-by-step
     instructions for one specific job.
 *   **Model Context Protocol (MCP):** The [Dart and Flutter MCP
     server](/ai/mcp-server) gives your agent access to specialized tools. If MCP
@@ -49,10 +49,10 @@ tailored specifically for our frameworks.
     These skills help the AI build responsive layouts,
     set up declarative routing, and implement JSON serialization.
 
-## Getting started
+## Install agent skills
 
-You can install official Flutter and Dart agent skills into your AI agent or
-coding assistant. Select your agent below for installation instructions:
+Select your AI coding agent below for instructions on how to install the official
+Flutter and Dart agent skills.
 
 <Tabs key="ai-client-tabs">
 <Tab name="Claude Code">
@@ -113,7 +113,7 @@ directory and downloads the requested skills into your project.
 </Tab>
 </Tabs>
 
-## Manage and verify skills
+## Manage and verify agent skills
 
 For more details on available skills, updating, and contributing, see the
 [Dart skills repository](https://github.com/dart-lang/skills) and the

--- a/sites/docs/src/content/ai/agent-skills.md
+++ b/sites/docs/src/content/ai/agent-skills.md
@@ -55,55 +55,59 @@ By default, compatible AI agents discover Agent Skills within the
 `.agents/skills` directory of your project workspace.
 
 <Tabs key="ai-client-tabs">
-    <Tab name="skills CLI">
-        To easily download and manage skills in that folder, you can use the
-        `skills` CLI tool. It's distributed through npm, so you'll need
-        [Node.js](https://nodejs.org/) installed to run it with `npx`.
+<Tab name="skills CLI">
 
-        To install the official Flutter skills:
+To easily download and manage skills in that folder, you can use the
+`skills` CLI tool. It's distributed through npm, so you'll need
+[Node.js](https://nodejs.org/) installed to run it with `npx`.
 
-        :::note
-        The `flutter/skills` repository has been renamed to
-        `flutter/agent-plugins`. If you previously installed skills using
-        `flutter/skills`, update your commands to use `flutter/agent-plugins`.
-        :::
+To install the official Flutter skills:
 
-        ```bash
-        npx skills add flutter/agent-plugins --skill '*' --agent universal
-        ```
+:::note
+The `flutter/skills` repository has been renamed to
+`flutter/agent-plugins`. If you previously installed skills using
+`flutter/skills`, update your commands to use `flutter/agent-plugins`.
+:::
 
-        And to install the official Dart skills:
+```bash
+npx skills add flutter/agent-plugins --skill '*' --agent universal
+```
 
-        ```bash
-        npx skills add dart-lang/skills --skill '*' --agent universal
-        ```
+And to install the official Dart skills:
 
-        Running these commands automatically creates the `.agents/skills`
-        directory and downloads the requested skills into your project.
-    </Tab>
-    <Tab name="Claude Code">
-        If you use Claude Code, you can install the official Flutter plugin.
-        This installs the Flutter and Dart agent skills alongside the
-        [Dart and Flutter MCP server](/ai/mcp-server):
+```bash
+npx skills add dart-lang/skills --skill '*' --agent universal
+```
 
-        1.  Add the Flutter marketplace for Claude plugins:
+Running these commands automatically creates the `.agents/skills`
+directory and downloads the requested skills into your project.
 
-            ```console
-            $ claude plugin marketplace add flutter/agent-plugins
-            ```
+</Tab>
+<Tab name="Claude Code">
 
-        2.  Install the plugin:
+If you use Claude Code, you can install the official Flutter plugin.
+This installs the Flutter and Dart agent skills alongside the
+[Dart and Flutter MCP server](/ai/mcp-server):
 
-            ```console
-            $ claude plugin install dart-flutter@dart-flutter
-            ```
+1.  Add the Flutter marketplace for Claude plugins:
 
-        3.  Verify the installation:
+    ```console
+    $ claude plugin marketplace add flutter/agent-plugins
+    ```
 
-            ```console
-            $ claude plugin marketplace list
-            ```
-    </Tab>
+2.  Install the plugin:
+
+    ```console
+    $ claude plugin install dart-flutter@dart-flutter
+    ```
+
+3.  Verify the installation:
+
+    ```console
+    $ claude plugin marketplace list
+    ```
+
+</Tab>
 </Tabs>
 
 For more details on available skills, updating, and contributing, see the

--- a/sites/docs/src/content/ai/agent-skills.md
+++ b/sites/docs/src/content/ai/agent-skills.md
@@ -51,11 +51,39 @@ tailored specifically for our frameworks.
 
 ## Getting started
 
-By default, compatible AI agents discover Agent Skills within the
-`.agents/skills` directory of your project workspace.
+You can install official Flutter and Dart agent skills into your AI agent or
+coding assistant. Select your tool below for installation instructions:
 
 <Tabs key="ai-client-tabs">
-<Tab name="skills CLI">
+<Tab name="Claude Code">
+
+If you use Claude Code, you can install the official Flutter plugin.
+This installs the Flutter and Dart agent skills alongside the
+[Dart and Flutter MCP server](/ai/mcp-server):
+
+1.  Add the Flutter marketplace for Claude plugins:
+
+    ```console
+    $ claude plugin marketplace add flutter/agent-plugins
+    ```
+
+2.  Install the plugin:
+
+    ```console
+    $ claude plugin install dart-flutter@dart-flutter
+    ```
+
+3.  Verify the installation:
+
+    ```console
+    $ claude plugin marketplace list
+    ```
+
+</Tab>
+<Tab name="Other agents">
+
+By default, compatible AI agents discover agent skills within the
+`.agents/skills` directory of your project workspace.
 
 To easily download and manage skills in that folder, you can use the
 `skills` CLI tool. It's distributed through npm, so you'll need
@@ -83,32 +111,9 @@ Running these commands automatically creates the `.agents/skills`
 directory and downloads the requested skills into your project.
 
 </Tab>
-<Tab name="Claude Code">
-
-If you use Claude Code, you can install the official Flutter plugin.
-This installs the Flutter and Dart agent skills alongside the
-[Dart and Flutter MCP server](/ai/mcp-server):
-
-1.  Add the Flutter marketplace for Claude plugins:
-
-    ```console
-    $ claude plugin marketplace add flutter/agent-plugins
-    ```
-
-2.  Install the plugin:
-
-    ```console
-    $ claude plugin install dart-flutter@dart-flutter
-    ```
-
-3.  Verify the installation:
-
-    ```console
-    $ claude plugin marketplace list
-    ```
-
-</Tab>
 </Tabs>
+
+## Manage and verify skills
 
 For more details on available skills, updating, and contributing, see the
 [Dart skills repository](https://github.com/dart-lang/skills) and the
@@ -116,7 +121,7 @@ For more details on available skills, updating, and contributing, see the
 
 :::tip
 Once you've added skills to your project, try asking your AI agent to review
-the `.agents/skills` directory. You can ask, "Which of my installed skills
+your installed skills. You can ask, "Which of my installed skills
 can help me with [your current task]?" or "Summarize the capabilities of the
 skills I have available."
 :::

--- a/sites/docs/src/content/ai/agent-skills.md
+++ b/sites/docs/src/content/ai/agent-skills.md
@@ -54,6 +54,8 @@ tailored specifically for our frameworks.
 By default, compatible AI agents discover Agent Skills within the
 `.agents/skills` directory of your project workspace.
 
+### Using the skills CLI
+
 To easily download and manage skills in that folder, you can use the `skills`
 CLI tool. It's distributed through npm, so you'll need
 [Node.js](https://nodejs.org/) installed to run it with `npx`.
@@ -78,6 +80,30 @@ npx skills add dart-lang/skills --skill '*' --agent universal
 
 Running these commands automatically creates the `.agents/skills` directory and
 downloads the requested skills into your project.
+
+### Using the Claude Code plugin
+
+If you use Claude Code, you can install the official Flutter plugin directly
+from GitHub. This installs Flutter and Dart agent skills alongside the
+[Dart and Flutter MCP server](/ai/mcp-server):
+
+1.  Add the Flutter marketplace for Claude plugins:
+
+    ```console
+    $ claude plugin marketplace add flutter/agent-plugins
+    ```
+
+2.  Install the plugin:
+
+    ```console
+    $ claude plugin install dart-flutter@dart-flutter
+    ```
+
+3.  Verify the installation:
+
+    ```console
+    $ claude plugin marketplace list
+    ```
 
 For more details on available skills, updating, and contributing, see the
 [Dart skills repository](https://github.com/dart-lang/skills) and the

--- a/sites/docs/src/content/ai/agent-skills.md
+++ b/sites/docs/src/content/ai/agent-skills.md
@@ -54,56 +54,57 @@ tailored specifically for our frameworks.
 By default, compatible AI agents discover Agent Skills within the
 `.agents/skills` directory of your project workspace.
 
-### Using the skills CLI
+<Tabs key="ai-client-tabs">
+    <Tab name="skills CLI">
+        To easily download and manage skills in that folder, you can use the
+        `skills` CLI tool. It's distributed through npm, so you'll need
+        [Node.js](https://nodejs.org/) installed to run it with `npx`.
 
-To easily download and manage skills in that folder, you can use the `skills`
-CLI tool. It's distributed through npm, so you'll need
-[Node.js](https://nodejs.org/) installed to run it with `npx`.
+        To install the official Flutter skills:
 
-To install the official Flutter skills:
+        :::note
+        The `flutter/skills` repository has been renamed to
+        `flutter/agent-plugins`. If you previously installed skills using
+        `flutter/skills`, update your commands to use `flutter/agent-plugins`.
+        :::
 
-:::note
-The `flutter/skills` repository has been renamed to `flutter/agent-plugins`.
-If you previously installed skills using `flutter/skills`,
-update your commands to use `flutter/agent-plugins`.
-:::
+        ```bash
+        npx skills add flutter/agent-plugins --skill '*' --agent universal
+        ```
 
-```bash
-npx skills add flutter/agent-plugins --skill '*' --agent universal
-```
+        And to install the official Dart skills:
 
-And to install the official Dart skills:
+        ```bash
+        npx skills add dart-lang/skills --skill '*' --agent universal
+        ```
 
-```bash
-npx skills add dart-lang/skills --skill '*' --agent universal
-```
+        Running these commands automatically creates the `.agents/skills`
+        directory and downloads the requested skills into your project.
+    </Tab>
+    <Tab name="Claude Code">
+        If you use Claude Code, you can install the official Flutter plugin.
+        This installs the Flutter and Dart agent skills alongside the
+        [Dart and Flutter MCP server](/ai/mcp-server):
 
-Running these commands automatically creates the `.agents/skills` directory and
-downloads the requested skills into your project.
+        1.  Add the Flutter marketplace for Claude plugins:
 
-### Using the Claude Code plugin
+            ```console
+            $ claude plugin marketplace add flutter/agent-plugins
+            ```
 
-If you use Claude Code, you can install the official Flutter plugin. This
-installs the Flutter and Dart agent skills alongside the
-[Dart and Flutter MCP server](/ai/mcp-server):
+        2.  Install the plugin:
 
-1.  Add the Flutter marketplace for Claude plugins:
+            ```console
+            $ claude plugin install dart-flutter@dart-flutter
+            ```
 
-    ```console
-    $ claude plugin marketplace add flutter/agent-plugins
-    ```
+        3.  Verify the installation:
 
-2.  Install the plugin:
-
-    ```console
-    $ claude plugin install dart-flutter@dart-flutter
-    ```
-
-3.  Verify the installation:
-
-    ```console
-    $ claude plugin marketplace list
-    ```
+            ```console
+            $ claude plugin marketplace list
+            ```
+    </Tab>
+</Tabs>
 
 For more details on available skills, updating, and contributing, see the
 [Dart skills repository](https://github.com/dart-lang/skills) and the

--- a/sites/docs/src/content/ai/coding-assistants.md
+++ b/sites/docs/src/content/ai/coding-assistants.md
@@ -44,14 +44,12 @@ For more details about Gemini CLI, visit the [Gemini CLI](https://geminicli.com/
 ## Claude Code
 
 [Claude Code](https://code.claude.com/) is an agentic coding assistant from
-Anthropic that runs in your terminal. You can equip Claude Code with domain
-expertise and tools for Flutter and Dart by installing the official Flutter
-plugin:
+Anthropic that runs in your terminal.
 
-```console
-$ claude plugin marketplace add flutter/agent-plugins
-$ claude plugin install dart-flutter@dart-flutter
-```
+You can equip Claude Code with domain expertise and tools for Flutter and Dart
+by installing the official Flutter plugin, which bundles official
+[agent skills](/ai/agent-skills) and the
+[Dart and Flutter MCP server](/ai/mcp-server).
 
-For more details on setting up skills and tools with Claude Code, see the
-[agent skills](/ai/agent-skills) and [MCP server](/ai/mcp-server) pages.
+To install the plugin, follow the Claude Code instructions in
+[Getting started with agent skills](/ai/agent-skills#getting-started).

--- a/sites/docs/src/content/ai/coding-assistants.md
+++ b/sites/docs/src/content/ai/coding-assistants.md
@@ -40,3 +40,18 @@ For individual developers, it is superseded by the new [Antigravity CLI](/ai/ant
 It continues to be supported for Gemini Enterprise users.
 
 For more details about Gemini CLI, visit the [Gemini CLI](https://geminicli.com/) website.
+
+## Claude Code
+
+[Claude Code](https://code.claude.com/) is an agentic coding assistant from
+Anthropic that runs in your terminal. You can equip Claude Code with domain
+expertise and tools for Flutter and Dart by installing the official Flutter
+plugin:
+
+```console
+$ claude plugin marketplace add flutter/agent-plugins
+$ claude plugin install dart-flutter@dart-flutter
+```
+
+For more details on setting up skills and tools with Claude Code, see the
+[Agent skills](/ai/agent-skills) and [MCP server](/ai/mcp-server) pages.

--- a/sites/docs/src/content/ai/coding-assistants.md
+++ b/sites/docs/src/content/ai/coding-assistants.md
@@ -52,4 +52,4 @@ by installing the official Flutter plugin, which bundles official
 [Dart and Flutter MCP server](/ai/mcp-server).
 
 To install the plugin, follow the Claude Code instructions in
-[Getting started with agent skills](/ai/agent-skills#getting-started).
+[Install agent skills](/ai/agent-skills#install-agent-skills).

--- a/sites/docs/src/content/ai/coding-assistants.md
+++ b/sites/docs/src/content/ai/coding-assistants.md
@@ -54,4 +54,4 @@ $ claude plugin install dart-flutter@dart-flutter
 ```
 
 For more details on setting up skills and tools with Claude Code, see the
-[Agent skills](/ai/agent-skills) and [MCP server](/ai/mcp-server) pages.
+[agent skills](/ai/agent-skills) and [MCP server](/ai/mcp-server) pages.

--- a/sites/docs/src/content/ai/mcp-server.md
+++ b/sites/docs/src/content/ai/mcp-server.md
@@ -309,7 +309,7 @@ by installing the official plugin or by configuring the server manually.
 
 The easiest way to set up the Dart and Flutter MCP server in Claude Code is to
 install the official Flutter plugin. This installs both the MCP
-server and official [Agent skills](/ai/agent-skills):
+server and official [agent skills](/ai/agent-skills):
 
 1.  Add the Flutter marketplace for Claude plugins:
 

--- a/sites/docs/src/content/ai/mcp-server.md
+++ b/sites/docs/src/content/ai/mcp-server.md
@@ -312,7 +312,7 @@ install the official Flutter plugin, which bundles both the MCP server and
 official [agent skills](/ai/agent-skills).
 
 To install the plugin, follow the Claude Code instructions in
-[Getting started with agent skills](/ai/agent-skills#getting-started).
+[Install agent skills](/ai/agent-skills#install-agent-skills).
 
 #### Configure manually
 

--- a/sites/docs/src/content/ai/mcp-server.md
+++ b/sites/docs/src/content/ai/mcp-server.md
@@ -308,7 +308,7 @@ by installing the official plugin or by configuring the server manually.
 #### Install via plugin (recommended)
 
 The easiest way to set up the Dart and Flutter MCP server in Claude Code is to
-install the official Flutter plugin from GitHub. This installs both the MCP
+install the official Flutter plugin. This installs both the MCP
 server and official [Agent skills](/ai/agent-skills):
 
 1.  Add the Flutter marketplace for Claude plugins:

--- a/sites/docs/src/content/ai/mcp-server.md
+++ b/sites/docs/src/content/ai/mcp-server.md
@@ -302,8 +302,37 @@ or in your project's `opencode key` configuration.
 
 ### Claude Code
 
-To configure Claude Code to use the Dart and Flutter MCP server
-for the current project, use the `claude mcp add` CLI command:
+You can configure Claude Code to use the Dart and Flutter MCP server either
+by installing the official plugin or by configuring the server manually.
+
+#### Install via plugin (recommended)
+
+The easiest way to set up the Dart and Flutter MCP server in Claude Code is to
+install the official Flutter plugin from GitHub. This installs both the MCP
+server and official [Agent skills](/ai/agent-skills):
+
+1.  Add the Flutter marketplace for Claude plugins:
+
+    ```console
+    $ claude plugin marketplace add flutter/agent-plugins
+    ```
+
+2.  Install the plugin:
+
+    ```console
+    $ claude plugin install dart-flutter@dart-flutter
+    ```
+
+3.  Verify the installation:
+
+    ```console
+    $ claude plugin marketplace list
+    ```
+
+#### Configure manually
+
+Alternatively, to configure Claude Code to use only the Dart and Flutter MCP
+server for the current project, use the `claude mcp add` CLI command:
 
 ```console
 $ claude mcp add --transport stdio dart -- dart mcp-server

--- a/sites/docs/src/content/ai/mcp-server.md
+++ b/sites/docs/src/content/ai/mcp-server.md
@@ -308,26 +308,11 @@ by installing the official plugin or by configuring the server manually.
 #### Install via plugin (recommended)
 
 The easiest way to set up the Dart and Flutter MCP server in Claude Code is to
-install the official Flutter plugin. This installs both the MCP
-server and official [agent skills](/ai/agent-skills):
+install the official Flutter plugin, which bundles both the MCP server and
+official [agent skills](/ai/agent-skills).
 
-1.  Add the Flutter marketplace for Claude plugins:
-
-    ```console
-    $ claude plugin marketplace add flutter/agent-plugins
-    ```
-
-2.  Install the plugin:
-
-    ```console
-    $ claude plugin install dart-flutter@dart-flutter
-    ```
-
-3.  Verify the installation:
-
-    ```console
-    $ claude plugin marketplace list
-    ```
+To install the plugin, follow the Claude Code instructions in
+[Getting started with agent skills](/ai/agent-skills#getting-started).
 
 #### Configure manually
 


### PR DESCRIPTION
This PR adds documentation for installing the official Flutter plugin for Claude Code across the AI assistance documentation pages ('agent-skills.md', 'mcp-server.md', and 'coding-assistants.md').

### Changes
- **'ai/agent-skills.md'**: Adds a '### Using the Claude Code plugin' section showing how to add the 'flutter/agent-plugins' marketplace and install 'dart-flutter@dart-flutter'.
- **'ai/mcp-server.md'**: Adds a '#### Install via plugin (recommended)' option under '### Claude Code' alongside the manual 'claude mcp add' option.
- **'ai/coding-assistants.md'**: Adds a '## Claude Code' section with overview and installation instructions.