### PR TITLE
Document PDB symbol files for obfuscated Windows x64 builds

### DIFF
--- a/sites/docs/src/content/deployment/obfuscate.md
+++ b/sites/docs/src/content/deployment/obfuscate.md
@@ -93,15 +93,30 @@ app in the future, you will need the symbol map.
       file should be placed. For example,
       `out/android`.
 
+   :::note
+   On Windows x64, the build generates a PDB file
+   (`app.windows-x64.pdb`) instead of a SYMBOLS file.
+   :::
+
 1. Once you've obfuscated your binary, **backup
-   the SYMBOLS file**. You might need this if you lose
-   your original SYMBOLS file and you
+   the SYMBOLS file** (or the PDB file on Windows x64).
+   You might need this if you lose
+   your original SYMBOLS file (or PDB file) and you
    want to de-obfuscate a stack trace.
 
 ## Read an obfuscated stack trace
 
 To debug a stack trace created by an obfuscated app,
 use the following steps to make it human readable:
+
+:::note
+On Windows x64, `--split-debug-info` generates a PDB file
+instead of a SYMBOLS file,
+and the `flutter symbolize` command doesn't support
+PDB files. To read a stack trace from an obfuscated
+Windows x64 build, load the PDB file in a Windows
+debugger such as WinDbg.
+:::
 
 1. Find the matching SYMBOLS file.
    For example, a crash from an Android arm64


### PR DESCRIPTION
## Summary

With PE/COFF AOT snapshots (flutter/flutter#187594), Windows x64 builds using `--split-debug-info` produce a PDB file (`app.windows-x64.pdb`) instead of an `app.windows-x64.symbols` DWARF file, and `flutter symbolize` doesn't support PDB files.

This updates the obfuscation docs to:

- Note that Windows x64 builds generate `app.windows-x64.pdb` instead of a SYMBOLS file.
- Note that `flutter symbolize` doesn't support PDB files, and that stack traces from obfuscated Windows x64 builds are read with a Windows debugger (for example, WinDbg) and the PDB file.

**Do not merge until flutter/flutter#187594 lands and reaches the stable channel**, since this page documents stable-channel behavior.

Fixes the docs question raised in https://github.com/flutter/flutter/pull/187594#issuecomment-5344177055