### PR TITLE
Add getting started instructions for various coding agents

### DIFF
--- a/sites/docs/src/content/ai/agent-skills.md
+++ b/sites/docs/src/content/ai/agent-skills.md
@@ -20,16 +20,6 @@ standardized way to give your AI agent a set of task-oriented blueprints to
 follow. By giving the agent actual domain expertise and repeatable workflows,
 you drastically reduce mistakes and can enforce consistent patterns.
 
-To understand how agent skills fit into your workflow, consider how they compare
-to other AI capabilities:
-
-*   **Rules files:** While [rules files](/ai/ai-rules) configure the agent's
-    general behavior across all tasks, agent skills give the AI step-by-step
-    instructions for one specific job.
-*   **Model Context Protocol (MCP):** The [Dart and Flutter MCP
-    server](/ai/mcp-server) gives your agent access to specialized tools. If MCP
-    provides the raw machinery, an Agent Skill provides the professional
-    know-how to operate that machinery correctly.
 
 Skills use what we call "progressive disclosure," which is similar to deferred
 loading in Flutter. Instead of loading every single instruction into the context
@@ -53,8 +43,10 @@ tailored specifically for our frameworks.
 
 The recommended way to install skills for your project is by following the
 [Get started with AI](/ai/get-started) guide, which provides step-by-step
-plugin and skill installation for Claude Code, Codex, Antigravity, Cursor, and
-other tools.
+instructions on how to install the official Flutter and Dart agent plugins for
+Claude Code, Codex, Antigravity, Cursor, and other tools. These plugins act as a
+complete package, bundling agent skills with the configuration for the Dart and
+Flutter MCP server.
 
 ### Universal agent installation
 

--- a/sites/docs/src/content/ai/agent-skills.md
+++ b/sites/docs/src/content/ai/agent-skills.md
@@ -51,67 +51,34 @@ tailored specifically for our frameworks.
 
 ## Install agent skills
 
-Select your AI coding agent below for instructions on how to install the official
-Flutter and Dart agent skills.
+The recommended way to install skills for your project is by following the
+[Get started with AI](/ai/get-started) guide, which provides step-by-step
+plugin and skill installation for Claude Code, Codex, Antigravity, Cursor, and
+other tools.
 
-<Tabs key="ai-client-tabs" wrapped="true">
-<Tab name="Claude Code">
-
-If you use Claude Code, install the official Flutter plugin.
-This installs the Flutter and Dart agent skills alongside the
-[Dart and Flutter MCP server](/ai/mcp-server):
-
-1.  Add the Flutter marketplace for Claude plugins:
-
-    ```console
-    $ claude plugin marketplace add flutter/agent-plugins
-    ```
-
-2.  Install the plugin:
-
-    ```console
-    $ claude plugin install dart-flutter@dart-flutter
-    ```
-
-3.  Verify the installation:
-
-    ```console
-    $ claude plugin marketplace list
-    ```
-
-</Tab>
-<Tab name="Other agents">
+### Universal agent installation
 
 By default, compatible AI agents discover agent skills within the
 `.agents/skills` directory of your project workspace.
 
