### PR TITLE
Remove video link from We Spot Turtles showcase

### DIFF
--- a/sites/www/content/showcase/we-spot-turtles.md
+++ b/sites/www/content/showcase/we-spot-turtles.md
@@ -11,7 +11,6 @@ appName: "We Spot Turtles!"
 companyName: "We Spot Turtles!"
 logo: "images/third_party/case_studies/we-spot-turtles/logo.webp"
 card: "images/third_party/case_studies/we-spot-turtles/case_study_card.webp"
-videoEmbedUrl: "https://www.youtube.com/embed/CfzhLOiczDQ"
 poster: "images/third_party/case_studies/we-spot-turtles/logo.webp"
 locations:
   - Europe


### PR DESCRIPTION
Removes the video link from the We Spot Turtles showcase entry.