### PR TITLE
docs: recommend Homebrew for CocoaPods installation

### DIFF
--- a/sites/docs/src/content/platform-integration/ios/setup.md
+++ b/sites/docs/src/content/platform-integration/ios/setup.md
@@ -44,7 +44,7 @@ an iOS physical device or on the iOS Simulator.
     ```
 
     If you downloaded Xcode elsewhere or need to use a different version,
-    replace `/Applications/Xcode.app` with the path to there instead.
+    replace `/Applications/Xcode.app` with the path to your Xcode installation.
 
  1. <h3>Agree to the Xcode licenses</h3>
 
@@ -138,7 +138,7 @@ Set up each iOS device on which you want to test.
 
        ![Trust Mac](/assets/images/docs/setup/trust-computer.png)
 
- 1. <h3>Configure your physical iOS device</h3>
+ 1. <h3>Enable Developer Mode</h3>
 
     Apple requires enabling **[Developer Mode][]**
     on the device to protect against malicious software.
@@ -181,7 +181,7 @@ Set up each iOS device on which you want to test.
 
     :::note Apple Developer program
     When you want to _deploy_ your app to the App Store,
-    you'll need to upgrade your personal Apple Developer account to
+    you must upgrade your personal Apple Developer account to
     a professional account.
     :::
 

--- a/sites/docs/src/content/platform-integration/ios/setup.md
+++ b/sites/docs/src/content/platform-integration/ios/setup.md
@@ -79,20 +79,16 @@ an iOS physical device or on the iOS Simulator.
     To support [Flutter plugins][] that use native iOS or macOS code,
     install the latest version of [CocoaPods][].
 
-    Install CocoaPods using [Homebrew][] by running the following command:
+    Install CocoaPods by following the
+    [CocoaPods installation guide][].
 
-    ```console
-    $ brew install cocoapods
-    ```
-
-    To learn about other installation methods,
-    see the [CocoaPods installation guide][].
+    If you've already installed CocoaPods,
+    update it by following the [CocoaPods update guide][].
 
 {: .steps}
 
 [xcode]: {{site.apple-dev}}/xcode/
 [cocoapods]: https://guides.cocoapods.org/using/getting-started.html#installation
-[Homebrew]: https://brew.sh/
 [Flutter plugins]: /packages-and-plugins/developing-packages#types
 [CocoaPods installation guide]: https://guides.cocoapods.org/using/getting-started.html#installation
 [CocoaPods update guide]: https://guides.cocoapods.org/using/getting-started.html#updating-cocoapods

--- a/sites/docs/src/content/platform-integration/ios/setup.md
+++ b/sites/docs/src/content/platform-integration/ios/setup.md
@@ -79,8 +79,7 @@ an iOS physical device or on the iOS Simulator.
     To support [Flutter plugins][] that use native iOS or macOS code,
     install the latest version of [CocoaPods][].
 
-    We recommend using [Homebrew][] to install CocoaPods.
-    Run the following command:
+    Install CocoaPods using [Homebrew][] by running the following command:
 
     ```console
     $ brew install cocoapods

--- a/sites/docs/src/content/platform-integration/ios/setup.md
+++ b/sites/docs/src/content/platform-integration/ios/setup.md
@@ -79,16 +79,21 @@ an iOS physical device or on the iOS Simulator.
     To support [Flutter plugins][] that use native iOS or macOS code,
     install the latest version of [CocoaPods][].
 
-    Install CocoaPods by following the
-    [CocoaPods installation guide][].
+    We recommend using [Homebrew][] to install CocoaPods.
+    Run the following command:
 
-    If you've already installed CocoaPods,
-    update it by following the [CocoaPods update guide][].
+    ```console
+    $ brew install cocoapods
+    ```
+
+    To learn about other installation methods,
+    see the [CocoaPods installation guide][].
 
 {: .steps}
 
 [xcode]: {{site.apple-dev}}/xcode/
 [cocoapods]: https://guides.cocoapods.org/using/getting-started.html#installation
