### PR TITLE
Update mermaid_core to 0.3.0

### DIFF
--- a/packages/site_shared/pubspec.yaml
+++ b/packages/site_shared/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   jaspr_content: ^0.5.3
   markdown: ^7.3.1
   markdown_description_list: ^0.2.0
-  mermaid_core: ^0.1.2
+  mermaid_core: ^0.3.0
   meta: ^1.18.2
   nanoid2: ^2.0.1
   opal: ^0.2.4


### PR DESCRIPTION
Updates `site_shared` from `mermaid_core ^0.1.2` to `^0.3.0`, following the integration in #13741.

> Note: this PR and verification has been generated by LLM model.

---

This includes the published diagram configuration, CSS color, and layout fixes, with ELK 0.2.0 resolved transitively.
The existing server-rendered light/dark SVG integration requires no API changes.

Release notes: https://github.com/orestesgaolin/mermaid/releases/tag/mermaid-v0.3.0

Validation with Dart 3.14.0-173.0.dev:

- Dependency resolution uses hosted `mermaid_core 0.3.0` and `elk 0.2.0`.
- Analysis of `site_shared`, `sites/docs`, and `sites/www` passes.
- All 75 existing `sites/www` tests pass.
- The actual `MermaidDiagram` component renders the current documentation example in both themes, preserves its `classDef` color, and preserves escaped source fallback for malformed input.
- The documentation page was served locally and visually inspected in both themes.
- Full docs static generation passes: all 1,424 routes generated.
  An isolated copy of Jaspr CLI 0.23.4 changed only its hard-coded proxy port
  from 5567 to 5577 to avoid an unrelated local server; the shared CLI and
  website source were unchanged. Build options match the standard docs build.
  The generated Markdown documentation page was inspected in both themes,
  with two SVG variants and no fallback.

Preview builds require `/gcbrun` from a Flutter website collaborator.

## Presubmit checklist

- [x] The Google CLA check passes.
- [x] This uses a published release and does not require a future Flutter release.
- [x] This PR follows the Google Developer Documentation Style Guidelines.
- [x] Markdown uses semantic line breaks of 80 characters or fewer.
