### PR TITLE
docs(ai): wrap agent skills installation tabs

### DIFF
--- a/sites/docs/src/content/ai/agent-skills.md
+++ b/sites/docs/src/content/ai/agent-skills.md
@@ -54,7 +54,7 @@ tailored specifically for our frameworks.
 Select your AI coding agent below for instructions on how to install the official
 Flutter and Dart agent skills.
 
-<Tabs key="ai-client-tabs">
+<Tabs key="ai-client-tabs" wrapped="true">
 <Tab name="Claude Code">
 
 If you use Claude Code, install the official Flutter plugin.


### PR DESCRIPTION
Adds wrapped="true" to the installation tabs on the agent skills page to improve visual grouping.

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
