### PR TITLE
Add go link for the video_player web Shaka Player design doc

### DIFF
--- a/sites/docs/firebase.json
+++ b/sites/docs/firebase.json
@@ -814,6 +814,7 @@
       { "source": "/go/verbatim-logical-keys-for-non-latin-layout", "destination": "https://docs.google.com/document/d/1ZNgNxito-NVUS1JKlcjdzHUcKyyiupy8Za-jb131dD4/edit?usp=sharing&resourcekey=0-eeEZ5X0jAzuqSTdmPWlv0w", "type": 301 },
       { "source": "/go/video-player-background-playback", "destination": "https://docs.google.com/document/d/12WgZg2qzpCGyCRgZbG4Jr8msAV8Jd4_MTzqWimhg56M/edit?usp=sharing", "type": 301 },
       { "source": "/go/video-player-drm", "destination": "https://docs.google.com/document/d/1T4LRRsicr_JuSkXBAXEcv7-9BnYPhmwgYnr1d6G6_o8/edit?usp=sharing", "type": 301 },
+      { "source": "/go/video-player-web-shaka", "destination": "https://docs.google.com/document/d/1WfP1Ji7Xe-2zbYH6GFeweX6J8tvOVLryZbEU-4NtyBc/edit?usp=sharing", "type": 301 },
       { "source": "/go/view-metrics-overrides", "destination": "https://docs.google.com/document/d/1SqDUerkvUmidI8-ulfW5kPYmXS3RQmJY6vkNVby4vAI/edit?usp=sharing", "type": 301 },
       { "source": "/go/web-add-to-app", "destination": "https://docs.google.com/document/d/1rFM0qmYds1JkntTruBh8eO72xbT2KoP9JdbizucAAwQ/edit", "type": 301 },
       { "source": "/go/web-astral-projections", "destination": "https://docs.google.com/document/d/1pvH-J8opXsjntTpFf1bbsbU8N1vFd8tPKvBgcNn8UKQ", "type": 301 },


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Adds a `flutter.dev/go/video-player-web-shaka` redirect for the design
document "Shaka Player integration for video_player web".

The document proposes a Shaka Player-backed `VideoPlayerPlatform`
implementation for Flutter web, which would add HLS and DASH playback plus
audio-track and video-quality selection to `video_player` on the web. The
go link is required by the Flutter design document process before the
corresponding design doc issue can be filed against `flutter/flutter`.

The new entry sits in alphabetical order between `/go/video-player-drm`
and `/go/view-metrics-overrides`.

_Issues fixed by this PR (if any):_

Relates to flutter/flutter#66931.

_PRs or commits this PR depends on (if any):_

None.

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
