### PR TITLE
Add whats new skill

### DIFF
--- a/.agents/skills/update_whats_new/SKILL.md
+++ b/.agents/skills/update_whats_new/SKILL.md
@@ -79,6 +79,7 @@ Use this skill when a new Flutter release has occurred and you need to update `s
     * **Formatting Rule:** Do NOT use bold topic prefixes followed by colons (e.g. do NOT write `* **Widget Previews:** Flutter [Widget Previews]...`). Instead, write clean, natural sentences with the links integrated inline, matching the style of past entries (e.g. `The Flutter [Widget Previews][widget-previewer] tool has graduated to stable...`).
     * Add a link to the relevant section or new page using markdown reference links.
     * If a community contributor was involved, thank them by including their GitHub handle in parentheses, for example: `(Thank you, [username][].)`. Only thank community contributors, not Flutter team members.
+    * **Breaking Changes Note:** Place the standard breaking changes note (e.g., `As always, check out the [breaking changes][bc-3-47] page...`) as a **standalone paragraph** directly below the bulleted list, separated by a blank line, rather than including it as a bullet point.
 
 7.  **Add and format link definitions**
 
@@ -89,6 +90,16 @@ Use this skill when a new Flutter release has occurred and you need to update `s
     [username]: https://github.com/username
     ```
 
-8.  **Request review**
+8.  **Output Writer Verification Guide**
 
-    Notify the developer that the `whats-new.md` page has been updated and ask them to verify the changes.
+    In your final chat response to the developer, provide a structured **Writer Verification Guide** to help the writer review your draft. This guide must contain:
+    *   A **Markdown Table** mapping:
+        *   The drafted bullet point description.
+        *   The local file path(s) modified or added in the codebase.
+        *   The Git commit hash or PR number that introduced the change.
+        *   The local preview URL (e.g., `http://lamek.c.googlers.com:5000/...`).
+    *   A **Step-by-Step Verification Checklist** explaining how to run the local preview server, navigate to the `/release/whats-new` page, and click through each link to verify it exists and is correct.
+
+9.  **Request review**
+
+    Notify the developer that the `whats-new.md` page has been updated and ask them to verify the changes using the Writer Verification Guide.

--- a/.agents/skills/update_whats_new/SKILL.md
+++ b/.agents/skills/update_whats_new/SKILL.md
@@ -68,12 +68,13 @@ Use this skill when a new Flutter release has occurred and you need to update `s
       <YouTubeEmbed id="VIDEO_ID" title="What's New in Dart and Flutter 3.47" fullWidth></YouTubeEmbed>
       </div>
       ```
-    * A list heading: `**Docs updated or added since the <Previous Version> release**`.
+    * A list heading: `**Docs updated or added since the <Previous Version> release**`. This heading should be followed immediately by the bulleted list (do not add extra filler sentences in between).
 
 6.  **Add entries for meaningful changes**
 
     For each meaningful change identified in Step 4:
     * Add a bullet point under the new release section.
+    * Leave a blank line between each bullet point in the list to ensure consistent spacing and readability.
     * Write a concise explanation of the change.
     * **Formatting Rule:** Do NOT use bold topic prefixes followed by colons (e.g. do NOT write `* **Widget Previews:** Flutter [Widget Previews]...`). Instead, write clean, natural sentences with the links integrated inline, matching the style of past entries (e.g. `The Flutter [Widget Previews][widget-previewer] tool has graduated to stable...`).
     * Add a link to the relevant section or new page using markdown reference links.

--- a/.agents/skills/update_whats_new/SKILL.md
+++ b/.agents/skills/update_whats_new/SKILL.md
@@ -1,34 +1,47 @@
 ---
 name: update-whats-new
-description: Update the whats-new page and archive old entries with changes to the website since the previous release.
+description: >-
+  Update the whats-new page and archive old entries with changes to the website
+  since the previous release.
 ---
 
 # Update what's new page
 
-Use this skill when a new Flutter release has occurred and you need to update `sites/docs/src/content/release/whats-new.md` to describe the changes to the documentation site since the previous release.
+Use this skill when a new Flutter release has occurred and you need to update
+`sites/docs/src/content/release/whats-new.md` to describe the changes to the
+documentation site since the previous release.
 
 ## Steps
 
 1.  **Identify the previous release date & version**
 
