### PR TITLE
Fix build due to scss compilation failure

### DIFF
--- a/packages/site_shared/lib/_sass/base/_breakpoints.scss
+++ b/packages/site_shared/lib/_sass/base/_breakpoints.scss
@@ -12,12 +12,12 @@ $breakpoints: (
 
 /// Emits a minimum-width media query for the specified named breakpoint.
 ///
-/// @param {string} $name - A key in `$breakpoints`.
+/// @param {string} $breakpoint-name - A key in `$breakpoints`.
 /// @content Styles to emit at or above the breakpoint width.
 @mixin screen($breakpoint-name) {
-  $value: map.get($breakpoints, $name);
+  $value: map.get($breakpoints, $breakpoint-name);
   @if $value == null {
-    @error 'Unknown breakpoint: #{$name}';
+    @error 'Unknown breakpoint: #{$breakpoint-name}';
   }
   @media (min-width: $value) {
     @content;
@@ -27,12 +27,12 @@ $breakpoints: (
 /// Emits a max-width media query that ends just below
 /// the specified named breakpoint.
 ///
-/// @param {string} $name - A key in `$breakpoints`.
+/// @param {string} $breakpoint-name - A key in `$breakpoints`.
 /// @content Styles to emit below the breakpoint width.
 @mixin screen-below($breakpoint-name) {
-  $value: map.get($breakpoints, $name);
+  $value: map.get($breakpoints, $breakpoint-name);
   @if $value == null {
-    @error 'Unknown breakpoint: #{$name}';
+    @error 'Unknown breakpoint: #{$breakpoint-name}';
   }
   @media (max-width: $value - 0.02px) {
     @content;


### PR DESCRIPTION
Fix build failure caused by https://github.com/flutter/website/commit/b3f6aeb09d7e180c8ddadd9ed376904f612d0dce not updating the usages of the renamed parameter.