### PR TITLE
docs(web): add Wasm compile error and migration guide

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -920,6 +920,7 @@
       { "source": "/to/use-mirror-site", "destination": "/community/china#configure-your-machine-to-use-a-mirror-site", "type": 301 },
       { "source": "/to/use-profile-mode", "destination": "/perf/ui-performance#run-in-profile-mode", "type": 301 },
       { "source": "/to/wasm", "destination": "/platform-integration/web/wasm", "type": 301 },
+      { "source": "/to/wasm-errors", "destination": "/platform-integration/web/wasm#diagnosing-wasm-compilation-errors", "type": 301 },
       { "source": "/to/web-bootstrapping", "destination": "/platform-integration/web/initialization", "type": 301 },
       { "source": "/to/web-html-renderer-deprecation", "destination": "https://github.com/flutter/flutter/issues/145954", "type": 301 },
       { "source": "/to/web-images", "destination": "/platform-integration/web/web-images", "type": 301 },

--- a/sites/docs/src/content/platform-integration/web/building.md
+++ b/sites/docs/src/content/platform-integration/web/building.md
@@ -158,6 +158,9 @@ To learn more about how to deploy these assets to the web,
 visit [Build and release a web app][].
 For answers to other common questions, visit the [Web FAQ][].
 
+If you encounter errors when compiling your app with Wasm, check out
+[Diagnosing Wasm compilation errors](/platform-integration/web/wasm#diagnosing-wasm-compilation-errors).
+
 ## Debugging
 
 Use [Flutter DevTools][] for the following tasks:

--- a/sites/docs/src/content/platform-integration/web/faq.md
+++ b/sites/docs/src/content/platform-integration/web/faq.md
@@ -105,8 +105,8 @@ which are not supported on Wasm):
 
 ```dart
 import 'fallback.dart'
-  if (dart.library.js_interop) 'wasm_web_interop.dart'
-  if (dart.library.js) 'legacy_web_interop.dart';
+  if (dart.library.js) 'legacy_web_interop.dart'
+  if (dart.library.js_interop) 'wasm_web_interop.dart';
 ```
 
 For more details, see the [documentation for conditional imports][]

--- a/sites/docs/src/content/platform-integration/web/faq.md
+++ b/sites/docs/src/content/platform-integration/web/faq.md
@@ -111,7 +111,7 @@ import 'fallback.dart'
 
 For more details, see the [documentation for conditional imports][]
 on [dart.dev]({{site.dart-site}}). For help dealing with Wasm compilation
