### PR TITLE
docs: clarify FlutterLoader.loadEntrypoint deprecation

### DIFF
--- a/sites/docs/src/content/platform-integration/web/initialization.md
+++ b/sites/docs/src/content/platform-integration/web/initialization.md
@@ -291,7 +291,16 @@ This warning occurs when an older `web/index.html` file uses
 The CLI message references the `FlutterLoader` interface,
 which JavaScript code accesses through `_flutter.loader`.
 
-To resolve this warning, update your bootstrap code in `web/index.html`
+If your app uses the default initialization and doesn't require
+custom bootstrapping, replace the legacy script block in `web/index.html`
+with the standard script tag:
+
+```html title="web/index.html"
+<script src="flutter_bootstrap.js" async></script>
+```
+
+If you customized your initialization logic,
+update your bootstrap code in `web/index.html`
 (or a custom `web/flutter_bootstrap.js` file)
 to call `_flutter.loader.load()` instead:
 

--- a/sites/docs/src/content/platform-integration/web/initialization.md
+++ b/sites/docs/src/content/platform-integration/web/initialization.md
@@ -260,7 +260,9 @@ _flutter.loader.load({
 });
 ```
 
-## Common warning
+## Common warnings {:#common-warnings}
+
+### Service worker version deprecation
 
 If you experience a warning similar to the following:
 
@@ -269,8 +271,40 @@ Warning: In index.html:37: Local variable for "serviceWorkerVersion" is deprecat
 Use "{{flutter_service_worker_version}}" template token instead.
 ```
 
-You can fix this by deleting the following line from the `web/index.html` file:
+Delete the following line from the `web/index.html` file:
 
 ```html title="web/index.html"
 var serviceWorkerVersion = null;
 ```
+
+### FlutterLoader.loadEntrypoint deprecation
+
+If you experience a warning similar to the following:
+
+```text
+Warning: In index.html:40: "FlutterLoader.loadEntrypoint" is deprecated.
+Use "FlutterLoader.load" instead.
+```
+
+This warning occurs when an older `web/index.html` file uses
+`_flutter.loader.loadEntrypoint()` instead of `_flutter.loader.load()`.
+The CLI message references the `FlutterLoader` interface,
+which JavaScript code accesses through `_flutter.loader`.
+
+To resolve this warning, update your bootstrap code in `web/index.html`
+(or a custom `web/flutter_bootstrap.js` file)
+to call `_flutter.loader.load()` instead:
+
+```js
+_flutter.loader.load({
+  onEntrypointLoaded: async function(engineInitializer) {
+    const appRunner = await engineInitializer.initializeEngine();
+    await appRunner.runApp();
+  }
+});
+```
+
+To review an example that updates DOM elements during startup,
+consult the [progress indicator example][].
+
+[progress indicator example]: #example-display-a-progress-indicator

--- a/sites/docs/src/content/platform-integration/web/initialization.md
+++ b/sites/docs/src/content/platform-integration/web/initialization.md
@@ -262,6 +262,9 @@ _flutter.loader.load({
 
 ## Common warnings {:#common-warnings}
 
+This section describes common web build and initialization warnings
+and how to resolve them.
+
 ### Service worker version deprecation
 
 If you experience a warning similar to the following:


### PR DESCRIPTION
Fixes #12184

Clarifies the deprecation of `FlutterLoader.loadEntrypoint` in favor of `_flutter.loader.load()` under a new subsection in the **Common warnings** section of the web initialization documentation. 

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
