### PR TITLE
docs(web): document --source-maps flag and deployment security

### DIFF
--- a/sites/docs/src/content/deployment/web.md
+++ b/sites/docs/src/content/deployment/web.md
@@ -54,6 +54,31 @@ Profile builds are specialized for performance profiling using Chrome DevTools,
 and debug builds can be used to configure dart2js
 to respect assertions and change the optimization level (using the `-O` flag.)
 
+### Source maps
+
+To generate source maps for symbolication in crash reporting services,
+pass the `--source-maps` flag:
+
+```console
+flutter build web --source-maps
+```
+
+Generating source maps creates a separate `.js.map` or `.wasm.map` file
+in the `build/web` directory without adding binary overhead
+to the compiled output.
+
+:::warning Exclude source maps from public hosting
+By default, standard web deployment tools upload all files in `build/web/`.
+If source maps are deployed publicly, browser DevTools will
+automatically download them, exposing un-minified symbol names,
+class hierarchies, and local file paths.
+
+Upload `.map` files to your private error-monitoring service
+(such as Sentry or Datadog) during CI/CD, and exclude `*.map` files
+from public web hosting (for example, using `ignore: ["**/*.map"]`
+in `firebase.json` or stripping them prior to deployment).
+:::
+
 ## Opting-in to WebAssembly
 
 To compile and optimize your app for WebAssembly,

--- a/sites/docs/src/content/deployment/web.md
+++ b/sites/docs/src/content/deployment/web.md
@@ -63,9 +63,9 @@ pass the `--source-maps` flag:
 flutter build web --source-maps
 ```
 
-Generating source maps creates a separate `.js.map` or `.wasm.map` file
-in the `build/web` directory without adding binary overhead
-to the compiled output.
+Generating source maps creates separate `.js.map` or `.wasm.map` files
+(or both, depending on your build target) in the `build/web` directory
+without adding binary overhead to the compiled output.
 
 :::warning Exclude source maps from public hosting
 By default, standard web deployment tools upload all files in `build/web/`.
@@ -75,7 +75,7 @@ class hierarchies, and local file paths.
 
 Upload `.map` files to your private error-monitoring service
 (such as Sentry or Datadog) during CI/CD, and exclude `*.map` files
-from public web hosting (for example, using `ignore: ["**/*.map"]`
+from public web hosting (for example, using `"ignore": ["**/*.map"]`
 in `firebase.json` or stripping them prior to deployment).
 :::
 

--- a/sites/docs/src/content/platform-integration/web/wasm.md
+++ b/sites/docs/src/content/platform-integration/web/wasm.md
@@ -76,9 +76,9 @@ By default, Wasm release builds strip debug symbols and omit source maps
 to minimize binary size.
 
 - **For Error Monitoring (Recommended)**: Pass `--source-maps` to generate
-  a `main.dart.wasm.map` file for symbolication in tools like Sentry or Datadog
-  without adding binary overhead to `main.dart.wasm`. Always exclude `*.map`
-  files from public web hosting.
+  a `main.dart.wasm.map` file for symbolication in error tracking services.
+  For security recommendations and deployment warnings, see
+  [Source maps](/deployment/web#source-maps).
 - **For Staging / QA Builds**: Pass `--no-strip-wasm` to preserve Wasm
   function names directly in browser console stack traces, at the cost of
   **~47% Wasm binary size increase**.

--- a/sites/docs/src/content/platform-integration/web/wasm.md
+++ b/sites/docs/src/content/platform-integration/web/wasm.md
@@ -70,6 +70,23 @@ $ flutter build web --wasm
 The command produces output into the `build/web` directory relative to the
 package root, just like `flutter build web`.
 
+#### Wasm Production Debugging
+
+By default, Wasm release builds strip debug symbols and omit source maps
+to minimize binary size.
+
+- **For Error Monitoring (Recommended)**: Pass `--source-maps` to generate
+  a `main.dart.wasm.map` file for symbolication in tools like Sentry or Datadog
+  without adding binary overhead to `main.dart.wasm`. Always exclude `*.map`
+  files from public web hosting.
+- **For Staging / QA Builds**: Pass `--no-strip-wasm` to preserve Wasm
+  function names directly in browser console stack traces, at the cost of
+  **~47% Wasm binary size increase**.
+
+```console
+$ flutter build web --wasm --source-maps
+```
+
 ### Open the app in a compatible web browser
 Even with the `--wasm` flag, Flutter will still compile the application to
 JavaScript. If WasmGC support is not detected at runtime, the JavaScript output

--- a/sites/docs/src/content/platform-integration/web/wasm.md
+++ b/sites/docs/src/content/platform-integration/web/wasm.md
@@ -70,21 +70,25 @@ $ flutter build web --wasm
 The command produces output into the `build/web` directory relative to the
 package root, just like `flutter build web`.
 
-#### Wasm Production Debugging
+#### Wasm production debugging
 
 By default, Wasm release builds strip debug symbols and omit source maps
 to minimize binary size.
 
-- **For Error Monitoring (Recommended)**: Pass `--source-maps` to generate
+- **For error monitoring (recommended)**: Pass `--source-maps` to generate
   a `main.dart.wasm.map` file for symbolication in error tracking services.
   For security recommendations and deployment warnings, see
   [Source maps](/deployment/web#source-maps).
-- **For Staging / QA Builds**: Pass `--no-strip-wasm` to preserve Wasm
+- **For staging or QA builds**: Pass `--no-strip-wasm` to preserve Wasm
   function names directly in browser console stack traces, at the cost of
-  **~47% Wasm binary size increase**.
+  an approximate **47% increase** in Wasm binary size.
 
 ```console
+# Generate source maps for production error tracking:
 $ flutter build web --wasm --source-maps
+
+# Preserve Wasm function names for staging/QA debugging:
+$ flutter build web --wasm --no-strip-wasm
 ```
 
 ### Open the app in a compatible web browser


### PR DESCRIPTION
Add documentation for the --source-maps CLI flag and deployment security practices to web deployment and WebAssembly documentation pages.

- Add --source-maps usage and public hosting security warning to deployment/web.md

- Add Wasm production debugging section and trade-offs to platform-integration/web/wasm.md

Closes https://github.com/flutter/website/issues/13650
