### PR TITLE
Update site banners for 3.47 release

### DIFF
--- a/sites/docs/src/data/banner.yml
+++ b/sites/docs/src/data/banner.yml
@@ -4,16 +4,9 @@
 # - `link` with `text`, `url`, and optional `newTab: true`.
 # - `newLine: true` for inserting a line break.
 
-- text: "Flutter 3.44 is here!"
-- newLine: true
-- text: "Watch "
-- link:
-    text: "What's new in Flutter"
-    url: https://www.youtube.com/watch?v=I1uIbGh1dGE
-    newTab: true
-- text: " and read the "
+- text: "Flutter 3.47 is here! Read the "
 - link:
     text: "blog post"
-    url: https://blog.flutter.dev/whats-new-in-flutter-3-44-b0cc1ad3c527
+    url: https://flutter.dev/blog/whats-new-in-flutter-3-47
     newTab: true
 - text: "."

--- a/sites/www/content/banner.yaml
+++ b/sites/www/content/banner.yaml
@@ -7,8 +7,8 @@
 # - link: Required, absolute https URL that the whole banner links to.
 
 text: >-
-  Flutter 3.44 is here! Everywhere, everyday, built by everyone, for everyone.
+  Flutter 3.47 is here! Standalone design packages are now opt-in.
   Learn more
 mobileText: >-
-  Flutter 3.44 is here! Learn more
-link: https://blog.flutter.dev/whats-new-in-flutter-3-44-b0cc1ad3c527
+  Flutter 3.47 is here! Learn more
+link: https://flutter.dev/blog/whats-new-in-flutter-3-47


### PR DESCRIPTION
Updates the site-wide announcement banners on both the marketing and documentation sites to announce the Flutter 3.47 / Dart 3.13 release.