### PR TITLE
docs: add previous versions guidance to supported platforms page

### DIFF
--- a/sites/docs/src/content/reference/supported-platforms.md
+++ b/sites/docs/src/content/reference/supported-platforms.md
@@ -129,3 +129,17 @@ Flutter supports deploying to the following platforms.
     deploy-to-link="/deployment/web"
   />
 </PlatformsGrid>
+
+## Previous Flutter versions
+
+For more information about support for previous versions of Flutter,
+see the following resources:
+
+*   [Flutter SDK release notes][].
+    Find breaking changes and support updates listed by release.
+*   [Supported platforms page history][supported-platforms-history].
+    To see historical support matrices,
+    view previous versions of this page.
+
+[Flutter SDK release notes]: /release/release-notes
+[supported-platforms-history]: {{site.repo.this}}/commits/main/sites/docs/src/content/reference/supported-platforms.md

--- a/sites/docs/src/content/reference/supported-platforms.md
+++ b/sites/docs/src/content/reference/supported-platforms.md
@@ -132,7 +132,7 @@ Flutter supports deploying to the following platforms.
 
 ## Previous Flutter versions
 
-For more information about support for previous versions of Flutter,
+To learn about support for previous versions of Flutter,
 see the following resources:
 
 *   [Flutter SDK release notes][].


### PR DESCRIPTION
Added a "Previous Flutter versions" section guiding users on how to check historical platform support matrices via GitHub page history and SDK release notes

Issues fixed by this PR (if any): https://github.com/flutter/website/issues/12970

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
