### PR TITLE
Fix code block and copy button style issues on blog

### DIFF
--- a/packages/site_shared/lib/_sass/components/_code.scss
+++ b/packages/site_shared/lib/_sass/components/_code.scss
@@ -376,6 +376,11 @@ pre {
       display: block;
       min-width: fit-content;
       width: 100%;
+
+      // Keep inline-code borders from leaking into code blocks when
+      // a consumer's site styles alter the cascade.
+      border: none;
+      border-radius: unset;
     }
   }
 }

--- a/sites/www/content/blog/a2ui-client-side-functions/index.md
+++ b/sites/www/content/blog/a2ui-client-side-functions/index.md
@@ -98,7 +98,7 @@ class CalculateCostFunction extends SynchronousClientFunction {
   @override
   String get name => 'calculateCost';
 
-// 2. Clear description provided to the LLM so it knows when
+  // 2. Clear description provided to the LLM so it knows when
   // and why to use the function.
   @override
   String get description =>

--- a/sites/www/lib/styles/pages/_blog_page.scss
+++ b/sites/www/lib/styles/pages/_blog_page.scss
@@ -1,3 +1,5 @@
+@use 'package:site_shared/_sass/base/mixins';
+
 .blog main {
   display: flex;
   flex-direction: row;
@@ -34,6 +36,50 @@
     @media (min-width: 576px) {
       > .content {
         padding: 2rem;
+      }
+    }
+
+    // Styles extracted from _button.scss until the www site can import it.
+    .code-block-wrapper .code-block-body .copy-button {
+      --site-interaction-base-values: 0 0 0;
+
+      display: flex;
+      align-items: center;
+      width: fit-content;
+      white-space: nowrap;
+      outline-offset: 1px;
+      border-radius: 24px;
+      gap: 0.3rem;
+      padding: 0.4rem 0.9rem;
+
+      font-family: var(--site-ui-fontFamily);
+      font-weight: 500;
+      color: var(--site-primary-color);
+      text-decoration: none;
+      cursor: pointer;
+      background: none;
+
+      &:not(:disabled):hover {
+        @include mixins.interaction-style(4%);
+      }
+
+      &:not(:disabled):active {
+        @include mixins.interaction-style(8%);
+      }
+
+      &.icon-button {
+        border-radius: 0.25rem;
+        padding: 0.25rem;
+        color: var(--site-base-fgColor-alt);
+        user-select: none;
+
+        >span {
+          font-size: 1.75rem;
+        }
+
+        &:not(:disabled):hover {
+          color: var(--site-base-fgColor);
+        }
       }
     }
   }


### PR DESCRIPTION
- Sets up code block copy button styles, extracted from the docs site's.
- Avoid a duplicate inner border added to code blocks when a user or an extension they have overrides styles.

Fixes https://github.com/flutter/website/issues/13756