### PR TITLE
[docs] Remove outdated minSdk instructions from Android platform views (#13672)

### DIFF
--- a/sites/docs/src/content/platform-integration/android/platform-views.md
+++ b/sites/docs/src/content/platform-integration/android/platform-views.md
@@ -482,18 +482,6 @@ For more information, visit the API docs for:
 [`PlatformViewFactory`]: {{site.api}}/javadoc/io/flutter/plugin/platform/PlatformViewFactory.html
 [`PlatformViewRegistry`]: {{site.api}}/javadoc/io/flutter/plugin/platform/PlatformViewRegistry.html
 
-Finally, modify your `build.gradle` file
-to require one of the minimal Android SDK versions:
-
-```kotlin
-android {
-    defaultConfig {
-        minSdk = 19 // if using hybrid composition
-        minSdk = 20 // if using virtual display.
-    }
-}
-```
-
 ### Manual view invalidation
 
 Certain Android Views don't invalidate themselves when their content changes.


### PR DESCRIPTION
Removes outdated `build.gradle` instructions in Android Platform Views documentation that advised manually setting `minSdk = 19` (for hybrid composition) or `minSdk = 20` (for virtual display). Since Flutter\'s default Android minimum SDK (`flutter.minSdkVersion`) is API 24, these overrides are no longer needed or recommended.

Fixes #13672