### PR TITLE
Add note about deferred loading to flutter.dev/platform-integration/web/wasm

### DIFF
--- a/sites/docs/src/content/platform-integration/web/wasm.md
+++ b/sites/docs/src/content/platform-integration/web/wasm.md
@@ -80,7 +80,7 @@ $ flutter build web --wasm --enable-wasm-deferred-loading
 ```
 
 This is available on the flutter main branch and will become generally
-available later this year in the 3.50.0 flutter stable release.
+available later this year in the 3.50 flutter stable release.
 :::
 
 #### Wasm production debugging

--- a/sites/docs/src/content/platform-integration/web/wasm.md
+++ b/sites/docs/src/content/platform-integration/web/wasm.md
@@ -80,7 +80,7 @@ $ flutter build web --wasm --enable-wasm-deferred-loading
 ```
 
 This is available on the flutter main branch and will become generally
-available later this year in the 3.47.0 flutter stable release.
+available later this year in the 3.50.0 flutter stable release.
 :::
 
 #### Wasm production debugging

--- a/sites/docs/src/content/platform-integration/web/wasm.md
+++ b/sites/docs/src/content/platform-integration/web/wasm.md
@@ -70,6 +70,19 @@ $ flutter build web --wasm
 The command produces output into the `build/web` directory relative to the
 package root, just like `flutter build web`.
 
+:::note
+Enabling Wasm compilation for a Flutter web app does not use deferred loading
+by default. Deferred loading in Wasm is experimental and can be enabled
+using the `--enable-wasm-deferred-loading` flag:
+
+```console
+$ flutter build web --wasm --enable-wasm-deferred-loading
+```
+
+This is available on the flutter main branch and will become generally
+available later this year in the 3.47.0 flutter stable release.
+:::
+
 #### Wasm production debugging
 
 By default, Wasm release builds strip debug symbols and omit source maps


### PR DESCRIPTION
We have recently added the `--enable-wasm-deferred-loading` flag and should mention it in the documentation to make users aware.