### PR TITLE
docs: add Dart import migration step to l10n breaking change guide

### DIFF
--- a/sites/docs/src/content/release/breaking-changes/flutter-generate-i10n-source.md
+++ b/sites/docs/src/content/release/breaking-changes/flutter-generate-i10n-source.md
@@ -71,15 +71,14 @@ To migrate away from importing `package:flutter_gen`:
     ```
 
  2. **Update imports**. Update your Dart import statements to point to the
-    new location of the generated files, replacing `my_app` with your
-    application's package name:
+    new location of the generated files:
 
     ```dart
     // Before
     import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
-    // After (assuming arb-dir: lib/i18n)
-    import 'package:my_app/i18n/app_localizations.dart';
+    // After (assuming arb-dir: lib/i18n, importing from lib/main.dart)
+    import 'i18n/app_localizations.dart';
     ```
 
 ## Timeline

--- a/sites/docs/src/content/release/breaking-changes/flutter-generate-i10n-source.md
+++ b/sites/docs/src/content/release/breaking-changes/flutter-generate-i10n-source.md
@@ -1,5 +1,5 @@
 ---
-title: Localized messages are generated into source, not a synthetic package.
+title: Localized messages are generated into source, not a synthetic package
 description: >-
   When using `package:flutter_localizations`, the default generated location
   (and eventually, only possible location) is within your source (`lib/`)
@@ -55,9 +55,10 @@ const MaterialApp(
 );
 ```
 
-There is one way to migrate away from importing `package:flutter_gen`:
+To migrate away from importing `package:flutter_gen`:
 
- 1. Specify `synthetic-package: false` in the accompanying [`l10n.yaml`][] file:
+ 1. **Update configuration**. Specify `synthetic-package: false` in the
+    accompanying [`l10n.yaml`][] file:
 
     ```yaml title="l10n.yaml"
     synthetic-package: false
@@ -67,6 +68,18 @@ There is one way to migrate away from importing `package:flutter_gen`:
 
     # Or, specifically provide an output path:
     output-dir: lib/src/generated/i18n
+    ```
+
+ 2. **Update imports**. Update your Dart import statements to point to the
+    new location of the generated files, replacing `my_app` with your
+    application's package name:
+
+    ```dart
+    // Before
+    import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+    // After (assuming arb-dir: lib/i18n)
+    import 'package:my_app/i18n/app_localizations.dart';
     ```
 
 ## Timeline


### PR DESCRIPTION
Updates the `flutter_gen` breaking change migration guide to include a step for updating Dart imports after disabling synthetic package generation, and removes an accidental trailing period from the title.

Fixes https://github.com/flutter/website/issues/12139

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
