### PR TITLE
docs: update Android launcher icon link to adaptive icon guidelines (#13859)

### DIFF
--- a/sites/docs/src/content/deployment/android.md
+++ b/sites/docs/src/content/deployment/android.md
@@ -42,8 +42,8 @@ To learn about customizing this icon, check out the
 
 Alternatively, you can do it manually using the following steps:
 
-1. Review the
-   [Material Design product icons][launchericons] guidelines for icon design.
+1. Review the Android [adaptive icon guidelines][adaptive-icons]
+   for icon design and sizing specifications.
 
 1. In the `[project]/android/app/src/main/res/` directory,
    place your icon files in folders named using
@@ -61,7 +61,8 @@ Alternatively, you can do it manually using the following steps:
    run your app and inspect the app icon in the Launcher.
 
 [flutter_launcher_icons]: {{site.pub}}/packages/flutter_launcher_icons
-[launchericons]: {{site.material}}/styles/icons
+[adaptive-icons]:
+  {{site.android-dev}}/develop/ui/views/launch/icon_design_adaptive
 [config-qual]: {{site.android-dev}}/guide/topics/resources/providing-resources#AlternativeResources
 [applicationtag]: {{site.android-dev}}/guide/topics/manifest/application-element
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Updates the Android deployment guide to link to Android's official adaptive icon guidelines on `developer.android.com` instead of Material 3 system icons (which only cover in-app symbols and glyphs, not app launcher icons).

_Issues fixed by this PR (if any):_

Fixes #13859

## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [x] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
