### PR TITLE
docs: update predictive back guide to reflect default behavior

### DIFF
--- a/sites/docs/src/content/platform-integration/android/predictive-back.md
+++ b/sites/docs/src/content/platform-integration/android/predictive-back.md
@@ -1,6 +1,6 @@
 ---
-title: Add the predictive-back gesture
-shortTitle: Predictive-back
+title: Add the predictive back gesture
+shortTitle: Predictive back
 description: >-
   Learn how to enable and handle Android predictive back gestures in Flutter.
 ---
@@ -12,8 +12,9 @@ before they commit to or cancel it.
 
 ## Overview
 
-Starting with Android 14 (API level 34), predictive back animations are
-enabled by default for system gestures when supported by the application.
+Starting with Android 14 (API level 34),
+predictive back animations are enabled by default for system gestures
+when supported by the application.
 Flutter provides built-in support for predictive back animations across
 default page route transitions and custom pop handling.
 
@@ -23,8 +24,9 @@ To support predictive back gestures in your Flutter app
 on Android 13 or later:
 
 1. Open `android/app/src/main/AndroidManifest.xml`.
-2. Add `android:enableOnBackInvokedCallback="true"` to the `<application>` tag:
+1. Add `android:enableOnBackInvokedCallback="true"` to the `<application>` tag:
 
+```xml
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
         android:label="my_app"
@@ -38,10 +40,11 @@ on Android 13 or later:
 
 ## Handle back gestures with PopScope
 
-To customize back navigation or prevent users from accidentally leaving a
-screen, use the [`PopScope`]({{site.api}}/flutter/widgets/PopScope-class.html)
-widget. `PopScope` replaces the deprecated `WillPopScope` widget and
-supports predictive back gestures.
+To customize back navigation or prevent users
+from accidentally leaving a screen,
+use the [`PopScope`][] widget.
+`PopScope` replaces the deprecated `WillPopScope` widget
+and supports predictive back gestures.
 
 ### Callback parameters
 
@@ -75,7 +78,9 @@ PopScope(
 
 ## More information
 
-For more details on API migrations, check out the
-[Android predictive back migration guide](
-/release/breaking-changes/android-predictive-back).
+For more details on API migrations,
+see the [Android predictive back migration guide][].
+
+[`PopScope`]: {{site.api}}/flutter/widgets/PopScope-class.html
+[Android predictive back migration guide]: /release/breaking-changes/android-predictive-back
 

--- a/sites/docs/src/content/platform-integration/android/predictive-back.md
+++ b/sites/docs/src/content/platform-integration/android/predictive-back.md
@@ -1,61 +1,49 @@
 ---
-title: Add the predictive-back gesture
-shortTitle: Predictive-back
+title: Add the predictive back gesture
+shortTitle: Predictive back
 description: >-
-  Learn how to add the predictive back gesture to your Android app.
+  Learn how to support the predictive back gesture in your Android app.
 ---
 
-This feature has landed in Flutter,
-but it's not enabled by default in Android itself yet.
-You can try it out using the following instructions.
+Flutter supports the predictive back gesture on Android by default.
+However, to opt in to the platform feature,
+you must configure your Android app.
 
 ## Configure your app
 
-Make sure your app supports Android API 33 or higher,
-as predictive back won't work on older versions of Android.
-Then, set the flag `android:enableOnBackInvokedCallback="true"`
-in `android/app/src/main/AndroidManifest.xml`.
+To support the predictive back gesture,
+your app must target Android API level 33 (Android 13) or higher.
+
+To opt in, add the `android:enableOnBackInvokedCallback="true"` attribute
+to the `<application>` tag
+in your `android/app/src/main/AndroidManifest.xml` file:
+
+```xml
+<application
+    ...
+    android:enableOnBackInvokedCallback="true">
+</application>
+```
 
 ## Configure your device
 
-You need to enable Developer Mode and set a flag on your device,
-so you can't yet expect predictive back to work on most users'
-Android devices. If you want to try it out on your own device though,
-make sure it's running API 33 or higher, and then in
-**Settings => System => Developer** options,
-make sure the switch is enabled next to **Predictive back animations**.
+Depending on the Android version of your test device,
+you might need to enable the gesture in the system settings:
 
-## Set up your app
-
-The predictive back route transitions are currently
-not enabled by default, so for now you'll need to enable them
-manually in your app.
-Typically, you do this by setting them in your theme:
-
-```dart
-MaterialApp(
-  theme: ThemeData(
-    pageTransitionsTheme: const PageTransitionsTheme(
-      builders: <TargetPlatform, PageTransitionsBuilder>{
-        // Set the predictive back transitions for Android.
-        TargetPlatform.android: PredictiveBackPageTransitionsBuilder(),
-      },
-    ),
-  ),
-  ...
-),
-```
+*   **Android 13 (API level 33):**
+    Enable **Predictive back animations** under
+    **Settings** > **System** > **Developer options**.
+*   **Android 14 (API level 34) and higher:**
+    The gesture and its animations are enabled by default.
 
 ## Run your app
 
-Lastly, just make sure you're using at least
-Flutter version 3.22.2 to run your app,
-which is the latest stable release at the time of this writing.
+To run your app with predictive back support,
+use Flutter 3.38 or higher.
 
-## For more information
+## See also
 
-You can find more information at the following link:
-
-* [Android predictive back][] breaking change
+For details,
+see [Android predictive back][].
 
 [Android predictive back]: /release/breaking-changes/android-predictive-back


### PR DESCRIPTION
Rewrote the page to reflect that predictive back is now enabled by default in Flutter, removing instructions for manual app-level transitions setup

https://github.com/flutter/website/issues/12201

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
