### PR TITLE
Add deprecation warnings for macOS Intel support

### DIFF
--- a/sites/docs/src/content/install/manual.md
+++ b/sites/docs/src/content/install/manual.md
@@ -200,7 +200,24 @@ then extract the SDK to where you want it stored.
 
 {: .steps .windows-only}
 
+<div class="macos-only">
+
+:::warning
+**Note for Intel Macs:**
+Flutter is deprecating support for Intel-based Macs (x64).
+Future Flutter releases will require Apple Silicon.
+For details, check out the
+[macOS Intel deprecation strategy](https://docs.google.com/document/d/1ty3js_Eg2sNIbDuyYS_aV7h4jYdx1hEpX_mV135gO4s/edit?tab=t.0#heading=h.cx7d8y57ce6p).
+:::
+
+</div>
+
  1. <h3>Download the Flutter SDK bundle</h3>
+
+    To choose the correct bundle,
+    you need to know your Mac's processor type.
+    *(To check, go to **Apple menu () > About This Mac**
+    and look at the **Processor** or **Chip** section.)*
 
     Depending on your macOS device's cpu architecture,
     download one of the following installation bundles to get the

--- a/sites/docs/src/content/install/with-vs-code.md
+++ b/sites/docs/src/content/install/with-vs-code.md
@@ -73,6 +73,18 @@ first install the following tools.
 
 {: .steps .chromeos-only}
 
+<div class="macos-only">
+
+:::warning
+**Note for Intel Macs:**
+Flutter is deprecating support for Intel-based Macs (x64).
+Future Flutter releases will require Apple Silicon.
+For details, check out the
+[macOS Intel deprecation strategy](https://docs.google.com/document/d/1ty3js_Eg2sNIbDuyYS_aV7h4jYdx1hEpX_mV135gO4s/edit?tab=t.0#heading=h.cx7d8y57ce6p).
+:::
+
+</div>
+
  1. <h3>Install the Xcode command-line tools</h3>
 
     Download the Xcode command-line tools to get access to

--- a/sites/docs/src/content/reference/supported-platforms.md
+++ b/sites/docs/src/content/reference/supported-platforms.md
@@ -44,6 +44,17 @@ Flutter supports deploying to the following platforms.
 
 ## Desktop platforms
 
+:::warning
+**macOS Intel (x64) Deprecation:**
+As Apple phases out Intel-based Macs,
+Flutter is phasing out support for Intel (x64) hardware.
+For details on the timeline and impact,
+check out the [macOS Intel deprecation strategy](https://docs.google.com/document/d/1ty3js_Eg2sNIbDuyYS_aV7h4jYdx1hEpX_mV135gO4s/edit?tab=t.0#heading=h.cx7d8y57ce6p).
+
+If you cannot migrate to an Apple Silicon Mac,
+you can continue using older Flutter releases from the [SDK archive](/install/archive).
+:::
+
 <PlatformsGrid>
   <PlatformCard
     name="Windows"


### PR DESCRIPTION
This adds note banners to the installation guides and supported platforms page to warn users that support for Intel-based Macs is being phased out, and points them to alternatives (Apple Silicon or older releases).

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
