### PR TITLE
Clean up references to personal GitHub repositories in docs

### DIFF
--- a/sites/docs/src/content/learn/pathway/tutorial/widget-fundamentals.md
+++ b/sites/docs/src/content/learn/pathway/tutorial/widget-fundamentals.md
@@ -46,8 +46,8 @@ Before you move on, you need to add this logic to your app.
 
 The `legalGuesses` and `legalWords` lists in `lib/game.dart` only contain a
 small sample of five-letter words (such as `aback`, `abase`, and `abate`) for
-brevity. When you test your app later in this tutorial, make sure to guess words
-defined in `lib/game.dart`.
+brevity. When testing your app later in this tutorial, only words defined in
+`lib/game.dart` are accepted as valid guesses.
 :::
 
 ### Anatomy of a stateless widget

--- a/sites/docs/src/content/learn/pathway/tutorial/widget-fundamentals.md
+++ b/sites/docs/src/content/learn/pathway/tutorial/widget-fundamentals.md
@@ -44,18 +44,11 @@ Before you move on, you need to add this logic to your app.
 
 :::note Game logic note
 
-You might notice the
-`legalGuesses` and `legalWords` lists only contain a few words.
-The full lists combined have over 10,000 words and were omitted for brevity.
-You don't need the full lists to continue the tutorial.
-When you're testing your app, make sure to use the words from those lists.
-
-Alternatively, you can find the full lists in
-[this GitHub repository][full-words], as well as
-instructions to import it into your project.
+The `legalGuesses` and `legalWords` lists in `lib/game.dart` only contain a
+small sample of five-letter words (such as `aback`, `abase`, and `abate`) for
+brevity. When you test your app later in this tutorial, make sure to guess words
+defined in `lib/game.dart`.
 :::
-
-[full-words]: https://github.com/ericwindmill/legal_wordle_words
 
 ### Anatomy of a stateless widget
 

--- a/sites/docs/src/content/platform-integration/web/embedding-flutter-web.md
+++ b/sites/docs/src/content/platform-integration/web/embedding-flutter-web.md
@@ -249,11 +249,11 @@ class _MultiViewAppState extends State<MultiViewApp> with WidgetsBindingObserver
 }
 ```
 
-For more information, check out [`WidgetsBinding` mixin][] in the API docs, or
-the [Multi View Playground repo][] that was used during development.
+For more information, check out the
+[`WidgetsBinding` mixin]({{site.api}}/flutter/widgets/WidgetsBinding-mixin.html)
+in the API docs.
 
 [`didChangeMetrics` method]: {{site.api}}/flutter/widgets/WidgetsBindingObserver/didChangeMetrics.html
-[Multi View Playground repo]: https://github.com/goderbauer/mvp
 [type `FlutterView`]: {{site.api}}/flutter/dart-ui/FlutterView-class.html
 [`View` widget]: {{site.api}}/flutter/widgets/View-class.html
 [`ViewCollection` widget]: {{site.api}}/flutter/widgets/ViewCollection-class.html

--- a/sites/docs/src/content/release/breaking-changes/paint-enableDithering.md
+++ b/sites/docs/src/content/release/breaking-changes/paint-enableDithering.md
@@ -82,12 +82,10 @@ As the plan is to _permanently_ remove the `enableDithering` property, please
 provide feedback in [Issue 112498][] if you have a use case that requires
 disabling dithering (due to performance, crashes).
 
-If for some reason you _must_ draw gradients without dithering, you'll need to
-write your own custom shader. Describing that is out of the scope of this
-migration guide, but you can find some resources and examples:
-
-- [Writing and using fragment shaders][]
-- [`hsl_linear_gradient.frag`][]
+If you must draw gradients without dithering, you can write a custom fragment
+shader. Describing how to write shaders is outside the scope of this migration
+guide. For more information, see
+[Writing and using fragment shaders](/ui/design/graphics/fragment-shaders).
 
 **NOTE**: Flutter web does not support dithering: [Issue 134250][].
 
@@ -131,5 +129,3 @@ Relevant PRs:
 [Issue 112498]: {{site.repo.flutter}}/issues/112498
 [Issue 118073]: {{site.repo.flutter}}/issues/118073
 [Issue 134250]: {{site.repo.flutter}}/issues/134250
-[Writing and using fragment shaders]: /ui/design/graphics/fragment-shaders
-[`hsl_linear_gradient.frag`]: https://github.com/jonahwilliams/awesome_gradients/blob/a4e09c47ef1760bd7073beb60f49dad8ede5bb2e/shaders/hsl_linear_gradient.frag

--- a/sites/docs/src/content/release/breaking-changes/paint-enableDithering.md
+++ b/sites/docs/src/content/release/breaking-changes/paint-enableDithering.md
@@ -84,7 +84,7 @@ disabling dithering (due to performance, crashes).
 
 If you must draw gradients without dithering, you can write a custom fragment
 shader. Describing how to write shaders is outside the scope of this migration
-guide. For more information, see
+guide. For more information, refer to
 [Writing and using fragment shaders](/ui/design/graphics/fragment-shaders).
 
 **NOTE**: Flutter web does not support dithering: [Issue 134250][].


### PR DESCRIPTION
## Description

This PR cleans up references to personal GitHub repositories in official documentation:

- **`widget-fundamentals.md`:** Removed reference to `ericwindmill/legal_wordle_words`. Clarified that the starter `lib/game.dart` file contains an abbreviated list of sample words (`aback`, `abase`, `abate`) for testing during the tutorial.
- **`embedding-flutter-web.md`:** Replaced reference to `goderbauer/mvp` with an in-line link to the official `WidgetsBinding` API documentation.
- **`paint-enableDithering.md`:** Replaced reference to `jonahwilliams/awesome_gradients` with an in-line link to the official guide on Writing and using fragment shaders.

## Related Issues
N/A