### PR TITLE
Update AI navigation links to /ai/get-started

### DIFF
--- a/sites/docs/lib/src/components/layout/header.dart
+++ b/sites/docs/lib/src/components/layout/header.dart
@@ -63,7 +63,7 @@ class DashHeader extends StatelessComponent {
             isActive: activeEntry == ActiveNavEntry.learn,
           ),
           _NavItem(
-            href: '/ai/create-with-ai',
+            href: '/ai/get-started',
             label: 'AI',
             isActive: activeEntry == ActiveNavEntry.ai,
           ),

--- a/sites/docs/lib/src/components/layout/sidenav.dart
+++ b/sites/docs/lib/src/components/layout/sidenav.dart
@@ -44,7 +44,7 @@ final class DashSideNav extends StatelessComponent {
           active: activeEntry == ActiveNavEntry.learn,
         ),
         _TopNavItem(
-          href: '/ai/create-with-ai',
+          href: '/ai/get-started',
           label: 'AI',
           iconId: 'auto_awesome',
           active: activeEntry == ActiveNavEntry.ai,

--- a/sites/docs/lib/src/layouts/doc_layout.dart
+++ b/sites/docs/lib/src/layouts/doc_layout.dart
@@ -30,7 +30,7 @@ class DocLayout extends FlutterDocsLayout {
         prerender: const {},
         prefetch: const {
           '/learn/pathway',
-          '/ai/create-with-ai',
+          '/ai/get-started',
         },
       );
     }


### PR DESCRIPTION
## Description

Update the AI navigation references from the removed `/ai/create-with-ai` route to `/ai/get-started`.

In PR #13778, the AI landing page was reorganized to `/ai/get-started` and a 301 redirect was configured in `firebase.json`. However, the site header, mobile sidenav, and speculation prefetch links still pointed to the old `/ai/create-with-ai` URL, which causes broken navigation in local preview where Firebase Hosting redirects are not active.

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.