### PR TITLE
Fix search AI preview text contrast in dark mode

### DIFF
--- a/sites/docs/lib/_sass/pages/_search.scss
+++ b/sites/docs/lib/_sass/pages/_search.scss
@@ -114,4 +114,28 @@
     color: var(--site-link-fgColor);
     fill: var(--site-link-fgColor);
   }
+
+  // Google Programmable Search AI Preview (SGE) styles.
+  .gsc-sge-container-header {
+    color: var(--site-link-fgColor);
+  }
+
+  .gsc-sge-icon,
+  .gsc-sge-paragraph-citation-link {
+    fill: var(--site-link-fgColor);
+  }
+
+  .gsc-sge-response,
+  .gsc-sge-citation-title {
+    color: var(--site-base-fgColor);
+  }
+
+  .gsc-sge-citation-snippet,
+  .gsc-sge-footer {
+    color: var(--site-base-fgColor-lighter);
+  }
+
+  .gsc-sge-feedback-icon {
+    fill: var(--site-base-fgColor-lighter);
+  }
 }

--- a/sites/docs/lib/_sass/pages/_search.scss
+++ b/sites/docs/lib/_sass/pages/_search.scss
@@ -125,6 +125,24 @@
     fill: var(--site-link-fgColor);
   }
 
+  .gsc-sge-citation-card {
+    background-color: var(--site-base-bgColor);
+
+    &.gsc-sge-citation-pulse {
+      animation-name: search-citation-pulse;
+    }
+  }
+
+  @keyframes search-citation-pulse {
+    from {
+      background-color: var(--site-raised-bgColor);
+    }
+
+    to {
+      background-color: var(--site-base-bgColor);
+    }
+  }
+
   .gsc-sge-response,
   .gsc-sge-citation-title {
     color: var(--site-base-fgColor);


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_

Google Programmable Search Engine recently introduced an AI Preview (SGE)
feature. The embedded script injects styles with hardcoded dark gray text
(`#4D5156`) intended for light backgrounds. In dark mode, this causes the AI
preview summary text, citation snippets, and footer to have very low contrast
against the dark background.

This adds styling overrides in `_search.scss` for `.gsc-sge-*` classes
to use the theme's foreground and link color variables.

Before:
<img width="1147" height="784" alt="Screenshot 2026-09-10 2 58 00 PM" src="https://github.com/user-attachments/assets/4bf1a845-6d4b-40e2-831e-84be2a50fb95" />

After:
<img width="863" height="556" alt="image" src="https://github.com/user-attachments/assets/23142740-06bb-4288-a574-af73eaf8fe39" />



## Presubmit checklist

- [x] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.