### PR TITLE
Remove client productionBuild guard in AnalyticsImplementation

### DIFF
--- a/packages/site_shared/lib/src/analytics/analytics_web.dart
+++ b/packages/site_shared/lib/src/analytics/analytics_web.dart
@@ -6,7 +6,6 @@ import 'package:meta/meta.dart';
 import 'package:universal_web/js_interop.dart';
 import 'package:universal_web/web.dart' as web;
 
-import '../../util.dart';
 import 'analytics.dart';
 
 /// Web implementation of [Analytics].
@@ -16,9 +15,6 @@ import 'analytics.dart';
 final class AnalyticsImplementation extends Analytics {
   @override
   void sendEvent(String eventName, Map<String, Object?> parameters) {
-    if (!productionBuild) {
-      return;
-    }
     final dataLayer = web.window['dataLayer'];
     if (dataLayer.isA<JSArray>()) {
       (dataLayer as JSArray).toDart.add(


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Removes the client-side `if (!productionBuild) return;` guard in `AnalyticsImplementation` within `site_shared`.

In client-side `dart2js` builds, the `PRODUCTION` environment variable is not passed to the compiler options in `build.yaml`, resulting in `productionBuild` evaluating to `false`. As a result, the `-O4` compiler stripped out the `window.dataLayer` push in `sendEvent`.

Feedback events are now verified and working on the Dart documentation site (`dart-lang/site-www`), and this update matches the implementation in `dart-lang/site-www` where `sendEvent` directly pushes to `dataLayer`. On local development builds, Google Tag Manager is not injected, so `window['dataLayer']` does not exist and calls to `sendEvent` safely evaluate to a no-op without requiring this check.

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_
#13849

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.