### PR TITLE
docs: update iOS universal links AASA file example to use components

### DIFF
--- a/sites/docs/src/content/cookbook/navigation/set-up-universal-links.md
+++ b/sites/docs/src/content/cookbook/navigation/set-up-universal-links.md
@@ -204,14 +204,10 @@ this file should resemble the following content:
 ```json
 {
   "applinks": {
-    "apps": [],
     "details": [
       {
         "appIDs": [
           "S8QB4VV633.com.example.deeplinkCookbook"
-        ],
-        "paths": [
-          "*"
         ],
         "components": [
           {
@@ -220,11 +216,6 @@ this file should resemble the following content:
         ]
       }
     ]
-  },
-  "webcredentials": {
-    "apps": [
-      "S8QB4VV633.com.example.deeplinkCookbook"
-    ]
   }
 }
 ```
@@ -232,11 +223,11 @@ this file should resemble the following content:
 1. Set one value in the `appIDs` array to
    `<team id>.<bundle id>`.
 
-1. Set the `paths` array to `["*"]`.
-   The `paths` array specifies the allowed universal links.
-   Using the asterisk, `*` redirects every path to the Flutter app.
-   If needed, change the `paths` array value to a setting more
-   appropriate to your app.
+1. Set the `components` array to specify the allowed paths.
+   In this example, the `/` key represents the URL path.
+   The value `/*` matches and redirects any path to the Flutter app.
+   If needed, customize the `components` array
+   to match only the paths appropriate for your app.
 
 1. Host the file at a URL that resembles the following structure.
 


### PR DESCRIPTION
Updated the apple-app-site-association JSON example to use the modern components key instead of the deprecated paths key, aligning with Apple's requirements for iOS 13+

https://github.com/flutter/website/issues/12362


## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
