### PR TITLE
Remove poster image from We Spot Turtles showcase

### DIFF
--- a/sites/www/content/showcase/we-spot-turtles.md
+++ b/sites/www/content/showcase/we-spot-turtles.md
@@ -11,7 +11,6 @@ appName: "We Spot Turtles!"
 companyName: "We Spot Turtles!"
 logo: "images/third_party/case_studies/we-spot-turtles/logo.webp"
 card: "images/third_party/case_studies/we-spot-turtles/case_study_card.webp"
-poster: "images/third_party/case_studies/we-spot-turtles/logo.webp"
 locations:
   - Europe
   - Oceania


### PR DESCRIPTION
Removes the `poster` image from the We Spot Turtles showcase frontmatter so the large logo image is no longer rendered at the top of the post.