### PR TITLE
[docs] Remove outdated minSdkVersion instructions from camera cookbook recipe (#13672)

### DIFF
--- a/sites/docs/src/content/cookbook/plugins/picture-using-camera.md
+++ b/sites/docs/src/content/cookbook/plugins/picture-using-camera.md
@@ -59,16 +59,15 @@ $ flutter pub add camera path_provider path
 ```
 
 :::tip
-- For android, You must update `minSdkVersion` to 21 (or higher).
-- On iOS, the following lines must be added inside
-  `ios/Runner/Info.plist` to the access the camera and microphone.
+On iOS, the following lines must be added inside
+`ios/Runner/Info.plist` to access the camera and microphone:
 
-  ```xml
-  <key>NSCameraUsageDescription</key>
-  <string>Explanation on why the camera access is needed.</string>
-  <key>NSMicrophoneUsageDescription</key>
-  <string>Explanation on why the microphone access is needed.</string>
-  ```
+```xml
+<key>NSCameraUsageDescription</key>
+<string>Explanation on why the camera access is needed.</string>
+<key>NSMicrophoneUsageDescription</key>
+<string>Explanation on why the microphone access is needed.</string>
+```
 :::
 
 ## 2. Get a list of the available cameras


### PR DESCRIPTION
Removes outdated instructions in the "Take a picture using the camera" cookbook recipe that advised updating Android `minSdkVersion` to 21 (or higher). Since Flutter\'s default Android minimum SDK (`flutter.minSdkVersion`) is API 24, this instruction is no longer needed. Also reformats the remaining iOS tip callout.

Closes https://github.com/flutter/website/issues/13672