-To easily download and manage skills in that folder, you can use the
-`skills` CLI tool. It's distributed through npm, so you'll need
-[Node.js](https://nodejs.org/) installed to run it with `npx`.
+To download and manage skills in that folder, you can use the `skills` CLI tool.
+It's distributed through npm, so you need [Node.js](https://nodejs.org/)
+installed to run it with `npx`.
 
 To install the official Flutter skills:
 
-:::note
-The `flutter/skills` repository has been renamed to
-`flutter/agent-plugins`. If you previously installed skills using
-`flutter/skills`, update your commands to use `flutter/agent-plugins`.
-:::
-
 ```bash
-npx skills add flutter/agent-plugins --skill '*' --agent universal
+npx skills add flutter/agent-plugins --skill '*' --agent universal --yes
 ```
 
 And to install the official Dart skills:
 
 ```bash
-npx skills add dart-lang/skills --skill '*' --agent universal
+npx skills add dart-lang/skills --skill '*' --agent universal --yes
 ```
 
 Running these commands automatically creates the `.agents/skills`
 directory and downloads the requested skills into your project.
-
-</Tab>
-</Tabs>
 
 ## Manage and verify agent skills
 

--- a/sites/docs/src/content/ai/agent-skills.md
+++ b/sites/docs/src/content/ai/agent-skills.md
@@ -4,11 +4,11 @@ sidenav: ai
 shortTitle: Agent skills
 description: >-
   Learn how to give AI agents new capabilities and expertise
-  using Agent Skills.
+  using agent skills.
 ---
 
 This guide covers how to enhance your AI agents and coding assistants
-with domain-specific capabilities using Agent Skills.
+with domain-specific capabilities using agent skills.
 
 ## Overview
 
@@ -28,7 +28,7 @@ to other AI capabilities:
     instructions for one specific job.
 *   **Model Context Protocol (MCP):** The [Dart and Flutter MCP
     server](/ai/mcp-server) gives your agent access to specialized tools. If MCP
-    provides the raw machinery, an Agent Skill provides the professional
+    provides the raw machinery, an agent skill provides the professional
     know-how to operate that machinery correctly.
 
 Skills use what we call "progressive disclosure," which is similar to deferred

--- a/sites/docs/src/content/ai/ai-rules.md
+++ b/sites/docs/src/content/ai/ai-rules.md
@@ -1,5 +1,5 @@
 ---
-title: AI rules for Flutter and Dart
+title: AI rules
 sidenav: ai
 shortTitle: AI rules
 description: >-
@@ -43,7 +43,7 @@ different tool limits:
   <span>Download the Flutter and Dart rules template</span>
 </a>
 
-## Device & editor specific limits
+## Device and editor specific limits
 
 Different AI coding assistants and tools have varying limits for their "rules"
 or "custom instructions" files. *Last updated: 2026-01-05.*

--- a/sites/docs/src/content/ai/antigravity.md
+++ b/sites/docs/src/content/ai/antigravity.md
@@ -56,10 +56,10 @@ the [Antigravity site](https://antigravity.google/download).
 
  1. <h3>Install the Dart and Flutter extensions</h3>
 
-    Open the **Extensions** menu in the left nav and search for Dart.
-    The search results bring up both the Dart and Flutter extensions.
-    Click the **Install** button for Dart and then do the same
-    for Flutter.
+    Open **Settings** (press <kbd class="special-key">Cmd/Ctrl</kbd> + <kbd>,</kbd>)
+    and navigate to the **Build with Google** screen.
+    Select **Dart & Flutter** and click **Install**
+    to install both the Dart and Flutter extensions.
 
  1. <h3>Set up any MCP servers that you use</h3>
 

--- a/sites/docs/src/content/ai/antigravity.md
+++ b/sites/docs/src/content/ai/antigravity.md
@@ -56,10 +56,10 @@ the [Antigravity site](https://antigravity.google/download).
 
  1. <h3>Install the Dart and Flutter extensions</h3>
 
-    Open **Settings** (press <kbd class="special-key">Cmd/Ctrl</kbd> + <kbd>,</kbd>)
-    and navigate to the **Build with Google** screen.
-    Select **Dart & Flutter** and click **Install**
-    to install both the Dart and Flutter extensions.
+    1. Open **Settings** (press <kbd class="special-key">Cmd/Ctrl</kbd> + <kbd>,</kbd>).
+    1. Click the **Customizations** tab.
+    1. In the **Build with Google Plugins** section, click **Customize**.
+    1. Click **Download** next to the **Dart and Flutter** integration.
 
  1. <h3>Set up any MCP servers that you use</h3>
 

--- a/sites/docs/src/content/ai/coding-assistants.md
+++ b/sites/docs/src/content/ai/coding-assistants.md
@@ -1,5 +1,5 @@
 ---
-title: AI Coding Assistants
+title: AI coding assistants
 sidenav: ai
 description: >
   Learn how to use AI-powered coding assistants like Antigravity
@@ -9,7 +9,7 @@ description: >
 AI tools are not only features in your app,
 but can also be powerful assistants in your development workflow.
 
-To set up your favorite AI coding agent with official Flutter plugins,
+To set up your preferred AI coding agent with official Flutter plugins,
 skills, and rules, check out the [Get started with AI](/ai/get-started) guide.
 
 Tools like Antigravity can help you write code faster,
@@ -28,13 +28,21 @@ Some of Antigravity's capabilities include:
 *   **Complex reasoning**: It can plan and execute multi-step workflows which makes it suitable for larger refactors or feature implementations.
 *   **Verification**: It can run tests and verify its own changes to ensure correctness.
 
-<YouTubeEmbed
-  id="YY2w2JEX2xk"
-  title="Flutter + Antigravity in 10 minutes">
-</YouTubeEmbed>
-
 To get started with the editor experience, see the [Antigravity IDE](/ai/antigravity) page.
 To get started with the command-line tool, see the [Antigravity CLI](/ai/antigravity-cli) page.
+
+## Gemini Code Assist
+
+[Gemini Code Assist](https://codeassist.google/) is an AI-powered collaborator
+available for IDEs like Visual Studio Code, JetBrains IDEs, and Android Studio.
+It has a deep understanding of your project's codebase and can help you with:
+
+* **Code completion and generation**: It suggests and generates entire blocks of
+  code based on the context of what you're writing.
+* **In-editor chat**: You can ask questions about your code, Flutter concepts,
+  or best practices directly within your IDE.
+* **Debugging and explanation**: If you encounter an error, you can ask Gemini
+  Code Assist to explain it and suggest a fix.
 
 ## Gemini CLI (Legacy)
 

--- a/sites/docs/src/content/ai/coding-assistants.md
+++ b/sites/docs/src/content/ai/coding-assistants.md
@@ -9,6 +9,9 @@ description: >
 AI tools are not only features in your app,
 but can also be powerful assistants in your development workflow.
 
+To set up your favorite AI coding agent with official Flutter plugins,
+skills, and rules, check out the [Get started with AI](/ai/get-started) guide.
+
 Tools like Antigravity can help you write code faster,
 understand complex concepts, and reduce boilerplate.
 

--- a/sites/docs/src/content/ai/create-with-ai.md
+++ b/sites/docs/src/content/ai/create-with-ai.md
@@ -2,200 +2,62 @@
 title: Create with AI
 sidenav: ai
 description: >
-  Learn how to use AI to build Flutter apps, from powerful SDKs that integrate
-  AI features directly into your app to tools that accelerate your development
-  workflow.
+  Learn how to use AI to build Flutter apps, and how to build AI experiences
+  into your apps.
 ---
 
-This guide covers how you can leverage AI tools to build AI-powered
-features for your Flutter apps and streamline your
-Flutter and Dart development.
+Use artificial intelligence to accelerate your Flutter development workflow and build intelligent, AI-powered features into your applications.
 
-AI can be used for building AI-powered apps with Flutter
-and for accelerating your development workflow.
+## Develop with AI
 
-You can integrate AI-powered features like natural language understanding
-and content generation directly into your Flutter app
-using powerful SDKs, like the Firebase SDK for Generative AI.
+Configure your development environment with official Flutter and Dart plugins, rules, and tools.
 
-You can also use AI tools, such as Gemini Code Assist and Antigravity CLI,
-to help with code generation and scaffolding.
+<div class="card-grid">
+  <Card title="Get started" link="/ai/get-started" outlined="true">
+    Set up your editor with official plugins, rules, and MCP configuration.
+  </Card>
+  <Card title="AI coding assistants" link="/ai/coding-assistants" outlined="true">
+    Learn about supported AI editors, IDEs, and CLI tools.
+  </Card>
+  <Card title="Agent skills" link="/ai/agent-skills" outlined="true">
+    Enhance your AI assistant with domain-specific task blueprints.
+  </Card>
+  <Card title="MCP server" link="/ai/mcp-server" outlined="true">
+    Connect your AI to Dart and Flutter developer tools.
+  </Card>
+  <Card title="AI rules" link="/ai/ai-rules" outlined="true">
+    Configure project-wide guidelines and best practices for models.
+  </Card>
+</div>
 
-These tools are powered by the Dart and Flutter MCP server,
-which provides AI with a rich context about your codebase.
+## Build AI-powered apps
 
-The Antigravity CLI makes it easy to leverage official rules,
-the MCP server, and custom commands for building your app.
+Integrate generative AI features directly into your Flutter applications.
 
-Additionally, rules files help fine-tune the AI's behavior
-and enforce project-specific best practices.
+<div class="card-grid">
+  <Card title="Flutter AI Toolkit" link="/ai/ai-toolkit" outlined="true">
+    Use pre-built chat widgets and feature integrations.
+  </Card>
+  <Card title="GenUI SDK" link="/ai/genui" outlined="true">
+    Orchestrate interactive conversational UIs in your app.
+  </Card>
+  <Card title="Firebase AI Logic" link="https://firebase.google.com/docs/ai-logic/get-started?platform=flutter" outlined="true">
+    Use Firebase to integrate Gemini and Vertex AI features.
+  </Card>
+  <Card title="Genkit Dart" link="https://genkit.dev/docs/dart/get-started" outlined="true">
+    Build and debug AI flows with an open-source framework.
+  </Card>
+  <Card title="AI best practices" link="/ai/best-practices" outlined="true">
+    Learn about prompting, tool calls, and interaction modes.
+  </Card>
+</div>
 
-## Build AI-powered experiences with Flutter
+## AI evaluations
 
-Using AI in your Flutter app unlocks new user experiences that allow your app to
-support natural language understanding and content generation.
+Measure the reliability and performance of your AI integrations.
 
-To get started building AI-powered experiences in Flutter, check out these
-resources:
-
-* [Firebase AI Logic Showcase][] - An application that demonstrates Firebase
-  AI Logic capabilities through a series of interactive demos.
-* [Firebase AI Logic][] - The official Firebase SDK for using generative AI
-  features directly in Flutter. Compatible with the Gemini Developer API or
-  Vertex AI. To get started, check out the
-  [official documentation][firebase-ai-logic-docs].
-* [Genkit Dart][] - An open-source framework for building AI-powered
-  features in Dart and Flutter with support for multiple model providers,
-  type-safe schemas, and built-in observability. To get started, check out the
-  [quickstart guide][genkit-dart-quickstart].
-* [Flutter AI Toolkit][] - A sample app with pre-built widgets to help you build
-  AI-powered features in Flutter.
-
-[Firebase AI Logic]: {{site.firebase}}/docs/ai-logic
-[Firebase AI Logic Showcase]: {{site.repo.demos}}/tree/main/firebase_ai_logic_showcase
-[firebase-ai-logic-docs]: {{site.firebase}}/docs/ai-logic/get-started
-[Genkit Dart]: https://genkit.dev
-[genkit-dart-quickstart]: https://genkit.dev/docs/dart/overview
-[Flutter AI Toolkit]: /ai/ai-toolkit
-
-## AI development tools
-
-AI isn't only a feature in your app, but can also be a powerful assistant in
-your development workflow. Tools like [Antigravity][],
-[Gemini Code Assist][], [Antigravity CLI][], [Claude Code][],
-[Cursor][], and [Windsurf][] can help you write code faster, understand complex
-concepts, and reduce boilerplate.
-
-[Antigravity]: /ai/antigravity
-[Gemini Code Assist]: /ai/coding-assistants
-[Antigravity CLI]: /ai/antigravity-cli
-[Claude Code]: https://www.claude.com/product/claude-code
-[Cursor]: https://cursor.com/
-[Windsurf]: https://windsurf.com/
-
-### GenUI SDK for Flutter {: #genui }
-
-The GenUI SDK transforms text-based conversations into rich,
-interactive experiences. Essentially, it acts as an orchestration layer
-that coordinates the flow of information between your user, your
-Flutter widgets, and an AI agent.
-
-<YouTubeEmbed id="nWr6eZKM6no" title="Getting started with GenUI"></YouTubeEmbed>
-
-:::experimental
-The `genui` package is in
-alpha and is likely to change.
-:::
-
-To learn more, visit the [GenUI SDK for Flutter][] documentation.
-
-[GenUI SDK for Flutter]: /ai/genui
-
-### Genkit Dart
-
-[Genkit Dart](https://genkit.dev) is an open-source, model-agnostic framework
-for building AI-powered applications in Dart and Flutter.
-It provides a structured way to integrate AI features into your app
-with support for multiple model providers, including
-Google Gemini, Anthropic Claude, and OpenAI.
-
-Key features include:
-
-*   **Model-agnostic API**: Switch between AI providers with minimal code changes.
-*   **Type-safe schemas**: Define strongly-typed inputs and outputs for AI
-    interactions using the [`schemantic`](https://pub.dev/packages/schemantic) package.
-*   **Flows**: Testable, observable, and deployable functions that wrap
-    AI logic with typed inputs and outputs.
-*   **Tools**: Define functions that models can invoke to fetch live data
-    or perform actions.
-*   **Developer UI**: A built-in web UI for testing prompts, viewing execution
-    traces, and debugging flows.
-
-Genkit Dart supports multiple deployment architectures for Flutter,
-including running AI logic entirely in the app,
-calling backend flows from Flutter, or proxying model requests
-through a Genkit backend.
-
-To get started, check out the
-[Genkit Dart quickstart](https://genkit.dev/docs/dart/get-started).
-
-### Antigravity
-
-[Antigravity](https://antigravity.google/) is a suite of agentic development tools that includes:
-
-*   **Antigravity 2.0**: The core agentic assistant experience (TUI/CLI-driven).
-*   **Antigravity IDE**: The focused editor experience featuring an integrated agent panel.
-
-Capabilities include:
-
-*   **Agentic capabilities**: Unlike chat-based assistants, Antigravity can
-    proactively edit files and run terminal commands to complete tasks.
-*   **Complex reasoning**: It can plan and execute multi-step workflows which
-    makes it suitable for larger refactors or feature implementations.
-*   **Verification**: It can run tests and verify its own changes to ensure
-    correctness.
-
-<YouTubeEmbed
-  id="YY2w2JEX2xk"
-  title="Flutter + Antigravity in 10 minutes">
-</YouTubeEmbed>
-
-To learn more, check out the [Antigravity IDE](/ai/antigravity) guide.
-
-### Gemini Code Assist
-
-[Gemini Code Assist](https://codeassist.google/) is an AI-powered collaborator available for IDEs like
-Visual Studio Code, JetBrains IDEs, and Android Studio. It has a deep
-understanding of your project's codebase and can help you with:
-
-* **Code completion and generation**: It suggests and generates entire blocks of
-  code based on the context of what you're writing.
-* **In-editor chat**: You can ask questions about your code, Flutter concepts,
-  or best practices directly within your IDE.
-* **Debugging and explanation**: If you encounter an error, you can ask Gemini
-  Code Assist to explain it and suggest a fix.
-
-To learn more, check out the [AI Coding Assistants](/ai/coding-assistants) guide.
-
-### Antigravity CLI
-
-The [Antigravity CLI](/ai/antigravity-cli) is a terminal-based interface (TUI) for the
-Antigravity 2.0 agentic coding assistant (`agy`). It allows you to:
-
-* Quickly scaffold a new Flutter widget, Dart function, or a complete app.
-* Use MCP server tools, such as the Dart and Flutter MCP server.
-* Automate tasks like committing and pushing changes to a Git repository.
-
-To learn more, check out the [Antigravity CLI](/ai/antigravity-cli) guide.
-
-[dart-mcp-dart-docs]: /ai/mcp-server
-[AI rules for Flutter and Dart]: /ai/ai-rules
-
-### Dart and Flutter MCP server
-
-To provide assistance during Flutter development, AI tools
-need to communicate with Dart and Flutter's developer tools.
-The Dart and Flutter MCP server facilitates this communication.
-The MCP (model context protocol) specification outlines how
-development tools can share the context of a user's code with an AI model,
-which allows the AI to better understand and interact with the code.
-
-The Dart and Flutter MCP server unlocks the full potential of your AI assistant
-by connecting it directly to your development environment. It enables the AI to:
-
-*   **Introspect the widget tree**: Visualize and debug layout issues in your running app.
-*   **Manage dependencies**: Search pub.dev for packages and add them to your project.
-*   **Control the runtime**: Trigger hot reloads and restarts to see changes instantly.
-*   **Fix complex errors**: Analyze static and runtime errors with deep context.
-
-This bridges the gap between the AI's natural language understanding,
-and Dart and Flutter's suite of developer tools.
-
-To get started, check out the official documentation for the
-[Dart and Flutter MCP server][dart-mcp-dart-docs].
-
-### Rules for Flutter and Dart
-
-You can use a rules file with AI-powered editors to provide
-context and instructions to an underlying LLM. To get
-started, visit the [AI rules for Flutter and Dart][] guide.
+<div class="card-grid">
+  <Card title="AI evaluations" link="/ai/evals" outlined="true">
+    Learn how we use benchmarks and datasets to test and improve AI tooling.
+  </Card>
+</div>

--- a/sites/docs/src/content/ai/get-started.md
+++ b/sites/docs/src/content/ai/get-started.md
@@ -77,9 +77,7 @@ installing the official plugin from
 
 :::note Rules status
 Claude Code plugins currently cannot bundle rules files automatically.
-We recommend installing Flutter rules manually into your project's
-`CLAUDE.md` file. Official recommended rules for Claude Code are currently TBD.
-For general guidance on formatting rules, see
+You can configure rules for your project by following [Rules for Flutter and Dart](/ai/ai-rules).
 [Rules for Flutter and Dart](/ai/ai-rules).
 :::
 
@@ -110,9 +108,7 @@ Equip Codex with official Flutter and Dart skills and MCP configuration:
 
 :::note Rules status
 Codex plugins currently cannot bundle rules files automatically.
-We recommend configuring rules manually for your project.
-Official recommended rules for Codex are currently TBD.
-For more information, see [Rules for Flutter and Dart](/ai/ai-rules).
+You can configure rules for your project by following [Rules for Flutter and Dart](/ai/ai-rules).
 :::
 
 </Tab>
@@ -134,9 +130,6 @@ You can install the plugin locally by copying it to your Cursor plugins director
 
 2. Restart Cursor. The editor automatically discovers and loads the skills
    under `skills/` and configures the MCP server defined in `.mcp.json`.
-
-For advanced or manual skill installation, see
-[Install agent skills](/ai/agent-skills#install-agent-skills).
 
 </Tab>
 

--- a/sites/docs/src/content/ai/get-started.md
+++ b/sites/docs/src/content/ai/get-started.md
@@ -148,11 +148,15 @@ For advanced or manual skill installation, see
 
 <Tab name="Other agents">
 
-If you are using another compatible agentic assistant, you can install official
-skills directly into your project's `.agents/skills` workspace directory.
+If you are using another compatible agentic assistant:
 
-For instructions on manually installing skills using the `skills` CLI tool, see
-[Install agent skills](/ai/agent-skills#install-agent-skills).
+* **MCP Server**: To connect your agent to Dart and Flutter developer tools,
+  see the [Dart & Flutter MCP server](/ai/mcp-server) setup guide.
+* **Agent Skills**: To manually install agent skills into your project's
+  `.agents/skills` directory using the `skills` CLI tool, see
+  [Install agent skills](/ai/agent-skills#install-agent-skills).
+* **Rules**: To configure rules and project best practices for your assistant,
+  see [Rules for Flutter and Dart](/ai/ai-rules).
 
 </Tab>
 

--- a/sites/docs/src/content/ai/get-started.md
+++ b/sites/docs/src/content/ai/get-started.md
@@ -56,13 +56,13 @@ installing the official plugin from
    $ claude plugin marketplace add flutter/agent-plugins
    ```
 
-2. Install the Flutter and Dart plugin:
+1. Install the Flutter and Dart plugin:
 
    ```console
    $ claude plugin install dart-flutter@dart-flutter
    ```
 
-3. Verify the installation:
+1. Verify the installation:
 
    ```console
    $ claude plugin marketplace list
@@ -77,7 +77,7 @@ You can configure rules for your project by following [Rules for Flutter and Dar
 
 <Tab name="Codex">
 
-[Codex](https://github.com/features/copilot) is an agentic coding assistant
+[Codex](https://chatgpt.com/codex) is an agentic coding assistant
 designed for terminal and IDE workflows.
 
 ### Install the official plugin
@@ -90,7 +90,7 @@ Equip Codex with official Flutter and Dart skills and MCP configuration:
    $ codex plugin marketplace add flutter/agent-plugins
    ```
 
-2. Install the Dart and Flutter plugin:
+1. Install the Dart and Flutter plugin:
 
    ```console
    $ codex plugin add dart-flutter@dart-flutter
@@ -111,14 +111,19 @@ You can configure rules for your project by following [Rules for Flutter and Dar
 
 You can install the plugin locally by copying it to your Cursor plugins directory:
 
-1. Copy the repository directory to your local Cursor plugins folder:
 
+1. Clone the repository:
    ```bash
-   mkdir -p ~/.cursor/plugins/local
-   cp -r /path/to/flutter/agent-plugins ~/.cursor/plugins/local/dart-flutter
+   git clone https://github.com/flutter/agent-plugins.git
    ```
 
-2. Restart Cursor. The editor automatically discovers and loads the skills
+1. Copy the repository directory to your local Cursor plugins folder:
+   ```bash
+   mkdir -p ~/.cursor/plugins/local
+   cp -r agent-plugins ~/.cursor/plugins/local/dart-flutter
+   ```
+
+1. Restart Cursor. The editor automatically discovers and loads the skills
    under `skills/` and configures the MCP server defined in `.mcp.json`.
 
 </Tab>

--- a/sites/docs/src/content/ai/get-started.md
+++ b/sites/docs/src/content/ai/get-started.md
@@ -25,22 +25,17 @@ set up rules for Flutter development.
 <Tab name="Antigravity">
 
 [Antigravity](https://antigravity.google/) is a suite of agentic development
-tools built by Google that includes the Antigravity IDE and Antigravity CLI
-(`agy`).
+tools built by Google that includes the Antigravity IDE and Antigravity CLI.
 
-### Plugin, skills, and rules support
+### Install the official plugin
 
-Antigravity natively supports bundled agent skills, MCP tools, and rules files
-out-of-the-box.
+Equip Antigravity with official Dart and Flutter tools
+by installing the plugin from the **Build with Google** screen in settings:
 
-* **Antigravity IDE**: Features an integrated agent panel, automatic rule
-  loading, and native support for Dart and Flutter tools. See the
-  [Antigravity IDE](/ai/antigravity) guide.
-* **Antigravity CLI**: A terminal-based agentic workflow tool (`agy`). See the
-  [Antigravity CLI](/ai/antigravity-cli) guide.
-
-For advanced or manual skill installation, see
-[Install agent skills](/ai/agent-skills#install-agent-skills).
+1. Open **Settings** in Antigravity by clicking the gear icon
+   or pressing <kbd>Cmd</kbd>+<kbd>,</kbd> (<kbd>Ctrl</kbd>+<kbd>,</kbd>).
+1. Navigate to the **Build with Google** screen in settings.
+1. Select **Dart & Flutter** and click **Install**.
 
 </Tab>
 
@@ -49,7 +44,7 @@ For advanced or manual skill installation, see
 [Claude Code](https://code.claude.com/) is an agentic coding assistant from
 Anthropic that runs in your terminal.
 
-### 1. Install the official plugin
+### Install the official plugin
 
 Equip Claude Code with domain expertise and tools for Flutter and Dart by
 installing the official plugin from
@@ -73,13 +68,10 @@ installing the official plugin from
    $ claude plugin marketplace list
    ```
 
-### 2. Rules setup
+### Rules setup
 
-:::note Rules status
 Claude Code plugins currently cannot bundle rules files automatically.
 You can configure rules for your project by following [Rules for Flutter and Dart](/ai/ai-rules).
-[Rules for Flutter and Dart](/ai/ai-rules).
-:::
 
 </Tab>
 
@@ -88,7 +80,7 @@ You can configure rules for your project by following [Rules for Flutter and Dar
 [Codex](https://github.com/features/copilot) is an agentic coding assistant
 designed for terminal and IDE workflows.
 
-### 1. Install the official plugin
+### Install the official plugin
 
 Equip Codex with official Flutter and Dart skills and MCP configuration:
 
@@ -104,12 +96,10 @@ Equip Codex with official Flutter and Dart skills and MCP configuration:
    $ codex plugin add dart-flutter@dart-flutter
    ```
 
-### 2. Rules setup
+### Rules setup
 
-:::note Rules status
 Codex plugins currently cannot bundle rules files automatically.
 You can configure rules for your project by following [Rules for Flutter and Dart](/ai/ai-rules).
-:::
 
 </Tab>
 

--- a/sites/docs/src/content/ai/get-started.md
+++ b/sites/docs/src/content/ai/get-started.md
@@ -33,7 +33,7 @@ Equip Antigravity with official Dart and Flutter tools
 by installing the plugin from the **Build with Google** screen in settings:
 
 1. Open **Settings** in Antigravity by clicking the gear icon
-   or pressing <kbd>Cmd</kbd>+<kbd>,</kbd> (<kbd>Ctrl</kbd>+<kbd>,</kbd>).
+   or pressing <kbd class="special-key">Cmd/Ctrl</kbd> + <kbd>,</kbd>.
 1. Navigate to the **Build with Google** screen in settings.
 1. Select **Dart & Flutter** and click **Install**.
 

--- a/sites/docs/src/content/ai/get-started.md
+++ b/sites/docs/src/content/ai/get-started.md
@@ -1,0 +1,165 @@
+---
+title: Get started developing with AI
+sidenav: ai
+shortTitle: Get started
+description: >-
+  Learn how to set up and use AI agent plugins for Flutter and Dart,
+  tailored for Antigravity, Claude Code, Codex, and Cursor.
+---
+
+AI coding assistants can accelerate your Flutter development workflow by
+writing code, fixing errors, and building complete features.
+
+To get the best experience with AI coding assistants, we recommend installing
+the official Flutter agent plugins, which bundle
+[agent skills](/ai/agent-skills) and configuration for the
+[Dart and Flutter MCP server](/ai/mcp-server).
+
+## Choose your AI coding agent
+
+Select your agent below for instructions on how to install official plugins and
+set up rules for Flutter development.
+
+<Tabs key="ai-agent-tabs" wrapped="true">
+
+<Tab name="Antigravity">
+
+[Antigravity](https://antigravity.google/) is a suite of agentic development
+tools built by Google that includes the Antigravity IDE and Antigravity CLI
+(`agy`).
+
+### Plugin, skills, and rules support
+
+Antigravity natively supports bundled agent skills, MCP tools, and rules files
+out-of-the-box.
+
+* **Antigravity IDE**: Features an integrated agent panel, automatic rule
+  loading, and native support for Dart and Flutter tools. See the
+  [Antigravity IDE](/ai/antigravity) guide.
+* **Antigravity CLI**: A terminal-based agentic workflow tool (`agy`). See the
+  [Antigravity CLI](/ai/antigravity-cli) guide.
+
+For advanced or manual skill installation, see
+[Install agent skills](/ai/agent-skills#install-agent-skills).
+
+</Tab>
+
+<Tab name="Claude Code">
+
+[Claude Code](https://code.claude.com/) is an agentic coding assistant from
+Anthropic that runs in your terminal.
+
+### 1. Install the official plugin
+
+Equip Claude Code with domain expertise and tools for Flutter and Dart by
+installing the official plugin from
+[flutter/agent-plugins](https://github.com/flutter/agent-plugins):
+
+1. Add the marketplace for Claude Code plugins:
+
+   ```console
+   $ claude plugin marketplace add flutter/agent-plugins
+   ```
+
+2. Install the Flutter and Dart plugin:
+
+   ```console
+   $ claude plugin install dart-flutter@dart-flutter
+   ```
+
+3. Verify the installation:
+
+   ```console
+   $ claude plugin marketplace list
+   ```
+
+### 2. Rules setup
+
+:::note Rules status
+Claude Code plugins currently cannot bundle rules files automatically.
+We recommend installing Flutter rules manually into your project's
+`CLAUDE.md` file. Official recommended rules for Claude Code are currently TBD.
+For general guidance on formatting rules, see
+[Rules for Flutter and Dart](/ai/ai-rules).
+:::
+
+</Tab>
+
+<Tab name="Codex">
+
+[Codex](https://github.com/features/copilot) is an agentic coding assistant
+designed for terminal and IDE workflows.
+
+### 1. Install the official plugin
+
+Equip Codex with official Flutter and Dart skills and MCP configuration:
+
+1. Add the Dart and Flutter marketplace for Codex plugins:
+
+   ```console
+   $ codex plugin marketplace add flutter/agent-plugins
+   ```
+
+2. Install the Dart and Flutter plugin:
+
+   ```console
+   $ codex plugin add dart-flutter@dart-flutter
+   ```
+
+### 2. Rules setup
+
+:::note Rules status
+Codex plugins currently cannot bundle rules files automatically.
+We recommend configuring rules manually for your project.
+Official recommended rules for Codex are currently TBD.
+For more information, see [Rules for Flutter and Dart](/ai/ai-rules).
+:::
+
+</Tab>
+
+<Tab name="Cursor">
+
+[Cursor](https://cursor.com/) is an AI-first code editor built on VS Code.
+
+### 1. Local plugin installation
+
+You can install the plugin locally by copying it to your Cursor plugins directory:
+
+1. Copy the repository directory to your local Cursor plugins folder:
+
+   ```bash
+   mkdir -p ~/.cursor/plugins/local
+   cp -r /path/to/flutter/agent-plugins ~/.cursor/plugins/local/dart-flutter
+   ```
+
+2. Restart Cursor. The editor automatically discovers and loads the skills
+   under `skills/` and configures the MCP server defined in `.mcp.json`.
+
+### 2. Rules support
+
+Cursor supports rules files (`.cursor/rules` or `AGENTS.md`) directly within
+your workspace context. For more details on rules configuration, see
+[Rules for Flutter and Dart](/ai/ai-rules).
+
+For advanced or manual skill installation, see
+[Install agent skills](/ai/agent-skills#install-agent-skills).
+
+</Tab>
+
+<Tab name="Other agents">
+
+If you are using another compatible agentic assistant, you can install official
+skills directly into your project's `.agents/skills` workspace directory.
+
+For instructions on manually installing skills using the `skills` CLI tool, see
+[Install agent skills](/ai/agent-skills#install-agent-skills).
+
+</Tab>
+
+</Tabs>
+
+## Next steps
+
+* Learn more about [Agent skills](/ai/agent-skills) and how agents use them.
+* Explore the [Dart & Flutter MCP server](/ai/mcp-server) integration.
+* Check out [Rules for Flutter and Dart](/ai/ai-rules) to customize model behavior.

--- a/sites/docs/src/content/ai/get-started.md
+++ b/sites/docs/src/content/ai/get-started.md
@@ -121,7 +121,7 @@ For more information, see [Rules for Flutter and Dart](/ai/ai-rules).
 
 [Cursor](https://cursor.com/) is an AI-first code editor built on VS Code.
 
-### 1. Local plugin installation
+### Install the local plugin
 
 You can install the plugin locally by copying it to your Cursor plugins directory:
 
@@ -134,12 +134,6 @@ You can install the plugin locally by copying it to your Cursor plugins director
 
 2. Restart Cursor. The editor automatically discovers and loads the skills
    under `skills/` and configures the MCP server defined in `.mcp.json`.
-
-### 2. Rules support
-
-Cursor supports rules files (`.cursor/rules` or `AGENTS.md`) directly within
-your workspace context. For more details on rules configuration, see
-[Rules for Flutter and Dart](/ai/ai-rules).
 
 For advanced or manual skill installation, see
 [Install agent skills](/ai/agent-skills#install-agent-skills).

--- a/sites/docs/src/content/ai/get-started.md
+++ b/sites/docs/src/content/ai/get-started.md
@@ -3,17 +3,16 @@ title: Get started developing with AI
 sidenav: ai
 shortTitle: Get started
 description: >-
-  Learn how to set up and use AI agent plugins for Flutter and Dart,
-  tailored for Antigravity, Claude Code, Codex, and Cursor.
+  Learn how to set up and use AI agent plugins for Flutter and Dart using
+  your preferred coding assistant.
 ---
 
 AI coding assistants can accelerate your Flutter development workflow by
 writing code, fixing errors, and building complete features.
 
-To get the best experience with AI coding assistants, we recommend installing
-the official Flutter agent plugins, which bundle
-[agent skills](/ai/agent-skills) and configuration for the
-[Dart and Flutter MCP server](/ai/mcp-server).
+To get the best experience with AI coding assistants, install the official
+Flutter agent plugins, which bundle [agent skills](/ai/agent-skills) and
+configuration for the [Dart and Flutter MCP server](/ai/mcp-server).
 
 ## Choose your AI coding agent
 
@@ -27,15 +26,16 @@ set up rules for Flutter development.
 [Antigravity](https://antigravity.google/) is a suite of agentic development
 tools built by Google that includes the Antigravity IDE and Antigravity CLI.
 
-### Install the official plugin
+**Install the official plugin**
 
 Equip Antigravity with official Dart and Flutter tools
-by installing the plugin from the **Build with Google** screen in settings:
+by installing the plugin from settings:
 
 1. Open **Settings** in Antigravity by clicking the gear icon
    or pressing <kbd class="special-key">Cmd/Ctrl</kbd> + <kbd>,</kbd>.
-1. Navigate to the **Build with Google** screen in settings.
-1. Select **Dart & Flutter** and click **Install**.
+1. Click the **Customizations** tab.
+1. In the **Build with Google Plugins** section, click **Customize**.
+1. Click **Download** next to the **Dart and Flutter** integration.
 
 </Tab>
 
@@ -44,7 +44,7 @@ by installing the plugin from the **Build with Google** screen in settings:
 [Claude Code](https://code.claude.com/) is an agentic coding assistant from
 Anthropic that runs in your terminal.
 
-### Install the official plugin
+**Install the official plugin**
 
 Equip Claude Code with domain expertise and tools for Flutter and Dart by
 installing the official plugin from
@@ -68,7 +68,7 @@ installing the official plugin from
    $ claude plugin marketplace list
    ```
 
-### Rules setup
+**Rules setup**
 
 Claude Code plugins currently cannot bundle rules files automatically.
 You can configure rules for your project by following [Rules for Flutter and Dart](/ai/ai-rules).
@@ -80,7 +80,7 @@ You can configure rules for your project by following [Rules for Flutter and Dar
 [Codex](https://chatgpt.com/codex) is an agentic coding assistant
 designed for terminal and IDE workflows.
 
-### Install the official plugin
+**Install the official plugin**
 
 Equip Codex with official Flutter and Dart skills and MCP configuration:
 
@@ -96,7 +96,7 @@ Equip Codex with official Flutter and Dart skills and MCP configuration:
    $ codex plugin add dart-flutter@dart-flutter
    ```
 
-### Rules setup
+**Rules setup**
 
 Codex plugins currently cannot bundle rules files automatically.
 You can configure rules for your project by following [Rules for Flutter and Dart](/ai/ai-rules).
@@ -107,7 +107,7 @@ You can configure rules for your project by following [Rules for Flutter and Dar
 
 [Cursor](https://cursor.com/) is an AI-first code editor built on VS Code.
 
-### Install the local plugin
+**Install the local plugin**
 
 You can install the plugin locally by copying it to your Cursor plugins directory:
 
@@ -130,10 +130,10 @@ You can install the plugin locally by copying it to your Cursor plugins director
 
 <Tab name="Other agents">
 
-If you are using another compatible agentic assistant:
+If you're using another compatible agentic assistant:
 
 * **MCP Server**: To connect your agent to Dart and Flutter developer tools,
-  see the [Dart & Flutter MCP server](/ai/mcp-server) setup guide.
+  see the [Dart and Flutter MCP server](/ai/mcp-server) setup guide.
 * **Agent Skills**: To manually install agent skills into your project's
   `.agents/skills` directory using the `skills` CLI tool, see
   [Install agent skills](/ai/agent-skills#install-agent-skills).
@@ -144,8 +144,21 @@ If you are using another compatible agentic assistant:
 
 </Tabs>
 
+## The AI tooling stack
+
+To get the most out of AI, it helps to understand how the different pieces work together:
+
+| Component | What it is | How it helps |
+| :--- | :--- | :--- |
+| **Plugins** | Packages MCP and Skills together for your editor. | **Start here.** Recommended for quick setup. |
+| **MCP Server** | Connects the AI to Flutter developer tools (hot reload, widget tree). | Provides the raw machinery for advanced tools. |
+| **Agent Skills** | Step-by-step blueprints for specific tasks. | Provides the professional know-how to operate tools. |
+| **AI Rules** | General guidelines and best practices for your project. | Enforces consistent coding standards. |
+
+{:.table .table-striped}
+
 ## Next steps
 
 * Learn more about [Agent skills](/ai/agent-skills) and how agents use them.
-* Explore the [Dart & Flutter MCP server](/ai/mcp-server) integration.
+* Explore the [Dart and Flutter MCP server](/ai/mcp-server) integration.
 * Check out [Rules for Flutter and Dart](/ai/ai-rules) to customize model behavior.

--- a/sites/docs/src/data/sidenav/ai.yml
+++ b/sites/docs/src/data/sidenav/ai.yml
@@ -6,25 +6,23 @@
   children:
     - title: Get started
       permalink: /ai/get-started
-    - title: Rules for Flutter and Dart
-      permalink: /ai/ai-rules
-    - title: Agent skills
-      permalink: /ai/agent-skills
-    - title: Dart & Flutter MCP server
-      permalink: /ai/mcp-server
     - title: AI coding assistants
       permalink: /ai/coding-assistants
       children:
         - title: Overview
           permalink: /ai/coding-assistants
-        - title: Antigravity IDE
+        - title: Antigravity
           permalink: /ai/antigravity
         - title: Antigravity CLI
           permalink: /ai/antigravity-cli
+    - title: Agent skills
+      permalink: /ai/agent-skills
+    - title: Dart and Flutter MCP server
+      permalink: /ai/mcp-server
+    - title: AI rules
+      permalink: /ai/ai-rules
     - title: Developer experience
       permalink: /ai/best-practices/developer-experience
-    - title: "AI evaluations (experimental)"
-      permalink: /ai/evals
 
 - title: Build AI-powered apps
   expanded: true
@@ -38,7 +36,7 @@
       children:
         - title: Overview
           permalink: /ai/genui
-        - title: Main components & concepts
+        - title: Main components and concepts
           permalink: /ai/genui/components
         - title: Get started
           permalink: /ai/genui/get-started
@@ -64,9 +62,12 @@
           permalink: /ai/best-practices
         - title: Prompting
           permalink: /ai/best-practices/prompting
-        - title: Structure & output
+        - title: Structure and output
           permalink: /ai/best-practices/structure-output
         - title: Tool calls (aka function calls)
           permalink: /ai/best-practices/tool-calls
         - title: Mode of interaction
           permalink: /ai/best-practices/mode-of-interaction
+
+- title: "AI evaluations (experimental)"
+  permalink: /ai/evals

--- a/sites/docs/src/data/sidenav/ai.yml
+++ b/sites/docs/src/data/sidenav/ai.yml
@@ -4,6 +4,8 @@
 - title: Develop with AI
   expanded: true
   children:
+    - title: Get started
+      permalink: /ai/get-started
     - title: Rules for Flutter and Dart
       permalink: /ai/ai-rules
     - title: Agent skills


### PR DESCRIPTION
This adds a new page (`/ai/getting-started`) that has the latest instructions for installing agent plugins (github.com/flutter/agent-plugins).

This also removes some installation instructions from the skills page.

cc: @keertip @lamek @jesskuras 

fixes https://github.com/flutter/website/issues/13707