-    Read `sites/docs/src/content/release/whats-new.md` and locate the topmost release section.
+    Read `sites/docs/src/content/release/whats-new.md` and locate the
+    topmost release section.
     Find the version and the release date for that release.
     This is your starting point.
 
 2.  **Archive the oldest release (if necessary)**
 
-    To keep the "What's new" page focused on recent updates, it should typically hold only the last 3 to 4 releases. 
-    If adding a new release exceeds this limit, move the oldest release section from `sites/docs/src/content/release/whats-new.md` to `sites/docs/src/content/release/archive-whats-new.md`.
-    
-    * Open `archive-whats-new.md` and insert the moved section at the top of the stable releases list (just below the introduction, separated by `---`).
-    * Ensure all reference link definitions for that archived release are also moved to the bottom of the archived section.
+    To keep the "What's new" page focused on recent updates, it should
+    typically hold only the last 3 to 4 releases.
+    If adding a new release exceeds this limit, move the oldest release section
+    from `sites/docs/src/content/release/whats-new.md` to
+    `sites/docs/src/content/release/archive-whats-new.md`.
+
+    * Open `archive-whats-new.md` and insert the moved section at the top of
+      the stable releases list (just below the introduction, separated
+      by `---`).
+    * Ensure all reference link definitions for that archived release are
+      also moved to the bottom of the archived section.
 
 3.  **Retrieve recent Git commits**
 
-    Retrieve the git commits made to the documentation content directory since the previous release date identified in Step 1.
+    Retrieve the git commits made to the documentation content directory
+    since the previous release date identified in Step 1.
     For example:
     ```bash
-    git log --after="<previous_release_date>" --oneline -- sites/docs/src/content/
+    git log --after="<previous_release_date>" \
+      --oneline -- sites/docs/src/content/
     ```
 
 4.  **Analyze commits for meaningful changes**
@@ -36,56 +49,96 @@ Use this skill when a new Flutter release has occurred and you need to update `s
     Review the content of each commit since that date.
     Identify changes that are significant to developers or users.
     Look for:
-    * New pages or guides (e.g. AI guides, dependency management).
+    * New pages or guides (such as AI guides or dependency management).
     * Large or significant page updates.
     * Deprecated pages or major migrations.
     * New cookbook recipes or tutorials.
 
     > [!IMPORTANT]
-    > ONLY include entries that are meaningful and user-facing to someone reading our documentation.
+    > ONLY include entries that are meaningful and user-facing to someone
+    > reading our documentation.
     >
     > **Do NOT include:**
     > * Non-user-facing infrastructure changes.
     > * Internal refactoring or maintenance simplifications.
-    > * Trivial tweaks (e.g. typos, link fixes, release notes index updates).
-    > * Commits from Dart/Flutter team members (e.g. Parker, Daco) unless they authored a major new guide.
+    > * Trivial tweaks (such as typos, link fixes, or release notes index
+    >   updates).
+    > * Commits from Dart and Flutter team members (such as Parker or Daco)
+    >   unless they authored a major new guide.
     >
     > **DO include specific, high-impact changes, for example:**
-    > * Added a new guide for [installing plugins in IDEs](/tools/widget-previewer).
-    > * Reworked the [Android Kotlin migration guide](/release/breaking-changes/kotlin-version).
-    > * Added support for [Swift Package Manager Add-to-App](/platform-integration/ios/app-extensions).
+    > * Added a new guide for
+    >   [installing plugins in IDEs](/tools/widget-previewer).
+    > * Reworked the [Android Kotlin migration guide][kotlin-guide].
+    > * Added support for [Swift Package Manager Add-to-App][swiftpm-app].
 
 5.  **Create a new release section**
 
-    In `sites/docs/src/content/release/whats-new.md`, create a new section at the top of the file (just below the introduction) for the new release.
+    In `sites/docs/src/content/release/whats-new.md`, create a new section
+    at the top of the file (just below the introduction) for the new release.
     Follow the formatting and structure of past releases on the page:
-    * A heading with the release date and version, like `## 12 August 2026: Release 3.47`.
-    * A concise announcement paragraph linking ONLY to the release blog post (e.g., `Flutter 3.47 is live! For details, check out the [Flutter 3.47 blog post][3.47-blog-post].`). Do not link breaking changes or release notes in this paragraph.
-    * If a release video is available, embed it using the `<YouTubeEmbed>` component:
+    * A heading with the release date and version,
+      like `## 12 August 2026: Release 3.47`.
+    * A concise announcement paragraph linking ONLY to the release blog post
+      (for example, `Flutter 3.47 is live! For details, check out the
+      [Flutter 3.47 blog post][3.47-blog-post].`). Do not link breaking
+      changes or release notes in this paragraph.
+    * If a release video is available, embed it
+      using the `<YouTubeEmbed>` component:
       ```html
       <div class="video-wrapper">
       <span class="video-intro">Check out the latest in Dart and Flutter</span>
-      <YouTubeEmbed id="VIDEO_ID" title="What's New in Dart and Flutter 3.47" fullWidth></YouTubeEmbed>
+      <YouTubeEmbed
+        id="VIDEO_ID"
+        title="What's New in Dart and Flutter 3.47"
+        fullWidth></YouTubeEmbed>
       </div>
       ```
