### PR TITLE
Update documented Flutter version to 3.47.2

### DIFF
--- a/sites/docs/src/data/site.yml
+++ b/sites/docs/src/data/site.yml
@@ -56,7 +56,7 @@ yt:
   watch: 'https://www.youtube.com/watch'
   playlist: 'https://www.youtube.com/playlist?list='
 
-currentFlutterVersion: '3.44.7'
+currentFlutterVersion: '3.47.2'
 
 # Settings for Jaspr.
 


### PR DESCRIPTION
Update `currentFlutterVersion` in `sites/docs/src/data/site.yml` from `3.44.7` to `3.47.2` (the latest stable Flutter release).

This updates the footer on docs.flutter.dev ("Unless stated otherwise, the documentation on this site reflects Flutter 3.47.2") as well as references like `supported-platforms.md`.

TAG=agy
CONV=1ceed62b-ef52-4e2a-b1cf-f23e2ee8260c