### PR TITLE
Add go/android-hide-passwords-physical-keyboards

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -323,6 +323,7 @@
       { "source": "/go/android-dependency-versions", "destination": "https://docs.google.com/document/d/1qeeM5QG-jiafttSgvc7yvC19IDRggFFZQTktBVxL6sI/edit?usp=sharing&resourcekey=0-HLEAiBOMxAlQxDs-mEeffw", "type": 301 },
       { "source": "/go/android-embedding-dependencies", "destination": "https://docs.google.com/document/d/1vITp2mUZRa-cmll0sPH0zjNgPlyvOMx7awxPNRAPyic/edit", "type": 301 },
       { "source": "/go/android-embedding-move", "destination": "https://docs.google.com/document/d/1nQujwZfEe3QOHTyZn160eImpoJOYioADP09DtumcLcc/edit?ts=5d8041db#", "type": 301 },
+      { "source": "/go/android-hide-passwords-physical-keyboards", "destination": "https://docs.google.com/document/d/1j2rgUcPdZ35BeJYwkC4xR7MFfW54lgAVyUtwLCrPO9Y/edit", "type": 301 },
       { "source": "/go/android-java-gradle-error", "destination": "/release/breaking-changes/android-java-gradle-migration-guide", "type": 301 },
       { "source": "/go/android-local-area-permission", "destination": "https://docs.google.com/document/d/1mxBIzO-tWEa_RJk0aMWVQjooE5FUmrmWalGQ402D2Ck", "type": 301 },
       { "source": "/go/android-migration-summary", "destination": "https://docs.google.com/document/d/1wKspwf6LQu6uo32uQ9NcukfiKhLL4ButV9cwpjeb8QI", "type": 301 },


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_ Add a new go link for the hide password on Android design doc.

_Issues fixed by this PR (if any):_ NA

_PRs or commits this PR depends on (if any):_ NA

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
