### PR TITLE
Post-decoupling internationalization

### DIFF
--- a/examples/internationalization/gen_l10n_example/lib/examples.dart
+++ b/examples/internationalization/gen_l10n_example/lib/examples.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: unused_local_variable
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'l10n/app_localizations.dart';
 

--- a/examples/internationalization/gen_l10n_example/lib/main.dart
+++ b/examples/internationalization/gen_l10n_example/lib/main.dart
@@ -1,5 +1,10 @@
 import 'package:flutter/material.dart';
 
+// #docregion localization-delegates-import
+import 'package:flutter_localizations/flutter_localizations.dart'
+    as flutter_localizations;
+// #enddocregion localization-delegates-import
+
 // #docregion app-localizations-import
 import 'l10n/app_localizations.dart';
 

--- a/examples/internationalization/gen_l10n_example/lib/main.dart
+++ b/examples/internationalization/gen_l10n_example/lib/main.dart
@@ -1,9 +1,5 @@
 import 'package:flutter/material.dart';
 
-// #docregion localization-delegates-import
-import 'package:flutter_localizations/flutter_localizations.dart';
-// #enddocregion localization-delegates-import
-
 // #docregion app-localizations-import
 import 'l10n/app_localizations.dart';
 
@@ -19,9 +15,7 @@ class MyApp extends StatelessWidget {
       title: 'Localizations Sample App',
       localizationsDelegates: [
         AppLocalizations.delegate, // Add this line
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
+        ...GlobalMaterialLocalizations.delegate,
       ],
       supportedLocales: [
         Locale('en'), // English

--- a/examples/internationalization/gen_l10n_example/lib/no_app_localizations.dart
+++ b/examples/internationalization/gen_l10n_example/lib/no_app_localizations.dart
@@ -1,14 +1,9 @@
 import 'package:material_ui/material_ui.dart';
 
-// #docregion localization-delegates-import
 import 'package:flutter_localizations/flutter_localizations.dart'
     as flutter_localizations;
-// #enddocregion localization-delegates-import
 
-// #docregion app-localizations-import
 import 'l10n/app_localizations.dart';
-
-// #enddocregion app-localizations-import
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
@@ -18,10 +13,7 @@ class MyApp extends StatelessWidget {
     // #docregion material-app
     return const MaterialApp(
       title: 'Localizations Sample App',
-      localizationsDelegates: [
-        AppLocalizations.delegate, // Add this line
-        ...GlobalMaterialLocalizations.delegate,
-      ],
+      localizationsDelegates: GlobalMaterialLocalizations.delegates,
       supportedLocales: [
         Locale('en'), // English
         Locale('es'), // Spanish
@@ -43,7 +35,6 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      // #docregion internationalized-title
       appBar: AppBar(
         // The [AppBar] title text should update its message
         // according to the system locale of the target platform.
@@ -51,7 +42,6 @@ class _MyHomePageState extends State<MyHomePage> {
         // cause this text to update.
         title: Text(AppLocalizations.of(context)!.helloWorld),
       ),
-      // #enddocregion internationalized-title
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -65,7 +55,6 @@ class _MyHomePageState extends State<MyHomePage> {
               // will pass the updated BuildContext to the new widget.
               child: Builder(
                 builder: (context) {
-                  // #docregion placeholder
                   // Examples of internationalized strings.
                   return Column(
                     children: <Widget>[
@@ -85,7 +74,6 @@ class _MyHomePageState extends State<MyHomePage> {
                       Text(AppLocalizations.of(context)!.pronoun('other')),
                     ],
                   );
-                  // #enddocregion placeholder
                 },
               ),
             ),

--- a/sites/docs/src/content/ui/internationalization/index.md
+++ b/sites/docs/src/content/ui/internationalization/index.md
@@ -57,6 +57,15 @@ in a directory of your choice with the `flutter create` command.
 $ flutter create <name_of_flutter_app>
 ```
 
+In the near future, Flutter projects will be encouraged to use the `material_ui`
+and `cupertino_ui` packages, but the `flutter create` command has not yet been
+updated to do this by default. You can get ahead of things and migrate now by
+running the following command:
+
+```console
+$ dart fix --apply --code=migrate_design_widgets
+```
+
 To use `flutter_localizations`, add the package as a dependency to your
 `pubspec.yaml` file, as well as the `intl` package:
 
@@ -87,13 +96,11 @@ import 'package:flutter_localizations/flutter_localizations.dart'
     as flutter_localizations;
 ```
 
-<?code-excerpt "gen_l10n_example/lib/main.dart (material-app)" remove="AppLocalizations.delegate"?>
+<?code-excerpt "gen_l10n_example/lib/no_app_localizations.dart (material-app)"?>
 ```dart
 return const MaterialApp(
   title: 'Localizations Sample App',
-  localizationsDelegates: [
-    ...GlobalMaterialLocalizations.delegate,
-  ],
+  localizationsDelegates: GlobalMaterialLocalizations.delegates,
   supportedLocales: [
     Locale('en'), // English
     Locale('es'), // Spanish
@@ -103,7 +110,7 @@ return const MaterialApp(
 ```
 
 After introducing the `flutter_localizations` package and adding the previous
-code, the `Material` and `Cupertino` packages should now be correctly localized
+code, the `Material` and `Cupertino` libraries should now be correctly localized
 in one of the supported locales. Widgets should be adapted to the localized
 messages, along with correct left-to-right or right-to-left layout.
 

--- a/sites/docs/src/content/ui/internationalization/index.md
+++ b/sites/docs/src/content/ui/internationalization/index.md
@@ -57,8 +57,35 @@ in a directory of your choice with the `flutter create` command.
 $ flutter create <name_of_flutter_app>
 ```
 
-Then specify `localizationsDelegates` and `supportedLocales` for your
-`MaterialApp` or `CupertinoApp`:
+To use `flutter_localizations`, add the package as a dependency to your
+`pubspec.yaml` file, as well as the `intl` package:
+
+```console
+$ flutter pub add flutter_localizations --sdk=flutter
+$ flutter pub add intl:any
+```
+
+This creates a `pubspec.yml` file with the following entries:
+
+<?code-excerpt "gen_l10n_example/pubspec.yaml (flutter-localizations)"?>
+```yaml
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  intl: any
+```
+
+Then import the `flutter_localizations` library and specify
+`localizationsDelegates` and `supportedLocales` for
+your `MaterialApp` or `CupertinoApp`:
+
+<?code-excerpt "gen_l10n_example/lib/main.dart (localization-delegates-import)"?>
+```dart
+import 'package:flutter_localizations/flutter_localizations.dart' as
+    flutter_localizations;
+```
 
 <?code-excerpt "gen_l10n_example/lib/main.dart (material-app)" remove="AppLocalizations.delegate"?>
 ```dart

--- a/sites/docs/src/content/ui/internationalization/index.md
+++ b/sites/docs/src/content/ui/internationalization/index.md
@@ -83,15 +83,17 @@ your `MaterialApp` or `CupertinoApp`:
 
 <?code-excerpt "gen_l10n_example/lib/main.dart (localization-delegates-import)"?>
 ```dart
-import 'package:flutter_localizations/flutter_localizations.dart' as
-    flutter_localizations;
+import 'package:flutter_localizations/flutter_localizations.dart'
+    as flutter_localizations;
 ```
 
 <?code-excerpt "gen_l10n_example/lib/main.dart (material-app)" remove="AppLocalizations.delegate"?>
 ```dart
 return const MaterialApp(
   title: 'Localizations Sample App',
-  localizationsDelegates: GlobalMaterialLocalizations.delegates,
+  localizationsDelegates: [
+    ...GlobalMaterialLocalizations.delegate,
+  ],
   supportedLocales: [
     Locale('en'), // English
     Locale('es'), // Spanish
@@ -281,8 +283,8 @@ dependencies:
    return const MaterialApp(
      title: 'Localizations Sample App',
      localizationsDelegates: [
-       AppLocalizations.delegate, // Add this delegate
-       ...GlobalMaterialLocalizations.delegates,
+       AppLocalizations.delegate, // Add this line
+       ...GlobalMaterialLocalizations.delegate,
      ],
      supportedLocales: [
        Locale('en'), // English
@@ -1148,7 +1150,8 @@ adds the `NnMaterialLocalizations` delegate instance to the app's
 ```dart
 const MaterialApp(
   localizationsDelegates: [
-    ...GlobalMaterialLocalizations.delegates,
+    GlobalWidgetsLocalizations.delegate,
+    GlobalMaterialLocalizations.delegate,
     NnMaterialLocalizations.delegate, // Add the newly created delegate
   ],
   supportedLocales: [Locale('en', 'US'), Locale('nn')],

--- a/sites/docs/src/content/ui/internationalization/index.md
+++ b/sites/docs/src/content/ui/internationalization/index.md
@@ -57,45 +57,14 @@ in a directory of your choice with the `flutter create` command.
 $ flutter create <name_of_flutter_app>
 ```
 
-To use `flutter_localizations`,
-add the package as a dependency to your `pubspec.yaml` file,
-as well as the `intl` package:
-
-```console
-$ flutter pub add flutter_localizations --sdk=flutter
-$ flutter pub add intl:any
-```
-
-This creates a `pubspec.yml` file with the following entries:
-
-<?code-excerpt "gen_l10n_example/pubspec.yaml (flutter-localizations)"?>
-```yaml
-dependencies:
-  flutter:
-    sdk: flutter
-  flutter_localizations:
-    sdk: flutter
-  intl: any
-```
-
-Then import the `flutter_localizations` library and specify
-`localizationsDelegates` and `supportedLocales` for
-your `MaterialApp` or `CupertinoApp`:
-
-<?code-excerpt "gen_l10n_example/lib/main.dart (localization-delegates-import)"?>
-```dart
-import 'package:flutter_localizations/flutter_localizations.dart';
-```
+Then specify `localizationsDelegates` and `supportedLocales` for your
+`MaterialApp` or `CupertinoApp`:
 
 <?code-excerpt "gen_l10n_example/lib/main.dart (material-app)" remove="AppLocalizations.delegate"?>
 ```dart
 return const MaterialApp(
   title: 'Localizations Sample App',
-  localizationsDelegates: [
-    GlobalMaterialLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-  ],
+  localizationsDelegates: GlobalMaterialLocalizations.delegates,
   supportedLocales: [
     Locale('en'), // English
     Locale('es'), // Spanish
@@ -104,19 +73,17 @@ return const MaterialApp(
 );
 ```
 
-After introducing the `flutter_localizations` package
-and adding the previous code,
-the `Material` and `Cupertino`
-packages should now be correctly localized in
-one of the supported locales.
-Widgets should be adapted to the localized messages,
-along with correct left-to-right or right-to-left layout.
+After introducing the `flutter_localizations` package and adding the previous
+code, the `Material` and `Cupertino` packages should now be correctly localized
+in one of the supported locales. Widgets should be adapted to the localized
+messages, along with correct left-to-right or right-to-left layout.
 
 Try switching the target platform's locale to
 Spanish (`es`) and the messages should be localized.
 
-Apps based on `WidgetsApp` are similar except that the
-`GlobalMaterialLocalizations.delegate` isn't needed.
+Apps that are not based on `MaterialApp` should instead use
+`GlobalCupertinoLocalizations.delegates` or
+`flutter_localizations.GlobalWidgetsLocalizations.delegate`.
 
 The full `Locale.fromSubtags` constructor is preferred
 as it supports [`scriptCode`][], though the `Locale` default
@@ -128,7 +95,7 @@ The elements of the `localizationsDelegates` list are
 factories that produce collections of localized values.
 `GlobalMaterialLocalizations.delegate` provides localized
 strings and other values for the Material Components
-library. `GlobalWidgetsLocalizations.delegate`
+library. `flutter_localizations.GlobalWidgetsLocalizations.delegate`
 defines the default text direction,
 either left-to-right or right-to-left, for the widgets library.
 
@@ -190,18 +157,29 @@ widget should re-render in Spanish.
 
 <a id="adding-localized-messages"></a>
 ### Adding your own localized messages
-
-After adding the `flutter_localizations` package,
-you can configure localization.
 To add localized text to your application,
 complete the following instructions:
 
-1. Add the `intl` package as a dependency, pulling
-   in the version pinned by `flutter_localizations`:
+1. Add the package `flutter_localizations` as a dependency to your
+   `pubspec.yaml` file, as well as the `intl` package, at the version pinned by
+   `flutter_localizations`:
 
-   ```console
-   $ flutter pub add intl:any
-   ```
+```console
+$ flutter pub add flutter_localizations --sdk=flutter
+$ flutter pub add intl:any
+```
+
+This creates the following entries in the `pubspec.yml` file:
+
+<?code-excerpt "gen_l10n_example/pubspec.yaml (flutter-localizations)"?>
+```yaml
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  intl: any
+```
 
 2. Open the `pubspec.yaml` file and enable the `generate` flag.
    This flag is found in the `flutter` section in the pubspec file.
@@ -276,10 +254,8 @@ complete the following instructions:
    return const MaterialApp(
      title: 'Localizations Sample App',
      localizationsDelegates: [
-       AppLocalizations.delegate, // Add this line
-       GlobalMaterialLocalizations.delegate,
-       GlobalWidgetsLocalizations.delegate,
-       GlobalCupertinoLocalizations.delegate,
+       AppLocalizations.delegate, // Add this delegate
+       ...GlobalMaterialLocalizations.delegates,
      ],
      supportedLocales: [
        Locale('en'), // English
@@ -1145,8 +1121,7 @@ adds the `NnMaterialLocalizations` delegate instance to the app's
 ```dart
 const MaterialApp(
   localizationsDelegates: [
-    GlobalWidgetsLocalizations.delegate,
-    GlobalMaterialLocalizations.delegate,
+    ...GlobalMaterialLocalizations.delegates,
     NnMaterialLocalizations.delegate, // Add the newly created delegate
   ],
   supportedLocales: [Locale('en', 'US'), Locale('nn')],


### PR DESCRIPTION
In a post-decoupling world, we recommend that instead of doing i18n like this:

```dart
  localizationsDelegates: [
    GlobalMaterialLocalizations.delegate,
    GlobalWidgetsLocalizations.delegate,
    GlobalCupertinoLocalizations.delegate,
  ],
```

They should instead do this:

```dart
localizationDelegates: GlobalMaterialLocalizations.delegates,
```

This is functionally the same thing! See the [docs](https://main-api.flutter.dev/flutter/flutter_localizations/GlobalMaterialLocalizations/delegates-constant.html). The difference is that currently, flutter_localizations's GlobalMaterialLocalizations and GlobalCupertinoLocalizations reference flutter/flutter's Material and Cupertino, which can cause an error if your app is using material_ui and/or cupertino_ui.

By avoiding the GlobalMaterialLocalizations and GlobalCupertinoLocalizations in flutter_localizations, we avoid this problem for users that have migrated, and for those that have not yet, everything still works exactly as before.

_Issues fixed by this PR (if any):_ None

_PRs or commits this PR depends on (if any):_ None

## Presubmit checklist

- [X] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [X] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