-failures due to unsupported imports, see
+failures due to unsupported imports, check out
 [Diagnosing Wasm compilation errors](/platform-integration/web/wasm#diagnosing-wasm-compilation-errors).
 
 ### Does Flutter web support concurrency?

--- a/sites/docs/src/content/platform-integration/web/faq.md
+++ b/sites/docs/src/content/platform-integration/web/faq.md
@@ -110,7 +110,9 @@ import 'fallback.dart'
 ```
 
 For more details, see the [documentation for conditional imports][]
-on [dart.dev]({{site.dart-site}}).
+on [dart.dev]({{site.dart-site}}). For help dealing with Wasm compilation
+failures due to unsupported imports, see
+[Diagnosing Wasm compilation errors](/platform-integration/web/wasm#diagnosing-wasm-compilation-errors).
 
 ### Does Flutter web support concurrency?
 

--- a/sites/docs/src/content/platform-integration/web/wasm.md
+++ b/sites/docs/src/content/platform-integration/web/wasm.md
@@ -202,7 +202,7 @@ tree, but this output can be buried in a long terminal exception stack trace.
 
 #### 1. Perform early detection
 
-You can detect incompatibilities early via dry-run warnings. When you run
+You can detect incompatibilities early with dry-run warnings. When you run
 `flutter build web` without the `--wasm` flag, a Wasm dry run is still performed
 automatically. If incompatibilities are found, you will see a non-fatal warning
 like this:

--- a/sites/docs/src/content/platform-integration/web/wasm.md
+++ b/sites/docs/src/content/platform-integration/web/wasm.md
@@ -241,14 +241,21 @@ packages to modern WebAssembly-compatible alternatives:
 - Replace `dart:html` and other legacy web libraries with [`package:web`][].
 - Replace `dart:js` and `package:js` with [`dart:js_interop`][].
 
+For comprehensive migration instructions, check out the
+[`package:web` migration guide on dart.dev]({{site.dart-site}}/interop/js-interop/package-web)
+and Dart's [JS interop usage guide]({{site.dart-site}}/interop/js-interop).
+
 If you need to support both legacy and modern environments during your
 migration, use conditional imports by checking for `dart.library.js_interop`:
 
 ```dart
 import 'fallback.dart'
-  if (dart.library.js_interop) 'wasm_web_interop.dart'
-  if (dart.library.js) 'legacy_web_interop.dart';
+  if (dart.library.js) 'legacy_web_interop.dart'
+  if (dart.library.js_interop) 'wasm_web_interop.dart';
 ```
+
+To learn more about selecting implementations at compile time, see the
+[conditional imports documentation on dart.dev]({{site.dart-site}}/interop/js-interop/package-web#conditional-imports).
 
 [`package:url_launcher`]: {{site.pub-pkg}}/url_launcher
 [`package:web` migration guide]: {{site.dart-site}}/interop/js-interop/package-web

--- a/sites/docs/src/content/platform-integration/web/wasm.md
+++ b/sites/docs/src/content/platform-integration/web/wasm.md
@@ -228,7 +228,7 @@ Context: The unavailable library 'dart:html' is imported through these packages:
 
     main.dart => package:my_app => dart:html
 
-Detailed import paths for (some of) the these imports:
+Detailed import paths for (some of) these imports:
 
     main.dart => package:my_app/main.dart => dart:html
 ```

--- a/sites/docs/src/content/platform-integration/web/wasm.md
+++ b/sites/docs/src/content/platform-integration/web/wasm.md
@@ -191,6 +191,65 @@ and the [package:web Zones section]({{site.dart-site}}/interop/js-interop/packag
 To learn more about JS interop in Dart,
 see Dart's [JS interop][] documentation page.
 
+### Diagnosing Wasm compilation errors {:#diagnosing-wasm-compilation-errors}
+
+When compiling a Flutter web project with `--wasm`, if your application or its
+packages import unsupported web APIs (such as `dart:html` or `package:js`),
+the compilation will fail. 
+
+By default, the Dart Wasm compiler emits a clean, structured dependency chain
+tree, but this output can be buried in a long terminal exception stack trace.
+
+#### 1. Perform early detection
+
+You can detect incompatibilities early via dry-run warnings. When you run
+`flutter build web` without the `--wasm` flag, a Wasm dry run is still performed
+automatically. If incompatibilities are found, you will see a non-fatal warning
+like this:
+
+```console
+Wasm dry run failed:
+Found incompatibilities with WebAssembly.
+
+package:my_app/main.dart 1:1 - dart:html unsupported (0)
+```
+
+#### 2. Isolate the compiler dependency tree
+
+If you run `flutter build web --wasm` and it fails, `flutter_tools` outputs
+a large exception stack trace (for example, `Target dart2wasm failed...`). 
+
+**Ignore the long stack trace and command string.** Instead, scroll up to the
+top of the error output to find the structured `Context` tree. This clean tree
+tells you exactly which package and file imported the unsupported library:
+
+```console
+Context: The unavailable library 'dart:html' is imported through these packages:
+
+    main.dart => package:my_app => dart:html
+
+Detailed import paths for (some of) the these imports:
+
+    main.dart => package:my_app/main.dart => dart:html
+```
+
+#### 3. Migrate legacy imports
+
+To fix these compilation errors, you must migrate from legacy JS interop
+packages to modern WebAssembly-compatible alternatives:
+
+- Replace `dart:html` and other legacy web libraries with [`package:web`][].
+- Replace `dart:js` and `package:js` with [`dart:js_interop`][].
+
+If you need to support both legacy and modern environments during your
+migration, use conditional imports by checking for `dart.library.js_interop`:
+
+```dart
+import 'fallback.dart'
+  if (dart.library.js_interop) 'wasm_web_interop.dart'
+  if (dart.library.js) 'legacy_web_interop.dart';
+```
+
 [`package:url_launcher`]: {{site.pub-pkg}}/url_launcher
 [`package:web` migration guide]: {{site.dart-site}}/interop/js-interop/package-web
 [JS interop]: {{site.dart-site}}/interop/js-interop


### PR DESCRIPTION
Add step-by-step guidance for developers encountering compile-time failures when targeting WebAssembly during Flutter web builds.

* Explains how to leverage dry-run warnings from `flutter build web` for early detection.
* Instructs developers on isolating the structured dependency import chain tree from verbose exception stack traces during `--wasm` builds.
* Documents migration strategies from legacy libraries (`dart:html`, `package:js`) to `package:web` and `dart:js_interop` via conditional imports.
* Cross-links compilation error troubleshooting in FAQ and web building guides.
