### PR TITLE
Fix inline feedback analytics event name

### DIFF
--- a/packages/site_shared/lib/src/analytics/analytics.dart
+++ b/packages/site_shared/lib/src/analytics/analytics.dart
@@ -15,6 +15,6 @@ abstract class Analytics {
 
   /// Reports whether the user found the current page [helpful].
   void sendFeedback(bool helpful) {
-    sendEvent('feedback', {'feedback_type': helpful ? 'up' : 'down'});
+    sendEvent('inline_feedback', {'feedback_type': helpful ? 'up' : 'down'});
   }
 }


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Updates `Analytics.sendFeedback` in `site_shared` to dispatch `inline_feedback` instead of `feedback`.

Google Tag Manager (`GTM-ND4LWWZ`) uses a custom event trigger configured to match `event == 'inline_feedback'` to fire the GA4 Event tag. Because the Jaspr migration dispatched `event: 'feedback'`, the GTM trigger was not matched, preventing thumbs-up and thumbs-down feedback events from reaching Google Analytics.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.