### PR TITLE
docs: update android buildTypes example in flavors guide

### DIFF
--- a/sites/docs/src/content/deployment/flavors.md
+++ b/sites/docs/src/content/deployment/flavors.md
@@ -79,18 +79,20 @@ to make sure that the flavors work as expected.
     * In the `flavors_example` project, navigate to the
       `android/app/` directory and open `build.gradle.kts`.
 
-    * Add the `flavorsDimension` property and the
-      `productFlavors` properties inside of the
-      `android {} block`. Make sure that the `android {}`
-      block also contains the default
-      `debug` and `release` build types:
+    * Add the `flavorDimensions` property and the
+      `productFlavors` properties inside the
+      `android {}` block. The default template explicitly defines
+      the `release` build type, while the `debug` build type is implicit:
 
       ```kotlin title="build.gradle.kts"
       android {
           ...
           buildTypes {
-            getByName("debug") {...}
-            getByName("release") {...}
+              release {
+                  // TODO: Add your own signing config for the release build.
+                  // Signing with the debug keys for now, so `flutter run --release` works.
+                  signingConfig = signingConfigs.getByName("debug")
+              }
           }
           ...
           flavorDimensions += "default"


### PR DESCRIPTION
Updated the build.gradle.kts snippet to reflect that the default Flutter template only explicitly configures the release build type, leaving debug as implicit

https://github.com/flutter/website/issues/12205

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