-    * A list heading: `**Docs updated or added since the <Previous Version> release**`. This heading should be followed immediately by the bulleted list (do not add extra filler sentences in between).
+    * A list heading:
+      `**Docs updated or added since the <Previous Version> release**`.
+      This heading should be followed immediately by the bulleted list
+      (do not add extra filler sentences in between).
 
 6.  **Add entries for meaningful changes**
 
     For each meaningful change identified in Step 4:
     * Add a bullet point under the new release section.
-    * Leave a blank line between each bullet point in the list to ensure consistent spacing and readability.
-    * Format all Markdown text using semantic line breaks and keep lines under 80 characters.
-    * **No First-Person Pronouns:** In accordance with the [Google developer documentation style guide](https://developers.google.com/style/voice), avoid first-person pronouns like "we", "I", "our", or "us" (e.g. do NOT write "* We reorganized...", "* We expanded...", "* We added..."). Instead, use neutral phrasing (e.g. "* A new guide page covers...", "* The AI documentation has been reorganized to...", "* Guidance has been added for...").
-    * **Formatting Rule:** Do NOT use bold topic prefixes followed by colons (e.g. do NOT write `* **Widget Previews:** Flutter [Widget Previews]...`). Instead, write clean, natural sentences with the links integrated inline, matching the style of past entries (e.g. `The Flutter [Widget Previews][widget-previewer] tool has graduated to stable...`).
-    * Add a link to the relevant section or new page using markdown reference links.
-    * If a community contributor was involved, thank them by including their GitHub handle in parentheses, for example: `(Thank you, [username][].)`. Only thank community contributors, not Flutter team members.
-    * **Breaking Changes Note:** Place the standard breaking changes note (e.g., `As always, check out the [breaking changes][bc-3-47] page...`) as a **standalone paragraph** directly below the bulleted list, separated by a blank line, rather than including it as a bullet point.
+    * Leave a blank line between each bullet point in the list
+      to ensure consistent spacing and readability.
+    * Format all Markdown text using semantic line breaks and keep lines
+      under 80 characters.
+    * **No First-Person Pronouns:** In accordance with the
+      [Google developer documentation style guide][style-guide-voice],
+      avoid first-person pronouns like "we", "I", "our", or "us"
+      (for example, do NOT write "* We reorganized...", "* We expanded...",
+      or "* We added..."). Instead, use neutral phrasing
+      (for example, "* A new guide page covers...",
+      "* The AI documentation has been reorganized to...",
+      or "* Guidance has been added for...").
+    * **Formatting Rule:** Do NOT use bold topic prefixes followed by colons
+      (for example, do not write
+      `* **Widget Previews:** Flutter [Widget Previews]...`).
+      Instead, write clean, natural sentences with the links integrated inline,
+      matching the style of past entries (for example,
+      `The Flutter [Widget Previews][widget-previewer] tool has graduated...`).
+    * Add a link to the relevant section or new page
+      using markdown reference links.
+    * If a community contributor was involved, thank them by including
+      their GitHub handle in parentheses, for example:
+      `(Thank you, [username][].)`. Only thank community contributors,
+      not Flutter team members.
+    * **Breaking Changes Note:** Place the standard breaking changes note
+      (for example, `As always, check out the [breaking changes] page...`)
+      as a **standalone paragraph** directly below the bulleted list,
+      separated by a blank line, rather than including it as a bullet point.
 
 7.  **Add and format link definitions**
 
-    Add the link definitions (reference links) to the bottom of the new release section, matching the style used throughout the document.
-    * **No Unused Link Definitions:** Verify that every link definition defined at the bottom is actively referenced in the text above. Remove any unused link definitions.
+    Add the link definitions (reference links) to the bottom of the new
+    release section, matching the style used throughout the document.
+    * **No Unused Link Definitions:** Verify that every link definition
+      defined at the bottom is actively referenced in the text above.
+      Remove any unused link definitions.
     For example:
     ```markdown
     [3.47-blog-post]: /blog/whats-new-in-flutter-3-47
@@ -94,14 +147,24 @@ Use this skill when a new Flutter release has occurred and you need to update `s
 
 8.  **Output Writer Verification Guide**
 
-    In your final chat response to the developer, provide a structured **Writer Verification Guide** to help the writer review your draft. This guide must contain:
+    In your final chat response to the developer, provide a structured
+    **Writer Verification Guide** to help the writer review your draft.
+    This guide must contain:
     *   A **Markdown Table** mapping:
         *   The drafted bullet point description.
         *   The local file path(s) modified or added in the codebase.
         *   The Git commit hash or PR number that introduced the change.
-        *   The local preview URL (e.g., `http://lamek.c.googlers.com:5000/...`).
-    *   A **Step-by-Step Verification Checklist** explaining how to run the local preview server, navigate to the `/release/whats-new` page, and click through each link to verify it exists and is correct.
+        *   The local preview URL (for example,
+            `http://lamek.c.googlers.com:5000/...`).
+    *   A **Step-by-Step Verification Checklist** explaining how to run
+        the local preview server, navigate to the `/release/whats-new` page,
+        and click through each link to verify it exists and is correct.
 
 9.  **Request review**
 
-    Notify the developer that the `whats-new.md` page has been updated and ask them to verify the changes using the Writer Verification Guide.
+    Notify the developer that the `whats-new.md` page has been updated
+    and ask them to verify the changes using the Writer Verification Guide.
+
+[kotlin-guide]: /release/breaking-changes/kotlin-version
+[style-guide-voice]: https://developers.google.com/style/voice
+[swiftpm-app]: /platform-integration/ios/app-extensions

--- a/.agents/skills/update_whats_new/SKILL.md
+++ b/.agents/skills/update_whats_new/SKILL.md
@@ -60,7 +60,7 @@ Use this skill when a new Flutter release has occurred and you need to update `s
     In `sites/docs/src/content/release/whats-new.md`, create a new section at the top of the file (just below the introduction) for the new release.
     Follow the formatting and structure of past releases on the page:
     * A heading with the release date and version, like `## 12 August 2026: Release 3.47`.
-    * An announcement paragraph linking to the release blog post: `check out the [Flutter 3.47 blog post][3.47-blog-post]`.
+    * A concise announcement paragraph linking ONLY to the release blog post (e.g., `Flutter 3.47 is live! For details, check out the [Flutter 3.47 blog post][3.47-blog-post].`). Do not link breaking changes or release notes in this paragraph.
     * If a release video is available, embed it using the `<YouTubeEmbed>` component:
       ```html
       <div class="video-wrapper">
@@ -75,6 +75,7 @@ Use this skill when a new Flutter release has occurred and you need to update `s
     For each meaningful change identified in Step 4:
     * Add a bullet point under the new release section.
     * Write a concise explanation of the change.
+    * **Formatting Rule:** Do NOT use bold topic prefixes followed by colons (e.g. do NOT write `* **Widget Previews:** Flutter [Widget Previews]...`). Instead, write clean, natural sentences with the links integrated inline, matching the style of past entries (e.g. `The Flutter [Widget Previews][widget-previewer] tool has graduated to stable...`).
     * Add a link to the relevant section or new page using markdown reference links.
     * If a community contributor was involved, thank them by including their GitHub handle in parentheses, for example: `(Thank you, [username][].)`. Only thank community contributors, not Flutter team members.
 

--- a/.agents/skills/update_whats_new/SKILL.md
+++ b/.agents/skills/update_whats_new/SKILL.md
@@ -107,14 +107,24 @@ documentation site since the previous release.
       to ensure consistent spacing and readability.
     * Format all Markdown text using semantic line breaks and keep lines
       under 80 characters.
-    * **No First-Person Pronouns:** In accordance with the
-      [Google developer documentation style guide][style-guide-voice],
-      avoid first-person pronouns like "we", "I", "our", or "us"
-      (for example, do NOT write "* We reorganized...", "* We expanded...",
-      or "* We added..."). Instead, use neutral phrasing
-      (for example, "* A new guide page covers...",
-      "* The AI documentation has been reorganized to...",
-      or "* Guidance has been added for...").
+    * **Active Voice & Strong Verbs (No First-Person or Passive Voice):**
+      * Avoid first-person pronouns like "we", "I", "our", or "us"
+        in accordance with the
+        [Google developer documentation style guide][style-guide-voice]
+        (for example, do NOT write "* We reorganized...", "* We expanded...",
+        or "* We added...").
+      * Avoid passive voice constructions (for example, do NOT write
+        `* Guidance has been added...` or `* The page has been updated...`).
+      * Avoid weak existential lead-ins (for example, do NOT write
+        `* There is a new guide...`).
+      * Make the documentation, guide, or tool the active subject
+        * `* A new guide on [Dependency management][dependency-mgmt]`
+          `explains how to...`
+        * `* The assets guide now explains how to bundle...`
+        * `* The [Add-to-app][add-to-app] documentation now includes...`
+        * `* A new migration guide helps you migrate...`
+        * `* The Flutter [Widget Previews][widget-previewer] tool has`
+          `graduated to stable...`
     * **Formatting Rule:** Do NOT use bold topic prefixes followed by colons
       (for example, do not write
       `* **Widget Previews:** Flutter [Widget Previews]...`).

--- a/.agents/skills/update_whats_new/SKILL.md
+++ b/.agents/skills/update_whats_new/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: update-whats-new
+description: Update the whats-new page and archive old entries with changes to the website since the previous release.
+---
+
+# Update what's new page
+
+Use this skill when a new Flutter release has occurred and you need to update `sites/docs/src/content/release/whats-new.md` to describe the changes to the documentation site since the previous release.
+
+## Steps
+
+1.  **Identify the previous release date & version**
+
+    Read `sites/docs/src/content/release/whats-new.md` and locate the topmost release section.
+    Find the version and the release date for that release.
+    This is your starting point.
+
+2.  **Archive the oldest release (if necessary)**
+
+    To keep the "What's new" page focused on recent updates, it should typically hold only the last 3 to 4 releases. 
+    If adding a new release exceeds this limit, move the oldest release section from `sites/docs/src/content/release/whats-new.md` to `sites/docs/src/content/release/archive-whats-new.md`.
+    
+    * Open `archive-whats-new.md` and insert the moved section at the top of the stable releases list (just below the introduction, separated by `---`).
+    * Ensure all reference link definitions for that archived release are also moved to the bottom of the archived section.
+
+3.  **Retrieve recent Git commits**
+
+    Retrieve the git commits made to the documentation content directory since the previous release date identified in Step 1.
+    For example:
+    ```bash
+    git log --after="<previous_release_date>" --oneline -- sites/docs/src/content/
+    ```
+
+4.  **Analyze commits for meaningful changes**
+
+    Review the content of each commit since that date.
+    Identify changes that are significant to developers or users.
+    Look for:
+    * New pages or guides (e.g. AI guides, dependency management).
+    * Large or significant page updates.
+    * Deprecated pages or major migrations.
+    * New cookbook recipes or tutorials.
+
+    > [!IMPORTANT]
+    > ONLY include entries that are meaningful and user-facing to someone reading our documentation.
+    >
+    > **Do NOT include:**
+    > * Non-user-facing infrastructure changes.
+    > * Internal refactoring or maintenance simplifications.
+    > * Trivial tweaks (e.g. typos, link fixes, release notes index updates).
+    > * Commits from Dart/Flutter team members (e.g. Parker, Daco) unless they authored a major new guide.
+    >
+    > **DO include specific, high-impact changes, for example:**
+    > * Added a new guide for [installing plugins in IDEs](/tools/widget-previewer).
+    > * Reworked the [Android Kotlin migration guide](/release/breaking-changes/kotlin-version).
+    > * Added support for [Swift Package Manager Add-to-App](/platform-integration/ios/app-extensions).
+
+5.  **Create a new release section**
+
+    In `sites/docs/src/content/release/whats-new.md`, create a new section at the top of the file (just below the introduction) for the new release.
+    Follow the formatting and structure of past releases on the page:
+    * A heading with the release date and version, like `## 12 August 2026: Release 3.47`.
+    * An announcement paragraph linking to the release blog post: `check out the [Flutter 3.47 blog post][3.47-blog-post]`.
+    * If a release video is available, embed it using the `<YouTubeEmbed>` component:
+      ```html
+      <div class="video-wrapper">
+      <span class="video-intro">Check out the latest in Dart and Flutter</span>
+      <YouTubeEmbed id="VIDEO_ID" title="What's New in Dart and Flutter 3.47" fullWidth></YouTubeEmbed>
+      </div>
+      ```
+    * A list heading: `**Docs updated or added since the <Previous Version> release**`.
+
+6.  **Add entries for meaningful changes**
+
+    For each meaningful change identified in Step 4:
+    * Add a bullet point under the new release section.
+    * Write a concise explanation of the change.
+    * Add a link to the relevant section or new page using markdown reference links.
+    * If a community contributor was involved, thank them by including their GitHub handle in parentheses, for example: `(Thank you, [username][].)`. Only thank community contributors, not Flutter team members.
+
+7.  **Add and format link definitions**
+
+    Add the link definitions (reference links) to the bottom of the new release section, matching the style used throughout the document.
+    For example:
+    ```markdown
+    [3.47-blog-post]: /blog/whats-new-in-flutter-3-47
+    [username]: https://github.com/username
+    ```
+
+8.  **Request review**
+
+    Notify the developer that the `whats-new.md` page has been updated and ask them to verify the changes.

--- a/.agents/skills/update_whats_new/SKILL.md
+++ b/.agents/skills/update_whats_new/SKILL.md
@@ -75,7 +75,8 @@ Use this skill when a new Flutter release has occurred and you need to update `s
     For each meaningful change identified in Step 4:
     * Add a bullet point under the new release section.
     * Leave a blank line between each bullet point in the list to ensure consistent spacing and readability.
-    * Write a concise explanation of the change.
+    * Format all Markdown text using semantic line breaks and keep lines under 80 characters.
+    * **No First-Person Pronouns:** In accordance with the [Google developer documentation style guide](https://developers.google.com/style/voice), avoid first-person pronouns like "we", "I", "our", or "us" (e.g. do NOT write "* We reorganized...", "* We expanded...", "* We added..."). Instead, use neutral phrasing (e.g. "* A new guide page covers...", "* The AI documentation has been reorganized to...", "* Guidance has been added for...").
     * **Formatting Rule:** Do NOT use bold topic prefixes followed by colons (e.g. do NOT write `* **Widget Previews:** Flutter [Widget Previews]...`). Instead, write clean, natural sentences with the links integrated inline, matching the style of past entries (e.g. `The Flutter [Widget Previews][widget-previewer] tool has graduated to stable...`).
     * Add a link to the relevant section or new page using markdown reference links.
     * If a community contributor was involved, thank them by including their GitHub handle in parentheses, for example: `(Thank you, [username][].)`. Only thank community contributors, not Flutter team members.
@@ -84,6 +85,7 @@ Use this skill when a new Flutter release has occurred and you need to update `s
 7.  **Add and format link definitions**
 
     Add the link definitions (reference links) to the bottom of the new release section, matching the style used throughout the document.
+    * **No Unused Link Definitions:** Verify that every link definition defined at the bottom is actively referenced in the text above. Remove any unused link definitions.
     For example:
     ```markdown
     [3.47-blog-post]: /blog/whats-new-in-flutter-3-47


### PR DESCRIPTION
Add update-whats-new agent skill for Flutter documentation.

I included a "writer verification guide" portion of the skill which nudges anyone who uses the skill on how they can dig in to verify the proposed content.


## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
