### PR TITLE
Remove built-in Kotlin workaround for plugin authors

### DIFF
--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
@@ -7,6 +7,16 @@ description: >-
 This guide outlines the migration steps specifically for plugin authors.
 
 :::warning
+Migrating to built-in Kotlin requires a minimum Flutter version of 3.44.
+
+This migration uses `kotlin.compilerOptions {}`,
+which requires Kotlin Gradle Plugin (KGP) 2.0.0 or higher.
+Flutter enforces a minimum KGP version of 2.0.0 starting in Flutter 3.44.
+Plugin authors must update their plugin's minimum Flutter version
+to at least 3.44 in `pubspec.yaml` when migrating.
+:::
+
+:::warning
 This guide only applies to plugins that already use the
 Kotlin Gradle Plugin (KGP).
 
@@ -31,12 +41,6 @@ follow the [migration guide for app developers][].
 [migration guide for app developers]: /release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers
 
 ## Update the Gradle file
-
-The following steps assume you can
-update your plugin's Flutter SDK minimum to 3.44.
-If you can't update the Flutter SDK minimum to 3.44,
-follow the instructions to
-[support Flutter versions earlier than 3.44][flutter-sdk-minimum-below-3.44].
 
 First, find the `kotlin-android` plugin
 (or the `org.jetbrains.kotlin.android` plugin).
@@ -192,8 +196,6 @@ kotlin {
 </Tab>
 </Tabs>
 
-[flutter-sdk-minimum-below-3.44]: #support-flutter-versions-earlier-than-3-44
-
 ## Update the plugin's `pubspec.yaml`
 
 Using the `kotlin.compilerOptions {}` DSL block requires
@@ -237,193 +239,6 @@ environment:
 
 # ...
 ```
-
-<a id="supporting-flutter-versions-earlier-than-3-44" aria-hidden="true"></a>
-
-## Support Flutter versions earlier than 3.44
-
-If you updated your plugin's Flutter SDK minimum to 3.44,
-skip this section and proceed to
-[updating the plugin's `CHANGELOG.md`](#update-the-plugins-changelog).
-
-If you can't update the plugin's Flutter SDK minimum to 3.44, you must
-make the following changes to `<plugin-project>/android/build.gradle` or
-`<plugin-project>/android/build.gradle.kts` to
-support apps on AGP versions less than 9 and versions on 9 or later.
-
-<Tabs key="workaround-for-plugins">
-<Tab name="Kotlin DSL fix">
-
-**Before**:
-
-```kotlin title="<app-src>/android/build.gradle.kts"
-plugins {
-    id("com.android.library")
-    id("kotlin-android")
-    // ...
-}
-
-android {
-    // ...
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
-    }
-    // ...
-}
-
-// ...
-```
-
-Next, remove the `kotlin-android` plugin and the `kotlinOptions` block:
-
-```kotlin diff title="<app-src>/android/build.gradle.kts"
-  plugins {
-      id("com.android.library")
--     id("kotlin-android")
-      // ...
-  }
-
-  android {
-      // ...
--     kotlinOptions {
--         jvmTarget = JavaVersion.VERSION_17.toString()
--     }
-      // ...
-  }
-```
-
-Add a check to apply the Kotlin Gradle Plugin only when
-the app's Android Gradle Plugin version is less than version 9.
-
-```kotlin diff title="<app-src>/android/build.gradle.kts"
-+ val agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.substringBefore('.').toInt()
-+
-+ if (agpMajor < 9) {
-+     apply(plugin = "org.jetbrains.kotlin.android")
-+ }
-```
-
-Add the `compilerOptions` configuration using the project extension:
-
-```kotlin diff title="<app-src>/android/build.gradle.kts"
-+ project.extensions.configure(org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension::class.java) {
-+     compilerOptions {
-+         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-+     }
-+ }
-```
-
-Here is how the file will likely end up:
-
-**After**:
-
-```kotlin title="<app-src>/android/build.gradle.kts"
-plugins {
-    id("com.android.library")
-    // ...
-}
-
-val agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.substringBefore('.').toInt()
-
-if (agpMajor < 9) {
-    apply(plugin = "org.jetbrains.kotlin.android")
-}
-
-android {
-    // ...
-}
-
-project.extensions.configure(org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension::class.java) {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
-}
-
-// ...
-```
-
-</Tab>
-<Tab name="Groovy DSL fix">
-
-**Before**:
-
-```groovy title="<app-src>/android/build.gradle"
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-
-android {
-    // ...
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
-    }
-    // ...
-}
-
-// ...
-```
-
-Next, remove the `kotlin-android` plugin and the `kotlinOptions` block:
-
-```groovy diff title="<app-src>/android/build.gradle"
-  apply plugin: 'com.android.library'
-- apply plugin: 'kotlin-android'
-
-  android {
-      // ...
--     kotlinOptions {
--         jvmTarget = JavaVersion.VERSION_17.toString()
--     }
-      // ...
-  }
-```
-
-Add a check to apply the Kotlin Gradle Plugin only when
-the app's Android Gradle Plugin version is less than version 9.
-
-```groovy diff title="<app-src>/android/build.gradle"
-+ def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-+
-+ if (agpMajor < 9) {
-+    apply plugin: 'kotlin-android'
-+ }
-```
-
-Add the `kotlin.compilerOptions{}` DSL block with the following:
-
-```groovy diff title="<app-src>/android/build.gradle"
-+ kotlin {
-+     compilerOptions {
-+         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-+     }
-+ }
-```
-
-Here is how the file will likely end up:
-
-**After**:
-
-```groovy title="<app-src>/android/build.gradle"
-apply plugin: 'com.android.library'
-
-def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
-    apply plugin: 'kotlin-android'
-}
-
-android {
-    // ...
-}
-
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
-}
-
-// ...
-```
-</Tab>
-</Tabs>
 
 <a id="update-the-plugins-changelog-md" aria-hidden="true"></a>
 

--- a/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
+++ b/sites/docs/src/content/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors.md
@@ -14,9 +14,7 @@ which requires Kotlin Gradle Plugin (KGP) 2.0.0 or higher.
 Flutter enforces a minimum KGP version of 2.0.0 starting in Flutter 3.44.
 Plugin authors must update their plugin's minimum Flutter version
 to at least 3.44 in `pubspec.yaml` when migrating.
-:::
 
-:::warning
 This guide only applies to plugins that already use the
 Kotlin Gradle Plugin (KGP).
 


### PR DESCRIPTION
Removes the "Support Flutter versions earlier than 3.44" workaround section from the built-in Kotlin plugin migration guide.

This pre-emptively removes the workaround to discourage plugin authors from adopting the Flutter 3.44 workaround across mixed migration states. Migrating to built-in Kotlin requires Flutter 3.44 or later because `kotlin.compilerOptions {}` requires KGP 2.0.0 or higher.

If we decide we actually want to allow plugin authors to use this workaround, we can always add it back later. This removal is to prevent further potential damage.

For more on removing the workaround, see this internal doc [here](https://docs.google.com/document/d/1c4vm5djk8AepvasnVomko_ho3XH7C2uHtEpe-uTRMYU/edit?tab=t.0).

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.