### PR TITLE
docs(agents): update technical writing guidance and skills to avoid using see when referring to things.

### DIFF
--- a/.agents/skills/write-technical-docs/SKILL.md
+++ b/.agents/skills/write-technical-docs/SKILL.md
@@ -81,11 +81,17 @@ Apply these rules to most developer-facing prose.
   only when it's part of the quoted content.
   For ordinary prose quotations,
   place commas and periods inside the closing quotation mark.
-  For examples, see [Punctuation](references/punctuation.md).
+  For examples, consult [Punctuation](references/punctuation.md).
 - Use the **serial comma**, also called the **Oxford comma**:
   "buttons, links, and menus".
 - Use **descriptive link text** that names the destination.
   Never link bare "click here", "here", "this", or "read more".
+- Avoid using "see", "see the", or "for more information, see" to introduce
+  links or cross-references.
+  Prefer action-oriented or descriptive phrasing such as
+  "refer to", "consult", or "visit"
+  (for example, "To learn about X, visit Y" or
+  "For details, consult the X documentation").
 - Write _and_, not `&`, except in code, a space-constrained label,
   or when matching a UI label.
 - Write **unambiguous dates**:
@@ -107,7 +113,7 @@ Apply these rules to most developer-facing prose.
 
 - **Don't pre-announce** unreleased features, dates, or plans.
   Document only released behavior.
-  For additional guidance, see [Voice and tone](references/voice-and-tone.md).
+  For additional guidance, consult [Voice and tone](references/voice-and-tone.md).
 - Write for a **global audience**: avoid idioms, cultural references,
   humor that doesn't translate, and directional words that assume a layout.
 - Use **inclusive language**:
@@ -116,7 +122,7 @@ Apply these rules to most developer-facing prose.
   _placeholder_ over _dummy_,
   and people-first or community-preferred phrasing.
   For additional guidance,
-  see [Inclusive and global writing](references/inclusive-and-global.md)
+  consult [Inclusive and global writing](references/inclusive-and-global.md)
   and [Word choice](references/word-choice.md).
 
 ## References

--- a/.agents/skills/write-technical-docs/references/formatting-and-structure.md
+++ b/.agents/skills/write-technical-docs/references/formatting-and-structure.md
@@ -227,10 +227,15 @@ Use these rules to structure and format documentation.
   or "read more" as the link text.
 - Don't use a bare URL as link text in prose.
   Link a meaningful phrase.
-- Introduce links naturally:
+- Introduce links naturally without using "see":
   "For more information about quotas,
-  see [Quotas and limits][]".
+  consult [Quotas and limits][]",
+  or "To learn about quotas, visit [Quotas and limits][]".
   Use "about", not "on".
+- Avoid using "see", "see the", or "for more information, see"
+  when directing readers to links or cross-references.
+  Prefer action-oriented or descriptive phrasing such as
+  "refer to", "consult", or "visit".
 - Don't say "the link below".
   Link the actual thing.
 - Write headings that produce stable, readable anchor links:

--- a/.agents/skills/write-technical-docs/references/word-choice.md
+++ b/.agents/skills/write-technical-docs/references/word-choice.md
@@ -3,7 +3,7 @@
 Use this reference for common terms and naming rules in developer documentation.
 
 For UI verbs such as _click_, _tap_, and _select_,
-see [UI elements and interaction](code-and-ui.md#ui-elements-and-interaction).
+consult [UI elements and interaction](code-and-ui.md#ui-elements-and-interaction).
 
 For a strict terminology review or guidance about a term not covered here,
 consult the [strict-review word list](word-list.yaml).
@@ -39,6 +39,10 @@ An explicit project convention takes precedence.
 - Instead of _above_ and _below_,
   refer to the named element or use _earlier_, _preceding_,
   _later_, or _following_ as appropriate.
+- Avoid using _see_ or _see the_ to introduce links or references.
+  Prefer _refer to_, _consult_, or _visit_
+  (for example, "To learn about X, visit Y" or
+  "For details, consult the X documentation").
 - Replace _via_ with _through_, _with_, or _by using_.
 - Replace the verbs _leverage_ and _utilize_ with _use_.
 - Use _sign in_, not _log in_, unless the UI uses _log in_.

--- a/.agents/skills/write-technical-docs/references/word-list.yaml
+++ b/.agents/skills/write-technical-docs/references/word-list.yaml
@@ -2008,9 +2008,12 @@
     Pluralize as SDKs without an apostrophe.
 
 - term: "see"
-  status: ok
+  status: caution
+  prefer: ["refer to", "consult", "visit"]
   guidance: >-
-    OK as a general term and for links and cross-references.
+    Avoid using to introduce links and cross-references.
+    Prefer action-oriented or descriptive phrasing such as
+    refer to, consult, or visit (for example, "To learn about X, visit Y").
 
 - term: "select"
   status: ok

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,12 @@ Writing should be consistent across the site and follow the
 In Markdown files, use [semantic line breaks](https://sembr.org/) and
 try to keep each line under 80 characters long.
 
+#### Cross-references and links
+
+Avoid using "see", "see the", or "for more information, see" to introduce
+links or references. Prefer action-oriented or descriptive phrasings such as
+"refer to", "consult", or "visit" (for example, "To learn about X, visit Y").
+
 ## Coding guidelines
 
 All Dart code should follow [Effective Dart](https://dart.dev/effective-dart),


### PR DESCRIPTION
Updated guidance on using "see" to refer to things.

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
