### PR TITLE
Fix parameter names in SCSS breakpoint mixins

### DIFF
--- a/packages/site_shared/lib/_sass/base/_breakpoints.scss
+++ b/packages/site_shared/lib/_sass/base/_breakpoints.scss
@@ -14,7 +14,7 @@ $breakpoints: (
 ///
 /// @param {string} $name - A key in `$breakpoints`.
 /// @content Styles to emit at or above the breakpoint width.
-@mixin screen($breakpoint-name) {
+@mixin screen($name) {
   $value: map.get($breakpoints, $name);
   @if $value == null {
     @error 'Unknown breakpoint: #{$name}';
@@ -29,7 +29,7 @@ $breakpoints: (
 ///
 /// @param {string} $name - A key in `$breakpoints`.
 /// @content Styles to emit below the breakpoint width.
-@mixin screen-below($breakpoint-name) {
+@mixin screen-below($name) {
   $value: map.get($breakpoints, $name);
   @if $value == null {
     @error 'Unknown breakpoint: #{$name}';


### PR DESCRIPTION
## Description

Fixes a site build failure introduced in #13766 where the `screen` and `screen-below` mixins declared their parameter as `$breakpoint-name` but referenced `$name` inside the mixin bodies, causing an "Undefined variable: $name" error during SCSS compilation.

- Updates `@mixin screen($breakpoint-name)` to `@mixin screen($name)`
- Updates `@mixin screen-below($breakpoint-name)` to `@mixin screen-below($name)`

## Related Issues
Fixes build failure on `main` following #13766