### PR TITLE
For iOS 27, DeviceHub replaces the Simulator app.

### DIFF
--- a/sites/docs/src/content/platform-integration/ios/setup.md
+++ b/sites/docs/src/content/platform-integration/ios/setup.md
@@ -103,7 +103,15 @@ physical device.
 <Tabs key="ios-simulator-or-physical-device">
 <Tab name="Simulator">
 
-Start the iOS Simulator with the following command:
+To start the simulator, run the command for your Xcode version.
+
+If you're using Xcode 27 or later, start the DeviceHub app:
+
+```console
+$ open -a DeviceHub
+```
+
+If you're using Xcode 26 or earlier, start the Simulator app:
 
 ```console
 $ open -a Simulator

--- a/sites/docs/src/content/platform-integration/ios/setup.md
+++ b/sites/docs/src/content/platform-integration/ios/setup.md
@@ -105,7 +105,7 @@ physical device.
 
 To start the simulator, run the command for your Xcode version.
 
-If you're using Xcode 27 or later, start the DeviceHub app:
+If you're using Xcode 27 or later, start the Device Hub app:
 
 ```console
 $ open -a DeviceHub


### PR DESCRIPTION
Fixes https://github.com/flutter/website/issues/13490