### PR TITLE
Add issue form template for documenting new Flutter features

### DIFF
--- a/.github/ISSUE_TEMPLATE/5_feature_doc.yml
+++ b/.github/ISSUE_TEMPLATE/5_feature_doc.yml
@@ -1,5 +1,7 @@
 name: Document a new Flutter feature
-description: Request or coordinate documentation on docs.flutter.dev for a new or updated Flutter feature.
+description: >-
+  Request or coordinate documentation on docs.flutter.dev for a new or
+  updated Flutter feature.
 labels: [co.request, from.user]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/5_feature_doc.yml
+++ b/.github/ISSUE_TEMPLATE/5_feature_doc.yml
@@ -12,7 +12,7 @@ body:
     id: pr-link
     attributes:
       label: Related code pull request or issue
-      description: Link to the pull request or issue in `flutter/flutter` or `flutter/packages`.
+      description: Link to the pull request or issue in a Flutter repository (such as `flutter/flutter` or `flutter/packages`).
       placeholder: "https://github.com/flutter/flutter/pull/12345"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/5_feature_doc.yml
+++ b/.github/ISSUE_TEMPLATE/5_feature_doc.yml
@@ -1,0 +1,64 @@
+name: Document a new Flutter feature
+description: Request or coordinate documentation on docs.flutter.dev for a new or updated Flutter feature.
+labels: [co.request, from.user]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing to Flutter! Use this form to request or coordinate documentation on [docs.flutter.dev](https://docs.flutter.dev) for new features or capabilities.
+  - type: input
+    id: pr-link
+    attributes:
+      label: Related code pull request
+      description: Link to the pull request in `flutter/flutter`, `flutter/engine`, or `flutter/packages`.
+      placeholder: "https://github.com/flutter/flutter/pull/12345"
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Feature summary
+      description: Provide a concise description of the new feature and the problem it solves for developers.
+      placeholder: Describe what changed, what developers can now do, and any key concepts...
+    validations:
+      required: true
+  - type: dropdown
+    id: doc-type
+    attributes:
+      label: Type of documentation needed
+      description: Select the primary type of documentation this change requires.
+      multiple: true
+      options:
+        - New conceptual page or guide
+        - Update to an existing guide on docs.flutter.dev
+        - Cookbook recipe or practical code sample
+        - CLI or tooling documentation
+        - Platform support or integration guide
+        - Breaking change migration guide
+    validations:
+      required: true
+  - type: textarea
+    id: code-sample
+    attributes:
+      label: Code snippet or usage example
+      description: Provide a minimal code snippet showing how developers will use this feature.
+      render: dart
+      placeholder: |
+        // Minimal code snippet showing feature usage
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context or resources
+      description: Link to design docs, screenshots, or any notes that will assist technical writers.
+    validations:
+      required: false
+  - type: checkboxes
+    id: volunteer
+    attributes:
+      label: I would like to help write this documentation.
+      description: Let us know if you want to author or draft the documentation PR yourself.
+      options:
+        - label: I will draft the documentation PR on docs.flutter.dev.
+          required: false

--- a/.github/ISSUE_TEMPLATE/5_feature_doc.yml
+++ b/.github/ISSUE_TEMPLATE/5_feature_doc.yml
@@ -9,11 +9,11 @@ body:
   - type: input
     id: pr-link
     attributes:
-      label: Related code pull request
-      description: Link to the pull request in `flutter/flutter`, `flutter/engine`, or `flutter/packages`.
+      label: Related code pull request or issue
+      description: Link to the pull request or issue in `flutter/flutter`, `flutter/engine`, or `flutter/packages`.
       placeholder: "https://github.com/flutter/flutter/pull/12345"
     validations:
-      required: true
+      required: false
   - type: textarea
     id: summary
     attributes:
@@ -26,7 +26,7 @@ body:
     id: doc-type
     attributes:
       label: Type of documentation needed
-      description: Select the primary type of documentation this change requires.
+      description: Select the types of documentation this change requires.
       multiple: true
       options:
         - New conceptual page or guide
@@ -57,8 +57,8 @@ body:
   - type: checkboxes
     id: volunteer
     attributes:
-      label: I would like to help write this documentation.
-      description: Let us know if you want to author or draft the documentation PR yourself.
+      label: Volunteer to help write this documentation
+      description: Let us know if you want to author or draft the documentation PR.
       options:
-        - label: I will draft the documentation PR on docs.flutter.dev.
+        - label: Draft the documentation PR on docs.flutter.dev.
           required: false

--- a/.github/ISSUE_TEMPLATE/5_feature_doc.yml
+++ b/.github/ISSUE_TEMPLATE/5_feature_doc.yml
@@ -10,7 +10,7 @@ body:
     id: pr-link
     attributes:
       label: Related code pull request or issue
-      description: Link to the pull request or issue in `flutter/flutter`, `flutter/engine`, or `flutter/packages`.
+      description: Link to the pull request or issue in `flutter/flutter` or `flutter/packages`.
       placeholder: "https://github.com/flutter/flutter/pull/12345"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/5_feature_doc.yml
+++ b/.github/ISSUE_TEMPLATE/5_feature_doc.yml
@@ -24,19 +24,18 @@ body:
       placeholder: Describe what changed, what developers can now do, and any key concepts...
     validations:
       required: true
-  - type: dropdown
+  - type: checkboxes
     id: doc-type
     attributes:
       label: Type of documentation needed
-      description: Select the types of documentation this change requires.
-      multiple: true
+      description: Select all types of documentation this change requires.
       options:
-        - New conceptual page or guide
-        - Update to an existing guide on docs.flutter.dev
-        - Cookbook recipe or practical code sample
-        - CLI or tooling documentation
-        - Platform support or integration guide
-        - Breaking change migration guide
+        - label: New conceptual page or guide
+        - label: Update to an existing guide on docs.flutter.dev
+        - label: Cookbook recipe or practical code sample
+        - label: CLI or tooling documentation
+        - label: Platform support or integration guide
+        - label: Breaking change migration guide
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Adds a dedicated GitHub Issue Form (`5_feature_doc.yml`) to allow community contributors and maintainers to easily request, track, and provide context for new Flutter features needing documentation on [docs.flutter.dev](https://docs.flutter.dev) ahead of releases.

_Issues fixed by this PR (if any):_

None

_PRs or commits this PR depends on (if any):_

Related: flutter/flutter#192080

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.