+[Homebrew]: https://brew.sh/
 [Flutter plugins]: /packages-and-plugins/developing-packages#types
 [CocoaPods installation guide]: https://guides.cocoapods.org/using/getting-started.html#installation
 [CocoaPods update guide]: https://guides.cocoapods.org/using/getting-started.html#updating-cocoapods

--- a/sites/docs/src/content/platform-integration/macos/setup.md
+++ b/sites/docs/src/content/platform-integration/macos/setup.md
@@ -44,7 +44,7 @@ compile and debug native Swift and Objective-C code.
     ```
 
     If you downloaded Xcode elsewhere or need to use a different version,
-    replace `/Applications/Xcode.app` with the path to there instead.
+    replace `/Applications/Xcode.app` with the path to your Xcode directory.
 
  1. <h3>Agree to the Xcode licenses</h3>
 

--- a/sites/docs/src/content/platform-integration/macos/setup.md
+++ b/sites/docs/src/content/platform-integration/macos/setup.md
@@ -72,21 +72,17 @@ compile and debug native Swift and Objective-C code.
     To support [Flutter plugins][] that use native macOS code,
     install the latest version of [CocoaPods][].
 
-    Install CocoaPods using [Homebrew][] by running the following command:
+    Install CocoaPods following the
+    [CocoaPods installation guide][].
 
-    ```console
-    $ brew install cocoapods
-    ```
-
-    To learn about other installation methods,
-    see the [CocoaPods installation guide][].
+    If you've already installed CocoaPods,
+    update it following the [CocoaPods update guide][].
 
 {: .steps}
 
 [xcode]: {{site.apple-dev}}/xcode/
 [Flutter plugins]: /packages-and-plugins/developing-packages#types
 [CocoaPods]: https://cocoapods.org/
-[Homebrew]: https://brew.sh/
 [CocoaPods installation guide]: https://guides.cocoapods.org/using/getting-started.html#installation
 [CocoaPods update guide]: https://guides.cocoapods.org/using/getting-started.html#updating-cocoapods
 

--- a/sites/docs/src/content/platform-integration/macos/setup.md
+++ b/sites/docs/src/content/platform-integration/macos/setup.md
@@ -72,8 +72,7 @@ compile and debug native Swift and Objective-C code.
     To support [Flutter plugins][] that use native macOS code,
     install the latest version of [CocoaPods][].
 
-    We recommend using [Homebrew][] to install CocoaPods.
-    Run the following command:
+    Install CocoaPods using [Homebrew][] by running the following command:
 
     ```console
     $ brew install cocoapods

--- a/sites/docs/src/content/platform-integration/macos/setup.md
+++ b/sites/docs/src/content/platform-integration/macos/setup.md
@@ -72,17 +72,22 @@ compile and debug native Swift and Objective-C code.
     To support [Flutter plugins][] that use native macOS code,
     install the latest version of [CocoaPods][].
 
-    Install CocoaPods following the
-    [CocoaPods installation guide][].
+    We recommend using [Homebrew][] to install CocoaPods.
+    Run the following command:
 
-    If you've already installed CocoaPods,
-    update it following the [CocoaPods update guide][].
+    ```console
+    $ brew install cocoapods
+    ```
+
+    To learn about other installation methods,
+    see the [CocoaPods installation guide][].
 
 {: .steps}
 
 [xcode]: {{site.apple-dev}}/xcode/
 [Flutter plugins]: /packages-and-plugins/developing-packages#types
 [CocoaPods]: https://cocoapods.org/
+[Homebrew]: https://brew.sh/
 [CocoaPods installation guide]: https://guides.cocoapods.org/using/getting-started.html#installation
 [CocoaPods update guide]: https://guides.cocoapods.org/using/getting-started.html#updating-cocoapods
 


### PR DESCRIPTION
Updates macOS and iOS setup guides to recommend installing CocoaPods via Homebrew to avoid Ruby permission errors. Applies style fixes for active voice and heading clarity.

Resolves https://github.com/flutter/website/issues/12446
