### PR TITLE
Reduce preview expiration time to 5d

### DIFF
--- a/tool/dash_site/lib/src/commands/stage_preview.dart
+++ b/tool/dash_site/lib/src/commands/stage_preview.dart
@@ -45,7 +45,7 @@ final class StagePreviewCommand extends Command<int> {
       )
       ..addOption(
         _expiresOption,
-        defaultsTo: '7d',
+        defaultsTo: '5d',
         help: 'How long the Firebase Hosting preview channel should live.',
         valueHelp: 'duration',
       )


### PR DESCRIPTION
The gives the entire work week before a preview expires, helping reduce the amount of . If needed, `/gcbrun` can be commented to update/recreate the preview.